### PR TITLE
fix(runtime): stringify manifest enum values before they reach the wire

### DIFF
--- a/packages/runtime/src/providers/manifest-models.ts
+++ b/packages/runtime/src/providers/manifest-models.ts
@@ -109,6 +109,14 @@ export function explicitTasks(n: ManifestNode): string[] | undefined {
  * Enum values declared for a manifest input field, by canonical API name.
  * Reads both the FAL/Replicate `inputFields` (`apiParamName ?? name` →
  * `enumValues`) and the Kie `fields` (`name` → `values`) conventions.
+ *
+ * Values are stringified rather than returned as read: the manifests are JSON
+ * and the declared `string[]` is a claim about them, not a guarantee. FAL's
+ * two LoRA trainers declare `resolution` as an enum of numbers (768/1024 and
+ * 512/1024), which reached `unifiedModel.resolutions` — `z.array(z.string())`
+ * — and failed output validation for the whole `models.imageByProvider`
+ * query. `videoConstraints` reads durations back with `Number()`, so a
+ * numeric enum still works there.
  */
 export function enumValuesFor(
   n: ManifestNode,
@@ -119,11 +127,11 @@ export function enumValuesFor(
     (f) => (f.apiParamName ?? f.name) === apiName
   );
   const fromInput = inputField?.enumValues;
-  if (fromInput && fromInput.length > 0) return fromInput;
+  if (fromInput && fromInput.length > 0) return fromInput.map(String);
   // Stryker disable next-line ArrayDeclaration: same rationale — a non-array node yields no matching field either way.
   const field = (n.fields ?? []).find((f) => f.name === apiName);
   const fromField = field?.values;
-  return fromField && fromField.length > 0 ? fromField : undefined;
+  return fromField && fromField.length > 0 ? fromField.map(String) : undefined;
 }
 
 /** Option constraints (duration/resolution/aspect) for a video endpoint. */

--- a/packages/runtime/tests/providers/manifest-models.enum-strings.test.ts
+++ b/packages/runtime/tests/providers/manifest-models.enum-strings.test.ts
@@ -1,0 +1,147 @@
+/**
+ * The manifests are JSON, so a field declared `string[]` in the reader's types
+ * is a claim about the data rather than a guarantee. FAL's two LoRA trainers
+ * declare `resolution` as an enum of numbers; those reached
+ * `unifiedModel.resolutions` (`z.array(z.string())`) and failed tRPC output
+ * validation for the whole `models.imageByProvider` query, which showed up as
+ * a console error on the settings page.
+ *
+ * Run with:
+ *   npm run test --workspace=packages/runtime -- manifest-models.enum-strings
+ */
+import { describe, it, expect } from "vitest";
+import {
+  enumValuesFor,
+  imageConstraints,
+  videoConstraints
+} from "../../src/providers/manifest-models.js";
+import { FalProvider } from "../../src/providers/fal-provider.js";
+import { unifiedModel } from "@nodetool-ai/protocol/api-schemas/models.js";
+
+/** A node whose enum values are numbers, as the trainers' really are. */
+const numericEnumNode = {
+  endpointId: "vendor/numeric-enum",
+  className: "NumericEnum",
+  outputType: "image" as const,
+  inputFields: [
+    {
+      name: "resolution",
+      propType: "enum",
+      // The manifest genuinely holds numbers here; the cast is the point.
+      enumValues: [768, 1024] as unknown as string[]
+    }
+  ]
+};
+
+describe("enumValuesFor", () => {
+  it("stringifies a numeric enum declared on an input field", () => {
+    expect(enumValuesFor(numericEnumNode, "resolution")).toEqual([
+      "768",
+      "1024"
+    ]);
+  });
+
+  it("stringifies a numeric enum declared the Kie way", () => {
+    const node = {
+      endpointId: "vendor/kie-numeric",
+      className: "KieNumeric",
+      outputType: "image" as const,
+      fields: [
+        {
+          name: "resolution",
+          values: [512, 1024] as unknown as string[]
+        }
+      ]
+    };
+    expect(enumValuesFor(node, "resolution")).toEqual(["512", "1024"]);
+  });
+
+  it("leaves string enums as they are", () => {
+    const node = {
+      endpointId: "vendor/string-enum",
+      className: "StringEnum",
+      outputType: "image" as const,
+      inputFields: [
+        { name: "resolution", propType: "enum", enumValues: ["720p", "1080p"] }
+      ]
+    };
+    expect(enumValuesFor(node, "resolution")).toEqual(["720p", "1080p"]);
+  });
+
+  it("carries the coercion into image and video constraints", () => {
+    expect(imageConstraints(numericEnumNode).resolutions).toEqual([
+      "768",
+      "1024"
+    ]);
+    const video = videoConstraints({
+      endpointId: "vendor/numeric-duration",
+      className: "NumericDuration",
+      outputType: "video" as const,
+      inputFields: [
+        {
+          name: "duration",
+          propType: "enum",
+          enumValues: [5, 10] as unknown as string[]
+        },
+        {
+          name: "resolution",
+          propType: "enum",
+          enumValues: [720, 1080] as unknown as string[]
+        }
+      ]
+    });
+    // Durations are read back as numbers, so stringifying first must not
+    // change what the video picker gets.
+    expect(video.durations).toEqual([5, 10]);
+    expect(video.resolutions).toEqual(["720", "1080"]);
+  });
+});
+
+describe("every shipped FAL media model satisfies the wire schema", () => {
+  /** The mapping `models.imageByProvider` applies before tRPC validates. */
+  function asUnified(
+    model: Record<string, unknown>,
+    type: string
+  ): Record<string, unknown> {
+    return {
+      id: model["id"],
+      type,
+      name: model["name"],
+      provider: model["provider"],
+      repo_id: null,
+      path: null,
+      downloaded: false,
+      tags: [model["provider"]],
+      supported_tasks: model["supportedTasks"] ?? null,
+      durations: model["durations"] ?? null,
+      resolutions: model["resolutions"] ?? null,
+      aspect_ratios: model["aspectRatios"] ?? null
+    };
+  }
+
+  const provider = new FalProvider({ apiKey: "not-used-for-listing" });
+
+  it("validates every image model, and finds some to validate", async () => {
+    const models = (await provider.getAvailableImageModels()) as unknown as Array<
+      Record<string, unknown>
+    >;
+    expect(models.length).toBeGreaterThan(100);
+    const failures = models
+      .map((m) => ({ id: m["id"], parsed: unifiedModel.safeParse(asUnified(m, "image_model")) }))
+      .filter((r) => !r.parsed.success)
+      .map((r) => `${String(r.id)}: ${JSON.stringify(r.parsed.error?.issues)}`);
+    expect(failures).toEqual([]);
+  });
+
+  it("validates every video model", async () => {
+    const models = (await provider.getAvailableVideoModels()) as unknown as Array<
+      Record<string, unknown>
+    >;
+    expect(models.length).toBeGreaterThan(100);
+    const failures = models
+      .map((m) => ({ id: m["id"], parsed: unifiedModel.safeParse(asUnified(m, "video_model")) }))
+      .filter((r) => !r.parsed.success)
+      .map((r) => `${String(r.id)}: ${JSON.stringify(r.parsed.error?.issues)}`);
+    expect(failures).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What changed

`enumValuesFor` in the shared manifest reader returned a manifest's declared enum values as read, typed `string[]`. The manifests are JSON, so that type was a claim about the data rather than a guarantee: seven shipped FAL endpoints declare `resolution` as an enum of **numbers** — `fal-ai/trellis-2` `[512, 1024, 1536]`, `fal-ai/pixal3d`, `fal-ai/reconviagen-0.5`, `fal-ai/trellis-2-lora`, `fal-ai/trellis-2/retexture`, `fal-ai/krea-2-trainer`, `fal-ai/trellis-2-lora-trainer`. Those numbers reached `unifiedModel.resolutions`, which is `z.array(z.string())`, so tRPC failed output validation for the whole `models.imageByProvider` query on `fal_ai`: the settings page logged a console error and the FAL image picker was empty. Coercing with `String` in the reader covers every manifest-backed provider (FAL, Replicate, Kie, AtlasCloud) rather than patching generated entries the next catalog sync would rewrite; `videoConstraints` reads durations back with `Number()`, so a numeric duration enum still yields numbers.

This is the fix that was carried on the tail of #5279 but did not make that merge — #5279 merged at head `830c43d8`, and this commit landed on the branch after. It is rebased onto current `main`, where the bug is still present and has grown from two endpoints to seven.

## Verification

- [x] `npm run test:affected -- --base origin/main` → `All affected suites passed.` (exit 0). Run at `TURBO_CONCURRENCY=2`: at full concurrency this container fails a different package on each run (`chat`, `deploy`, `reliability-harness` across three runs), and each of those passes in isolation.
- [x] `npm run typecheck:web` → exit 0; `npm run typecheck:electron` → exit 0. `typecheck:mobile` cannot run here — `mobile/node_modules` is absent, since mobile is not a root workspace — and that was equally true before this branch.
- [x] `npm run lint` — no findings in the changed files.
- [x] End to end against the seeded screenshot backend: `POST /trpc/models.imageByProvider {"provider":"fal_ai"}` returned `{"error":{"message":"Output validation failed"}}` before and the model list after. Every other seeded provider returned data both times.

## New checks

`packages/runtime/tests/providers/manifest-models.enum-strings.test.ts` — three unit cases on the coercion (FAL/Replicate `enumValues`, Kie `values`, string enums left alone, and the durations round trip), plus an audit that maps every shipped FAL image and video model the way `models.imageByProvider` does and validates each against `unifiedModel`.

- [x] Inverted once, on this base: reverting the two `.map(String)` calls fails 4 of the 6 cases, including `× validates every image model, and finds some to validate`.
- [x] The audit asserts it found its targets (`expect(models.length).toBeGreaterThan(100)`), so it cannot pass by matching nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014X4ftkucHLePJPZsFDN5wS

---
_Generated by [Claude Code](https://claude.ai/code/session_014X4ftkucHLePJPZsFDN5wS)_