### PR TITLE
Update documentation to simplify key concepts

### DIFF
--- a/docs/key-concepts.md
+++ b/docs/key-concepts.md
@@ -12,23 +12,13 @@ assumed. If you want a quick definition of a single word instead, the
 
 ## What NodeTool is
 
-A visual way to use AI. Instead of writing code, you place boxes on a page and
-draw lines between them. Each box does one job, and the lines carry results from
-one box to the next.
+NodeTool is a visual way to use AI. Instead of writing code, you place boxes on a page and draw lines between them. Each box does one job, and the lines carry results from one box to the next.
 
-- **You can ask instead of place.** An agent lives in the app and builds those
-  boxes and lines for you when you describe what you want. What it produces is
-  the same picture you would have drawn, so you can read it and change it.
-- **It runs on your computer.** Models that run locally use your own hardware,
-  and what they produce stays on your disk.
-- **You bring your own accounts.** When a workflow uses an online AI service
-  such as OpenAI, Anthropic, Gemini, FAL, KIE, or Replicate, the request goes
-  straight from your machine to that company and they bill you their normal
-  price. NodeTool adds nothing on top.
-- **You can mix the two.** One workflow can use a local model for one step and
-  an online service for the next.
-- **It's open source.** Licensed AGPL-3.0. The code we host is the code you can
-  run yourself.
+- **Ask instead of build.** Describe what you want, and an AI agent builds the boxes and lines for you. You can read and change what it builds.
+- **Run locally.** Models that run on your computer use your own hardware, keeping your data private on your disk.
+- **Use your own accounts.** When a workflow uses an online AI service like OpenAI or Anthropic, you use your own API keys. You pay the provider directly; NodeTool takes no cut.
+- **Mix local and online.** A single workflow can use a local model for one step and an online service for another.
+- **Open source.** NodeTool is open source software (AGPL-3.0). You can run the exact same code we use.
 
 ---
 
@@ -36,32 +26,25 @@ one box to the next.
 
 ### The agent
 
-The **agent** is the assistant you talk to in the Chats panel. Give it a goal in
-plain English and it works out the steps, calls tools, and edits your documents:
-it plans a graph, checks it against the node library, saves it as a workflow,
-runs it, and tells you what came back.
+The **agent** is the AI assistant in the Chats panel. Give it a goal in plain English, and it figures out the steps to achieve it. It can build workflows, call tools, and edit your documents directly.
 
-Two things make it different from a chatbot that writes instructions for you:
+Here's how it differs from a standard chatbot:
 
-- **It acts on the document you have open.** A workflow, a sketch, a timeline, a
-  storyboard, a script, a mini app. It uses the same actions the interface
-  offers, so you see each change land and can undo it.
-- **It leaves everything editable.** There is no generated artifact you can only
-  regenerate. Whatever it builds, you can open, read, and rewire.
+- **It works directly on your open documents.** Whether you have a workflow, sketch, or timeline open, the agent acts on it using the same tools you do. You can see its changes and undo them if needed.
+- **Everything remains editable.** The agent doesn't create unchangeable results. You can open, understand, and modify anything it builds.
 
-A permission chip on each thread sets how far it may go on its own: propose
-only, ask before acting, or run everything. See [Chat](global-chat.md).
+You control the agent's permissions. You can set it to only suggest changes, ask for permission before acting, or run tasks automatically. See [Chat](global-chat.md) for more details.
 
 ### Nodes
 
 A **node** is one box that does one thing.
 
-| Node | What it does | Example |
-|------|------|---------|
-| **Image Generator** | Turns a description into a picture | "Sunset over mountains" → an image |
-| **Agent** | Works out the steps for a task and carries them out | "Summarize this document" → an organized summary |
-| **TextToSpeech** | Reads text aloud | A blog post → an audio file |
-| **Filter** | Throws away items that don't match a rule | Keep only the good results |
+| Node                | What it does                                        | Example                                          |
+| ------------------- | --------------------------------------------------- | ------------------------------------------------ |
+| **Image Generator** | Turns a description into a picture                  | "Sunset over mountains" → an image               |
+| **Agent**           | Works out the steps for a task and carries them out | "Summarize this document" → an organized summary |
+| **TextToSpeech**    | Reads text aloud                                    | A blog post → an audio file                      |
+| **Filter**          | Throws away items that don't match a rule           | Keep only the good results                       |
 
 Every node takes things in on its left side, sends results out its right side,
 and has settings that appear in the panel on the right when you click it.
@@ -134,7 +117,7 @@ Timelines are where results become finished media:
 
 ### Agent nodes
 
-The agent above builds workflows. An **Agent node** is an agent placed *inside*
+The agent above builds workflows. An **Agent node** is an agent placed _inside_
 one: it takes a goal written in plain English, works out the steps itself, and
 uses tools such as web search, file access, or running code to get there. Use
 one when a step of your pipeline is describable but not scriptable. A normal
@@ -171,13 +154,13 @@ can do by hand or ask for.
 
 {% mermaid %}
 graph LR
-    A[Assets] --> B[Workflow]
-    B --> C[Generated assets]
-    C --> D[Sketch]
-    C --> E[Timeline]
-    D --> A
-    E --> A
-    B --> F[Mini-App]
+A[Assets] --> B[Workflow]
+B --> C[Generated assets]
+C --> D[Sketch]
+C --> E[Timeline]
+D --> A
+E --> A
+B --> F[Mini-App]
 {% endmermaid %}
 
 ### Worked example: a short product video
@@ -198,22 +181,22 @@ graph LR
 A **model** is a trained AI you call from a node. You don't train it; you use
 it.
 
-| Kind of model | Produces | Used for |
-|------|--------|-----|
-| Image | Pictures | Posters, concept art, mockups |
-| Video | Clips | Animation, motion |
-| Audio | Sound | Narration, music, effects |
-| Text | Words | Scripts, summaries, analysis |
+| Kind of model | Produces | Used for                      |
+| ------------- | -------- | ----------------------------- |
+| Image         | Pictures | Posters, concept art, mockups |
+| Video         | Clips    | Animation, motion             |
+| Audio         | Sound    | Narration, music, effects     |
+| Text          | Words    | Scripts, summaries, analysis  |
 
 ### On your machine, or online
 
-| | On your machine | Online service |
-|--|-------|-------|
-| Cost | Free once downloaded | The provider's price, billed to your account |
-| Where it runs | Your computer | Their servers |
-| Speed | Depends on your hardware | Depends on theirs |
-| Internet | Works offline | Required |
-| To set up | Download 4-20 GB per model | Paste an API key |
+|               | On your machine            | Online service                               |
+| ------------- | -------------------------- | -------------------------------------------- |
+| Cost          | Free once downloaded       | The provider's price, billed to your account |
+| Where it runs | Your computer              | Their servers                                |
+| Speed         | Depends on your hardware   | Depends on theirs                            |
+| Internet      | Works offline              | Required                                     |
+| To set up     | Download 4-20 GB per model | Paste an API key                             |
 
 You can mix them and choose per node, so an expensive online model can handle
 the one step that needs it while the rest runs locally.
@@ -222,24 +205,24 @@ the one step that needs it while the rest runs locally.
 
 ## Words you'll see
 
-| Term | What it means |
-|------|------|
-| **Workflow** | Nodes joined by lines |
-| **Node** | One box that does one job |
-| **Edge / connection** | A line carrying data between nodes |
-| **Input / output** | Where data enters and leaves a node |
-| **Preview** | A node that displays whatever reaches it, for checking your work |
-| **Run** | Execute the workflow |
-| **Asset** | A stored file used by workflows, sketches, timelines, chats, or collections |
-| **Sketch** | A layered image document for painting, masking, and combining |
-| **Timeline** | Tracks for arranging video, audio, and images over time |
-| **Clip** | One piece of media placed on a timeline track |
-| **Generated clip / layer** | A clip or layer produced by a workflow instead of imported |
-| **Stale** | A generated result whose settings changed since it was last produced |
-| **Agent** | The assistant you ask for changes, and the node that plans its own steps |
-| **Permission mode** | How far the agent may act without asking: Plan, Default, or Auto |
-| **Model** | The trained AI a node calls |
-| **Provider** | Whoever runs the model: your own machine, OpenAI, FAL, and so on |
+| Term                       | What it means                                                               |
+| -------------------------- | --------------------------------------------------------------------------- |
+| **Workflow**               | Nodes joined by lines                                                       |
+| **Node**                   | One box that does one job                                                   |
+| **Edge / connection**      | A line carrying data between nodes                                          |
+| **Input / output**         | Where data enters and leaves a node                                         |
+| **Preview**                | A node that displays whatever reaches it, for checking your work            |
+| **Run**                    | Execute the workflow                                                        |
+| **Asset**                  | A stored file used by workflows, sketches, timelines, chats, or collections |
+| **Sketch**                 | A layered image document for painting, masking, and combining               |
+| **Timeline**               | Tracks for arranging video, audio, and images over time                     |
+| **Clip**                   | One piece of media placed on a timeline track                               |
+| **Generated clip / layer** | A clip or layer produced by a workflow instead of imported                  |
+| **Stale**                  | A generated result whose settings changed since it was last produced        |
+| **Agent**                  | The assistant you ask for changes, and the node that plans its own steps    |
+| **Permission mode**        | How far the agent may act without asking: Plan, Default, or Auto            |
+| **Model**                  | The trained AI a node calls                                                 |
+| **Provider**               | Whoever runs the model: your own machine, OpenAI, FAL, and so on            |
 
 ---
 
@@ -255,11 +238,11 @@ On <kbd>Ctrl/⌘ + Enter</kbd>:
 
 {% mermaid %}
 graph LR
-    A[Input: Prompt] --> B[Agent: Plan]
-    B --> C[Image Generator]
-    B --> D[Text Writer]
-    C --> E[Preview: Image]
-    D --> F[Preview: Text]
+A[Input: Prompt] --> B[Agent: Plan]
+B --> C[Image Generator]
+B --> D[Text Writer]
+C --> E[Preview: Image]
+D --> F[Preview: Text]
 {% endmermaid %}
 
 Here the Agent goes first. Image Generator and Text Writer both wait only on the
@@ -276,12 +259,12 @@ never specify it.
 Everything above is also available as a TypeScript API, so you can build and run
 the same workflows from code.
 
-| Piece | What it is |
-|-----------|------|
-| **Graph** | Nodes plus connections. Build one with `workflow(...)`, run it with `run(...)` or `runGraph(...)` (`@nodetool-ai/dsl`, `packages/dsl/src/core.ts`). |
-| **DSL** | The [TypeScript DSL](developer/ts-dsl-guide.md) (`@nodetool-ai/dsl`), typed factory functions for building graphs in code. |
-| **WorkflowRunner** | Schedules the nodes, manages the GPU, streams progress back. |
-| **ProcessingContext** | Everything a running node can reach: user, auth, assets, cache (`@nodetool-ai/runtime`). |
+| Piece                 | What it is                                                                                                                                          |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Graph**             | Nodes plus connections. Build one with `workflow(...)`, run it with `run(...)` or `runGraph(...)` (`@nodetool-ai/dsl`, `packages/dsl/src/core.ts`). |
+| **DSL**               | The [TypeScript DSL](developer/ts-dsl-guide.md) (`@nodetool-ai/dsl`), typed factory functions for building graphs in code.                          |
+| **WorkflowRunner**    | Schedules the nodes, manages the GPU, streams progress back.                                                                                        |
+| **ProcessingContext** | Everything a running node can reach: user, auth, assets, cache (`@nodetool-ai/runtime`).                                                            |
 
 ### How a node type is found
 


### PR DESCRIPTION
This PR simplifies the language in `docs/key-concepts.md` to make it easier for users to understand without technical jargon. 

Changes include:
- Refactoring the "What NodeTool is" bullet points to be shorter and punchier.
- Simplifying "The agent" description to get straight to the point.
- Applying `npx prettier --write` to fix minor formatting issues.

---
*PR created automatically by Jules for task [14849253093317013807](https://jules.google.com/task/14849253093317013807) started by @georgi*