### PR TITLE
feat(fal): add MiniMax H3 Max video nodes

### DIFF
--- a/packages/fal-codegen/src/configs/image-to-video.ts
+++ b/packages/fal-codegen/src/configs/image-to-video.ts
@@ -137,6 +137,27 @@ export const config: ModuleConfig = {
       ]
     },
 
+    "minimax/h3-max/image-to-video": {
+      className: "MinimaxH3MaxImageToVideo",
+      docstring:
+        "MiniMax H3 Max animates a still into video at higher fidelity than H3, optionally toward an end frame.",
+      tags: [
+        "video",
+        "generation",
+        "image-to-video",
+        "img2vid",
+        "minimax",
+        "h3"
+      ],
+      useCases: [
+        "Deliver a final animated still",
+        "Animate key art at full fidelity",
+        "Interpolate between a first and last frame",
+        "Add motion to product photography",
+        "Finish a shot approved from an H3 draft"
+      ]
+    },
+
     "minimax/h3/reference-to-video": {
       className: "MinimaxH3ReferenceToVideo",
       docstring:
@@ -3405,6 +3426,28 @@ export const config: ModuleConfig = {
         "Hold character identity across clips",
         "Apply a custom style to animation",
         "Generate video with matching audio",
+        "Produce consistent series content"
+      ]
+    },
+
+    "minimax/h3-max/image-to-video/lora": {
+      className: "MinimaxH3MaxImageToVideoLora",
+      docstring:
+        "MiniMax H3 Max animates a still into video with trained LoRAs applied at adjustable strength.",
+      tags: [
+        "generation",
+        "image-to-video",
+        "img2vid",
+        "video",
+        "minimax",
+        "h3",
+        "lora"
+      ],
+      useCases: [
+        "Animate a still with a trained subject",
+        "Hold character identity across clips",
+        "Apply a custom style to animation",
+        "Stack several LoRAs on one shot",
         "Produce consistent series content"
       ]
     },

--- a/packages/fal-codegen/src/configs/text-to-video.ts
+++ b/packages/fal-codegen/src/configs/text-to-video.ts
@@ -51,6 +51,27 @@ export const config: ModuleConfig = {
       ]
     },
 
+    "minimax/h3-max/text-to-video": {
+      className: "MinimaxH3MaxTextToVideo",
+      docstring:
+        "MiniMax H3 Max generates video from text at higher fidelity than H3, with optional prompt expansion.",
+      tags: [
+        "video",
+        "generation",
+        "text-to-video",
+        "txt2vid",
+        "minimax",
+        "h3"
+      ],
+      useCases: [
+        "Render the final take of a written shot",
+        "Generate high-fidelity narrative clips",
+        "Produce ads from a script",
+        "Expand a terse prompt before generating",
+        "Finish a shot approved from an H3 draft"
+      ]
+    },
+
     "xai/grok-imagine-video/v1.5/text-to-video": {
       className: "GrokImagineVideoV15TextToVideo",
       docstring: "Grok Imagine Video 1.5 generates videos from text prompts.",
@@ -2205,6 +2226,28 @@ export const config: ModuleConfig = {
         "Apply a learned motion signature",
         "Blend a LoRA at partial strength",
         "Produce branded video with audio"
+      ]
+    },
+
+    "minimax/h3-max/text-to-video/lora": {
+      className: "MinimaxH3MaxTextToVideoLora",
+      docstring:
+        "MiniMax H3 Max generates video from text with trained LoRAs applied at adjustable strength.",
+      tags: [
+        "generation",
+        "text-to-video",
+        "txt2vid",
+        "video",
+        "minimax",
+        "h3",
+        "lora"
+      ],
+      useCases: [
+        "Generate video in a fine-tuned style",
+        "Keep a trained character consistent",
+        "Stack several LoRAs on one shot",
+        "Blend a LoRA at partial strength",
+        "Produce branded video at full fidelity"
       ]
     },
 

--- a/packages/fal-nodes/src/fal-manifest.json
+++ b/packages/fal-nodes/src/fal-manifest.json
@@ -349259,5 +349259,825 @@
       }
     ],
     "moduleName": "video_to_video"
+  },
+  {
+    "endpointId": "minimax/h3-max/image-to-video",
+    "className": "MinimaxH3MaxImageToVideo",
+    "docstring": "MiniMax H3 Max animates a still into video at higher fidelity than H3, optionally toward an end frame.",
+    "tags": [
+      "video",
+      "generation",
+      "image-to-video",
+      "img2vid",
+      "minimax",
+      "h3"
+    ],
+    "useCases": [
+      "Deliver a final animated still",
+      "Animate key art at full fidelity",
+      "Interpolate between a first and last frame",
+      "Add motion to product photography",
+      "Finish a shot approved from an H3 draft"
+    ],
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Optional URL of the image to use as the first frame. When provided, the output aspect ratio follows this image. When omitted, the request is handled as text-to-video (16:9 by default).",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "768P",
+        "description": "The native generation resolution of the video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480P",
+          "768P"
+        ]
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, the safety checker will be enabled.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt_expansion_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "balanced",
+        "description": "How much effort to spend rewriting the prompt before generation. 'disabled' skips prompt expansion. 'balanced' returns in about a second. 'quality' spends up to ~30s on a richer prompt.",
+        "fieldType": "input",
+        "required": true,
+        "enumRef": "PromptExpansionMode",
+        "enumValues": [
+          "disabled",
+          "balanced",
+          "quality"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5,
+        "description": "The duration of the video in seconds.",
+        "fieldType": "input",
+        "required": false,
+        "min": 5,
+        "max": 15
+      },
+      {
+        "name": "end_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Optional URL of the image to use as the last frame, for first-to-last keyframe generation.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "end_image_url"
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 50000
+      },
+      {
+        "name": "sync_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Return the generated video as base64 instead of a CDN URL.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Random seed. A random seed is selected when omitted.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "timings",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Timing breakdown in seconds. 'inference' is the DiT denoising time on the GPU backend. Null on routes that do not report backend timings.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "expanded_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt after expansion, as sent to the model. Null when prompt expansion was disabled, left the prompt unchanged, or was performed internally by MiniMax's hosted API.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480P"
+          ],
+          [
+            "VALUE_768P",
+            "768P"
+          ]
+        ],
+        "description": "The native generation resolution of the video."
+      },
+      {
+        "name": "PromptExpansionMode",
+        "values": [
+          [
+            "DISABLED",
+            "disabled"
+          ],
+          [
+            "BALANCED",
+            "balanced"
+          ],
+          [
+            "QUALITY",
+            "quality"
+          ]
+        ],
+        "description": "How much effort to spend rewriting the prompt before generation. 'disabled' skips prompt expansion. 'balanced' returns in about a second. 'quality' spends up to ~30s on a richer prompt."
+      }
+    ],
+    "moduleName": "image_to_video"
+  },
+  {
+    "endpointId": "minimax/h3-max/image-to-video/lora",
+    "className": "MinimaxH3MaxImageToVideoLora",
+    "docstring": "MiniMax H3 Max animates a still into video with trained LoRAs applied at adjustable strength.",
+    "tags": [
+      "generation",
+      "image-to-video",
+      "img2vid",
+      "video",
+      "minimax",
+      "h3",
+      "lora"
+    ],
+    "useCases": [
+      "Animate a still with a trained subject",
+      "Hold character identity across clips",
+      "Apply a custom style to animation",
+      "Stack several LoRAs on one shot",
+      "Produce consistent series content"
+    ],
+    "inputFields": [
+      {
+        "name": "image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Optional URL of the image to use as the first frame. When provided, the output aspect ratio follows this image. When omitted, the request is handled as text-to-video (16:9 by default).",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "image_url"
+      },
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "768P",
+        "description": "The native generation resolution of the video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480P",
+          "768P"
+        ]
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, the safety checker will be enabled.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt_expansion_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "balanced",
+        "description": "How much effort to spend rewriting the prompt before generation. 'disabled' skips prompt expansion. 'balanced' returns in about a second. 'quality' spends up to ~30s on a richer prompt.",
+        "fieldType": "input",
+        "required": true,
+        "enumRef": "PromptExpansionMode",
+        "enumValues": [
+          "disabled",
+          "balanced",
+          "quality"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5,
+        "description": "The duration of the video in seconds.",
+        "fieldType": "input",
+        "required": false,
+        "min": 5,
+        "max": 15
+      },
+      {
+        "name": "end_image",
+        "tsType": "image",
+        "propType": "image",
+        "default": null,
+        "description": "Optional URL of the image to use as the last frame, for first-to-last keyframe generation.",
+        "fieldType": "input",
+        "required": false,
+        "apiParamName": "end_image_url"
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 50000
+      },
+      {
+        "name": "sync_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Return the generated video as base64 instead of a CDN URL.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "loras",
+        "tsType": "LoRAInput[]",
+        "propType": "list[LoRAInput]",
+        "default": [],
+        "description": "List of LoRA adapters to apply to the transformer.",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 3
+      },
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Random seed. A random seed is selected when omitted.",
+        "fieldType": "input",
+        "required": false
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "timings",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Timing breakdown in seconds. 'inference' is the DiT denoising time on the GPU backend. Null on routes that do not report backend timings.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "expanded_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt after expansion, as sent to the model. Null when prompt expansion was disabled, left the prompt unchanged, or was performed internally by MiniMax's hosted API.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480P"
+          ],
+          [
+            "VALUE_768P",
+            "768P"
+          ]
+        ],
+        "description": "The native generation resolution of the video."
+      },
+      {
+        "name": "PromptExpansionMode",
+        "values": [
+          [
+            "DISABLED",
+            "disabled"
+          ],
+          [
+            "BALANCED",
+            "balanced"
+          ],
+          [
+            "QUALITY",
+            "quality"
+          ]
+        ],
+        "description": "How much effort to spend rewriting the prompt before generation. 'disabled' skips prompt expansion. 'balanced' returns in about a second. 'quality' spends up to ~30s on a richer prompt."
+      }
+    ],
+    "moduleName": "image_to_video"
+  },
+  {
+    "endpointId": "minimax/h3-max/text-to-video",
+    "className": "MinimaxH3MaxTextToVideo",
+    "docstring": "MiniMax H3 Max generates video from text at higher fidelity than H3, with optional prompt expansion.",
+    "tags": [
+      "video",
+      "generation",
+      "text-to-video",
+      "txt2vid",
+      "minimax",
+      "h3"
+    ],
+    "useCases": [
+      "Render the final take of a written shot",
+      "Generate high-fidelity narrative clips",
+      "Produce ads from a script",
+      "Expand a terse prompt before generating",
+      "Finish a shot approved from an H3 draft"
+    ],
+    "inputFields": [
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "768P",
+        "description": "The native generation resolution of the video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480P",
+          "768P"
+        ]
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, the safety checker will be enabled.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt_expansion_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "balanced",
+        "description": "How much effort to spend rewriting the prompt before generation. 'disabled' skips prompt expansion. 'balanced' returns in about a second. 'quality' spends up to ~30s on a richer prompt.",
+        "fieldType": "input",
+        "required": true,
+        "enumRef": "PromptExpansionMode",
+        "enumValues": [
+          "disabled",
+          "balanced",
+          "quality"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5,
+        "description": "The duration of the video in seconds.",
+        "fieldType": "input",
+        "required": false,
+        "min": 5,
+        "max": 15
+      },
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Random seed. A random seed is selected when omitted.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 50000
+      },
+      {
+        "name": "sync_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Return the generated video as base64 instead of a CDN URL.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "The aspect ratio of the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "timings",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Timing breakdown in seconds. 'inference' is the DiT denoising time on the GPU backend. Null on routes that do not report backend timings.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "expanded_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt after expansion, as sent to the model. Null when prompt expansion was disabled, left the prompt unchanged, or was performed internally by MiniMax's hosted API.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480P"
+          ],
+          [
+            "VALUE_768P",
+            "768P"
+          ]
+        ],
+        "description": "The native generation resolution of the video."
+      },
+      {
+        "name": "PromptExpansionMode",
+        "values": [
+          [
+            "DISABLED",
+            "disabled"
+          ],
+          [
+            "BALANCED",
+            "balanced"
+          ],
+          [
+            "QUALITY",
+            "quality"
+          ]
+        ],
+        "description": "How much effort to spend rewriting the prompt before generation. 'disabled' skips prompt expansion. 'balanced' returns in about a second. 'quality' spends up to ~30s on a richer prompt."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio of the generated video."
+      }
+    ],
+    "moduleName": "text_to_video"
+  },
+  {
+    "endpointId": "minimax/h3-max/text-to-video/lora",
+    "className": "MinimaxH3MaxTextToVideoLora",
+    "docstring": "MiniMax H3 Max generates video from text with trained LoRAs applied at adjustable strength.",
+    "tags": [
+      "generation",
+      "text-to-video",
+      "txt2vid",
+      "video",
+      "minimax",
+      "h3",
+      "lora"
+    ],
+    "useCases": [
+      "Generate video in a fine-tuned style",
+      "Keep a trained character consistent",
+      "Stack several LoRAs on one shot",
+      "Blend a LoRA at partial strength",
+      "Produce branded video at full fidelity"
+    ],
+    "inputFields": [
+      {
+        "name": "resolution",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "768P",
+        "description": "The native generation resolution of the video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "Resolution",
+        "enumValues": [
+          "480P",
+          "768P"
+        ]
+      },
+      {
+        "name": "enable_safety_checker",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": true,
+        "description": "If set to true, the safety checker will be enabled.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt_expansion_mode",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "balanced",
+        "description": "How much effort to spend rewriting the prompt before generation. 'disabled' skips prompt expansion. 'balanced' returns in about a second. 'quality' spends up to ~30s on a richer prompt.",
+        "fieldType": "input",
+        "required": true,
+        "enumRef": "PromptExpansionMode",
+        "enumValues": [
+          "disabled",
+          "balanced",
+          "quality"
+        ]
+      },
+      {
+        "name": "duration",
+        "tsType": "number",
+        "propType": "int",
+        "default": 5,
+        "description": "The duration of the video in seconds.",
+        "fieldType": "input",
+        "required": false,
+        "min": 5,
+        "max": 15
+      },
+      {
+        "name": "seed",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Random seed. A random seed is selected when omitted.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Text prompt for video generation",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 50000
+      },
+      {
+        "name": "sync_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "Return the generated video as base64 instead of a CDN URL.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "16:9",
+        "description": "The aspect ratio of the generated video.",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "loras",
+        "tsType": "LoRAInput[]",
+        "propType": "list[LoRAInput]",
+        "default": [],
+        "description": "List of LoRA adapters to apply to the transformer.",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 3
+      }
+    ],
+    "outputType": "video",
+    "outputFields": [
+      {
+        "name": "timings",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "Timing breakdown in seconds. 'inference' is the DiT denoising time on the GPU backend. Null on routes that do not report backend timings.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "expanded_prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The prompt after expansion, as sent to the model. Null when prompt expansion was disabled, left the prompt unchanged, or was performed internally by MiniMax's hosted API.",
+        "fieldType": "output",
+        "required": false
+      },
+      {
+        "name": "video",
+        "tsType": "video",
+        "propType": "video",
+        "default": null,
+        "description": "The generated video",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "Resolution",
+        "values": [
+          [
+            "VALUE_480P",
+            "480P"
+          ],
+          [
+            "VALUE_768P",
+            "768P"
+          ]
+        ],
+        "description": "The native generation resolution of the video."
+      },
+      {
+        "name": "PromptExpansionMode",
+        "values": [
+          [
+            "DISABLED",
+            "disabled"
+          ],
+          [
+            "BALANCED",
+            "balanced"
+          ],
+          [
+            "QUALITY",
+            "quality"
+          ]
+        ],
+        "description": "How much effort to spend rewriting the prompt before generation. 'disabled' skips prompt expansion. 'balanced' returns in about a second. 'quality' spends up to ~30s on a richer prompt."
+      },
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ]
+        ],
+        "description": "The aspect ratio of the generated video."
+      }
+    ],
+    "moduleName": "text_to_video"
   }
 ]


### PR DESCRIPTION
## What changed

fal serves four MiniMax H3 Max endpoints alongside the H3 family — `minimax/h3-max/text-to-video`, `minimax/h3-max/image-to-video`, and a `/lora` variant of each — and NodeTool carried none of them. This adds their codegen configs (`packages/fal-codegen/src/configs/{text,image}-to-video.ts`) next to their H3 siblings, plus the four manifest entries generated from the endpoints' live OpenAPI schemas through the same `SchemaParser` + `NodeGenerator` path `generate:fal` uses, appended to `fal-manifest.json` the way earlier batches were. The registry now carries `fal.text_to_video.MinimaxH3MaxTextToVideo`, `MinimaxH3MaxTextToVideoLora`, `fal.image_to_video.MinimaxH3MaxImageToVideo` and `MinimaxH3MaxImageToVideoLora`.

The pricing bundles are untouched: fal reports no unit price for the H3 family, and the existing H3 nodes carry none either. `minimax/h3-max/reference-to-video` and the H3 trainer routes return 404 on fal's OpenAPI endpoint, so they are not in this diff.

## Verification

Node counts and titles read off the built factory:

```
$ node -e "… FAL_NODES.filter(n => /H3Max/.test(n.nodeType)) …"
fal.image_to_video.MinimaxH3MaxImageToVideo      | Minimax H3Max Image To Video      | function
fal.image_to_video.MinimaxH3MaxImageToVideoLora  | Minimax H3Max Image To Video Lora | function
fal.text_to_video.MinimaxH3MaxTextToVideo        | Minimax H3Max Text To Video       | function
fal.text_to_video.MinimaxH3MaxTextToVideoLora    | Minimax H3Max Text To Video Lora  | function
count 4 total 1578
```

- [x] `npm run test:affected` — green after `npm run build:packages`. On the first run `@nodetool-ai/data-nodes` failed with `Failed to resolve entry for package "@nodetool-ai/data-nodes"`; that is a missing `dist/` in this sandbox, not the diff — building the package makes the same test pass (1/1).
- [x] `npm run typecheck` — web and electron clean. `typecheck:mobile` fails on `Cannot find module 'expo'`/`'react-native'` etc., i.e. `mobile/node_modules` is not installed in this environment; this diff touches no mobile code.
- [x] `npm run lint` — exit 0.
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 12/12 selfchecks passed`, including `provider-codegen` (`fal: 5 generated output(s) match the checked-in fixtures`).

Also ran the two package suites directly: `packages/fal-nodes` 152/152, `packages/fal-codegen` 148/148.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VcP6MvN4pfaCHjH68magx4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcP6MvN4pfaCHjH68magx4)_