### PR TITLE
feat(web): move Entities from the logo menu to the sidebar

### DIFF
--- a/web/src/components/entities/EntityAssetPickerDialog.tsx
+++ b/web/src/components/entities/EntityAssetPickerDialog.tsx
@@ -1,0 +1,115 @@
+/**
+ * EntityAssetPickerDialog — pick the image asset an entity is tagged onto.
+ * Shared by the entities page and the sidebar panel so both start the same
+ * "pick an image, then describe it" flow.
+ */
+
+import React, { memo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useTheme } from "@mui/material/styles";
+import {
+  BORDER_RADIUS,
+  Caption,
+  Dialog,
+  EmptyState,
+  FlexRow,
+  LoadingSpinner,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
+import type { Asset } from "../../stores/ApiTypes";
+import { trpcClient } from "../../trpc/client";
+import ImageRefPreview from "../node/ImageRefPreview";
+
+const gridStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))",
+  gap: getSpacingPx(SPACING.md),
+  width: "100%",
+  maxHeight: "60vh",
+  overflow: "auto"
+};
+
+interface EntityAssetPickerDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onPick: (assetId: string) => void;
+}
+
+const EntityAssetPickerDialogInternal: React.FC<
+  EntityAssetPickerDialogProps
+> = ({ open, onClose, onPick }) => {
+  const theme = useTheme();
+  const { data, isLoading } = useQuery({
+    queryKey: ["entity-asset-picker"],
+    queryFn: async (): Promise<Asset[]> => {
+      const result = await trpcClient.assets.search.query({
+        query: "",
+        page_size: 500
+      });
+      return (result.assets as Asset[]).filter((a) =>
+        (a.content_type ?? "").startsWith("image/")
+      );
+    },
+    enabled: open,
+    staleTime: 30_000
+  });
+
+  return (
+    <Dialog open={open} onClose={onClose} title="Pick a reference image">
+      {isLoading ? (
+        <FlexRow align="center" justify="center" sx={{ p: 3 }}>
+          <LoadingSpinner />
+        </FlexRow>
+      ) : !data || data.length === 0 ? (
+        <EmptyState
+          variant="no-data"
+          title="No images"
+          description="Generate or upload an image first."
+          size="small"
+        />
+      ) : (
+        <div style={gridStyle}>
+          {data.map((asset) => (
+            <button
+              key={asset.id}
+              type="button"
+              onClick={() => onPick(asset.id)}
+              style={{
+                border: `1px solid ${theme.vars.palette.divider}`,
+                borderRadius: BORDER_RADIUS.sm,
+                padding: 0,
+                background: "transparent",
+                cursor: "pointer",
+                overflow: "hidden"
+              }}
+            >
+              <div style={{ width: "100%", aspectRatio: "1 / 1" }}>
+                <ImageRefPreview
+                  value={{
+                    type: "image",
+                    uri: asset.thumb_url ?? asset.get_url
+                  }}
+                />
+              </div>
+              <Caption
+                sx={{
+                  display: "block",
+                  p: 0.5,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap"
+                }}
+              >
+                {asset.name}
+              </Caption>
+            </button>
+          ))}
+        </div>
+      )}
+    </Dialog>
+  );
+};
+
+export const EntityAssetPickerDialog = memo(EntityAssetPickerDialogInternal);
+export default EntityAssetPickerDialog;

--- a/web/src/components/entities/EntityLibrary.tsx
+++ b/web/src/components/entities/EntityLibrary.tsx
@@ -5,12 +5,9 @@
  */
 
 import React, { memo, useCallback, useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { useTheme } from "@mui/material/styles";
 import AddIcon from "@mui/icons-material/Add";
 import type { Entity } from "@nodetool-ai/protocol";
 import {
-  Dialog,
   Text,
   Caption,
   EmptyState,
@@ -19,16 +16,13 @@ import {
   FlexColumn,
   EditorButton,
   SPACING,
-  getSpacingPx,
-  BORDER_RADIUS
+  getSpacingPx
 } from "../ui_primitives";
-import type { Asset } from "../../stores/ApiTypes";
-import { trpcClient } from "../../trpc/client";
 import {
   useEntities,
   useDeleteEntity
 } from "../../serverState/useEntities";
-import ImageRefPreview from "../node/ImageRefPreview";
+import EntityAssetPickerDialog from "./EntityAssetPickerDialog";
 import EntityCard from "./EntityCard";
 import EntityEditorDialog from "./EntityEditorDialog";
 
@@ -37,81 +31,6 @@ const gridStyle: React.CSSProperties = {
   gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))",
   gap: getSpacingPx(SPACING.md),
   width: "100%"
-};
-
-/** Small dialog that lists image assets so one can be tagged as an entity. */
-const AssetPickerDialog: React.FC<{
-  open: boolean;
-  onClose: () => void;
-  onPick: (assetId: string) => void;
-}> = ({ open, onClose, onPick }) => {
-  const theme = useTheme();
-  const { data, isLoading } = useQuery({
-    queryKey: ["entity-asset-picker"],
-    queryFn: async (): Promise<Asset[]> => {
-      const result = await trpcClient.assets.search.query({
-        query: "",
-        page_size: 500
-      });
-      return (result.assets as Asset[]).filter((a) =>
-        (a.content_type ?? "").startsWith("image/")
-      );
-    },
-    enabled: open,
-    staleTime: 30_000
-  });
-
-  return (
-    <Dialog open={open} onClose={onClose} title="Pick a reference image">
-      {isLoading ? (
-        <FlexRow align="center" justify="center" sx={{ p: 3 }}>
-          <LoadingSpinner />
-        </FlexRow>
-      ) : !data || data.length === 0 ? (
-        <EmptyState
-          variant="no-data"
-          title="No images"
-          description="Generate or upload an image first."
-          size="small"
-        />
-      ) : (
-        <div style={{ ...gridStyle, maxHeight: "60vh", overflow: "auto" }}>
-          {data.map((asset) => (
-            <button
-              key={asset.id}
-              type="button"
-              onClick={() => onPick(asset.id)}
-              style={{
-                border: `1px solid ${theme.vars.palette.divider}`,
-                borderRadius: BORDER_RADIUS.sm,
-                padding: 0,
-                background: "transparent",
-                cursor: "pointer",
-                overflow: "hidden"
-              }}
-            >
-              <div style={{ width: "100%", aspectRatio: "1 / 1" }}>
-                <ImageRefPreview
-                  value={{ type: "image", uri: asset.thumb_url ?? asset.get_url }}
-                />
-              </div>
-              <Caption
-                sx={{
-                  display: "block",
-                  p: 0.5,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap"
-                }}
-              >
-                {asset.name}
-              </Caption>
-            </button>
-          ))}
-        </div>
-      )}
-    </Dialog>
-  );
 };
 
 const EntityLibraryInternal: React.FC = () => {
@@ -198,7 +117,7 @@ const EntityLibraryInternal: React.FC = () => {
 
       {content}
 
-      <AssetPickerDialog
+      <EntityAssetPickerDialog
         open={pickerOpen}
         onClose={() => setPickerOpen(false)}
         onPick={handlePick}

--- a/web/src/components/entities/EntityListPanel.tsx
+++ b/web/src/components/entities/EntityListPanel.tsx
@@ -1,0 +1,129 @@
+/**
+ * EntityListPanel — the entity library as a left-panel view, next to
+ * storyboards. Entities are tagged image assets rather than documents, so the
+ * panel shows the same cards the page does (edit / remove in place) instead of
+ * opening a workspace tab per row.
+ */
+
+import AddIcon from "@mui/icons-material/Add";
+import React, { memo, useCallback, useState } from "react";
+import type { Entity } from "@nodetool-ai/protocol";
+
+import { useDeleteEntity, useEntities } from "../../serverState/useEntities";
+import {
+  EmptyState,
+  FlexRow,
+  LoadingSpinner,
+  ScrollArea,
+  SPACING,
+  ToolbarIconButton,
+  Tooltip,
+  getSpacingPx
+} from "../ui_primitives";
+import EntityAssetPickerDialog from "./EntityAssetPickerDialog";
+import EntityCard from "./EntityCard";
+import EntityEditorDialog from "./EntityEditorDialog";
+
+const gridStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))",
+  gap: getSpacingPx(SPACING.md),
+  padding: getSpacingPx(SPACING.md),
+  width: "100%"
+};
+
+/** Picks an image asset, then opens the editor to describe it. */
+export const CreateEntityButton = memo(function CreateEntityButton() {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [assetId, setAssetId] = useState<string | null>(null);
+
+  const handlePick = useCallback((picked: string) => {
+    setPickerOpen(false);
+    setAssetId(picked);
+  }, []);
+
+  return (
+    <>
+      <Tooltip title="New entity" placement="right-start">
+        <ToolbarIconButton
+          ariaLabel="New entity"
+          onClick={() => setPickerOpen(true)}
+          tabIndex={-1}
+          icon={<AddIcon />}
+        />
+      </Tooltip>
+      <EntityAssetPickerDialog
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        onPick={handlePick}
+      />
+      {assetId && (
+        <EntityEditorDialog
+          open
+          onClose={() => setAssetId(null)}
+          assetId={assetId}
+        />
+      )}
+    </>
+  );
+});
+
+const EntityListPanelInternal: React.FC = () => {
+  const { data: entities, isLoading } = useEntities();
+  const deleteEntity = useDeleteEntity();
+  const [editing, setEditing] = useState<Entity | null>(null);
+
+  const handleRemove = useCallback(
+    (entity: Entity) => {
+      deleteEntity.mutate(entity.id);
+    },
+    [deleteEntity]
+  );
+
+  if (isLoading) {
+    return (
+      <FlexRow align="center" justify="center" sx={{ p: 3 }}>
+        <LoadingSpinner />
+      </FlexRow>
+    );
+  }
+
+  if (!entities || entities.length === 0) {
+    return (
+      <EmptyState
+        variant="empty"
+        title="No entities yet"
+        description="Tag an image as a character, location, style, or prop with the + button above."
+        size="small"
+      />
+    );
+  }
+
+  return (
+    <>
+      <ScrollArea fullHeight>
+        <div style={gridStyle}>
+          {entities.map((entity) => (
+            <EntityCard
+              key={entity.id}
+              entity={entity}
+              onEdit={setEditing}
+              onRemove={handleRemove}
+            />
+          ))}
+        </div>
+      </ScrollArea>
+      {editing && (
+        <EntityEditorDialog
+          open
+          onClose={() => setEditing(null)}
+          assetId={editing.id}
+          entity={editing}
+        />
+      )}
+    </>
+  );
+};
+
+export const EntityListPanel = memo(EntityListPanelInternal);
+export default EntityListPanel;

--- a/web/src/components/entities/__tests__/EntityListPanel.test.tsx
+++ b/web/src/components/entities/__tests__/EntityListPanel.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import type { Entity } from "@nodetool-ai/protocol";
+import mockTheme from "../../../__mocks__/themeMock";
+
+jest.mock("../../node/ImageRefPreview", () => ({
+  __esModule: true,
+  default: () => null
+}));
+
+const mockDelete = jest.fn();
+const mockUseEntities = jest.fn();
+
+jest.mock("../../../serverState/useEntities", () => ({
+  useEntities: () => mockUseEntities(),
+  useDeleteEntity: () => ({ mutate: mockDelete })
+}));
+
+jest.mock("../EntityAssetPickerDialog", () => ({
+  __esModule: true,
+  default: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="asset-picker" /> : null
+}));
+
+jest.mock("../EntityEditorDialog", () => ({
+  __esModule: true,
+  default: ({ entity }: { entity?: Entity }) => (
+    <div data-testid="entity-editor">{entity?.name ?? "new"}</div>
+  )
+}));
+
+import EntityListPanel, { CreateEntityButton } from "../EntityListPanel";
+
+const entity: Entity = {
+  type: "entity",
+  id: "asset-1",
+  kind: "character",
+  name: "Mara",
+  descriptor: "a tall woman with red hair"
+};
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>);
+
+describe("EntityListPanel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("lists the entities", () => {
+    mockUseEntities.mockReturnValue({ data: [entity], isLoading: false });
+    renderWithTheme(<EntityListPanel />);
+    expect(screen.getByText("Mara")).toBeInTheDocument();
+  });
+
+  it("points at the + button when there is nothing to show", () => {
+    mockUseEntities.mockReturnValue({ data: [], isLoading: false });
+    renderWithTheme(<EntityListPanel />);
+    expect(screen.getByText("No entities yet")).toBeInTheDocument();
+  });
+
+  it("removes an entity through the delete mutation", async () => {
+    mockUseEntities.mockReturnValue({ data: [entity], isLoading: false });
+    renderWithTheme(<EntityListPanel />);
+    await userEvent.click(screen.getByRole("button", { name: /remove/i }));
+    expect(mockDelete).toHaveBeenCalledWith("asset-1");
+  });
+});
+
+describe("CreateEntityButton", () => {
+  it("opens the asset picker", async () => {
+    renderWithTheme(<CreateEntityButton />);
+    expect(screen.queryByTestId("asset-picker")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /new entity/i }));
+    expect(screen.getByTestId("asset-picker")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/node_menu/__tests__/QuickAccessSidebar.test.tsx
+++ b/web/src/components/node_menu/__tests__/QuickAccessSidebar.test.tsx
@@ -43,6 +43,7 @@ describe("QuickAccessSidebar", () => {
       "Sketches",
       "Scripts",
       "Storyboards",
+      "Entities",
       "Timelines",
       "JS Scripts"
     ]);

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -38,6 +38,9 @@ import SketchListPanel, { CreateSketchButton } from "../sketch/SketchListPanel";
 import StoryboardListPanel, {
   CreateStoryboardButton
 } from "../storyboard/StoryboardListPanel";
+import EntityListPanel, {
+  CreateEntityButton
+} from "../entities/EntityListPanel";
 import ScriptListPanel, { CreateScriptButton } from "../script/ScriptListPanel";
 import JsScriptListPanel, {
   CreateJsScriptButton
@@ -336,6 +339,17 @@ const PanelContent = memo(function PanelContent({
     handlePanelToggle("assets");
   }, [openTab, navigate, handlePanelToggle]);
 
+  const handleEntitiesFullscreenClick = useCallback(() => {
+    openTab({
+      type: "page",
+      ref: "entities",
+      mode: "view",
+      title: PAGE_TAB_TITLES.entities
+    });
+    navigate("/workspace");
+    handlePanelToggle("entities");
+  }, [openTab, navigate, handlePanelToggle]);
+
   if (activeView === "nodes") {
     return (
       <NodeLibrary
@@ -557,6 +571,38 @@ const PanelContent = memo(function PanelContent({
           <StoryboardListPanel />
         </FlexColumn>
       )}
+      {activeView === "entities" && (
+        <FlexColumn
+          className="entity-list-container"
+          fullWidth
+          fullHeight
+          sx={{
+            overflow: "hidden"
+          }}
+        >
+          {!isMobile && (
+            <PanelHeadline
+              title="Entities"
+              docsTopic={activeCategory.docsTopic}
+              description={headlineDescription}
+              actions={
+                <>
+                  <Tooltip title="Open in full page" placement="right-start">
+                    <ToolbarIconButton
+                      onClick={handleEntitiesFullscreenClick}
+                      tabIndex={-1}
+                      icon={<Fullscreen />}
+                      ariaLabel="Open entities in full page"
+                    />
+                  </Tooltip>
+                  <CreateEntityButton />
+                </>
+              }
+            />
+          )}
+          <EntityListPanel />
+        </FlexColumn>
+      )}
       {activeView === "scripts" && (
         <FlexColumn
           className="script-list-container"
@@ -740,6 +786,7 @@ const MOBILE_CREATE_ACTIONS: Partial<Record<LeftPanelView, React.FC>> = {
   sketches: CreateSketchButton,
   timelines: CreateTimelineButton,
   storyboards: CreateStoryboardButton,
+  entities: CreateEntityButton,
   scripts: CreateScriptButton,
   jsscripts: CreateJsScriptButton,
   apps: CreateApplicationButton
@@ -1028,6 +1075,7 @@ const PanelLeft: React.FC = () => {
                   displayActiveView === "sketches" ||
                   displayActiveView === "timelines" ||
                   displayActiveView === "storyboards" ||
+                  displayActiveView === "entities" ||
                   displayActiveView === "scripts" ||
                   displayActiveView === "jsscripts")
               ) {

--- a/web/src/components/panels/RailAppMenu.tsx
+++ b/web/src/components/panels/RailAppMenu.tsx
@@ -16,7 +16,6 @@ import ViewInArOutlinedIcon from "@mui/icons-material/ViewInArOutlined";
 import Inventory2OutlinedIcon from "@mui/icons-material/Inventory2Outlined";
 import LibraryBooksOutlinedIcon from "@mui/icons-material/LibraryBooksOutlined";
 import FolderSpecialOutlinedIcon from "@mui/icons-material/FolderSpecialOutlined";
-import PersonOutlineOutlinedIcon from "@mui/icons-material/PersonOutlineOutlined";
 
 import { isProduction } from "../../lib/env";
 import { useCombo } from "../../stores/KeyPressedStore";
@@ -136,7 +135,6 @@ const RailAppMenu: React.FC<RailAppMenuProps> = ({ onAction }) => {
   const goPackages = useCallback(() => openPage("packages"), [openPage]);
   const goCollections = useCallback(() => openPage("collections"), [openPage]);
   const goAssets = useCallback(() => openPage("assets"), [openPage]);
-  const goEntities = useCallback(() => openPage("entities"), [openPage]);
   const goWorkspaces = useCallback(() => openPage("workspaces"), [openPage]);
   const goSettings = useCallback(() => openPage("settings"), [openPage]);
 
@@ -240,11 +238,6 @@ const RailAppMenu: React.FC<RailAppMenuProps> = ({ onAction }) => {
             label="Collections"
             icon={<LibraryBooksOutlinedIcon />}
             onClick={goCollections}
-          />
-          <MenuItemPrimitive
-            label="Entities"
-            icon={<PersonOutlineOutlinedIcon />}
-            onClick={goEntities}
           />
           <MenuItemPrimitive
             label="Workspaces"

--- a/web/src/components/panels/__tests__/PanelLeftMobile.test.tsx
+++ b/web/src/components/panels/__tests__/PanelLeftMobile.test.tsx
@@ -151,7 +151,7 @@ it("keeps the visible desktop groups in the mobile tab row", () => {
     )
   ).toEqual([
     ["Workflows", "Apps", "Chats"],
-    ["Sketches", "Scripts", "Storyboards", "Timelines"],
+    ["Sketches", "Scripts", "Storyboards", "Entities", "Timelines"],
     ["JS Scripts"],
     ["Assets", "Library"]
   ]);

--- a/web/src/config/__tests__/quickAccessCategories.test.ts
+++ b/web/src/config/__tests__/quickAccessCategories.test.ts
@@ -33,7 +33,7 @@ const idsIn = (category: NodeCategoryId, all: NodeMetadata[]): string[] =>
   );
 
 describe("quickAccessCategories", () => {
-  it("ships fourteen top-level views in order", () => {
+  it("ships fifteen top-level views in order", () => {
     const ids = LEFT_PANEL_TOP_LEVEL.map((c) => c.id);
     expect(ids).toEqual([
       "nodes",
@@ -45,6 +45,7 @@ describe("quickAccessCategories", () => {
       "sketches",
       "scripts",
       "storyboards",
+      "entities",
       "timelines",
       "jsscripts",
       "settings",
@@ -74,7 +75,13 @@ describe("quickAccessCategories", () => {
       {
         id: "editors",
         placement: "top",
-        views: ["sketches", "scripts", "storyboards", "timelines"]
+        views: [
+          "sketches",
+          "scripts",
+          "storyboards",
+          "entities",
+          "timelines"
+        ]
       },
       {
         id: "developer-tools",

--- a/web/src/config/quickAccessCategories.tsx
+++ b/web/src/config/quickAccessCategories.tsx
@@ -35,6 +35,7 @@ import HubIcon from "@mui/icons-material/Hub";
 import PermMediaOutlinedIcon from "@mui/icons-material/PermMediaOutlined";
 import CollectionsOutlinedIcon from "@mui/icons-material/CollectionsOutlined";
 import ForumOutlinedIcon from "@mui/icons-material/ForumOutlined";
+import PersonOutlineOutlinedIcon from "@mui/icons-material/PersonOutlineOutlined";
 
 import type { NodeMetadata } from "../stores/ApiTypes";
 import {
@@ -166,6 +167,14 @@ const LEFT_PANEL_CATEGORY_BY_ID: Readonly<
     docsTopic: "storyboards",
     icon: <DashboardOutlinedIcon />
   },
+  entities: {
+    id: "entities",
+    label: "Entities",
+    description:
+      "Reusable characters, locations, styles, and props for prompts and shots.",
+    docsTopic: "storyboards",
+    icon: <PersonOutlineOutlinedIcon />
+  },
   timelines: {
     id: "timelines",
     label: "Timelines",
@@ -225,6 +234,7 @@ export const LEFT_PANEL_GROUPS: readonly LeftPanelGroup[] = [
       LEFT_PANEL_CATEGORY_BY_ID.sketches,
       LEFT_PANEL_CATEGORY_BY_ID.scripts,
       LEFT_PANEL_CATEGORY_BY_ID.storyboards,
+      LEFT_PANEL_CATEGORY_BY_ID.entities,
       LEFT_PANEL_CATEGORY_BY_ID.timelines
     ]
   },

--- a/web/src/stores/PanelStore.ts
+++ b/web/src/stores/PanelStore.ts
@@ -17,6 +17,7 @@ export type LeftPanelView =
   | "sketches"
   | "timelines"
   | "storyboards"
+  | "entities"
   | "scripts"
   | "jsscripts"
   | "apps"
@@ -77,6 +78,7 @@ const VALID_VIEWS: LeftPanelView[] = [
   "sketches",
   "timelines",
   "storyboards",
+  "entities",
   "scripts",
   "jsscripts",
   "apps",


### PR DESCRIPTION
## What changed

Entities were reachable only through the logo menu, which opened the library as a page tab — two clicks away from the storyboards and prompts that consume them. Entities is now a rail view in the editors group, directly after Storyboards: the drawer lists the entity cards with edit and remove in place, the panel headline carries a `+` that picks an image asset and opens the entity editor, and a fullscreen action still opens the full-page library, so the `entities` page tab keeps an opener. The asset picker moved out of `EntityLibrary` into `EntityAssetPickerDialog` so the page and the panel start the same add flow instead of two copies of it.

## Verification

- [x] `npm run test:affected` — the branch diffs 861 files against its merge-base, so this ran every workspace. `@nodetool-ai/kernel` failed under turbo but passes on its own (`npm run test --workspace=packages/kernel`: 70 files, 983 tests, 0 failures), and the diff is `web/`-only. Web side, `jest --findRelatedTests` over the seven changed source files: 190 suites, 1606 passed, 0 failed — including the three view-order tests this change had to update (`quickAccessCategories`, `PanelLeftMobile`, `QuickAccessSidebar`).
- [x] `npm run typecheck` — clean on the first run. A later run reports 51 errors, all `TS2307` module-not-found against `@nodetool-ai/*-nodes` plus 9 knock-on errors in `packages/websocket`, after the turbo run left package `dist/` output incomplete. None are in `web/src`.
- [x] `npm run lint` — no findings in the changed files; the only output is pre-existing warnings elsewhere.
- [ ] `npm run dev:nodetool -- harness gate --base main` — not run; the diff touches no harness-covered surface (frontend panel wiring only).

New test: `web/src/components/entities/__tests__/EntityListPanel.test.tsx` covers the list, the empty state, the delete mutation, and the `+` button opening the picker.

## Agent capabilities

No capability added or re-declared — `packages/agents/src/capabilities/entities.ts` is untouched.

## New checks

No check, rule, or audit added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T2KD2grzCUmZYLnEwVC1i4)_