### PR TITLE
docs: simplify and improve language in global-chat-agents.md

### DIFF
--- a/docs/global-chat-agents.md
+++ b/docs/global-chat-agents.md
@@ -4,56 +4,44 @@ title: "Chat & Agents"
 description: "The agent that builds your workflows, sketches, timelines, and apps — in the app, from the CLI, or over the API."
 ---
 
-The agent is how most work in NodeTool starts. Describe the result, and it plans
-the graph, wires the nodes, picks models, runs it, and edits whatever document
-you have open. Every turn in chat runs the agent loop; there is no mode to
-switch on.
+Most tasks in NodeTool start with the agent. Just describe what you want, and it handles the rest: it plans the process, connects the right parts, selects the best models, runs the task, and edits your open document. Every time you send a message, the agent springs into action—there are no confusing modes to turn on or off.
 
 ## What it can build
 
-| Ask for | It works on | Reference |
+| What you ask for | What it works on | Learn more |
 |---|---|---|
-| A workflow, a change to one, a fix | The node graph | [Workflow Editor](workflow-editor.md) |
-| A layer, a mask, a generated fill | The open sketch | [Sketch Editor](sketch-editor.md) |
-| A track, a cut, an animated clip | The open timeline | [Video Editor](video-editor.md) |
-| Shots, stills, clips, an assembled cut | The storyboard | [Creative Agent](creative-agent.md) |
-| Voiced lines and subtitles | The script | [Creative Agent](creative-agent.md) |
-| A form: fields, buttons, outputs | The mini app | [App Builder](app-builder.md) |
+| Create, change, or fix a workflow | Workflows | [Workflow Editor](workflow-editor.md) |
+| Add a layer, mask, or fill | Sketches | [Sketch Editor](sketch-editor.md) |
+| Add a track, cut, or animation | Timelines | [Video Editor](video-editor.md) |
+| Create shots, stills, clips, or a cut | Storyboards | [Creative Agent](creative-agent.md) |
+| Add voiced lines or subtitles | Scripts | [Creative Agent](creative-agent.md) |
+| Build forms, fields, buttons, or outputs | Mini Apps | [App Builder](app-builder.md) |
 
-It uses the same actions the interface offers, so every change is visible while
-it happens, and what it leaves behind is an ordinary document you can edit by
-hand.
+The agent uses the same tools you do, so you can watch changes happen in real time. And when it’s done, you’re left with a normal document you can continue editing yourself.
 
 ## Core guides
 
-- **[Chat](global-chat.md)** — The composer, threads, permission modes, and the agent loop.
-- **[Agent Memory](agent-memory.md)** & **[Long-Term Memory](long-term-memory.md)** — What it carries between turns and between threads.
-- **[Agent CLI](agent-cli.md)** — Run the agent loop from the command line.
-- **[Chat CLI](chat-cli.md)** & **[Chat Server](chat-server.md)** — Automate conversations or drive a custom frontend.
-- **[Chat API](chat-api.md)** — Run chats, stream output, and issue tool calls from your own code.
+- **[Chat](global-chat.md)** — How to use the composer, threads, permissions, and the agent.
+- **[Agent Memory](agent-memory.md)** & **[Long-Term Memory](long-term-memory.md)** — How the agent remembers things between messages and threads.
+- **[Agent CLI](agent-cli.md)** — Run the agent from your terminal.
+- **[Chat CLI](chat-cli.md)** & **[Chat Server](chat-server.md)** — Automate chats or build your own custom interface.
+- **[Chat API](chat-api.md)** — Start chats, get responses, and run tools from your own code.
 
-## Typical flows
+## Typical workflows
 
-1. **Have it build a workflow from a description**
-   Open Chat, pick a model, say what the workflow should do. It plans, validates
-   the graph against the node library, saves the workflow, and runs it.
+1. **Build a workflow from a prompt**
+   Open Chat, pick an AI model, and describe what the workflow should do. The agent will plan the steps, make sure they work with the available tools, save the workflow, and run it.
 
-2. **Have it change what is in front of you**
-   With a workflow, sketch, or timeline open, ask for the edit: "add an upscale
-   step", "put the narration on a new audio track". It edits that document.
+2. **Edit what you're working on**
+   With a workflow, sketch, or timeline open, just ask for the change you want: "add an upscale step" or "put the narration on a new audio track." The agent will update your document right away.
 
 3. **Run a saved workflow from chat**
-   Save the workflow in the editor, then choose it in the composer or ask for it
-   by name. Results stream back into the thread.
+   Save your workflow in the editor, then select it in the chat or ask for it by name. The results will appear directly in your thread.
 
-4. **Set how much it does unattended**
-   The permission chip is per thread: *Plan* proposes only, *Default* asks
-   before actions, *Auto* runs everything. See
-   [Chat](global-chat.md#permission-modes).
+4. **Control how much the agent does automatically**
+   You can set permissions for each thread: *Plan* just gives you a proposal, *Default* asks before making changes, and *Auto* does everything automatically. Learn more in the [Chat guide](global-chat.md#permission-modes).
 
-5. **Run agents headlessly**
-   Use the [Agent CLI](agent-cli.md) for scripted runs, or the
-   [Chat API](chat-api.md) from a backend service.
+5. **Run agents behind the scenes**
+   Use the [Agent CLI](agent-cli.md) for automated scripts, or the [Chat API](chat-api.md) to connect the agent to a backend service.
 
-Pair this with the [Cookbook](cookbook.md) for agent patterns, or the
-[Deployment Guide](deployment.md) to move agents into production.
+For more examples, check out the [Cookbook](cookbook.md), or see the [Deployment Guide](deployment.md) to learn how to put agents into production.


### PR DESCRIPTION
This PR simplifies the language used in `docs/global-chat-agents.md`.

**Changes:**
- Rewrote the introduction to be more conversational and direct.
- Simplified the descriptions in the "What it can build" table.
- Updated the "Typical workflows" section to use clearer, less technical language.

**Impact:**
- Improves readability and user comprehension.
- Maintains all existing structural formatting and internal document links.

**Verification:**
- Verified via `git diff` that only copy changes were made and no markdown syntax or links were broken.
- Pre-existing monorepo `oxlint` config issue prevents running linting, but manual inspection confirms the changes are purely textual.

---
*PR created automatically by Jules for task [15597654230980449661](https://jules.google.com/task/15597654230980449661) started by @georgi*