### PR TITLE
fix(oauth,mcp): bound registration, expire MCP sessions, harden token grants

### DIFF
--- a/docs/document-sync-plan.md
+++ b/docs/document-sync-plan.md
@@ -1,6 +1,6 @@
 # Document sync: merge external changes into a dirty draft
 
-Decisions: [ADR 0001](adr/0001-document-sync-draft-wins.md). Terms: [CONTEXT.md](../CONTEXT.md).
+Decisions: [ADR 0001](adr/0001-document-sync-draft-wins.md). Terms: [CONTEXT.md](https://github.com/nodetool-ai/nodetool/blob/main/CONTEXT.md).
 
 Today `documentSync.ts` reloads a clean editor and warns a dirty one. A dirty editor's next autosave fails the CAS and the only recovery is a refresh. This plan replaces the warning with a per-merge-unit merge, draft wins, one conflict banner.
 

--- a/docs/mcp-oauth-design.md
+++ b/docs/mcp-oauth-design.md
@@ -191,9 +191,14 @@ timeout 5 s), and never trusted across the `client_id` mismatch.
 `POST /oauth/register` accepts `{client_name, redirect_uris, grant_types,
 token_endpoint_auth_method: "none", application_type}` and answers a generated
 `client_id` (`ntc_<random>`), no secret. Rows live in a new `mcp_oauth_clients`
-table. Registration is open (that is the point of DCR) but rate-limited via the
-existing `fastifyRateLimit` registration, and rows are garbage-collected when
-they age out with no grant ever issued (30 days).
+table. Registration is open (that is the point of DCR) but bounded three ways:
+the existing `fastifyRateLimit` registration caps requests, a route-level
+`bodyLimit` of 8 KB caps each one (the server's own limit is 100 MB, which at
+ten requests a minute is a gigabyte a minute of durable client metadata), and
+the document itself is capped — `client_name` ≤ 256 characters, at most 10
+`redirect_uris`, each ≤ 2048 characters. Rows are garbage-collected when they
+age out with no grant ever issued (30 days), on the server's periodic cleanup
+tick.
 
 Redirect URIs at registration and at authorize time must be `https://…` or
 loopback (`http://127.0.0.1[:port]/…`, `http://localhost[:port]/…`); anything
@@ -229,16 +234,22 @@ redirect_uri) render in-page and never redirect — open-redirect rule.
 `POST /oauth/token`, `application/x-www-form-urlencoded`:
 
 - **`grant_type=authorization_code`** — verify: code exists, unexpired
-  (≤ 10 min), unused; `client_id` matches; `redirect_uri` exact-matches the
+  (≤ 10 min); `client_id` matches; `redirect_uri` exact-matches the
   authorize request; `code_verifier` S256-hashes to the stored
   `code_challenge` (constant-time compare — `PKCEHelper` in
   `packages/runtime/src/providers/oauth/pkce-helper.ts` already implements
-  S256); `resource`, when sent, equals the one bound at authorize time. A
-  **reused** code revokes every token already issued from it (OAuth 2.1 code
-  replay rule), not just fails.
+  S256); `resource`, when sent, equals the one bound at authorize time. Every
+  one of those is checked *before* the code is spent, so someone holding a
+  leaked code but not the verifier cannot burn it — redeeming first made the
+  legitimate exchange look like a replay and revoked the grant. Only once the
+  bindings hold is the code consumed, and a **reused** code then revokes every
+  token already issued from it (OAuth 2.1 code replay rule).
 - **`grant_type=refresh_token`** — rotate: verify the `ntr_` token, issue a
   new access + refresh pair, invalidate the old refresh token. A rotated-out
   refresh token presented again is reuse-detection: revoke the whole grant.
+  The rotation runs in one transaction, and only the unique-index violation on
+  `rotated_from` counts as reuse — a transient write failure rolls the whole
+  attempt back and propagates, rather than revoking a working grant.
 
 Response: `access_token` (`nta_…`, `expires_in: 3600`), `token_type:
 "Bearer"`, `refresh_token` (`ntr_…`, absolute lifetime 30 days), `scope`.
@@ -300,6 +311,8 @@ escape hatch for an operator who wants token-paste only.
 - AS endpoints HTTPS in production; loopback exception local — enforced per request by the shared gate (`oauth/gate.ts`).
 - Secrets stored hashed; raw token appears once in the token response — token model.
 - Rate limits on `/oauth/token` and `/oauth/register` — existing `fastifyRateLimit`.
+- Size limits on `/oauth/register` (8 KB body, bounded name and redirect URIs) — register route.
+- Code bindings validated before the code is consumed — token endpoint.
 
 ## Out of scope, deliberately
 

--- a/packages/models/src/mcp-oauth.ts
+++ b/packages/models/src/mcp-oauth.ts
@@ -26,7 +26,7 @@ import { randomBytes } from "node:crypto";
 import { digestsMatch, hashSecret } from "./access-token.js";
 import { and, eq, isNull, lt, notInArray } from "drizzle-orm";
 import { DBModel, createTimeOrderedUuid } from "./base-model.js";
-import { getDb } from "./db.js";
+import { getDb, getDbType, type DbTransaction } from "./db.js";
 import {
   mcpOauthClients,
   mcpOauthGrants,
@@ -350,9 +350,16 @@ function tokenPrefix(kind: "access" | "refresh"): string {
     : MCP_OAUTH_REFRESH_TOKEN_PREFIX;
 }
 
-async function saveTokenRow(row: MintedTokenRow): Promise<void> {
-  const db = getDb();
-  await db.insert(mcpOauthTokens).values({
+function tokenValues(row: MintedTokenRow): {
+  id: string;
+  grant_id: string;
+  kind: "access" | "refresh";
+  secret_hash: string;
+  expires_at: string;
+  rotated_from: string | null;
+  last_used_at: string | null;
+} {
+  return {
     id: row.id,
     grant_id: row.grant_id,
     kind: row.kind,
@@ -360,7 +367,263 @@ async function saveTokenRow(row: MintedTokenRow): Promise<void> {
     expires_at: row.expiresAt.toISOString(),
     rotated_from: row.rotatedFrom,
     last_used_at: null
-  });
+  };
+}
+
+async function saveTokenRow(row: MintedTokenRow): Promise<void> {
+  const db = getDb();
+  await db.insert(mcpOauthTokens).values(tokenValues(row));
+}
+
+/** The name of the unique index that makes a rotation an atomic claim. */
+const ROTATED_FROM_INDEX = "idx_mcp_oauth_token_rotated_from";
+
+/**
+ * True only for the unique-index violation on `rotated_from` — the one error
+ * that means another rotation already claimed this refresh token, which is
+ * reuse. Every other failure (a closed connection, a full disk, a timeout) is
+ * transient and must propagate: classifying it as reuse would revoke a working
+ * grant because the database hiccuped.
+ */
+function isRotatedFromConflict(err: unknown): boolean {
+  let current: unknown = err;
+  for (let depth = 0; current != null && depth < 5; depth += 1) {
+    const candidate = current as {
+      code?: unknown;
+      constraint_name?: unknown;
+      message?: unknown;
+      cause?: unknown;
+    };
+    const code = typeof candidate.code === "string" ? candidate.code : "";
+    const constraint =
+      typeof candidate.constraint_name === "string"
+        ? candidate.constraint_name
+        : "";
+    const message =
+      typeof candidate.message === "string" ? candidate.message : "";
+    // better-sqlite3
+    if (
+      code === "SQLITE_CONSTRAINT_UNIQUE" &&
+      message.includes("mcp_oauth_tokens.rotated_from")
+    ) {
+      return true;
+    }
+    // postgres.js
+    if (
+      code === "23505" &&
+      (constraint === ROTATED_FROM_INDEX || message.includes(ROTATED_FROM_INDEX))
+    ) {
+      return true;
+    }
+    if (candidate.cause === current) break;
+    current = candidate.cause;
+  }
+  return false;
+}
+
+/** Mark a grant revoked and delete every token minted for it. */
+function revokeGrantSync(tx: DbTransaction, grant_id: string): void {
+  tx.delete(mcpOauthTokens).where(eq(mcpOauthTokens.grant_id, grant_id)).run();
+  tx.update(mcpOauthGrants)
+    .set({ revoked_at: isoNow() })
+    .where(eq(mcpOauthGrants.id, grant_id))
+    .run();
+}
+
+async function revokeGrantAsync(
+  tx: DbTransaction,
+  grant_id: string
+): Promise<void> {
+  await tx.delete(mcpOauthTokens).where(eq(mcpOauthTokens.grant_id, grant_id));
+  await tx
+    .update(mcpOauthGrants)
+    .set({ revoked_at: isoNow() })
+    .where(eq(mcpOauthGrants.id, grant_id));
+}
+
+/** Revoke a grant in its own transaction — the two writes never land apart. */
+async function revokeGrantCompletely(grant_id: string): Promise<void> {
+  const db = getDb();
+  if (getDbType() === "sqlite") {
+    // better-sqlite3 transactions must be fully synchronous; an async callback
+    // returns a Promise the driver rejects.
+    db.transaction((tx: DbTransaction): void => revokeGrantSync(tx, grant_id));
+    return;
+  }
+  await db.transaction(
+    async (tx: DbTransaction): Promise<void> => revokeGrantAsync(tx, grant_id)
+  );
+}
+
+/** The grant a refresh-token row belongs to, read outside any transaction. */
+async function grantIdOfToken(tokenId: string): Promise<string | null> {
+  const rows = await getDb()
+    .select({ grant_id: mcpOauthTokens.grant_id })
+    .from(mcpOauthTokens)
+    .where(eq(mcpOauthTokens.id, tokenId))
+    .limit(1);
+  return rows[0]?.grant_id ?? null;
+}
+
+/** What one refresh rotation decided. */
+export type RefreshRotation =
+  | {
+      accessToken: string;
+      refreshToken: string;
+      expiresAt: Date;
+      grantId: string;
+    }
+  | { reuseDetected: true }
+  | null;
+
+interface ParsedToken {
+  id: string;
+  secret: string;
+}
+
+type RotationStep =
+  | { verdict: "unknown" }
+  | { verdict: "reuse"; grantId: string }
+  | { verdict: "expired"; grantId: string }
+  | { verdict: "rotate"; record: McpOauthToken };
+
+/**
+ * The rotation decision that needs no database access: what the presented row
+ * means. Shared by both dialect branches so they cannot drift.
+ */
+function rotationStep(
+  row: Record<string, unknown> | undefined,
+  parsed: ParsedToken,
+  hasSuccessor: boolean,
+  now: number
+): RotationStep {
+  if (!row) return { verdict: "unknown" };
+  const record = new McpOauthToken(row);
+  if (!digestsMatch(record.secret_hash, hashSecret(parsed.secret))) {
+    return { verdict: "unknown" };
+  }
+  if (hasSuccessor) return { verdict: "reuse", grantId: record.grant_id };
+  if (isRowExpired(record.expires_at, now)) {
+    return { verdict: "expired", grantId: record.grant_id };
+  }
+  return { verdict: "rotate", record };
+}
+
+/** The pair a rotation mints, given the row it replaces. */
+function rotationPair(record: McpOauthToken): {
+  access: MintedTokenRow;
+  refresh: MintedTokenRow;
+} {
+  return {
+    access: mintTokenRow(record.grant_id, "access", MCP_OAUTH_ACCESS_TTL_MS),
+    refresh: mintTokenRow(
+      record.grant_id,
+      "refresh",
+      MCP_OAUTH_REFRESH_TTL_MS,
+      record.id,
+      new Date(record.expires_at)
+    )
+  };
+}
+
+function rotated(
+  access: MintedTokenRow,
+  refresh: MintedTokenRow,
+  grantId: string
+): RefreshRotation {
+  return {
+    accessToken: rawToken(access),
+    refreshToken: rawToken(refresh),
+    expiresAt: access.expiresAt,
+    grantId
+  };
+}
+
+function rotateSqlite(
+  tx: DbTransaction,
+  parsed: ParsedToken,
+  now: number
+): RefreshRotation {
+  const row = tx
+    .select()
+    .from(mcpOauthTokens)
+    .where(
+      and(eq(mcpOauthTokens.id, parsed.id), eq(mcpOauthTokens.kind, "refresh"))
+    )
+    .limit(1)
+    .get();
+  const successor = row
+    ? tx
+        .select({ id: mcpOauthTokens.id })
+        .from(mcpOauthTokens)
+        .where(eq(mcpOauthTokens.rotated_from, parsed.id))
+        .limit(1)
+        .get()
+    : undefined;
+  const step = rotationStep(
+    row as Record<string, unknown> | undefined,
+    parsed,
+    successor !== undefined,
+    now
+  );
+  if (step.verdict === "unknown") return null;
+  if (step.verdict === "reuse") {
+    revokeGrantSync(tx, step.grantId);
+    return { reuseDetected: true };
+  }
+  if (step.verdict === "expired") {
+    tx.delete(mcpOauthTokens).where(eq(mcpOauthTokens.id, parsed.id)).run();
+    return null;
+  }
+  const { access, refresh } = rotationPair(step.record);
+  // The refresh row goes first: the unique index on `rotated_from` makes it
+  // the atomic claim on this rotation. Two concurrent presentations of the
+  // same token both pass the successor check above, but only one insert
+  // survives the constraint — the loser is a reuse presentation, classified
+  // by `isRotatedFromConflict` and handled by the caller.
+  tx.insert(mcpOauthTokens).values(tokenValues(refresh)).run();
+  tx.insert(mcpOauthTokens).values(tokenValues(access)).run();
+  return rotated(access, refresh, step.record.grant_id);
+}
+
+async function rotatePostgres(
+  tx: DbTransaction,
+  parsed: ParsedToken,
+  now: number
+): Promise<RefreshRotation> {
+  const rows = await tx
+    .select()
+    .from(mcpOauthTokens)
+    .where(
+      and(eq(mcpOauthTokens.id, parsed.id), eq(mcpOauthTokens.kind, "refresh"))
+    )
+    .limit(1);
+  const successors = rows[0]
+    ? await tx
+        .select({ id: mcpOauthTokens.id })
+        .from(mcpOauthTokens)
+        .where(eq(mcpOauthTokens.rotated_from, parsed.id))
+        .limit(1)
+    : [];
+  const step = rotationStep(
+    rows[0] as Record<string, unknown> | undefined,
+    parsed,
+    successors.length > 0,
+    now
+  );
+  if (step.verdict === "unknown") return null;
+  if (step.verdict === "reuse") {
+    await revokeGrantAsync(tx, step.grantId);
+    return { reuseDetected: true };
+  }
+  if (step.verdict === "expired") {
+    await tx.delete(mcpOauthTokens).where(eq(mcpOauthTokens.id, parsed.id));
+    return null;
+  }
+  const { access, refresh } = rotationPair(step.record);
+  await tx.insert(mcpOauthTokens).values(tokenValues(refresh));
+  await tx.insert(mcpOauthTokens).values(tokenValues(access));
+  return rotated(access, refresh, step.record.grant_id);
 }
 
 function rawToken(row: MintedTokenRow): string {
@@ -460,84 +723,33 @@ export class McpOauthToken extends DBModel {
    * is exactly what makes reuse detectable: presenting it again finds a
    * successor already pointing back at it and revokes the whole grant.
    */
-  static async rotateRefresh(token: string): Promise<
-    | { accessToken: string; refreshToken: string; expiresAt: Date; grantId: string }
-    | { reuseDetected: true }
-    | null
-  > {
+  static async rotateRefresh(token: string): Promise<RefreshRotation> {
     const parsed = parseToken(token, MCP_OAUTH_REFRESH_TOKEN_PREFIX);
     if (!parsed) return null;
     const db = getDb();
-    const rows = await db
-      .select()
-      .from(mcpOauthTokens)
-      .where(
-        and(
-          eq(mcpOauthTokens.id, parsed.id),
-          eq(mcpOauthTokens.kind, "refresh")
-        )
-      )
-      .limit(1);
-    const row = rows[0];
-    if (!row) return null;
-    const record = new McpOauthToken(row as Record<string, unknown>);
-    if (!digestsMatch(record.secret_hash, hashSecret(parsed.secret))) {
-      return null;
-    }
-
-    const successors = await db
-      .select({ id: mcpOauthTokens.id })
-      .from(mcpOauthTokens)
-      .where(eq(mcpOauthTokens.rotated_from, record.id))
-      .limit(1);
-    if (successors.length > 0) {
-      await McpOauthToken.revokeGrantTokens(record.grant_id);
-      await db
-        .update(mcpOauthGrants)
-        .set({ revoked_at: isoNow() })
-        .where(eq(mcpOauthGrants.id, record.grant_id));
-      return { reuseDetected: true };
-    }
-
-    if (isRowExpired(record.expires_at, Date.now())) {
-      await record.delete();
-      return null;
-    }
-
-    const access = mintTokenRow(
-      record.grant_id,
-      "access",
-      MCP_OAUTH_ACCESS_TTL_MS
-    );
-    const refresh = mintTokenRow(
-      record.grant_id,
-      "refresh",
-      MCP_OAUTH_REFRESH_TTL_MS,
-      record.id,
-      new Date(record.expires_at)
-    );
-    // The refresh row goes first: the unique index on `rotated_from` makes
-    // it the atomic claim on this rotation. Two concurrent presentations of
-    // the same token both pass the successor check above, but only one
-    // insert survives the constraint — the loser is a reuse presentation,
-    // and reuse revokes the grant.
+    const now = Date.now();
     try {
-      await saveTokenRow(refresh);
-    } catch {
-      await McpOauthToken.revokeGrantTokens(record.grant_id);
-      await db
-        .update(mcpOauthGrants)
-        .set({ revoked_at: isoNow() })
-        .where(eq(mcpOauthGrants.id, record.grant_id));
+      if (getDbType() === "sqlite") {
+        // better-sqlite3 transactions must be fully synchronous; an async
+        // callback returns a Promise the driver rejects.
+        return db.transaction((tx: DbTransaction): RefreshRotation =>
+          rotateSqlite(tx, parsed, now)
+        );
+      }
+      return await db.transaction(
+        async (tx: DbTransaction): Promise<RefreshRotation> =>
+          rotatePostgres(tx, parsed, now)
+      );
+    } catch (err) {
+      if (!isRotatedFromConflict(err)) throw err;
+      // Another presentation of this same token claimed the rotation while
+      // this one was in flight — that, and only that, is reuse. The
+      // transaction rolled back, so nothing of this attempt survives; the
+      // grant goes.
+      const grantId = await grantIdOfToken(parsed.id);
+      if (grantId) await revokeGrantCompletely(grantId);
       return { reuseDetected: true };
     }
-    await saveTokenRow(access);
-    return {
-      accessToken: rawToken(access),
-      refreshToken: rawToken(refresh),
-      expiresAt: access.expiresAt,
-      grantId: record.grant_id
-    };
   }
 
   /** Delete every token row for a grant. Used by rotation-reuse and by
@@ -575,11 +787,7 @@ export class McpOauthToken extends DBModel {
       return false;
     }
     if (record.kind === "refresh") {
-      await McpOauthToken.revokeGrantTokens(record.grant_id);
-      await db
-        .update(mcpOauthGrants)
-        .set({ revoked_at: isoNow() })
-        .where(eq(mcpOauthGrants.id, record.grant_id));
+      await revokeGrantCompletely(record.grant_id);
       return true;
     }
     await record.delete();

--- a/packages/models/tests/mcp-oauth.test.ts
+++ b/packages/models/tests/mcp-oauth.test.ts
@@ -299,6 +299,38 @@ describe("McpOauthGrant + McpOauthToken", () => {
     ).rejects.toThrow();
   });
 
+  it("a write failure mid-rotation rolls back and is not read as reuse", async () => {
+    const grantId = await makeGrant();
+    const pair = await McpOauthToken.mintPair(grantId);
+    const { getRawDb } = await import("../src/db.js");
+    // Stand in for a transient database failure on the second insert: the
+    // refresh row is already written when the access row fails.
+    getRawDb().exec(
+      "CREATE TRIGGER fail_access_insert BEFORE INSERT ON mcp_oauth_tokens " +
+        "WHEN NEW.kind = 'access' BEGIN SELECT RAISE(ABORT, 'disk on fire'); END;"
+    );
+    try {
+      await expect(
+        McpOauthToken.rotateRefresh(pair.refreshToken)
+      ).rejects.toThrow(/disk on fire/);
+    } finally {
+      getRawDb().exec("DROP TRIGGER fail_access_insert;");
+    }
+
+    // Only a `rotated_from` conflict means reuse. A transient failure must
+    // leave the grant working.
+    const grant = await McpOauthGrant.get(grantId);
+    expect(grant!.revoked_at).toBeNull();
+
+    // The rolled-back attempt kept nothing, so the client's retry is an
+    // ordinary rotation rather than a presentation that looks superseded.
+    const retried = await McpOauthToken.rotateRefresh(pair.refreshToken);
+    expect(retried).not.toBeNull();
+    expect("reuseDetected" in (retried as object)).toBe(false);
+    const { accessToken } = retried as { accessToken: string };
+    expect(await McpOauthToken.verifyAccess(accessToken)).not.toBeNull();
+  });
+
   it("revokeByRawToken returns false for an unknown or malformed token", async () => {
     expect(await McpOauthToken.revokeByRawToken("nta_deadbeef_x")).toBe(
       false

--- a/packages/websocket/src/mcp-server.ts
+++ b/packages/websocket/src/mcp-server.ts
@@ -86,6 +86,19 @@ export function createMcpStdioTransport(): StdioServerTransport {
   return new StdioServerTransport();
 }
 
+/**
+ * How long an HTTP session may sit idle before it is closed. Every session
+ * holds a transport, an `McpServer`, and that session's whole tool registry,
+ * and `onclose` only fires when the transport is explicitly closed — normally
+ * a DELETE. A client that simply goes away never sends one, so without this
+ * sweep the maps grow for the life of the process.
+ */
+export const MCP_SESSION_IDLE_TTL_MS = 30 * 60 * 1000;
+/** Concurrent sessions one user may hold; opening another closes their oldest. */
+export const MCP_MAX_SESSIONS_PER_USER = 8;
+/** Concurrent sessions across every user. A new one past this is refused. */
+export const MCP_MAX_SESSIONS = 256;
+
 // Per-session transport map for stateful HTTP MCP
 const sessionTransports = new Map<
   string,
@@ -98,9 +111,72 @@ const sessionTransports = new Map<
 // here.
 const sessionOwners = new Map<string, string>();
 
+// When each session was last used, for idle eviction and for picking a user's
+// oldest session when they are over their cap.
+const sessionLastSeen = new Map<string, number>();
+
 function forgetSession(sessionId: string): void {
   sessionTransports.delete(sessionId);
   sessionOwners.delete(sessionId);
+  sessionLastSeen.delete(sessionId);
+}
+
+function touchSession(sessionId: string, now: number = Date.now()): void {
+  if (sessionTransports.has(sessionId)) sessionLastSeen.set(sessionId, now);
+}
+
+/**
+ * Drop a session and close its transport, which releases the `McpServer`
+ * behind it. `forgetSession` runs first so the transport's own `onclose`
+ * finds nothing left to do.
+ */
+function closeSession(sessionId: string): void {
+  const transport = sessionTransports.get(sessionId);
+  forgetSession(sessionId);
+  void transport?.close().catch((err: unknown) => {
+    log.warn("Closing MCP session transport failed", {
+      sessionId,
+      error: err instanceof Error ? err.message : String(err)
+    });
+  });
+}
+
+/** Close every session idle for longer than the TTL. Lazy — runs per request,
+ * so an idle process holds no timer. */
+function sweepIdleSessions(now: number): void {
+  for (const [sessionId, lastSeen] of sessionLastSeen) {
+    if (now - lastSeen > MCP_SESSION_IDLE_TTL_MS) {
+      log.debug("Evicting idle MCP session", { sessionId });
+      closeSession(sessionId);
+    }
+  }
+}
+
+/** Close a user's oldest sessions until opening one more keeps them at the cap. */
+function evictOverflowForUser(userId: string): void {
+  const owned = [...sessionOwners]
+    .filter(([, owner]) => owner === userId)
+    .map(([sessionId]) => sessionId);
+  const overflow = owned.length - (MCP_MAX_SESSIONS_PER_USER - 1);
+  if (overflow <= 0) return;
+  const oldestFirst = owned.sort(
+    (a, b) => (sessionLastSeen.get(a) ?? 0) - (sessionLastSeen.get(b) ?? 0)
+  );
+  for (const sessionId of oldestFirst.slice(0, overflow)) {
+    log.debug("Evicting oldest MCP session for user over cap", {
+      userId,
+      sessionId
+    });
+    closeSession(sessionId);
+  }
+}
+
+/** Close every open HTTP session. For shutdown, and for tests that need a
+ * clean process-wide session table. */
+export function closeAllMcpHttpSessions(): void {
+  for (const sessionId of [...sessionTransports.keys()]) {
+    closeSession(sessionId);
+  }
 }
 
 /**
@@ -123,6 +199,30 @@ function isForeignSession(
  */
 function sessionNotFound(): Response {
   return new Response("Session not found", { status: 404 });
+}
+
+/** Refusal for an initialize the mount has no room for. Retryable: an idle
+ * session frees a slot on the next sweep. */
+function sessionsExhausted(): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: null,
+      error: {
+        code: -32002,
+        message:
+          "This server is holding its maximum number of MCP sessions. " +
+          "Close an existing session with DELETE /mcp, or retry later."
+      }
+    }),
+    {
+      status: 503,
+      headers: {
+        "content-type": "application/json",
+        "retry-after": "60"
+      }
+    }
+  );
 }
 
 export function getLocalMcpServerUrl(): string {
@@ -158,6 +258,8 @@ export async function handleMcpHttpRequest(
   if (!url.pathname.startsWith("/mcp")) return null;
 
   const method = request.method;
+  const now = Date.now();
+  sweepIdleSessions(now);
 
   if (method === "POST") {
     // Check for existing session
@@ -165,6 +267,7 @@ export async function handleMcpHttpRequest(
     if (sessionId && sessionTransports.has(sessionId)) {
       if (isForeignSession(sessionId, options)) return sessionNotFound();
       const transport = sessionTransports.get(sessionId)!;
+      touchSession(sessionId, now);
       return transport.handleRequest(request);
     }
     // A session id that is present but unknown must NOT fall through to the
@@ -184,12 +287,23 @@ export async function handleMcpHttpRequest(
 
     // New session — create transport and server
     const ownerUserId = options.agentToolsScope.userId;
+    // One user's clients cannot crowd out everyone else's: their oldest
+    // session goes first. The global cap is what is left after that, and it
+    // refuses rather than evicting a stranger's live session.
+    evictOverflowForUser(ownerUserId);
+    if (sessionTransports.size >= MCP_MAX_SESSIONS) {
+      log.warn("Refusing MCP session: server session cap reached", {
+        cap: MCP_MAX_SESSIONS
+      });
+      return sessionsExhausted();
+    }
     const transport = new WebStandardStreamableHTTPServerTransport({
       enableJsonResponse: true,
       sessionIdGenerator: () => crypto.randomUUID(),
       onsessioninitialized: (id) => {
         sessionTransports.set(id, transport);
         sessionOwners.set(id, ownerUserId);
+        sessionLastSeen.set(id, Date.now());
       }
     });
     // Evict the session when the transport closes (client disconnect without an
@@ -212,6 +326,7 @@ export async function handleMcpHttpRequest(
       !isForeignSession(sessionId, options)
     ) {
       const transport = sessionTransports.get(sessionId)!;
+      touchSession(sessionId, now);
       return transport.handleRequest(request);
     }
     return sessionNotFound();

--- a/packages/websocket/src/oauth/pending-store.ts
+++ b/packages/websocket/src/oauth/pending-store.ts
@@ -37,6 +37,24 @@ interface CodeEntry {
   consumed: boolean;
 }
 
+/** What a code redeems to: the request it was minted for, who approved it,
+ * and whether it had already been spent. */
+export interface CodeRedemption {
+  request: PendingAuthorizeRequest;
+  userId: string;
+  grantId: string;
+  consumedBefore: boolean;
+}
+
+function redemption(entry: CodeEntry): CodeRedemption {
+  return {
+    request: entry.request,
+    userId: entry.userId,
+    grantId: entry.grantId,
+    consumedBefore: entry.consumed
+  };
+}
+
 export class PendingStore {
   private readonly requests = new Map<string, PendingAuthorizeRequest>();
   private readonly codes = new Map<string, CodeEntry>();
@@ -113,6 +131,32 @@ export class PendingStore {
     return code;
   }
 
+  /** The live entry for a code, or null when it is unknown or expired. */
+  private liveEntry(code: string): CodeEntry | null {
+    this.pruneCodes();
+    const entry = this.codes.get(code);
+    if (!entry) {
+      return null;
+    }
+    if (Date.now() - entry.createdAt > CODE_TTL_MS) {
+      this.codes.delete(code);
+      return null;
+    }
+    return entry;
+  }
+
+  /**
+   * Read a code's entry without consuming it, so the token endpoint can check
+   * every binding the code carries — client_id, redirect_uri, PKCE, resource —
+   * before spending it. Redeeming first let anyone holding a leaked code burn
+   * it with one bad exchange: the legitimate client's exchange then looked
+   * like a replay and revoked the grant.
+   */
+  peekCode(code: string): CodeRedemption | null {
+    const entry = this.liveEntry(code);
+    return entry ? redemption(entry) : null;
+  }
+
   /**
    * Consume an authorization code at the token endpoint. `consumedBefore`
    * is true when this code was already consumed once — the OAuth 2.1 code
@@ -123,29 +167,14 @@ export class PendingStore {
    * nothing. Accepted narrowing — a leaked code is valuable immediately or
    * not at all, and the 10-minute window covers the realistic race.
    */
-  consumeCode(code: string): {
-    request: PendingAuthorizeRequest;
-    userId: string;
-    grantId: string;
-    consumedBefore: boolean;
-  } | null {
-    this.pruneCodes();
-    const entry = this.codes.get(code);
+  consumeCode(code: string): CodeRedemption | null {
+    const entry = this.liveEntry(code);
     if (!entry) {
-      return null;
-    }
-    if (Date.now() - entry.createdAt > CODE_TTL_MS) {
-      this.codes.delete(code);
       return null;
     }
     const consumedBefore = entry.consumed;
     entry.consumed = true;
-    return {
-      request: entry.request,
-      userId: entry.userId,
-      grantId: entry.grantId,
-      consumedBefore
-    };
+    return { ...redemption(entry), consumedBefore };
   }
 }
 

--- a/packages/websocket/src/routes/oauth-as.ts
+++ b/packages/websocket/src/routes/oauth-as.ts
@@ -57,6 +57,18 @@ import { isClientIdUrl, fetchClientMetadata } from "../oauth/cimd.js";
 const OAUTH_ROUTE_RATE_LIMIT = { max: 30, timeWindow: "1 minute" };
 const OAUTH_REGISTER_RATE_LIMIT = { max: 10, timeWindow: "1 minute" };
 
+/**
+ * Bounds on what an anonymous `/oauth/register` may write. The route is
+ * unauthenticated and its row is durable, so the rate limit alone is not a
+ * size limit: ten requests a minute at the server's 100 MB body cap is a
+ * gigabyte a minute of client metadata. A registration document is a name and
+ * a handful of redirect URIs — 8 KB is generous for that.
+ */
+const REGISTER_BODY_LIMIT_BYTES = 8 * 1024;
+const MAX_CLIENT_NAME_LENGTH = 256;
+const MAX_REDIRECT_URIS = 10;
+const MAX_REDIRECT_URI_LENGTH = 2048;
+
 function notFound(reply: FastifyReply): FastifyReply {
   return reply.status(404).send({ error: "not_found" });
 }
@@ -365,8 +377,12 @@ export const oauthAsRoutes: FastifyPluginAsync = async (app) => {
       return oauthError(reply, 400, "invalid_request", "missing code");
     }
 
-    const entry = pendingStore.consumeCode(code);
-    if (!entry) {
+    // Every binding the code carries is checked before the code is spent.
+    // Consuming first meant one bad exchange from anyone holding a leaked
+    // code burned it permanently, and the legitimate client's exchange then
+    // read as a replay and revoked the grant.
+    const peeked = pendingStore.peekCode(code);
+    if (!peeked) {
       return oauthError(
         reply,
         400,
@@ -375,17 +391,7 @@ export const oauthAsRoutes: FastifyPluginAsync = async (app) => {
       );
     }
 
-    if (entry.consumedBefore) {
-      await McpOauthGrant.revoke(entry.userId, entry.grantId);
-      return oauthError(
-        reply,
-        400,
-        "invalid_grant",
-        "authorization code has already been used"
-      );
-    }
-
-    const { request } = entry;
+    const { request } = peeked;
 
     if (params.get("client_id") !== request.clientId) {
       return oauthError(
@@ -416,6 +422,27 @@ export const oauthAsRoutes: FastifyPluginAsync = async (app) => {
         400,
         "invalid_target",
         "resource does not match this server's MCP endpoint"
+      );
+    }
+
+    // Bindings hold: spend the code. A second correctly-bound exchange is the
+    // OAuth 2.1 replay case and revokes the grant.
+    const entry = pendingStore.consumeCode(code);
+    if (!entry) {
+      return oauthError(
+        reply,
+        400,
+        "invalid_grant",
+        "authorization code is invalid or expired"
+      );
+    }
+    if (entry.consumedBefore) {
+      await McpOauthGrant.revoke(entry.userId, entry.grantId);
+      return oauthError(
+        reply,
+        400,
+        "invalid_grant",
+        "authorization code has already been used"
       );
     }
 
@@ -497,81 +524,112 @@ export const oauthAsRoutes: FastifyPluginAsync = async (app) => {
 
   // ── POST /oauth/register (RFC 7591) ─────────────────────────────────
 
-  app.post("/oauth/register", { config: { rateLimit: OAUTH_REGISTER_RATE_LIMIT } }, async (req, reply) => {
-    const publicUrl = resolveEnabledPublicUrl();
-    if (!publicUrl) return notFound(reply);
+  app.post(
+    "/oauth/register",
+    {
+      bodyLimit: REGISTER_BODY_LIMIT_BYTES,
+      config: { rateLimit: OAUTH_REGISTER_RATE_LIMIT }
+    },
+    async (req, reply) => {
+      const publicUrl = resolveEnabledPublicUrl();
+      if (!publicUrl) return notFound(reply);
 
-    const body = req.body;
-    const doc =
-      typeof body === "object" && body !== null
-        ? (body as Record<string, unknown>)
-        : null;
-    if (!doc) {
-      return oauthError(
-        reply,
-        400,
-        "invalid_client_metadata",
-        "request body must be a JSON object"
-      );
+      const body = req.body;
+      const doc =
+        typeof body === "object" && body !== null
+          ? (body as Record<string, unknown>)
+          : null;
+      if (!doc) {
+        return oauthError(
+          reply,
+          400,
+          "invalid_client_metadata",
+          "request body must be a JSON object"
+        );
+      }
+
+      const authMethod = doc["token_endpoint_auth_method"];
+      if (authMethod !== undefined && authMethod !== "none") {
+        return oauthError(
+          reply,
+          400,
+          "invalid_client_metadata",
+          "only public clients (token_endpoint_auth_method=none) are supported"
+        );
+      }
+
+      const clientName = doc["client_name"];
+      if (typeof clientName !== "string" || clientName.length === 0) {
+        return oauthError(
+          reply,
+          400,
+          "invalid_client_metadata",
+          "client_name is required"
+        );
+      }
+      if (clientName.length > MAX_CLIENT_NAME_LENGTH) {
+        return oauthError(
+          reply,
+          400,
+          "invalid_client_metadata",
+          `client_name must be at most ${MAX_CLIENT_NAME_LENGTH} characters`
+        );
+      }
+
+      const redirectUris = doc["redirect_uris"];
+      if (
+        !Array.isArray(redirectUris) ||
+        redirectUris.length === 0 ||
+        !redirectUris.every((uri): uri is string => typeof uri === "string")
+      ) {
+        return oauthError(
+          reply,
+          400,
+          "invalid_client_metadata",
+          "redirect_uris must be a non-empty array of strings"
+        );
+      }
+      if (redirectUris.length > MAX_REDIRECT_URIS) {
+        return oauthError(
+          reply,
+          400,
+          "invalid_client_metadata",
+          `redirect_uris must hold at most ${MAX_REDIRECT_URIS} entries`
+        );
+      }
+      if (redirectUris.some((uri) => uri.length > MAX_REDIRECT_URI_LENGTH)) {
+        return oauthError(
+          reply,
+          400,
+          "invalid_redirect_uri",
+          `each redirect_uri must be at most ${MAX_REDIRECT_URI_LENGTH} characters`
+        );
+      }
+      if (!redirectUris.every((uri) => isAllowedRedirectUri(uri))) {
+        return oauthError(
+          reply,
+          400,
+          "invalid_redirect_uri",
+          "redirect_uris must be https, or http on 127.0.0.1/localhost"
+        );
+      }
+
+      const { id } = await McpOauthClient.create({
+        client_name: clientName,
+        redirect_uris: redirectUris
+      });
+
+      return reply.status(201).send({
+        client_id: id,
+        client_id_issued_at: Math.floor(Date.now() / 1000),
+        client_name: clientName,
+        redirect_uris: redirectUris,
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        token_endpoint_auth_method: "none"
+      });
     }
-
-    const authMethod = doc["token_endpoint_auth_method"];
-    if (authMethod !== undefined && authMethod !== "none") {
-      return oauthError(
-        reply,
-        400,
-        "invalid_client_metadata",
-        "only public clients (token_endpoint_auth_method=none) are supported"
-      );
-    }
-
-    const clientName = doc["client_name"];
-    if (typeof clientName !== "string" || clientName.length === 0) {
-      return oauthError(
-        reply,
-        400,
-        "invalid_client_metadata",
-        "client_name is required"
-      );
-    }
-
-    const redirectUris = doc["redirect_uris"];
-    if (
-      !Array.isArray(redirectUris) ||
-      redirectUris.length === 0 ||
-      !redirectUris.every((uri): uri is string => typeof uri === "string")
-    ) {
-      return oauthError(
-        reply,
-        400,
-        "invalid_client_metadata",
-        "redirect_uris must be a non-empty array of strings"
-      );
-    }
-    if (!redirectUris.every((uri) => isAllowedRedirectUri(uri))) {
-      return oauthError(
-        reply,
-        400,
-        "invalid_redirect_uri",
-        "redirect_uris must be https, or http on 127.0.0.1/localhost"
-      );
-    }
-
-    const { id } = await McpOauthClient.create({
-      client_name: clientName,
-      redirect_uris: redirectUris
-    });
-
-    return reply.status(201).send({
-      client_id: id,
-      client_id_issued_at: Math.floor(Date.now() / 1000),
-      client_name: clientName,
-      redirect_uris: redirectUris,
-      grant_types: ["authorization_code", "refresh_token"],
-      response_types: ["code"],
-      token_endpoint_auth_method: "none"
-    });
-  });
+  );
 
   // ── POST /oauth/revoke (RFC 7009) ───────────────────────────────────
 

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -64,6 +64,7 @@ import {
   initDb,
   initPostgresDb,
   isAccessToken,
+  McpOauthClient,
   MCP_OAUTH_ACCESS_TOKEN_PREFIX,
   migrateSqliteDb,
   runSeeds
@@ -79,6 +80,9 @@ import { runAutomaticStorageCleanup } from "./storage-retention.js";
 
 /** User id the auth middleware assigns in local (no-account) mode. */
 const LOCAL_USER_ID = "1";
+/** How long an MCP OAuth client nobody ever approved is kept before the
+ * periodic cleanup deletes it. */
+const UNUSED_OAUTH_CLIENT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 import type { SdkV1RouteApiOptions } from "./routes/sdk-v1.js";
 import { TRPC_MAX_BATCH_SIZE } from "@nodetool-ai/protocol";
 import { handleMcpHttpRequest } from "./mcp-server.js";
@@ -325,6 +329,21 @@ try {
       .catch((error) => {
         log.warn(
           "Automatic history cleanup failed",
+          error instanceof Error ? error : new Error(String(error))
+        );
+      });
+    // `/oauth/register` is anonymous and writes a durable row, so the rows it
+    // leaves behind need a sweep of their own: a client nobody ever approved
+    // is dead weight. One with any grant — active or revoked — is kept.
+    void McpOauthClient.gcUnused(UNUSED_OAUTH_CLIENT_TTL_MS)
+      .then((deleted) => {
+        if (deleted > 0) {
+          log.info("Deleted unapproved MCP OAuth clients", { deleted });
+        }
+      })
+      .catch((error) => {
+        log.warn(
+          "MCP OAuth client cleanup failed",
           error instanceof Error ? error : new Error(String(error))
         );
       });

--- a/packages/websocket/tests/mcp-server.test.ts
+++ b/packages/websocket/tests/mcp-server.test.ts
@@ -5,7 +5,16 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+  vi
+} from "vitest";
 import {
   MCP_GUEST_CONTRACT,
   MCP_SANDBOX_ASSET_SNIPPET,
@@ -19,10 +28,14 @@ import {
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import {
+  closeAllMcpHttpSessions,
   createMcpServer,
   createMcpStdioTransport,
   handleMcpHttpRequest,
-  MCP_SCOPE_REQUIRED_MESSAGE
+  MCP_MAX_SESSIONS,
+  MCP_MAX_SESSIONS_PER_USER,
+  MCP_SCOPE_REQUIRED_MESSAGE,
+  MCP_SESSION_IDLE_TTL_MS
 } from "../src/mcp-server.js";
 import {
   MCP_CAPABILITIES_RESOURCE_URI,
@@ -391,6 +404,11 @@ describe("sandbox snippets run", () => {
 });
 
 describe("session scope", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    closeAllMcpHttpSessions();
+  });
+
   it("refuses to build a session with no bound user", () => {
     expect(() => createMcpServer()).toThrow(MCP_SCOPE_REQUIRED_MESSAGE);
   });
@@ -471,6 +489,98 @@ describe("session scope", () => {
     );
     expect(owned!.status).toBeLessThan(400);
   });
+
+  it("evicts a session that goes idle past the TTL", async () => {
+    const sessionId = await openHttpSession("alice");
+    const alice = { agentToolsScope: { userId: "alice", source: "http-session" as const } };
+    expect(
+      (await handleMcpHttpRequest(sessionRequest("POST", sessionId), alice))!.status
+    ).toBe(200);
+
+    // A client that disappears sends no DELETE. Only `Date` is faked —
+    // faking timers wholesale stalls the transport's own async work.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(Date.now() + MCP_SESSION_IDLE_TTL_MS + 1);
+    const afterIdle = await handleMcpHttpRequest(
+      sessionRequest("POST", sessionId),
+      alice
+    );
+    expect(afterIdle!.status).toBe(404);
+  });
+
+  it("keeps a session alive while it is being used", async () => {
+    const sessionId = await openHttpSession("alice");
+    const alice = { agentToolsScope: { userId: "alice", source: "http-session" as const } };
+    vi.useFakeTimers({ toFake: ["Date"] });
+    for (let step = 0; step < 3; step += 1) {
+      vi.setSystemTime(Date.now() + MCP_SESSION_IDLE_TTL_MS - 1000);
+      const response = await handleMcpHttpRequest(
+        sessionRequest("POST", sessionId),
+        alice
+      );
+      expect(response!.status).toBe(200);
+    }
+  });
+
+  it("caps one user's concurrent sessions, dropping their oldest first", async () => {
+    const alice = { agentToolsScope: { userId: "alice", source: "http-session" as const } };
+    const sessions: string[] = [];
+    for (let i = 0; i < MCP_MAX_SESSIONS_PER_USER + 1; i += 1) {
+      sessions.push(await openHttpSession("alice"));
+    }
+
+    // The first one opened is the one that went.
+    const evicted = await handleMcpHttpRequest(
+      sessionRequest("POST", sessions[0]!),
+      alice
+    );
+    expect(evicted!.status).toBe(404);
+
+    // Everything after it still answers — the cap drops one session, not the
+    // whole tail.
+    const statuses: number[] = [];
+    for (const sessionId of sessions.slice(1)) {
+      const response = await handleMcpHttpRequest(
+        sessionRequest("POST", sessionId),
+        alice
+      );
+      statuses.push(response!.status);
+    }
+    expect(statuses).toEqual(new Array(MCP_MAX_SESSIONS_PER_USER).fill(200));
+  });
+
+  it("does not evict another user's sessions when one user hits their cap", async () => {
+    const bobSession = await openHttpSession("bob");
+    for (let i = 0; i < MCP_MAX_SESSIONS_PER_USER + 1; i += 1) {
+      await openHttpSession("alice");
+    }
+    const response = await handleMcpHttpRequest(
+      sessionRequest("POST", bobSession),
+      { agentToolsScope: { userId: "bob", source: "http-session" } }
+    );
+    expect(response!.status).toBe(200);
+  });
+
+  it("refuses a new session once the server-wide cap is reached", async () => {
+    // One session each, so the per-user cap never fires and the global one is
+    // what answers.
+    for (let i = 0; i < MCP_MAX_SESSIONS; i += 1) {
+      await openHttpSession(`user-${i}`);
+    }
+    const refused = await handleMcpHttpRequest(
+      new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream"
+        },
+        body: initializeBody
+      }),
+      { agentToolsScope: { userId: "one-too-many", source: "http-session" } }
+    );
+    expect(refused!.status).toBe(503);
+    expect(refused!.headers.get("retry-after")).toBe("60");
+  }, 60_000);
 
   it("refuses an unscoped HTTP initialize with the fix named", async () => {
     const response = await handleMcpHttpRequest(

--- a/packages/websocket/tests/oauth-as-routes.test.ts
+++ b/packages/websocket/tests/oauth-as-routes.test.ts
@@ -264,6 +264,69 @@ describe("POST /oauth/register", () => {
     expect(res.json().error).toBe("invalid_client_metadata");
   });
 
+  it("rejects an over-long client_name", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/oauth/register",
+      payload: JSON.stringify({
+        client_name: "x".repeat(257),
+        redirect_uris: ["https://client.example/cb"]
+      }),
+      headers: { "content-type": "application/json" }
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("invalid_client_metadata");
+  });
+
+  it("rejects more redirect_uris than a client can plausibly need", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/oauth/register",
+      payload: JSON.stringify({
+        client_name: "Greedy",
+        redirect_uris: Array.from(
+          { length: 11 },
+          (_unused, i) => `https://client.example/cb${i}`
+        )
+      }),
+      headers: { "content-type": "application/json" }
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("invalid_client_metadata");
+  });
+
+  it("rejects an over-long redirect_uri", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/oauth/register",
+      payload: JSON.stringify({
+        client_name: "Long redirect",
+        redirect_uris: [`https://client.example/${"p".repeat(2048)}`]
+      }),
+      headers: { "content-type": "application/json" }
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("invalid_redirect_uri");
+  });
+
+  it("refuses a body past the route's own limit, well under the server's", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/oauth/register",
+      payload: JSON.stringify({
+        client_name: "Padded",
+        redirect_uris: ["https://client.example/cb"],
+        padding: "x".repeat(16 * 1024)
+      }),
+      headers: { "content-type": "application/json" }
+    });
+    expect(res.statusCode).toBe(413);
+  });
+
   it("rejects an unregisterable redirect_uri", async () => {
     const app = await buildApp();
     const res = await app.inject({
@@ -474,6 +537,48 @@ describe("POST /oauth/token — authorization_code", () => {
     });
     expect(res.statusCode).toBe(400);
     expect(res.json().error).toBe("invalid_grant");
+  });
+
+  it("a failed exchange does not burn the code — the real client still redeems it", async () => {
+    const app = await buildApp();
+    const { clientId, redirectUri, verifier, code, grantId } =
+      await authorizeAndApprove(app);
+
+    // Someone holding the code but not the verifier gets one refusal...
+    const stolen = await app.inject({
+      method: "POST",
+      url: "/oauth/token",
+      payload: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        code_verifier: "not-the-right-verifier"
+      }).toString(),
+      headers: { "content-type": "application/x-www-form-urlencoded" }
+    });
+    expect(stolen.statusCode).toBe(400);
+
+    // ...and the legitimate exchange still works, instead of reading as a
+    // replay and revoking the grant.
+    const real = await app.inject({
+      method: "POST",
+      url: "/oauth/token",
+      payload: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        code_verifier: verifier
+      }).toString(),
+      headers: { "content-type": "application/x-www-form-urlencoded" }
+    });
+    expect(real.statusCode).toBe(200);
+    expect(real.json().access_token.startsWith("nta_")).toBe(true);
+
+    const { McpOauthGrant } = await import("@nodetool-ai/models");
+    const grant = await McpOauthGrant.get(grantId);
+    expect(grant!.revoked_at).toBeNull();
   });
 
   it("rejects an expired code", async () => {


### PR DESCRIPTION
## What changed

Four findings from a security review of the MCP OAuth surface. `/oauth/register` is anonymous and writes a durable row, so its rate limit was never a size limit — ten requests a minute at the server's 100 MB body cap is a gigabyte a minute of client metadata; the route now carries an 8 KB `bodyLimit`, caps `client_name` at 256 characters and `redirect_uris` at 10 entries of 2048 characters each, and `McpOauthClient.gcUnused` (written but never called outside tests) runs on the server's periodic cleanup tick. Every MCP HTTP session held a transport, an `McpServer`, and that session's whole tool registry until `onclose` fired — which happens on an explicit DELETE, not when an ordinary JSON-response request finishes — so a client that disappeared leaked all three for the life of the process; sessions now carry a last-seen stamp, are swept after 30 idle minutes, and are capped at 8 per user (oldest evicted) and 256 overall (503 with `Retry-After`). The token endpoint consumed an authorization code before checking `client_id`, `redirect_uri`, PKCE, and `resource`, so anyone holding a leaked code but not the verifier could burn it with one bad exchange and make the legitimate exchange read as a replay and revoke the grant; the bindings are now checked against a peeked entry and the code is spent only once they hold. Refresh rotation spanned independent reads and writes and classified every successor-insert error as reuse; it now runs in one transaction per dialect, and only the `rotated_from` unique-index violation counts as reuse — a transient write failure rolls the attempt back and propagates instead of revoking a working grant.

## Verification

- [x] `npm run test:affected -- --base HEAD~1` — `All affected suites passed.` (24 backend packages, web, electron). The base run needed `apt-get install -y mesa-vulkan-drivers`: without a Vulkan ICD, 14 shader-backed `packages/base-nodes` tests fail with "No WebGPU adapter available (Node/Dawn)", the environment gap AGENTS.md documents. With the driver: `Test Files 33 passed (33) / Tests 2027 passed | 13 skipped`.
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run nodetool -- harness gate --base HEAD~1` — `9 changed file(s) touch 0 surface(s)`, `0 selfcheck(s) to run`
- [x] Targeted suites: `packages/models -- mcp-oauth` (17 passed), `packages/websocket -- oauth-as` (37 passed), `-- mcp-server` (40 passed), `-- mcp-oauth-integration mcp-mount oauth-core trpc-mcp-config` (82 passed)

Each new assertion was inverted once and observed failing:

| Inversion | Failing test |
|---|---|
| `isRotatedFromConflict` → `return true` | `× a write failure mid-rotation rolls back and is not read as reuse` |
| rotation runs outside the transaction | `× a write failure mid-rotation rolls back and is not read as reuse` |
| `sweepIdleSessions(now)` commented out | `× evicts a session that goes idle past the TTL` |
| global session cap check disabled | `× refuses a new session once the server-wide cap is reached` |
| `peekCode` delegating to `consumeCode` | `× a failed exchange does not burn the code — the real client still redeems it` (plus 4 pre-existing token tests) |

The per-user cap test caught a real bug while being written: `slice(0, owned.length - (CAP - 1))` counts from the end on a negative bound, so it evicted a session on every open below the cap.

## Agent capabilities

No capability added; no declared contract changed.

## New checks

- [x] Every new assertion was inverted once and observed failing — table above
- [x] No new scanning audit in this diff


---
_Generated by [Claude Code](https://claude.ai/code/session_014X4ftkucHLePJPZsFDN5wS)_