### PR TITLE
feat(fal): add 101 new fal.ai models

### DIFF
--- a/packages/fal-codegen/src/configs/3d-to-3d.ts
+++ b/packages/fal-codegen/src/configs/3d-to-3d.ts
@@ -119,6 +119,75 @@ export const config: ModuleConfig = {
         "Professional applications",
         "Rapid prototyping"
       ]
+    },
+
+    "hitem3d/hi3d/texture": {
+      className: "Hi3dTexture",
+      docstring:
+        "Hi3D textures an existing geometry mesh from a reference image.",
+      tags: ["3d-to-3d", "3d", "mesh", "texture", "hi3d"],
+      useCases: [
+        "Texture an untextured mesh",
+        "Apply a reference look to geometry",
+        "Retexture an imported model",
+        "Produce PBR-ready assets",
+        "Match a mesh to concept art"
+      ]
+    },
+
+    "hitem3d/hi3d/split": {
+      className: "Hi3dSplit",
+      docstring: "Hi3D splits a 3D model into separate parts.",
+      tags: ["3d-to-3d", "3d", "mesh", "segmentation", "hi3d"],
+      useCases: [
+        "Split a model for separate printing",
+        "Break a mesh into editable parts",
+        "Prepare components for rigging",
+        "Isolate parts for texturing",
+        "Decompose an asset for reuse"
+      ]
+    },
+
+    "hitem3d/hi3d/multicolor": {
+      className: "Hi3dMulticolor",
+      docstring:
+        "Hi3D converts a textured 3D model into a multicolor model suited to multicolor 3D printing.",
+      tags: ["3d-to-3d", "3d", "mesh", "3d-printing", "color", "hi3d"],
+      useCases: [
+        "Prepare a model for multicolor printing",
+        "Convert textures into printable color",
+        "Produce color-separated geometry",
+        "Ready an asset for a color printer",
+        "Turn a textured mesh into print parts"
+      ]
+    },
+
+    "tripo3d/tripo/remesh": {
+      className: "Tripo3dRemesh",
+      docstring:
+        "Tripo3D converts triangle meshes into clean quad topology at a target polygon count.",
+      tags: ["3d-to-3d", "3d", "mesh", "retopology", "quad", "tripo"],
+      useCases: [
+        "Retopologize a scanned mesh",
+        "Prepare geometry for animation",
+        "Hit a polygon budget for a game",
+        "Clean up generated 3D output",
+        "Convert triangles to quads"
+      ]
+    },
+
+    "tripo3d/tripo/segment": {
+      className: "Tripo3dSegment",
+      docstring:
+        "Tripo3D splits a 3D model into semantic parts for editing, texturing, and rigging.",
+      tags: ["3d-to-3d", "3d", "mesh", "segmentation", "tripo"],
+      useCases: [
+        "Separate a model into named parts",
+        "Prepare a mesh for rigging",
+        "Texture parts independently",
+        "Edit one component of an asset",
+        "Extract parts for reuse"
+      ]
     }
   }
 };

--- a/packages/fal-codegen/src/configs/audio-to-video.ts
+++ b/packages/fal-codegen/src/configs/audio-to-video.ts
@@ -283,6 +283,50 @@ export const config: ModuleConfig = {
         "Professional applications",
         "Rapid prototyping"
       ]
+    },
+
+    "lightricks/ltx-2.5/audio-to-video/fast": {
+      className: "Ltx25AudioToVideoFast",
+      docstring:
+        "LTX 2.5 generates video timed to a supplied audio clip in a speed-optimized pass.",
+      tags: [
+        "generation",
+        "audio-to-video",
+        "video",
+        "ltx",
+        "ltx-2-5",
+        "lipsync",
+        "fast"
+      ],
+      useCases: [
+        "Preview visuals against a music track",
+        "Draft a dialogue-led short",
+        "Time a clip to an existing voiceover",
+        "Iterate on a music video concept",
+        "Test sync before a final render"
+      ]
+    },
+
+    "lightricks/ltx-2.5/audio-to-video/pro": {
+      className: "Ltx25AudioToVideoPro",
+      docstring:
+        "LTX 2.5 generates video timed to a supplied audio clip in a quality-optimized pass.",
+      tags: [
+        "generation",
+        "audio-to-video",
+        "video",
+        "ltx",
+        "ltx-2-5",
+        "lipsync",
+        "quality"
+      ],
+      useCases: [
+        "Render final visuals for a track",
+        "Produce a music-driven video",
+        "Sync footage to recorded dialogue",
+        "Deliver an ad keyed to a soundtrack",
+        "Finish an approved audio-timed draft"
+      ]
     }
   }
 };

--- a/packages/fal-codegen/src/configs/image-to-3d.ts
+++ b/packages/fal-codegen/src/configs/image-to-3d.ts
@@ -501,6 +501,104 @@ export const config: ModuleConfig = {
         "Professional applications",
         "Rapid prototyping"
       ]
+    },
+
+    "hitem3d/hi3d/image-to-3d": {
+      className: "Hi3dImageTo3d",
+      docstring: "Hi3D generates a 3D model from a single image.",
+      tags: ["generation", "image-to-3d", "3d", "mesh", "hi3d"],
+      useCases: [
+        "Turn a product photo into a mesh",
+        "Generate 3D props from concept art",
+        "Build game assets from references",
+        "Prototype a model from one photo",
+        "Create printable geometry from an image"
+      ]
+    },
+
+    "hitem3d/hi3d/multi-view-to-3d": {
+      className: "Hi3dMultiViewTo3d",
+      docstring:
+        "Hi3D generates a 3D model from several view images of one object.",
+      tags: ["generation", "image-to-3d", "multiview", "3d", "mesh", "hi3d"],
+      useCases: [
+        "Reconstruct an object from photos",
+        "Build a mesh from turntable shots",
+        "Improve accuracy over single-image 3D",
+        "Digitize a physical product",
+        "Generate game assets from reference sheets"
+      ]
+    },
+
+    "hitem3d/hi3d/v3.0/image-to-3d": {
+      className: "Hi3dV30ImageTo3d",
+      docstring: "Hi3D V3.0 generates a 3D model from a single image.",
+      tags: ["generation", "image-to-3d", "3d", "mesh", "hi3d", "v3"],
+      useCases: [
+        "Generate a mesh from one photo",
+        "Convert concept art to 3D",
+        "Produce game-ready props",
+        "Prototype geometry for print",
+        "Rebuild an object from a reference"
+      ]
+    },
+
+    "hitem3d/hi3d/v3.0/multi-view-to-3d": {
+      className: "Hi3dV30MultiViewTo3d",
+      docstring:
+        "Hi3D V3.0 generates a 3D model from several view images of one object.",
+      tags: [
+        "generation",
+        "image-to-3d",
+        "multiview",
+        "3d",
+        "mesh",
+        "hi3d",
+        "v3"
+      ],
+      useCases: [
+        "Reconstruct an object from multiple angles",
+        "Digitize a product for a catalog",
+        "Build accurate meshes from photo sets",
+        "Generate assets from reference sheets",
+        "Capture geometry without a scanner"
+      ]
+    },
+
+    "meshy/v7/image-to-3d": {
+      className: "MeshyV7ImageTo3d",
+      docstring:
+        "Meshy V7 turns a single image into a textured PBR-ready mesh with game-ready topology.",
+      tags: ["generation", "image-to-3d", "3d", "mesh", "pbr", "meshy"],
+      useCases: [
+        "Convert concept art to a game asset",
+        "Generate a mesh from a product photo",
+        "Produce PBR textures automatically",
+        "Control polygon count for engines",
+        "Prototype 3D from a single image"
+      ]
+    },
+
+    "meshy/v7/multi-image-to-3d": {
+      className: "MeshyV7MultiImageTo3d",
+      docstring:
+        "Meshy V7 reconstructs a textured mesh from several angle views of one object, with polygon control.",
+      tags: [
+        "generation",
+        "image-to-3d",
+        "multiview",
+        "3d",
+        "mesh",
+        "pbr",
+        "meshy"
+      ],
+      useCases: [
+        "Reconstruct an object from photo sets",
+        "Improve fidelity over single-image 3D",
+        "Digitize props for a game",
+        "Produce game-ready topology from photos",
+        "Capture geometry without a scanner"
+      ]
     }
   }
 };

--- a/packages/fal-codegen/src/configs/image-to-image.ts
+++ b/packages/fal-codegen/src/configs/image-to-image.ts
@@ -34,14 +34,7 @@ export const config: ModuleConfig = {
       className: "Flux2LoraEdit",
       docstring:
         "FLUX.2 Edit with LoRA weights applies custom-trained styles and subjects while editing an image.",
-      tags: [
-        "editing",
-        "image-to-image",
-        "img2img",
-        "flux",
-        "flux-2",
-        "lora"
-      ],
+      tags: ["editing", "image-to-image", "img2img", "flux", "flux-2", "lora"],
       useCases: [
         "Edit images in a custom-trained style",
         "Insert a fine-tuned subject into a photo",
@@ -5938,6 +5931,299 @@ export const config: ModuleConfig = {
         "Batch processing",
         "Professional applications",
         "Rapid prototyping"
+      ]
+    },
+
+    "bria/fibo-edit-1.5/edit": {
+      className: "BriaFiboEdit15",
+      docstring:
+        "Fibo Edit 1.5 edits an image from a natural-language instruction plus up to four reference images.",
+      tags: [
+        "image-to-image",
+        "img2img",
+        "image",
+        "bria",
+        "fibo",
+        "editing",
+        "reference",
+        "licensed"
+      ],
+      useCases: [
+        "Combine a subject with reference objects",
+        "Replace a background from a reference",
+        "Run virtual try-on with a garment image",
+        "Transfer a style from reference images",
+        "Composite characters into a scene"
+      ]
+    },
+
+    "bytedance/seedream/v5/pro/layerize": {
+      className: "BytedanceSeedreamV5ProLayerize",
+      docstring:
+        "Seedream 5.0 Pro Layerize splits an image into 2 to 17 independent transparent-PNG layers described in text.",
+      tags: [
+        "image-to-image",
+        "img2img",
+        "image",
+        "seedream",
+        "bytedance",
+        "layers",
+        "editing",
+        "utility"
+      ],
+      useCases: [
+        "Split a composite into editable layers",
+        "Extract a subject onto transparency",
+        "Recover a background plate",
+        "Prepare assets for a design tool",
+        "Enable non-destructive image reuse"
+      ]
+    },
+
+    "google/virtual-try-on": {
+      className: "GoogleVirtualTryOn",
+      docstring:
+        "Google Virtual Try On renders a person image wearing a supplied clothing product image.",
+      tags: [
+        "image-to-image",
+        "img2img",
+        "image",
+        "virtual-try-on",
+        "fashion",
+        "ecommerce",
+        "google"
+      ],
+      useCases: [
+        "Show a garment on a model without a shoot",
+        "Build try-on previews for a storefront",
+        "Generate catalog imagery per size run",
+        "Swap outfits on an existing photo",
+        "Preview styling combinations"
+      ]
+    },
+
+    "xai/grok-imagine-image/v2.0/edit": {
+      className: "GrokImagineImageV20Edit",
+      docstring:
+        "Grok Imagine 2.0 edits an existing image from a text instruction.",
+      tags: [
+        "image-to-image",
+        "img2img",
+        "image",
+        "editing",
+        "xai",
+        "grok",
+        "grok-imagine"
+      ],
+      useCases: [
+        "Apply a described edit to a photo",
+        "Change an object in an existing image",
+        "Restyle artwork with an instruction",
+        "Fix details without a redraw",
+        "Iterate on an approved composition"
+      ]
+    },
+
+    "topaz/adjust/image": {
+      className: "TopazAdjustImage",
+      docstring:
+        "Topaz Adjust corrects exposure, white balance, and color, and can colorize black-and-white photos.",
+      tags: [
+        "image-to-image",
+        "img2img",
+        "image",
+        "topaz",
+        "color-correction",
+        "exposure",
+        "enhancement"
+      ],
+      useCases: [
+        "Fix exposure on an underlit photo",
+        "Remove a color cast",
+        "Colorize a black-and-white image",
+        "Batch-correct a photo set",
+        "Normalize color before publishing"
+      ]
+    },
+
+    "topaz/sharpen/image": {
+      className: "TopazSharpenImage",
+      docstring:
+        "Topaz Sharpen removes lens, motion, portrait, and wildlife blur, with a generative mode for severe blur.",
+      tags: [
+        "image-to-image",
+        "img2img",
+        "image",
+        "topaz",
+        "sharpen",
+        "deblur",
+        "enhancement"
+      ],
+      useCases: [
+        "Rescue an out-of-focus shot",
+        "Remove motion blur from action photos",
+        "Sharpen portraits without halos",
+        "Recover severely blurred images",
+        "Prepare soft images for print"
+      ]
+    },
+
+    "topaz/denoise/image": {
+      className: "TopazDenoiseImage",
+      docstring:
+        "Topaz Denoise cleans image noise at source resolution, with a generative mode that recovers detail.",
+      tags: [
+        "image-to-image",
+        "img2img",
+        "image",
+        "topaz",
+        "denoise",
+        "noise-reduction",
+        "enhancement"
+      ],
+      useCases: [
+        "Clean high-ISO night photography",
+        "Remove sensor noise from raw exports",
+        "Recover detail lost to noise",
+        "Batch-denoise an event shoot",
+        "Prepare noisy images for upscaling"
+      ]
+    },
+
+    "topaz/restore/image": {
+      className: "TopazRestoreImage",
+      docstring:
+        "Topaz Restore rebuilds detail in degraded photos and removes film dust and scratches.",
+      tags: [
+        "image-to-image",
+        "img2img",
+        "image",
+        "topaz",
+        "restoration",
+        "film",
+        "enhancement"
+      ],
+      useCases: [
+        "Restore an old family photograph",
+        "Clean dust and scratches from scans",
+        "Rebuild detail in a degraded image",
+        "Digitize a print archive",
+        "Prepare heritage images for print"
+      ]
+    },
+
+    "topaz/upscale/image/precision": {
+      className: "TopazUpscaleImagePrecision",
+      docstring:
+        "Topaz Gigapixel precision models enlarge images up to 4x while staying faithful to the source.",
+      tags: [
+        "image-to-image",
+        "img2img",
+        "image",
+        "topaz",
+        "upscale",
+        "gigapixel",
+        "super-resolution"
+      ],
+      useCases: [
+        "Enlarge a photo for large-format print",
+        "Upscale without inventing detail",
+        "Prepare CGI renders at higher resolution",
+        "Refine text inside an enlarged image",
+        "Scale catalog photography"
+      ]
+    },
+
+    "topaz/upscale/image/generative": {
+      className: "TopazUpscaleImageGenerative",
+      docstring:
+        "Topaz generative upscaling rebuilds sharp detail in small or blurry images, with prompt-guided and extreme-recovery modes.",
+      tags: [
+        "image-to-image",
+        "img2img",
+        "image",
+        "topaz",
+        "upscale",
+        "generative",
+        "super-resolution"
+      ],
+      useCases: [
+        "Rebuild detail in a low-resolution source",
+        "Guide an upscale with a prompt",
+        "Recover an extremely small image",
+        "Enlarge web-sized assets for print",
+        "Restore thumbnails to usable size"
+      ]
+    },
+
+    "topaz/upscale/image/creative": {
+      className: "TopazUpscaleImageCreative",
+      docstring:
+        "Topaz creative upscaling reinvents detail with adjustable creativity and color preservation.",
+      tags: [
+        "image-to-image",
+        "img2img",
+        "image",
+        "topaz",
+        "upscale",
+        "creative",
+        "super-resolution"
+      ],
+      useCases: [
+        "Enhance AI-generated images at scale",
+        "Add invented detail to flat renders",
+        "Push a stylized image to high resolution",
+        "Trade fidelity for visual impact",
+        "Finish concept art for presentation"
+      ]
+    },
+
+    "topaz/upscale/image/transparent": {
+      className: "TopazUpscaleImageTransparent",
+      docstring:
+        "Topaz transparent upscaling enlarges images while preserving the alpha channel, returning PNG.",
+      tags: [
+        "image-to-image",
+        "img2img",
+        "image",
+        "topaz",
+        "upscale",
+        "transparency",
+        "alpha",
+        "png"
+      ],
+      useCases: [
+        "Upscale a logo without losing alpha",
+        "Enlarge stickers and cutout assets",
+        "Prepare transparent art for print",
+        "Scale UI assets with transparency",
+        "Keep alpha intact through an upscale"
+      ]
+    },
+
+    "hitem3d/hi3d/image-to-relief": {
+      className: "Hi3dImageToRelief",
+      docstring: "Hi3D generates a 3D relief depth map from a single image.",
+      tags: ["image-to-image", "depth", "relief", "3d", "hi3d"],
+      useCases: [
+        "Generate a relief for CNC carving",
+        "Produce a depth map from a photo",
+        "Create embossed artwork",
+        "Prepare a bas-relief for printing",
+        "Derive depth for a parallax effect"
+      ]
+    },
+
+    "fal-ai/workflow-utilities/pick-image-by-index": {
+      className: "WorkflowUtilitiesPickImageByIndex",
+      docstring: "Picks the Nth image from a list of image URLs.",
+      tags: ["utility", "workflow", "image", "list"],
+      useCases: [
+        "Select one image from a batch",
+        "Pick a specific variation to continue with",
+        "Branch a workflow on an index",
+        "Feed one result into the next node",
+        "Reduce a list output to a single image"
       ]
     }
   }

--- a/packages/fal-codegen/src/configs/image-to-video.ts
+++ b/packages/fal-codegen/src/configs/image-to-video.ts
@@ -3228,6 +3228,209 @@ export const config: ModuleConfig = {
         "Professional applications",
         "Rapid prototyping"
       ]
+    },
+
+    "alibaba/wan-3.0/image-to-video": {
+      className: "Wan30ImageToVideo",
+      docstring:
+        "Wan 3.0 animates a still image into video while keeping the source composition and identity.",
+      tags: [
+        "generation",
+        "image-to-video",
+        "img2vid",
+        "video",
+        "wan",
+        "wan-3"
+      ],
+      useCases: [
+        "Animate a product photo",
+        "Bring a character illustration to life",
+        "Add camera movement to a still",
+        "Turn concept art into motion",
+        "Extend a photo into a short clip"
+      ]
+    },
+
+    "alibaba/wan-3.0/reference-to-video": {
+      className: "Wan30ReferenceToVideo",
+      docstring:
+        "Wan 3.0 generates video that follows reference images for character, style, and scene consistency.",
+      tags: [
+        "generation",
+        "image-to-video",
+        "img2vid",
+        "video",
+        "reference",
+        "wan",
+        "wan-3"
+      ],
+      useCases: [
+        "Keep one character consistent across shots",
+        "Lock a visual style from references",
+        "Reuse a set across scenes",
+        "Generate variations of a referenced subject",
+        "Match brand art direction in video"
+      ]
+    },
+
+    "alibaba/wan-3.0-prime/image-to-video": {
+      className: "Wan30PrimeImageToVideo",
+      docstring:
+        "Wan 3.0 Prime animates a still image into video with rapid turnaround and natural motion.",
+      tags: [
+        "generation",
+        "image-to-video",
+        "img2vid",
+        "video",
+        "wan",
+        "wan-3",
+        "fast"
+      ],
+      useCases: [
+        "Animate stills quickly for review",
+        "Add motion to product photography",
+        "Preview an animation direction",
+        "Generate looping clips from art",
+        "Batch-animate a photo set"
+      ]
+    },
+
+    "bytedance/seedance-2.5/image-to-video": {
+      className: "BytedanceSeedance25ImageToVideo",
+      docstring:
+        "Seedance 2.5 animates one still into a native 30-second clip at up to 720p without multi-clip stitching.",
+      tags: [
+        "generation",
+        "image-to-video",
+        "img2vid",
+        "video",
+        "seedance",
+        "bytedance",
+        "long-form"
+      ],
+      useCases: [
+        "Extend a single frame into a long take",
+        "Animate key art into a full shot",
+        "Produce drift-free long animation",
+        "Turn a photo into a 30-second clip",
+        "Generate continuous motion from a still"
+      ]
+    },
+
+    "bytedance/seedance-2.5/reference-to-video": {
+      className: "BytedanceSeedance25ReferenceToVideo",
+      docstring:
+        "Seedance 2.5 generates video from up to 50 image, video, audio, and style references, locking character and palette across a 30-second take.",
+      tags: [
+        "generation",
+        "image-to-video",
+        "img2vid",
+        "video",
+        "reference",
+        "seedance",
+        "bytedance",
+        "long-form"
+      ],
+      useCases: [
+        "Lock a character across a long take",
+        "Hold a set and palette consistent",
+        "Drive video from many reference inputs",
+        "Match an existing production look",
+        "Generate continuity-safe scenes"
+      ]
+    },
+
+    "lightricks/ltx-2.5/image-to-video/fast": {
+      className: "Ltx25ImageToVideoFast",
+      docstring:
+        "LTX 2.5 animates a still into video with synchronized audio in a speed-optimized pass.",
+      tags: [
+        "generation",
+        "image-to-video",
+        "img2vid",
+        "video",
+        "ltx",
+        "ltx-2-5",
+        "audio",
+        "fast"
+      ],
+      useCases: [
+        "Preview how a still will animate",
+        "Iterate on motion direction cheaply",
+        "Animate key art with sound",
+        "Batch-draft clips from a photo set",
+        "Test a shot before a quality render"
+      ]
+    },
+
+    "lightricks/ltx-2.5/image-to-video/pro": {
+      className: "Ltx25ImageToVideoPro",
+      docstring:
+        "LTX 2.5 animates a still into video with synchronized audio in a quality-optimized pass.",
+      tags: [
+        "generation",
+        "image-to-video",
+        "img2vid",
+        "video",
+        "ltx",
+        "ltx-2-5",
+        "audio",
+        "quality"
+      ],
+      useCases: [
+        "Deliver a final animated still",
+        "Produce high-fidelity motion from key art",
+        "Animate product photography with sound",
+        "Finish an approved motion draft",
+        "Create polished clips from images"
+      ]
+    },
+
+    "minimax/h3/image-to-video/lora": {
+      className: "MinimaxH3ImageToVideoLora",
+      docstring:
+        "MiniMax H3 animates an image into video with synchronized audio, with LoRA support for subject consistency.",
+      tags: [
+        "generation",
+        "image-to-video",
+        "img2vid",
+        "video",
+        "minimax",
+        "h3",
+        "lora",
+        "audio"
+      ],
+      useCases: [
+        "Animate a still with a trained subject",
+        "Hold character identity across clips",
+        "Apply a custom style to animation",
+        "Generate video with matching audio",
+        "Produce consistent series content"
+      ]
+    },
+
+    "mirage-api/avatar-x/reference-to-video": {
+      className: "AvatarXReferenceToVideo",
+      docstring:
+        "Avatar X generates a talking-head video from reference material, preserving the referenced identity.",
+      tags: [
+        "generation",
+        "image-to-video",
+        "img2vid",
+        "video",
+        "avatar",
+        "lipsync",
+        "talking-head",
+        "reference",
+        "mirage"
+      ],
+      useCases: [
+        "Animate a reference portrait as a presenter",
+        "Keep one avatar identity across videos",
+        "Produce lip-synced spokesperson clips",
+        "Reuse a cast member in new scripts",
+        "Generate consistent avatar series"
+      ]
     }
   }
 };

--- a/packages/fal-codegen/src/configs/llm.ts
+++ b/packages/fal-codegen/src/configs/llm.ts
@@ -97,6 +97,20 @@ export const config: ModuleConfig = {
         "Professional applications",
         "Rapid prototyping"
       ]
+    },
+
+    "openrouter/router/enterprise": {
+      className: "OpenRouterEnterprise",
+      docstring:
+        "Runs any OpenRouter LLM through fal on the enterprise routing tier.",
+      tags: ["llm", "text", "chat", "openrouter", "enterprise"],
+      useCases: [
+        "Route prompts to any OpenRouter model",
+        "Compare models behind one endpoint",
+        "Run enterprise-tier inference",
+        "Fall back across providers",
+        "Centralize LLM access through fal"
+      ]
     }
   }
 };

--- a/packages/fal-codegen/src/configs/text-to-3d.ts
+++ b/packages/fal-codegen/src/configs/text-to-3d.ts
@@ -148,6 +148,20 @@ export const config: ModuleConfig = {
         "Professional applications",
         "Rapid prototyping"
       ]
+    },
+
+    "meshy/v7/text-to-3d": {
+      className: "MeshyV7TextTo3d",
+      docstring:
+        "Meshy V7 generates a textured PBR-ready mesh from text, with game-ready topology at a target polygon count.",
+      tags: ["generation", "text-to-3d", "3d", "mesh", "pbr", "meshy"],
+      useCases: [
+        "Generate a game prop from a prompt",
+        "Create PBR assets without modelling",
+        "Hit a polygon budget from text",
+        "Prototype 3D concepts quickly",
+        "Fill an asset library from descriptions"
+      ]
     }
   }
 };

--- a/packages/fal-codegen/src/configs/text-to-audio.ts
+++ b/packages/fal-codegen/src/configs/text-to-audio.ts
@@ -717,6 +717,27 @@ export const config: ModuleConfig = {
         "Professional applications",
         "Rapid prototyping"
       ]
+    },
+
+    "minimax/music-3": {
+      className: "MinimaxMusic3",
+      docstring:
+        "MiniMax Music 3 generates complete songs up to five minutes long from a prompt and lyrics.",
+      tags: [
+        "generation",
+        "audio",
+        "music",
+        "text-to-audio",
+        "song",
+        "minimax"
+      ],
+      useCases: [
+        "Generate a full-length song from a brief",
+        "Write backing music for a video",
+        "Produce royalty-free tracks",
+        "Turn lyrics into a finished song",
+        "Create theme music for a product"
+      ]
     }
   }
 };

--- a/packages/fal-codegen/src/configs/text-to-image.ts
+++ b/packages/fal-codegen/src/configs/text-to-image.ts
@@ -3541,6 +3541,146 @@ export const config: ModuleConfig = {
         "Professional applications",
         "Rapid prototyping"
       ]
+    },
+
+    "bria/fibo-gen-1.5/text-to-image": {
+      className: "BriaFiboGen15TextToImage",
+      docstring:
+        "Fibo Gen 1.5 generates images from text or JSON-structured prompts, trained on licensed data for commercial use.",
+      tags: [
+        "generation",
+        "text-to-image",
+        "txt2img",
+        "image",
+        "bria",
+        "fibo",
+        "typography",
+        "licensed"
+      ],
+      useCases: [
+        "Generate commercially safe product visuals",
+        "Render accurate typography in images",
+        "Drive generation from structured JSON prompts",
+        "Produce photoreal marketing imagery",
+        "Create on-brand illustrations at scale"
+      ]
+    },
+
+    "xai/grok-imagine-image/v2.0/text-to-image": {
+      className: "GrokImagineImageV20",
+      docstring: "Grok Imagine 2.0 generates images from text.",
+      tags: [
+        "generation",
+        "text-to-image",
+        "txt2img",
+        "image",
+        "xai",
+        "grok",
+        "grok-imagine"
+      ],
+      useCases: [
+        "Generate illustrations from a prompt",
+        "Produce concept art quickly",
+        "Create social imagery at scale",
+        "Render product visuals",
+        "Explore visual directions for a brief"
+      ]
+    },
+
+    "recraft/v4/style/text-to-image": {
+      className: "RecraftV4StyleTextToImage",
+      docstring:
+        "Recraft V4 Styles generates raster images that hold a consistent style from a style id or reference images.",
+      tags: [
+        "generation",
+        "text-to-image",
+        "txt2img",
+        "image",
+        "recraft",
+        "recraft-v4",
+        "style",
+        "consistency"
+      ],
+      useCases: [
+        "Generate a set of on-style images",
+        "Apply a saved style id to a prompt",
+        "Keep campaign visuals consistent",
+        "Produce illustrations in a house style",
+        "Render variations without style drift"
+      ]
+    },
+
+    "recraft/v4/style/text-to-vector": {
+      className: "RecraftV4StyleTextToVector",
+      docstring:
+        "Recraft V4 Styles generates vector images that hold a consistent style from a style id or reference images.",
+      tags: [
+        "generation",
+        "text-to-image",
+        "txt2img",
+        "image",
+        "recraft",
+        "recraft-v4",
+        "style",
+        "vector",
+        "svg"
+      ],
+      useCases: [
+        "Generate on-style vector icons",
+        "Produce scalable brand illustrations",
+        "Build a consistent icon set",
+        "Create logos in a saved style",
+        "Deliver print-ready vector art"
+      ]
+    },
+
+    "recraft/v4/style/pro/text-to-image": {
+      className: "RecraftV4StyleProTextToImage",
+      docstring:
+        "Recraft V4 Styles Pro generates raster images that hold a consistent style from a style id or reference images.",
+      tags: [
+        "generation",
+        "text-to-image",
+        "txt2img",
+        "image",
+        "recraft",
+        "recraft-v4",
+        "style",
+        "pro",
+        "consistency"
+      ],
+      useCases: [
+        "Render final on-style raster assets",
+        "Apply a Pro style id at delivery quality",
+        "Keep a campaign visually uniform",
+        "Produce hero imagery in a house style",
+        "Scale approved art direction"
+      ]
+    },
+
+    "recraft/v4/style/pro/text-to-vector": {
+      className: "RecraftV4StyleProTextToVector",
+      docstring:
+        "Recraft V4 Styles Pro generates vector images that hold a consistent style from a style id or reference images.",
+      tags: [
+        "generation",
+        "text-to-image",
+        "txt2img",
+        "image",
+        "recraft",
+        "recraft-v4",
+        "style",
+        "pro",
+        "vector",
+        "svg"
+      ],
+      useCases: [
+        "Deliver final vector assets on style",
+        "Produce a Pro-quality icon set",
+        "Render scalable brand marks",
+        "Keep vector art consistent across a suite",
+        "Prepare print-ready illustrations"
+      ]
     }
   }
 };

--- a/packages/fal-codegen/src/configs/text-to-video.ts
+++ b/packages/fal-codegen/src/configs/text-to-video.ts
@@ -53,8 +53,7 @@ export const config: ModuleConfig = {
 
     "xai/grok-imagine-video/v1.5/text-to-video": {
       className: "GrokImagineVideoV15TextToVideo",
-      docstring:
-        "Grok Imagine Video 1.5 generates videos from text prompts.",
+      docstring: "Grok Imagine Video 1.5 generates videos from text prompts.",
       tags: ["video", "generation", "text-to-video", "txt2vid", "grok", "xai"],
       useCases: [
         "Generate clips from a written prompt",
@@ -2079,6 +2078,156 @@ export const config: ModuleConfig = {
         "Batch processing",
         "Professional applications",
         "Rapid prototyping"
+      ]
+    },
+
+    "alibaba/wan-3.0/text-to-video": {
+      className: "Wan30TextToVideo",
+      docstring:
+        "Wan 3.0 generates video from a text prompt with smoother motion and stronger scene coherence than Wan 2.x.",
+      tags: ["generation", "text-to-video", "txt2vid", "video", "wan", "wan-3"],
+      useCases: [
+        "Generate cinematic shots from a written prompt",
+        "Produce social clips without filming",
+        "Storyboard a scene as motion",
+        "Iterate on shot ideas quickly",
+        "Create B-roll for edits"
+      ]
+    },
+
+    "alibaba/wan-3.0-prime/text-to-video": {
+      className: "Wan30PrimeTextToVideo",
+      docstring:
+        "Wan 3.0 Prime generates video from text with faster turnaround than the base Wan 3.0 endpoint.",
+      tags: [
+        "generation",
+        "text-to-video",
+        "txt2vid",
+        "video",
+        "wan",
+        "wan-3",
+        "fast"
+      ],
+      useCases: [
+        "Iterate on shot ideas at speed",
+        "Preview a prompt before a final render",
+        "Generate short social videos in bulk",
+        "Draft motion for a storyboard",
+        "Explore several takes of one scene"
+      ]
+    },
+
+    "bytedance/seedance-2.5/text-to-video": {
+      className: "BytedanceSeedance25TextToVideo",
+      docstring:
+        "Seedance 2.5 generates a native 30-second single-shot video at up to 720p from one text prompt.",
+      tags: [
+        "generation",
+        "text-to-video",
+        "txt2vid",
+        "video",
+        "seedance",
+        "bytedance",
+        "long-form"
+      ],
+      useCases: [
+        "Generate a full 30-second shot in one pass",
+        "Avoid stitching several short clips",
+        "Produce single-take narrative video",
+        "Create long social videos from a prompt",
+        "Keep lighting consistent across a shot"
+      ]
+    },
+
+    "lightricks/ltx-2.5/text-to-video/fast": {
+      className: "Ltx25TextToVideoFast",
+      docstring:
+        "LTX 2.5 generates synchronized video and audio from text in a speed-optimized pass.",
+      tags: [
+        "generation",
+        "text-to-video",
+        "txt2vid",
+        "video",
+        "ltx",
+        "ltx-2-5",
+        "audio",
+        "fast"
+      ],
+      useCases: [
+        "Preview a prompt before a final render",
+        "Iterate on shots cheaply",
+        "Generate video with matching audio",
+        "Draft social clips at speed",
+        "Explore several takes of one idea"
+      ]
+    },
+
+    "lightricks/ltx-2.5/text-to-video/pro": {
+      className: "Ltx25TextToVideoPro",
+      docstring:
+        "LTX 2.5 generates synchronized video and audio from text in a quality-optimized pass.",
+      tags: [
+        "generation",
+        "text-to-video",
+        "txt2vid",
+        "video",
+        "ltx",
+        "ltx-2-5",
+        "audio",
+        "quality"
+      ],
+      useCases: [
+        "Render the final take of a shot",
+        "Produce video with its own soundtrack",
+        "Deliver high-fidelity generated footage",
+        "Create ads with synchronized audio",
+        "Finish a shot approved from a fast preview"
+      ]
+    },
+
+    "minimax/h3/text-to-video/lora": {
+      className: "MinimaxH3TextToVideoLora",
+      docstring:
+        "MiniMax H3 generates video with synchronized audio from text, with a trained LoRA applied at adjustable strength.",
+      tags: [
+        "generation",
+        "text-to-video",
+        "txt2vid",
+        "video",
+        "minimax",
+        "h3",
+        "lora",
+        "audio"
+      ],
+      useCases: [
+        "Generate video in a fine-tuned style",
+        "Keep a trained character consistent",
+        "Apply a learned motion signature",
+        "Blend a LoRA at partial strength",
+        "Produce branded video with audio"
+      ]
+    },
+
+    "mirage-api/avatar-x/text-to-video": {
+      className: "AvatarXTextToVideo",
+      docstring:
+        "Avatar X generates a talking-head video from text with strong identity preservation and expressive delivery.",
+      tags: [
+        "generation",
+        "text-to-video",
+        "txt2vid",
+        "video",
+        "avatar",
+        "lipsync",
+        "talking-head",
+        "mirage"
+      ],
+      useCases: [
+        "Generate a presenter video from a script",
+        "Produce training content without filming",
+        "Localize a spokesperson video",
+        "Create avatar-led product explainers",
+        "Automate recurring video updates"
       ]
     }
   }

--- a/packages/fal-codegen/src/configs/training.ts
+++ b/packages/fal-codegen/src/configs/training.ts
@@ -399,6 +399,837 @@ export const config: ModuleConfig = {
         "Professional applications",
         "Rapid prototyping"
       ]
+    },
+
+    "minimax/h3/t2v/trainer": {
+      className: "MinimaxH3T2vTrainer",
+      docstring:
+        "Trains a MiniMax H3 LoRA on captioned clips for text-to-video generation with matching audio.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "minimax",
+        "h3",
+        "video"
+      ],
+      useCases: [
+        "Teach H3 a custom visual style",
+        "Train a recurring character",
+        "Learn a studio's motion language",
+        "Adapt H3 to a product catalog",
+        "Fine-tune for a series look"
+      ]
+    },
+
+    "minimax/h3/i2v/trainer": {
+      className: "MinimaxH3I2vTrainer",
+      docstring:
+        "Trains a MiniMax H3 LoRA with first-frame conditioning, so a still animates into video with audio.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "minimax",
+        "h3",
+        "image-to-video"
+      ],
+      useCases: [
+        "Train an animation style for stills",
+        "Teach H3 how a subject moves",
+        "Fine-tune product photo animation",
+        "Learn a character's motion from clips",
+        "Adapt first-frame animation to a brand"
+      ]
+    },
+
+    "minimax/h3/flf2v/trainer": {
+      className: "MinimaxH3Flf2vTrainer",
+      docstring:
+        "Trains a MiniMax H3 LoRA on first, last, or both keyframes to generate video with audio between them.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "minimax",
+        "h3",
+        "keyframes"
+      ],
+      useCases: [
+        "Train keyframe-to-keyframe motion",
+        "Teach transitions between two stills",
+        "Fine-tune in-between generation",
+        "Learn a studio's transition style",
+        "Adapt H3 to storyboard keyframes"
+      ]
+    },
+
+    "minimax/h3/ref2va/trainer": {
+      className: "MinimaxH3Ref2vaTrainer",
+      docstring:
+        "Trains a MiniMax H3 LoRA with reference conditioning, so references animate into video with audio.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "minimax",
+        "h3",
+        "reference"
+      ],
+      useCases: [
+        "Train reference-driven video generation",
+        "Teach H3 a reusable cast",
+        "Fine-tune multimodal conditioning",
+        "Learn a look from reference material",
+        "Adapt reference control to a franchise"
+      ]
+    },
+
+    "recraft/v4/create-style": {
+      className: "RecraftV4CreateStyle",
+      docstring:
+        "Creates a reusable Recraft V4 style from reference images and returns a style id for generation.",
+      tags: ["training", "style", "recraft", "recraft-v4"],
+      useCases: [
+        "Capture a brand style from references",
+        "Reuse one look across many images",
+        "Share a style id across a team",
+        "Build a style library",
+        "Lock art direction before generation"
+      ]
+    },
+
+    "recraft/v4/pro/create-style": {
+      className: "RecraftV4ProCreateStyle",
+      docstring:
+        "Creates a reusable Recraft V4 Pro style from reference images and returns a style id for Pro generation.",
+      tags: ["training", "style", "recraft", "recraft-v4", "pro"],
+      useCases: [
+        "Capture a style for Pro generation",
+        "Standardize art direction at higher quality",
+        "Build a reusable brand style",
+        "Share one style across campaigns",
+        "Version a studio look"
+      ]
+    },
+
+    "fal-ai/krea-2-trainer": {
+      className: "Krea2Trainer",
+      docstring:
+        "Trains a Krea 2 LoRA on your images to teach a new subject, character, or style.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "krea",
+        "krea-2",
+        "image"
+      ],
+      useCases: [
+        "Teach Krea 2 a product or character",
+        "Train a house illustration style",
+        "Fine-tune on a photo set",
+        "Produce weights for the Krea 2 LoRA endpoint",
+        "Personalize generation with a trigger word"
+      ]
+    },
+
+    "fal-ai/stable-audio-3-trainer": {
+      className: "StableAudio3Trainer",
+      docstring:
+        "Trains a Stable Audio 3 LoRA on paired audio and captions to adapt generation to a style or sound palette.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "audio",
+        "music",
+        "sfx",
+        "stable-audio"
+      ],
+      useCases: [
+        "Adapt Stable Audio 3 to a genre",
+        "Train a custom sound palette",
+        "Fine-tune on a sample library",
+        "Teach a signature instrument set",
+        "Produce weights for branded audio"
+      ]
+    },
+
+    "fal-ai/trellis-2-lora-trainer": {
+      className: "Trellis2LoraTrainer",
+      docstring: "Trains LoRA adapters for TRELLIS.2 3D generation.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "trellis",
+        "3d"
+      ],
+      useCases: [
+        "Teach TRELLIS.2 a custom asset style",
+        "Fine-tune 3D generation on a catalog",
+        "Train a recurring 3D character",
+        "Adapt geometry style to a game",
+        "Produce weights for TRELLIS.2 inference"
+      ]
+    },
+
+    "ideogram/v4/trainer": {
+      className: "IdeogramV4Trainer",
+      docstring:
+        "Trains custom LoRAs on top of Ideogram V4 for personalization and styles.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ideogram",
+        "ideogram-v4",
+        "image"
+      ],
+      useCases: [
+        "Personalize Ideogram V4 on a subject",
+        "Train a brand illustration style",
+        "Fine-tune typography treatments",
+        "Teach a recurring character",
+        "Produce weights for Ideogram LoRA endpoints"
+      ]
+    },
+
+    "fal-ai/phota/create-profile": {
+      className: "PhotaCreateProfile",
+      docstring:
+        "Creates a Phota profile from 30 to 50 images of a subject for later generation.",
+      tags: ["training", "personalization", "profile", "phota", "portrait"],
+      useCases: [
+        "Build a personal photo profile",
+        "Train a portrait identity",
+        "Prepare a subject for headshot generation",
+        "Create a reusable likeness profile",
+        "Register a model for a photo product"
+      ]
+    },
+
+    "fal-ai/wan-22-trainer/t2v-a14b": {
+      className: "Wan22TrainerT2vA14b",
+      docstring: "Trains a custom LoRA for Wan 2.2 T2V A14B at 480p.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "wan",
+        "wan-2-2",
+        "text-to-video"
+      ],
+      useCases: [
+        "Teach Wan 2.2 a text-to-video style",
+        "Train a recurring character for video",
+        "Fine-tune motion on your clips",
+        "Adapt Wan 2.2 to a brand look",
+        "Produce weights for Wan 2.2 inference"
+      ]
+    },
+
+    "fal-ai/wan-22-trainer/i2v-a14b": {
+      className: "Wan22TrainerI2vA14b",
+      docstring: "Trains a custom LoRA for Wan 2.2 I2V A14B at 480p.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "wan",
+        "wan-2-2",
+        "image-to-video"
+      ],
+      useCases: [
+        "Teach Wan 2.2 how a subject animates",
+        "Train image-to-video motion on your clips",
+        "Fine-tune product photo animation",
+        "Adapt animation style to a brand",
+        "Produce weights for Wan 2.2 I2V"
+      ]
+    },
+
+    "fal-ai/ltx23-video-trainer": {
+      className: "Ltx23VideoTrainer",
+      docstring: "Trains LTX-2.3 22B for custom styles and effects.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "video"
+      ],
+      useCases: [
+        "Teach LTX 2.3 a visual style",
+        "Train a recurring effect",
+        "Fine-tune on studio footage",
+        "Adapt LTX to a brand look",
+        "Produce weights for LTX inference"
+      ]
+    },
+
+    "fal-ai/ltx23-v2v-trainer": {
+      className: "Ltx23V2vTrainer",
+      docstring:
+        "Trains LTX-2.3 22B for video transformation and video-conditioned generation.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "video-to-video"
+      ],
+      useCases: [
+        "Train a video-to-video transformation",
+        "Teach a restyle from paired clips",
+        "Fine-tune video-conditioned generation",
+        "Learn an effect from before/after footage",
+        "Produce weights for LTX v2v"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/t2v": {
+      className: "Ltx23TrainerV2T2v",
+      docstring:
+        "Trains an LTX 2.3 LoRA on your clips for text-to-video generation.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "text-to-video"
+      ],
+      useCases: [
+        "Teach LTX a new subject or style",
+        "Train a recurring character",
+        "Fine-tune on studio footage",
+        "Adapt text-to-video to a brand",
+        "Produce weights for LTX inference"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/i2v": {
+      className: "Ltx23TrainerV2I2v",
+      docstring:
+        "Trains an LTX 2.3 LoRA that animates a starting image into video.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "image-to-video"
+      ],
+      useCases: [
+        "Train how a still should animate",
+        "Teach a subject's motion from clips",
+        "Fine-tune product photo animation",
+        "Adapt first-frame animation to a brand",
+        "Produce weights for LTX i2v"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/v2v": {
+      className: "Ltx23TrainerV2V2v",
+      docstring:
+        "Trains an LTX 2.3 LoRA for a video-to-video transformation steered by a reference video.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "video-to-video"
+      ],
+      useCases: [
+        "Learn a restyle from paired clips",
+        "Train a reference-steered transformation",
+        "Teach a look transfer for footage",
+        "Fine-tune an effect on before/after pairs",
+        "Produce weights for LTX v2v"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/v2v-masked": {
+      className: "Ltx23TrainerV2V2vMasked",
+      docstring:
+        "Trains an LTX 2.3 LoRA that regenerates only a masked video region, guided by kept pixels and a reference video.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "video-to-video",
+        "inpainting",
+        "mask"
+      ],
+      useCases: [
+        "Train targeted region replacement",
+        "Teach masked restyling of footage",
+        "Fine-tune object swaps in video",
+        "Learn a mask-aware transformation",
+        "Produce weights for masked v2v"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/inpaint": {
+      className: "Ltx23TrainerV2Inpaint",
+      docstring:
+        "Trains an LTX 2.3 LoRA that regenerates a masked video region while keeping the rest unchanged.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "inpainting",
+        "mask"
+      ],
+      useCases: [
+        "Train video object removal",
+        "Teach masked region regeneration",
+        "Fine-tune cleanup of unwanted elements",
+        "Learn seamless blending with surroundings",
+        "Produce weights for video inpainting"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/outpaint": {
+      className: "Ltx23TrainerV2Outpaint",
+      docstring:
+        "Trains an LTX 2.3 LoRA that expands the video frame outward from a fixed inner rectangle.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "outpainting"
+      ],
+      useCases: [
+        "Train aspect-ratio expansion",
+        "Teach frame extension for reframing",
+        "Fine-tune outward generation",
+        "Convert vertical footage to wide",
+        "Produce weights for video outpainting"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/interpolate": {
+      className: "Ltx23TrainerV2Interpolate",
+      docstring:
+        "Trains an LTX 2.3 LoRA that generates the video between supplied keyframes.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "keyframes",
+        "interpolation"
+      ],
+      useCases: [
+        "Train keyframe in-betweening",
+        "Teach transitions between stills",
+        "Fine-tune motion between frames",
+        "Learn a studio's transition style",
+        "Produce weights for keyframe interpolation"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/extend-prefix": {
+      className: "Ltx23TrainerV2ExtendPrefix",
+      docstring:
+        "Trains an LTX 2.3 LoRA that continues a video forward in time from an opening clip.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "extension"
+      ],
+      useCases: [
+        "Train forward video continuation",
+        "Teach what follows an opening shot",
+        "Fine-tune clip extension",
+        "Learn a scene's continuation style",
+        "Produce weights for forward extension"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/extend-suffix": {
+      className: "Ltx23TrainerV2ExtendSuffix",
+      docstring:
+        "Trains an LTX 2.3 LoRA that generates the lead-in to a video, extending it backward in time.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "extension"
+      ],
+      useCases: [
+        "Train backward video extension",
+        "Generate a lead-in to an existing clip",
+        "Fine-tune prefix generation",
+        "Learn how a shot should begin",
+        "Produce weights for backward extension"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/a2v": {
+      className: "Ltx23TrainerV2A2v",
+      docstring:
+        "Trains an LTX 2.3 LoRA that generates video from a start image and a conditioning audio track.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "audio-to-video"
+      ],
+      useCases: [
+        "Train audio-driven animation",
+        "Teach motion that matches sound",
+        "Fine-tune music-timed video",
+        "Learn lip and beat synchronization",
+        "Produce weights for audio-to-video"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/v2a": {
+      className: "Ltx23TrainerV2V2a",
+      docstring:
+        "Trains an LTX 2.3 LoRA that generates foley and sound design for silent video.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "video-to-audio",
+        "foley"
+      ],
+      useCases: [
+        "Train foley generation for footage",
+        "Teach a sound palette for scenes",
+        "Fine-tune soundtrack generation",
+        "Learn effects that match on-screen action",
+        "Produce weights for video-to-audio"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/t2a": {
+      className: "Ltx23TrainerV2T2a",
+      docstring:
+        "Trains an LTX 2.3 LoRA that generates audio from a text prompt.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "text-to-audio"
+      ],
+      useCases: [
+        "Train text-to-audio on your clips",
+        "Teach a signature sound",
+        "Fine-tune a sound-effect library",
+        "Learn a musical style from samples",
+        "Produce weights for text-to-audio"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/a2a": {
+      className: "Ltx23TrainerV2A2a",
+      docstring:
+        "Trains an LTX 2.3 LoRA that maps one audio clip to another from paired examples.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "audio-to-audio"
+      ],
+      useCases: [
+        "Train an audio transformation",
+        "Teach a timbre or style transfer",
+        "Fine-tune on paired audio",
+        "Learn a mastering signature",
+        "Produce weights for audio-to-audio"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/audio-inpaint": {
+      className: "Ltx23TrainerV2AudioInpaint",
+      docstring:
+        "Trains an LTX 2.3 LoRA that regenerates masked time spans of an audio clip.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "audio",
+        "inpainting",
+        "mask"
+      ],
+      useCases: [
+        "Train audio gap repair",
+        "Teach removal of unwanted sounds",
+        "Fine-tune masked audio regeneration",
+        "Learn seamless audio patching",
+        "Produce weights for audio inpainting"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/audio-extend-prefix": {
+      className: "Ltx23TrainerV2AudioExtendPrefix",
+      docstring:
+        "Trains an LTX 2.3 LoRA that continues an audio clip forward in time.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "audio",
+        "extension"
+      ],
+      useCases: [
+        "Train forward audio continuation",
+        "Extend a track past its ending",
+        "Fine-tune audio outros",
+        "Learn how a piece should continue",
+        "Produce weights for audio extension"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/audio-extend-suffix": {
+      className: "Ltx23TrainerV2AudioExtendSuffix",
+      docstring:
+        "Trains an LTX 2.3 LoRA that generates the lead-in to an audio clip.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "audio",
+        "extension"
+      ],
+      useCases: [
+        "Train backward audio extension",
+        "Generate an intro for a track",
+        "Fine-tune audio lead-ins",
+        "Learn how a piece should begin",
+        "Produce weights for audio prefix generation"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/av2av": {
+      className: "Ltx23TrainerV2Av2av",
+      docstring:
+        "Trains an LTX 2.3 LoRA for a joint audio and video transformation conditioned on a reference clip.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "audio",
+        "video-to-video",
+        "reference"
+      ],
+      useCases: [
+        "Train joint audio-video restyling",
+        "Teach a reference-conditioned transform",
+        "Fine-tune paired sound and picture",
+        "Learn a full-clip transformation",
+        "Produce weights for av2av"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/av2av-masked": {
+      className: "Ltx23TrainerV2Av2avMasked",
+      docstring:
+        "Trains an LTX 2.3 LoRA that regenerates a masked video region while generating audio from a reference.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "audio",
+        "inpainting",
+        "mask",
+        "reference"
+      ],
+      useCases: [
+        "Train masked audio-video regeneration",
+        "Teach region replacement with sound",
+        "Fine-tune masked multimodal edits",
+        "Learn reference-guided repair",
+        "Produce weights for masked av2av"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/ic-lora/v2v": {
+      className: "Ltx23TrainerV2IcLoraV2v",
+      docstring:
+        "Trains an LTX 2.3 IC-LoRA for a video-to-video transformation conditioned on a control video.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "ic-lora",
+        "video-to-video"
+      ],
+      useCases: [
+        "Train an in-context video transform",
+        "Teach control-video conditioning",
+        "Fine-tune from paired clips",
+        "Learn a restyle steered at inference",
+        "Produce IC-LoRA weights for v2v"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/ic-lora/v2v-masked": {
+      className: "Ltx23TrainerV2IcLoraV2vMasked",
+      docstring:
+        "Trains an LTX 2.3 IC-LoRA that regenerates a masked video region guided by kept pixels and a control video.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "ic-lora",
+        "video-to-video",
+        "mask"
+      ],
+      useCases: [
+        "Train masked in-context transforms",
+        "Teach reference-guided region edits",
+        "Fine-tune object replacement",
+        "Learn mask-aware conditioning",
+        "Produce IC-LoRA weights for masked v2v"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/ic-lora/a2a": {
+      className: "Ltx23TrainerV2IcLoraA2a",
+      docstring:
+        "Trains an LTX 2.3 IC-LoRA that transforms audio conditioned on a reference clip.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "ic-lora",
+        "audio-to-audio"
+      ],
+      useCases: [
+        "Train in-context audio transforms",
+        "Teach reference-driven timbre transfer",
+        "Fine-tune on paired audio",
+        "Learn a style steered at inference",
+        "Produce IC-LoRA weights for a2a"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/ic-lora/av2av": {
+      className: "Ltx23TrainerV2IcLoraAv2av",
+      docstring:
+        "Trains an LTX 2.3 IC-LoRA for a joint audio and video transformation from a reference clip.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "ic-lora",
+        "audio",
+        "video-to-video"
+      ],
+      useCases: [
+        "Train in-context audio-video transforms",
+        "Teach reference-conditioned restyling",
+        "Fine-tune sound and picture together",
+        "Learn a full-clip mapping",
+        "Produce IC-LoRA weights for av2av"
+      ]
+    },
+
+    "fal-ai/ltx23-trainer-v2/ic-lora/av2av-masked": {
+      className: "Ltx23TrainerV2IcLoraAv2avMasked",
+      docstring:
+        "Trains an LTX 2.3 IC-LoRA that regenerates a masked video region while generating audio from a reference.",
+      tags: [
+        "training",
+        "fine-tuning",
+        "lora",
+        "model-training",
+        "ltx",
+        "ltx-2-3",
+        "ic-lora",
+        "audio",
+        "mask",
+        "inpainting"
+      ],
+      useCases: [
+        "Train masked in-context multimodal edits",
+        "Teach guided region repair with sound",
+        "Fine-tune reference-driven inpainting",
+        "Learn mask-aware av conditioning",
+        "Produce IC-LoRA weights for masked av2av"
+      ]
     }
   }
 };

--- a/packages/fal-codegen/src/configs/video-to-video.ts
+++ b/packages/fal-codegen/src/configs/video-to-video.ts
@@ -2924,6 +2924,241 @@ export const config: ModuleConfig = {
         "Professional applications",
         "Rapid prototyping"
       ]
+    },
+
+    "alibaba/wan-3.0-prime/reference-to-video": {
+      className: "Wan30PrimeReferenceToVideo",
+      docstring:
+        "Wan 3.0 Prime combines reference images, video, and audio into one clip with multimodal coherence.",
+      tags: ["video-to-video", "vid2vid", "video", "reference", "wan", "wan-3"],
+      useCases: [
+        "Drive a video from image and audio references",
+        "Keep an identity consistent across takes",
+        "Restyle footage against a reference",
+        "Match motion from a reference clip",
+        "Produce controlled character animation"
+      ]
+    },
+
+    "blackforestlabs/flux-video-upscale": {
+      className: "FluxVideoUpscale",
+      docstring:
+        "FLUX video super-resolution upscales footage to 1080p, 2K, or 4K in a precise or creative detail mode.",
+      tags: [
+        "video-to-video",
+        "vid2vid",
+        "video",
+        "upscale",
+        "super-resolution",
+        "flux",
+        "enhancement"
+      ],
+      useCases: [
+        "Upscale archive footage to 4K",
+        "Sharpen low-resolution clips for delivery",
+        "Enhance AI-generated video before edit",
+        "Prepare social clips for large displays",
+        "Recover detail in compressed footage"
+      ]
+    },
+
+    "minimax/h3/reference-to-video/lora": {
+      className: "MinimaxH3ReferenceToVideoLora",
+      docstring:
+        "MiniMax H3 generates video with synchronized audio from references, with LoRA support.",
+      tags: [
+        "video-to-video",
+        "vid2vid",
+        "video",
+        "reference",
+        "minimax",
+        "h3",
+        "lora",
+        "audio"
+      ],
+      useCases: [
+        "Drive video from reference material",
+        "Combine a LoRA with reference control",
+        "Keep a set and cast consistent",
+        "Restyle references into new shots",
+        "Produce continuity across episodes"
+      ]
+    },
+
+    "topaz/upscale/video/precision": {
+      className: "TopazUpscaleVideoPrecision",
+      docstring:
+        "Topaz precision video models enhance footage up to 4x while staying faithful to the source.",
+      tags: [
+        "video-to-video",
+        "vid2vid",
+        "video",
+        "topaz",
+        "upscale",
+        "super-resolution",
+        "enhancement"
+      ],
+      useCases: [
+        "Upscale real-world footage to 4K",
+        "Enhance interviews without artifacts",
+        "Prepare archive video for delivery",
+        "Scale drone footage faithfully",
+        "Deliver clean natural upscales"
+      ]
+    },
+
+    "topaz/upscale/video/generative": {
+      className: "TopazUpscaleVideoGenerative",
+      docstring:
+        "Topaz Starlight generative video upscaling rebuilds detail absent from the source, with cheaper fast variants.",
+      tags: [
+        "video-to-video",
+        "vid2vid",
+        "video",
+        "topaz",
+        "upscale",
+        "generative",
+        "super-resolution"
+      ],
+      useCases: [
+        "Restore heavily compressed footage",
+        "Rebuild detail in archive video",
+        "Upscale low-quality user clips",
+        "Recover detail lost to re-encoding",
+        "Trade cost for quality with fast variants"
+      ]
+    },
+
+    "topaz/upscale/video/creative": {
+      className: "TopazUpscaleVideoCreative",
+      docstring:
+        "Topaz Astra creative video upscaling reimagines fine detail and typically delivers 4K output.",
+      tags: [
+        "video-to-video",
+        "vid2vid",
+        "video",
+        "topaz",
+        "upscale",
+        "creative",
+        "super-resolution"
+      ],
+      useCases: [
+        "Push a hero shot to maximum impact",
+        "Reimagine detail in cinematic footage",
+        "Finish stylized clips at 4K",
+        "Enhance generated video for delivery",
+        "Add invented texture to flat footage"
+      ]
+    },
+
+    "topaz/denoise/video": {
+      className: "TopazDenoiseVideo",
+      docstring:
+        "Topaz Nyx models remove video noise at source resolution, with a lighter fast pass.",
+      tags: [
+        "video-to-video",
+        "vid2vid",
+        "video",
+        "topaz",
+        "denoise",
+        "noise-reduction",
+        "enhancement"
+      ],
+      useCases: [
+        "Clean low-light footage",
+        "Remove grain from high-ISO clips",
+        "Denoise before upscaling",
+        "Reduce noise in night interviews",
+        "Run a cheaper fast denoise pass"
+      ]
+    },
+
+    "topaz/deblur/video": {
+      className: "TopazDeblurVideo",
+      docstring:
+        "Topaz Themis 2 restores clarity to motion-blurred footage at source resolution.",
+      tags: [
+        "video-to-video",
+        "vid2vid",
+        "video",
+        "topaz",
+        "deblur",
+        "motion-blur",
+        "enhancement"
+      ],
+      useCases: [
+        "Sharpen fast-moving sports footage",
+        "Recover clarity in action clips",
+        "Fix handheld motion blur",
+        "Clean up panning shots",
+        "Prepare blurred footage for upscale"
+      ]
+    },
+
+    "topaz/interpolate/video": {
+      className: "TopazInterpolateVideo",
+      docstring:
+        "Topaz Apollo, Chronos, and Aion retime footage up to 120 fps for smooth motion or slow motion.",
+      tags: [
+        "video-to-video",
+        "vid2vid",
+        "video",
+        "topaz",
+        "interpolate",
+        "frame-rate",
+        "slow-motion"
+      ],
+      useCases: [
+        "Convert 24 fps footage to 60 fps",
+        "Create extreme slow motion",
+        "Smooth stuttering motion",
+        "Retime clips for a timeline",
+        "Generate 120 fps from standard footage"
+      ]
+    },
+
+    "topaz/colorize/video": {
+      className: "TopazColorizeVideo",
+      docstring:
+        "Topaz video colorization brings natural color to black-and-white footage, upscaled to at least 1080p.",
+      tags: [
+        "video-to-video",
+        "vid2vid",
+        "video",
+        "topaz",
+        "colorize",
+        "restoration",
+        "archival"
+      ],
+      useCases: [
+        "Colorize historical footage",
+        "Restore black-and-white home movies",
+        "Prepare archive clips for a documentary",
+        "Add color to vintage advertising",
+        "Modernize monochrome material"
+      ]
+    },
+
+    "topaz/sdr-to-hdr/video": {
+      className: "TopazSdrToHdrVideo",
+      docstring:
+        "Topaz Hyperion 2.5 converts SDR footage to HDR, preserving detail in text, faces, and motion.",
+      tags: [
+        "video-to-video",
+        "vid2vid",
+        "video",
+        "topaz",
+        "hdr",
+        "sdr-to-hdr",
+        "color"
+      ],
+      useCases: [
+        "Give SDR footage an HDR look",
+        "Prepare legacy video for HDR delivery",
+        "Expand dynamic range without clipping",
+        "Grade archive material for HDR displays",
+        "Convert a catalog to HDR"
+      ]
     }
   }
 };

--- a/packages/fal-nodes/src/fal-manifest.json
+++ b/packages/fal-nodes/src/fal-manifest.json
@@ -323827,5 +323827,25437 @@
     ],
     "enums": [],
     "moduleName": "video_to_video"
+  },
+  {
+    "endpointId": "hitem3d/hi3d/texture",
+    "className": "Hi3dTexture",
+    "docstring": "Hi3D textures an existing geometry mesh from a reference image.",
+    "tags": [
+      "3d-to-3d",
+      "3d",
+      "mesh",
+      "texture",
+      "hi3d"
+    ],
+    "useCases": [
+      "Texture an untextured mesh",
+      "Apply a reference look to geometry",
+      "Retexture an imported model",
+      "Produce PBR-ready assets",
+      "Match a mesh to concept art"
+    ],
+    "inputFields": [
+      {
+        "name": "export_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "glb",
+        "description": "File format of the generated model.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ExportFormat",
+        "enumValues": [
+          "glb",
+          "obj",
+          "stl",
+          "fbx",
+          "usdz"
+        ]
+      },
+      {
+        "name": "mesh_url",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL of the geometry model to texture. Only GLB format is supported (e.g. the geometry output of the image-to-3d endpoint with enable_texture=false).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "hitem3dv1.5",
+        "description": "Model version used for texturing. Only v1.5 models support the staged texture task.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "hitem3dv1.5",
+          "scene-portraitv1.5"
+        ]
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, input images are checked for safety before processing.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL of the reference image used to texture the model. PNG, JPEG and WebP formats are supported, up to 20MB.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": null,
+        "description": "Texture generation resolution. hitem3dv1.5 accepts 512, 1024, 1536 and 1536pro; scene-portraitv1.5 accepts 1536. Defaults to the model's recommended resolution.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "512",
+          "1024",
+          "1536",
+          "1536pro"
+        ]
+      }
+    ],
+    "outputType": "model_3d",
+    "outputFields": [
+      {
+        "name": "model_mesh",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generated 3D model file.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "thumbnail",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Preview image of the generated model, when available.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "ExportFormat",
+        "values": [
+          [
+            "GLB",
+            "glb"
+          ],
+          [
+            "OBJ",
+            "obj"
+          ],
+          [
+            "STL",
+            "stl"
+          ],
+          [
+            "FBX",
+            "fbx"
+          ],
+          [
+            "USDZ",
+            "usdz"
+          ]
+        ],
+        "description": "File format of the generated model."
+      },
+      {
+        "name": "Model",
+        "values": [
+          [
+            "HITEM3DV1_5",
+            "hitem3dv1.5"
+          ],
+          [
+            "SCENE_PORTRAITV1_5",
+            "scene-portraitv1.5"
+          ]
+        ],
+        "description": "Model version used for texturing. Only v1.5 models support the staged texture task."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_512",
+            "512"
+          ],
+          [
+            "VALUE_1024",
+            "1024"
+          ],
+          [
+            "VALUE_1536",
+            "1536"
+          ],
+          [
+            "VALUE_1536PRO",
+            "1536pro"
+          ]
+        ],
+        "description": "Texture generation resolution. hitem3dv1.5 accepts 512, 1024, 1536 and 1536pro; scene-portraitv1.5 accepts 1536. Defaults to the model's recommended resolution."
+      }
+    ],
+    "moduleName": "3d_to_3d"
+  },
+  {
+    "endpointId": "hitem3d/hi3d/split",
+    "className": "Hi3dSplit",
+    "docstring": "Hi3D splits a 3D model into separate parts.",
+    "tags": [
+      "3d-to-3d",
+      "3d",
+      "mesh",
+      "segmentation",
+      "hi3d"
+    ],
+    "useCases": [
+      "Split a model for separate printing",
+      "Break a mesh into editable parts",
+      "Prepare components for rigging",
+      "Isolate parts for texturing",
+      "Decompose an asset for reuse"
+    ],
+    "inputFields": [
+      {
+        "name": "mesh_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL of the input model to split. GLB, STL and OBJ formats are supported, up to 200MB.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "joint",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "ball",
+        "description": "Joint type added between character parts (used when model is 'character').",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Joint",
+        "enumValues": [
+          "none",
+          "ball",
+          "dovetail"
+        ]
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "character",
+        "description": "Split model type: 'character' splits humanoid models using a template with optional joints; 'general' splits any model by granularity level.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "character",
+          "general"
+        ]
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, inputs are checked for safety before processing.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "export_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "glb",
+        "description": "File format of the generated model. Character split currently supports only 'glb'.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ExportFormat",
+        "enumValues": [
+          "glb",
+          "obj",
+          "stl",
+          "fbx",
+          "usdz"
+        ]
+      },
+      {
+        "name": "level",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Split granularity (used when model is 'general').",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Level",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "part",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "a",
+        "description": "Character split template (used when model is 'character'): 'a' 6 parts, 'b' 5 parts, 'c' 4 parts excluding head, 'd' 4 parts including head, 'e' 3 parts, 'f' 2 parts.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Part",
+        "enumValues": [
+          "a",
+          "b",
+          "c",
+          "d",
+          "e",
+          "f"
+        ]
+      }
+    ],
+    "outputType": "model_3d",
+    "outputFields": [
+      {
+        "name": "model_mesh",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generated 3D model file.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "thumbnail",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Preview image of the generated model, when available.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "Joint",
+        "values": [
+          [
+            "NONE",
+            "none"
+          ],
+          [
+            "BALL",
+            "ball"
+          ],
+          [
+            "DOVETAIL",
+            "dovetail"
+          ]
+        ],
+        "description": "Joint type added between character parts (used when model is 'character')."
+      },
+      {
+        "name": "Model",
+        "values": [
+          [
+            "CHARACTER",
+            "character"
+          ],
+          [
+            "GENERAL",
+            "general"
+          ]
+        ],
+        "description": "Split model type: 'character' splits humanoid models using a template with optional joints; 'general' splits any model by granularity level."
+      },
+      {
+        "name": "ExportFormat",
+        "values": [
+          [
+            "GLB",
+            "glb"
+          ],
+          [
+            "OBJ",
+            "obj"
+          ],
+          [
+            "STL",
+            "stl"
+          ],
+          [
+            "FBX",
+            "fbx"
+          ],
+          [
+            "USDZ",
+            "usdz"
+          ]
+        ],
+        "description": "File format of the generated model. Character split currently supports only 'glb'."
+      },
+      {
+        "name": "Level",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Split granularity (used when model is 'general')."
+      },
+      {
+        "name": "Part",
+        "values": [
+          [
+            "A",
+            "a"
+          ],
+          [
+            "B",
+            "b"
+          ],
+          [
+            "C",
+            "c"
+          ],
+          [
+            "D",
+            "d"
+          ],
+          [
+            "E",
+            "e"
+          ],
+          [
+            "F",
+            "f"
+          ]
+        ],
+        "description": "Character split template (used when model is 'character'): 'a' 6 parts, 'b' 5 parts, 'c' 4 parts excluding head, 'd' 4 parts including head, 'e' 3 parts, 'f' 2 parts."
+      }
+    ],
+    "moduleName": "3d_to_3d"
+  },
+  {
+    "endpointId": "hitem3d/hi3d/multicolor",
+    "className": "Hi3dMulticolor",
+    "docstring": "Hi3D converts a textured 3D model into a multicolor model suited to multicolor 3D printing.",
+    "tags": [
+      "3d-to-3d",
+      "3d",
+      "mesh",
+      "3d-printing",
+      "color",
+      "hi3d"
+    ],
+    "useCases": [
+      "Prepare a model for multicolor printing",
+      "Convert textures into printable color",
+      "Produce color-separated geometry",
+      "Ready an asset for a color printer",
+      "Turn a textured mesh into print parts"
+    ],
+    "inputFields": [
+      {
+        "name": "export_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "glb",
+        "description": "File format of the generated model. STL, USDZ and 3MF are not currently supported by the partner.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ExportFormat",
+        "enumValues": [
+          "glb",
+          "obj",
+          "fbx"
+        ]
+      },
+      {
+        "name": "mesh_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL of the input textured model. Only GLB format is supported, up to 200MB.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, inputs are checked for safety before processing.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "number_of_colors",
+        "tsType": "number",
+        "propType": "int",
+        "default": 4,
+        "description": "Number of colors in the generated model (1-8), or 0 for the maximum. Use 0 if you plan to edit the colors later.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 8
+      }
+    ],
+    "outputType": "model_3d",
+    "outputFields": [
+      {
+        "name": "model_mesh",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generated 3D model file.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "thumbnail",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Preview image of the generated model, when available.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "ExportFormat",
+        "values": [
+          [
+            "GLB",
+            "glb"
+          ],
+          [
+            "OBJ",
+            "obj"
+          ],
+          [
+            "FBX",
+            "fbx"
+          ]
+        ],
+        "description": "File format of the generated model. STL, USDZ and 3MF are not currently supported by the partner."
+      }
+    ],
+    "moduleName": "3d_to_3d"
+  },
+  {
+    "endpointId": "tripo3d/tripo/remesh",
+    "className": "Tripo3dRemesh",
+    "docstring": "Tripo3D converts triangle meshes into clean quad topology at a target polygon count.",
+    "tags": [
+      "3d-to-3d",
+      "3d",
+      "mesh",
+      "retopology",
+      "quad",
+      "tripo"
+    ],
+    "useCases": [
+      "Retopologize a scanned mesh",
+      "Prepare geometry for animation",
+      "Hit a polygon budget for a game",
+      "Clean up generated 3D output",
+      "Convert triangles to quads"
+    ],
+    "inputFields": [
+      {
+        "name": "quad",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Generate quad (4-sided) mesh topology instead of triangles. Forces FBX output. When enabled and 'face_limit' is unset, 'face_limit' defaults to 10000.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "mesh_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL of the input 3D model to remesh. Supported formats: GLB, OBJ, FBX, STL (max 150MB).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "bake",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Bake textures onto the remeshed model during generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "part_names",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Optional list of part names (as returned by a prior mesh segmentation) to preserve as separate parts while remeshing.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "face_limit",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Target face count of the remeshed model. Range 500-20000 (500-10000 when 'quad' is true). If unset, the model determines the count adaptively.",
+        "fieldType": "input",
+        "required": false,
+        "min": 500,
+        "max": 20000
+      }
+    ],
+    "outputType": "model_3d",
+    "outputFields": [
+      {
+        "name": "model_urls",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URLs for different 3D model variants.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "model_mesh",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generated 3D model file. May be GLB or FBX depending on Tripo output.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "rendered_image",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Preview render of the generated 3D model.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [],
+    "moduleName": "3d_to_3d"
+  },
+  {
+    "endpointId": "tripo3d/tripo/segment",
+    "className": "Tripo3dSegment",
+    "docstring": "Tripo3D splits a 3D model into semantic parts for editing, texturing, and rigging.",
+    "tags": [
+      "3d-to-3d",
+      "3d",
+      "mesh",
+      "segmentation",
+      "tripo"
+    ],
+    "useCases": [
+      "Separate a model into named parts",
+      "Prepare a mesh for rigging",
+      "Texture parts independently",
+      "Edit one component of an asset",
+      "Extract parts for reuse"
+    ],
+    "inputFields": [
+      {
+        "name": "mesh_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL of the input 3D model to segment. Supported formats: GLB, OBJ, FBX, STL (max 150MB).",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputType": "model_3d",
+    "outputFields": [
+      {
+        "name": "model_urls",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URLs for different 3D model variants of the segmented model.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "model_mesh",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Segmented 3D model file. May be GLB or FBX depending on Tripo output.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "part_names",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "Names of the segmented parts, when reported by Tripo. Pass these to the remesh endpoint's 'part_names' to preserve parts.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "rendered_image",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Preview render of the segmented 3D model.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [],
+    "moduleName": "3d_to_3d"
+  },
+  {
+    "endpointId": "lightricks/ltx-2.5/audio-to-video/fast",
+    "className": "Ltx25AudioToVideoFast",
+    "docstring": "LTX 2.5 generates video timed to a supplied audio clip in a speed-optimized pass.",
+    "tags": [
+      "generation",
+      "audio-to-video",
+      "video",
+      "ltx",
+      "ltx-2-5",
+      "lipsync",
+      "fast"
+    ],
+    "useCases": [
+      "Preview visuals against a music track",
+      "Draft a dialogue-led short",
+      "Time a clip to an existing voiceover",
+      "Iterate on a music video concept",
+      "Test sync before a final render"
+    ],
+    "inputFields": [
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of how the video should be generated. Required if image_url is not provided. When image_url is provided, this describes how the image should be animated.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 5000
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL of an image to use as the first frame of the video. If not provided, prompt is required.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "The aspect ratio of the generated video. If 'auto', the aspect ratio will be determined automatically based on the input image, or defaults to 16:9 if no image is provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "auto",
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "guidance_scale",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Guidance scale for video generation. Higher values make the output more closely follow the prompt. Defaults to 5 for text-to-video, or 9 when providing an image.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "URL of the audio file to generate a video from. Duration must be between 2 and 20 seconds; pro models support a maximum of 10 seconds. Must be publicly accessible or base64 data URI.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "audio_url"
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video file",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio of the generated video. If 'auto', the aspect ratio will be determined automatically based on the input image, or defaults to 16:9 if no image is provided."
+      }
+    ],
+    "moduleName": "audio_to_video"
+  },
+  {
+    "endpointId": "lightricks/ltx-2.5/audio-to-video/pro",
+    "className": "Ltx25AudioToVideoPro",
+    "docstring": "LTX 2.5 generates video timed to a supplied audio clip in a quality-optimized pass.",
+    "tags": [
+      "generation",
+      "audio-to-video",
+      "video",
+      "ltx",
+      "ltx-2-5",
+      "lipsync",
+      "quality"
+    ],
+    "useCases": [
+      "Render final visuals for a track",
+      "Produce a music-driven video",
+      "Sync footage to recorded dialogue",
+      "Deliver an ad keyed to a soundtrack",
+      "Finish an approved audio-timed draft"
+    ],
+    "inputFields": [
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of how the video should be generated. Required if image_url is not provided. When image_url is provided, this describes how the image should be animated.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 5000
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL of an image to use as the first frame of the video. If not provided, prompt is required.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "The aspect ratio of the generated video. If 'auto', the aspect ratio will be determined automatically based on the input image, or defaults to 16:9 if no image is provided.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "auto",
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "guidance_scale",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Guidance scale for video generation. Higher values make the output more closely follow the prompt. Defaults to 5 for text-to-video, or 9 when providing an image.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "URL of the audio file to generate a video from. Duration must be between 2 and 20 seconds; pro models support a maximum of 10 seconds. Must be publicly accessible or base64 data URI.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "audio_url"
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video file",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio of the generated video. If 'auto', the aspect ratio will be determined automatically based on the input image, or defaults to 16:9 if no image is provided."
+      }
+    ],
+    "moduleName": "audio_to_video"
+  },
+  {
+    "endpointId": "bria/fibo-edit-1.5/edit",
+    "className": "BriaFiboEdit15",
+    "docstring": "Fibo Edit 1.5 edits an image from a natural-language instruction plus up to four reference images.",
+    "tags": [
+      "image-to-image",
+      "img2img",
+      "image",
+      "bria",
+      "fibo",
+      "editing",
+      "reference",
+      "licensed"
+    ],
+    "useCases": [
+      "Combine a subject with reference objects",
+      "Replace a background from a reference",
+      "Run virtual try-on with a garment image",
+      "Transfer a style from reference images",
+      "Composite characters into a scene"
+    ],
+    "inputFields": [
+      {
+        "name": "mask",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Mask (file or URL) marking the region to regenerate: white where the model should edit, black elsewhere. Single-reference requests only, and it must be the same size as that image. A masked edit comes back at the reference's own resolution.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "mask_url"
+      },
+      {
+        "name": "sync_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, returns the image directly in the response (increases latency).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": null,
+        "description": "Output aspect ratio. Left unset, the output keeps the ratio of the first reference image. A chosen ratio applies only with two or more reference images; with a single reference the output keeps that image's ratio either way.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "2:3",
+          "3:2",
+          "3:4",
+          "4:3",
+          "4:5",
+          "5:4",
+          "9:16",
+          "16:9"
+        ]
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": null,
+        "description": "1-4 reference images (files or URLs). Order is significant: the instruction is resolved against the images in the order they are sent.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "image_urls"
+      },
+      {
+        "name": "instruction",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Instruction for image editing.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "structured_instruction",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A pre-built structured prompt, used verbatim instead of having VGL build one when no instruction is sent. Accepts what a previous edit returned.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5555,
+        "description": "Random seed for reproducibility.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Generated image.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "structured_instruction",
+        "tsType": "object",
+        "propType": "dict[str, any]",
+        "default": "",
+        "description": "Current instruction.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "images",
+        "tsType": "Image[]",
+        "propType": "list[Image]",
+        "default": [],
+        "description": "Generated images.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ]
+        ],
+        "description": "Output aspect ratio. Left unset, the output keeps the ratio of the first reference image. A chosen ratio applies only with two or more reference images; with a single reference the output keeps that image's ratio either way."
+      }
+    ],
+    "moduleName": "image_to_image"
+  },
+  {
+    "endpointId": "bytedance/seedream/v5/pro/layerize",
+    "className": "BytedanceSeedreamV5ProLayerize",
+    "docstring": "Seedream 5.0 Pro Layerize splits an image into 2 to 17 independent transparent-PNG layers described in text.",
+    "tags": [
+      "image-to-image",
+      "img2img",
+      "image",
+      "seedream",
+      "bytedance",
+      "layers",
+      "editing",
+      "utility"
+    ],
+    "useCases": [
+      "Split a composite into editable layers",
+      "Extract a subject onto transparency",
+      "Recover a background plate",
+      "Prepare assets for a design tool",
+      "Enable non-destructive image reuse"
+    ],
+    "inputFields": [
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Resolution tier for the output base image and layers. `auto` adapts to the input image while preserving each element's aspect ratio.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "auto",
+          "auto_1K",
+          "auto_1.5K",
+          "auto_2K"
+        ]
+      },
+      {
+        "name": "sync_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If `True`, the media will be returned as a data URI and the output data won't be available in the request history.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Optional instructions describing which elements to separate. When empty, the model automatically separates the major elements. Normalized `<bbox>left top right bottom</bbox>` tags may be used for precise coordinate targeting.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "enhance_prompt_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "standard",
+        "description": "Prompt optimization mode. `standard` prioritizes image quality; `fast` reduces generation time.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "EnhancePromptMode",
+        "enumValues": [
+          "standard",
+          "fast"
+        ]
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL of the image to decompose into a base image and independently editable layers. The image must contain between 512x512 and 6000x6000 total pixels, have an aspect ratio between 1/16 and 16, and be no larger than 30 MB.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, the safety checker will be enabled. Disabling it requires account authorization; unauthorized requests are always checked.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "layers",
+        "tsType": "SeedDream50ProLayer[]",
+        "propType": "list[SeedDream50ProLayer]",
+        "default": [],
+        "description": "The base image followed by up to 16 separated layers, ordered by increasing z_index.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "images",
+        "tsType": "Image[]",
+        "propType": "list[Image]",
+        "default": [],
+        "description": "The same images as `layers`, in the same order, flattened for gallery rendering.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "AUTO_1K",
+            "auto_1K"
+          ],
+          [
+            "AUTO_1_5K",
+            "auto_1.5K"
+          ],
+          [
+            "AUTO_2K",
+            "auto_2K"
+          ]
+        ],
+        "description": "Resolution tier for the output base image and layers. `auto` adapts to the input image while preserving each element's aspect ratio."
+      },
+      {
+        "name": "EnhancePromptMode",
+        "values": [
+          [
+            "STANDARD",
+            "standard"
+          ],
+          [
+            "FAST",
+            "fast"
+          ]
+        ],
+        "description": "Prompt optimization mode. `standard` prioritizes image quality; `fast` reduces generation time."
+      }
+    ],
+    "moduleName": "image_to_image"
+  },
+  {
+    "endpointId": "google/virtual-try-on",
+    "className": "GoogleVirtualTryOn",
+    "docstring": "Google Virtual Try On renders a person image wearing a supplied clothing product image.",
+    "tags": [
+      "image-to-image",
+      "img2img",
+      "image",
+      "virtual-try-on",
+      "fashion",
+      "ecommerce",
+      "google"
+    ],
+    "useCases": [
+      "Show a garment on a model without a shoot",
+      "Build try-on previews for a storefront",
+      "Generate catalog imagery per size run",
+      "Swap outfits on an existing photo",
+      "Preview styling combinations"
+    ],
+    "inputFields": [
+      {
+        "name": "product_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The URL of the product image to try on.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "product_image_url"
+      },
+      {
+        "name": "person_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The URL of the image of the person trying on the product.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "person_image_url"
+      },
+      {
+        "name": "num_images",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "The number of virtual try-on images to generate.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "images",
+        "tsType": "ImageFile[]",
+        "propType": "list[ImageFile]",
+        "default": [],
+        "description": "The generated virtual try-on images.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [],
+    "moduleName": "image_to_image"
+  },
+  {
+    "endpointId": "xai/grok-imagine-image/v2.0/edit",
+    "className": "GrokImagineImageV20Edit",
+    "docstring": "Grok Imagine 2.0 edits an existing image from a text instruction.",
+    "tags": [
+      "image-to-image",
+      "img2img",
+      "image",
+      "editing",
+      "xai",
+      "grok",
+      "grok-imagine"
+    ],
+    "useCases": [
+      "Apply a described edit to a photo",
+      "Change an object in an existing image",
+      "Restyle artwork with an instruction",
+      "Fix details without a redraw",
+      "Iterate on an approved composition"
+    ],
+    "inputFields": [
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1k",
+        "description": "Resolution of the generated image. `1k` for standard resolution, `2k` for high resolution.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "1k",
+          "2k"
+        ]
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "List of URLs of the images to edit. A maximum of 3 images are supported.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "image_urls"
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of the desired image.",
+        "fieldType": "input",
+        "required": true,
+        "max": 8000
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Aspect ratio of the edited image. When set to `auto` (the default), the output preserves the aspect ratio of the first input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "auto",
+          "2:1",
+          "20:9",
+          "19.5:9",
+          "16:9",
+          "4:3",
+          "3:2",
+          "1:1",
+          "2:3",
+          "3:4",
+          "9:16",
+          "9:19.5",
+          "9:20",
+          "1:2"
+        ]
+      },
+      {
+        "name": "sync_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If `True`, the media will be returned as a data URI and the output data won't be available in the request history.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "quality",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Quality level of the edited image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Quality",
+        "enumValues": [
+          "low",
+          "medium"
+        ]
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpeg",
+        "description": "The format of the generated image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpeg",
+          "png",
+          "webp"
+        ]
+      },
+      {
+        "name": "num_images",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Number of images to generate.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "images",
+        "tsType": "ImageFile[]",
+        "propType": "list[ImageFile]",
+        "default": [],
+        "description": "The URL of the edited image.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "revised_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The enhanced prompt that was used to generate the image.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_1K",
+            "1k"
+          ],
+          [
+            "VALUE_2K",
+            "2k"
+          ]
+        ],
+        "description": "Resolution of the generated image. `1k` for standard resolution, `2k` for high resolution."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_20_9",
+            "20:9"
+          ],
+          [
+            "VALUE_19_5_9",
+            "19.5:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "VALUE_9_19_5",
+            "9:19.5"
+          ],
+          [
+            "RATIO_9_20",
+            "9:20"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ]
+        ],
+        "description": "Aspect ratio of the edited image. When set to `auto` (the default), the output preserves the aspect ratio of the first input image."
+      },
+      {
+        "name": "Quality",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ]
+        ],
+        "description": "Quality level of the edited image."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPEG",
+            "jpeg"
+          ],
+          [
+            "PNG",
+            "png"
+          ],
+          [
+            "WEBP",
+            "webp"
+          ]
+        ],
+        "description": "The format of the generated image."
+      }
+    ],
+    "moduleName": "image_to_image"
+  },
+  {
+    "endpointId": "topaz/adjust/image",
+    "className": "TopazAdjustImage",
+    "docstring": "Topaz Adjust corrects exposure, white balance, and color, and can colorize black-and-white photos.",
+    "tags": [
+      "image-to-image",
+      "img2img",
+      "image",
+      "topaz",
+      "color-correction",
+      "exposure",
+      "enhancement"
+    ],
+    "useCases": [
+      "Fix exposure on an underlit photo",
+      "Remove a color cast",
+      "Colorize a black-and-white image",
+      "Batch-correct a photo set",
+      "Normalize color before publishing"
+    ],
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Url of the image to process",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Adjust V2",
+        "description": "Color & lighting correction. Adjust V2 fixes exposure/lighting; White Balance corrects color; Colorize adds color to B&W images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "Adjust V2",
+          "White Balance",
+          "Colorize"
+        ]
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpeg",
+        "description": "Output format of the processed image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpeg",
+          "png"
+        ]
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The upscaled image.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Model",
+        "values": [
+          [
+            "ADJUST_V2",
+            "Adjust V2"
+          ],
+          [
+            "WHITE_BALANCE",
+            "White Balance"
+          ],
+          [
+            "COLORIZE",
+            "Colorize"
+          ]
+        ],
+        "description": "Color & lighting correction. Adjust V2 fixes exposure/lighting; White Balance corrects color; Colorize adds color to B&W images."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPEG",
+            "jpeg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format of the processed image."
+      }
+    ],
+    "moduleName": "image_to_image"
+  },
+  {
+    "endpointId": "topaz/sharpen/image",
+    "className": "TopazSharpenImage",
+    "docstring": "Topaz Sharpen removes lens, motion, portrait, and wildlife blur, with a generative mode for severe blur.",
+    "tags": [
+      "image-to-image",
+      "img2img",
+      "image",
+      "topaz",
+      "sharpen",
+      "deblur",
+      "enhancement"
+    ],
+    "useCases": [
+      "Rescue an out-of-focus shot",
+      "Remove motion blur from action photos",
+      "Sharpen portraits without halos",
+      "Recover severely blurred images",
+      "Prepare soft images for print"
+    ],
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Url of the image to process",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Standard",
+        "description": "Sharpen model tuned per blur type (defocus, motion, portrait, wildlife, …). Super Focus is Topaz's generative deblur for severely blurred images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "Standard",
+          "Strong",
+          "Lens Blur V2",
+          "Motion Blur",
+          "Natural",
+          "Refocus",
+          "Wildlife",
+          "Portrait",
+          "Auto Sharpen",
+          "Super Focus V3",
+          "Super Focus V2"
+        ]
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpeg",
+        "description": "Output format of the processed image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpeg",
+          "png"
+        ]
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The upscaled image.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Model",
+        "values": [
+          [
+            "STANDARD",
+            "Standard"
+          ],
+          [
+            "STRONG",
+            "Strong"
+          ],
+          [
+            "LENS_BLUR_V2",
+            "Lens Blur V2"
+          ],
+          [
+            "MOTION_BLUR",
+            "Motion Blur"
+          ],
+          [
+            "NATURAL",
+            "Natural"
+          ],
+          [
+            "REFOCUS",
+            "Refocus"
+          ],
+          [
+            "WILDLIFE",
+            "Wildlife"
+          ],
+          [
+            "PORTRAIT",
+            "Portrait"
+          ],
+          [
+            "AUTO_SHARPEN",
+            "Auto Sharpen"
+          ],
+          [
+            "SUPER_FOCUS_V3",
+            "Super Focus V3"
+          ],
+          [
+            "SUPER_FOCUS_V2",
+            "Super Focus V2"
+          ]
+        ],
+        "description": "Sharpen model tuned per blur type (defocus, motion, portrait, wildlife, …). Super Focus is Topaz's generative deblur for severely blurred images."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPEG",
+            "jpeg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format of the processed image."
+      }
+    ],
+    "moduleName": "image_to_image"
+  },
+  {
+    "endpointId": "topaz/denoise/image",
+    "className": "TopazDenoiseImage",
+    "docstring": "Topaz Denoise cleans image noise at source resolution, with a generative mode that recovers detail.",
+    "tags": [
+      "image-to-image",
+      "img2img",
+      "image",
+      "topaz",
+      "denoise",
+      "noise-reduction",
+      "enhancement"
+    ],
+    "useCases": [
+      "Clean high-ISO night photography",
+      "Remove sensor noise from raw exports",
+      "Recover detail lost to noise",
+      "Batch-denoise an event shoot",
+      "Prepare noisy images for upscaling"
+    ],
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Url of the image to process",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Normal",
+        "description": "Denoise model. Normal is general-purpose; Strong and Extreme remove progressively more noise; Denoise Max is Topaz's highest-quality generative denoiser.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "Normal",
+          "Strong",
+          "Extreme",
+          "Denoise Max"
+        ]
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpeg",
+        "description": "Output format of the processed image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpeg",
+          "png"
+        ]
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The upscaled image.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Model",
+        "values": [
+          [
+            "NORMAL",
+            "Normal"
+          ],
+          [
+            "STRONG",
+            "Strong"
+          ],
+          [
+            "EXTREME",
+            "Extreme"
+          ],
+          [
+            "DENOISE_MAX",
+            "Denoise Max"
+          ]
+        ],
+        "description": "Denoise model. Normal is general-purpose; Strong and Extreme remove progressively more noise; Denoise Max is Topaz's highest-quality generative denoiser."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPEG",
+            "jpeg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format of the processed image."
+      }
+    ],
+    "moduleName": "image_to_image"
+  },
+  {
+    "endpointId": "topaz/restore/image",
+    "className": "TopazRestoreImage",
+    "docstring": "Topaz Restore rebuilds detail in degraded photos and removes film dust and scratches.",
+    "tags": [
+      "image-to-image",
+      "img2img",
+      "image",
+      "topaz",
+      "restoration",
+      "film",
+      "enhancement"
+    ],
+    "useCases": [
+      "Restore an old family photograph",
+      "Clean dust and scratches from scans",
+      "Rebuild detail in a degraded image",
+      "Digitize a print archive",
+      "Prepare heritage images for print"
+    ],
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Url of the image to process",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Recover 3",
+        "description": "Restoration. Recover 3 rebuilds natural detail; Dust-Scratch V2 cleans up film dust and scratches.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "Recover 3",
+          "Dust-Scratch V2"
+        ]
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpeg",
+        "description": "Output format of the processed image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpeg",
+          "png"
+        ]
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The upscaled image.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Model",
+        "values": [
+          [
+            "RECOVER_3",
+            "Recover 3"
+          ],
+          [
+            "DUST_SCRATCH_V2",
+            "Dust-Scratch V2"
+          ]
+        ],
+        "description": "Restoration. Recover 3 rebuilds natural detail; Dust-Scratch V2 cleans up film dust and scratches."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPEG",
+            "jpeg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format of the processed image."
+      }
+    ],
+    "moduleName": "image_to_image"
+  },
+  {
+    "endpointId": "topaz/upscale/image/precision",
+    "className": "TopazUpscaleImagePrecision",
+    "docstring": "Topaz Gigapixel precision models enlarge images up to 4x while staying faithful to the source.",
+    "tags": [
+      "image-to-image",
+      "img2img",
+      "image",
+      "topaz",
+      "upscale",
+      "gigapixel",
+      "super-resolution"
+    ],
+    "useCases": [
+      "Enlarge a photo for large-format print",
+      "Upscale without inventing detail",
+      "Prepare CGI renders at higher resolution",
+      "Refine text inside an enlarged image",
+      "Scale catalog photography"
+    ],
+    "inputFields": [
+      {
+        "name": "denoise",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Denoising level (0.0-1.0). Default varies by model.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Standard V2",
+        "description": "Precision upscaling model. Standard V2 fits most photos; High Fidelity V3/V2 preserve detail in professional shots; Low Resolution V2 recovers compressed sources; CGI targets art and rendered graphics; Text Refine keeps text and shapes crisp.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "Standard V2",
+          "High Fidelity V3",
+          "High Fidelity V2",
+          "Low Resolution V2",
+          "CGI",
+          "Text Refine"
+        ]
+      },
+      {
+        "name": "strength",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Enhancement strength (0.01-1.0). Applies to Text Refine model only.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.01,
+        "max": 1
+      },
+      {
+        "name": "face_enhancement_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.8,
+        "description": "Strength of the face enhancement. 0.0 means no enhancement, 1.0 means maximum enhancement. Ignored if face enhancement is disabled.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "subject_detection",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "All",
+        "description": "Subject detection mode for the image enhancement.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "SubjectDetection",
+        "enumValues": [
+          "All",
+          "Foreground",
+          "Background"
+        ]
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpeg",
+        "description": "Output format of the upscaled image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpeg",
+          "png"
+        ]
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Url of the image to be upscaled",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "face_enhancement",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to apply face enhancement to the image.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "sharpen",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Sharpening level (0.0-1.0). Default varies by model.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "fix_compression",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Compression artifact removal level (0.0-1.0). Not supported by the CGI model.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "crop_to_fill",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "face_enhancement_creativity",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Creativity level for face enhancement. 0.0 means no creativity, 1.0 means maximum creativity. Ignored if face enhancement is disabled.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "upscale_factor",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2,
+        "description": "Factor to upscale the image by (e.g. 2.0 doubles width and height)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The upscaled image.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Model",
+        "values": [
+          [
+            "STANDARD_V2",
+            "Standard V2"
+          ],
+          [
+            "HIGH_FIDELITY_V3",
+            "High Fidelity V3"
+          ],
+          [
+            "HIGH_FIDELITY_V2",
+            "High Fidelity V2"
+          ],
+          [
+            "LOW_RESOLUTION_V2",
+            "Low Resolution V2"
+          ],
+          [
+            "CGI",
+            "CGI"
+          ],
+          [
+            "TEXT_REFINE",
+            "Text Refine"
+          ]
+        ],
+        "description": "Precision upscaling model. Standard V2 fits most photos; High Fidelity V3/V2 preserve detail in professional shots; Low Resolution V2 recovers compressed sources; CGI targets art and rendered graphics; Text Refine keeps text and shapes crisp."
+      },
+      {
+        "name": "SubjectDetection",
+        "values": [
+          [
+            "ALL",
+            "All"
+          ],
+          [
+            "FOREGROUND",
+            "Foreground"
+          ],
+          [
+            "BACKGROUND",
+            "Background"
+          ]
+        ],
+        "description": "Subject detection mode for the image enhancement."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPEG",
+            "jpeg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format of the upscaled image."
+      }
+    ],
+    "moduleName": "image_to_image"
+  },
+  {
+    "endpointId": "topaz/upscale/image/generative",
+    "className": "TopazUpscaleImageGenerative",
+    "docstring": "Topaz generative upscaling rebuilds sharp detail in small or blurry images, with prompt-guided and extreme-recovery modes.",
+    "tags": [
+      "image-to-image",
+      "img2img",
+      "image",
+      "topaz",
+      "upscale",
+      "generative",
+      "super-resolution"
+    ],
+    "useCases": [
+      "Rebuild detail in a low-resolution source",
+      "Guide an upscale with a prompt",
+      "Recover an extremely small image",
+      "Enlarge web-sized assets for print",
+      "Restore thumbnails to usable size"
+    ],
+    "inputFields": [
+      {
+        "name": "creativity",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Creativity level for generative upscaling (1-6). Higher values produce more creative/hallucinated details. Applies to Redefine model only.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 6
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Wonder 3",
+        "description": "Generative upscaling model. Wonder 3.5 is the latest Wonder with finer detail and fewer repetitive patterns; Wonder 3 is Topaz's most advanced generative realism model (Wonder 2/Wonder are earlier generations); Recover 3 rebuilds natural detail; Standard MAX is high-quality precision-leaning upscaling; Redefine adds prompt-guided creative detail; Recovery and Recovery V2 rebuild extreme low-resolution images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "Wonder 3.5",
+          "Wonder 3",
+          "Wonder 2",
+          "Wonder",
+          "Recover 3",
+          "Standard MAX",
+          "Redefine",
+          "Recovery V2",
+          "Recovery"
+        ]
+      },
+      {
+        "name": "texture",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Texture detail level for generative upscaling (1-5). Applies to Redefine model only.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 5
+      },
+      {
+        "name": "subject_detection",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "All",
+        "description": "Subject detection mode for the image enhancement. Applies to Wonder 3, Recovery and Recovery V2 models.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "SubjectDetection",
+        "enumValues": [
+          "All",
+          "Foreground",
+          "Background"
+        ]
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpeg",
+        "description": "Output format of the upscaled image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpeg",
+          "png"
+        ]
+      },
+      {
+        "name": "sharpen",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Sharpening level (0.0-1.0). Applies to Redefine model only.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "crop_to_fill",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "face_enhancement_creativity",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Creativity level for face enhancement. 0.0 means no creativity, 1.0 means maximum creativity. Ignored if face enhancement is disabled.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "autoprompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Enable automatic prompt generation for generative upscaling. Applies to Redefine model only.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "denoise",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Denoising level (0.0-1.0). Applies to Redefine model only.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt to guide generative upscaling (max 1024 chars). Applies to Redefine model only.",
+        "fieldType": "input",
+        "required": false,
+        "max": 1024
+      },
+      {
+        "name": "face_enhancement_strength",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.8,
+        "description": "Strength of the face enhancement. 0.0 means no enhancement, 1.0 means maximum enhancement. Ignored if face enhancement is disabled.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "detail",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Detail recovery level (0.0-1.0). Applies to Recovery V2 model only.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "enhancement_strength",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": null,
+        "description": "Enhancement strength for generative upscaling. Applies to Wonder 3 and Wonder 3.5 models. When omitted, Topaz auto-configures it.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "EnhancementStrength",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Url of the image to be upscaled",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "face_enhancement",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to apply face enhancement to the image.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "upscale_factor",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2,
+        "description": "Factor to upscale the image by (e.g. 2.0 doubles width and height)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The upscaled image.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Model",
+        "values": [
+          [
+            "WONDER_3_5",
+            "Wonder 3.5"
+          ],
+          [
+            "WONDER_3",
+            "Wonder 3"
+          ],
+          [
+            "WONDER_2",
+            "Wonder 2"
+          ],
+          [
+            "WONDER",
+            "Wonder"
+          ],
+          [
+            "RECOVER_3",
+            "Recover 3"
+          ],
+          [
+            "STANDARD_MAX",
+            "Standard MAX"
+          ],
+          [
+            "REDEFINE",
+            "Redefine"
+          ],
+          [
+            "RECOVERY_V2",
+            "Recovery V2"
+          ],
+          [
+            "RECOVERY",
+            "Recovery"
+          ]
+        ],
+        "description": "Generative upscaling model. Wonder 3.5 is the latest Wonder with finer detail and fewer repetitive patterns; Wonder 3 is Topaz's most advanced generative realism model (Wonder 2/Wonder are earlier generations); Recover 3 rebuilds natural detail; Standard MAX is high-quality precision-leaning upscaling; Redefine adds prompt-guided creative detail; Recovery and Recovery V2 rebuild extreme low-resolution images."
+      },
+      {
+        "name": "SubjectDetection",
+        "values": [
+          [
+            "ALL",
+            "All"
+          ],
+          [
+            "FOREGROUND",
+            "Foreground"
+          ],
+          [
+            "BACKGROUND",
+            "Background"
+          ]
+        ],
+        "description": "Subject detection mode for the image enhancement. Applies to Wonder 3, Recovery and Recovery V2 models."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPEG",
+            "jpeg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format of the upscaled image."
+      },
+      {
+        "name": "EnhancementStrength",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Enhancement strength for generative upscaling. Applies to Wonder 3 and Wonder 3.5 models. When omitted, Topaz auto-configures it."
+      }
+    ],
+    "moduleName": "image_to_image"
+  },
+  {
+    "endpointId": "topaz/upscale/image/creative",
+    "className": "TopazUpscaleImageCreative",
+    "docstring": "Topaz creative upscaling reinvents detail with adjustable creativity and color preservation.",
+    "tags": [
+      "image-to-image",
+      "img2img",
+      "image",
+      "topaz",
+      "upscale",
+      "creative",
+      "super-resolution"
+    ],
+    "useCases": [
+      "Enhance AI-generated images at scale",
+      "Add invented detail to flat renders",
+      "Push a stylized image to high resolution",
+      "Trade fidelity for visual impact",
+      "Finish concept art for presentation"
+    ],
+    "inputFields": [
+      {
+        "name": "autoprompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Enable automatic prompt generation. Applies to Bloom 2 only; Topaz defaults it to true when omitted.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Bloom 2",
+        "description": "Creative (Bloom) upscaling model. Bloom 2 is the latest and most capable; Bloom creatively upscales and transforms AI-generated images; Bloom Realism biases the added detail toward photorealism.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "Bloom 2",
+          "Bloom",
+          "Bloom Realism"
+        ]
+      },
+      {
+        "name": "creativity",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Creativity level (1-9). Higher values produce more creative/hallucinated details. Applies to Bloom 2 only.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 9
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpeg",
+        "description": "Output format of the upscaled image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpeg",
+          "png"
+        ]
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Url of the image to be upscaled",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "crop_to_fill",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "color_preservation",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Preserve the source image's colors in the output. Applies to Bloom 2 only.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "upscale_factor",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2,
+        "description": "Factor to upscale the image by (e.g. 2.0 doubles width and height)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The upscaled image.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Model",
+        "values": [
+          [
+            "BLOOM_2",
+            "Bloom 2"
+          ],
+          [
+            "BLOOM",
+            "Bloom"
+          ],
+          [
+            "BLOOM_REALISM",
+            "Bloom Realism"
+          ]
+        ],
+        "description": "Creative (Bloom) upscaling model. Bloom 2 is the latest and most capable; Bloom creatively upscales and transforms AI-generated images; Bloom Realism biases the added detail toward photorealism."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPEG",
+            "jpeg"
+          ],
+          [
+            "PNG",
+            "png"
+          ]
+        ],
+        "description": "Output format of the upscaled image."
+      }
+    ],
+    "moduleName": "image_to_image"
+  },
+  {
+    "endpointId": "topaz/upscale/image/transparent",
+    "className": "TopazUpscaleImageTransparent",
+    "docstring": "Topaz transparent upscaling enlarges images while preserving the alpha channel, returning PNG.",
+    "tags": [
+      "image-to-image",
+      "img2img",
+      "image",
+      "topaz",
+      "upscale",
+      "transparency",
+      "alpha",
+      "png"
+    ],
+    "useCases": [
+      "Upscale a logo without losing alpha",
+      "Enlarge stickers and cutout assets",
+      "Prepare transparent art for print",
+      "Scale UI assets with transparency",
+      "Keep alpha intact through an upscale"
+    ],
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Url of the image to process",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "output_format",
+        "tsType": "string",
+        "propType": "str",
+        "default": "png",
+        "description": "Transparent upscaling always outputs PNG to preserve the alpha channel.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "upscale_factor",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2,
+        "description": "Factor to upscale the image by (e.g. 2.0 doubles width and height).",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The upscaled image.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [],
+    "moduleName": "image_to_image"
+  },
+  {
+    "endpointId": "hitem3d/hi3d/image-to-relief",
+    "className": "Hi3dImageToRelief",
+    "docstring": "Hi3D generates a 3D relief depth map from a single image.",
+    "tags": [
+      "image-to-image",
+      "depth",
+      "relief",
+      "3d",
+      "hi3d"
+    ],
+    "useCases": [
+      "Generate a relief for CNC carving",
+      "Produce a depth map from a photo",
+      "Create embossed artwork",
+      "Prepare a bas-relief for printing",
+      "Derive depth for a parallax effect"
+    ],
+    "inputFields": [
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, input images are checked for safety before processing.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL of the input image. PNG, JPEG and WebP formats are supported, up to 20MB.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "png",
+        "description": "File format of the generated depth map.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "png",
+          "exr"
+        ]
+      },
+      {
+        "name": "remove_background",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to remove the image background before generation.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "dict",
+    "outputFields": [
+      {
+        "name": "depth_map",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generated depth map file (PNG or EXR).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "thumbnail",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Preview image of the generated relief, when available.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "PNG",
+            "png"
+          ],
+          [
+            "EXR",
+            "exr"
+          ]
+        ],
+        "description": "File format of the generated depth map."
+      }
+    ],
+    "moduleName": "image_to_image"
+  },
+  {
+    "endpointId": "fal-ai/workflow-utilities/pick-image-by-index",
+    "className": "WorkflowUtilitiesPickImageByIndex",
+    "docstring": "Picks the Nth image from a list of image URLs.",
+    "tags": [
+      "utility",
+      "workflow",
+      "image",
+      "list"
+    ],
+    "useCases": [
+      "Select one image from a batch",
+      "Pick a specific variation to continue with",
+      "Branch a workflow on an index",
+      "Feed one result into the next node",
+      "Reduce a list output to a single image"
+    ],
+    "inputFields": [
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Array of image URLs to select from",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "image_urls"
+      },
+      {
+        "name": "fallback_index",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "first-image",
+        "description": "Behavior when `index` exceeds the length of `image_urls`. When `first-image`, returns the first image in the array. When `last-image`, returns the last image in the array. This input has no effect when `index` is within range, when `index` is below 1, or when `image_urls` is empty (the latter two cases still return validation errors). Default is `first-image`.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "FallbackIndex",
+        "enumValues": [
+          "first-image",
+          "last-image"
+        ]
+      },
+      {
+        "name": "index",
+        "tsType": "number",
+        "propType": "int",
+        "default": 0,
+        "description": "1-based position of the image to return. Value 1 returns the first image, 2 returns the second, and so on.",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "images",
+        "tsType": "Image[]",
+        "propType": "list[Image]",
+        "default": [],
+        "description": "Single-element array containing the selected image. Included so downstream nodes that expect an `images` reference (matching merge and other utilities) work without changes.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The image at the requested position",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "FallbackIndex",
+        "values": [
+          [
+            "FIRST_IMAGE",
+            "first-image"
+          ],
+          [
+            "LAST_IMAGE",
+            "last-image"
+          ]
+        ],
+        "description": "Behavior when `index` exceeds the length of `image_urls`. When `first-image`, returns the first image in the array. When `last-image`, returns the last image in the array. This input has no effect when `index` is within range, when `index` is below 1, or when `image_urls` is empty (the latter two cases still return validation errors). Default is `first-image`."
+      }
+    ],
+    "moduleName": "image_to_image"
+  },
+  {
+    "endpointId": "hitem3d/hi3d/image-to-3d",
+    "className": "Hi3dImageTo3d",
+    "docstring": "Hi3D generates a 3D model from a single image.",
+    "tags": [
+      "generation",
+      "image-to-3d",
+      "3d",
+      "mesh",
+      "hi3d"
+    ],
+    "useCases": [
+      "Turn a product photo into a mesh",
+      "Generate 3D props from concept art",
+      "Build game assets from references",
+      "Prototype a model from one photo",
+      "Create printable geometry from an image"
+    ],
+    "inputFields": [
+      {
+        "name": "export_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "glb",
+        "description": "File format of the generated model.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ExportFormat",
+        "enumValues": [
+          "glb",
+          "obj",
+          "stl",
+          "fbx",
+          "usdz"
+        ]
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "hitem3dv2.1",
+        "description": "Model version used for generation. 'hitem3d*' are the general models; 'scene-portrait*' are tuned for portraits/characters.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "hitem3dv1.5",
+          "hitem3dv2.0",
+          "hitem3dv2.1",
+          "scene-portraitv1.5",
+          "scene-portraitv2.0",
+          "scene-portraitv2.1"
+        ]
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, input images are checked for safety before processing.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL of the input image. PNG, JPEG and WebP formats are supported, up to 20MB.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "enable_texture",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate textures in addition to geometry. When false, only the geometry mesh is generated (and billed).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "face_count",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Target face count of the generated model. When unset, the partner picks the recommended count for the resolution (e.g. 500k for 512, 1M for 1024, 2M for 1536).",
+        "fieldType": "input",
+        "required": false,
+        "min": 100000,
+        "max": 2000000
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": null,
+        "description": "Generation resolution. Supported values depend on the model: v1.5/v2.0 accept 512, 1024, 1536 and 1536pro; v2.1 accepts 1536fast and 1536pro; scene-portraitv1.5 accepts 1536; scene-portraitv2.0 accepts 1536pro; scene-portraitv2.1 accepts 1536profast and 1536pro. Defaults to the model's recommended resolution (1024 for v1.5/v2.0, the fast tier otherwise).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "512",
+          "1024",
+          "1536",
+          "1536pro",
+          "1536fast",
+          "1536profast"
+        ]
+      },
+      {
+        "name": "enable_pbr",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Generate PBR material maps together with the texture. Only supported (and billed) for v2.0/v2.1 and v3.0 models when enable_texture is true; ignored otherwise.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "model_3d",
+    "outputFields": [
+      {
+        "name": "model_mesh",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generated 3D model file.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "thumbnail",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Preview image of the generated model, when available.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "ExportFormat",
+        "values": [
+          [
+            "GLB",
+            "glb"
+          ],
+          [
+            "OBJ",
+            "obj"
+          ],
+          [
+            "STL",
+            "stl"
+          ],
+          [
+            "FBX",
+            "fbx"
+          ],
+          [
+            "USDZ",
+            "usdz"
+          ]
+        ],
+        "description": "File format of the generated model."
+      },
+      {
+        "name": "Model",
+        "values": [
+          [
+            "HITEM3DV1_5",
+            "hitem3dv1.5"
+          ],
+          [
+            "HITEM3DV2_0",
+            "hitem3dv2.0"
+          ],
+          [
+            "HITEM3DV2_1",
+            "hitem3dv2.1"
+          ],
+          [
+            "SCENE_PORTRAITV1_5",
+            "scene-portraitv1.5"
+          ],
+          [
+            "SCENE_PORTRAITV2_0",
+            "scene-portraitv2.0"
+          ],
+          [
+            "SCENE_PORTRAITV2_1",
+            "scene-portraitv2.1"
+          ]
+        ],
+        "description": "Model version used for generation. 'hitem3d*' are the general models; 'scene-portrait*' are tuned for portraits/characters."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_512",
+            "512"
+          ],
+          [
+            "VALUE_1024",
+            "1024"
+          ],
+          [
+            "VALUE_1536",
+            "1536"
+          ],
+          [
+            "VALUE_1536PRO",
+            "1536pro"
+          ],
+          [
+            "VALUE_1536FAST",
+            "1536fast"
+          ],
+          [
+            "VALUE_1536PROFAST",
+            "1536profast"
+          ]
+        ],
+        "description": "Generation resolution. Supported values depend on the model: v1.5/v2.0 accept 512, 1024, 1536 and 1536pro; v2.1 accepts 1536fast and 1536pro; scene-portraitv1.5 accepts 1536; scene-portraitv2.0 accepts 1536pro; scene-portraitv2.1 accepts 1536profast and 1536pro. Defaults to the model's recommended resolution (1024 for v1.5/v2.0, the fast tier otherwise)."
+      }
+    ],
+    "moduleName": "image_to_3d"
+  },
+  {
+    "endpointId": "hitem3d/hi3d/multi-view-to-3d",
+    "className": "Hi3dMultiViewTo3d",
+    "docstring": "Hi3D generates a 3D model from several view images of one object.",
+    "tags": [
+      "generation",
+      "image-to-3d",
+      "multiview",
+      "3d",
+      "mesh",
+      "hi3d"
+    ],
+    "useCases": [
+      "Reconstruct an object from photos",
+      "Build a mesh from turntable shots",
+      "Improve accuracy over single-image 3D",
+      "Digitize a physical product",
+      "Generate game assets from reference sheets"
+    ],
+    "inputFields": [
+      {
+        "name": "export_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "glb",
+        "description": "File format of the generated model.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ExportFormat",
+        "enumValues": [
+          "glb",
+          "obj",
+          "stl",
+          "fbx",
+          "usdz"
+        ]
+      },
+      {
+        "name": "right_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL of the right view image (PNG/JPEG/WebP, up to 20MB).",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "right_image_url"
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "hitem3dv2.1",
+        "description": "Model version used for generation. 'hitem3d*' are the general models; 'scene-portrait*' are tuned for portraits/characters.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "hitem3dv1.5",
+          "hitem3dv2.0",
+          "hitem3dv2.1",
+          "scene-portraitv1.5",
+          "scene-portraitv2.0",
+          "scene-portraitv2.1"
+        ]
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, input images are checked for safety before processing.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "back_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL of the back view image (PNG/JPEG/WebP, up to 20MB).",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "back_image_url"
+      },
+      {
+        "name": "left_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL of the left view image (PNG/JPEG/WebP, up to 20MB).",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "left_image_url"
+      },
+      {
+        "name": "enable_texture",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate textures in addition to geometry. When false, only the geometry mesh is generated (and billed).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "face_count",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Target face count of the generated model. When unset, the partner picks the recommended count for the resolution (e.g. 500k for 512, 1M for 1024, 2M for 1536).",
+        "fieldType": "input",
+        "required": false,
+        "min": 100000,
+        "max": 2000000
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": null,
+        "description": "Generation resolution. Supported values depend on the model: v1.5/v2.0 accept 512, 1024, 1536 and 1536pro; v2.1 accepts 1536fast and 1536pro; scene-portraitv1.5 accepts 1536; scene-portraitv2.0 accepts 1536pro; scene-portraitv2.1 accepts 1536profast and 1536pro. Defaults to the model's recommended resolution (1024 for v1.5/v2.0, the fast tier otherwise).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "512",
+          "1024",
+          "1536",
+          "1536pro",
+          "1536fast",
+          "1536profast"
+        ]
+      },
+      {
+        "name": "enable_pbr",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Generate PBR material maps together with the texture. Only supported (and billed) for v2.0/v2.1 and v3.0 models when enable_texture is true; ignored otherwise.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "front_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL of the front view image (PNG/JPEG/WebP, up to 20MB).",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "front_image_url"
+      }
+    ],
+    "outputType": "model_3d",
+    "outputFields": [
+      {
+        "name": "model_mesh",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generated 3D model file.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "thumbnail",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Preview image of the generated model, when available.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "ExportFormat",
+        "values": [
+          [
+            "GLB",
+            "glb"
+          ],
+          [
+            "OBJ",
+            "obj"
+          ],
+          [
+            "STL",
+            "stl"
+          ],
+          [
+            "FBX",
+            "fbx"
+          ],
+          [
+            "USDZ",
+            "usdz"
+          ]
+        ],
+        "description": "File format of the generated model."
+      },
+      {
+        "name": "Model",
+        "values": [
+          [
+            "HITEM3DV1_5",
+            "hitem3dv1.5"
+          ],
+          [
+            "HITEM3DV2_0",
+            "hitem3dv2.0"
+          ],
+          [
+            "HITEM3DV2_1",
+            "hitem3dv2.1"
+          ],
+          [
+            "SCENE_PORTRAITV1_5",
+            "scene-portraitv1.5"
+          ],
+          [
+            "SCENE_PORTRAITV2_0",
+            "scene-portraitv2.0"
+          ],
+          [
+            "SCENE_PORTRAITV2_1",
+            "scene-portraitv2.1"
+          ]
+        ],
+        "description": "Model version used for generation. 'hitem3d*' are the general models; 'scene-portrait*' are tuned for portraits/characters."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_512",
+            "512"
+          ],
+          [
+            "VALUE_1024",
+            "1024"
+          ],
+          [
+            "VALUE_1536",
+            "1536"
+          ],
+          [
+            "VALUE_1536PRO",
+            "1536pro"
+          ],
+          [
+            "VALUE_1536FAST",
+            "1536fast"
+          ],
+          [
+            "VALUE_1536PROFAST",
+            "1536profast"
+          ]
+        ],
+        "description": "Generation resolution. Supported values depend on the model: v1.5/v2.0 accept 512, 1024, 1536 and 1536pro; v2.1 accepts 1536fast and 1536pro; scene-portraitv1.5 accepts 1536; scene-portraitv2.0 accepts 1536pro; scene-portraitv2.1 accepts 1536profast and 1536pro. Defaults to the model's recommended resolution (1024 for v1.5/v2.0, the fast tier otherwise)."
+      }
+    ],
+    "moduleName": "image_to_3d"
+  },
+  {
+    "endpointId": "hitem3d/hi3d/v3.0/image-to-3d",
+    "className": "Hi3dV30ImageTo3d",
+    "docstring": "Hi3D V3.0 generates a 3D model from a single image.",
+    "tags": [
+      "generation",
+      "image-to-3d",
+      "3d",
+      "mesh",
+      "hi3d",
+      "v3"
+    ],
+    "useCases": [
+      "Generate a mesh from one photo",
+      "Convert concept art to 3D",
+      "Produce game-ready props",
+      "Prototype geometry for print",
+      "Rebuild an object from a reference"
+    ],
+    "inputFields": [
+      {
+        "name": "shading",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "De-shading strength.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "export_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "glb",
+        "description": "File format of the generated model.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ExportFormat",
+        "enumValues": [
+          "glb",
+          "obj",
+          "stl",
+          "fbx",
+          "usdz"
+        ]
+      },
+      {
+        "name": "model",
+        "tsType": "string",
+        "propType": "str",
+        "default": "hi3dv3.0",
+        "description": "Hi3D v3.0 model version used by this endpoint.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, input images are checked for safety before processing.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL of the input image. PNG, JPEG and WebP formats are supported, up to 20MB.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "enable_texture",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate textures in addition to geometry. When false, only the geometry mesh is generated (and billed).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "face_count",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Target face count. The partner recommends 2,000,000 for 2048quality and 5,000,000 for 2048master.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100000,
+        "max": 5000000
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "2048quality",
+        "description": "Generation resolution. 2048quality is the faster default; 2048master provides the highest quality.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "2048quality",
+          "2048master"
+        ]
+      },
+      {
+        "name": "enable_pbr",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Generate PBR material maps together with the texture. Only supported (and billed) for v2.0/v2.1 and v3.0 models when enable_texture is true; ignored otherwise.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "model_3d",
+    "outputFields": [
+      {
+        "name": "model_mesh",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generated 3D model file.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "thumbnail",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Preview image of the generated model, when available.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "ExportFormat",
+        "values": [
+          [
+            "GLB",
+            "glb"
+          ],
+          [
+            "OBJ",
+            "obj"
+          ],
+          [
+            "STL",
+            "stl"
+          ],
+          [
+            "FBX",
+            "fbx"
+          ],
+          [
+            "USDZ",
+            "usdz"
+          ]
+        ],
+        "description": "File format of the generated model."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_2048QUALITY",
+            "2048quality"
+          ],
+          [
+            "VALUE_2048MASTER",
+            "2048master"
+          ]
+        ],
+        "description": "Generation resolution. 2048quality is the faster default; 2048master provides the highest quality."
+      }
+    ],
+    "moduleName": "image_to_3d"
+  },
+  {
+    "endpointId": "hitem3d/hi3d/v3.0/multi-view-to-3d",
+    "className": "Hi3dV30MultiViewTo3d",
+    "docstring": "Hi3D V3.0 generates a 3D model from several view images of one object.",
+    "tags": [
+      "generation",
+      "image-to-3d",
+      "multiview",
+      "3d",
+      "mesh",
+      "hi3d",
+      "v3"
+    ],
+    "useCases": [
+      "Reconstruct an object from multiple angles",
+      "Digitize a product for a catalog",
+      "Build accurate meshes from photo sets",
+      "Generate assets from reference sheets",
+      "Capture geometry without a scanner"
+    ],
+    "inputFields": [
+      {
+        "name": "shading",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "De-shading strength.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "right_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL of the right view image (PNG/JPEG/WebP, up to 20MB).",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "right_image_url"
+      },
+      {
+        "name": "model",
+        "tsType": "string",
+        "propType": "str",
+        "default": "hi3dv3.0",
+        "description": "Hi3D v3.0 model version used by this endpoint.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, input images are checked for safety before processing.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "back_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL of the back view image (PNG/JPEG/WebP, up to 20MB).",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "back_image_url"
+      },
+      {
+        "name": "left_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL of the left view image (PNG/JPEG/WebP, up to 20MB).",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "left_image_url"
+      },
+      {
+        "name": "enable_texture",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate textures in addition to geometry. When false, only the geometry mesh is generated (and billed).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "face_count",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Target face count. The partner recommends 2,000,000 for 2048quality and 5,000,000 for 2048master.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100000,
+        "max": 5000000
+      },
+      {
+        "name": "export_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "glb",
+        "description": "File format of the generated model.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ExportFormat",
+        "enumValues": [
+          "glb",
+          "obj",
+          "stl",
+          "fbx",
+          "usdz"
+        ]
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "2048quality",
+        "description": "Generation resolution. 2048quality is the faster default; 2048master provides the highest quality.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "2048quality",
+          "2048master"
+        ]
+      },
+      {
+        "name": "enable_pbr",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Generate PBR material maps together with the texture. Only supported (and billed) for v2.0/v2.1 and v3.0 models when enable_texture is true; ignored otherwise.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "front_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL of the front view image (PNG/JPEG/WebP, up to 20MB).",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "front_image_url"
+      }
+    ],
+    "outputType": "model_3d",
+    "outputFields": [
+      {
+        "name": "model_mesh",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generated 3D model file.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "thumbnail",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Preview image of the generated model, when available.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "ExportFormat",
+        "values": [
+          [
+            "GLB",
+            "glb"
+          ],
+          [
+            "OBJ",
+            "obj"
+          ],
+          [
+            "STL",
+            "stl"
+          ],
+          [
+            "FBX",
+            "fbx"
+          ],
+          [
+            "USDZ",
+            "usdz"
+          ]
+        ],
+        "description": "File format of the generated model."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_2048QUALITY",
+            "2048quality"
+          ],
+          [
+            "VALUE_2048MASTER",
+            "2048master"
+          ]
+        ],
+        "description": "Generation resolution. 2048quality is the faster default; 2048master provides the highest quality."
+      }
+    ],
+    "moduleName": "image_to_3d"
+  },
+  {
+    "endpointId": "meshy/v7/image-to-3d",
+    "className": "MeshyV7ImageTo3d",
+    "docstring": "Meshy V7 turns a single image into a textured PBR-ready mesh with game-ready topology.",
+    "tags": [
+      "generation",
+      "image-to-3d",
+      "3d",
+      "mesh",
+      "pbr",
+      "meshy"
+    ],
+    "useCases": [
+      "Convert concept art to a game asset",
+      "Generate a mesh from a product photo",
+      "Produce PBR textures automatically",
+      "Control polygon count for engines",
+      "Prototype 3D from a single image"
+    ],
+    "inputFields": [
+      {
+        "name": "pose_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "",
+        "description": "Pose mode for the generated model. 'a-pose' generates an A-pose, 't-pose' generates a T-pose, empty string for no specific pose.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "PoseMode",
+        "enumValues": [
+          "a-pose",
+          "t-pose",
+          ""
+        ]
+      },
+      {
+        "name": "symmetry_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Controls symmetry behavior during model generation. Off disables symmetry, Auto determines it automatically, On enforces symmetry.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "SymmetryMode",
+        "enumValues": [
+          "off",
+          "auto",
+          "on"
+        ]
+      },
+      {
+        "name": "rigging_height_meters",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1.7,
+        "description": "Approximate height of the character in meters. Only used when enable_rigging is true.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "texture_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "2D image to guide the texturing process",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "texture_image_url"
+      },
+      {
+        "name": "topology",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "triangle",
+        "description": "Specify the topology of the generated model. Quad for smooth surfaces, Triangle for detailed geometry.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Topology",
+        "enumValues": [
+          "quad",
+          "triangle"
+        ]
+      },
+      {
+        "name": "enable_animation",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Apply an animation preset to the rigged model. Requires enable_rigging to be true.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "is_a_t_pose",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Deprecated: use pose_mode instead. When true, generates a T-pose model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "model_type",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "standard",
+        "description": "Type of 3D mesh generation. 'standard' produces a regular high-detail mesh; 'lowpoly' produces a low-poly mesh optimized for cleaner polygons; 'smart-topology' uses Meshy-T2 for clean, natively separated parts. When set to 'lowpoly', the remesh controls (topology, target_polycount, should_remesh) are ignored by Meshy.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ModelType",
+        "enumValues": [
+          "standard",
+          "lowpoly",
+          "smart-topology"
+        ]
+      },
+      {
+        "name": "animation_action_id",
+        "tsType": "number",
+        "propType": "int",
+        "default": 92,
+        "description": "Animation preset ID from Meshy's library. Only used when enable_animation is true; in that case it must be in [0, 696] (``0`` is the \"Idle\" preset) and is otherwise rejected with a 422. See https://docs.meshy.ai/en/api/animation-library for available action IDs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 696
+      },
+      {
+        "name": "should_texture",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate textures",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "target_polycount",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30000,
+        "description": "Target number of polygons in the generated model. When model_type is 'smart-topology' and this is left unset, Meshy's lower smart-topology default (4,000) is used instead; smart topology accepts at most 15,000.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 300000
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Image URL or base64 data URI for 3D model creation. Supports .jpg, .jpeg, and .png formats. Also supports AVIF and HEIF formats which will be automatically converted.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "enable_rigging",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically rig the generated model as a humanoid character. Includes basic walking and running animations. Best results with humanoid characters that have clearly defined limbs.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "ultra_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable higher-fidelity geometry with finer surface detail. Only available for standard generation (ultra requires Meshy-7; it cannot be combined with smart topology or lowpoly).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "texture_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt to guide the texturing process",
+        "fieldType": "input",
+        "required": false,
+        "max": 600
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, input data will be checked for safety before processing.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "should_remesh",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to enable the remesh phase",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "enable_pbr",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Generate PBR Maps (metallic, roughness, normal) in addition to base color",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "model_3d",
+    "outputFields": [
+      {
+        "name": "rig_task_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Rigging task ID. Only present when enable_rigging is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "basic_animations",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Basic walking and running animations. Only present when enable_rigging is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "rigged_character_fbx",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Rigged character in FBX format. Only present when enable_rigging is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The seed used for generation (if available)",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "animation_glb",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Animated 3D model in GLB format. Only present when enable_animation is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "texture_urls",
+        "tsType": "TextureFiles[]",
+        "propType": "list[TextureFiles]",
+        "default": [],
+        "description": "Array of texture file objects, matching Meshy API structure",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "rigged_character_glb",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Rigged character in GLB format. Only present when enable_rigging is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "animation_fbx",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Animated 3D model in FBX format. Only present when enable_animation is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "model_urls",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URLs for different 3D model formats",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "model_glb",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generated 3D object in GLB format.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "thumbnail",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Preview thumbnail of the generated model",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "PoseMode",
+        "values": [
+          [
+            "A_POSE",
+            "a-pose"
+          ],
+          [
+            "T_POSE",
+            "t-pose"
+          ],
+          [
+            "VALUE_UNKNOWN",
+            ""
+          ]
+        ],
+        "description": "Pose mode for the generated model. 'a-pose' generates an A-pose, 't-pose' generates a T-pose, empty string for no specific pose."
+      },
+      {
+        "name": "SymmetryMode",
+        "values": [
+          [
+            "OFF",
+            "off"
+          ],
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "ON",
+            "on"
+          ]
+        ],
+        "description": "Controls symmetry behavior during model generation. Off disables symmetry, Auto determines it automatically, On enforces symmetry."
+      },
+      {
+        "name": "Topology",
+        "values": [
+          [
+            "QUAD",
+            "quad"
+          ],
+          [
+            "TRIANGLE",
+            "triangle"
+          ]
+        ],
+        "description": "Specify the topology of the generated model. Quad for smooth surfaces, Triangle for detailed geometry."
+      },
+      {
+        "name": "ModelType",
+        "values": [
+          [
+            "STANDARD",
+            "standard"
+          ],
+          [
+            "LOWPOLY",
+            "lowpoly"
+          ],
+          [
+            "SMART_TOPOLOGY",
+            "smart-topology"
+          ]
+        ],
+        "description": "Type of 3D mesh generation. 'standard' produces a regular high-detail mesh; 'lowpoly' produces a low-poly mesh optimized for cleaner polygons; 'smart-topology' uses Meshy-T2 for clean, natively separated parts. When set to 'lowpoly', the remesh controls (topology, target_polycount, should_remesh) are ignored by Meshy."
+      }
+    ],
+    "moduleName": "image_to_3d"
+  },
+  {
+    "endpointId": "meshy/v7/multi-image-to-3d",
+    "className": "MeshyV7MultiImageTo3d",
+    "docstring": "Meshy V7 reconstructs a textured mesh from several angle views of one object, with polygon control.",
+    "tags": [
+      "generation",
+      "image-to-3d",
+      "multiview",
+      "3d",
+      "mesh",
+      "pbr",
+      "meshy"
+    ],
+    "useCases": [
+      "Reconstruct an object from photo sets",
+      "Improve fidelity over single-image 3D",
+      "Digitize props for a game",
+      "Produce game-ready topology from photos",
+      "Capture geometry without a scanner"
+    ],
+    "inputFields": [
+      {
+        "name": "pose_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "",
+        "description": "Pose mode for the generated model. 'a-pose' generates an A-pose, 't-pose' generates a T-pose, empty string for no specific pose.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "PoseMode",
+        "enumValues": [
+          "a-pose",
+          "t-pose",
+          ""
+        ]
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "1 to 4 images for 3D model creation. All images should depict the same object from different angles. Supports .jpg, .jpeg, .png formats, and AVIF/HEIF which will be automatically converted. If more than 4 images are provided, only the first 4 will be used.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "image_urls"
+      },
+      {
+        "name": "rigging_height_meters",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1.7,
+        "description": "Approximate height of the character in meters. Only used when enable_rigging is true.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "texture_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "2D image to guide the texturing process. Requires should_texture to be true.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "texture_image_url"
+      },
+      {
+        "name": "symmetry_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Controls symmetry behavior during model generation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "SymmetryMode",
+        "enumValues": [
+          "off",
+          "auto",
+          "on"
+        ]
+      },
+      {
+        "name": "topology",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "triangle",
+        "description": "Specify the topology of the generated model. Quad for smooth surfaces, Triangle for detailed geometry.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Topology",
+        "enumValues": [
+          "quad",
+          "triangle"
+        ]
+      },
+      {
+        "name": "enable_animation",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Apply an animation preset to the rigged model. Requires enable_rigging to be true.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "is_a_t_pose",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Deprecated: use pose_mode instead. When true, generates a T-pose model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "animation_action_id",
+        "tsType": "number",
+        "propType": "int",
+        "default": 92,
+        "description": "Animation preset ID from Meshy's library. Only used when enable_animation is true; in that case it must be in [0, 696] (``0`` is the \"Idle\" preset) and is otherwise rejected with a 422. See https://docs.meshy.ai/en/api/animation-library for available action IDs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 696
+      },
+      {
+        "name": "target_polycount",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30000,
+        "description": "Target number of polygons in the generated model",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 300000
+      },
+      {
+        "name": "should_texture",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate textures. False provides mesh without textures for 5 credits, True adds texture generation for additional 10 credits.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "enable_rigging",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically rig the generated model as a humanoid character. Includes basic walking and running animations. Best results with humanoid characters that have clearly defined limbs.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "texture_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt to guide the texturing process. Requires should_texture to be true.",
+        "fieldType": "input",
+        "required": false,
+        "max": 600
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, input data will be checked for safety before processing.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "should_remesh",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to enable the remesh phase. When false, returns triangular mesh ignoring topology and target_polycount.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "enable_pbr",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Generate PBR Maps (metallic, roughness, normal) in addition to base color. Requires should_texture to be true.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "model_3d",
+    "outputFields": [
+      {
+        "name": "rig_task_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Rigging task ID. Only present when enable_rigging is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "basic_animations",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Basic walking and running animations. Only present when enable_rigging is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "rigged_character_fbx",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Rigged character in FBX format. Only present when enable_rigging is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The seed used for generation (if available)",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "animation_glb",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Animated 3D model in GLB format. Only present when enable_animation is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "texture_urls",
+        "tsType": "TextureFiles[]",
+        "propType": "list[TextureFiles]",
+        "default": [],
+        "description": "Array of texture file objects",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "rigged_character_glb",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Rigged character in GLB format. Only present when enable_rigging is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "animation_fbx",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Animated 3D model in FBX format. Only present when enable_animation is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "model_urls",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URLs for different 3D model formats",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "model_glb",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generated 3D object in GLB format.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "thumbnail",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Preview thumbnail of the generated model",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "PoseMode",
+        "values": [
+          [
+            "A_POSE",
+            "a-pose"
+          ],
+          [
+            "T_POSE",
+            "t-pose"
+          ],
+          [
+            "VALUE_UNKNOWN",
+            ""
+          ]
+        ],
+        "description": "Pose mode for the generated model. 'a-pose' generates an A-pose, 't-pose' generates a T-pose, empty string for no specific pose."
+      },
+      {
+        "name": "SymmetryMode",
+        "values": [
+          [
+            "OFF",
+            "off"
+          ],
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "ON",
+            "on"
+          ]
+        ],
+        "description": "Controls symmetry behavior during model generation."
+      },
+      {
+        "name": "Topology",
+        "values": [
+          [
+            "QUAD",
+            "quad"
+          ],
+          [
+            "TRIANGLE",
+            "triangle"
+          ]
+        ],
+        "description": "Specify the topology of the generated model. Quad for smooth surfaces, Triangle for detailed geometry."
+      }
+    ],
+    "moduleName": "image_to_3d"
+  },
+  {
+    "endpointId": "alibaba/wan-3.0/image-to-video",
+    "className": "Wan30ImageToVideo",
+    "docstring": "Wan 3.0 animates a still image into video while keeping the source composition and identity.",
+    "tags": [
+      "generation",
+      "image-to-video",
+      "img2vid",
+      "video",
+      "wan",
+      "wan-3"
+    ],
+    "useCases": [
+      "Animate a product photo",
+      "Bring a character illustration to life",
+      "Add camera movement to a still",
+      "Turn concept art into motion",
+      "Extend a photo into a short clip"
+    ],
+    "inputFields": [
+      {
+        "name": "audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Include generated audio.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt describing the motion to generate.",
+        "fieldType": "input",
+        "required": false,
+        "max": 5000
+      },
+      {
+        "name": "duration",
+        "tsType": "string",
+        "propType": "str",
+        "default": 5,
+        "description": "Output duration in seconds. Set to null for smart duration, which lets the model pick a length from the prompt and reference media.",
+        "fieldType": "input",
+        "required": false,
+        "min": 2,
+        "max": 30
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable content moderation for input and output. Disabling it requires account authorization; unauthorized requests are always checked.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "enable_thinking",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable enhanced reasoning before generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "end_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Last frame of the generated video. Requires start_image_url.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "end_image_url"
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "adaptive",
+        "description": "Output aspect ratio, or adaptive selection.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "adaptive",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      },
+      {
+        "name": "start_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "First frame of the generated video.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "start_image_url"
+      },
+      {
+        "name": "enable_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable intelligent prompt rewriting. Disabling it can save roughly 20-60 seconds of latency but is likely to degrade generation quality.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "Output video resolution tier.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p",
+          "1080p"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video file.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Generated video duration in seconds.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "actual_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "ADAPTIVE",
+            "adaptive"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Output aspect ratio, or adaptive selection."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480p"
+          ],
+          [
+            "VALUE_720P",
+            "720p"
+          ],
+          [
+            "VALUE_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Output video resolution tier."
+      }
+    ],
+    "moduleName": "image_to_video"
+  },
+  {
+    "endpointId": "alibaba/wan-3.0/reference-to-video",
+    "className": "Wan30ReferenceToVideo",
+    "docstring": "Wan 3.0 generates video that follows reference images for character, style, and scene consistency.",
+    "tags": [
+      "generation",
+      "image-to-video",
+      "img2vid",
+      "video",
+      "reference",
+      "wan",
+      "wan-3"
+    ],
+    "useCases": [
+      "Keep one character consistent across shots",
+      "Lock a visual style from references",
+      "Reuse a set across scenes",
+      "Generate variations of a referenced subject",
+      "Match brand art direction in video"
+    ],
+    "inputFields": [
+      {
+        "name": "audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Include generated audio.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_video_urls",
+        "tsType": "video[]",
+        "propType": "list[video]",
+        "default": [],
+        "description": "Up to 5 reference video URLs totaling at most 15 seconds. Each clip must be at least 16 fps.",
+        "fieldType": "input",
+        "required": false,
+        "max": 5
+      },
+      {
+        "name": "duration",
+        "tsType": "string",
+        "propType": "str",
+        "default": 5,
+        "description": "Output duration in seconds. Set to null for smart duration, which lets the model pick a length from the prompt and reference media.",
+        "fieldType": "input",
+        "required": false,
+        "min": 2,
+        "max": 30
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable content moderation for input and output. Disabling it requires account authorization; unauthorized requests are always checked.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "enable_thinking",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable enhanced reasoning before generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "web_url",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Public webpage URL to base the video on. Requires enable_thinking=true. Only pages that do not require login can be read.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "adaptive",
+        "description": "Output aspect ratio, or adaptive selection.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "adaptive",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      },
+      {
+        "name": "enable_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable intelligent prompt rewriting. Disabling it can save roughly 20-60 seconds of latency but is likely to degrade generation quality.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Up to 10 reference image URLs.",
+        "fieldType": "input",
+        "required": false,
+        "max": 10,
+        "apiParamName": "reference_image_urls"
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "Output video resolution tier.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt directing how the reference media is used. Reference media can be addressed positionally, e.g. 'the subject in Image 1 walks past Video 1'.",
+        "fieldType": "input",
+        "required": false,
+        "max": 5000
+      },
+      {
+        "name": "file_url",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Document URL to base the video on. Requires enable_thinking=true.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_audio_urls",
+        "tsType": "audio[]",
+        "propType": "list[audio]",
+        "default": [],
+        "description": "Up to 5 reference audio URLs totaling at most 15 seconds.",
+        "fieldType": "input",
+        "required": false,
+        "max": 5
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video file.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Generated video duration in seconds.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "actual_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "ADAPTIVE",
+            "adaptive"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Output aspect ratio, or adaptive selection."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480p"
+          ],
+          [
+            "VALUE_720P",
+            "720p"
+          ],
+          [
+            "VALUE_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Output video resolution tier."
+      }
+    ],
+    "moduleName": "image_to_video"
+  },
+  {
+    "endpointId": "alibaba/wan-3.0-prime/image-to-video",
+    "className": "Wan30PrimeImageToVideo",
+    "docstring": "Wan 3.0 Prime animates a still image into video with rapid turnaround and natural motion.",
+    "tags": [
+      "generation",
+      "image-to-video",
+      "img2vid",
+      "video",
+      "wan",
+      "wan-3",
+      "fast"
+    ],
+    "useCases": [
+      "Animate stills quickly for review",
+      "Add motion to product photography",
+      "Preview an animation direction",
+      "Generate looping clips from art",
+      "Batch-animate a photo set"
+    ],
+    "inputFields": [
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "Output video resolution tier.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable content moderation for input and output. Disabling it requires account authorization; unauthorized requests are always checked.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      },
+      {
+        "name": "end_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Last frame of the generated video. Requires start_image_url.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "end_image_url"
+      },
+      {
+        "name": "audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Include generated audio.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "enable_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable intelligent prompt rewriting. Disabling it can save roughly 20-60 seconds of latency but is likely to degrade generation quality.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "adaptive",
+        "description": "Output aspect ratio, or adaptive selection.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "adaptive",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "string",
+        "propType": "str",
+        "default": 5,
+        "description": "Output duration in seconds. Set to null for smart duration, which lets the model pick a length from the prompt and reference media.",
+        "fieldType": "input",
+        "required": false,
+        "min": 2,
+        "max": 30
+      },
+      {
+        "name": "enable_thinking",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable enhanced reasoning before generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt describing the motion to generate.",
+        "fieldType": "input",
+        "required": false,
+        "max": 5000
+      },
+      {
+        "name": "start_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "First frame of the generated video.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "start_image_url"
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Generated video duration in seconds.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "actual_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video file.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480p"
+          ],
+          [
+            "VALUE_720P",
+            "720p"
+          ],
+          [
+            "VALUE_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Output video resolution tier."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "ADAPTIVE",
+            "adaptive"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Output aspect ratio, or adaptive selection."
+      }
+    ],
+    "moduleName": "image_to_video"
+  },
+  {
+    "endpointId": "bytedance/seedance-2.5/image-to-video",
+    "className": "BytedanceSeedance25ImageToVideo",
+    "docstring": "Seedance 2.5 animates one still into a native 30-second clip at up to 720p without multi-clip stitching.",
+    "tags": [
+      "generation",
+      "image-to-video",
+      "img2vid",
+      "video",
+      "seedance",
+      "bytedance",
+      "long-form"
+    ],
+    "useCases": [
+      "Extend a single frame into a long take",
+      "Animate key art into a full shot",
+      "Produce drift-free long animation",
+      "Turn a photo into a 30-second clip",
+      "Generate continuous motion from a still"
+    ],
+    "inputFields": [
+      {
+        "name": "end_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The URL of the image to use as the last frame of the video. When provided, the generated video will transition from the starting image to this ending image. Supported formats: JPEG, PNG, WebP. Max 30 MB.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "end_image_url"
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "auto",
+          "4",
+          "5",
+          "6",
+          "7",
+          "8",
+          "9",
+          "10",
+          "11",
+          "12",
+          "13",
+          "14",
+          "15",
+          "16",
+          "17",
+          "18",
+          "19",
+          "20",
+          "21",
+          "22",
+          "23",
+          "24",
+          "25",
+          "26",
+          "27",
+          "28",
+          "29",
+          "30"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The text prompt describing the desired motion and action for the video.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "end_user_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The unique user ID of the end user.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "bitrate_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "standard",
+        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "BitrateMode",
+        "enumValues": [
+          "standard",
+          "high"
+        ]
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The URL of the starting frame image to animate. Supported formats: JPEG, PNG, WebP. Max 30 MB.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "string",
+        "propType": "str",
+        "default": "auto",
+        "description": "The aspect ratio of the generated video. Always \"auto\" for image-to-video",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video file.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "VALUE_4",
+            "4"
+          ],
+          [
+            "VALUE_5",
+            "5"
+          ],
+          [
+            "VALUE_6",
+            "6"
+          ],
+          [
+            "VALUE_7",
+            "7"
+          ],
+          [
+            "VALUE_8",
+            "8"
+          ],
+          [
+            "VALUE_9",
+            "9"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ],
+          [
+            "VALUE_11",
+            "11"
+          ],
+          [
+            "VALUE_12",
+            "12"
+          ],
+          [
+            "VALUE_13",
+            "13"
+          ],
+          [
+            "VALUE_14",
+            "14"
+          ],
+          [
+            "VALUE_15",
+            "15"
+          ],
+          [
+            "VALUE_16",
+            "16"
+          ],
+          [
+            "VALUE_17",
+            "17"
+          ],
+          [
+            "VALUE_18",
+            "18"
+          ],
+          [
+            "VALUE_19",
+            "19"
+          ],
+          [
+            "VALUE_20",
+            "20"
+          ],
+          [
+            "VALUE_21",
+            "21"
+          ],
+          [
+            "VALUE_22",
+            "22"
+          ],
+          [
+            "VALUE_23",
+            "23"
+          ],
+          [
+            "VALUE_24",
+            "24"
+          ],
+          [
+            "VALUE_25",
+            "25"
+          ],
+          [
+            "VALUE_26",
+            "26"
+          ],
+          [
+            "VALUE_27",
+            "27"
+          ],
+          [
+            "VALUE_28",
+            "28"
+          ],
+          [
+            "VALUE_29",
+            "29"
+          ],
+          [
+            "VALUE_30",
+            "30"
+          ]
+        ],
+        "description": "Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480p"
+          ],
+          [
+            "VALUE_720P",
+            "720p"
+          ],
+          [
+            "VALUE_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality."
+      },
+      {
+        "name": "BitrateMode",
+        "values": [
+          [
+            "STANDARD",
+            "standard"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate."
+      }
+    ],
+    "moduleName": "image_to_video"
+  },
+  {
+    "endpointId": "bytedance/seedance-2.5/reference-to-video",
+    "className": "BytedanceSeedance25ReferenceToVideo",
+    "docstring": "Seedance 2.5 generates video from up to 50 image, video, audio, and style references, locking character and palette across a 30-second take.",
+    "tags": [
+      "generation",
+      "image-to-video",
+      "img2vid",
+      "video",
+      "reference",
+      "seedance",
+      "bytedance",
+      "long-form"
+    ],
+    "useCases": [
+      "Lock a character across a long take",
+      "Hold a set and palette consistent",
+      "Drive video from many reference inputs",
+      "Match an existing production look",
+      "Generate continuity-safe scenes"
+    ],
+    "inputFields": [
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "auto",
+          "4",
+          "5",
+          "6",
+          "7",
+          "8",
+          "9",
+          "10",
+          "11",
+          "12",
+          "13",
+          "14",
+          "15",
+          "16",
+          "17",
+          "18",
+          "19",
+          "20",
+          "21",
+          "22",
+          "23",
+          "24",
+          "25",
+          "26",
+          "27",
+          "28",
+          "29",
+          "30"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The text prompt used to generate the video.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "end_user_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The unique user ID of the end user.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "bitrate_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "standard",
+        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "BitrateMode",
+        "enumValues": [
+          "standard",
+          "high"
+        ]
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Reference images to guide video generation. Refer to them in the prompt as @Image1, @Image2, etc. Supported formats: JPG, PNG, WebP, BMP, TIFF, GIF, HEIC, HEIF. Max 30 MB per image. Up to 30 images. Total files across all modalities must not exceed 50.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "image_urls"
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "audio_urls",
+        "tsType": "audio[]",
+        "propType": "list[audio]",
+        "default": [],
+        "description": "Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 10 files. Each file must be 1.8 to 30.2 seconds and no larger than 15 MB; combined duration must not exceed 30.2 seconds. If audio is provided, at least one reference image or video is required.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "auto",
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "video_urls",
+        "tsType": "video[]",
+        "propType": "list[video]",
+        "default": [],
+        "description": "Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 10 videos. Each video must be 1.8 to 30.2 seconds and no larger than 200 MB; combined duration must not exceed 30.2 seconds. Dimensions must be 300 to 6,000 pixels per side, aspect ratio 0.4 to 2.5, and frame rate 24 to 60 FPS.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video file.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "VALUE_4",
+            "4"
+          ],
+          [
+            "VALUE_5",
+            "5"
+          ],
+          [
+            "VALUE_6",
+            "6"
+          ],
+          [
+            "VALUE_7",
+            "7"
+          ],
+          [
+            "VALUE_8",
+            "8"
+          ],
+          [
+            "VALUE_9",
+            "9"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ],
+          [
+            "VALUE_11",
+            "11"
+          ],
+          [
+            "VALUE_12",
+            "12"
+          ],
+          [
+            "VALUE_13",
+            "13"
+          ],
+          [
+            "VALUE_14",
+            "14"
+          ],
+          [
+            "VALUE_15",
+            "15"
+          ],
+          [
+            "VALUE_16",
+            "16"
+          ],
+          [
+            "VALUE_17",
+            "17"
+          ],
+          [
+            "VALUE_18",
+            "18"
+          ],
+          [
+            "VALUE_19",
+            "19"
+          ],
+          [
+            "VALUE_20",
+            "20"
+          ],
+          [
+            "VALUE_21",
+            "21"
+          ],
+          [
+            "VALUE_22",
+            "22"
+          ],
+          [
+            "VALUE_23",
+            "23"
+          ],
+          [
+            "VALUE_24",
+            "24"
+          ],
+          [
+            "VALUE_25",
+            "25"
+          ],
+          [
+            "VALUE_26",
+            "26"
+          ],
+          [
+            "VALUE_27",
+            "27"
+          ],
+          [
+            "VALUE_28",
+            "28"
+          ],
+          [
+            "VALUE_29",
+            "29"
+          ],
+          [
+            "VALUE_30",
+            "30"
+          ]
+        ],
+        "description": "Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480p"
+          ],
+          [
+            "VALUE_720P",
+            "720p"
+          ],
+          [
+            "VALUE_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality."
+      },
+      {
+        "name": "BitrateMode",
+        "values": [
+          [
+            "STANDARD",
+            "standard"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide."
+      }
+    ],
+    "moduleName": "image_to_video"
+  },
+  {
+    "endpointId": "lightricks/ltx-2.5/image-to-video/fast",
+    "className": "Ltx25ImageToVideoFast",
+    "docstring": "LTX 2.5 animates a still into video with synchronized audio in a speed-optimized pass.",
+    "tags": [
+      "generation",
+      "image-to-video",
+      "img2vid",
+      "video",
+      "ltx",
+      "ltx-2-5",
+      "audio",
+      "fast"
+    ],
+    "useCases": [
+      "Preview how a still will animate",
+      "Iterate on motion direction cheaply",
+      "Animate key art with sound",
+      "Batch-draft clips from a photo set",
+      "Test a shot before a quality render"
+    ],
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The URL of the start image to use for the generated video.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "The resolution of the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720p",
+          "1080p",
+          "1440p",
+          "2160p"
+        ]
+      },
+      {
+        "name": "fps",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 25,
+        "description": "The frames per second of the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Fps",
+        "enumValues": [
+          24,
+          25,
+          48,
+          50
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "The duration of the generated video in seconds. At 720p and 1080p, 24 or 25 FPS supports up to 20 seconds, while 48 or 50 FPS supports up to 10 seconds. At 1440p and 2160p, all frame rates support up to 10 seconds. Set to 'auto' to let the model choose the duration automatically.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          6,
+          8,
+          10,
+          12,
+          14,
+          16,
+          18,
+          20,
+          "auto"
+        ]
+      },
+      {
+        "name": "end_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The URL of the end image to use for the generated video. When provided, generates a transition video between start and end frames.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "end_image_url"
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt to use for the generated video",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 5000
+      },
+      {
+        "name": "camera_motion",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": null,
+        "description": "Optional camera motion applied to the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "CameraMotion",
+        "enumValues": [
+          "dolly_in",
+          "dolly_out",
+          "dolly_left",
+          "dolly_right",
+          "jib_up",
+          "jib_down",
+          "static",
+          "focus_shift"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "The aspect ratio of the generated video. If 'auto', the aspect ratio will be determined automatically based on the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "auto",
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate audio for the generated video",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video file",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_720P",
+            "720p"
+          ],
+          [
+            "VALUE_1080P",
+            "1080p"
+          ],
+          [
+            "VALUE_1440P",
+            "1440p"
+          ],
+          [
+            "VALUE_2160P",
+            "2160p"
+          ]
+        ],
+        "description": "The resolution of the generated video."
+      },
+      {
+        "name": "Fps",
+        "values": [
+          [
+            "VALUE_24",
+            24
+          ],
+          [
+            "VALUE_25",
+            25
+          ],
+          [
+            "VALUE_48",
+            48
+          ],
+          [
+            "VALUE_50",
+            50
+          ]
+        ],
+        "description": "The frames per second of the generated video."
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_6",
+            6
+          ],
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_10",
+            10
+          ],
+          [
+            "VALUE_12",
+            12
+          ],
+          [
+            "VALUE_14",
+            14
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_18",
+            18
+          ],
+          [
+            "VALUE_20",
+            20
+          ],
+          [
+            "AUTO",
+            "auto"
+          ]
+        ],
+        "description": "The duration of the generated video in seconds. At 720p and 1080p, 24 or 25 FPS supports up to 20 seconds, while 48 or 50 FPS supports up to 10 seconds. At 1440p and 2160p, all frame rates support up to 10 seconds. Set to 'auto' to let the model choose the duration automatically."
+      },
+      {
+        "name": "CameraMotion",
+        "values": [
+          [
+            "DOLLY_IN",
+            "dolly_in"
+          ],
+          [
+            "DOLLY_OUT",
+            "dolly_out"
+          ],
+          [
+            "DOLLY_LEFT",
+            "dolly_left"
+          ],
+          [
+            "DOLLY_RIGHT",
+            "dolly_right"
+          ],
+          [
+            "JIB_UP",
+            "jib_up"
+          ],
+          [
+            "JIB_DOWN",
+            "jib_down"
+          ],
+          [
+            "STATIC",
+            "static"
+          ],
+          [
+            "FOCUS_SHIFT",
+            "focus_shift"
+          ]
+        ],
+        "description": "Optional camera motion applied to the generated video."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio of the generated video. If 'auto', the aspect ratio will be determined automatically based on the input image."
+      }
+    ],
+    "moduleName": "image_to_video"
+  },
+  {
+    "endpointId": "lightricks/ltx-2.5/image-to-video/pro",
+    "className": "Ltx25ImageToVideoPro",
+    "docstring": "LTX 2.5 animates a still into video with synchronized audio in a quality-optimized pass.",
+    "tags": [
+      "generation",
+      "image-to-video",
+      "img2vid",
+      "video",
+      "ltx",
+      "ltx-2-5",
+      "audio",
+      "quality"
+    ],
+    "useCases": [
+      "Deliver a final animated still",
+      "Produce high-fidelity motion from key art",
+      "Animate product photography with sound",
+      "Finish an approved motion draft",
+      "Create polished clips from images"
+    ],
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The URL of the start image to use for the generated video.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "The resolution of the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "fps",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 25,
+        "description": "The frames per second of the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Fps",
+        "enumValues": [
+          24,
+          25,
+          50
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "The duration of the generated video in seconds, up to 10 seconds. Set to 'auto' to let the model choose the duration automatically.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          6,
+          8,
+          10,
+          "auto"
+        ]
+      },
+      {
+        "name": "end_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "The URL of the end image to use for the generated video. When provided, generates a transition video between start and end frames.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "end_image_url"
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt to use for the generated video",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 5000
+      },
+      {
+        "name": "camera_motion",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": null,
+        "description": "Optional camera motion applied to the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "CameraMotion",
+        "enumValues": [
+          "dolly_in",
+          "dolly_out",
+          "dolly_left",
+          "dolly_right",
+          "jib_up",
+          "jib_down",
+          "static",
+          "focus_shift"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "The aspect ratio of the generated video. If 'auto', the aspect ratio will be determined automatically based on the input image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "auto",
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate audio for the generated video",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video file",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_720P",
+            "720p"
+          ],
+          [
+            "VALUE_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "The resolution of the generated video."
+      },
+      {
+        "name": "Fps",
+        "values": [
+          [
+            "VALUE_24",
+            24
+          ],
+          [
+            "VALUE_25",
+            25
+          ],
+          [
+            "VALUE_50",
+            50
+          ]
+        ],
+        "description": "The frames per second of the generated video."
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_6",
+            6
+          ],
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_10",
+            10
+          ],
+          [
+            "AUTO",
+            "auto"
+          ]
+        ],
+        "description": "The duration of the generated video in seconds, up to 10 seconds. Set to 'auto' to let the model choose the duration automatically."
+      },
+      {
+        "name": "CameraMotion",
+        "values": [
+          [
+            "DOLLY_IN",
+            "dolly_in"
+          ],
+          [
+            "DOLLY_OUT",
+            "dolly_out"
+          ],
+          [
+            "DOLLY_LEFT",
+            "dolly_left"
+          ],
+          [
+            "DOLLY_RIGHT",
+            "dolly_right"
+          ],
+          [
+            "JIB_UP",
+            "jib_up"
+          ],
+          [
+            "JIB_DOWN",
+            "jib_down"
+          ],
+          [
+            "STATIC",
+            "static"
+          ],
+          [
+            "FOCUS_SHIFT",
+            "focus_shift"
+          ]
+        ],
+        "description": "Optional camera motion applied to the generated video."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio of the generated video. If 'auto', the aspect ratio will be determined automatically based on the input image."
+      }
+    ],
+    "moduleName": "image_to_video"
+  },
+  {
+    "endpointId": "minimax/h3/image-to-video/lora",
+    "className": "MinimaxH3ImageToVideoLora",
+    "docstring": "MiniMax H3 animates an image into video with synchronized audio, with LoRA support for subject consistency.",
+    "tags": [
+      "generation",
+      "image-to-video",
+      "img2vid",
+      "video",
+      "minimax",
+      "h3",
+      "lora",
+      "audio"
+    ],
+    "useCases": [
+      "Animate a still with a trained subject",
+      "Hold character identity across clips",
+      "Apply a custom style to animation",
+      "Generate video with matching audio",
+      "Produce consistent series content"
+    ],
+    "inputFields": [
+      {
+        "name": "end_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Optional URL of the image to use as the last frame, for first-to-last keyframe generation.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "end_image_url"
+      },
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Random seed. A random seed is selected when omitted.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5,
+        "description": "The duration of the video in seconds.",
+        "fieldType": "input",
+        "required": false,
+        "min": 5,
+        "max": 15
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Optional URL of the image to use as the first frame. When provided, the output aspect ratio follows this image. When omitted, the request is handled as text-to-video (16:9 by default).",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "prompt_expansion_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "balanced",
+        "description": "How much effort to spend rewriting the prompt before generation. 'disabled' skips prompt expansion. 'fast' returns in about a second. 'quality' spends up to ~30s on a richer prompt. 'balanced' picks per request.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "PromptExpansionMode",
+        "enumValues": [
+          "disabled",
+          "fast",
+          "balanced",
+          "quality"
+        ]
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, the safety checker will be enabled.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "2K",
+        "description": "The resolution of the generated video. 480P and 768P are native generation modes; 2K and 4K upscale a 768P base result.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480P",
+          "768P",
+          "2K",
+          "4K"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 50000
+      },
+      {
+        "name": "sync_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Return the generated video as base64 instead of a CDN URL.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "loras",
+        "tsType": "LoRAInput[]",
+        "propType": "list[LoRAInput]",
+        "default": [],
+        "description": "List of LoRA adapters to apply to the transformer.",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 3
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "expanded_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt after expansion, as sent to the model. Null when prompt expansion was disabled, left the prompt unchanged, or was performed internally by MiniMax's hosted API.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "PromptExpansionMode",
+        "values": [
+          [
+            "DISABLED",
+            "disabled"
+          ],
+          [
+            "FAST",
+            "fast"
+          ],
+          [
+            "BALANCED",
+            "balanced"
+          ],
+          [
+            "QUALITY",
+            "quality"
+          ]
+        ],
+        "description": "How much effort to spend rewriting the prompt before generation. 'disabled' skips prompt expansion. 'fast' returns in about a second. 'quality' spends up to ~30s on a richer prompt. 'balanced' picks per request."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480P"
+          ],
+          [
+            "VALUE_768P",
+            "768P"
+          ],
+          [
+            "VALUE_2K",
+            "2K"
+          ],
+          [
+            "VALUE_4K",
+            "4K"
+          ]
+        ],
+        "description": "The resolution of the generated video. 480P and 768P are native generation modes; 2K and 4K upscale a 768P base result."
+      }
+    ],
+    "moduleName": "image_to_video"
+  },
+  {
+    "endpointId": "mirage-api/avatar-x/reference-to-video",
+    "className": "AvatarXReferenceToVideo",
+    "docstring": "Avatar X generates a talking-head video from reference material, preserving the referenced identity.",
+    "tags": [
+      "generation",
+      "image-to-video",
+      "img2vid",
+      "video",
+      "avatar",
+      "lipsync",
+      "talking-head",
+      "reference",
+      "mirage"
+    ],
+    "useCases": [
+      "Animate a reference portrait as a presenter",
+      "Keep one avatar identity across videos",
+      "Produce lip-synced spokesperson clips",
+      "Reuse a cast member in new scripts",
+      "Generate consistent avatar series"
+    ],
+    "inputFields": [
+      {
+        "name": "video_reference",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Publicly fetchable HTTPS URL of the reference video; no cookies or authorization headers. Takes precedence over image_reference_url when both are supplied. Supports H.264, H.265/HEVC, or ProRes in .mp4, .mov, or .m4v and VP8 or VP9 in .webm, from 1 to 120 seconds and up to 1 GiB, with exactly one video stream and a 9:16 or 16:9 display aspect ratio (within 5%). The video must contain a usable one-second reference window; any audio track is ignored.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "video_reference_url"
+      },
+      {
+        "name": "image_reference",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Publicly fetchable HTTPS URL of the reference image; no cookies or authorization headers. Ignored when video_reference_url is also supplied. Supports one static .jpg, .jpeg, .png, or .webp image up to 25 MiB, with a short edge of at least 512 px, no edge over 8192 px, at most 25 megapixels, and a 9:16 or 16:9 aspect ratio (within 5%).",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "image_reference_url"
+      },
+      {
+        "name": "avatar",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": null,
+        "description": "Stock visual that can be used instead of an image or video reference; it does not supply audio. Browse the [avatar catalog](https://captions.ai/help/docs/api/actor-catalog) to preview the available visuals and copy the exact Avatar value. Default and None both mean no avatar. Any supplied image or video reference overrides the selection, and audio always comes from audio_url.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Avatar",
+        "enumValues": [
+          "None",
+          "Ayesha",
+          "Ayesha (16:9)",
+          "Farhan",
+          "Farhan (16:9)",
+          "Giulia",
+          "Giulia (16:9)",
+          "Jasmine",
+          "Jasmine (16:9)",
+          "Luke",
+          "Luke (16:9)",
+          "Maya",
+          "Maya (16:9)",
+          "Michael",
+          "Michael (16:9)",
+          "Neha",
+          "Neha (16:9)",
+          "Tariq",
+          "Tariq (16:9)",
+          "Valerie",
+          "Valerie (16:9)"
+        ]
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Publicly fetchable HTTPS URL of the driving audio; no cookies or authorization headers. Supports MP3, PCM WAV or AIFF, AAC or ALAC, Opus or Vorbis, and FLAC audio from 3 to 180 seconds and up to 64 MiB, with one mono or stereo stream sampled from 8 to 48 kHz. The generated video follows this audio.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "audio_url"
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Avatar",
+        "values": [
+          [
+            "NONE",
+            "None"
+          ],
+          [
+            "AYESHA",
+            "Ayesha"
+          ],
+          [
+            "AYESHA_16_9",
+            "Ayesha (16:9)"
+          ],
+          [
+            "FARHAN",
+            "Farhan"
+          ],
+          [
+            "FARHAN_16_9",
+            "Farhan (16:9)"
+          ],
+          [
+            "GIULIA",
+            "Giulia"
+          ],
+          [
+            "GIULIA_16_9",
+            "Giulia (16:9)"
+          ],
+          [
+            "JASMINE",
+            "Jasmine"
+          ],
+          [
+            "JASMINE_16_9",
+            "Jasmine (16:9)"
+          ],
+          [
+            "LUKE",
+            "Luke"
+          ],
+          [
+            "LUKE_16_9",
+            "Luke (16:9)"
+          ],
+          [
+            "MAYA",
+            "Maya"
+          ],
+          [
+            "MAYA_16_9",
+            "Maya (16:9)"
+          ],
+          [
+            "MICHAEL",
+            "Michael"
+          ],
+          [
+            "MICHAEL_16_9",
+            "Michael (16:9)"
+          ],
+          [
+            "NEHA",
+            "Neha"
+          ],
+          [
+            "NEHA_16_9",
+            "Neha (16:9)"
+          ],
+          [
+            "TARIQ",
+            "Tariq"
+          ],
+          [
+            "TARIQ_16_9",
+            "Tariq (16:9)"
+          ],
+          [
+            "VALERIE",
+            "Valerie"
+          ],
+          [
+            "VALERIE_16_9",
+            "Valerie (16:9)"
+          ]
+        ],
+        "description": "Stock visual that can be used instead of an image or video reference; it does not supply audio. Browse the [avatar catalog](https://captions.ai/help/docs/api/actor-catalog) to preview the available visuals and copy the exact Avatar value. Default and None both mean no avatar. Any supplied image or video reference overrides the selection, and audio always comes from audio_url."
+      }
+    ],
+    "moduleName": "image_to_video"
+  },
+  {
+    "endpointId": "openrouter/router/enterprise",
+    "className": "OpenRouterEnterprise",
+    "docstring": "Runs any OpenRouter LLM through fal on the enterprise routing tier.",
+    "tags": [
+      "llm",
+      "text",
+      "chat",
+      "openrouter",
+      "enterprise"
+    ],
+    "useCases": [
+      "Route prompts to any OpenRouter model",
+      "Compare models behind one endpoint",
+      "Run enterprise-tier inference",
+      "Fall back across providers",
+      "Centralize LLM access through fal"
+    ],
+    "inputFields": [
+      {
+        "name": "enable_web_search",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Give the model access to real-time web information via OpenRouter's web search server tool. When enabled, the model decides when to search and may search multiple times per request. Search costs are charged in addition to token usage.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reasoning",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Should reasoning be the part of the final answer.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt to be used for the chat completion",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "System prompt to provide context or instructions to the model",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "model",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Name of the model to use. Charged based on actual token usage.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "temperature",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "This setting influences the variety in the model's responses. Lower values lead to more predictable and typical responses, while higher values encourage more diverse and less common responses. At 0, the model always gives the same response for a given input.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "web_search_options",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Options for web search (engine, result limits, domain filters, ...). Ignored unless enable_web_search is true.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "max_tokens",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "This sets the upper limit for the number of tokens the model can generate in response. It won't produce more than this limit. The maximum value is the context length minus the prompt length.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1
+      }
+    ],
+    "outputType": "dict",
+    "outputFields": [
+      {
+        "name": "error",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Error message if an error occurred",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "partial",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Whether the output is partial",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "reasoning",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generated reasoning for the final answer",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "output",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generated output",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "usage",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Token usage information",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [],
+    "moduleName": "llm"
+  },
+  {
+    "endpointId": "meshy/v7/text-to-3d",
+    "className": "MeshyV7TextTo3d",
+    "docstring": "Meshy V7 generates a textured PBR-ready mesh from text, with game-ready topology at a target polygon count.",
+    "tags": [
+      "generation",
+      "text-to-3d",
+      "3d",
+      "mesh",
+      "pbr",
+      "meshy"
+    ],
+    "useCases": [
+      "Generate a game prop from a prompt",
+      "Create PBR assets without modelling",
+      "Hit a polygon budget from text",
+      "Prototype 3D concepts quickly",
+      "Fill an asset library from descriptions"
+    ],
+    "inputFields": [
+      {
+        "name": "pose_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "",
+        "description": "Pose mode for the generated model. 'a-pose' generates an A-pose, 't-pose' generates a T-pose, empty string for no specific pose.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "PoseMode",
+        "enumValues": [
+          "a-pose",
+          "t-pose",
+          ""
+        ]
+      },
+      {
+        "name": "symmetry_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Controls symmetry behavior during model generation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "SymmetryMode",
+        "enumValues": [
+          "off",
+          "auto",
+          "on"
+        ]
+      },
+      {
+        "name": "rigging_height_meters",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1.7,
+        "description": "Approximate height of the character in meters. Only used when enable_rigging is true.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "texture_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "2D image to guide the texturing process (only used in 'full' mode)",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "texture_image_url"
+      },
+      {
+        "name": "mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "full",
+        "description": "Generation mode. 'preview' returns untextured geometry only, 'full' returns textured model (preview + refine).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Mode",
+        "enumValues": [
+          "preview",
+          "full"
+        ]
+      },
+      {
+        "name": "topology",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "triangle",
+        "description": "Specify the topology of the generated model. Quad for smooth surfaces, Triangle for detailed geometry.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Topology",
+        "enumValues": [
+          "quad",
+          "triangle"
+        ]
+      },
+      {
+        "name": "enable_animation",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Apply an animation preset to the rigged model. Requires enable_rigging to be true.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "is_a_t_pose",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Deprecated: use pose_mode instead. When true, generates a T-pose model.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "model_type",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "standard",
+        "description": "Type of 3D mesh generation. 'standard' produces a regular high-detail mesh; 'lowpoly' produces a low-poly mesh optimized for cleaner polygons; 'smart-topology' uses Meshy-T2 for clean, natively separated parts on the geometry (preview) step. When set to 'lowpoly', the remesh controls (topology, target_polycount, should_remesh) are ignored by Meshy.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ModelType",
+        "enumValues": [
+          "standard",
+          "lowpoly",
+          "smart-topology"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Describe what kind of object the 3D model is. Maximum 600 characters.",
+        "fieldType": "input",
+        "required": true,
+        "max": 600
+      },
+      {
+        "name": "animation_action_id",
+        "tsType": "number",
+        "propType": "int",
+        "default": 92,
+        "description": "Animation preset ID from Meshy's library. Only used when enable_animation is true; in that case it must be in [0, 696] (``0`` is the \"Idle\" preset) and is otherwise rejected with a 422. See https://docs.meshy.ai/en/api/animation-library for available action IDs.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 696
+      },
+      {
+        "name": "target_polycount",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30000,
+        "description": "Target number of polygons in the generated model. When model_type is 'smart-topology' and this is left unset, Meshy's lower smart-topology default (4,000) is used instead; smart topology accepts at most 15,000.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 300000
+      },
+      {
+        "name": "ultra_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable higher-fidelity geometry with finer surface detail on the preview (geometry) step. Only available for standard generation (ultra requires Meshy-7; it cannot be combined with smart topology or lowpoly).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "enable_rigging",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Automatically rig the generated model as a humanoid character. Includes basic walking and running animations. Best results with humanoid characters that have clearly defined limbs.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Seed for reproducible results. Same prompt and seed usually generate the same result.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "texture_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Additional text prompt to guide the texturing process (only used in 'full' mode)",
+        "fieldType": "input",
+        "required": false,
+        "max": 600
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, input data will be checked for safety before processing.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "should_remesh",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to enable the remesh phase. When false, returns unprocessed triangular mesh.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "enable_pbr",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Generate PBR Maps (metallic, roughness, normal) in addition to base color.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "enable_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Whether to enable prompt expansion. This will use a large language model to expand the prompt with additional details while maintaining the original meaning.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "model_3d",
+    "outputFields": [
+      {
+        "name": "rig_task_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Rigging task ID. Only present when enable_rigging is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "basic_animations",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Basic walking and running animations. Only present when enable_rigging is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "rigged_character_fbx",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Rigged character in FBX format. Only present when enable_rigging is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The seed used for generation",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "actual_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The actual prompt used if prompt expansion was enabled",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "animation_glb",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Animated 3D model in GLB format. Only present when enable_animation is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "texture_urls",
+        "tsType": "TextureFiles[]",
+        "propType": "list[TextureFiles]",
+        "default": [],
+        "description": "Array of texture file objects",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "rigged_character_glb",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Rigged character in GLB format. Only present when enable_rigging is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "animation_fbx",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Animated 3D model in FBX format. Only present when enable_animation is true.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "model_urls",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URLs for different 3D model formats",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "model_glb",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Generated 3D object in GLB format.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The text prompt used for generation",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "thumbnail",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Preview thumbnail of the generated model",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "PoseMode",
+        "values": [
+          [
+            "A_POSE",
+            "a-pose"
+          ],
+          [
+            "T_POSE",
+            "t-pose"
+          ],
+          [
+            "VALUE_UNKNOWN",
+            ""
+          ]
+        ],
+        "description": "Pose mode for the generated model. 'a-pose' generates an A-pose, 't-pose' generates a T-pose, empty string for no specific pose."
+      },
+      {
+        "name": "SymmetryMode",
+        "values": [
+          [
+            "OFF",
+            "off"
+          ],
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "ON",
+            "on"
+          ]
+        ],
+        "description": "Controls symmetry behavior during model generation."
+      },
+      {
+        "name": "Mode",
+        "values": [
+          [
+            "PREVIEW",
+            "preview"
+          ],
+          [
+            "FULL",
+            "full"
+          ]
+        ],
+        "description": "Generation mode. 'preview' returns untextured geometry only, 'full' returns textured model (preview + refine)."
+      },
+      {
+        "name": "Topology",
+        "values": [
+          [
+            "QUAD",
+            "quad"
+          ],
+          [
+            "TRIANGLE",
+            "triangle"
+          ]
+        ],
+        "description": "Specify the topology of the generated model. Quad for smooth surfaces, Triangle for detailed geometry."
+      },
+      {
+        "name": "ModelType",
+        "values": [
+          [
+            "STANDARD",
+            "standard"
+          ],
+          [
+            "LOWPOLY",
+            "lowpoly"
+          ],
+          [
+            "SMART_TOPOLOGY",
+            "smart-topology"
+          ]
+        ],
+        "description": "Type of 3D mesh generation. 'standard' produces a regular high-detail mesh; 'lowpoly' produces a low-poly mesh optimized for cleaner polygons; 'smart-topology' uses Meshy-T2 for clean, natively separated parts on the geometry (preview) step. When set to 'lowpoly', the remesh controls (topology, target_polycount, should_remesh) are ignored by Meshy."
+      }
+    ],
+    "moduleName": "text_to_3d"
+  },
+  {
+    "endpointId": "minimax/music-3",
+    "className": "MinimaxMusic3",
+    "docstring": "MiniMax Music 3 generates complete songs up to five minutes long from a prompt and lyrics.",
+    "tags": [
+      "generation",
+      "audio",
+      "music",
+      "text-to-audio",
+      "song",
+      "minimax"
+    ],
+    "useCases": [
+      "Generate a full-length song from a brief",
+      "Write backing music for a video",
+      "Produce royalty-free tracks",
+      "Turn lyrics into a finished song",
+      "Create theme music for a product"
+    ],
+    "inputFields": [
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Random seed for reproducibility. If not provided, a random seed will be used.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "float",
+        "default": 60,
+        "description": "Upper bound on the generated audio length in seconds. The model may stop earlier; the actual duration is returned in the output.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 300
+      },
+      {
+        "name": "lyrics",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The lyrics to sing. Structure tags such as [intro], [verse], [pre-chorus], [chorus], [post-chorus], [bridge], [instrumental], [solo] and [outro] must each be on their own line; text on the same line as a leading tag is dropped by the model's input contract.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "guidance_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1.7,
+        "description": "Classifier-free guidance scale of the flow-matching stage.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 20
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Music description: style, mood, vocals, instrumentation and arrangement. For precise control use a Structured Caption with global metadata (genre, BPM, key, emotional progression), vocal details, and a section-by-section arrangement.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "num_inference_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 30,
+        "description": "Number of flow-matching Euler steps per 8-second denoising chunk. More steps improve quality at the cost of speed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 100
+      }
+    ],
+    "outputType": "audio",
+    "outputFields": [
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The random seed used for the generation process.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "The actual duration of the generated audio in seconds (may be shorter than the requested duration).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "The generated audio file (44.1 kHz 16-bit stereo WAV).",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [],
+    "moduleName": "text_to_audio"
+  },
+  {
+    "endpointId": "bria/fibo-gen-1.5/text-to-image",
+    "className": "BriaFiboGen15TextToImage",
+    "docstring": "Fibo Gen 1.5 generates images from text or JSON-structured prompts, trained on licensed data for commercial use.",
+    "tags": [
+      "generation",
+      "text-to-image",
+      "txt2img",
+      "image",
+      "bria",
+      "fibo",
+      "typography",
+      "licensed"
+    ],
+    "useCases": [
+      "Generate commercially safe product visuals",
+      "Render accurate typography in images",
+      "Drive generation from structured JSON prompts",
+      "Produce photoreal marketing imagery",
+      "Create on-brand illustrations at scale"
+    ],
+    "inputFields": [
+      {
+        "name": "structured_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The structured prompt to generate an image from.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "sync_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, returns the image directly in the response (increases latency).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "style_preset",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "No Style",
+        "description": "Style preset is a named, predefined visual look you can optionally apply to an image generation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "StylePreset",
+        "enumValues": [
+          "No Style",
+          "Photoreal"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5555,
+        "description": "Random seed for reproducibility.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio. Options: 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "1:1",
+          "2:3",
+          "3:2",
+          "3:4",
+          "4:3",
+          "4:5",
+          "5:4",
+          "9:16",
+          "16:9"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Prompt for image generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1MP",
+        "description": "Output image resolution",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "1MP",
+          "4MP"
+        ]
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "structured_prompt",
+        "tsType": "object",
+        "propType": "dict[str, any]",
+        "default": "",
+        "description": "Current prompt.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Generated image.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "images",
+        "tsType": "object[]",
+        "propType": "list[dict[str, any]]",
+        "default": [],
+        "description": "Generated images.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "StylePreset",
+        "values": [
+          [
+            "NO_STYLE",
+            "No Style"
+          ],
+          [
+            "PHOTOREAL",
+            "Photoreal"
+          ]
+        ],
+        "description": "Style preset is a named, predefined visual look you can optionally apply to an image generation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_4_5",
+            "4:5"
+          ],
+          [
+            "RATIO_5_4",
+            "5:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ]
+        ],
+        "description": "Aspect ratio. Options: 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_1MP",
+            "1MP"
+          ],
+          [
+            "VALUE_4MP",
+            "4MP"
+          ]
+        ],
+        "description": "Output image resolution"
+      }
+    ],
+    "moduleName": "text_to_image"
+  },
+  {
+    "endpointId": "xai/grok-imagine-image/v2.0/text-to-image",
+    "className": "GrokImagineImageV20",
+    "docstring": "Grok Imagine 2.0 generates images from text.",
+    "tags": [
+      "generation",
+      "text-to-image",
+      "txt2img",
+      "image",
+      "xai",
+      "grok",
+      "grok-imagine"
+    ],
+    "useCases": [
+      "Generate illustrations from a prompt",
+      "Produce concept art quickly",
+      "Create social imagery at scale",
+      "Render product visuals",
+      "Explore visual directions for a brief"
+    ],
+    "inputFields": [
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text description of the desired image.",
+        "fieldType": "input",
+        "required": true,
+        "max": 8000
+      },
+      {
+        "name": "num_images",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Number of images to generate.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1k",
+        "description": "Resolution of the generated image. `1k` for standard resolution, `2k` for high resolution.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "1k",
+          "2k"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio of the generated image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "2:1",
+          "20:9",
+          "19.5:9",
+          "16:9",
+          "4:3",
+          "3:2",
+          "1:1",
+          "2:3",
+          "3:4",
+          "9:16",
+          "9:19.5",
+          "9:20",
+          "1:2"
+        ]
+      },
+      {
+        "name": "sync_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If `True`, the media will be returned as a data URI and the output data won't be available in the request history.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "quality",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Quality level of the generated image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Quality",
+        "enumValues": [
+          "low",
+          "medium"
+        ]
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "jpeg",
+        "description": "The format of the generated image.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpeg",
+          "png",
+          "webp"
+        ]
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "images",
+        "tsType": "ImageFile[]",
+        "propType": "list[ImageFile]",
+        "default": [],
+        "description": "The URL of the generated image.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "revised_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The enhanced prompt that was used to generate the image.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_1K",
+            "1k"
+          ],
+          [
+            "VALUE_2K",
+            "2k"
+          ]
+        ],
+        "description": "Resolution of the generated image. `1k` for standard resolution, `2k` for high resolution."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_2_1",
+            "2:1"
+          ],
+          [
+            "RATIO_20_9",
+            "20:9"
+          ],
+          [
+            "VALUE_19_5_9",
+            "19.5:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "VALUE_9_19_5",
+            "9:19.5"
+          ],
+          [
+            "RATIO_9_20",
+            "9:20"
+          ],
+          [
+            "RATIO_1_2",
+            "1:2"
+          ]
+        ],
+        "description": "Aspect ratio of the generated image."
+      },
+      {
+        "name": "Quality",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ]
+        ],
+        "description": "Quality level of the generated image."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPEG",
+            "jpeg"
+          ],
+          [
+            "PNG",
+            "png"
+          ],
+          [
+            "WEBP",
+            "webp"
+          ]
+        ],
+        "description": "The format of the generated image."
+      }
+    ],
+    "moduleName": "text_to_image"
+  },
+  {
+    "endpointId": "recraft/v4/style/text-to-image",
+    "className": "RecraftV4StyleTextToImage",
+    "docstring": "Recraft V4 Styles generates raster images that hold a consistent style from a style id or reference images.",
+    "tags": [
+      "generation",
+      "text-to-image",
+      "txt2img",
+      "image",
+      "recraft",
+      "recraft-v4",
+      "style",
+      "consistency"
+    ],
+    "useCases": [
+      "Generate a set of on-style images",
+      "Apply a saved style id to a prompt",
+      "Keep campaign visuals consistent",
+      "Produce illustrations in a house style",
+      "Render variations without style drift"
+    ],
+    "inputFields": [
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 10000
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, the safety checker will be enabled. Disabling it requires account authorization; unauthorized requests are always checked.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": null,
+        "description": "The URLs of the style reference images. Supports PNG, JPG, and WEBP; provide between 1 and 10 images.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10,
+        "apiParamName": "image_urls"
+      },
+      {
+        "name": "style_match",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": null,
+        "description": "Override how closely the generation follows the custom style.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "StyleMatch",
+        "enumValues": [
+          "precise",
+          "flexible"
+        ]
+      },
+      {
+        "name": "colors",
+        "tsType": "RGBColor[]",
+        "propType": "list[RGBColor]",
+        "default": [],
+        "description": "An array of preferable colors",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "square_hd",
+        "description": "",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "square_hd",
+          "square",
+          "portrait_4_3",
+          "portrait_16_9",
+          "landscape_4_3",
+          "landscape_16_9"
+        ]
+      },
+      {
+        "name": "background_color",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The preferable background color of the generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "style_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The ID of an existing V4 custom style.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "images",
+        "tsType": "File[]",
+        "propType": "list[File]",
+        "default": [],
+        "description": "",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "style_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The custom style used or created for this generation.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "StyleMatch",
+        "values": [
+          [
+            "PRECISE",
+            "precise"
+          ],
+          [
+            "FLEXIBLE",
+            "flexible"
+          ]
+        ],
+        "description": "Override how closely the generation follows the custom style."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "SQUARE_HD",
+            "square_hd"
+          ],
+          [
+            "SQUARE",
+            "square"
+          ],
+          [
+            "PORTRAIT_4_3",
+            "portrait_4_3"
+          ],
+          [
+            "PORTRAIT_16_9",
+            "portrait_16_9"
+          ],
+          [
+            "LANDSCAPE_4_3",
+            "landscape_4_3"
+          ],
+          [
+            "LANDSCAPE_16_9",
+            "landscape_16_9"
+          ]
+        ],
+        "description": ""
+      }
+    ],
+    "moduleName": "text_to_image"
+  },
+  {
+    "endpointId": "recraft/v4/style/text-to-vector",
+    "className": "RecraftV4StyleTextToVector",
+    "docstring": "Recraft V4 Styles generates vector images that hold a consistent style from a style id or reference images.",
+    "tags": [
+      "generation",
+      "text-to-image",
+      "txt2img",
+      "image",
+      "recraft",
+      "recraft-v4",
+      "style",
+      "vector",
+      "svg"
+    ],
+    "useCases": [
+      "Generate on-style vector icons",
+      "Produce scalable brand illustrations",
+      "Build a consistent icon set",
+      "Create logos in a saved style",
+      "Deliver print-ready vector art"
+    ],
+    "inputFields": [
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 10000
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, the safety checker will be enabled. Disabling it requires account authorization; unauthorized requests are always checked.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": null,
+        "description": "The URLs of the style reference images. Supports PNG, JPG, and WEBP; provide between 1 and 10 images.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10,
+        "apiParamName": "image_urls"
+      },
+      {
+        "name": "style_match",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": null,
+        "description": "Override how closely the generation follows the custom style.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "StyleMatch",
+        "enumValues": [
+          "precise",
+          "flexible"
+        ]
+      },
+      {
+        "name": "colors",
+        "tsType": "RGBColor[]",
+        "propType": "list[RGBColor]",
+        "default": [],
+        "description": "An array of preferable colors",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "square_hd",
+        "description": "",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "square_hd",
+          "square",
+          "portrait_4_3",
+          "portrait_16_9",
+          "landscape_4_3",
+          "landscape_16_9"
+        ]
+      },
+      {
+        "name": "background_color",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The preferable background color of the generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "style_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The ID of an existing V4 custom style.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "images",
+        "tsType": "File[]",
+        "propType": "list[File]",
+        "default": [],
+        "description": "",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "style_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The custom style used or created for this generation.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "StyleMatch",
+        "values": [
+          [
+            "PRECISE",
+            "precise"
+          ],
+          [
+            "FLEXIBLE",
+            "flexible"
+          ]
+        ],
+        "description": "Override how closely the generation follows the custom style."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "SQUARE_HD",
+            "square_hd"
+          ],
+          [
+            "SQUARE",
+            "square"
+          ],
+          [
+            "PORTRAIT_4_3",
+            "portrait_4_3"
+          ],
+          [
+            "PORTRAIT_16_9",
+            "portrait_16_9"
+          ],
+          [
+            "LANDSCAPE_4_3",
+            "landscape_4_3"
+          ],
+          [
+            "LANDSCAPE_16_9",
+            "landscape_16_9"
+          ]
+        ],
+        "description": ""
+      }
+    ],
+    "moduleName": "text_to_image"
+  },
+  {
+    "endpointId": "recraft/v4/style/pro/text-to-image",
+    "className": "RecraftV4StyleProTextToImage",
+    "docstring": "Recraft V4 Styles Pro generates raster images that hold a consistent style from a style id or reference images.",
+    "tags": [
+      "generation",
+      "text-to-image",
+      "txt2img",
+      "image",
+      "recraft",
+      "recraft-v4",
+      "style",
+      "pro",
+      "consistency"
+    ],
+    "useCases": [
+      "Render final on-style raster assets",
+      "Apply a Pro style id at delivery quality",
+      "Keep a campaign visually uniform",
+      "Produce hero imagery in a house style",
+      "Scale approved art direction"
+    ],
+    "inputFields": [
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 10000
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, the safety checker will be enabled. Disabling it requires account authorization; unauthorized requests are always checked.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": null,
+        "description": "The URLs of the style reference images. Supports PNG, JPG, and WEBP; provide between 1 and 10 images.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10,
+        "apiParamName": "image_urls"
+      },
+      {
+        "name": "style_match",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": null,
+        "description": "Override how closely the generation follows the custom style.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "StyleMatch",
+        "enumValues": [
+          "precise",
+          "flexible"
+        ]
+      },
+      {
+        "name": "colors",
+        "tsType": "RGBColor[]",
+        "propType": "list[RGBColor]",
+        "default": [],
+        "description": "An array of preferable colors",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "square_hd",
+        "description": "",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "square_hd",
+          "square",
+          "portrait_4_3",
+          "portrait_16_9",
+          "landscape_4_3",
+          "landscape_16_9"
+        ]
+      },
+      {
+        "name": "background_color",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The preferable background color of the generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "style_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The ID of an existing V4 custom style.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "images",
+        "tsType": "File[]",
+        "propType": "list[File]",
+        "default": [],
+        "description": "",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "style_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The custom style used or created for this generation.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "StyleMatch",
+        "values": [
+          [
+            "PRECISE",
+            "precise"
+          ],
+          [
+            "FLEXIBLE",
+            "flexible"
+          ]
+        ],
+        "description": "Override how closely the generation follows the custom style."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "SQUARE_HD",
+            "square_hd"
+          ],
+          [
+            "SQUARE",
+            "square"
+          ],
+          [
+            "PORTRAIT_4_3",
+            "portrait_4_3"
+          ],
+          [
+            "PORTRAIT_16_9",
+            "portrait_16_9"
+          ],
+          [
+            "LANDSCAPE_4_3",
+            "landscape_4_3"
+          ],
+          [
+            "LANDSCAPE_16_9",
+            "landscape_16_9"
+          ]
+        ],
+        "description": ""
+      }
+    ],
+    "moduleName": "text_to_image"
+  },
+  {
+    "endpointId": "recraft/v4/style/pro/text-to-vector",
+    "className": "RecraftV4StyleProTextToVector",
+    "docstring": "Recraft V4 Styles Pro generates vector images that hold a consistent style from a style id or reference images.",
+    "tags": [
+      "generation",
+      "text-to-image",
+      "txt2img",
+      "image",
+      "recraft",
+      "recraft-v4",
+      "style",
+      "pro",
+      "vector",
+      "svg"
+    ],
+    "useCases": [
+      "Deliver final vector assets on style",
+      "Produce a Pro-quality icon set",
+      "Render scalable brand marks",
+      "Keep vector art consistent across a suite",
+      "Prepare print-ready illustrations"
+    ],
+    "inputFields": [
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 10000
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, the safety checker will be enabled. Disabling it requires account authorization; unauthorized requests are always checked.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": null,
+        "description": "The URLs of the style reference images. Supports PNG, JPG, and WEBP; provide between 1 and 10 images.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10,
+        "apiParamName": "image_urls"
+      },
+      {
+        "name": "style_match",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": null,
+        "description": "Override how closely the generation follows the custom style.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "StyleMatch",
+        "enumValues": [
+          "precise",
+          "flexible"
+        ]
+      },
+      {
+        "name": "colors",
+        "tsType": "RGBColor[]",
+        "propType": "list[RGBColor]",
+        "default": [],
+        "description": "An array of preferable colors",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "image_size",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "square_hd",
+        "description": "",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ImageSize",
+        "enumValues": [
+          "square_hd",
+          "square",
+          "portrait_4_3",
+          "portrait_16_9",
+          "landscape_4_3",
+          "landscape_16_9"
+        ]
+      },
+      {
+        "name": "background_color",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The preferable background color of the generated images.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "style_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The ID of an existing V4 custom style.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "images",
+        "tsType": "File[]",
+        "propType": "list[File]",
+        "default": [],
+        "description": "",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "style_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The custom style used or created for this generation.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "StyleMatch",
+        "values": [
+          [
+            "PRECISE",
+            "precise"
+          ],
+          [
+            "FLEXIBLE",
+            "flexible"
+          ]
+        ],
+        "description": "Override how closely the generation follows the custom style."
+      },
+      {
+        "name": "ImageSize",
+        "values": [
+          [
+            "SQUARE_HD",
+            "square_hd"
+          ],
+          [
+            "SQUARE",
+            "square"
+          ],
+          [
+            "PORTRAIT_4_3",
+            "portrait_4_3"
+          ],
+          [
+            "PORTRAIT_16_9",
+            "portrait_16_9"
+          ],
+          [
+            "LANDSCAPE_4_3",
+            "landscape_4_3"
+          ],
+          [
+            "LANDSCAPE_16_9",
+            "landscape_16_9"
+          ]
+        ],
+        "description": ""
+      }
+    ],
+    "moduleName": "text_to_image"
+  },
+  {
+    "endpointId": "alibaba/wan-3.0/text-to-video",
+    "className": "Wan30TextToVideo",
+    "docstring": "Wan 3.0 generates video from a text prompt with smoother motion and stronger scene coherence than Wan 2.x.",
+    "tags": [
+      "generation",
+      "text-to-video",
+      "txt2vid",
+      "video",
+      "wan",
+      "wan-3"
+    ],
+    "useCases": [
+      "Generate cinematic shots from a written prompt",
+      "Produce social clips without filming",
+      "Storyboard a scene as motion",
+      "Iterate on shot ideas quickly",
+      "Create B-roll for edits"
+    ],
+    "inputFields": [
+      {
+        "name": "audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Include generated audio.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for the generated video.",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 5000
+      },
+      {
+        "name": "duration",
+        "tsType": "string",
+        "propType": "str",
+        "default": 5,
+        "description": "Output duration in seconds. Set to null for smart duration, which lets the model pick a length from the prompt and reference media.",
+        "fieldType": "input",
+        "required": false,
+        "min": 2,
+        "max": 30
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable content moderation for input and output. Disabling it requires account authorization; unauthorized requests are always checked.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "enable_thinking",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable enhanced reasoning before generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "adaptive",
+        "description": "Output aspect ratio, or adaptive selection.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "adaptive",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      },
+      {
+        "name": "enable_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable intelligent prompt rewriting. Disabling it can save roughly 20-60 seconds of latency but is likely to degrade generation quality.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "Output video resolution tier.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p",
+          "1080p"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video file.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Generated video duration in seconds.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "actual_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "ADAPTIVE",
+            "adaptive"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Output aspect ratio, or adaptive selection."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480p"
+          ],
+          [
+            "VALUE_720P",
+            "720p"
+          ],
+          [
+            "VALUE_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Output video resolution tier."
+      }
+    ],
+    "moduleName": "text_to_video"
+  },
+  {
+    "endpointId": "alibaba/wan-3.0-prime/text-to-video",
+    "className": "Wan30PrimeTextToVideo",
+    "docstring": "Wan 3.0 Prime generates video from text with faster turnaround than the base Wan 3.0 endpoint.",
+    "tags": [
+      "generation",
+      "text-to-video",
+      "txt2vid",
+      "video",
+      "wan",
+      "wan-3",
+      "fast"
+    ],
+    "useCases": [
+      "Iterate on shot ideas at speed",
+      "Preview a prompt before a final render",
+      "Generate short social videos in bulk",
+      "Draft motion for a storyboard",
+      "Explore several takes of one scene"
+    ],
+    "inputFields": [
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "Output video resolution tier.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable content moderation for input and output. Disabling it requires account authorization; unauthorized requests are always checked.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      },
+      {
+        "name": "enable_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable intelligent prompt rewriting. Disabling it can save roughly 20-60 seconds of latency but is likely to degrade generation quality.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Include generated audio.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "duration",
+        "tsType": "string",
+        "propType": "str",
+        "default": 5,
+        "description": "Output duration in seconds. Set to null for smart duration, which lets the model pick a length from the prompt and reference media.",
+        "fieldType": "input",
+        "required": false,
+        "min": 2,
+        "max": 30
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "adaptive",
+        "description": "Output aspect ratio, or adaptive selection.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "adaptive",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for the generated video.",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 5000
+      },
+      {
+        "name": "enable_thinking",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable enhanced reasoning before generation.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Generated video duration in seconds.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "actual_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video file.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480p"
+          ],
+          [
+            "VALUE_720P",
+            "720p"
+          ],
+          [
+            "VALUE_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Output video resolution tier."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "ADAPTIVE",
+            "adaptive"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Output aspect ratio, or adaptive selection."
+      }
+    ],
+    "moduleName": "text_to_video"
+  },
+  {
+    "endpointId": "bytedance/seedance-2.5/text-to-video",
+    "className": "BytedanceSeedance25TextToVideo",
+    "docstring": "Seedance 2.5 generates a native 30-second single-shot video at up to 720p from one text prompt.",
+    "tags": [
+      "generation",
+      "text-to-video",
+      "txt2vid",
+      "video",
+      "seedance",
+      "bytedance",
+      "long-form"
+    ],
+    "useCases": [
+      "Generate a full 30-second shot in one pass",
+      "Avoid stitching several short clips",
+      "Produce single-take narrative video",
+      "Create long social videos from a prompt",
+      "Keep lighting consistent across a shot"
+    ],
+    "inputFields": [
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "720p",
+        "description": "Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The text prompt used to generate the video",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          "auto",
+          "4",
+          "5",
+          "6",
+          "7",
+          "8",
+          "9",
+          "10",
+          "11",
+          "12",
+          "13",
+          "14",
+          "15",
+          "16",
+          "17",
+          "18",
+          "19",
+          "20",
+          "21",
+          "22",
+          "23",
+          "24",
+          "25",
+          "26",
+          "27",
+          "28",
+          "29",
+          "30"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "bitrate_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "standard",
+        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "BitrateMode",
+        "enumValues": [
+          "standard",
+          "high"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "auto",
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "end_user_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The unique user ID of the end user.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video file.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480p"
+          ],
+          [
+            "VALUE_720P",
+            "720p"
+          ],
+          [
+            "VALUE_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality."
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "VALUE_4",
+            "4"
+          ],
+          [
+            "VALUE_5",
+            "5"
+          ],
+          [
+            "VALUE_6",
+            "6"
+          ],
+          [
+            "VALUE_7",
+            "7"
+          ],
+          [
+            "VALUE_8",
+            "8"
+          ],
+          [
+            "VALUE_9",
+            "9"
+          ],
+          [
+            "VALUE_10",
+            "10"
+          ],
+          [
+            "VALUE_11",
+            "11"
+          ],
+          [
+            "VALUE_12",
+            "12"
+          ],
+          [
+            "VALUE_13",
+            "13"
+          ],
+          [
+            "VALUE_14",
+            "14"
+          ],
+          [
+            "VALUE_15",
+            "15"
+          ],
+          [
+            "VALUE_16",
+            "16"
+          ],
+          [
+            "VALUE_17",
+            "17"
+          ],
+          [
+            "VALUE_18",
+            "18"
+          ],
+          [
+            "VALUE_19",
+            "19"
+          ],
+          [
+            "VALUE_20",
+            "20"
+          ],
+          [
+            "VALUE_21",
+            "21"
+          ],
+          [
+            "VALUE_22",
+            "22"
+          ],
+          [
+            "VALUE_23",
+            "23"
+          ],
+          [
+            "VALUE_24",
+            "24"
+          ],
+          [
+            "VALUE_25",
+            "25"
+          ],
+          [
+            "VALUE_26",
+            "26"
+          ],
+          [
+            "VALUE_27",
+            "27"
+          ],
+          [
+            "VALUE_28",
+            "28"
+          ],
+          [
+            "VALUE_29",
+            "29"
+          ],
+          [
+            "VALUE_30",
+            "30"
+          ]
+        ],
+        "description": "Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt."
+      },
+      {
+        "name": "BitrateMode",
+        "values": [
+          [
+            "STANDARD",
+            "standard"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "AUTO",
+            "auto"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide."
+      }
+    ],
+    "moduleName": "text_to_video"
+  },
+  {
+    "endpointId": "lightricks/ltx-2.5/text-to-video/fast",
+    "className": "Ltx25TextToVideoFast",
+    "docstring": "LTX 2.5 generates synchronized video and audio from text in a speed-optimized pass.",
+    "tags": [
+      "generation",
+      "text-to-video",
+      "txt2vid",
+      "video",
+      "ltx",
+      "ltx-2-5",
+      "audio",
+      "fast"
+    ],
+    "useCases": [
+      "Preview a prompt before a final render",
+      "Iterate on shots cheaply",
+      "Generate video with matching audio",
+      "Draft social clips at speed",
+      "Explore several takes of one idea"
+    ],
+    "inputFields": [
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt to use for the generated video",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 5000
+      },
+      {
+        "name": "camera_motion",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": null,
+        "description": "Optional camera motion applied to the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "CameraMotion",
+        "enumValues": [
+          "dolly_in",
+          "dolly_out",
+          "dolly_left",
+          "dolly_right",
+          "jib_up",
+          "jib_down",
+          "static",
+          "focus_shift"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "The aspect ratio of the generated video",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate audio for the generated video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "The resolution of the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720p",
+          "1080p",
+          "1440p",
+          "2160p"
+        ]
+      },
+      {
+        "name": "fps",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 25,
+        "description": "The frames per second of the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Fps",
+        "enumValues": [
+          24,
+          25,
+          48,
+          50
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "The duration of the generated video in seconds. At 720p and 1080p, 24 or 25 FPS supports up to 20 seconds, while 48 or 50 FPS supports up to 10 seconds. At 1440p and 2160p, all frame rates support up to 10 seconds. Set to 'auto' to let the model choose the duration automatically.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          6,
+          8,
+          10,
+          12,
+          14,
+          16,
+          18,
+          20,
+          "auto"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video file",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "CameraMotion",
+        "values": [
+          [
+            "DOLLY_IN",
+            "dolly_in"
+          ],
+          [
+            "DOLLY_OUT",
+            "dolly_out"
+          ],
+          [
+            "DOLLY_LEFT",
+            "dolly_left"
+          ],
+          [
+            "DOLLY_RIGHT",
+            "dolly_right"
+          ],
+          [
+            "JIB_UP",
+            "jib_up"
+          ],
+          [
+            "JIB_DOWN",
+            "jib_down"
+          ],
+          [
+            "STATIC",
+            "static"
+          ],
+          [
+            "FOCUS_SHIFT",
+            "focus_shift"
+          ]
+        ],
+        "description": "Optional camera motion applied to the generated video."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio of the generated video"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_720P",
+            "720p"
+          ],
+          [
+            "VALUE_1080P",
+            "1080p"
+          ],
+          [
+            "VALUE_1440P",
+            "1440p"
+          ],
+          [
+            "VALUE_2160P",
+            "2160p"
+          ]
+        ],
+        "description": "The resolution of the generated video."
+      },
+      {
+        "name": "Fps",
+        "values": [
+          [
+            "VALUE_24",
+            24
+          ],
+          [
+            "VALUE_25",
+            25
+          ],
+          [
+            "VALUE_48",
+            48
+          ],
+          [
+            "VALUE_50",
+            50
+          ]
+        ],
+        "description": "The frames per second of the generated video."
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_6",
+            6
+          ],
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_10",
+            10
+          ],
+          [
+            "VALUE_12",
+            12
+          ],
+          [
+            "VALUE_14",
+            14
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_18",
+            18
+          ],
+          [
+            "VALUE_20",
+            20
+          ],
+          [
+            "AUTO",
+            "auto"
+          ]
+        ],
+        "description": "The duration of the generated video in seconds. At 720p and 1080p, 24 or 25 FPS supports up to 20 seconds, while 48 or 50 FPS supports up to 10 seconds. At 1440p and 2160p, all frame rates support up to 10 seconds. Set to 'auto' to let the model choose the duration automatically."
+      }
+    ],
+    "moduleName": "text_to_video"
+  },
+  {
+    "endpointId": "lightricks/ltx-2.5/text-to-video/pro",
+    "className": "Ltx25TextToVideoPro",
+    "docstring": "LTX 2.5 generates synchronized video and audio from text in a quality-optimized pass.",
+    "tags": [
+      "generation",
+      "text-to-video",
+      "txt2vid",
+      "video",
+      "ltx",
+      "ltx-2-5",
+      "audio",
+      "quality"
+    ],
+    "useCases": [
+      "Render the final take of a shot",
+      "Produce video with its own soundtrack",
+      "Deliver high-fidelity generated footage",
+      "Create ads with synchronized audio",
+      "Finish a shot approved from a fast preview"
+    ],
+    "inputFields": [
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt to use for the generated video",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 5000
+      },
+      {
+        "name": "camera_motion",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": null,
+        "description": "Optional camera motion applied to the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "CameraMotion",
+        "enumValues": [
+          "dolly_in",
+          "dolly_out",
+          "dolly_left",
+          "dolly_right",
+          "jib_up",
+          "jib_down",
+          "static",
+          "focus_shift"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "The aspect ratio of the generated video",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate audio for the generated video",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "The resolution of the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "fps",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 25,
+        "description": "The frames per second of the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Fps",
+        "enumValues": [
+          24,
+          25,
+          50
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "auto",
+        "description": "The duration of the generated video in seconds, up to 10 seconds. Set to 'auto' to let the model choose the duration automatically.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Duration",
+        "enumValues": [
+          6,
+          8,
+          10,
+          "auto"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video file",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "CameraMotion",
+        "values": [
+          [
+            "DOLLY_IN",
+            "dolly_in"
+          ],
+          [
+            "DOLLY_OUT",
+            "dolly_out"
+          ],
+          [
+            "DOLLY_LEFT",
+            "dolly_left"
+          ],
+          [
+            "DOLLY_RIGHT",
+            "dolly_right"
+          ],
+          [
+            "JIB_UP",
+            "jib_up"
+          ],
+          [
+            "JIB_DOWN",
+            "jib_down"
+          ],
+          [
+            "STATIC",
+            "static"
+          ],
+          [
+            "FOCUS_SHIFT",
+            "focus_shift"
+          ]
+        ],
+        "description": "Optional camera motion applied to the generated video."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio of the generated video"
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_720P",
+            "720p"
+          ],
+          [
+            "VALUE_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "The resolution of the generated video."
+      },
+      {
+        "name": "Fps",
+        "values": [
+          [
+            "VALUE_24",
+            24
+          ],
+          [
+            "VALUE_25",
+            25
+          ],
+          [
+            "VALUE_50",
+            50
+          ]
+        ],
+        "description": "The frames per second of the generated video."
+      },
+      {
+        "name": "Duration",
+        "values": [
+          [
+            "VALUE_6",
+            6
+          ],
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_10",
+            10
+          ],
+          [
+            "AUTO",
+            "auto"
+          ]
+        ],
+        "description": "The duration of the generated video in seconds, up to 10 seconds. Set to 'auto' to let the model choose the duration automatically."
+      }
+    ],
+    "moduleName": "text_to_video"
+  },
+  {
+    "endpointId": "minimax/h3/text-to-video/lora",
+    "className": "MinimaxH3TextToVideoLora",
+    "docstring": "MiniMax H3 generates video with synchronized audio from text, with a trained LoRA applied at adjustable strength.",
+    "tags": [
+      "generation",
+      "text-to-video",
+      "txt2vid",
+      "video",
+      "minimax",
+      "h3",
+      "lora",
+      "audio"
+    ],
+    "useCases": [
+      "Generate video in a fine-tuned style",
+      "Keep a trained character consistent",
+      "Apply a learned motion signature",
+      "Blend a LoRA at partial strength",
+      "Produce branded video with audio"
+    ],
+    "inputFields": [
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Random seed. A random seed is selected when omitted.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5,
+        "description": "The duration of the video in seconds.",
+        "fieldType": "input",
+        "required": false,
+        "min": 5,
+        "max": 15
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 50000
+      },
+      {
+        "name": "prompt_expansion_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "balanced",
+        "description": "How much effort to spend rewriting the prompt before generation. 'disabled' skips prompt expansion. 'fast' returns in about a second. 'quality' spends up to ~30s on a richer prompt. 'balanced' picks per request.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "PromptExpansionMode",
+        "enumValues": [
+          "disabled",
+          "fast",
+          "balanced",
+          "quality"
+        ]
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, the safety checker will be enabled.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "2K",
+        "description": "The resolution of the generated video. 480P and 768P are native generation modes; 2K and 4K upscale a 768P base result.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480P",
+          "768P",
+          "2K",
+          "4K"
+        ]
+      },
+      {
+        "name": "sync_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Return the generated video as base64 instead of a CDN URL.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "loras",
+        "tsType": "LoRAInput[]",
+        "propType": "list[LoRAInput]",
+        "default": [],
+        "description": "List of LoRA adapters to apply to the transformer.",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 3
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "The aspect ratio of the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "expanded_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt after expansion, as sent to the model. Null when prompt expansion was disabled, left the prompt unchanged, or was performed internally by MiniMax's hosted API.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "PromptExpansionMode",
+        "values": [
+          [
+            "DISABLED",
+            "disabled"
+          ],
+          [
+            "FAST",
+            "fast"
+          ],
+          [
+            "BALANCED",
+            "balanced"
+          ],
+          [
+            "QUALITY",
+            "quality"
+          ]
+        ],
+        "description": "How much effort to spend rewriting the prompt before generation. 'disabled' skips prompt expansion. 'fast' returns in about a second. 'quality' spends up to ~30s on a richer prompt. 'balanced' picks per request."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480P"
+          ],
+          [
+            "VALUE_768P",
+            "768P"
+          ],
+          [
+            "VALUE_2K",
+            "2K"
+          ],
+          [
+            "VALUE_4K",
+            "4K"
+          ]
+        ],
+        "description": "The resolution of the generated video. 480P and 768P are native generation modes; 2K and 4K upscale a 768P base result."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio of the generated video."
+      }
+    ],
+    "moduleName": "text_to_video"
+  },
+  {
+    "endpointId": "mirage-api/avatar-x/text-to-video",
+    "className": "AvatarXTextToVideo",
+    "docstring": "Avatar X generates a talking-head video from text with strong identity preservation and expressive delivery.",
+    "tags": [
+      "generation",
+      "text-to-video",
+      "txt2vid",
+      "video",
+      "avatar",
+      "lipsync",
+      "talking-head",
+      "mirage"
+    ],
+    "useCases": [
+      "Generate a presenter video from a script",
+      "Produce training content without filming",
+      "Localize a spokesperson video",
+      "Create avatar-led product explainers",
+      "Automate recurring video updates"
+    ],
+    "inputFields": [
+      {
+        "name": "video_reference",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Publicly fetchable HTTPS URL of a reference video. When supplied, audio_reference_url is also required and the selected avatar is ignored; no cookies or authorization headers. Supports H.264, H.265/HEVC, or ProRes in .mp4, .mov, or .m4v and VP8 or VP9 in .webm, from 1 to 120 seconds and up to 1 GiB, with a 9:16 or 16:9 display aspect ratio (within 5%). Any audio track is ignored.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "video_reference_url"
+      },
+      {
+        "name": "avatar",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Jasmine",
+        "description": "Stock visual and voice. Browse the [avatar catalog](https://captions.ai/help/docs/api/actor-catalog) to preview every available avatar and copy the exact Avatar value. Select None to send no avatar. When video_reference_url and audio_reference_url are both supplied, the references replace the avatar entirely and it may be omitted.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Avatar",
+        "enumValues": [
+          "None",
+          "Ayesha",
+          "Ayesha (16:9)",
+          "Farhan",
+          "Farhan (16:9)",
+          "Giulia",
+          "Giulia (16:9)",
+          "Jasmine",
+          "Jasmine (16:9)",
+          "Luke",
+          "Luke (16:9)",
+          "Maya",
+          "Maya (16:9)",
+          "Michael",
+          "Michael (16:9)",
+          "Neha",
+          "Neha (16:9)",
+          "Tariq",
+          "Tariq (16:9)",
+          "Valerie",
+          "Valerie (16:9)"
+        ]
+      },
+      {
+        "name": "audio_reference",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Publicly fetchable HTTPS URL of a voice reference. When supplied, video_reference_url is also required and the selected avatar is ignored; no cookies or authorization headers. Supports MP3, PCM WAV or AIFF, AAC or ALAC, Opus or Vorbis, and FLAC audio from 10 to 180 seconds and up to 64 MiB, with one mono or stereo stream sampled from 8 to 48 kHz. Only the first 60 seconds are used.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "audio_reference_url"
+      },
+      {
+        "name": "script",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Use 50 to 1,500 characters. The 50-character minimum typically produces about four seconds of speech. Generated speech must be 180 seconds or shorter; speaking pace may cause shorter scripts to exceed this limit.",
+        "fieldType": "input",
+        "required": true,
+        "min": 50,
+        "max": 1500
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Avatar",
+        "values": [
+          [
+            "NONE",
+            "None"
+          ],
+          [
+            "AYESHA",
+            "Ayesha"
+          ],
+          [
+            "AYESHA_16_9",
+            "Ayesha (16:9)"
+          ],
+          [
+            "FARHAN",
+            "Farhan"
+          ],
+          [
+            "FARHAN_16_9",
+            "Farhan (16:9)"
+          ],
+          [
+            "GIULIA",
+            "Giulia"
+          ],
+          [
+            "GIULIA_16_9",
+            "Giulia (16:9)"
+          ],
+          [
+            "JASMINE",
+            "Jasmine"
+          ],
+          [
+            "JASMINE_16_9",
+            "Jasmine (16:9)"
+          ],
+          [
+            "LUKE",
+            "Luke"
+          ],
+          [
+            "LUKE_16_9",
+            "Luke (16:9)"
+          ],
+          [
+            "MAYA",
+            "Maya"
+          ],
+          [
+            "MAYA_16_9",
+            "Maya (16:9)"
+          ],
+          [
+            "MICHAEL",
+            "Michael"
+          ],
+          [
+            "MICHAEL_16_9",
+            "Michael (16:9)"
+          ],
+          [
+            "NEHA",
+            "Neha"
+          ],
+          [
+            "NEHA_16_9",
+            "Neha (16:9)"
+          ],
+          [
+            "TARIQ",
+            "Tariq"
+          ],
+          [
+            "TARIQ_16_9",
+            "Tariq (16:9)"
+          ],
+          [
+            "VALERIE",
+            "Valerie"
+          ],
+          [
+            "VALERIE_16_9",
+            "Valerie (16:9)"
+          ]
+        ],
+        "description": "Stock visual and voice. Browse the [avatar catalog](https://captions.ai/help/docs/api/actor-catalog) to preview every available avatar and copy the exact Avatar value. Select None to send no avatar. When video_reference_url and audio_reference_url are both supplied, the references replace the avatar entirely and it may be omitted."
+      }
+    ],
+    "moduleName": "text_to_video"
+  },
+  {
+    "endpointId": "minimax/h3/t2v/trainer",
+    "className": "MinimaxH3T2vTrainer",
+    "docstring": "Trains a MiniMax H3 LoRA on captioned clips for text-to-video generation with matching audio.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "minimax",
+      "h3",
+      "video"
+    ],
+    "useCases": [
+      "Teach H3 a custom visual style",
+      "Train a recurring character",
+      "Learn a studio's motion language",
+      "Adapt H3 to a product catalog",
+      "Fine-tune for a series look"
+    ],
+    "inputFields": [
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 15000
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization. Higher values can lead to faster training but may cause overfitting.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "first_frame_conditioning_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Fixed at 0: this endpoint trains the pure text-to-video-audio objective. Use the image-to-video-audio or first-last-frame endpoints for keyframe conditioning.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 0
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 73,
+        "description": "Number of frames per training sample. Must satisfy frames % 17 == 5 (e.g., 22, 39, 56, 73, 90, 107, 124).",
+        "fieldType": "input",
+        "required": false,
+        "min": 22,
+        "max": 124
+      },
+      {
+        "name": "strict_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Reject dataset-quality fallbacks during preprocessing, including captions that would use a blank prompt, missing sidecar keyframes, and videos without a readable audio track. By default these cases are reported in logs and use the documented blank-prompt, clip-frame, or silence fallback.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the video.",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio to use for training. Matches the aspect ratios supported by the MiniMax H3 API.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL to zip archive with video clips. Try to use at least 10 clips, although more is better.\n\n        **Supported video formats:** .mp4, .mov, .avi, .mkv\n\n        Note: The dataset must contain ONLY videos. Image datasets are not supported - images cannot serve as training media (some endpoints accept images as conditioning sidecars; see the endpoint's documentation). Mixed image/video archives are also rejected.\n\n        The archive can also contain text files with captions. Each text file should have the same base name as the video clip it corresponds to.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "dict",
+    "outputFields": [
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A downloadable archive containing the preprocessed training data. Only present when `debug_dataset` is enabled in the input.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training. Matches the aspect ratios supported by the MiniMax H3 API."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "minimax/h3/i2v/trainer",
+    "className": "MinimaxH3I2vTrainer",
+    "docstring": "Trains a MiniMax H3 LoRA with first-frame conditioning, so a still animates into video with audio.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "minimax",
+      "h3",
+      "image-to-video"
+    ],
+    "useCases": [
+      "Train an animation style for stills",
+      "Teach H3 how a subject moves",
+      "Fine-tune product photo animation",
+      "Learn a character's motion from clips",
+      "Adapt first-frame animation to a brand"
+    ],
+    "inputFields": [
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 15000
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization. Higher values can lead to faster training but may cause overfitting.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "first_frame_conditioning_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "Probability of conditioning on the first frame during training. Higher values improve image-to-video performance.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 73,
+        "description": "Number of frames per training sample. Must satisfy frames % 17 == 5 (e.g., 22, 39, 56, 73, 90, 107, 124).",
+        "fieldType": "input",
+        "required": false,
+        "min": 22,
+        "max": 124
+      },
+      {
+        "name": "strict_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Reject dataset-quality fallbacks during preprocessing, including captions that would use a blank prompt, missing sidecar keyframes, and videos without a readable audio track. By default these cases are reported in logs and use the documented blank-prompt, clip-frame, or silence fallback.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the video.",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio to use for training. Matches the aspect ratios supported by the MiniMax H3 API.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL to zip archive with video clips. Try to use at least 10 clips, although more is better.\n\n        **Supported video formats:** .mp4, .mov, .avi, .mkv\n\n        Note: The dataset must contain ONLY videos. Image datasets are not supported - images cannot serve as training media (some endpoints accept images as conditioning sidecars; see the endpoint's documentation). Mixed image/video archives are also rejected.\n\n        The archive can also contain text files with captions. Each text file should have the same base name as the video clip it corresponds to.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "dict",
+    "outputFields": [
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A downloadable archive containing the preprocessed training data. Only present when `debug_dataset` is enabled in the input.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training. Matches the aspect ratios supported by the MiniMax H3 API."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "minimax/h3/flf2v/trainer",
+    "className": "MinimaxH3Flf2vTrainer",
+    "docstring": "Trains a MiniMax H3 LoRA on first, last, or both keyframes to generate video with audio between them.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "minimax",
+      "h3",
+      "keyframes"
+    ],
+    "useCases": [
+      "Train keyframe-to-keyframe motion",
+      "Teach transitions between two stills",
+      "Fine-tune in-between generation",
+      "Learn a studio's transition style",
+      "Adapt H3 to storyboard keyframes"
+    ],
+    "inputFields": [
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 15000
+      },
+      {
+        "name": "first_last_frame_conditioning_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.4,
+        "description": "Probability of conditioning on BOTH the first and last frames (the API's first-to-last keyframe mode). The remaining probability mass trains unconditioned text-to-video-audio.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization. Higher values can lead to faster training but may cause overfitting.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "first_frame_conditioning_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.2,
+        "description": "Probability of conditioning on the first frame only.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 73,
+        "description": "Number of frames per training sample. Must satisfy frames % 17 == 5 (e.g., 22, 39, 56, 73, 90, 107, 124).",
+        "fieldType": "input",
+        "required": false,
+        "min": 22,
+        "max": 124
+      },
+      {
+        "name": "strict_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Reject dataset-quality fallbacks during preprocessing, including captions that would use a blank prompt, missing sidecar keyframes, and videos without a readable audio track. By default these cases are reported in logs and use the documented blank-prompt, clip-frame, or silence fallback.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "last_frame_conditioning_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.2,
+        "description": "Probability of conditioning on the last frame only.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the video.",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio to use for training. Matches the aspect ratios supported by the MiniMax H3 API.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL to zip archive with video clips. Try to use at least 10 clips, although more is better.\n\n        **Supported video formats:** .mp4, .mov, .avi, .mkv\n\n        Note: The dataset must contain ONLY videos. Image datasets are not supported - images cannot serve as training media (some endpoints accept images as conditioning sidecars; see the endpoint's documentation). Mixed image/video archives are also rejected.\n\n        The archive can also contain text files with captions. Each text file should have the same base name as the video clip it corresponds to.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "dict",
+    "outputFields": [
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A downloadable archive containing the preprocessed training data. Only present when `debug_dataset` is enabled in the input.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training. Matches the aspect ratios supported by the MiniMax H3 API."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "minimax/h3/ref2va/trainer",
+    "className": "MinimaxH3Ref2vaTrainer",
+    "docstring": "Trains a MiniMax H3 LoRA with reference conditioning, so references animate into video with audio.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "minimax",
+      "h3",
+      "reference"
+    ],
+    "useCases": [
+      "Train reference-driven video generation",
+      "Teach H3 a reusable cast",
+      "Fine-tune multimodal conditioning",
+      "Learn a look from reference material",
+      "Adapt reference control to a franchise"
+    ],
+    "inputFields": [
+      {
+        "name": "strict_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Reject dataset-quality fallbacks during preprocessing, including captions that would use a blank prompt, missing reference sidecars, and videos without a readable audio track. By default these cases are reported in logs and use the documented fallback.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL to zip archive with video clips of your subject. Try to use at least 10 clips, although more is better.\n\n        **Supported video formats:** .mp4, .mov, .avi, .mkv\n\n        Note: The dataset must contain ONLY videos. Image datasets are not supported - images cannot serve as training media (provide them as reference sidecars instead, see below). Mixed image/video archives are also rejected.\n\n        Optional per-clip extras, matched by base name: a caption text file (`clip01.txt`), and ORDERED reference sidecars `clip01.ref_1.<ext>` .. `clip01.ref_4.<ext>` where the extension picks the modality — images (.png/.jpg/.jpeg), videos (.mp4/.mov/.avi/.mkv/.webm; their soundtrack becomes an audio reference too), or audio (.wav/.mp3/.flac/.m4a/.ogg/.aac). Clips without reference sidecars train against a frame of the clip itself as the reference.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 15000
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, captions and reference images were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes. Note: reference sidecars are dropped for clips that get split.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resume_from_lora_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL of a previously trained LoRA (.safetensors) from this trainer to WARM-START from: its weights initialize the adapter and training continues for number_of_steps more steps. Weights only — the optimizer and learning-rate schedule start fresh.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the video.",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "reference_conditioning_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.9,
+        "description": "Probability of conditioning on the reference images during training. The remaining probability mass trains unconditioned text-to-video-audio, which keeps prompt-only generation stable.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 73,
+        "description": "Number of frames per training sample. Must satisfy frames % 17 == 5 (e.g., 22, 39, 56, 73, 90, 107, 124).",
+        "fieldType": "input",
+        "required": false,
+        "min": 22,
+        "max": 124
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "Aspect ratio to use for training. Matches the aspect ratios supported by the MiniMax H3 API.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization. Higher values can lead to faster training but may cause overfitting.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      }
+    ],
+    "outputType": "dict",
+    "outputFields": [
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A downloadable archive containing the preprocessed training data. Only present when `debug_dataset` is enabled in the input.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training. Matches the aspect ratios supported by the MiniMax H3 API."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "recraft/v4/create-style",
+    "className": "RecraftV4CreateStyle",
+    "docstring": "Creates a reusable Recraft V4 style from reference images and returns a style id for generation.",
+    "tags": [
+      "training",
+      "style",
+      "recraft",
+      "recraft-v4"
+    ],
+    "useCases": [
+      "Capture a brand style from references",
+      "Reuse one look across many images",
+      "Share a style id across a team",
+      "Build a style library",
+      "Lock art direction before generation"
+    ],
+    "inputFields": [
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "The URLs of the style reference images. Supports PNG, JPG, and WEBP; provide between 1 and 10 images.",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 10,
+        "apiParamName": "image_urls"
+      },
+      {
+        "name": "image_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "One weight per image URL, in the same order as `image_urls`.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "base_style",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "any",
+        "description": "The base style of the generated images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "BaseStyle",
+        "enumValues": [
+          "any",
+          "vector_illustration"
+        ]
+      },
+      {
+        "name": "match",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "precise",
+        "description": "How closely generated images should follow the style.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Match",
+        "enumValues": [
+          "precise",
+          "flexible"
+        ]
+      }
+    ],
+    "outputType": "str",
+    "outputFields": [
+      {
+        "name": "style_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The ID of the created style, this ID can be used to reference the style in the future.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "BaseStyle",
+        "values": [
+          [
+            "ANY",
+            "any"
+          ],
+          [
+            "VECTOR_ILLUSTRATION",
+            "vector_illustration"
+          ]
+        ],
+        "description": "The base style of the generated images."
+      },
+      {
+        "name": "Match",
+        "values": [
+          [
+            "PRECISE",
+            "precise"
+          ],
+          [
+            "FLEXIBLE",
+            "flexible"
+          ]
+        ],
+        "description": "How closely generated images should follow the style."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "recraft/v4/pro/create-style",
+    "className": "RecraftV4ProCreateStyle",
+    "docstring": "Creates a reusable Recraft V4 Pro style from reference images and returns a style id for Pro generation.",
+    "tags": [
+      "training",
+      "style",
+      "recraft",
+      "recraft-v4",
+      "pro"
+    ],
+    "useCases": [
+      "Capture a style for Pro generation",
+      "Standardize art direction at higher quality",
+      "Build a reusable brand style",
+      "Share one style across campaigns",
+      "Version a studio look"
+    ],
+    "inputFields": [
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "The URLs of the style reference images. Supports PNG, JPG, and WEBP; provide between 1 and 10 images.",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 10,
+        "apiParamName": "image_urls"
+      },
+      {
+        "name": "image_weights",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "One weight per image URL, in the same order as `image_urls`.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "base_style",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "any",
+        "description": "The base style of the generated images.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "BaseStyle",
+        "enumValues": [
+          "any",
+          "vector_illustration"
+        ]
+      },
+      {
+        "name": "match",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "precise",
+        "description": "How closely generated images should follow the style.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Match",
+        "enumValues": [
+          "precise",
+          "flexible"
+        ]
+      }
+    ],
+    "outputType": "str",
+    "outputFields": [
+      {
+        "name": "style_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The ID of the created style, this ID can be used to reference the style in the future.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "BaseStyle",
+        "values": [
+          [
+            "ANY",
+            "any"
+          ],
+          [
+            "VECTOR_ILLUSTRATION",
+            "vector_illustration"
+          ]
+        ],
+        "description": "The base style of the generated images."
+      },
+      {
+        "name": "Match",
+        "values": [
+          [
+            "PRECISE",
+            "precise"
+          ],
+          [
+            "FLEXIBLE",
+            "flexible"
+          ]
+        ],
+        "description": "How closely generated images should follow the style."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/krea-2-trainer",
+    "className": "Krea2Trainer",
+    "docstring": "Trains a Krea 2 LoRA on your images to teach a new subject, character, or style.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "krea",
+      "krea-2",
+      "image"
+    ],
+    "useCases": [
+      "Teach Krea 2 a product or character",
+      "Train a house illustration style",
+      "Fine-tune on a photo set",
+      "Produce weights for the Krea 2 LoRA endpoint",
+      "Personalize generation with a trigger word"
+    ],
+    "inputFields": [
+      {
+        "name": "auto_captioning",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Off",
+        "description": "Optional automatic captioning mode. Off preserves the existing behavior: every image must include a same-stem .txt caption or fall back to trigger_phrase. Object/Character, Style, and Custom use dataset-captioner to generate captions with google/gemma-4-31B-it; trigger_phrase is included in the captioning prompt and normalized in the final sidecars using the selected LoRA captioning convention. Cost of captioning will be passed through directly.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AutoCaptioning",
+        "enumValues": [
+          "Off",
+          "Object/Character",
+          "Style",
+          "Custom"
+        ]
+      },
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0005,
+        "description": "Learning rate for the LoRA B factor (and for A when lora_a_lr_multiplier=1). Krea recommends 3e-4–7e-4 (constant schedule). For muon this is the match_rms_adamw-scaled (AdamW-equivalent) rate.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 0.01
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Instance phrase used as the caption for any image that ships no .txt caption file (DreamBooth-style); also seeds the default validation prompts. Required when some images have no caption file and auto_captioning is Off.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 768,
+        "description": "Training resolution (images are cover-resized + center-cropped to a square). 768 trains ~1.7x faster at lower VRAM with near-identical style quality; 1024 maximizes fine detail.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          768,
+          1024
+        ]
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, returns a downloadable archive of the exact dataset used for training after caption backfill or auto-captioning.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 100,
+        "description": "Number of LoRA training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 50,
+        "max": 10000
+      },
+      {
+        "name": "images_data",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL to a .zip archive of training images (PNG/JPG/JPEG/WebP). Each image may carry a same-stem caption: an image named ROOT.EXT (e.g. 001.jpg) pairs with a caption file named ROOT.txt (e.g. 001.txt). Images with no caption file fall back to `trigger_phrase`, so each image must have either a caption file or a non-empty `trigger_phrase` — otherwise the request is rejected (422).",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "images_data_url"
+      }
+    ],
+    "outputType": "dict",
+    "outputFields": [
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the training/LoRA configuration JSON.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the prepared training data, including auto-generated captions, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained Krea-2 LoRA weights (safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "prompt_enhancement_system_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "System prompt for writing or enhancing inference prompts so they match the captioning convention used during auto-captioned training. Returned when auto_captioning is enabled.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "AutoCaptioning",
+        "values": [
+          [
+            "OFF",
+            "Off"
+          ],
+          [
+            "OBJECT_CHARACTER",
+            "Object/Character"
+          ],
+          [
+            "STYLE",
+            "Style"
+          ],
+          [
+            "CUSTOM",
+            "Custom"
+          ]
+        ],
+        "description": "Optional automatic captioning mode. Off preserves the existing behavior: every image must include a same-stem .txt caption or fall back to trigger_phrase. Object/Character, Style, and Custom use dataset-captioner to generate captions with google/gemma-4-31B-it; trigger_phrase is included in the captioning prompt and normalized in the final sidecars using the selected LoRA captioning convention. Cost of captioning will be passed through directly."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_768",
+            768
+          ],
+          [
+            "VALUE_1024",
+            1024
+          ]
+        ],
+        "description": "Training resolution (images are cover-resized + center-cropped to a square). 768 trains ~1.7x faster at lower VRAM with near-identical style quality; 1024 maximizes fine detail."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/stable-audio-3-trainer",
+    "className": "StableAudio3Trainer",
+    "docstring": "Trains a Stable Audio 3 LoRA on paired audio and captions to adapt generation to a style or sound palette.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "audio",
+      "music",
+      "sfx",
+      "stable-audio"
+    ],
+    "useCases": [
+      "Adapt Stable Audio 3 to a genre",
+      "Train a custom sound palette",
+      "Fine-tune on a sample library",
+      "Teach a signature instrument set",
+      "Produce weights for branded audio"
+    ],
+    "inputFields": [
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1000,
+        "description": "Number of LoRA training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 20000
+      },
+      {
+        "name": "duration",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Clip duration in seconds for crop/pad sizing. Leave unset to auto-detect from the dataset (the longest clip). Always capped at the chosen model's native training length.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 380
+      },
+      {
+        "name": "base_precision",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "bf16",
+        "description": "Precision for frozen base weights; LoRA params stay fp32.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "BasePrecision",
+        "enumValues": [
+          "bf16",
+          "bfloat16",
+          "fp16",
+          "float16"
+        ]
+      },
+      {
+        "name": "rank",
+        "tsType": "number",
+        "propType": "int",
+        "default": 16,
+        "description": "LoRA rank.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 256
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": 42,
+        "description": "Random seed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      },
+      {
+        "name": "exclude",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Skip modules whose names contain these substrings.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "audio_data",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "URL to a zip archive containing audio files and matching `.txt` captions. Each audio file must have a sibling caption file with the same basename, for example `clip.wav` and `clip.txt`.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "audio_data_url"
+      },
+      {
+        "name": "lora_checkpoint_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Optional `.safetensors` LoRA checkpoint URL to resume from.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "pre_encode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Pre-encode the audio archive to SAME latents before LoRA training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium-base",
+        "description": "Stable Audio 3 base checkpoint to fine-tune.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "medium-base",
+          "small-music-base",
+          "small-sfx-base"
+        ]
+      },
+      {
+        "name": "batch_size",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Training batch size. Runs with batch_size > 1 are billed additional units proportional to batch_size x clip duration.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 8
+      },
+      {
+        "name": "include",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Only add LoRA to modules whose names contain these substrings.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0001,
+        "description": "AdamW learning rate for LoRA parameters.",
+        "fieldType": "input",
+        "required": false,
+        "max": 0.01
+      },
+      {
+        "name": "adapter_type",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "dora-rows",
+        "description": "LoRA adapter family to train.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AdapterType",
+        "enumValues": [
+          "lora",
+          "dora",
+          "dora-rows",
+          "dora-cols",
+          "bora",
+          "lora-xs",
+          "dora-rows-xs",
+          "dora-cols-xs",
+          "bora-xs"
+        ]
+      }
+    ],
+    "outputType": "dict",
+    "outputFields": [
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Trained Stable Audio 3 LoRA weights.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "JSON metadata for the training run and compatible inference model.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "BasePrecision",
+        "values": [
+          [
+            "BF16",
+            "bf16"
+          ],
+          [
+            "BFLOAT16",
+            "bfloat16"
+          ],
+          [
+            "FP16",
+            "fp16"
+          ],
+          [
+            "FLOAT16",
+            "float16"
+          ]
+        ],
+        "description": "Precision for frozen base weights; LoRA params stay fp32."
+      },
+      {
+        "name": "Model",
+        "values": [
+          [
+            "MEDIUM_BASE",
+            "medium-base"
+          ],
+          [
+            "SMALL_MUSIC_BASE",
+            "small-music-base"
+          ],
+          [
+            "SMALL_SFX_BASE",
+            "small-sfx-base"
+          ]
+        ],
+        "description": "Stable Audio 3 base checkpoint to fine-tune."
+      },
+      {
+        "name": "AdapterType",
+        "values": [
+          [
+            "LORA",
+            "lora"
+          ],
+          [
+            "DORA",
+            "dora"
+          ],
+          [
+            "DORA_ROWS",
+            "dora-rows"
+          ],
+          [
+            "DORA_COLS",
+            "dora-cols"
+          ],
+          [
+            "BORA",
+            "bora"
+          ],
+          [
+            "LORA_XS",
+            "lora-xs"
+          ],
+          [
+            "DORA_ROWS_XS",
+            "dora-rows-xs"
+          ],
+          [
+            "DORA_COLS_XS",
+            "dora-cols-xs"
+          ],
+          [
+            "BORA_XS",
+            "bora-xs"
+          ]
+        ],
+        "description": "LoRA adapter family to train."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/trellis-2-lora-trainer",
+    "className": "Trellis2LoraTrainer",
+    "docstring": "Trains LoRA adapters for TRELLIS.2 3D generation.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "trellis",
+      "3d"
+    ],
+    "useCases": [
+      "Teach TRELLIS.2 a custom asset style",
+      "Fine-tune 3D generation on a catalog",
+      "Train a recurring 3D character",
+      "Adapt geometry style to a game",
+      "Produce weights for TRELLIS.2 inference"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0001,
+        "description": "Learning rate for LoRA optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 0.01
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 512,
+        "description": "Training resolution. Must match the resolution the dataset is preprocessed at. Sparse-structure training uses the same config at both resolutions; geometry and texture have dedicated 512/1024 configs.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          512,
+          1024
+        ]
+      },
+      {
+        "name": "training_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1000,
+        "description": "Number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a .zip archive containing raw 3D assets or a TRELLIS.2 preprocessed dataset zip returned by the data_preprocessing endpoint.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "denoisers",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "TRELLIS.2 denoisers to fine-tune. One LoRA adapter is trained per entry, and all selected denoisers are trained in parallel from the same preprocessed dataset. Provide 1-3 unique values out of sparse_structure, geometry, and texture.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 3
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "LoRA rank. Higher values increase adapter capacity.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          16,
+          32,
+          64
+        ]
+      }
+    ],
+    "outputType": "dict",
+    "outputFields": [
+      {
+        "name": "preprocessed_data_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Reusable TRELLIS.2 preprocessed dataset zip used for training.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "adapters",
+        "tsType": "LoraAdapterResult[]",
+        "propType": "list[LoraAdapterResult]",
+        "default": [],
+        "description": "Trained LoRA adapters, one per denoiser that completed successfully. Use each adapter's file in the matching trellis-2-lora inference field.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "failed",
+        "tsType": "LoraTrainingFailure[]",
+        "propType": "list[LoraTrainingFailure]",
+        "default": [],
+        "description": "Denoisers whose training did not complete. Empty when every requested denoiser succeeded.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_512",
+            512
+          ],
+          [
+            "VALUE_1024",
+            1024
+          ]
+        ],
+        "description": "Training resolution. Must match the resolution the dataset is preprocessed at. Sparse-structure training uses the same config at both resolutions; geometry and texture have dedicated 512/1024 configs."
+      },
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ]
+        ],
+        "description": "LoRA rank. Higher values increase adapter capacity."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "ideogram/v4/trainer",
+    "className": "IdeogramV4Trainer",
+    "docstring": "Trains custom LoRAs on top of Ideogram V4 for personalization and styles.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ideogram",
+      "ideogram-v4",
+      "image"
+    ],
+    "useCases": [
+      "Personalize Ideogram V4 on a subject",
+      "Train a brand illustration style",
+      "Fine-tune typography treatments",
+      "Teach a recurring character",
+      "Produce weights for Ideogram LoRA endpoints"
+    ],
+    "inputFields": [
+      {
+        "name": "steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1000,
+        "description": "Number of LoRA training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 40000
+      },
+      {
+        "name": "resolution",
+        "tsType": "string",
+        "propType": "str",
+        "default": "auto",
+        "description": "Training image size. Use auto to pick the largest common no-upscale crop from the dataset. Images are center-cropped without upscaling. Available presets: square 1024x1024, landscape 1536x1024, portrait 1024x1536, widescreen 1920x1088, ultrawide 2048x768, phone_wallpaper 1024x1792, social_banner 1584x400. You can also pass a custom WIDTHxHEIGHT string when both values are divisible by 16.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0001,
+        "description": "",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 0.01
+      },
+      {
+        "name": "output_lora_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "fal",
+        "description": "Dictates the naming scheme for the output weights",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputLoraFormat",
+        "enumValues": [
+          "fal",
+          "comfy"
+        ]
+      },
+      {
+        "name": "default_caption",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Caption to use when an image has no caption file. If force_default_caption is true, this caption replaces all caption files.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "images_data",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL to a zip archive with training images and captions. The trainer uses the target-only dataset prepared by prepare_dataset_dir. Captions are read from same-stem .txt files.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "images_data_url"
+      }
+    ],
+    "outputType": "dict",
+    "outputFields": [
+      {
+        "name": "diffusers_lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained Ideogram V4 LoRA weights.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the public training configuration.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "OutputLoraFormat",
+        "values": [
+          [
+            "FAL",
+            "fal"
+          ],
+          [
+            "COMFY",
+            "comfy"
+          ]
+        ],
+        "description": "Dictates the naming scheme for the output weights"
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/phota/create-profile",
+    "className": "PhotaCreateProfile",
+    "docstring": "Creates a Phota profile from 30 to 50 images of a subject for later generation.",
+    "tags": [
+      "training",
+      "personalization",
+      "profile",
+      "phota",
+      "portrait"
+    ],
+    "useCases": [
+      "Build a personal photo profile",
+      "Train a portrait identity",
+      "Prepare a subject for headshot generation",
+      "Create a reusable likeness profile",
+      "Register a model for a photo product"
+    ],
+    "inputFields": [
+      {
+        "name": "image_data",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL to a ZIP archive containing the profile images.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "image_data_url"
+      }
+    ],
+    "outputType": "str",
+    "outputFields": [
+      {
+        "name": "profile_id",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The Photalabs profile ID.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/wan-22-trainer/t2v-a14b",
+    "className": "Wan22TrainerT2vA14b",
+    "docstring": "Trains a custom LoRA for Wan 2.2 T2V A14B at 480p.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "wan",
+      "wan-2-2",
+      "text-to-video"
+    ],
+    "useCases": [
+      "Teach Wan 2.2 a text-to-video style",
+      "Train a recurring character for video",
+      "Fine-tune motion on your clips",
+      "Adapt Wan 2.2 to a brand look",
+      "Produce weights for Wan 2.2 inference"
+    ],
+    "inputFields": [
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, the input will be automatically scale the video to 81 frames at 16fps.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The phrase that will trigger the model to generate an image.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "The rate at which the model learns. Higher values can lead to faster training, but over-fitting.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL to zip archive with images of a consistent style. Try to use at least 10 images and/or videos, although more is better.\n\n        In addition to images the archive can contain text files with captions. Each text file should have the same name as the image/video file it corresponds to.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 400,
+        "description": "The number of steps to train for.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 20000
+      }
+    ],
+    "outputType": "dict",
+    "outputFields": [
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up the inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/wan-22-trainer/i2v-a14b",
+    "className": "Wan22TrainerI2vA14b",
+    "docstring": "Trains a custom LoRA for Wan 2.2 I2V A14B at 480p.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "wan",
+      "wan-2-2",
+      "image-to-video"
+    ],
+    "useCases": [
+      "Teach Wan 2.2 how a subject animates",
+      "Train image-to-video motion on your clips",
+      "Fine-tune product photo animation",
+      "Adapt animation style to a brand",
+      "Produce weights for Wan 2.2 I2V"
+    ],
+    "inputFields": [
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, the input will be automatically scale the video to 81 frames at 16fps.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The phrase that will trigger the model to generate an image.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "The rate at which the model learns. Higher values can lead to faster training, but over-fitting.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL to zip archive with images of a consistent style. Try to use at least 10 images and/or videos, although more is better.\n\n        In addition to images the archive can contain text files with captions. Each text file should have the same name as the image/video file it corresponds to.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 400,
+        "description": "The number of steps to train for.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 20000
+      }
+    ],
+    "outputType": "dict",
+    "outputFields": [
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up the inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-video-trainer",
+    "className": "Ltx23VideoTrainer",
+    "docstring": "Trains LTX-2.3 22B for custom styles and effects.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "video"
+    ],
+    "useCases": [
+      "Teach LTX 2.3 a visual style",
+      "Train a recurring effect",
+      "Fine-tune on studio footage",
+      "Adapt LTX to a brand look",
+      "Produce weights for LTX inference"
+    ],
+    "inputFields": [
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "generate_audio_in_validation",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Whether to generate audio in validation samples.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation",
+        "tsType": "Validation[]",
+        "propType": "list[Validation]",
+        "default": [],
+        "description": "A list of validation prompts to use during training. When providing an image, _all_ validation inputs must have an image.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "audio_preserve_pitch",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "When audio duration doesn't match video duration, stretch/compress audio without changing pitch. If disabled, audio is trimmed or padded with silence.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "with_audio",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Enable joint audio-video training. If None (default), automatically detects whether input videos have audio. Set to True to force audio training, or False to disable.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "audio_normalize",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Normalize audio peak amplitude to a consistent level. Recommended for consistent audio levels across the dataset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 6000
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 25,
+        "description": "Target frames per second for validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization. Higher values can lead to faster training but may cause overfitting.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 25,
+        "description": "Target frames per second for the video.",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "first_frame_conditioning_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "Probability of conditioning on the first frame during training. Higher values improve image-to-video performance.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "worst quality, inconsistent motion, blurry, jittery, distorted",
+        "description": "A negative prompt to use for validation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL to zip archive with videos or images. Try to use at least 10 files, although more is better.\n\n        **Supported video formats:** .mp4, .mov, .avi, .mkv\n        **Supported image formats:** .png, .jpg, .jpeg\n\n        Note: The dataset must contain ONLY videos OR ONLY images - mixed datasets are not supported.\n\n        The archive can also contain text files with captions. Each text file should have the same name as the media file it corresponds to.",
+        "fieldType": "input",
+        "required": true
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The URL to the validation videos, if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A downloadable archive containing the preprocessed training data, including decoded videos and audio. Only present when `debug_dataset` is enabled in the input.",
+        "fieldType": "output",
+        "required": false
+      }
+    ],
+    "enums": [
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-v2v-trainer",
+    "className": "Ltx23V2vTrainer",
+    "docstring": "Trains LTX-2.3 22B for video transformation and video-conditioned generation.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "video-to-video"
+    ],
+    "useCases": [
+      "Train a video-to-video transformation",
+      "Teach a restyle from paired clips",
+      "Fine-tune video-conditioned generation",
+      "Learn an effect from before/after footage",
+      "Produce weights for LTX v2v"
+    ],
+    "inputFields": [
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 25,
+        "description": "Target frames per second for the video.",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "validation",
+        "tsType": "V2VValidation[]",
+        "propType": "list[V2VValidation]",
+        "default": [],
+        "description": "A list of validation inputs with prompts and reference videos.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "first_frame_conditioning_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.1,
+        "description": "Probability of conditioning on the first frame during training. Lower values work better for video-to-video transformation.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization. Higher values can lead to faster training but may cause overfitting.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 25,
+        "description": "Target frames per second for validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "URL to zip archive with videos or images. Try to use at least 10 files, although more is better.\n\n        **Supported video formats:** .mp4, .mov, .avi, .mkv\n        **Supported image formats:** .png, .jpg, .jpeg\n\n        Note: The dataset must contain ONLY videos OR ONLY images - mixed datasets are not supported.\n\n        The archive can also contain text files with captions. Each text file should have the same name as the media file it corresponds to.",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 20000
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "worst quality, inconsistent motion, blurry, jittery, distorted",
+        "description": "A negative prompt to use for validation.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained IC-LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The URL to the validation videos (with reference videos side-by-side), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A downloadable archive containing the preprocessed training data, including decoded videos. Only present when `debug_dataset` is enabled in the input.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/t2v",
+    "className": "Ltx23TrainerV2T2v",
+    "docstring": "Trains an LTX 2.3 LoRA on your clips for text-to-video generation.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "text-to-video"
+    ],
+    "useCases": [
+      "Teach LTX a new subject or style",
+      "Train a recurring character",
+      "Fine-tune on studio footage",
+      "Adapt text-to-video to a brand",
+      "Produce weights for LTX inference"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "audio_normalize",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Peak-normalize audio for consistent levels across the dataset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "with_audio",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Enable joint audio-video training. If None (default), auto-detects whether input videos have audio. Set True to force audio training, or False to disable.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "audio_preserve_pitch",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preserve pitch when fitting audio to video duration (vs trimming/padding).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "validation",
+        "tsType": "T2VValidation[]",
+        "propType": "list[T2VValidation]",
+        "default": [],
+        "description": "A list of validation prompts to use during training.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/i2v",
+    "className": "Ltx23TrainerV2I2v",
+    "docstring": "Trains an LTX 2.3 LoRA that animates a starting image into video.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "image-to-video"
+    ],
+    "useCases": [
+      "Train how a still should animate",
+      "Teach a subject's motion from clips",
+      "Fine-tune product photo animation",
+      "Adapt first-frame animation to a brand",
+      "Produce weights for LTX i2v"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "audio_normalize",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Peak-normalize audio for consistent levels across the dataset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "with_audio",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Enable joint audio-video training. If None (default), auto-detects whether input videos have audio. Set True to force audio training, or False to disable.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "audio_preserve_pitch",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preserve pitch when fitting audio to video duration (vs trimming/padding).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "validation",
+        "tsType": "I2VValidation[]",
+        "propType": "list[I2VValidation]",
+        "default": [],
+        "description": "A list of validation prompts, each with a first-frame image.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "first_frame_conditioning_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "Probability of conditioning on the first frame during training. 0.5 trains a versatile LoRA usable for both image-to-video and text-to-video inference.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/v2v",
+    "className": "Ltx23TrainerV2V2v",
+    "docstring": "Trains an LTX 2.3 LoRA for a video-to-video transformation steered by a reference video.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "video-to-video"
+    ],
+    "useCases": [
+      "Learn a restyle from paired clips",
+      "Train a reference-steered transformation",
+      "Teach a look transfer for footage",
+      "Fine-tune an effect on before/after pairs",
+      "Produce weights for LTX v2v"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation",
+        "tsType": "V2VValidation[]",
+        "propType": "list[V2VValidation]",
+        "default": [],
+        "description": "A list of validation inputs with prompts and reference videos.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "reference_temporal_scale_factor",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Temporally downsample the reference (IC-LoRA control) video by this factor (lower fps) before encoding, so the LoRA can be driven by a low-fps reference. 1 = same fps (default; unchanged behavior).",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 8
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 3000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "first_frame_conditioning_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.1,
+        "description": "Probability of conditioning on the first frame during training. Lower values work better for video-to-video transformation.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_downscale_factor",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Spatially downscale the reference (IC-LoRA control) video by this factor before encoding, so the LoRA learns to drive a full-resolution output from a coarse / low-res reference (e.g. a small pose/depth/sketch proxy). 1 = same resolution (default; unchanged behavior). Both the reference width/height and width/height divided by the factor must be divisible by 32.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 8
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/v2v-masked",
+    "className": "Ltx23TrainerV2V2vMasked",
+    "docstring": "Trains an LTX 2.3 LoRA that regenerates only a masked video region, guided by kept pixels and a reference video.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "video-to-video",
+      "inpainting",
+      "mask"
+    ],
+    "useCases": [
+      "Train targeted region replacement",
+      "Teach masked restyling of footage",
+      "Fine-tune object swaps in video",
+      "Learn a mask-aware transformation",
+      "Produce weights for masked v2v"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Off for masked v2v: the paired target/reference/mask prep ignores scene splitting (it would desync the _start/_end/_mask triplet). Provide pre-split clips.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation",
+        "tsType": "V2VMaskedValidation[]",
+        "propType": "list[V2VMaskedValidation]",
+        "default": [],
+        "description": "A list of validation inputs with a prompt, source video, mask, and reference video.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 3000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/inpaint",
+    "className": "Ltx23TrainerV2Inpaint",
+    "docstring": "Trains an LTX 2.3 LoRA that regenerates a masked video region while keeping the rest unchanged.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "inpainting",
+      "mask"
+    ],
+    "useCases": [
+      "Train video object removal",
+      "Teach masked region regeneration",
+      "Fine-tune cleanup of unwanted elements",
+      "Learn seamless blending with surroundings",
+      "Produce weights for video inpainting"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Off for inpainting: scene splitting would desync a clip from its mask. Provide pre-split clips instead.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation",
+        "tsType": "InpaintValidation[]",
+        "propType": "list[InpaintValidation]",
+        "default": [],
+        "description": "A list of validation prompts, each with a source video + a mask.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/outpaint",
+    "className": "Ltx23TrainerV2Outpaint",
+    "docstring": "Trains an LTX 2.3 LoRA that expands the video frame outward from a fixed inner rectangle.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "outpainting"
+    ],
+    "useCases": [
+      "Train aspect-ratio expansion",
+      "Teach frame extension for reframing",
+      "Fine-tune outward generation",
+      "Convert vertical footage to wide",
+      "Produce weights for video outpainting"
+    ],
+    "inputFields": [
+      {
+        "name": "crop_top_left",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "(x1, y1) top-left corner of the KEPT inner rectangle, in TRAINING-resolution pixels — i.e. the bucket chosen by resolution x aspect_ratio, NOT the uploaded video's native size (clips are resized to that bucket before the crop is applied). Coordinates snap to a 32px latent grid.",
+        "fieldType": "input",
+        "required": true,
+        "min": 2,
+        "max": 2
+      },
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "crop_bottom_right",
+        "tsType": "string[]",
+        "propType": "list[str]",
+        "default": [],
+        "description": "(x2, y2) bottom-right corner of the KEPT inner rectangle, in TRAINING-resolution pixels. Must satisfy x2 > x1 and y2 > y1 and lie within the training frame; everything outside this rectangle is what the model generates.",
+        "fieldType": "input",
+        "required": true,
+        "min": 2,
+        "max": 2
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation",
+        "tsType": "OutpaintValidation[]",
+        "propType": "list[OutpaintValidation]",
+        "default": [],
+        "description": "A list of validation prompts, each with a full-canvas video to outpaint.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/interpolate",
+    "className": "Ltx23TrainerV2Interpolate",
+    "docstring": "Trains an LTX 2.3 LoRA that generates the video between supplied keyframes.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "keyframes",
+      "interpolation"
+    ],
+    "useCases": [
+      "Train keyframe in-betweening",
+      "Teach transitions between stills",
+      "Fine-tune motion between frames",
+      "Learn a studio's transition style",
+      "Produce weights for keyframe interpolation"
+    ],
+    "inputFields": [
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "include_middle_keyframe",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Also keep a middle keyframe (first+middle+last -> video) instead of just first+last. When true, every validation sample must provide middle_image_url.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation",
+        "tsType": "InterpolateValidation[]",
+        "propType": "list[InterpolateValidation]",
+        "default": [],
+        "description": "A list of validation inputs, each with a prompt and keyframe images.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      },
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/extend-prefix",
+    "className": "Ltx23TrainerV2ExtendPrefix",
+    "docstring": "Trains an LTX 2.3 LoRA that continues a video forward in time from an opening clip.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "extension"
+    ],
+    "useCases": [
+      "Train forward video continuation",
+      "Teach what follows an opening shot",
+      "Fine-tune clip extension",
+      "Learn a scene's continuation style",
+      "Produce weights for forward extension"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "audio_normalize",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Peak-normalize audio for consistent levels across the dataset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "with_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Set true to jointly extend audio AND video — the model continues both from the same prefix window. Requires every training clip AND each validation clip to contain an audio track. Default (false): video-only extension (silent output).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "conditioning_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 9,
+        "description": "Number of leading PIXEL frames used as the clean prefix condition (for audio too, when with_audio). Must be ≡ 1 (mod 8) (e.g. 9, 17, 25). Converted to the latent temporal_boundary (conditioning_frames-1)//8+1, which must be smaller than the clip's latent length so there is a continuation to generate.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "audio_preserve_pitch",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preserve pitch when fitting audio to video duration (vs trimming/padding).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "validation",
+        "tsType": "ExtendValidation[]",
+        "propType": "list[ExtendValidation]",
+        "default": [],
+        "description": "A list of validation prompts, each with a video to extend forward.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/extend-suffix",
+    "className": "Ltx23TrainerV2ExtendSuffix",
+    "docstring": "Trains an LTX 2.3 LoRA that generates the lead-in to a video, extending it backward in time.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "extension"
+    ],
+    "useCases": [
+      "Train backward video extension",
+      "Generate a lead-in to an existing clip",
+      "Fine-tune prefix generation",
+      "Learn how a shot should begin",
+      "Produce weights for backward extension"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "audio_normalize",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Peak-normalize audio for consistent levels across the dataset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "with_audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Set true to jointly extend audio AND video — the model continues both from the same suffix window. Requires every training clip AND each validation clip to contain an audio track. Default (false): video-only extension (silent output).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "conditioning_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 8,
+        "description": "Number of trailing PIXEL frames used as the clean suffix condition (for audio too, when with_audio). Must be ≡ 0 (mod 8) (e.g. 8, 16, 24). Converted to the latent temporal_boundary conditioning_frames//8, which must be smaller than the clip's latent length so there is a lead-in to generate.",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 121
+      },
+      {
+        "name": "audio_preserve_pitch",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preserve pitch when fitting audio to video duration (vs trimming/padding).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "validation",
+        "tsType": "ExtendValidation[]",
+        "propType": "list[ExtendValidation]",
+        "default": [],
+        "description": "A list of validation prompts, each with a video to extend backward.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/a2v",
+    "className": "Ltx23TrainerV2A2v",
+    "docstring": "Trains an LTX 2.3 LoRA that generates video from a start image and a conditioning audio track.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "audio-to-video"
+    ],
+    "useCases": [
+      "Train audio-driven animation",
+      "Teach motion that matches sound",
+      "Fine-tune music-timed video",
+      "Learn lip and beat synchronization",
+      "Produce weights for audio-to-video"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "audio_normalize",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Peak-normalize conditioning audio for consistent levels across the dataset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "audio_preserve_pitch",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preserve pitch when fitting audio to video duration (vs trimming/padding).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, synthesized training videos above the duration threshold are split into scenes after start-image/audio assembly.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "validation",
+        "tsType": "A2VValidation[]",
+        "propType": "list[A2VValidation]",
+        "default": [],
+        "description": "A list of validation prompts, each with a conditioning audio track.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/v2a",
+    "className": "Ltx23TrainerV2V2a",
+    "docstring": "Trains an LTX 2.3 LoRA that generates foley and sound design for silent video.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "video-to-audio",
+      "foley"
+    ],
+    "useCases": [
+      "Train foley generation for footage",
+      "Teach a sound palette for scenes",
+      "Fine-tune soundtrack generation",
+      "Learn effects that match on-screen action",
+      "Produce weights for video-to-audio"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, long videos are split into scenes. Off by default for v2a: every clip must keep an audio track (the model generates audio), and scene splitting can produce silent trailing segments that would fail the per-clip audio check with a confusing error. Mirrors the a2v default.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation",
+        "tsType": "V2AValidation[]",
+        "propType": "list[V2AValidation]",
+        "default": [],
+        "description": "A list of validation prompts, each with a silent video to generate audio for.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/t2a",
+    "className": "Ltx23TrainerV2T2a",
+    "docstring": "Trains an LTX 2.3 LoRA that generates audio from a text prompt.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "text-to-audio"
+    ],
+    "useCases": [
+      "Train text-to-audio on your clips",
+      "Teach a signature sound",
+      "Fine-tune a sound-effect library",
+      "Learn a musical style from samples",
+      "Produce weights for text-to-audio"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "audio_normalize",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Peak-normalize audio for consistent levels across the dataset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "audio_preserve_pitch",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preserve pitch when fitting audio duration (vs trimming/padding).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "validation",
+        "tsType": "T2AValidation[]",
+        "propType": "list[T2AValidation]",
+        "default": [],
+        "description": "A list of validation prompts (audio is generated from each).",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "audio_duration_seconds",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Target audio clip length in seconds (the audio duration bucket). Clips shorter than this are skipped; longer clips are trimmed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.5,
+        "max": 60
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/a2a",
+    "className": "Ltx23TrainerV2A2a",
+    "docstring": "Trains an LTX 2.3 LoRA that maps one audio clip to another from paired examples.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "audio-to-audio"
+    ],
+    "useCases": [
+      "Train an audio transformation",
+      "Teach a timbre or style transfer",
+      "Fine-tune on paired audio",
+      "Learn a mastering signature",
+      "Produce weights for audio-to-audio"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "audio_normalize",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Peak-normalize audio for consistent levels across the dataset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "audio_preserve_pitch",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preserve pitch when fitting audio duration (vs trimming/padding).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Off for a2a: the paired target/reference audio prep ignores scene splitting (it would desync the pair). Provide pre-split clips instead.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "validation",
+        "tsType": "A2AValidation[]",
+        "propType": "list[A2AValidation]",
+        "default": [],
+        "description": "A list of validation prompts, each with a reference audio clip.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "audio_duration_seconds",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Target audio clip length in seconds (the audio duration bucket). Clips shorter than this are skipped; longer clips are trimmed. Audio-only modes need this because there is no video frame-count to derive a length from.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.5,
+        "max": 60
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/audio-inpaint",
+    "className": "Ltx23TrainerV2AudioInpaint",
+    "docstring": "Trains an LTX 2.3 LoRA that regenerates masked time spans of an audio clip.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "audio",
+      "inpainting",
+      "mask"
+    ],
+    "useCases": [
+      "Train audio gap repair",
+      "Teach removal of unwanted sounds",
+      "Fine-tune masked audio regeneration",
+      "Learn seamless audio patching",
+      "Produce weights for audio inpainting"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "audio_normalize",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Peak-normalize audio for consistent levels across the dataset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "audio_preserve_pitch",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preserve pitch when fitting audio duration (vs trimming/padding).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "validation",
+        "tsType": "AudioInpaintValidation[]",
+        "propType": "list[AudioInpaintValidation]",
+        "default": [],
+        "description": "A list of validation prompts, each with an audio clip + time ranges.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "audio_duration_seconds",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Target audio clip length in seconds (the audio duration bucket). Clips shorter than this are skipped; longer clips are trimmed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.5,
+        "max": 60
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/audio-extend-prefix",
+    "className": "Ltx23TrainerV2AudioExtendPrefix",
+    "docstring": "Trains an LTX 2.3 LoRA that continues an audio clip forward in time.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "audio",
+      "extension"
+    ],
+    "useCases": [
+      "Train forward audio continuation",
+      "Extend a track past its ending",
+      "Fine-tune audio outros",
+      "Learn how a piece should continue",
+      "Produce weights for audio extension"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "audio_normalize",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Peak-normalize audio for consistent levels across the dataset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "audio_preserve_pitch",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preserve pitch when fitting audio duration (vs trimming/padding).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "validation",
+        "tsType": "AudioExtendValidation[]",
+        "propType": "list[AudioExtendValidation]",
+        "default": [],
+        "description": "A list of validation prompts, each with an audio clip to extend forward.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "conditioning_seconds",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Seconds of leading audio kept as the clean prefix condition. Must be < audio_duration_seconds so there is a continuation to generate.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.1,
+        "max": 30
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "audio_duration_seconds",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Target audio clip length in seconds (the audio duration bucket). Clips shorter than this are skipped; longer clips are trimmed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.5,
+        "max": 60
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/audio-extend-suffix",
+    "className": "Ltx23TrainerV2AudioExtendSuffix",
+    "docstring": "Trains an LTX 2.3 LoRA that generates the lead-in to an audio clip.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "audio",
+      "extension"
+    ],
+    "useCases": [
+      "Train backward audio extension",
+      "Generate an intro for a track",
+      "Fine-tune audio lead-ins",
+      "Learn how a piece should begin",
+      "Produce weights for audio prefix generation"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "audio_normalize",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Peak-normalize audio for consistent levels across the dataset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "audio_preserve_pitch",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preserve pitch when fitting audio duration (vs trimming/padding).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "validation",
+        "tsType": "AudioExtendValidation[]",
+        "propType": "list[AudioExtendValidation]",
+        "default": [],
+        "description": "A list of validation prompts, each with an audio clip to extend backward.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "conditioning_seconds",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Seconds of trailing audio kept as the clean suffix condition. Must be < audio_duration_seconds so there is a lead-in to generate.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.1,
+        "max": 30
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "audio_duration_seconds",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Target audio clip length in seconds (the audio duration bucket). Clips shorter than this are skipped; longer clips are trimmed.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.5,
+        "max": 60
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/av2av",
+    "className": "Ltx23TrainerV2Av2av",
+    "docstring": "Trains an LTX 2.3 LoRA for a joint audio and video transformation conditioned on a reference clip.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "audio",
+      "video-to-video",
+      "reference"
+    ],
+    "useCases": [
+      "Train joint audio-video restyling",
+      "Teach a reference-conditioned transform",
+      "Fine-tune paired sound and picture",
+      "Learn a full-clip transformation",
+      "Produce weights for av2av"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "audio_normalize",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Peak-normalize audio for consistent levels across the dataset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "audio_preserve_pitch",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preserve pitch when fitting audio to video duration (vs trimming).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Off for av2av: the paired target/reference prep ignores scene splitting (it would desync the _start/_end pair). Provide pre-split clips instead.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation",
+        "tsType": "AV2AVValidation[]",
+        "propType": "list[AV2AVValidation]",
+        "default": [],
+        "description": "A list of validation prompts, each with a reference video (+audio).",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "reference_temporal_scale_factor",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Temporally downsample the reference VIDEO by this factor (lower fps) before encoding. 1 = same fps (default).",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 8
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_downscale_factor",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Spatially downscale the reference VIDEO by this factor before encoding (coarse/low-res control proxy -> full-res output). 1 = same resolution (default). Reference width/height and width/height divided by the factor must be divisible by 32.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 8
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/av2av-masked",
+    "className": "Ltx23TrainerV2Av2avMasked",
+    "docstring": "Trains an LTX 2.3 LoRA that regenerates a masked video region while generating audio from a reference.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "audio",
+      "inpainting",
+      "mask",
+      "reference"
+    ],
+    "useCases": [
+      "Train masked audio-video regeneration",
+      "Teach region replacement with sound",
+      "Fine-tune masked multimodal edits",
+      "Learn reference-guided repair",
+      "Produce weights for masked av2av"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "audio_normalize",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Peak-normalize audio for consistent levels across the dataset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "audio_preserve_pitch",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preserve pitch when fitting audio to video duration (vs trimming).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Off for masked av2av: the paired target/reference/mask prep ignores scene splitting (it would desync the _start/_end/_mask triplet). Provide pre-split clips.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "validation",
+        "tsType": "AV2AVMaskedValidation[]",
+        "propType": "list[AV2AVMaskedValidation]",
+        "default": [],
+        "description": "A list of validation inputs with a prompt, source video, mask, and reference video (+audio).",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/ic-lora/v2v",
+    "className": "Ltx23TrainerV2IcLoraV2v",
+    "docstring": "Trains an LTX 2.3 IC-LoRA for a video-to-video transformation conditioned on a control video.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "ic-lora",
+      "video-to-video"
+    ],
+    "useCases": [
+      "Train an in-context video transform",
+      "Teach control-video conditioning",
+      "Fine-tune from paired clips",
+      "Learn a restyle steered at inference",
+      "Produce IC-LoRA weights for v2v"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If true, videos above a certain duration threshold will be split into scenes.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation",
+        "tsType": "V2VValidation[]",
+        "propType": "list[V2VValidation]",
+        "default": [],
+        "description": "A list of validation inputs with prompts and reference videos.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "reference_temporal_scale_factor",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Temporally downsample the reference (IC-LoRA control) video by this factor (lower fps) before encoding, so the LoRA can be driven by a low-fps reference. 1 = same fps (default; unchanged behavior).",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 8
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 3000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "first_frame_conditioning_p",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.1,
+        "description": "Probability of conditioning on the first frame during training. Lower values work better for video-to-video transformation.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_downscale_factor",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Spatially downscale the reference (IC-LoRA control) video by this factor before encoding, so the LoRA learns to drive a full-resolution output from a coarse / low-res reference (e.g. a small pose/depth/sketch proxy). 1 = same resolution (default; unchanged behavior). Both the reference width/height and width/height divided by the factor must be divisible by 32.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 8
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/ic-lora/v2v-masked",
+    "className": "Ltx23TrainerV2IcLoraV2vMasked",
+    "docstring": "Trains an LTX 2.3 IC-LoRA that regenerates a masked video region guided by kept pixels and a control video.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "ic-lora",
+      "video-to-video",
+      "mask"
+    ],
+    "useCases": [
+      "Train masked in-context transforms",
+      "Teach reference-guided region edits",
+      "Fine-tune object replacement",
+      "Learn mask-aware conditioning",
+      "Produce IC-LoRA weights for masked v2v"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Off for masked v2v: the paired target/reference/mask prep ignores scene splitting (it would desync the _start/_end/_mask triplet). Provide pre-split clips.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation",
+        "tsType": "V2VMaskedValidation[]",
+        "propType": "list[V2VMaskedValidation]",
+        "default": [],
+        "description": "A list of validation inputs with a prompt, source video, mask, and reference video.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 3000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/ic-lora/a2a",
+    "className": "Ltx23TrainerV2IcLoraA2a",
+    "docstring": "Trains an LTX 2.3 IC-LoRA that transforms audio conditioned on a reference clip.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "ic-lora",
+      "audio-to-audio"
+    ],
+    "useCases": [
+      "Train in-context audio transforms",
+      "Teach reference-driven timbre transfer",
+      "Fine-tune on paired audio",
+      "Learn a style steered at inference",
+      "Produce IC-LoRA weights for a2a"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "audio_normalize",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Peak-normalize audio for consistent levels across the dataset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "audio_preserve_pitch",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preserve pitch when fitting audio duration (vs trimming/padding).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Off for a2a: the paired target/reference audio prep ignores scene splitting (it would desync the pair). Provide pre-split clips instead.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "validation",
+        "tsType": "A2AValidation[]",
+        "propType": "list[A2AValidation]",
+        "default": [],
+        "description": "A list of validation prompts, each with a reference audio clip.",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "audio_duration_seconds",
+        "tsType": "number",
+        "propType": "float",
+        "default": 5,
+        "description": "Target audio clip length in seconds (the audio duration bucket). Clips shorter than this are skipped; longer clips are trimmed. Audio-only modes need this because there is no video frame-count to derive a length from.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.5,
+        "max": 60
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/ic-lora/av2av",
+    "className": "Ltx23TrainerV2IcLoraAv2av",
+    "docstring": "Trains an LTX 2.3 IC-LoRA for a joint audio and video transformation from a reference clip.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "ic-lora",
+      "audio",
+      "video-to-video"
+    ],
+    "useCases": [
+      "Train in-context audio-video transforms",
+      "Teach reference-conditioned restyling",
+      "Fine-tune sound and picture together",
+      "Learn a full-clip mapping",
+      "Produce IC-LoRA weights for av2av"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "audio_normalize",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Peak-normalize audio for consistent levels across the dataset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "audio_preserve_pitch",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preserve pitch when fitting audio to video duration (vs trimming).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Off for av2av: the paired target/reference prep ignores scene splitting (it would desync the _start/_end pair). Provide pre-split clips instead.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation",
+        "tsType": "AV2AVValidation[]",
+        "propType": "list[AV2AVValidation]",
+        "default": [],
+        "description": "A list of validation prompts, each with a reference video (+audio).",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "reference_temporal_scale_factor",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Temporally downsample the reference VIDEO by this factor (lower fps) before encoding. 1 = same fps (default).",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 8
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_downscale_factor",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Spatially downscale the reference VIDEO by this factor before encoding (coarse/low-res control proxy -> full-res output). 1 = same resolution (default). Reference width/height and width/height divided by the factor must be divisible by 32.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 8
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "fal-ai/ltx23-trainer-v2/ic-lora/av2av-masked",
+    "className": "Ltx23TrainerV2IcLoraAv2avMasked",
+    "docstring": "Trains an LTX 2.3 IC-LoRA that regenerates a masked video region while generating audio from a reference.",
+    "tags": [
+      "training",
+      "fine-tuning",
+      "lora",
+      "model-training",
+      "ltx",
+      "ltx-2-3",
+      "ic-lora",
+      "audio",
+      "mask",
+      "inpainting"
+    ],
+    "useCases": [
+      "Train masked in-context multimodal edits",
+      "Teach guided region repair with sound",
+      "Fine-tune reference-driven inpainting",
+      "Learn mask-aware av conditioning",
+      "Produce IC-LoRA weights for masked av2av"
+    ],
+    "inputFields": [
+      {
+        "name": "learning_rate",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.0002,
+        "description": "Learning rate for optimization.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0.000001,
+        "max": 1
+      },
+      {
+        "name": "rank",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 32,
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Rank",
+        "enumValues": [
+          8,
+          16,
+          32,
+          64,
+          128
+        ]
+      },
+      {
+        "name": "validation_resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "high",
+        "description": "The resolution to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationResolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "stg_scale",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "STG (Spatio-Temporal Guidance) scale. 0.0 disables STG. Recommended value is 1.0.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 3
+      },
+      {
+        "name": "split_input_duration_threshold",
+        "tsType": "number",
+        "propType": "float",
+        "default": 30,
+        "description": "The duration threshold in seconds. If a video is longer than this, it will be split into scenes.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 60
+      },
+      {
+        "name": "audio_normalize",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Peak-normalize audio for consistent levels across the dataset.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "The aspect ratio to use for validation.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "ValidationAspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1:1",
+        "description": "Aspect ratio to use for training.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "16:9",
+          "1:1",
+          "9:16"
+        ]
+      },
+      {
+        "name": "frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for the training video (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "audio_preserve_pitch",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Preserve pitch when fitting audio to video duration (vs trimming).",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "split_input_into_scenes",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Off for masked av2av: the paired target/reference/mask prep ignores scene splitting (it would desync the _start/_end/_mask triplet). Provide pre-split clips.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "trigger_phrase",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "A phrase that will trigger the LoRA style. Will be prepended to captions during training.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "training_data_url",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to a `.zip` archive of your training data. The exact file layout depends on the training mode — see this endpoint's documentation for the required structure. You can include a `.txt` caption alongside each media file (same base name).",
+        "fieldType": "input",
+        "required": true
+      },
+      {
+        "name": "validation",
+        "tsType": "AV2AVMaskedValidation[]",
+        "propType": "list[AV2AVMaskedValidation]",
+        "default": [],
+        "description": "A list of validation inputs with a prompt, source video, mask, and reference video (+audio).",
+        "fieldType": "input",
+        "required": false,
+        "max": 2
+      },
+      {
+        "name": "validation_negative_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts.",
+        "description": "A negative prompt to use for validation. Note: validation previews are single-stage approximations of the production two-stage (distilled) inference, so preview quality and guidance differ from final inference.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "validation_number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "The number of frames in validation videos.",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_frames",
+        "tsType": "number",
+        "propType": "int",
+        "default": 89,
+        "description": "Number of frames per training sample. Must satisfy frames % 8 == 1 (e.g., 1, 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97).",
+        "fieldType": "input",
+        "required": false,
+        "min": 9,
+        "max": 121
+      },
+      {
+        "name": "number_of_steps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2000,
+        "description": "The number of training steps.",
+        "fieldType": "input",
+        "required": false,
+        "min": 100,
+        "max": 10000
+      },
+      {
+        "name": "validation_frame_rate",
+        "tsType": "number",
+        "propType": "int",
+        "default": 24,
+        "description": "Target frames per second for validation videos (LTX-2.3 native is 24).",
+        "fieldType": "input",
+        "required": false,
+        "min": 8,
+        "max": 60
+      },
+      {
+        "name": "auto_scale_input",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If true, videos will be automatically scaled to the target frame count and fps. This option has no effect on image datasets.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "When enabled, the trainer returns a downloadable archive of your preprocessed training data for manual inspection. Use this to verify that your videos, images, and captions were processed correctly before committing to a full training run.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "medium",
+        "description": "Resolution to use for training. Higher resolutions require more memory.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Combined validation video preview (video-producing endpoints), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "audio",
+        "propType": "audio",
+        "default": null,
+        "description": "Combined validation audio preview for the audio-only-output endpoints (/v2a, /a2a, /t2a, /audio-extend-prefix, /audio-extend-suffix, /audio-inpaint), if any.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "lora_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "URL to the trained LoRA weights (.safetensors).",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "debug_dataset",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Downloadable archive of the preprocessed training data, when debug_dataset is enabled.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "config_file",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Configuration used for setting up inference endpoints.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Rank",
+        "values": [
+          [
+            "VALUE_8",
+            8
+          ],
+          [
+            "VALUE_16",
+            16
+          ],
+          [
+            "VALUE_32",
+            32
+          ],
+          [
+            "VALUE_64",
+            64
+          ],
+          [
+            "VALUE_128",
+            128
+          ]
+        ],
+        "description": "The rank of the LoRA adaptation. Higher values increase capacity but use more memory."
+      },
+      {
+        "name": "ValidationResolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "The resolution to use for validation."
+      },
+      {
+        "name": "ValidationAspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio to use for validation."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Aspect ratio to use for training."
+      },
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "LOW",
+            "low"
+          ],
+          [
+            "MEDIUM",
+            "medium"
+          ],
+          [
+            "HIGH",
+            "high"
+          ]
+        ],
+        "description": "Resolution to use for training. Higher resolutions require more memory."
+      }
+    ],
+    "moduleName": "training"
+  },
+  {
+    "endpointId": "alibaba/wan-3.0-prime/reference-to-video",
+    "className": "Wan30PrimeReferenceToVideo",
+    "docstring": "Wan 3.0 Prime combines reference images, video, and audio into one clip with multimodal coherence.",
+    "tags": [
+      "video-to-video",
+      "vid2vid",
+      "video",
+      "reference",
+      "wan",
+      "wan-3"
+    ],
+    "useCases": [
+      "Drive a video from image and audio references",
+      "Keep an identity consistent across takes",
+      "Restyle footage against a reference",
+      "Match motion from a reference clip",
+      "Produce controlled character animation"
+    ],
+    "inputFields": [
+      {
+        "name": "enable_prompt_expansion",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable intelligent prompt rewriting. Disabling it can save roughly 20-60 seconds of latency but is likely to degrade generation quality.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt directing how the reference media is used. Reference media can be addressed positionally, e.g. 'the subject in Image 1 walks past Video 1'.",
+        "fieldType": "input",
+        "required": false,
+        "max": 5000
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "1080p",
+        "description": "Output video resolution tier.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480p",
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Enable content moderation for input and output. Disabling it requires account authorization; unauthorized requests are always checked.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "duration",
+        "tsType": "string",
+        "propType": "str",
+        "default": 5,
+        "description": "Output duration in seconds. Set to null for smart duration, which lets the model pick a length from the prompt and reference media.",
+        "fieldType": "input",
+        "required": false,
+        "min": 2,
+        "max": 30
+      },
+      {
+        "name": "file_url",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Document URL to base the video on. Requires enable_thinking=true.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "audio",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "Include generated audio.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Up to 10 reference image URLs.",
+        "fieldType": "input",
+        "required": false,
+        "max": 10,
+        "apiParamName": "reference_image_urls"
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "adaptive",
+        "description": "Output aspect ratio, or adaptive selection.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "adaptive",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "reference_video_urls",
+        "tsType": "video[]",
+        "propType": "list[video]",
+        "default": [],
+        "description": "Up to 5 reference video URLs totaling at most 15 seconds. Each clip must be at least 16 fps.",
+        "fieldType": "input",
+        "required": false,
+        "max": 5
+      },
+      {
+        "name": "enable_thinking",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Enable enhanced reasoning before generation.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_audio_urls",
+        "tsType": "audio[]",
+        "propType": "list[audio]",
+        "default": [],
+        "description": "Up to 5 reference audio URLs totaling at most 15 seconds.",
+        "fieldType": "input",
+        "required": false,
+        "max": 5
+      },
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      },
+      {
+        "name": "web_url",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "Public webpage URL to base the video on. Requires enable_thinking=true. Only pages that do not require login can be read.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0,
+        "description": "Generated video duration in seconds.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "actual_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "number",
+        "propType": "int",
+        "default": -1,
+        "description": "The seed used for generation.",
+        "fieldType": "output",
+        "required": true
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video file.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480p"
+          ],
+          [
+            "VALUE_720P",
+            "720p"
+          ],
+          [
+            "VALUE_1080P",
+            "1080p"
+          ]
+        ],
+        "description": "Output video resolution tier."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "ADAPTIVE",
+            "adaptive"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "Output aspect ratio, or adaptive selection."
+      }
+    ],
+    "moduleName": "video_to_video"
+  },
+  {
+    "endpointId": "blackforestlabs/flux-video-upscale",
+    "className": "FluxVideoUpscale",
+    "docstring": "FLUX video super-resolution upscales footage to 1080p, 2K, or 4K in a precise or creative detail mode.",
+    "tags": [
+      "video-to-video",
+      "vid2vid",
+      "video",
+      "upscale",
+      "super-resolution",
+      "flux",
+      "enhancement"
+    ],
+    "useCases": [
+      "Upscale archive footage to 4K",
+      "Sharpen low-resolution clips for delivery",
+      "Enhance AI-generated video before edit",
+      "Prepare social clips for large displays",
+      "Recover detail in compressed footage"
+    ],
+    "inputFields": [
+      {
+        "name": "upscale_factor",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2,
+        "description": "Output scaling factor. The source aspect ratio is preserved.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1.5,
+        "max": 3
+      },
+      {
+        "name": "creativity",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": 1,
+        "description": "Use 0 for a source-faithful upscale or 1 for creative detail enhancement.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Creativity",
+        "enumValues": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "URL of the MP4 video to upscale. The video must be at most 20 seconds and 50 MB.",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "video_url"
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Optional description used to guide creative detail enhancement.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "safety_tolerance",
+        "tsType": "number",
+        "propType": "int",
+        "default": 2,
+        "description": "Moderation strictness. Lower values are stricter.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 4
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The upscaled MP4 video.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Creativity",
+        "values": [
+          [
+            "VALUE_0",
+            0
+          ],
+          [
+            "VALUE_1",
+            1
+          ]
+        ],
+        "description": "Use 0 for a source-faithful upscale or 1 for creative detail enhancement."
+      }
+    ],
+    "moduleName": "video_to_video"
+  },
+  {
+    "endpointId": "minimax/h3/reference-to-video/lora",
+    "className": "MinimaxH3ReferenceToVideoLora",
+    "docstring": "MiniMax H3 generates video with synchronized audio from references, with LoRA support.",
+    "tags": [
+      "video-to-video",
+      "vid2vid",
+      "video",
+      "reference",
+      "minimax",
+      "h3",
+      "lora",
+      "audio"
+    ],
+    "useCases": [
+      "Drive video from reference material",
+      "Combine a LoRA with reference control",
+      "Keep a set and cast consistent",
+      "Restyle references into new shots",
+      "Produce continuity across episodes"
+    ],
+    "inputFields": [
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Random seed. A random seed is selected when omitted.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5,
+        "description": "The duration of the video in seconds.",
+        "fieldType": "input",
+        "required": false,
+        "min": 5,
+        "max": 15
+      },
+      {
+        "name": "reference_images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "URLs of subject/style reference images, referenced in the prompt as Image 1, Image 2, and so on. Reference images, videos, and audio clips must add up to at most 12 files.",
+        "fieldType": "input",
+        "required": false,
+        "max": 9,
+        "apiParamName": "reference_image_urls"
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "2K",
+        "description": "The resolution of the generated video. 480P and 768P are native generation modes; 2K and 4K upscale a 768P base result.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480P",
+          "768P",
+          "2K",
+          "4K"
+        ]
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, the safety checker will be enabled.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_video_urls",
+        "tsType": "video[]",
+        "propType": "list[video]",
+        "default": [],
+        "description": "URLs of motion/reference video clips (2-15 seconds each, combined duration at most 15 seconds), referenced in the prompt as Video 1, Video 2, and so on. Reference images, videos, and audio clips must add up to at most 12 files.",
+        "fieldType": "input",
+        "required": false,
+        "max": 3
+      },
+      {
+        "name": "prompt_expansion_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "balanced",
+        "description": "How much effort to spend rewriting the prompt before generation. 'disabled' skips prompt expansion. 'fast' returns in about a second. 'quality' spends up to ~30s on a richer prompt. 'balanced' picks per request.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "PromptExpansionMode",
+        "enumValues": [
+          "disabled",
+          "fast",
+          "balanced",
+          "quality"
+        ]
+      },
+      {
+        "name": "sync_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Return the generated video as base64 instead of a CDN URL.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "reference_audio_urls",
+        "tsType": "audio[]",
+        "propType": "list[audio]",
+        "default": [],
+        "description": "URLs of reference audio clips (2-15 seconds each, combined duration at most 15 seconds), referenced in the prompt as Audio 1, Audio 2, and so on. Audio cannot be the only reference input; provide at least one reference image or video with it. Reference images, videos, and audio clips must add up to at most 12 files.",
+        "fieldType": "input",
+        "required": false,
+        "max": 3
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation. Refer to reference assets by their modality and order in the reference lists: Image 1, Image 2, Video 1, Audio 1, and so on.",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 50000
+      },
+      {
+        "name": "loras",
+        "tsType": "LoRAInput[]",
+        "propType": "list[LoRAInput]",
+        "default": [],
+        "description": "List of LoRA adapters to apply to the transformer.",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 3
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "adaptive",
+        "description": "The aspect ratio of the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "adaptive",
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "expanded_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt after expansion, as sent to the model. Null when prompt expansion was disabled, left the prompt unchanged, or was performed internally by MiniMax's hosted API.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480P"
+          ],
+          [
+            "VALUE_768P",
+            "768P"
+          ],
+          [
+            "VALUE_2K",
+            "2K"
+          ],
+          [
+            "VALUE_4K",
+            "4K"
+          ]
+        ],
+        "description": "The resolution of the generated video. 480P and 768P are native generation modes; 2K and 4K upscale a 768P base result."
+      },
+      {
+        "name": "PromptExpansionMode",
+        "values": [
+          [
+            "DISABLED",
+            "disabled"
+          ],
+          [
+            "FAST",
+            "fast"
+          ],
+          [
+            "BALANCED",
+            "balanced"
+          ],
+          [
+            "QUALITY",
+            "quality"
+          ]
+        ],
+        "description": "How much effort to spend rewriting the prompt before generation. 'disabled' skips prompt expansion. 'fast' returns in about a second. 'quality' spends up to ~30s on a richer prompt. 'balanced' picks per request."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "ADAPTIVE",
+            "adaptive"
+          ],
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio of the generated video."
+      }
+    ],
+    "moduleName": "video_to_video"
+  },
+  {
+    "endpointId": "topaz/upscale/video/precision",
+    "className": "TopazUpscaleVideoPrecision",
+    "docstring": "Topaz precision video models enhance footage up to 4x while staying faithful to the source.",
+    "tags": [
+      "video-to-video",
+      "vid2vid",
+      "video",
+      "topaz",
+      "upscale",
+      "super-resolution",
+      "enhancement"
+    ],
+    "useCases": [
+      "Upscale real-world footage to 4K",
+      "Enhance interviews without artifacts",
+      "Prepare archive video for delivery",
+      "Scale drone footage faithfully",
+      "Deliver clean natural upscales"
+    ],
+    "inputFields": [
+      {
+        "name": "target_fps",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Target FPS for the output. Frame interpolation is enabled only when this differs from the source FPS.",
+        "fieldType": "input",
+        "required": false,
+        "min": 16,
+        "max": 60
+      },
+      {
+        "name": "halo",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Halo reduction level (0.0-1.0). Default varies by model.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Proteus",
+        "description": "Precision (non-generative) enhancement model. Proteus fits most real-world footage; Proteus Natural is a softer variant; Iris recovers faces; Dione deinterlaces legacy/interlaced sources; Artemis denoises and sharpens degraded footage; Gaia refines high-quality footage and CG (Gaia 2 upscales animation at 2x); Rhea maximizes fine detail via an internal 4x pass; Theia gives manual detail/fidelity control.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "Proteus",
+          "Proteus Natural",
+          "Iris",
+          "Iris Low Quality",
+          "Dione DV",
+          "Dione TV",
+          "Dione Robust",
+          "Dione Dehalo",
+          "Dione Robust Dehalo",
+          "Artemis High Quality",
+          "Artemis Medium Quality",
+          "Artemis Low Quality",
+          "Artemis Strong Halo",
+          "Artemis Medium Halo",
+          "Artemis Aliasing & Moire",
+          "Gaia HQ",
+          "Gaia CG",
+          "Gaia 2",
+          "Rhea",
+          "Theia Fine Tune Detail",
+          "Theia Fine Tune Fidelity"
+        ]
+      },
+      {
+        "name": "grain",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Film grain amount (0.0-0.1). Default varies by model.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 0.1
+      },
+      {
+        "name": "noise",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Noise reduction level (0.0-1.0). Default varies by model.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "compression",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Compression artifact removal level (0.0-1.0). Default varies by model.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "URL of the video to upscale",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "video_url"
+      },
+      {
+        "name": "recover_detail",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Recover original detail level (0.0-1.0). Higher values preserve more original detail.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "H264_output",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Whether to use H264 codec for output video. Default is H265.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "upscale_factor",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2,
+        "description": "Factor to upscale the video by (e.g. 2.0 doubles width and height)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The upscaled video file",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Model",
+        "values": [
+          [
+            "PROTEUS",
+            "Proteus"
+          ],
+          [
+            "PROTEUS_NATURAL",
+            "Proteus Natural"
+          ],
+          [
+            "IRIS",
+            "Iris"
+          ],
+          [
+            "IRIS_LOW_QUALITY",
+            "Iris Low Quality"
+          ],
+          [
+            "DIONE_DV",
+            "Dione DV"
+          ],
+          [
+            "DIONE_TV",
+            "Dione TV"
+          ],
+          [
+            "DIONE_ROBUST",
+            "Dione Robust"
+          ],
+          [
+            "DIONE_DEHALO",
+            "Dione Dehalo"
+          ],
+          [
+            "DIONE_ROBUST_DEHALO",
+            "Dione Robust Dehalo"
+          ],
+          [
+            "ARTEMIS_HIGH_QUALITY",
+            "Artemis High Quality"
+          ],
+          [
+            "ARTEMIS_MEDIUM_QUALITY",
+            "Artemis Medium Quality"
+          ],
+          [
+            "ARTEMIS_LOW_QUALITY",
+            "Artemis Low Quality"
+          ],
+          [
+            "ARTEMIS_STRONG_HALO",
+            "Artemis Strong Halo"
+          ],
+          [
+            "ARTEMIS_MEDIUM_HALO",
+            "Artemis Medium Halo"
+          ],
+          [
+            "ARTEMIS_ALIASING_AND_MOIRE",
+            "Artemis Aliasing & Moire"
+          ],
+          [
+            "GAIA_HQ",
+            "Gaia HQ"
+          ],
+          [
+            "GAIA_CG",
+            "Gaia CG"
+          ],
+          [
+            "GAIA_2",
+            "Gaia 2"
+          ],
+          [
+            "RHEA",
+            "Rhea"
+          ],
+          [
+            "THEIA_FINE_TUNE_DETAIL",
+            "Theia Fine Tune Detail"
+          ],
+          [
+            "THEIA_FINE_TUNE_FIDELITY",
+            "Theia Fine Tune Fidelity"
+          ]
+        ],
+        "description": "Precision (non-generative) enhancement model. Proteus fits most real-world footage; Proteus Natural is a softer variant; Iris recovers faces; Dione deinterlaces legacy/interlaced sources; Artemis denoises and sharpens degraded footage; Gaia refines high-quality footage and CG (Gaia 2 upscales animation at 2x); Rhea maximizes fine detail via an internal 4x pass; Theia gives manual detail/fidelity control."
+      }
+    ],
+    "moduleName": "video_to_video"
+  },
+  {
+    "endpointId": "topaz/upscale/video/generative",
+    "className": "TopazUpscaleVideoGenerative",
+    "docstring": "Topaz Starlight generative video upscaling rebuilds detail absent from the source, with cheaper fast variants.",
+    "tags": [
+      "video-to-video",
+      "vid2vid",
+      "video",
+      "topaz",
+      "upscale",
+      "generative",
+      "super-resolution"
+    ],
+    "useCases": [
+      "Restore heavily compressed footage",
+      "Rebuild detail in archive video",
+      "Upscale low-quality user clips",
+      "Recover detail lost to re-encoding",
+      "Trade cost for quality with fast variants"
+    ],
+    "inputFields": [
+      {
+        "name": "target_fps",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Target FPS for the output. Frame interpolation is enabled only when this differs from the source FPS.",
+        "fieldType": "input",
+        "required": false,
+        "min": 16,
+        "max": 60
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Starlight Precise 2.6",
+        "description": "Generative diffusion enhancement model. Starlight Precise 2.6 adds realism to AI-generated video; Starlight HQ maximizes quality on high-resolution sources; Starlight Mini restores archival footage; Starlight Sharp is fast restoration with sharper detail; Starlight Fast 2 is the fastest, cheapest diffusion upscaler.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "Starlight Precise 2.6",
+          "Starlight HQ",
+          "Starlight Mini",
+          "Starlight Sharp",
+          "Starlight Fast 2"
+        ]
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "URL of the video to upscale",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "video_url"
+      },
+      {
+        "name": "H264_output",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Whether to use H264 codec for output video. Default is H265.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "softness",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "How much softening the model applies to the output, from 1 (sharpest) to 5 (softest). Starlight Precise 2.6 only; leave unset for Topaz's default.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 5
+      },
+      {
+        "name": "upscale_factor",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2,
+        "description": "Factor to upscale the video by (e.g. 2.0 doubles width and height)",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The upscaled video file",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Model",
+        "values": [
+          [
+            "STARLIGHT_PRECISE_2_6",
+            "Starlight Precise 2.6"
+          ],
+          [
+            "STARLIGHT_HQ",
+            "Starlight HQ"
+          ],
+          [
+            "STARLIGHT_MINI",
+            "Starlight Mini"
+          ],
+          [
+            "STARLIGHT_SHARP",
+            "Starlight Sharp"
+          ],
+          [
+            "STARLIGHT_FAST_2",
+            "Starlight Fast 2"
+          ]
+        ],
+        "description": "Generative diffusion enhancement model. Starlight Precise 2.6 adds realism to AI-generated video; Starlight HQ maximizes quality on high-resolution sources; Starlight Mini restores archival footage; Starlight Sharp is fast restoration with sharper detail; Starlight Fast 2 is the fastest, cheapest diffusion upscaler."
+      }
+    ],
+    "moduleName": "video_to_video"
+  },
+  {
+    "endpointId": "topaz/upscale/video/creative",
+    "className": "TopazUpscaleVideoCreative",
+    "docstring": "Topaz Astra creative video upscaling reimagines fine detail and typically delivers 4K output.",
+    "tags": [
+      "video-to-video",
+      "vid2vid",
+      "video",
+      "topaz",
+      "upscale",
+      "creative",
+      "super-resolution"
+    ],
+    "useCases": [
+      "Push a hero shot to maximum impact",
+      "Reimagine detail in cinematic footage",
+      "Finish stylized clips at 4K",
+      "Enhance generated video for delivery",
+      "Add invented texture to flat footage"
+    ],
+    "inputFields": [
+      {
+        "name": "upscale_factor",
+        "tsType": "number",
+        "propType": "float",
+        "default": 2,
+        "description": "Requested upscale factor (e.g. 2.0 doubles width and height). Note: Astra 2 snaps to its own supported output resolutions (typically 4K when upscaling) and may override the requested target. Billing is based on the delivered resolution.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Optional text prompt guiding the detail Astra 2 generates. When set, the input video is limited to 450 frames.",
+        "fieldType": "input",
+        "required": false,
+        "max": 1024
+      },
+      {
+        "name": "target_fps",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Target FPS for the output. Frame interpolation is enabled only when this differs from the source FPS.",
+        "fieldType": "input",
+        "required": false,
+        "min": 16,
+        "max": 60
+      },
+      {
+        "name": "realism",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Bias generated detail toward photorealism (0.0-1.0).",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "sharp",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Output sharpness. 0.0 softens, 0.5 is neutral passthrough, 1.0 applies strong sharpening. Defaults to Topaz's neutral 0.5.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "URL of the video to upscale",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "video_url"
+      },
+      {
+        "name": "H264_output",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Whether to use H264 codec for output video. Default is H265.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "creativity",
+        "tsType": "number",
+        "propType": "float",
+        "default": 0.5,
+        "description": "How much new detail and texture Astra 2 invents. 0.0 stays faithful to the source, 1.0 is maximally creative.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The upscaled video file",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [],
+    "moduleName": "video_to_video"
+  },
+  {
+    "endpointId": "topaz/denoise/video",
+    "className": "TopazDenoiseVideo",
+    "docstring": "Topaz Nyx models remove video noise at source resolution, with a lighter fast pass.",
+    "tags": [
+      "video-to-video",
+      "vid2vid",
+      "video",
+      "topaz",
+      "denoise",
+      "noise-reduction",
+      "enhancement"
+    ],
+    "useCases": [
+      "Clean low-light footage",
+      "Remove grain from high-ISO clips",
+      "Denoise before upscaling",
+      "Reduce noise in night interviews",
+      "Run a cheaper fast denoise pass"
+    ],
+    "inputFields": [
+      {
+        "name": "noise",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Noise reduction level (0.0-1.0). Default varies by model.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "halo",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Halo reduction level (0.0-1.0). Default varies by model.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Nyx",
+        "description": "Denoise model. Nyx is high-quality denoising with texture preservation; Nyx Fast trades quality for speed on high-volume workloads; Nyx XL targets extreme noise; Nyx HF is precision denoising for pipeline-ready outputs (denoise only, no upscaling).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "Nyx",
+          "Nyx Fast",
+          "Nyx XL",
+          "Nyx HF"
+        ]
+      },
+      {
+        "name": "compression",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Compression artifact removal level (0.0-1.0). Default varies by model.",
+        "fieldType": "input",
+        "required": false,
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "URL of the video to denoise",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "video_url"
+      },
+      {
+        "name": "H264_output",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Whether to use H264 codec for output video. Default is H265.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "upscale_factor",
+        "tsType": "number",
+        "propType": "float",
+        "default": 1,
+        "description": "Optional upscale applied on top of denoising. 1.0 keeps the source resolution.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 4
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The upscaled video file",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Model",
+        "values": [
+          [
+            "NYX",
+            "Nyx"
+          ],
+          [
+            "NYX_FAST",
+            "Nyx Fast"
+          ],
+          [
+            "NYX_XL",
+            "Nyx XL"
+          ],
+          [
+            "NYX_HF",
+            "Nyx HF"
+          ]
+        ],
+        "description": "Denoise model. Nyx is high-quality denoising with texture preservation; Nyx Fast trades quality for speed on high-volume workloads; Nyx XL targets extreme noise; Nyx HF is precision denoising for pipeline-ready outputs (denoise only, no upscaling)."
+      }
+    ],
+    "moduleName": "video_to_video"
+  },
+  {
+    "endpointId": "topaz/deblur/video",
+    "className": "TopazDeblurVideo",
+    "docstring": "Topaz Themis 2 restores clarity to motion-blurred footage at source resolution.",
+    "tags": [
+      "video-to-video",
+      "vid2vid",
+      "video",
+      "topaz",
+      "deblur",
+      "motion-blur",
+      "enhancement"
+    ],
+    "useCases": [
+      "Sharpen fast-moving sports footage",
+      "Recover clarity in action clips",
+      "Fix handheld motion blur",
+      "Clean up panning shots",
+      "Prepare blurred footage for upscale"
+    ],
+    "inputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "URL of the video to deblur (motion deblur, Themis 2)",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "video_url"
+      },
+      {
+        "name": "H264_output",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Whether to use H264 codec for output video. Default is H265.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The upscaled video file",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [],
+    "moduleName": "video_to_video"
+  },
+  {
+    "endpointId": "topaz/interpolate/video",
+    "className": "TopazInterpolateVideo",
+    "docstring": "Topaz Apollo, Chronos, and Aion retime footage up to 120 fps for smooth motion or slow motion.",
+    "tags": [
+      "video-to-video",
+      "vid2vid",
+      "video",
+      "topaz",
+      "interpolate",
+      "frame-rate",
+      "slow-motion"
+    ],
+    "useCases": [
+      "Convert 24 fps footage to 60 fps",
+      "Create extreme slow motion",
+      "Smooth stuttering motion",
+      "Retime clips for a timeline",
+      "Generate 120 fps from standard footage"
+    ],
+    "inputFields": [
+      {
+        "name": "target_fps",
+        "tsType": "number",
+        "propType": "int",
+        "default": 60,
+        "description": "Target frames per second for the interpolated output.",
+        "fieldType": "input",
+        "required": false,
+        "min": 16,
+        "max": 120
+      },
+      {
+        "name": "model",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "Apollo",
+        "description": "Frame interpolation model. Apollo is general-purpose; Chronos targets real-world motion; Aion handles extreme/complex motion.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Model",
+        "enumValues": [
+          "Apollo",
+          "Chronos",
+          "Aion"
+        ]
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "URL of the video to retime / interpolate",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "video_url"
+      },
+      {
+        "name": "slowdown_factor",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "Slow-motion factor: 2 makes the output twice as long at the target FPS (2x slow motion), up to 8x. 1 keeps the original speed. The extra generated frames are billed like interpolated frames.",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 8
+      },
+      {
+        "name": "H264_output",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Whether to use H264 codec for output video. Default is H265.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The upscaled video file",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Model",
+        "values": [
+          [
+            "APOLLO",
+            "Apollo"
+          ],
+          [
+            "CHRONOS",
+            "Chronos"
+          ],
+          [
+            "AION",
+            "Aion"
+          ]
+        ],
+        "description": "Frame interpolation model. Apollo is general-purpose; Chronos targets real-world motion; Aion handles extreme/complex motion."
+      }
+    ],
+    "moduleName": "video_to_video"
+  },
+  {
+    "endpointId": "topaz/colorize/video",
+    "className": "TopazColorizeVideo",
+    "docstring": "Topaz video colorization brings natural color to black-and-white footage, upscaled to at least 1080p.",
+    "tags": [
+      "video-to-video",
+      "vid2vid",
+      "video",
+      "topaz",
+      "colorize",
+      "restoration",
+      "archival"
+    ],
+    "useCases": [
+      "Colorize historical footage",
+      "Restore black-and-white home movies",
+      "Prepare archive clips for a documentary",
+      "Add color to vintage advertising",
+      "Modernize monochrome material"
+    ],
+    "inputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "URL of the black-and-white video to colorize",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "video_url"
+      },
+      {
+        "name": "H264_output",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Whether to use H264 codec for output video. Default is H265.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The upscaled video file",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [],
+    "moduleName": "video_to_video"
+  },
+  {
+    "endpointId": "topaz/sdr-to-hdr/video",
+    "className": "TopazSdrToHdrVideo",
+    "docstring": "Topaz Hyperion 2.5 converts SDR footage to HDR, preserving detail in text, faces, and motion.",
+    "tags": [
+      "video-to-video",
+      "vid2vid",
+      "video",
+      "topaz",
+      "hdr",
+      "sdr-to-hdr",
+      "color"
+    ],
+    "useCases": [
+      "Give SDR footage an HDR look",
+      "Prepare legacy video for HDR delivery",
+      "Expand dynamic range without clipping",
+      "Grade archive material for HDR displays",
+      "Convert a catalog to HDR"
+    ],
+    "inputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "URL of the SDR video to convert to HDR",
+        "fieldType": "input",
+        "required": true,
+        "apiParamName": "video_url"
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "mp4",
+        "description": "Output container/codec: mp4 delivers 10-bit H265 HDR10; prores delivers 10-bit ProRes 422 HQ in a .mov, Topaz's recommended format for grading and mastering workflows (much larger files).",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "mp4",
+          "prores"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The upscaled video file",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "MP4",
+            "mp4"
+          ],
+          [
+            "PRORES",
+            "prores"
+          ]
+        ],
+        "description": "Output container/codec: mp4 delivers 10-bit H265 HDR10; prores delivers 10-bit ProRes 422 HQ in a .mov, Topaz's recommended format for grading and mastering workflows (much larger files)."
+      }
+    ],
+    "moduleName": "video_to_video"
   }
 ]


### PR DESCRIPTION
## What changed

Diffed fal.ai's live model catalog (1,479 public models) against the generated manifest and added every 2026 release NodeTool was missing — 101 endpoints, taking the manifest from 1,473 to 1,574. Video: Wan 3.0 and 3.0 Prime, Seedance 2.5, LTX 2.5, MiniMax H3 LoRA, Mirage Avatar X, FLUX video upscale. Image: Bria Fibo 1.5 gen and edit, Grok Imagine 2.0, Recraft V4 Styles, Seedream 5.0 Pro layerize, Google Virtual Try On. Restoration: 17 Topaz image and video endpoints (upscale, denoise, deblur, interpolate, colorize, SDR-to-HDR, restore, sharpen, adjust). 3D: Meshy V7, Hi3D, Tripo3D remesh and segment. Audio: MiniMax Music 3. Training: 38 trainers, including the 22-endpoint LTX 2.3 trainer-v2 family, MiniMax H3, Wan 2.2, Krea 2, Stable Audio 3, TRELLIS.2 and Ideogram V4.

Endpoints are declared in `packages/fal-codegen/src/configs/`; `fal-manifest.json` was regenerated with `scripts/append-new-endpoints.ts`, which fetches only the schemas the manifest lacks, so the 1,473 existing entries are byte-identical (the manifest diff is 25,432 insertions, 0 deletions). Class names carry the vendor prefix wherever the derived name would be ambiguous (`TopazUpscaleImagePrecision`, `MeshyV7ImageTo3d`, `IdeogramV4Trainer`), and every new node type — `fal.{module}.{ClassName}` — was checked against the existing set, with no collisions. Two endpoints fal lists but whose schema API returns 404, `alibaba/happy-oyster` and `fal-ai/controlfoley`, are left out.

Two things this deliberately does not do. Pre-2026 gaps (29 endpoints, mostly superseded 2024–2025 models) are out of scope for "newest". And unit pricing needs `FAL_API_KEY` to fetch, which this environment has none of, so the generated pricing bundles are untouched — the new nodes report no cost estimate until the next priced `generate:fal` run, the same state 55 already-shipped endpoints are in. `getFalPricing` returns null for an unpriced node type and the estimate is skipped, so nothing breaks.

## Verification

- [x] `npm run test:affected` — all affected suites passed (23 packages, web, electron; 684 electron tests, 2,027 base-nodes tests). The 14 base-nodes failures on the first run were the documented WebGPU gap ("No WebGPU adapter available (Node/Dawn)"); after `apt-get install -y mesa-vulkan-drivers` per AGENTS.md, all 33 base-nodes files pass.
- [x] `npm run typecheck` — web and electron clean. Mobile fails on `Cannot find module 'react-native'` etc. because `mobile/node_modules` does not exist in this session; unrelated to this diff, which no mobile code imports.
- [x] `npm run lint` — clean (pre-existing warnings only, none in the changed files).
- [x] `npm run nodetool -- harness gate --base HEAD~1` — 13 changed files select the `provider-codegen` surface; `generate:fal:check --strict` (5 outputs) and `generate:kie:check --strict` (7 outputs) both match the checked-in fixtures.

Also run directly: `npm run test --workspace=packages/fal-codegen` (148 passed), `npm run test --workspace=packages/fal-nodes` (152 passed), and `tsc --noEmit` in `packages/fal-codegen`.

Manifest invariants asserted after regeneration: 1,574 entries, zero duplicate node types, zero malformed entries, and no new entry with an empty input or output field list. The one duplicate endpoint id the check reports, `fal-ai/stable-video`, is pre-existing on `main` and untouched here.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YY8jpGLZSvnJrUpbusKZiR