### PR TITLE
Fix luma invariant reading on premul rgb in threshold shader

### DIFF
--- a/packages/gpu/src/shaders/filters/threshold/v1/module.ts
+++ b/packages/gpu/src/shaders/filters/threshold/v1/module.ts
@@ -33,7 +33,7 @@ export const filtersThresholdV1 = defineModule({
   version: 1,
   surface: "internal",
   category: "filters",
-  linearity: "nonlinear-in-rgb",
+  linearity: "linear-in-rgb",
   kind: "fragment",
   params: ThresholdParams,
   paramDefaults: { threshold: 0.7, softness: 0.1 },
@@ -48,10 +48,12 @@ export const filtersThresholdV1 = defineModule({
 fn fs_main(@location(0) uv: vec2f) -> @location(0) vec4f {
   let src = textureSample(layout.$.source, layout.$.samp, uv);
   let p = layout.$.params;
-  let luma = dot(src.rgb, vec3f(0.299, 0.587, 0.114)); // premul: ok TODO(invariant-fixes): see review §BUGS — luma read on premul rgb
+  let safeA = max(src.a, 1.0 / 255.0);
+  let straight = src.rgb / safeA;
+  let luma = dot(straight, vec3f(0.299, 0.587, 0.114));
   let soft = max(p.softness, 0.0001);
   let t = smoothstep(p.threshold - soft, p.threshold + soft, luma);
-  return vec4f(src.rgb * t, src.a * t); // premul: ok — scalar '* t' preserves rgb <= a; mis-tagged as nonlinear (TODO retag linear)
+  return vec4f(src.rgb * t, src.a * t);
 }
 `,
   io: {

--- a/test_plan.txt
+++ b/test_plan.txt
@@ -1,0 +1,3 @@
+1. Modify `packages/gpu/src/shaders/filters/threshold/v1/module.ts` to un-premultiply `src.rgb` before calculating `luma`. This correctly computes luma for alpha-independent comparisons.
+2. Change the `linearity` tag of `filters.threshold@1` from `nonlinear-in-rgb` to `linear-in-rgb` since the operation `vec4f(src.rgb * t, src.a * t)` preserves linear-in-rgb assumptions (scalar multiplication).
+3. Remove the suppression comments `// premul: ok TODO(invariant-fixes): see review §BUGS — luma read on premul rgb` and `// premul: ok — scalar '* t' preserves rgb <= a; mis-tagged as nonlinear (TODO retag linear)`.


### PR DESCRIPTION
The threshold shader was incorrectly computing luma directly on premultiplied RGB values, causing invariant violations. This fix unpremultiplies the RGB components before calculating the luma. The `linearity` tag was also updated from `nonlinear-in-rgb` to `linear-in-rgb` because the shader only performs a scalar multiplication that preserves the premultiplied assumptions.

---
*PR created automatically by Jules for task [16367269465854154084](https://jules.google.com/task/16367269465854154084) started by @georgi*