### PR TITLE
⚡ Bolt: Optimize provider instantiation to run in parallel

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -99,3 +99,6 @@
 ## 2026-05-25 - O(N*C^2) mapping optimization in TableActions paste operation
 **Learning:** Found an $O(N \times C^2)$ performance bottleneck in `web/src/components/node/DataTable/TableActions.tsx` when pasting large sets of data into the DataTable. For every column in every row, the code looped over `columnMapping.entries()` (which is size $C$) to find the corresponding paste column index.
 **Action:** Replaced the paste column index lookup via `Map.entries()` iteration with a pre-computed `$O(1)$` lookup. By inverting the map from `columnMapping` to `dfIdxToPasteIdx` (mapping dataframe column index to pasted index), the time complexity of pasting data is reduced to $O(N \times C)$.
+## 2024-06-25 - Bolt: Optimize provider instantiation to run in parallel
+**Learning:** Checking configurations and instantiating providers sequentially in a `for...of` loop creates an O(N) wait bounded by I/O. Using `Promise.all` mapping over the array of provider IDs resolves them in parallel, reducing wait time to roughly O(1) in terms of latency, resulting in significantly faster resolution (e.g. going from 252ms down to 50ms in testing).
+**Action:** Refactored `getProvidersInfo` in `packages/websocket/src/models-api.ts` to utilize `Promise.all` and `.map` to fetch providers concurrently instead of iterating sequentially with `await` in a loop.

--- a/packages/websocket/src/models-api.ts
+++ b/packages/websocket/src/models-api.ts
@@ -472,19 +472,21 @@ async function instantiateProvider(
 }
 
 async function getProvidersInfo(userId = "1"): Promise<ProviderInfo[]> {
-  const infos: ProviderInfo[] = [];
-  for (const provider of await getAvailableProviderIds(userId)) {
-    const instance = await instantiateProvider(provider, userId);
-    if (!instance) continue;
-    const metadata = getRegisteredProvider(provider)?.metadata;
-    infos.push({
-      provider,
-      capabilities: instance.getCapabilities(),
-      access: metadata?.access ?? "remote_api",
-      display_name: metadata?.displayName ?? provider
-    });
-  }
-  return infos;
+  const providerIds = await getAvailableProviderIds(userId);
+  const infos = await Promise.all(
+    providerIds.map(async (provider) => {
+      const instance = await instantiateProvider(provider, userId);
+      if (!instance) return null;
+      const metadata = getRegisteredProvider(provider)?.metadata;
+      return {
+        provider,
+        capabilities: instance.getCapabilities() as string[],
+        access: metadata?.access ?? "remote_api",
+        display_name: metadata?.displayName ?? provider
+      };
+    })
+  );
+  return infos.filter((info): info is ProviderInfo => info !== null);
 }
 
 async function withProvider<T>(


### PR DESCRIPTION
## What
Refactored `getProvidersInfo` to map over provider IDs and use `Promise.all` instead of sequentially awaiting in a `for...of` loop.

## Why
When retrieving available providers, the code iterates over available provider IDs and calls `instantiateProvider` sequentially. Since `instantiateProvider` can involve asynchronous secret retrieval and initialization (I/O-bound operations), doing this in a loop introduces an O(N) wait time where N is the number of providers. 

## Impact
Using `Promise.all` allows the instantiation of all available providers concurrently, reducing the latency down to roughly O(1) in terms of wall-clock time for the longest initialization. In a local benchmark script simulating 50ms latency per instantiation on 5 providers, the sequential execution averaged ~250ms while the concurrent execution dropped to ~50ms.

## Verification
- Wrote and ran a local benchmark simulation demonstrating the speedup from sequential to parallel execution.
- Verified TypeScript checks (`npm run typecheck`) and ESLint checks (`npm run lint`).
- Confirmed unit tests pass with `cd packages/websocket && npm run test`.

---
*PR created automatically by Jules for task [518389931401380444](https://jules.google.com/task/518389931401380444) started by @georgi*