### PR TITLE
fix(gpu): retag vignette scalar multiplication as linear

### DIFF
--- a/packages/gpu/src/shaders/filters/vignette/v1/module.ts
+++ b/packages/gpu/src/shaders/filters/vignette/v1/module.ts
@@ -28,7 +28,7 @@ export const vignetteV1 = defineModule({
   // since Phase 2 and the falloff math is unchanged.
   surface: "published",
   category: "filters",
-  linearity: "nonlinear-in-rgb",
+  linearity: "linear-in-rgb",
   kind: "compute",
   params: VignetteParams,
   paramDefaults: { intensity: 0, radius: 0.9, softness: 0.5 },
@@ -59,7 +59,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
   let t = clamp((dist - inner) / (outer - inner), 0.0, 1.0);
   let fade = t * t * (3.0 - 2.0 * t);
   let dim = 1.0 - v.intensity * fade;
-  textureStore(layout.$.outputTexture, coords, vec4<f32>(color.rgb * dim, color.a)); // premul: ok — scalar '* dim' preserves rgb <= a; mis-tagged as nonlinear (TODO retag linear)
+  textureStore(layout.$.outputTexture, coords, vec4<f32>(color.rgb * dim, color.a)); // premul: ok — scalar '* dim' preserves rgb <= a
 }
 `,
   io: {


### PR DESCRIPTION
The vignette shader's `textureStore` output calculation uses scalar multiplication (`color.rgb * dim`) which preserves premultiplied alpha invariants. It was incorrectly tagged as `nonlinear-in-rgb`. 

This PR updates the linearity tag to `linear-in-rgb` and removes the associated TODO comment in the wgsl source.

Verified by running `npx turbo run test --filter="./packages/gpu"` with 0 regressions.

---
*PR created automatically by Jules for task [4292213529045072495](https://jules.google.com/task/4292213529045072495) started by @georgi*