### PR TITLE
feat(atlascloud): ship the 27 newest AtlasCloud image and video models

### DIFF
--- a/packages/atlascloud-nodes/AGENTS.md
+++ b/packages/atlascloud-nodes/AGENTS.md
@@ -27,8 +27,23 @@ Package specifics from shipped fixes:
   for extension-less / `asset://` URIs.
 - **Model multi-image inputs as `list[image]`**, not a single `image` with
   `array: true`.
+- **A mixed reference array is `wrapInto`, not one untyped list.** Wan 3.0 and
+  MiniMax H3 reference-to-video take a single `refers: [{url, type}]` covering
+  images, videos and audio. The manifest splits that into typed
+  `reference_images` / `reference_videos` / `reference_audios` inputs, each
+  carrying `"wrapInto": "refers"`; the factory appends their resolved URLs into
+  one array in field order and tags each entry with the kind its input
+  declared. The wire name is never a node property — the runtime provider reads
+  the same flag so its generic `imageToVideo` posts `refers`, not
+  `reference_images`. Seedance 2.5 keeps the per-kind names because its API
+  really does take three arrays.
 - **Don't expose an API option that yields an extra output** the single-output
   node can't surface (the `return_last_frame` Seedance option was dropped).
+  The same rule keeps whole models out: `pickOutputUrl` returns the first
+  output, so `bytedance/seedream-v5.0-pro/layer-decomposition` — whose point is
+  the *set* of layers it returns — is deliberately not shipped. A model that
+  returns N interchangeable variants (`n`, `num_images`) is fine; one whose
+  outputs are not interchangeable is not.
 - **The manifest is generated, not hand-edited.** `node
   scripts/sync-atlascloud-manifest.mjs` reconciles every entry's fields against
   the `Input` schema AtlasCloud publishes for that model (reachable from the

--- a/packages/atlascloud-nodes/README.md
+++ b/packages/atlascloud-nodes/README.md
@@ -3,8 +3,9 @@
 AtlasCloud.ai nodes for [NodeTool](https://nodetool.ai).
 
 Run [AtlasCloud](https://www.atlascloud.ai) image and video models inside NodeTool
-workflows — GPT Image, Nano Banana, Seedream, Qwen Image and Wan for images;
-Seedance, Veo, Kling, Wan, HappyHorse and Grok Imagine for video.
+workflows — GPT Image, Nano Banana, Seedream, Qwen Image, Reve, Youchuan and Wan
+for images; Seedance, Veo, Kling, Wan, MiniMax, HappyHorse and Grok Imagine for
+video.
 
 Node fields are generated from AtlasCloud's published model schemas. Re-sync them
 with `node scripts/sync-atlascloud-manifest.mjs` (or `--check` to detect drift).
@@ -26,6 +27,8 @@ npm install @nodetool-ai/atlascloud-nodes
 | GPT Image 1.5 — Text to Image | `atlascloud.image.GPTImage15TextToImage` |
 | GPT Image 2 — Edit | `atlascloud.image.GPTImage2Edit` |
 | GPT Image 2 — Text to Image | `atlascloud.image.GPTImage2TextToImage` |
+| Grok Imagine Image 2.0 — Edit | `atlascloud.image.GrokImagineImage2Edit` |
+| Grok Imagine Image 2.0 — Text to Image | `atlascloud.image.GrokImagineImage2TextToImage` |
 | Grok Imagine Image Quality — Edit | `atlascloud.image.GrokImagineImageQualityEdit` |
 | Grok Imagine Image Quality — Text to Image | `atlascloud.image.GrokImagineImageQualityTextToImage` |
 | MAI Image 2.5 — Edit | `atlascloud.image.MaiImage25Edit` |
@@ -43,6 +46,13 @@ npm install @nodetool-ai/atlascloud-nodes
 | Qwen Image 2.0 — Text to Image | `atlascloud.image.QwenImage2TextToImage` |
 | Qwen Image 2.0 Pro — Edit | `atlascloud.image.QwenImage2ProEdit` |
 | Qwen Image 2.0 Pro — Text to Image | `atlascloud.image.QwenImage2ProTextToImage` |
+| Qwen Image 3.0 — Edit | `atlascloud.image.QwenImage3Edit` |
+| Qwen Image 3.0 — Text to Image | `atlascloud.image.QwenImage3TextToImage` |
+| Qwen Image 3.0 Pro — Edit | `atlascloud.image.QwenImage3ProEdit` |
+| Qwen Image 3.0 Pro — Text to Image | `atlascloud.image.QwenImage3ProTextToImage` |
+| Reve 2.1 — Edit | `atlascloud.image.Reve21Edit` |
+| Reve 2.1 — Remix | `atlascloud.image.Reve21Remix` |
+| Reve 2.1 — Text to Image | `atlascloud.image.Reve21TextToImage` |
 | Seedream v5.0 Lite — Edit | `atlascloud.image.SeedreamV5LiteEdit` |
 | Seedream v5.0 Lite — Text to Image | `atlascloud.image.SeedreamV5LiteTextToImage` |
 | Seedream v5.0 Pro — Edit | `atlascloud.image.SeedreamV5ProEdit` |
@@ -56,6 +66,11 @@ npm install @nodetool-ai/atlascloud-nodes
 | Youchuan v8.1 — Remove Background | `atlascloud.image.YouchuanV81RemoveBackground` |
 | Youchuan v8.1 — Style Transfer | `atlascloud.image.YouchuanV81StyleTransfer` |
 | Youchuan v8.1 — Text to Image | `atlascloud.image.YouchuanV81TextToImage` |
+| Youchuan v8.2 — Blend | `atlascloud.image.YouchuanV82Blend` |
+| Youchuan v8.2 — Image to Image | `atlascloud.image.YouchuanV82ImageToImage` |
+| Youchuan v8.2 — Remove Background | `atlascloud.image.YouchuanV82RemoveBackground` |
+| Youchuan v8.2 — Style Transfer | `atlascloud.image.YouchuanV82StyleTransfer` |
+| Youchuan v8.2 — Text to Image | `atlascloud.image.YouchuanV82TextToImage` |
 | Z-Image Turbo — Text to Image | `atlascloud.image.ZImageTurboTextToImage` |
 | Avatar Omni Human 1.5 — Audio to Video | `atlascloud.video.AvatarOmniHuman15` |
 | Gemini Omni Flash — Image to Video | `atlascloud.video.GeminiOmniFlashImageToVideo` |
@@ -74,6 +89,9 @@ npm install @nodetool-ai/atlascloud-nodes
 | Kling v3.0 Turbo — Text to Video | `atlascloud.video.KlingV3TurboTextToVideo` |
 | Kling Video O3 4K — Image to Video | `atlascloud.video.KlingVideoO34kImageToVideo` |
 | Kling Video O3 4K — Text to Video | `atlascloud.video.KlingVideoO34kTextToVideo` |
+| MiniMax H3 — Image to Video | `atlascloud.video.MinimaxH3ImageToVideo` |
+| MiniMax H3 — Reference to Video | `atlascloud.video.MinimaxH3ReferenceToVideo` |
+| MiniMax H3 — Text to Video | `atlascloud.video.MinimaxH3TextToVideo` |
 | Seedance 2.0 — Image to Video | `atlascloud.video.Seedance2ImageToVideo` |
 | Seedance 2.0 — Reference to Video | `atlascloud.video.Seedance2ReferenceToVideo` |
 | Seedance 2.0 — Text to Video | `atlascloud.video.Seedance2TextToVideo` |
@@ -83,6 +101,9 @@ npm install @nodetool-ai/atlascloud-nodes
 | Seedance 2.0 Mini — Image to Video | `atlascloud.video.Seedance2MiniImageToVideo` |
 | Seedance 2.0 Mini — Reference to Video | `atlascloud.video.Seedance2MiniReferenceToVideo` |
 | Seedance 2.0 Mini — Text to Video | `atlascloud.video.Seedance2MiniTextToVideo` |
+| Seedance 2.5 — Image to Video | `atlascloud.video.Seedance25ImageToVideo` |
+| Seedance 2.5 — Reference to Video | `atlascloud.video.Seedance25ReferenceToVideo` |
+| Seedance 2.5 — Text to Video | `atlascloud.video.Seedance25TextToVideo` |
 | Veo 3.1 — Image to Video | `atlascloud.video.Veo31ImageToVideo` |
 | Veo 3.1 — Text to Video | `atlascloud.video.Veo31TextToVideo` |
 | Veo 3.1 Fast — Image to Video | `atlascloud.video.Veo31FastImageToVideo` |
@@ -91,7 +112,14 @@ npm install @nodetool-ai/atlascloud-nodes
 | Veo 3.1 Lite — Text to Video | `atlascloud.video.Veo31LiteTextToVideo` |
 | Wan 2.7 — Image to Video | `atlascloud.video.Wan27ImageToVideo` |
 | Wan 2.7 — Text to Video | `atlascloud.video.Wan27TextToVideo` |
+| Wan 3.0 — Image to Video | `atlascloud.video.Wan30ImageToVideo` |
+| Wan 3.0 — Reference to Video | `atlascloud.video.Wan30ReferenceToVideo` |
+| Wan 3.0 — Text to Video | `atlascloud.video.Wan30TextToVideo` |
+| Wan 3.0 Prime — Image to Video | `atlascloud.video.Wan30PrimeImageToVideo` |
+| Wan 3.0 Prime — Reference to Video | `atlascloud.video.Wan30PrimeReferenceToVideo` |
+| Wan 3.0 Prime — Text to Video | `atlascloud.video.Wan30PrimeTextToVideo` |
 | Youchuan v8.1 — Image to Video | `atlascloud.video.YouchuanV81ImageToVideo` |
+| Youchuan v8.2 — Image to Video | `atlascloud.video.YouchuanV82ImageToVideo` |
 
 ## Configuration
 

--- a/packages/atlascloud-nodes/src/atlascloud-factory.ts
+++ b/packages/atlascloud-nodes/src/atlascloud-factory.ts
@@ -67,6 +67,17 @@ export interface AtlasFieldDef {
    * array. Used by AtlasCloud `*-edit` endpoints which expect `images: [url]`.
    */
   array?: boolean;
+  /**
+   * Send this asset field's resolved URLs as `{ url, type }` objects appended
+   * to the named request array instead of under the field's own name.
+   *
+   * AtlasCloud's newer reference-to-video models (Wan 3.0, MiniMax H3) take one
+   * mixed `refers` array rather than per-kind lists. Splitting it into typed
+   * `reference_images` / `reference_videos` / `reference_audios` node inputs
+   * keeps the editor's asset wiring, and the media kind each input declares is
+   * exactly the `type` those objects require.
+   */
+  wrapInto?: string;
 }
 
 export interface AtlasManifestEntry {
@@ -544,6 +555,26 @@ function promptAssetOverrides(
   return mapPromptAssetsToInputs(textFields, assetFields, context);
 }
 
+/**
+ * Append resolved asset URLs to a request array of `{ url, type }` objects,
+ * creating it on first use. Order follows manifest field order, so a model
+ * that reads its references positionally sees images before videos before
+ * audio.
+ */
+function appendWrapped(
+  input: Record<string, unknown>,
+  key: string,
+  urls: string[],
+  kind: "image" | "video" | "audio"
+): void {
+  const existing = input[key];
+  const bucket = Array.isArray(existing) ? existing : [];
+  for (const url of urls) {
+    bucket.push({ url, type: kind });
+  }
+  input[key] = bucket;
+}
+
 export function createAtlasNodeClass(spec: AtlasManifestEntry): NodeClass {
   const nodeType = `atlascloud.${spec.moduleName}.${spec.className}`;
   const title = spec.title || classNameToTitle(spec.className);
@@ -572,7 +603,11 @@ export function createAtlasNodeClass(spec: AtlasManifestEntry): NodeClass {
           const resolved =
             v == null ? null : await resolveAssetForAtlas(v, context, inner);
           if (resolved !== null) {
-            input[f.name] = f.array ? [resolved] : resolved;
+            if (f.wrapInto) {
+              appendWrapped(input, f.wrapInto, [resolved], inner);
+            } else {
+              input[f.name] = f.array ? [resolved] : resolved;
+            }
           } else if (f.required) {
             throw new Error(
               `${specRef.title}: the ${inner} input "${f.title ?? f.name}" is empty — connect or upload a${inner === "image" ? "n" : ""} ${inner}`
@@ -592,7 +627,13 @@ export function createAtlasNodeClass(spec: AtlasManifestEntry): NodeClass {
             const r = await resolveAssetForAtlas(item, context, inner);
             if (r !== null) resolved.push(r);
           }
-          if (resolved.length > 0) input[f.name] = resolved;
+          if (resolved.length > 0) {
+            if (f.wrapInto) {
+              appendWrapped(input, f.wrapInto, resolved, inner);
+            } else {
+              input[f.name] = resolved;
+            }
+          }
           continue;
         }
 

--- a/packages/atlascloud-nodes/src/atlascloud-manifest.json
+++ b/packages/atlascloud-nodes/src/atlascloud-manifest.json
@@ -5269,5 +5269,2470 @@
         "description": "The random seed to use for the generation. -1 means a random seed will be used."
       }
     ]
+  },
+  {
+    "className": "Wan30TextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "alibaba/wan-3.0/text-to-video",
+    "outputType": "video",
+    "title": "Wan 3.0 — Text to Video",
+    "description": "AtlasCloud / Alibaba Wan 3.0 — cinematic video from a text prompt, up to 30s with native audio.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text prompt describing the scene, subject, and action (up to 20000 characters).",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1080p",
+        "title": "Resolution",
+        "description": "Output resolution. Native tiers: 480p, 720p, 1080p. ESR tiers: 720p-esr, 1080p-esr, 1440p-esr, 4k-esr.",
+        "values": [
+          "1080p",
+          "720p",
+          "480p",
+          "720p-esr",
+          "1080p-esr",
+          "1440p-esr",
+          "4k-esr"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration (seconds)",
+        "description": "Video length in seconds (2-30). Pass -1 for smart-duration (the model picks the best length).",
+        "values": [
+          -1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24,
+          25,
+          26,
+          27,
+          28,
+          29,
+          30
+        ]
+      },
+      {
+        "name": "ratio",
+        "type": "enum",
+        "default": "adaptive",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video. Use 'adaptive' to let the model choose.",
+        "values": [
+          "adaptive",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "audio",
+        "type": "bool",
+        "default": true,
+        "title": "Generate Audio",
+        "description": "Whether the output video includes an audio track. Same price either way."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
+      }
+    ]
+  },
+  {
+    "className": "Wan30ImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "alibaba/wan-3.0/image-to-video",
+    "outputType": "video",
+    "title": "Wan 3.0 — Image to Video",
+    "description": "AtlasCloud / Alibaba Wan 3.0 — animates a first frame (and an optional last frame) into cinematic video.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text prompt describing the motion / action for the video (up to 20000 characters).",
+        "required": true
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "First frame of the video (strict first-frame mode). Public URL. Formats: jpeg, jpg, png (no alpha), bmp, webp. Single edge 240-8000px, aspect ratio <= 8:1, <= 20MB.",
+        "required": true
+      },
+      {
+        "name": "last_image",
+        "type": "image",
+        "default": null,
+        "title": "Last Frame Image",
+        "description": "Optional last frame of the video. When provided, the model interpolates from the first frame to this one. Same format limits as 'image'."
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1080p",
+        "title": "Resolution",
+        "description": "Output resolution. Native tiers: 480p, 720p, 1080p. ESR tiers: 720p-esr, 1080p-esr, 1440p-esr, 4k-esr.",
+        "values": [
+          "1080p",
+          "720p",
+          "480p",
+          "720p-esr",
+          "1080p-esr",
+          "1440p-esr",
+          "4k-esr"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration (seconds)",
+        "description": "Video length in seconds (2-30). Pass -1 for smart-duration (the model picks the best length).",
+        "values": [
+          -1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24,
+          25,
+          26,
+          27,
+          28,
+          29,
+          30
+        ]
+      },
+      {
+        "name": "audio",
+        "type": "bool",
+        "default": true,
+        "title": "Generate Audio",
+        "description": "Whether the output video includes an audio track. Same price either way."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
+      }
+    ]
+  },
+  {
+    "className": "Wan30ReferenceToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "alibaba/wan-3.0/reference-to-video",
+    "outputType": "video",
+    "title": "Wan 3.0 — Reference to Video",
+    "description": "AtlasCloud / Alibaba Wan 3.0 — generates video from reference images, videos and audio. Up to 20 references per request.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text prompt describing the scene and action for the referenced subjects (up to 20000 characters).",
+        "required": true
+      },
+      {
+        "name": "reference_images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Reference Images",
+        "description": "Reference images that anchor the generation. Formats: jpeg, jpg, png, bmp, webp. Reference mode is mutually exclusive with the first/last-frame mode.",
+        "wrapInto": "refers"
+      },
+      {
+        "name": "reference_videos",
+        "type": "list[video]",
+        "default": null,
+        "title": "Reference Videos",
+        "description": "Reference videos that anchor the generation. Formats: mp4, mov.",
+        "wrapInto": "refers"
+      },
+      {
+        "name": "reference_audios",
+        "type": "list[audio]",
+        "default": null,
+        "title": "Reference Audios",
+        "description": "Reference audio that anchors the generation. Formats: wav, mp3.",
+        "wrapInto": "refers"
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1080p",
+        "title": "Resolution",
+        "description": "Output resolution. Native tiers: 480p, 720p, 1080p. ESR tiers: 720p-esr, 1080p-esr, 1440p-esr, 4k-esr.",
+        "values": [
+          "1080p",
+          "720p",
+          "480p",
+          "720p-esr",
+          "1080p-esr",
+          "1440p-esr",
+          "4k-esr"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration (seconds)",
+        "description": "Video length in seconds (2-30). Pass -1 for smart-duration (the model picks the best length).",
+        "values": [
+          -1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24,
+          25,
+          26,
+          27,
+          28,
+          29,
+          30
+        ]
+      },
+      {
+        "name": "ratio",
+        "type": "enum",
+        "default": "adaptive",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video. Use 'adaptive' to let the model choose from the references.",
+        "values": [
+          "adaptive",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "audio",
+        "type": "bool",
+        "default": true,
+        "title": "Generate Audio",
+        "description": "Whether the output video includes an audio track. Same price either way."
+      },
+      {
+        "name": "enable_thinking",
+        "type": "bool",
+        "default": false,
+        "title": "Enable Thinking",
+        "description": "Enable deep thinking mode. Required when providing a file or link input (document / webpage parsing). Not recommended when no file/link is provided."
+      },
+      {
+        "name": "file",
+        "type": "str",
+        "default": "",
+        "title": "Document URL",
+        "description": "Optional document input to parse (requires enable_thinking). Public URL. Formats: docx, doc, xlsx, xls, pptx, ppt, pdf, txt, key, pages, numbers, md; <= 100MB, <= 50 pages."
+      },
+      {
+        "name": "link",
+        "type": "str",
+        "default": "",
+        "title": "Webpage URL",
+        "description": "Optional public webpage URL to parse (requires enable_thinking). Only pages that need no login. Mutually exclusive with 'file'."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
+      }
+    ]
+  },
+  {
+    "className": "Wan30PrimeTextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "alibaba/wan-3.0-prime/text-to-video",
+    "outputType": "video",
+    "title": "Wan 3.0 Prime — Text to Video",
+    "description": "AtlasCloud / Alibaba Wan 3.0 Prime — hyper-real video from a text prompt, up to 30s with native audio.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text prompt describing the scene, subject, and action (up to 20000 characters).",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1080p",
+        "title": "Resolution",
+        "description": "Output resolution. Native tiers: 480p, 720p, 1080p. ESR tiers: 720p-esr, 1080p-esr, 1440p-esr, 4k-esr.",
+        "values": [
+          "1080p",
+          "720p",
+          "480p",
+          "720p-esr",
+          "1080p-esr",
+          "1440p-esr",
+          "4k-esr"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration (seconds)",
+        "description": "Video length in seconds (2-30). Pass -1 for smart-duration (the model picks the best length).",
+        "values": [
+          -1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24,
+          25,
+          26,
+          27,
+          28,
+          29,
+          30
+        ]
+      },
+      {
+        "name": "ratio",
+        "type": "enum",
+        "default": "adaptive",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video. Use 'adaptive' to let the model choose.",
+        "values": [
+          "adaptive",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "audio",
+        "type": "bool",
+        "default": true,
+        "title": "Generate Audio",
+        "description": "Whether the output video includes an audio track. Same price either way."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
+      }
+    ]
+  },
+  {
+    "className": "Wan30PrimeImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "alibaba/wan-3.0-prime/image-to-video",
+    "outputType": "video",
+    "title": "Wan 3.0 Prime — Image to Video",
+    "description": "AtlasCloud / Alibaba Wan 3.0 Prime — animates a first frame (and an optional last frame) into hyper-real video.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text prompt describing the motion / action for the video (up to 20000 characters).",
+        "required": true
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "First frame of the video (strict first-frame mode). Public URL. Formats: jpeg, jpg, png (no alpha), bmp, webp. Single edge 240-8000px, aspect ratio <= 8:1, <= 20MB.",
+        "required": true
+      },
+      {
+        "name": "last_image",
+        "type": "image",
+        "default": null,
+        "title": "Last Frame Image",
+        "description": "Optional last frame of the video. When provided, the model interpolates from the first frame to this one. Same format limits as 'image'."
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1080p",
+        "title": "Resolution",
+        "description": "Output resolution. Native tiers: 480p, 720p, 1080p. ESR tiers: 720p-esr, 1080p-esr, 1440p-esr, 4k-esr.",
+        "values": [
+          "1080p",
+          "720p",
+          "480p",
+          "720p-esr",
+          "1080p-esr",
+          "1440p-esr",
+          "4k-esr"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration (seconds)",
+        "description": "Video length in seconds (2-30). Pass -1 for smart-duration (the model picks the best length).",
+        "values": [
+          -1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24,
+          25,
+          26,
+          27,
+          28,
+          29,
+          30
+        ]
+      },
+      {
+        "name": "audio",
+        "type": "bool",
+        "default": true,
+        "title": "Generate Audio",
+        "description": "Whether the output video includes an audio track. Same price either way."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
+      }
+    ]
+  },
+  {
+    "className": "Wan30PrimeReferenceToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "alibaba/wan-3.0-prime/reference-to-video",
+    "outputType": "video",
+    "title": "Wan 3.0 Prime — Reference to Video",
+    "description": "AtlasCloud / Alibaba Wan 3.0 Prime — generates video from reference images, videos and audio. Up to 20 references per request.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text prompt describing the scene and action for the referenced subjects (up to 20000 characters).",
+        "required": true
+      },
+      {
+        "name": "reference_images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Reference Images",
+        "description": "Reference images that anchor the generation. Formats: jpeg, jpg, png, bmp, webp. Reference mode is mutually exclusive with the first/last-frame mode.",
+        "wrapInto": "refers"
+      },
+      {
+        "name": "reference_videos",
+        "type": "list[video]",
+        "default": null,
+        "title": "Reference Videos",
+        "description": "Reference videos that anchor the generation. Formats: mp4, mov.",
+        "wrapInto": "refers"
+      },
+      {
+        "name": "reference_audios",
+        "type": "list[audio]",
+        "default": null,
+        "title": "Reference Audios",
+        "description": "Reference audio that anchors the generation. Formats: wav, mp3.",
+        "wrapInto": "refers"
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1080p",
+        "title": "Resolution",
+        "description": "Output resolution. Native tiers: 480p, 720p, 1080p. ESR tiers: 720p-esr, 1080p-esr, 1440p-esr, 4k-esr.",
+        "values": [
+          "1080p",
+          "720p",
+          "480p",
+          "720p-esr",
+          "1080p-esr",
+          "1440p-esr",
+          "4k-esr"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration (seconds)",
+        "description": "Video length in seconds (2-30). Pass -1 for smart-duration (the model picks the best length).",
+        "values": [
+          -1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24,
+          25,
+          26,
+          27,
+          28,
+          29,
+          30
+        ]
+      },
+      {
+        "name": "ratio",
+        "type": "enum",
+        "default": "adaptive",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video. Use 'adaptive' to let the model choose from the references.",
+        "values": [
+          "adaptive",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "audio",
+        "type": "bool",
+        "default": true,
+        "title": "Generate Audio",
+        "description": "Whether the output video includes an audio track. Same price either way."
+      },
+      {
+        "name": "enable_thinking",
+        "type": "bool",
+        "default": true,
+        "title": "Enable Thinking",
+        "description": "Enable deep thinking mode. Required when providing a file or link input (document / webpage parsing). Not recommended when no file/link is provided."
+      },
+      {
+        "name": "file",
+        "type": "str",
+        "default": "",
+        "title": "Document URL",
+        "description": "Optional document input to parse (requires enable_thinking). Public URL. Formats: docx, doc, xlsx, xls, pptx, ppt, pdf, txt, key, pages, numbers, md; <= 100MB, <= 50 pages."
+      },
+      {
+        "name": "link",
+        "type": "str",
+        "default": "",
+        "title": "Webpage URL",
+        "description": "Optional public webpage URL to parse (requires enable_thinking). Only pages that need no login. Mutually exclusive with 'file'."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
+      }
+    ]
+  },
+  {
+    "className": "Seedance25TextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "bytedance/seedance-2.5/text-to-video",
+    "outputType": "video",
+    "title": "Seedance 2.5 — Text to Video",
+    "description": "AtlasCloud / ByteDance Seedance 2.5 — generates video from text with native audio, up to 30s and 4K.",
+    "pollInterval": 5000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "A golden retriever running on a sunny beach, waves crashing in the background, cinematic lighting",
+        "title": "Prompt",
+        "description": "Text prompt describing the desired video. Supports Chinese and English. Recommended length: Chinese < 500 characters, English < 1000 words.",
+        "required": true
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration (seconds)",
+        "description": "Video duration in seconds (4-30), or -1 for model to choose automatically.",
+        "values": [
+          -1,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24,
+          25,
+          26,
+          27,
+          28,
+          29,
+          30
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "Video resolution. 480p, 720p, and 1080p are native Seedance outputs.",
+        "values": [
+          "480p",
+          "720p",
+          "720p-sr",
+          "720p-esr",
+          "1080p",
+          "1080p-sr",
+          "1080p-esr",
+          "1080p-esr & 60fps",
+          "1440p-sr",
+          "1440p-esr",
+          "4k-esr"
+        ]
+      },
+      {
+        "name": "ratio",
+        "type": "enum",
+        "default": "adaptive",
+        "title": "Aspect Ratio",
+        "description": "Aspect ratio. 'adaptive' automatically selects based on prompt context.",
+        "values": [
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16",
+          "21:9",
+          "adaptive"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "type": "bool",
+        "default": true,
+        "title": "Generate Audio",
+        "description": "Whether to generate synchronized audio (voice, sound effects, background music)."
+      },
+      {
+        "name": "watermark",
+        "type": "bool",
+        "default": false,
+        "title": "Watermark",
+        "description": "Whether to add a watermark."
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "mp4",
+        "title": "Output Format",
+        "description": "Output video container format. 'mp4' is the default; 'mov' encodes yuv444p for higher color fidelity, suited to multi-round editing/extension pipelines where recompression loss acc…",
+        "values": [
+          "mp4",
+          "mov"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "Seedance25ImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "bytedance/seedance-2.5/image-to-video",
+    "outputType": "video",
+    "title": "Seedance 2.5 — Image to Video",
+    "description": "AtlasCloud / ByteDance Seedance 2.5 — animates a first frame (and an optional last frame) into video with native audio.",
+    "pollInterval": 5000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "The scene comes alive with gentle motion and cinematic lighting",
+        "title": "Prompt",
+        "description": "Text prompt describing the desired video motion. Optional but recommended."
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "First-frame image URL, Base64, or asset reference (asset://<ASSET_ID>). The video starts from this image.",
+        "required": true
+      },
+      {
+        "name": "last_image",
+        "type": "image",
+        "default": null,
+        "title": "Last Frame Image",
+        "description": "Last-frame image URL, Base64, or asset reference. The video transitions from the first frame to this last frame. Same format requirements as image."
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration (seconds)",
+        "description": "Video duration in seconds (4-30), or -1 for model to choose automatically.",
+        "values": [
+          -1,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24,
+          25,
+          26,
+          27,
+          28,
+          29,
+          30
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "Video resolution. 480p, 720p, and 1080p are native Seedance outputs.",
+        "values": [
+          "480p",
+          "720p",
+          "720p-sr",
+          "720p-esr",
+          "1080p",
+          "1080p-sr",
+          "1080p-esr",
+          "1080p-esr & 60fps",
+          "1440p-sr",
+          "1440p-esr",
+          "4k-esr"
+        ]
+      },
+      {
+        "name": "ratio",
+        "type": "enum",
+        "default": "adaptive",
+        "title": "Aspect Ratio",
+        "description": "Aspect ratio. Seedance 2.5 image-to-video (first-frame and first+last-frame) accepts only 'adaptive': the output preserves the source image's aspect ratio.",
+        "values": [
+          "adaptive"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "type": "bool",
+        "default": true,
+        "title": "Generate Audio",
+        "description": "Whether to generate synchronized audio."
+      },
+      {
+        "name": "watermark",
+        "type": "bool",
+        "default": false,
+        "title": "Watermark",
+        "description": "Whether to add a watermark."
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "mp4",
+        "title": "Output Format",
+        "description": "Output video container format. 'mp4' is the default; 'mov' encodes yuv444p for higher color fidelity, suited to multi-round editing/extension pipelines where recompression loss acc…",
+        "values": [
+          "mp4",
+          "mov"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "Seedance25ReferenceToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "bytedance/seedance-2.5/reference-to-video",
+    "outputType": "video",
+    "title": "Seedance 2.5 — Reference to Video",
+    "description": "AtlasCloud / ByteDance Seedance 2.5 — generates video from reference images, videos and audio. Audio-only referencing drives pacing and lip-sync.",
+    "pollInterval": 5000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "The character in image 1 dances gracefully to the music",
+        "title": "Prompt",
+        "description": "Text prompt describing the desired video. Cite reference inputs in submission order with @-syntax: @Image1, @Video1, @Audio1, etc. Prompts phrased as EDITING an input video (e.g."
+      },
+      {
+        "name": "reference_images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Reference Images",
+        "description": "Reference image URLs, Base64, or asset references (asset://<ASSET_ID>). Up to 30 images for character/style/scene references, video editing, or combined generation."
+      },
+      {
+        "name": "reference_videos",
+        "type": "list[video]",
+        "default": null,
+        "title": "Reference Videos",
+        "description": "Reference video URLs or asset references for multimodal reference, video editing, or extension. Up to 10 videos."
+      },
+      {
+        "name": "reference_audios",
+        "type": "list[audio]",
+        "default": null,
+        "title": "Reference Audios",
+        "description": "Reference audio URLs, Base64, or asset references. Formats: wav/mp3, duration [2,30]s per clip, max 15MB each."
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration (seconds)",
+        "description": "Video duration in seconds (4-30), or -1 for the model to choose automatically.",
+        "values": [
+          -1,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24,
+          25,
+          26,
+          27,
+          28,
+          29,
+          30
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "Video resolution. 480p, 720p, and 1080p are native Seedance outputs.",
+        "values": [
+          "480p",
+          "720p",
+          "720p-sr",
+          "720p-esr",
+          "1080p",
+          "1080p-sr",
+          "1080p-esr",
+          "1080p-esr & 60fps",
+          "1440p-sr",
+          "1440p-esr",
+          "4k-esr"
+        ]
+      },
+      {
+        "name": "ratio",
+        "type": "enum",
+        "default": "adaptive",
+        "title": "Aspect Ratio",
+        "description": "Aspect ratio. 'adaptive' uses the primary media aspect ratio.",
+        "values": [
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16",
+          "21:9",
+          "adaptive"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "type": "bool",
+        "default": true,
+        "title": "Generate Audio",
+        "description": "Whether to generate synchronized audio."
+      },
+      {
+        "name": "watermark",
+        "type": "bool",
+        "default": false,
+        "title": "Watermark",
+        "description": "Whether to add a watermark."
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "mp4",
+        "title": "Output Format",
+        "description": "Output video container format. 'mp4' is the default; 'mov' encodes yuv444p for higher color fidelity, suited to multi-round editing/extension pipelines where recompression loss acc…",
+        "values": [
+          "mp4",
+          "mov"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "GrokImagineImage2TextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "xai/grok-imagine-image-2.0/text-to-image",
+    "outputType": "image",
+    "title": "Grok Imagine Image 2.0 — Text to Image",
+    "description": "AtlasCloud / xAI Grok Imagine Image 2.0 — generates up to four images per call at 1K or 2K.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Natural-language description of the image to generate. Up to 8000 characters.",
+        "required": true
+      },
+      {
+        "name": "num_images",
+        "type": "int",
+        "default": 1,
+        "title": "Number of Images",
+        "description": "Number of images to generate. Each image is billed separately.",
+        "values": [
+          1,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "1:1",
+        "title": "Aspect Ratio",
+        "description": "Aspect ratio of the generated image.",
+        "values": [
+          "1:1",
+          "3:4",
+          "4:3",
+          "9:16",
+          "16:9",
+          "2:3",
+          "3:2",
+          "9:19.5",
+          "19.5:9",
+          "9:20",
+          "20:9",
+          "1:2",
+          "2:1"
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1k",
+        "title": "Resolution",
+        "description": "Output resolution. 1k = 1024x1024, 2k = 2048x2048. Combined with `quality` this sets the per-image price: low/1k $0.04, low/2k $0.06, medium/1k $0.06, medium/2k $0.08.",
+        "values": [
+          "1k",
+          "2k"
+        ]
+      },
+      {
+        "name": "quality",
+        "type": "enum",
+        "default": "medium",
+        "title": "Quality",
+        "description": "Rendering quality tier. `low` is cheaper and roughly 8x faster (~10s vs ~84s at 1K); `medium` is the default and produces the model's best output.",
+        "values": [
+          "low",
+          "medium"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "GrokImagineImage2Edit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "xai/grok-imagine-image-2.0/edit",
+    "outputType": "image",
+    "title": "Grok Imagine Image 2.0 — Edit",
+    "description": "AtlasCloud / xAI Grok Imagine Image 2.0 — edits up to three source images from a text instruction.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Editing instruction describing the change to apply. When supplying multiple source images, cite them as <IMAGE_0>, <IMAGE_1>, <IMAGE_2>. Up to 8000 characters.",
+        "required": true
+      },
+      {
+        "name": "image_urls",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "Source images. Up to 3 are supported. Each entry is either a public URL or a base64-encoded data URI (e.g. `data:image/png;base64,...`). Each input image is billed at $0.01.",
+        "required": true
+      },
+      {
+        "name": "num_images",
+        "type": "int",
+        "default": 1,
+        "title": "Number of Images",
+        "description": "Number of edited images to generate. Each output image is billed separately.",
+        "values": [
+          1,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "auto",
+        "title": "Aspect Ratio",
+        "description": "Aspect ratio of the edited image. The output generally respects the source image's aspect ratio regardless of this value. `auto` lets the model pick.",
+        "values": [
+          "auto",
+          "1:1",
+          "3:4",
+          "4:3",
+          "9:16",
+          "16:9",
+          "2:3",
+          "3:2",
+          "9:19.5",
+          "19.5:9",
+          "9:20",
+          "20:9",
+          "1:2",
+          "2:1"
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1k",
+        "title": "Resolution",
+        "description": "Output resolution. 1k = 1024x1024, 2k = 2048x2048. Combined with `quality` this sets the per-image price: low/1k $0.04, low/2k $0.06, medium/1k $0.06, medium/2k $0.08.",
+        "values": [
+          "1k",
+          "2k"
+        ]
+      },
+      {
+        "name": "quality",
+        "type": "enum",
+        "default": "medium",
+        "title": "Quality",
+        "description": "Rendering quality tier. `low` is cheaper and roughly 8x faster (~10s vs ~84s at 1K); `medium` is the default and produces the model's best output.",
+        "values": [
+          "low",
+          "medium"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "QwenImage3TextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "qwen-image-3.0/text-to-image",
+    "outputType": "image",
+    "title": "Qwen Image 3.0 — Text to Image",
+    "description": "AtlasCloud / Alibaba Qwen Image 3.0 — generates up to four images per call. Resolutions from 512*512 to 2048*2048.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text prompt describing the image to generate.",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "str",
+        "default": "",
+        "title": "Size",
+        "description": "Output resolution as width*height (e.g. 2048*2048). Omit to let the model pick a resolution automatically from the prompt. Valid range: 512*512–2048*2048."
+      },
+      {
+        "name": "n",
+        "type": "int",
+        "default": 1,
+        "title": "Number of Images",
+        "description": "Number of images to generate.",
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "Describes content that should NOT appear in the generated image."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "Seed for reproducible generation, range [0, 2147483647]. Omit for a random seed.",
+        "min": 0,
+        "max": 2147483647
+      },
+      {
+        "name": "prompt_extend",
+        "type": "bool",
+        "default": true,
+        "title": "Expand Prompt",
+        "description": "Enable intelligent prompt rewriting for richer results."
+      },
+      {
+        "name": "prompt_extend_mode",
+        "type": "enum",
+        "default": "direct",
+        "title": "Prompt Rewrite Mode",
+        "description": "Prompt rewriting strategy. 'direct' (DPE) rewrites in a single pass; 'agent' (APE) uses an agentic rewrite pipeline.",
+        "values": [
+          "direct",
+          "agent"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "QwenImage3Edit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "qwen-image-3.0/edit",
+    "outputType": "image",
+    "title": "Qwen Image 3.0 — Edit",
+    "description": "AtlasCloud / Alibaba Qwen Image 3.0 — edits one image, or composes up to three reference images into a subject-driven edit.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The editing instruction describing how to transform the reference image(s).",
+        "required": true
+      },
+      {
+        "name": "reference_image_urls",
+        "type": "list[image]",
+        "default": null,
+        "title": "Reference Images",
+        "description": "Reference image URLs for image editing. Provide one URL for single-image editing, or up to three URLs for multi-image reference / subject-driven editing.",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "str",
+        "default": "",
+        "title": "Size",
+        "description": "Output resolution as width*height (e.g. 1440*1440). Omit to let the model pick a resolution automatically. Valid range: 512*512–1440*1440."
+      },
+      {
+        "name": "n",
+        "type": "int",
+        "default": 1,
+        "title": "Number of Images",
+        "description": "Number of images to generate.",
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "Describes content that should NOT appear in the generated image."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "Seed for reproducible generation, range [0, 2147483647]. Omit for a random seed.",
+        "min": 0,
+        "max": 2147483647
+      },
+      {
+        "name": "prompt_extend",
+        "type": "bool",
+        "default": true,
+        "title": "Expand Prompt",
+        "description": "Enable intelligent prompt rewriting for richer results."
+      },
+      {
+        "name": "prompt_extend_mode",
+        "type": "enum",
+        "default": "direct",
+        "title": "Prompt Rewrite Mode",
+        "description": "Prompt rewriting strategy. 'direct' (DPE) rewrites in a single pass; 'agent' (APE) uses an agentic rewrite pipeline.",
+        "values": [
+          "direct"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "QwenImage3ProTextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "qwen-image-3.0-pro/text-to-image",
+    "outputType": "image",
+    "title": "Qwen Image 3.0 Pro — Text to Image",
+    "description": "AtlasCloud / Alibaba Qwen Image 3.0 Pro — generates up to four high-fidelity images per call. Resolutions from 512*512 to 2048*2048.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text prompt describing the image to generate.",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "str",
+        "default": "",
+        "title": "Size",
+        "description": "Output resolution as width*height (e.g. 2048*2048). Omit to let the model pick a resolution automatically from the prompt. Valid range: 512*512–2048*2048."
+      },
+      {
+        "name": "n",
+        "type": "int",
+        "default": 1,
+        "title": "Number of Images",
+        "description": "Number of images to generate.",
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "Describes content that should NOT appear in the generated image."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "Seed for reproducible generation, range [0, 2147483647]. Omit for a random seed.",
+        "min": 0,
+        "max": 2147483647
+      },
+      {
+        "name": "prompt_extend",
+        "type": "bool",
+        "default": true,
+        "title": "Expand Prompt",
+        "description": "Enable intelligent prompt rewriting for richer results."
+      },
+      {
+        "name": "prompt_extend_mode",
+        "type": "enum",
+        "default": "direct",
+        "title": "Prompt Rewrite Mode",
+        "description": "Prompt rewriting strategy. 'direct' (DPE) rewrites in a single pass; 'agent' (APE) uses an agentic rewrite pipeline.",
+        "values": [
+          "direct",
+          "agent"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "QwenImage3ProEdit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "qwen-image-3.0-pro/edit",
+    "outputType": "image",
+    "title": "Qwen Image 3.0 Pro — Edit",
+    "description": "AtlasCloud / Alibaba Qwen Image 3.0 Pro — edits one image, or composes up to three reference images into a subject-driven edit.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The editing instruction describing how to transform the reference image(s).",
+        "required": true
+      },
+      {
+        "name": "reference_image_urls",
+        "type": "list[image]",
+        "default": null,
+        "title": "Reference Images",
+        "description": "Reference image URLs for image editing. Provide one URL for single-image editing, or up to three URLs for multi-image reference / subject-driven editing.",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "str",
+        "default": "",
+        "title": "Size",
+        "description": "Output resolution as width*height (e.g. 1440*1440). Omit to let the model pick a resolution automatically. Valid range: 512*512–1440*1440."
+      },
+      {
+        "name": "n",
+        "type": "int",
+        "default": 1,
+        "title": "Number of Images",
+        "description": "Number of images to generate.",
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "Describes content that should NOT appear in the generated image."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "Seed for reproducible generation, range [0, 2147483647]. Omit for a random seed.",
+        "min": 0,
+        "max": 2147483647
+      },
+      {
+        "name": "prompt_extend",
+        "type": "bool",
+        "default": true,
+        "title": "Expand Prompt",
+        "description": "Enable intelligent prompt rewriting for richer results."
+      },
+      {
+        "name": "prompt_extend_mode",
+        "type": "enum",
+        "default": "direct",
+        "title": "Prompt Rewrite Mode",
+        "description": "Prompt rewriting strategy. 'direct' (DPE) rewrites in a single pass; 'agent' (APE) uses an agentic rewrite pipeline.",
+        "values": [
+          "direct"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "MinimaxH3TextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "minimax/h3/text-to-video",
+    "outputType": "video",
+    "title": "MiniMax H3 — Text to Video",
+    "description": "AtlasCloud / MiniMax H3 — generates 4-15s video from text at 768P or 2K.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text prompt describing the video to generate.",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "2K",
+        "title": "Resolution",
+        "description": "The resolution of the generated video.",
+        "values": [
+          "768P",
+          "2K"
+        ],
+        "required": true
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 8,
+        "title": "Duration (seconds)",
+        "description": "The duration of the generated video in seconds.",
+        "values": [
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ],
+        "required": true
+      },
+      {
+        "name": "ratio",
+        "type": "enum",
+        "default": "1:1",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video.",
+        "values": [
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "MinimaxH3ImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "minimax/h3/image-to-video",
+    "outputType": "video",
+    "title": "MiniMax H3 — Image to Video",
+    "description": "AtlasCloud / MiniMax H3 — animates a first frame (and an optional end frame) into 4-15s video.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text prompt describing the motion / action for the video.",
+        "required": true
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "First frame of the video. Public URL or Base64. Formats: png, jpeg, jpg, webp.",
+        "required": true
+      },
+      {
+        "name": "end_image",
+        "type": "image",
+        "default": null,
+        "title": "End Frame Image",
+        "description": "Optional last frame of the video. Public URL or Base64. Formats: png, jpeg, jpg, webp."
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "2K",
+        "title": "Resolution",
+        "description": "The resolution of the generated video.",
+        "values": [
+          "768P",
+          "2K"
+        ],
+        "required": true
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 8,
+        "title": "Duration (seconds)",
+        "description": "The duration of the generated video in seconds.",
+        "values": [
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ],
+        "required": true
+      },
+      {
+        "name": "ratio",
+        "type": "enum",
+        "default": "adaptive",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video. Use 'adaptive' to let the model choose.",
+        "values": [
+          "adaptive"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "MinimaxH3ReferenceToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "minimax/h3/reference-to-video",
+    "outputType": "video",
+    "title": "MiniMax H3 — Reference to Video",
+    "description": "AtlasCloud / MiniMax H3 — generates video from reference images, videos and audio.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text prompt describing the video to generate.",
+        "required": true
+      },
+      {
+        "name": "reference_images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Reference Images",
+        "description": "Reference images that anchor the generation. Formats: png, jpeg, jpg, webp. At least one reference image or video is required.",
+        "wrapInto": "refers",
+        "required": true
+      },
+      {
+        "name": "reference_videos",
+        "type": "list[video]",
+        "default": null,
+        "title": "Reference Videos",
+        "description": "Reference videos that anchor the generation. Formats: mp4, mov. At least one reference image or video is required.",
+        "wrapInto": "refers",
+        "required": true
+      },
+      {
+        "name": "reference_audios",
+        "type": "list[audio]",
+        "default": null,
+        "title": "Reference Audios",
+        "description": "Reference audio that anchors the generation. Formats: mp3, wav. Audio alone is not enough — pair it with an image or video.",
+        "wrapInto": "refers",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "2K",
+        "title": "Resolution",
+        "description": "The resolution of the generated video.",
+        "values": [
+          "768P",
+          "2K"
+        ],
+        "required": true
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 8,
+        "title": "Duration (seconds)",
+        "description": "The duration of the generated video in seconds.",
+        "values": [
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ],
+        "required": true
+      },
+      {
+        "name": "ratio",
+        "type": "enum",
+        "default": "adaptive",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video. Use 'adaptive' to let the model choose.",
+        "values": [
+          "adaptive",
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "Reve21TextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "reve-ai/reve-2.1/text-to-image",
+    "outputType": "image",
+    "title": "Reve 2.1 — Text to Image",
+    "description": "AtlasCloud / Reve 2.1 — generates a 4K image from text, with optional background removal.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text description of the desired image. The maximum length is 2560 characters. The prompt is automatically enhanced by the model.",
+        "required": true
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "auto",
+        "title": "Aspect Ratio",
+        "description": "The desired aspect ratio of the generated image. Use \"auto\" to let the model pick the most appropriate aspect ratio.",
+        "values": [
+          "auto",
+          "4:1",
+          "3:1",
+          "21:9",
+          "2:1",
+          "17:9",
+          "16:9",
+          "3:2",
+          "4:3",
+          "5:4",
+          "1:1",
+          "4:5",
+          "3:4",
+          "2:3",
+          "9:16",
+          "1:2",
+          "1:3",
+          "1:4"
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "4k",
+        "title": "Resolution",
+        "description": "The output resolution. 4k is the default resolution.",
+        "values": [
+          "4k"
+        ]
+      },
+      {
+        "name": "remove_background",
+        "type": "bool",
+        "default": false,
+        "title": "Remove Background",
+        "description": "If enabled, keeps only the central subject and makes the background of the image transparent as a post-processing step."
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "png",
+        "title": "Output Format",
+        "description": "The format of the output image.",
+        "values": [
+          "png",
+          "jpeg",
+          "webp"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "Reve21Edit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "reve-ai/reve-2.1/edit",
+    "outputType": "image",
+    "title": "Reve 2.1 — Edit",
+    "description": "AtlasCloud / Reve 2.1 — edits one image at 4K from a text instruction.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text description of the desired image. The maximum length is 4000 characters.",
+        "required": true
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "The input image to edit. Can be a URL or a base64-encoded image string.",
+        "required": true
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "auto",
+        "title": "Aspect Ratio",
+        "description": "The desired aspect ratio of the generated image. Use \"auto\" to keep the aspect ratio of the input image.",
+        "values": [
+          "auto",
+          "4:1",
+          "3:1",
+          "21:9",
+          "2:1",
+          "17:9",
+          "16:9",
+          "3:2",
+          "4:3",
+          "5:4",
+          "1:1",
+          "4:5",
+          "3:4",
+          "2:3",
+          "9:16",
+          "1:2",
+          "1:3",
+          "1:4"
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "4k",
+        "title": "Resolution",
+        "description": "The output resolution. 4k is the default resolution.",
+        "values": [
+          "4k"
+        ]
+      },
+      {
+        "name": "remove_background",
+        "type": "bool",
+        "default": false,
+        "title": "Remove Background",
+        "description": "If enabled, keeps only the central subject and makes the background of the image transparent as a post-processing step."
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "png",
+        "title": "Output Format",
+        "description": "The format of the output image.",
+        "values": [
+          "png",
+          "jpeg",
+          "webp"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "Reve21Remix",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "reve-ai/reve-2.1/remix",
+    "outputType": "image",
+    "title": "Reve 2.1 — Remix",
+    "description": "AtlasCloud / Reve 2.1 — remixes 1-6 reference images at 4K. Refer to them in the prompt with <frame>0</frame> tags.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text description of the desired image. The maximum length is 4000 characters.",
+        "required": true
+      },
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "A list of reference images. Each image can be a URL or a base64-encoded image string. You must provide between 1 and 6 reference images.",
+        "required": true
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "auto",
+        "title": "Aspect Ratio",
+        "description": "The desired aspect ratio of the generated image. Use \"auto\" to let the model pick the most appropriate aspect ratio.",
+        "values": [
+          "auto",
+          "4:1",
+          "3:1",
+          "21:9",
+          "2:1",
+          "17:9",
+          "16:9",
+          "3:2",
+          "4:3",
+          "5:4",
+          "1:1",
+          "4:5",
+          "3:4",
+          "2:3",
+          "9:16",
+          "1:2",
+          "1:3",
+          "1:4"
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "4k",
+        "title": "Resolution",
+        "description": "The output resolution. 4k is the default resolution.",
+        "values": [
+          "4k"
+        ]
+      },
+      {
+        "name": "remove_background",
+        "type": "bool",
+        "default": false,
+        "title": "Remove Background",
+        "description": "If enabled, keeps only the central subject and makes the background of the image transparent as a post-processing step."
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "png",
+        "title": "Output Format",
+        "description": "The format of the output image.",
+        "values": [
+          "png",
+          "jpeg",
+          "webp"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "YouchuanV82TextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "youchuan/v8.2/text-to-image",
+    "outputType": "image",
+    "title": "Youchuan v8.2 — Text to Image",
+    "description": "AtlasCloud / Youchuan v8.2 — generates four images per task with optional native 2K HD.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Natural-language description of the image to generate. Maximum 1024 characters (Youchuan command flags embedded in the prompt are not counted toward the limit).",
+        "required": true
+      },
+      {
+        "name": "sref",
+        "type": "str",
+        "default": "",
+        "title": "Style Reference URL",
+        "description": "Optional URL of a style-reference image. Must be a publicly reachable https image URL."
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "1:1",
+        "title": "Aspect Ratio",
+        "description": "Aspect ratio of the generated image.",
+        "values": [
+          "1:1",
+          "9:16",
+          "16:9",
+          "4:3",
+          "3:4",
+          "2:3",
+          "3:2",
+          "9:21",
+          "21:9"
+        ]
+      },
+      {
+        "name": "hd",
+        "type": "bool",
+        "default": false,
+        "title": "HD (2K)",
+        "description": "Enable native 2K HD generation. Costs 1.5x."
+      },
+      {
+        "name": "stylize",
+        "type": "int",
+        "default": 0,
+        "title": "Stylize",
+        "description": "Controls how strongly the model's default aesthetic is applied (0-1000).",
+        "min": 0,
+        "max": 1000
+      },
+      {
+        "name": "chaos",
+        "type": "int",
+        "default": 0,
+        "title": "Chaos",
+        "description": "Higher values produce more unusual and varied results (0-100).",
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "weird",
+        "type": "int",
+        "default": 0,
+        "title": "Weird",
+        "description": "Makes results quirky and unconventional (0-3000).",
+        "min": 0,
+        "max": 3000
+      },
+      {
+        "name": "quality",
+        "type": "int",
+        "default": 1,
+        "title": "Quality",
+        "description": "Controls image detail. 4 = higher detail at the same price (slower). v8.2 supports 1 or 4 only.",
+        "values": [
+          1,
+          4
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Use the same seed and prompt to get reproducible results. -1 = random."
+      }
+    ]
+  },
+  {
+    "className": "YouchuanV82ImageToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "youchuan/v8.2/image-to-image",
+    "outputType": "image",
+    "title": "Youchuan v8.2 — Image to Image",
+    "description": "AtlasCloud / Youchuan v8.2 — restyles an input image from a text prompt.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Input image to re-imagine. A publicly reachable https image URL (or upload). Each task returns 4 images.",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt guiding the generation. Maximum 1024 characters. Each task returns 4 images.",
+        "required": true
+      },
+      {
+        "name": "sref",
+        "type": "str",
+        "default": "",
+        "title": "Style Reference URL",
+        "description": "Optional URL of a style-reference image. Must be a publicly reachable https image URL."
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "1:1",
+        "title": "Aspect Ratio",
+        "description": "Aspect ratio of the generated image.",
+        "values": [
+          "1:1",
+          "9:16",
+          "16:9",
+          "4:3",
+          "3:4",
+          "2:3",
+          "3:2",
+          "9:21",
+          "21:9"
+        ]
+      },
+      {
+        "name": "hd",
+        "type": "bool",
+        "default": false,
+        "title": "HD (2K)",
+        "description": "Enable native 2K HD generation. Costs 1.5x."
+      },
+      {
+        "name": "stylize",
+        "type": "int",
+        "default": 0,
+        "title": "Stylize",
+        "description": "Controls how strongly the model's default aesthetic is applied (0-1000).",
+        "min": 0,
+        "max": 1000
+      },
+      {
+        "name": "chaos",
+        "type": "int",
+        "default": 0,
+        "title": "Chaos",
+        "description": "Higher values produce more unusual and varied results (0-100).",
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "weird",
+        "type": "int",
+        "default": 0,
+        "title": "Weird",
+        "description": "Makes results quirky and unconventional (0-3000).",
+        "min": 0,
+        "max": 3000
+      },
+      {
+        "name": "quality",
+        "type": "int",
+        "default": 1,
+        "title": "Quality",
+        "description": "Controls image detail. 4 = higher detail at the same price (slower). v8.2 supports 1 or 4 only.",
+        "values": [
+          1,
+          4
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Use the same seed and inputs to get reproducible results. -1 = random."
+      }
+    ]
+  },
+  {
+    "className": "YouchuanV82Blend",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "youchuan/v8.2/blend",
+    "outputType": "image",
+    "title": "Youchuan v8.2 — Blend",
+    "description": "AtlasCloud / Youchuan v8.2 — fuses 2-5 input images into blended results.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "Two to five input images to blend. Publicly reachable https image URLs (or uploads). Each task returns 4 fused images.",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Optional text prompt guiding the blend. Maximum 1024 characters."
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "1:1",
+        "title": "Aspect Ratio",
+        "description": "Aspect ratio of the generated image.",
+        "values": [
+          "1:1",
+          "9:16",
+          "16:9",
+          "4:3",
+          "3:4",
+          "2:3",
+          "3:2",
+          "9:21",
+          "21:9"
+        ]
+      },
+      {
+        "name": "hd",
+        "type": "bool",
+        "default": false,
+        "title": "HD (2K)",
+        "description": "Enable native 2K HD generation. Costs 1.5x."
+      },
+      {
+        "name": "stylize",
+        "type": "int",
+        "default": 0,
+        "title": "Stylize",
+        "description": "Controls how strongly the model's default aesthetic is applied (0-1000).",
+        "min": 0,
+        "max": 1000
+      },
+      {
+        "name": "chaos",
+        "type": "int",
+        "default": 0,
+        "title": "Chaos",
+        "description": "Higher values produce more unusual and varied results (0-100).",
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "weird",
+        "type": "int",
+        "default": 0,
+        "title": "Weird",
+        "description": "Makes results quirky and unconventional (0-3000).",
+        "min": 0,
+        "max": 3000
+      },
+      {
+        "name": "quality",
+        "type": "int",
+        "default": 1,
+        "title": "Quality",
+        "description": "Controls image detail. 4 = higher detail at the same price (slower). v8.2 supports 1 or 4 only.",
+        "values": [
+          1,
+          4
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Use the same seed and inputs to get reproducible results. -1 = random."
+      }
+    ]
+  },
+  {
+    "className": "YouchuanV82StyleTransfer",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "youchuan/v8.2/style-transfer",
+    "outputType": "image",
+    "title": "Youchuan v8.2 — Style Transfer",
+    "description": "AtlasCloud / Youchuan v8.2 — applies a described style to an input image.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Input image to restyle. A publicly reachable https image URL (or upload). Each task returns 4 restyled images that keep the original composition.",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Description of the target artistic style (e.g. 'cyberpunk neon night style').",
+        "required": true
+      }
+    ]
+  },
+  {
+    "className": "YouchuanV82RemoveBackground",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "youchuan/v8.2/remove-background",
+    "outputType": "image",
+    "title": "Youchuan v8.2 — Remove Background",
+    "description": "AtlasCloud / Youchuan v8.2 — removes the background from an input image.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Input image whose background will be removed. A publicly reachable https image URL (or upload). Returns 1 image with transparent background.",
+        "required": true
+      }
+    ]
+  },
+  {
+    "className": "YouchuanV82ImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "youchuan/v8.2/image-to-video",
+    "outputType": "video",
+    "title": "Youchuan v8.2 — Image to Video",
+    "description": "AtlasCloud / Youchuan v8.2 — four 5-second videos per task at 480p/720p from an input image.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "First-frame image to animate. A publicly reachable https image URL (or upload). The generated video keeps the input image's aspect ratio. Each task returns 4 five-second videos.",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Optional text describing the motion / scene for the generated video."
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "480p",
+        "title": "Resolution",
+        "description": "Output resolution. 720p costs 3x of 480p.",
+        "values": [
+          "480p",
+          "720p"
+        ]
+      },
+      {
+        "name": "motion",
+        "type": "enum",
+        "default": "low",
+        "title": "Motion",
+        "description": "Amount of motion in the generated video.",
+        "values": [
+          "low",
+          "high"
+        ]
+      }
+    ]
   }
 ]

--- a/packages/atlascloud-nodes/tests/atlascloud-factory.test.ts
+++ b/packages/atlascloud-nodes/tests/atlascloud-factory.test.ts
@@ -508,6 +508,163 @@ describe("createAtlasNodeClass.process", () => {
     });
   });
 
+  it("merges wrapInto asset fields into one {url, type} array", async () => {
+    const submitted: { body: unknown } = { body: null };
+    global.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (u.endsWith("/generateVideo")) {
+        submitted.body = JSON.parse(init!.body as string);
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ data: { id: "r" } })
+        } as Response;
+      }
+      if (u.includes("/prediction/r")) {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          text: async () =>
+            JSON.stringify({
+              data: { status: "completed", outputs: ["https://cdn/out.mp4"] }
+            })
+        } as Response;
+      }
+      if (u === "https://cdn/out.mp4") {
+        return {
+          ok: true,
+          arrayBuffer: async () => Uint8Array.from([1]).buffer
+        } as Response;
+      }
+      throw new Error(`unexpected: ${u}`);
+    }) as unknown as typeof fetch;
+
+    const Cls = createAtlasNodeClass(
+      makeSpec({
+        modality: "video",
+        outputType: "video",
+        modelId: "test/model/r2v",
+        fields: [
+          { name: "prompt", type: "str", default: "" },
+          {
+            name: "reference_images",
+            type: "list[image]",
+            wrapInto: "refers",
+            default: null
+          },
+          {
+            name: "reference_videos",
+            type: "list[video]",
+            wrapInto: "refers",
+            default: null
+          },
+          {
+            name: "reference_audios",
+            type: "list[audio]",
+            wrapInto: "refers",
+            default: null
+          }
+        ]
+      })
+    ) as unknown as new () => {
+      prompt: string;
+      reference_images: unknown;
+      reference_videos: unknown;
+      reference_audios: unknown;
+      process: (ctx: unknown) => Promise<Record<string, unknown>>;
+      setDynamic: (k: string, v: unknown) => void;
+    };
+    const node = new Cls();
+    node.setDynamic("_secrets", { ATLASCLOUD_API_KEY: "tk" });
+    node.prompt = "dance to this";
+    node.reference_images = [
+      { uri: "https://input/a.png" },
+      { uri: "https://input/b.png" }
+    ];
+    node.reference_videos = [{ uri: "https://input/c.mp4" }];
+    node.reference_audios = [{ uri: "https://input/d.mp3" }];
+
+    await node.process({ storage: null });
+
+    // One mixed array in manifest field order, each entry tagged with the
+    // media kind its input declared — never the per-kind field names.
+    expect(submitted.body).toEqual({
+      model: "test/model/r2v",
+      prompt: "dance to this",
+      refers: [
+        { url: "https://input/a.png", type: "image" },
+        { url: "https://input/b.png", type: "image" },
+        { url: "https://input/c.mp4", type: "video" },
+        { url: "https://input/d.mp3", type: "audio" }
+      ]
+    });
+  });
+
+  it("omits the wrapInto array entirely when no reference is wired", async () => {
+    const submitted: { body: unknown } = { body: null };
+    global.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (u.endsWith("/generateVideo")) {
+        submitted.body = JSON.parse(init!.body as string);
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ data: { id: "r" } })
+        } as Response;
+      }
+      if (u.includes("/prediction/r")) {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          text: async () =>
+            JSON.stringify({
+              data: { status: "completed", outputs: ["https://cdn/out.mp4"] }
+            })
+        } as Response;
+      }
+      if (u === "https://cdn/out.mp4") {
+        return {
+          ok: true,
+          arrayBuffer: async () => Uint8Array.from([1]).buffer
+        } as Response;
+      }
+      throw new Error(`unexpected: ${u}`);
+    }) as unknown as typeof fetch;
+
+    const Cls = createAtlasNodeClass(
+      makeSpec({
+        modality: "video",
+        outputType: "video",
+        modelId: "test/model/r2v",
+        fields: [
+          { name: "prompt", type: "str", default: "" },
+          {
+            name: "reference_images",
+            type: "list[image]",
+            wrapInto: "refers",
+            default: null
+          }
+        ]
+      })
+    ) as unknown as new () => {
+      prompt: string;
+      process: (ctx: unknown) => Promise<Record<string, unknown>>;
+      setDynamic: (k: string, v: unknown) => void;
+    };
+    const node = new Cls();
+    node.setDynamic("_secrets", { ATLASCLOUD_API_KEY: "tk" });
+    node.prompt = "no references";
+
+    await node.process({ storage: null });
+
+    expect(submitted.body).toEqual({
+      model: "test/model/r2v",
+      prompt: "no references"
+    });
+  });
+
   it("resolves list[image] fields element-by-element", async () => {
     const submitted: { body: unknown } = { body: null };
     global.fetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
@@ -914,6 +1071,22 @@ describe("atlascloud-manifest", () => {
       .filter((e) => e.fields.some((f) => f.name === "return_last_frame"))
       .map((e) => e.className);
     expect(offenders).toEqual([]);
+  });
+
+  it("only wraps asset fields, and never collides with a declared field name", () => {
+    const wrapped = manifest.flatMap((e) =>
+      e.fields
+        .filter((f) => f.wrapInto !== undefined)
+        .map((f) => ({ entry: e, field: f }))
+    );
+    // Wan 3.0 / Wan 3.0 Prime / MiniMax H3 reference-to-video: 3 inputs each.
+    expect(wrapped.length).toBe(9);
+    for (const { entry, field } of wrapped) {
+      expect(field.type).toMatch(/^list\[(image|video|audio)\]$/);
+      // The wrap target is the API parameter, so no node property may claim it
+      // — the factory would overwrite one with the wrapped array.
+      expect(entry.fields.some((f) => f.name === field.wrapInto)).toBe(false);
+    }
   });
 
   it("models multi-image edit inputs as list[image], not a single wrapped image", () => {

--- a/packages/runtime/src/providers/atlascloud-provider.ts
+++ b/packages/runtime/src/providers/atlascloud-provider.ts
@@ -95,6 +95,8 @@ interface FieldInfo {
   /** Allowed values when the field is an enum. Numbers stay numbers. */
   values?: Array<string | number>;
   default?: unknown;
+  /** Request array this field belongs in, as `{url, type}` — see the manifest. */
+  wrapInto?: string;
 }
 
 interface ModelInfo {
@@ -133,6 +135,9 @@ function buildModelMap(): Map<string, ModelInfo> {
       }
       if (f.default !== undefined) {
         field.default = f.default;
+      }
+      if (f.wrapInto !== undefined) {
+        field.wrapInto = f.wrapInto;
       }
       fields.set(f.name, field);
     }
@@ -760,18 +765,24 @@ export class AtlasCloudProvider extends OpenAICompatProvider {
     }
     const info = this.resolveModel(params.model.id, "video");
     const input = mapVideoParams(info, params);
-    // Seedance image-to-video uses `image` (singular); Grok Imagine Video uses
-    // `image_url`. Reference-to-video has `reference_images` (list) instead —
-    // generic imageToVideo can't target it.
+    // Each endpoint family names its input image differently: Seedance uses
+    // `image` (singular), Grok Imagine Video `image_url`, the edit endpoints
+    // `images`, and reference-to-video `reference_images`. First match wins.
     const dataUri = bytesToImageDataUri(image);
-    if (info.fields.has("image")) {
-      input.image = dataUri;
-    } else if (info.fields.has("image_url")) {
-      input.image_url = dataUri;
-    } else if (info.fields.has("images")) {
-      input.images = [dataUri];
-    } else if (info.fields.has("reference_images")) {
-      input.reference_images = [dataUri];
+    const imageField = ["image", "image_url", "images", "reference_images"].find(
+      (name) => info.fields.has(name)
+    );
+    if (imageField) {
+      // Wan 3.0 / MiniMax H3 take one mixed `refers` array of `{url, type}`
+      // objects; the manifest splits it into typed inputs that name it.
+      const wrapInto = info.fields.get(imageField)?.wrapInto;
+      if (wrapInto) {
+        input[wrapInto] = [{ url: dataUri, type: "image" }];
+      } else if (imageField === "images" || imageField === "reference_images") {
+        input[imageField] = [dataUri];
+      } else {
+        input[imageField] = dataUri;
+      }
     } else {
       throw new Error(
         `AtlasCloud model ${params.model.id} does not accept an input image (try the Seedance image-to-video variant)`

--- a/packages/runtime/src/providers/manifest-models.ts
+++ b/packages/runtime/src/providers/manifest-models.ts
@@ -40,6 +40,8 @@ interface ManifestField {
   required?: boolean;
   min?: number;
   max?: number;
+  /** AtlasCloud: send this field inside the named `{url, type}` array instead. */
+  wrapInto?: string;
 }
 
 /**
@@ -607,6 +609,12 @@ export interface ModelInputField {
    * provider enforce the cap before spending the round trip.
    */
   max?: number;
+  /**
+   * The request array this field's value belongs in, as `{ url, type }`
+   * objects, rather than under `name`. AtlasCloud's reference-to-video models
+   * take one mixed `refers` array; the manifest splits it into typed inputs.
+   */
+  wrapInto?: string;
 }
 
 /**
@@ -641,6 +649,9 @@ export function getModelInputFields(
       }
       if (isNumber(f.max)) {
         field.max = f.max;
+      }
+      if (f.wrapInto !== undefined) {
+        field.wrapInto = f.wrapInto;
       }
       return field;
     });

--- a/packages/runtime/tests/providers/atlascloud-provider.test.ts
+++ b/packages/runtime/tests/providers/atlascloud-provider.test.ts
@@ -453,4 +453,21 @@ describe("AtlasCloudProvider — imageToVideo", () => {
       /^data:image\/png;base64,/
     );
   });
+
+  it("sends one `refers` array on a model whose manifest wraps its references", async () => {
+    const capture: { submitBody?: Record<string, unknown> } = {};
+    mockAtlasFetch({ capture });
+    const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
+    await p.imageToVideo([Uint8Array.from([0x89, 0x50, 0x4e, 0x47])], {
+      model: videoModel("minimax/h3/reference-to-video"),
+      prompt: "anchor on this"
+    });
+    const body = capture.submitBody!;
+    // MiniMax H3 takes `refers: [{url, type}]`, not per-kind lists — posting
+    // `reference_images` would be rejected by the endpoint.
+    expect(body.reference_images).toBeUndefined();
+    expect(body.refers).toEqual([
+      { url: expect.stringMatching(/^data:image\/png;base64,/), type: "image" }
+    ]);
+  });
 });


### PR DESCRIPTION
## What changed

AtlasCloud's catalog ranks 28 image/video models above everything the manifest carried (priority 90035–90051 against a ceiling of 90032); this ships 27 of them as nodes — Wan 3.0 and Wan 3.0 Prime, Seedance 2.5, MiniMax H3, Grok Imagine Image 2.0, Qwen Image 3.0 and 3.0 Pro, Reve 2.1, and Youchuan v8.2. Every field is generated from the model's own published `Input` schema, so `sync-atlascloud-manifest.mjs --check` reports no writable drift on any new entry. Two of them needed a mechanism the factory lacked: Wan 3.0 and MiniMax H3 reference-to-video take one mixed `refers: [{url, type}]` array rather than per-kind lists, so a field can now declare `wrapInto` and the manifest splits that array into typed `reference_images` / `reference_videos` / `reference_audios` inputs — the editor keeps its asset wiring, and the media kind each input declares is exactly the `type` the objects require. The runtime provider reads the same flag, so its generic `imageToVideo` posts `refers` rather than a `reference_images` the endpoint would reject. Numeric option lists are typed `int`, not `enum`: NodeTool serializes an `enum` prop as a string and AtlasCloud rejects `"5"` where it wants `5`, which is how the shipped Seedance and Youchuan entries already type `duration`, `quality` and `n`. AtlasCloud's chat models need no change — the provider discovers them from `GET /v1/models`.

`bytedance/seedream-v5.0-pro/layer-decomposition` is the 28th and is deliberately left out: `pickOutputUrl` returns the first output, and that model's point is the *set* of layers it returns, so the node would silently drop what the call was for. A model returning N interchangeable variants (`n`, `num_images`) is fine; one whose outputs are not interchangeable is not. `packages/atlascloud-nodes/AGENTS.md` records both that rule and the `wrapInto` convention.

Two things found and **not** fixed here, since neither is this change's scope:

- 27 writable drifts against upstream schemas on models already shipped — `nano-banana-2` / `-pro` / `-2-lite` gained `seed`/`top_p`/`temperature`, `seedream-v5.0-pro` gained `prompt_optimization_mode` and `background`, and `happyhorse-1.1`'s `resolution` enum is cased `"1080P"` where upstream now says `"1080p"`. The last one looks like a live bug. `node scripts/sync-atlascloud-manifest.mjs` applies all of them; it wants its own review.
- The catalog carries 376 further models we do not ship, mostly older generations.

## Verification

- [x] `npm run test:affected` — green. `web` 1174/1174 suites and 13476 tests passed; `electron` 63/63 suites and 684/684 tests passed. Two failures needed environment fixes rather than code: `document-nodes` / `data-nodes` failed on a missing `dist/` in a fresh checkout (fixed by `npm run build:packages`), and `image-nodes` failed with `VK_ERROR_INCOMPATIBLE_DRIVER` — the documented headless-WebGPU gap, which passes 24/24 files and 231/231 tests once `mesa-vulkan-drivers` (lavapipe) is installed, as CI already does. One flake: `packages/cli` `run-dsl.test.ts` timed out at 30s under the parallel load (38s observed) and passes 10/10 in isolation.
- [x] `npm run typecheck` — exit 0
- [x] `npm run lint` — exit 0 (pre-existing warnings only, none in the touched files)
- [x] `npm run dev:nodetool -- harness gate --base main` — run as `--base HEAD~1` against the commit; `Gate: 4/4 selfchecks passed` (5 Ring 0 reliability journeys, provider contract probes, and 2 more).

Beyond the gate: all 27 new classes instantiate from the built manifest and register their 186 properties; `sync-atlascloud-manifest.mjs --check` reports no writable drift on any new entry.

## Agent capabilities

No capability added, and no capability's declared contract changed.

## New checks

Three tests were added and each was inverted once and observed failing:

- `merges wrapInto asset fields into one {url, type} array` — with `appendWrapped` tagging every entry `"image"` instead of the field's kind: `Test Files 1 failed | 1 passed (2)`, `Tests 1 failed | 80 passed (81)`.
- `sends one 'refers' array on a model whose manifest wraps its references` — with the provider's `wrapInto` lookup forced to `undefined`: `Test Files 1 failed (1)`, `Tests 1 failed | 27 passed (28)`.
- `only wraps asset fields, and never collides with a declared field name` is a manifest invariant that asserts it found its targets (`expect(wrapped.length).toBe(9)`), so it cannot pass by matching nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uz2G7JafBHqXSMQeQLQFi1