### PR TITLE
fix(workspace): show agent file writes in the explorer and stop the ghost-file state

### DIFF
--- a/packages/agents/src/capabilities/files.ts
+++ b/packages/agents/src/capabilities/files.ts
@@ -92,13 +92,78 @@ const DEFAULT_READ_LIMIT = 2000;
 /** Context variable holding the set of file paths read in this session. */
 const READ_TRACKER_KEY = "__nt_read_files";
 
-function readSet(context: ProcessingContext): Set<string> {
+/**
+ * The session's read set, or null on a context with no variable store.
+ *
+ * The tracker is a guard rail, not a guarantee: a host that wires a context
+ * without variables (a node running one tool, a test double) still gets to
+ * edit files. It loses only the "read it before you overwrite it" memory, and
+ * `wasRead` then answers false — the conservative side of that guard.
+ */
+function readSet(context: ProcessingContext): Set<string> | null {
+  if (typeof context.get !== "function" || typeof context.set !== "function") {
+    return null;
+  }
   let set = context.get<Set<string>>(READ_TRACKER_KEY);
   if (!set) {
     set = new Set<string>();
     context.set(READ_TRACKER_KEY, set);
   }
   return set;
+}
+
+/**
+ * The tracker's key for a path: the workspace's own normalized key, never the
+ * string the model typed.
+ *
+ * `notes.md`, `./notes.md` and `/workspace/notes.md` are one file, and keying
+ * on the spelling made `write_file` refuse a file the model had just read under
+ * a different one — "exists but has not been read in this session", about a
+ * file it was looking at. Falls back to the raw path only when the workspace
+ * rejects it, where the caller is about to report that anyway.
+ */
+function trackerKey(workspace: Workspace, path: string): string {
+  try {
+    return workspace.key(path);
+  } catch {
+    return path;
+  }
+}
+
+function markRead(
+  context: ProcessingContext,
+  workspace: Workspace,
+  path: string
+): void {
+  readSet(context)?.add(trackerKey(workspace, path));
+}
+
+function wasRead(
+  context: ProcessingContext,
+  workspace: Workspace,
+  path: string
+): boolean {
+  return readSet(context)?.has(trackerKey(workspace, path)) === true;
+}
+
+/**
+ * Whether a path is a directory, for the tools that must not treat one as a
+ * file.
+ *
+ * `exists` answers true for a directory and `read` answers null for one, so a
+ * tool that asks only those two reports a state that cannot happen: the file is
+ * there and its contents are missing. That is what sent an agent hunting for a
+ * "ghost" file — it was the folder it had just created.
+ */
+async function isDirectory(
+  workspace: Workspace,
+  path: string
+): Promise<boolean> {
+  try {
+    return (await workspace.stat(path))?.isDirectory === true;
+  } catch {
+    return false;
+  }
 }
 
 function formatNumberedLines(content: string, startLine: number): string {
@@ -198,6 +263,9 @@ const readFileCapability: CapabilityExport = {
       return `Error: Path '${filePath}' is outside the workspace: ${msg}`;
     }
     if (!bytes) {
+      if (await isDirectory(workspace, filePath)) {
+        return `Error: ${filePath} is a directory, not a file. Use list_directory to see what is in it.`;
+      }
       return `Error: ${filePath} does not exist`;
     }
 
@@ -237,7 +305,7 @@ const readFileCapability: CapabilityExport = {
       );
     }
 
-    readSet(context).add(filePath);
+    markRead(context, workspace, filePath);
     const numbered = formatNumberedLines(content, offset);
     if (truncated) {
       return (
@@ -273,15 +341,22 @@ const writeFileCapability: CapabilityExport = {
 
     // Classify the path before writing: `exists` answers false for a path that
     // escapes, so without this the refusal would surface as a write failure.
-    let exists: boolean;
+    let existing;
     try {
       workspace.key(filePath);
-      exists = await workspace.exists(filePath);
+      existing = await workspace.stat(filePath);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       return `Error: Path '${filePath}' is outside the workspace: ${msg}`;
     }
-    if (exists && !readSet(context).has(filePath)) {
+    // A directory is not an overwritable file. Answering "read it first" here
+    // sent the model to read_file, which answers "does not exist" for the same
+    // path — a contradiction it cannot act on.
+    if (existing?.isDirectory) {
+      return `Error: ${filePath} is a directory, not a file. Write to a path inside it instead.`;
+    }
+    const exists = existing !== null;
+    if (exists && !wasRead(context, workspace, filePath)) {
       return (
         `Error: ${filePath} exists but has not been read in this session. ` +
         `Call read_file on it first so you know what you're overwriting.`
@@ -293,7 +368,7 @@ const writeFileCapability: CapabilityExport = {
       // After a successful write, treat the file as "read" — the model knows
       // its current contents (it just wrote them) and shouldn't have to re-read
       // before the next overwrite.
-      readSet(context).add(filePath);
+      markRead(context, workspace, filePath);
       return exists ? `Updated ${filePath}` : `Created ${filePath}`;
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -703,6 +778,7 @@ const editFile: CapabilityExport = {
       }
       try {
         await workspace.write(rawPath, newString, mimeForPath(rawPath));
+        markRead(context, workspace, rawPath);
         return { success: true, path: rawPath, created: true };
       } catch (e) {
         return {
@@ -713,6 +789,12 @@ const editFile: CapabilityExport = {
     }
 
     if (existing === null) {
+      if (await isDirectory(workspace, rawPath)) {
+        return {
+          success: false,
+          error: `${rawPath} is a directory, not a file. Edit a file inside it instead.`
+        };
+      }
       return { success: false, error: `File not found: ${rawPath}` };
     }
 
@@ -784,6 +866,9 @@ const editFile: CapabilityExport = {
       }
 
       await workspace.write(rawPath, newContent, mimeForPath(rawPath));
+      // An edit is a read plus a write: `write_file` must not go on to demand a
+      // read of the file this call just showed the model and rewrote.
+      markRead(context, workspace, rawPath);
 
       return {
         success: true,

--- a/packages/agents/tests/capabilities-files.test.ts
+++ b/packages/agents/tests/capabilities-files.test.ts
@@ -178,6 +178,74 @@ describe("files capabilities over a real workspace", () => {
     );
   });
 
+  it("takes a read under any spelling of the same path", async () => {
+    const run = runFor(workspace);
+    await run.invoke("write_file", { file_path: "notes.txt", content: "one" });
+
+    // Same file, three spellings the model mixes freely. Keying the read
+    // tracker on the string made the second and third read as unread files.
+    expect(await run.invoke("read_file", { file_path: "./notes.txt" })).toBe(
+      "1\tone"
+    );
+    for (const spelling of [
+      "notes.txt",
+      "./notes.txt",
+      "/workspace/notes.txt"
+    ]) {
+      expect(
+        await run.invoke("write_file", {
+          file_path: spelling,
+          content: `written as ${spelling}`
+        })
+      ).toBe(`Updated ${spelling}`);
+    }
+  });
+
+  it("lets write_file follow edit_file without a re-read", async () => {
+    await writeFile(join(workspace, "code.ts"), "const a = 1;\n");
+    const run = runFor(workspace);
+
+    await run.invoke("edit_file", {
+      path: "code.ts",
+      old_string: "const a = 1;",
+      new_string: "const a = 2;"
+    });
+    expect(
+      await run.invoke("write_file", {
+        file_path: "code.ts",
+        content: "const a = 3;\n"
+      })
+    ).toBe("Updated code.ts");
+  });
+
+  it("says a directory is a directory instead of contradicting itself", async () => {
+    await mkdir(join(workspace, "prompts"));
+    await writeFile(join(workspace, "prompts/one.md"), "hi");
+    const run = runFor(workspace);
+
+    // `exists` answers true for a directory and `read` answers null for one, so
+    // these two used to report the folder as a file that is there with no
+    // contents — the "ghost" an agent then hunted for.
+    expect(await run.invoke("read_file", { file_path: "prompts" })).toContain(
+      "is a directory"
+    );
+    expect(
+      await run.invoke("write_file", { file_path: "prompts", content: "x" })
+    ).toContain("is a directory");
+    const edited = (await run.invoke("edit_file", {
+      path: "prompts",
+      old_string: "a",
+      new_string: "b"
+    })) as { success: boolean; error: string };
+    expect(edited.success).toBe(false);
+    expect(edited.error).toContain("is a directory");
+
+    // The folder is untouched and still lists its file.
+    expect(await run.invoke("list_directory", { path: "prompts" })).toContain(
+      "one.md"
+    );
+  });
+
   it("edits an existing file by exact replacement", async () => {
     await writeFile(join(workspace, "code.ts"), "const a = 1;\n");
     const result = (await runFor(workspace).invoke("edit_file", {

--- a/packages/agents/tests/edit-search-tools-coverage.test.ts
+++ b/packages/agents/tests/edit-search-tools-coverage.test.ts
@@ -164,7 +164,10 @@ describe("EditFileTool — validation and error paths", () => {
     expect(res).toMatchObject({ success: true, created: true });
   });
 
-  it("reports a directory targeted as a file as not found", async () => {
+  it("names a directory a directory instead of calling it a missing file", async () => {
+    // "File not found" about a folder that is plainly there is the answer that
+    // sent an agent hunting for a ghost: write_file said the path existed,
+    // read_file and edit_file said it did not.
     await mkdir(join(workspace, "adir"));
     const res: any = await tool.process(ctxFor(workspace), {
       path: "adir",
@@ -172,7 +175,7 @@ describe("EditFileTool — validation and error paths", () => {
       new_string: "y"
     });
     expect(res.success).toBe(false);
-    expect(res.error).toMatch(/File not found/);
+    expect(res.error).toMatch(/is a directory/);
   });
 
   it("only replaces the first occurrence when replace_all is false and unique context differs", async () => {

--- a/packages/execution/src/service/index.ts
+++ b/packages/execution/src/service/index.ts
@@ -31,9 +31,11 @@ export {
   resolveWorkflowWorkspaceDir,
   workspaceFromRow,
   setWorkspaceCloudStorage,
+  setWorkspaceChangeNotifier,
   usesCloudWorkspaces,
   buildWorkspaceExecutionContext
 } from "./workflow-workspace.js";
+export type { WorkspaceFileChange } from "./workflow-workspace.js";
 
 export { createAppServerRunner } from "./app-run-server.js";
 export type { AppServerRunnerOptions } from "./app-run-server.js";

--- a/packages/execution/src/service/workflow-workspace.ts
+++ b/packages/execution/src/service/workflow-workspace.ts
@@ -4,8 +4,10 @@ import {
   ProcessingContext,
   createLocalWorkspace,
   createWorkspace,
+  observeWorkspace,
   type StorageAdapter,
-  type Workspace
+  type Workspace,
+  type WorkspaceChange
 } from "@nodetool-ai/runtime";
 
 const log = createLogger("nodetool.execution.workspace");
@@ -24,17 +26,49 @@ export function setWorkspaceCloudStorage(storage: StorageAdapter | null): void {
   cloudStorage = storage;
 }
 
+/** What a host is told when a run writes in a workspace. */
+export interface WorkspaceFileChange extends WorkspaceChange {
+  workspaceId: string;
+  userId: string;
+}
+
+/**
+ * Told about every file a run writes, so a host can push the change to a
+ * client watching that workspace.
+ *
+ * Injected the way {@link setWorkspaceCloudStorage} is: `@nodetool-ai/execution`
+ * has no websocket to broadcast on, and the workspace row id — which the
+ * {@link Workspace} interface deliberately does not carry — is known only here,
+ * where the row is read.
+ */
+let changeNotifier: ((change: WorkspaceFileChange) => void) | null = null;
+
+/** Called once at startup by a host that pushes workspace changes to clients. */
+export function setWorkspaceChangeNotifier(
+  notify: ((change: WorkspaceFileChange) => void) | null
+): void {
+  changeNotifier = notify;
+}
+
 /** Build the {@link Workspace} a workspace row describes. */
 export function workspaceFromRow(row: WorkspaceRow): Workspace | null {
-  if (!row.isVirtual()) return createLocalWorkspace(row.path);
-  if (!cloudStorage) {
+  const workspace = !row.isVirtual()
+    ? createLocalWorkspace(row.path)
+    : cloudStorage
+      ? createWorkspace(cloudStorage, { prefix: row.path })
+      : null;
+  if (!workspace) {
     log.warn(
       "A virtual workspace was requested but no cloud storage is configured",
       { workspaceId: row.id }
     );
     return null;
   }
-  return createWorkspace(cloudStorage, { prefix: row.path });
+  const notify = changeNotifier;
+  if (!notify) return workspace;
+  return observeWorkspace(workspace, (change) =>
+    notify({ ...change, workspaceId: row.id, userId: row.user_id })
+  );
 }
 
 /**

--- a/packages/execution/tests/workspace-change-notifier.test.ts
+++ b/packages/execution/tests/workspace-change-notifier.test.ts
@@ -1,0 +1,88 @@
+/**
+ * A run's workspace reports what it wrote.
+ *
+ * Workspace files are not database rows, so `ModelObserver` never sees them and
+ * the Workspace Explorer had no way to learn that a chat turn wrote one. The
+ * notifier registered here is what closes that gap, and the workspace row id it
+ * carries — which the `Workspace` interface deliberately does not expose — is
+ * known only where the row is read.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("@nodetool-ai/models", () => ({
+  Workflow: { find: vi.fn() },
+  Workspace: { find: vi.fn(), ensureDefault: vi.fn() },
+  getSecret: vi.fn()
+}));
+
+import {
+  setWorkspaceChangeNotifier,
+  workspaceFromRow,
+  type WorkspaceFileChange
+} from "../src/service/workflow-workspace.js";
+
+type WorkspaceRowLike = Parameters<typeof workspaceFromRow>[0];
+
+function rowFor(dir: string): WorkspaceRowLike {
+  return {
+    id: "ws-1",
+    user_id: "user-1",
+    path: dir,
+    isVirtual: () => false
+  } as unknown as WorkspaceRowLike;
+}
+
+const dirs: string[] = [];
+
+async function tempWorkspaceDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "workspace-notifier-"));
+  dirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  setWorkspaceChangeNotifier(null);
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("workspace change notifier", () => {
+  it("reports the workspace and user a write landed in", async () => {
+    const changes: WorkspaceFileChange[] = [];
+    setWorkspaceChangeNotifier((change) => changes.push(change));
+
+    const workspace = workspaceFromRow(rowFor(await tempWorkspaceDir()));
+    await workspace?.write("out/report.md", "done");
+
+    expect(changes).toEqual([
+      {
+        kind: "write",
+        path: "out/report.md",
+        workspaceId: "ws-1",
+        userId: "user-1"
+      }
+    ]);
+  });
+
+  it("says nothing when no host registered a notifier", async () => {
+    const workspace = workspaceFromRow(rowFor(await tempWorkspaceDir()));
+    await expect(workspace?.write("notes.md", "x")).resolves.toBeUndefined();
+    expect(await workspace?.readText("notes.md")).toBe("x");
+  });
+
+  it("stays quiet on reads and listings", async () => {
+    const changes: WorkspaceFileChange[] = [];
+    setWorkspaceChangeNotifier((change) => changes.push(change));
+    const workspace = workspaceFromRow(rowFor(await tempWorkspaceDir()));
+    await workspace?.write("notes.md", "x");
+    changes.length = 0;
+
+    await workspace?.readText("notes.md");
+    await workspace?.list(".");
+    await workspace?.stat("notes.md");
+    expect(changes).toEqual([]);
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -32,7 +32,9 @@ export {
 export {
   WorkspacePathError,
   WorkspaceNotLocalError,
+  observeWorkspace,
   type Workspace,
+  type WorkspaceChange,
   type WorkspaceEntry,
   type WorkspaceStat
 } from "./workspace.js";

--- a/packages/runtime/src/workspace.ts
+++ b/packages/runtime/src/workspace.ts
@@ -118,3 +118,84 @@ export class WorkspaceNotLocalError extends Error {
     this.name = "WorkspaceNotLocalError";
   }
 }
+
+/** What a mutation did, for a host that wants to react to it. */
+export interface WorkspaceChange {
+  kind: "write" | "delete" | "mkdir" | "copy" | "move";
+  /** The path written, created or removed. Workspace-relative. */
+  path: string;
+}
+
+/**
+ * A workspace that reports its own mutations.
+ *
+ * The Workspace Explorer lists files over tRPC and has no way to learn that a
+ * chat turn just wrote one — workspace files are not database rows, so the
+ * `resource_change` broadcast that keeps every other panel live never fires for
+ * them. Wrapping the workspace a run resolves is the one place every writer
+ * passes through: the file capabilities, the save nodes, and anything else that
+ * goes through the interface rather than `node:fs`.
+ *
+ * `onChange` fires only after the underlying call resolves, so a rejected write
+ * never announces a file that is not there. It is called synchronously and must
+ * not throw — a notifier is a side channel, and a run must not fail because a
+ * listener did.
+ */
+export function observeWorkspace(
+  inner: Workspace,
+  onChange: (change: WorkspaceChange) => void
+): Workspace {
+  const notify = (kind: WorkspaceChange["kind"], path: string): void => {
+    try {
+      onChange({ kind, path });
+    } catch {
+      // A listener must never break the write it is reporting.
+    }
+  };
+
+  return {
+    get localDir() {
+      return inner.localDir;
+    },
+    key: (path) => inner.key(path),
+    uri: (path) => inner.uri(path),
+    read: (path) => inner.read(path),
+    readText: (path) => inner.readText(path),
+    exists: (path) => inner.exists(path),
+    stat: (path) => inner.stat(path),
+    list: (path, opts) => inner.list(path, opts),
+    materialize: (path) => inner.materialize(path),
+    scratchDir: () => inner.scratchDir(),
+
+    async write(path, data, contentType) {
+      await inner.write(path, data, contentType);
+      notify("write", path);
+    },
+    async delete(path) {
+      const removed = await inner.delete(path);
+      if (removed) notify("delete", path);
+      return removed;
+    },
+    async deleteAll(path) {
+      const count = await inner.deleteAll(path);
+      if (count > 0) notify("delete", path);
+      return count;
+    },
+    async mkdir(path) {
+      await inner.mkdir(path);
+      notify("mkdir", path);
+    },
+    async copy(from, to) {
+      await inner.copy(from, to);
+      notify("copy", to);
+    },
+    async move(from, to) {
+      await inner.move(from, to);
+      notify("move", to);
+    },
+    async absorb(localPath, path) {
+      await inner.absorb(localPath, path);
+      notify("write", path);
+    }
+  };
+}

--- a/packages/runtime/tests/observe-workspace.test.ts
+++ b/packages/runtime/tests/observe-workspace.test.ts
@@ -1,0 +1,74 @@
+/**
+ * `observeWorkspace` is what tells the Workspace Explorer a run wrote a file.
+ * Workspace files are not database rows, so nothing else reports them.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { InMemoryStorageAdapter } from "../src/context.js";
+import { StorageWorkspace } from "../src/storage-workspace.js";
+import {
+  observeWorkspace,
+  type Workspace,
+  type WorkspaceChange
+} from "../src/workspace.js";
+
+describe("observeWorkspace", () => {
+  let inner: Workspace;
+  let observed: Workspace;
+  let changes: WorkspaceChange[];
+
+  beforeEach(() => {
+    inner = new StorageWorkspace(new InMemoryStorageAdapter());
+    changes = [];
+    observed = observeWorkspace(inner, (change) => changes.push(change));
+  });
+
+  it("reports a write once the bytes are stored", async () => {
+    await observed.write("notes.md", "hello");
+    expect(changes).toEqual([{ kind: "write", path: "notes.md" }]);
+    expect(await inner.readText("notes.md")).toBe("hello");
+  });
+
+  it("stays quiet on reads", async () => {
+    await observed.write("notes.md", "hello");
+    changes.length = 0;
+    await observed.readText("notes.md");
+    await observed.list(".");
+    await observed.stat("notes.md");
+    await observed.exists("notes.md");
+    expect(changes).toEqual([]);
+  });
+
+  it("does not announce a file a failed write never created", async () => {
+    await expect(observed.write("../escape.md", "x")).rejects.toThrow();
+    expect(changes).toEqual([]);
+  });
+
+  it("reports delete only when something went", async () => {
+    await observed.write("gone.md", "x");
+    changes.length = 0;
+    expect(await observed.delete("gone.md")).toBe(true);
+    expect(await observed.delete("gone.md")).toBe(false);
+    expect(changes).toEqual([{ kind: "delete", path: "gone.md" }]);
+  });
+
+  it("reports copy and move against the destination", async () => {
+    await observed.write("a.md", "x");
+    changes.length = 0;
+    await observed.copy("a.md", "b.md");
+    await observed.move("b.md", "c.md");
+    expect(changes).toEqual([
+      { kind: "copy", path: "b.md" },
+      { kind: "move", path: "c.md" }
+    ]);
+  });
+
+  it("survives a listener that throws", async () => {
+    const rigged = observeWorkspace(inner, () => {
+      throw new Error("listener blew up");
+    });
+    await expect(rigged.write("notes.md", "hello")).resolves.toBeUndefined();
+    expect(await inner.readText("notes.md")).toBe("hello");
+  });
+});

--- a/packages/websocket/src/lib/workflow-workspace.ts
+++ b/packages/websocket/src/lib/workflow-workspace.ts
@@ -6,10 +6,13 @@
  * which object store backs a virtual workspace.
  */
 import {
+  setWorkspaceChangeNotifier,
   setWorkspaceCloudStorage,
-  usesCloudWorkspaces
+  usesCloudWorkspaces,
+  type WorkspaceFileChange
 } from "@nodetool-ai/execution/service";
 import { getAssetAdapter } from "./storage.js";
+import { notifyResourceChange } from "../resource-events.js";
 
 export {
   resolveWorkflowWorkspace,
@@ -29,4 +32,49 @@ export {
 export function initWorkspaceStorage(): void {
   if (!usesCloudWorkspaces()) return;
   setWorkspaceCloudStorage(getAssetAdapter());
+}
+
+/**
+ * How long writes are pooled before the browser is told, in ms.
+ *
+ * An agent that unpacks an archive writes hundreds of files in a burst, and
+ * every one of them would otherwise be a websocket frame and a full re-listing.
+ * The explorer only ever refetches, so one message per workspace per window
+ * says everything a hundred would.
+ */
+const WORKSPACE_CHANGE_COALESCE_MS = 400;
+
+const pendingWorkspaceChanges = new Map<
+  string,
+  { userId: string; timer: NodeJS.Timeout }
+>();
+
+/**
+ * Push workspace file writes to the clients browsing that workspace.
+ *
+ * Workspace files are not database rows, so `ModelObserver` never sees them and
+ * the Workspace Explorer had no way to learn that a chat turn had written one —
+ * it showed whatever the panel happened to fetch when it mounted. This closes
+ * that gap with the emitter the other non-DBModel resources already use.
+ */
+export function initWorkspaceChangeEvents(): void {
+  setWorkspaceChangeNotifier((change: WorkspaceFileChange) => {
+    const pending = pendingWorkspaceChanges.get(change.workspaceId);
+    if (pending) return;
+    const timer = setTimeout(() => {
+      pendingWorkspaceChanges.delete(change.workspaceId);
+      notifyResourceChange({
+        event: "updated",
+        resource_type: "workspacefile",
+        resource: { id: change.workspaceId },
+        userId: change.userId
+      });
+    }, WORKSPACE_CHANGE_COALESCE_MS);
+    // A pending flush must not hold the process open at shutdown.
+    timer.unref?.();
+    pendingWorkspaceChanges.set(change.workspaceId, {
+      userId: change.userId,
+      timer
+    });
+  });
 }

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -150,7 +150,10 @@ import { createSdkV1TemporaryAssetService } from "./sdk/sdk-temporary-asset-serv
 import { getTempAdapter } from "./lib/storage.js";
 import { FrontendRendererRegistry } from "./frontend-renderer-registry.js";
 import workspaceRoutes from "./routes/workspace.js";
-import { initWorkspaceStorage } from "./lib/workflow-workspace.js";
+import {
+  initWorkspaceChangeEvents,
+  initWorkspaceStorage
+} from "./lib/workflow-workspace.js";
 import filesRoutes from "./routes/files.js";
 import collectionsRoutes from "./routes/collections.js";
 import applicationsRoutes from "./routes/applications.js";
@@ -1470,6 +1473,9 @@ await app.register(workspaceRoutes, routeOpts);
 // A cloud deployment keeps workspaces in the asset bucket rather than on the
 // machine's disk, which it would lose on every replacement. No-op locally.
 initWorkspaceStorage();
+// The Workspace Explorer has no other way to hear about a file a run wrote:
+// workspace files are not database rows.
+initWorkspaceChangeEvents();
 await app.register(filesRoutes, routeOpts);
 await app.register(collectionsRoutes, routeOpts);
 await app.register(applicationsRoutes, routeOpts);

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -4686,6 +4686,34 @@ export class UnifiedWebSocketRunner {
     };
   }
 
+  /**
+   * Which workflow decides where this conversation's files go.
+   *
+   * The workspace must not move between turns of one conversation: a file
+   * written in the previous message has to still be there in the next. The
+   * message's own `workflow_id` is not stable enough to key it on — the client
+   * attaches the id it has when it sends, so a turn sent before the thread list
+   * loaded carries none, resolves the default workspace instead of the
+   * workflow's, and the files the agent wrote a moment ago read as wiped. The
+   * thread's binding is the durable one, so it fills in whenever the message
+   * omits it.
+   */
+  private async threadWorkspaceWorkflowId(
+    userId: string,
+    threadId: string,
+    messageWorkflowId: string | null
+  ): Promise<string | null> {
+    if (messageWorkflowId) return messageWorkflowId;
+    if (!threadId) return null;
+    try {
+      const thread = await Thread.find(userId, threadId);
+      return isNonEmptyString(thread?.workflow_id) ? thread.workflow_id : null;
+    } catch (err) {
+      this.logError("thread workspace lookup failed", err);
+      return null;
+    }
+  }
+
   private async ensureThreadExists(
     threadId?: string,
     workflowId?: string | null
@@ -5828,7 +5856,10 @@ export class UnifiedWebSocketRunner {
     // default one. It used to fall back to the whole OS temp dir, which is
     // neither bounded nor anywhere the user would look for what an agent wrote.
     const chatWorkspace = this.workspaceResolver
-      ? await this.workspaceResolver(workflowId ?? null, userId)
+      ? await this.workspaceResolver(
+          await this.threadWorkspaceWorkflowId(userId, threadId, workflowId),
+          userId
+        )
       : null;
     const ctx = createRuntimeContext({
       jobId: randomUUID(),

--- a/packages/websocket/tests/workspace-change-events.test.ts
+++ b/packages/websocket/tests/workspace-change-events.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The server's half of workspace-file live updates: turn the resolver's
+ * per-write notifications into one `resource_change` per workspace, on the same
+ * emitter every other non-DBModel resource broadcasts through.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let registered: ((change: unknown) => void) | null = null;
+
+vi.mock("@nodetool-ai/execution/service", () => ({
+  setWorkspaceChangeNotifier: (notify: ((change: unknown) => void) | null) => {
+    registered = notify;
+  },
+  setWorkspaceCloudStorage: vi.fn(),
+  usesCloudWorkspaces: () => false,
+  resolveWorkflowWorkspace: vi.fn(),
+  workspaceFromRow: vi.fn(),
+  buildWorkspaceExecutionContext: vi.fn()
+}));
+
+vi.mock("../src/lib/storage.js", () => ({
+  getAssetAdapter: vi.fn()
+}));
+
+import { initWorkspaceChangeEvents } from "../src/lib/workflow-workspace.js";
+import { resourceEvents } from "../src/resource-events.js";
+
+const seen: unknown[] = [];
+const record = (payload: unknown): void => {
+  seen.push(payload);
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  registered = null;
+  seen.length = 0;
+  resourceEvents.on("change", record);
+  initWorkspaceChangeEvents();
+});
+
+afterEach(() => {
+  resourceEvents.off("change", record);
+  vi.useRealTimers();
+});
+
+describe("initWorkspaceChangeEvents", () => {
+  it("broadcasts one change per workspace no matter how many files landed", () => {
+    expect(registered).toBeTypeOf("function");
+    for (let i = 0; i < 50; i++) {
+      registered?.({
+        kind: "write",
+        path: `out/${i}.md`,
+        workspaceId: "ws-1",
+        userId: "user-1"
+      });
+    }
+    // Nothing until the window closes — an unpacked archive would otherwise be
+    // fifty frames and fifty re-listings.
+    expect(seen).toEqual([]);
+
+    vi.runAllTimers();
+    expect(seen).toEqual([
+      {
+        event: "updated",
+        resource_type: "workspacefile",
+        resource: { id: "ws-1" },
+        userId: "user-1"
+      }
+    ]);
+  });
+
+  it("keeps two workspaces apart", () => {
+    registered?.({ kind: "write", path: "a.md", workspaceId: "ws-1", userId: "u1" });
+    registered?.({ kind: "write", path: "b.md", workspaceId: "ws-2", userId: "u2" });
+    vi.runAllTimers();
+
+    expect(seen).toHaveLength(2);
+    expect(seen.map((s) => (s as { resource: { id: string } }).resource.id).sort()).toEqual([
+      "ws-1",
+      "ws-2"
+    ]);
+  });
+
+  it("broadcasts again after the window has closed", () => {
+    registered?.({ kind: "write", path: "a.md", workspaceId: "ws-1", userId: "u1" });
+    vi.runAllTimers();
+    registered?.({ kind: "write", path: "b.md", workspaceId: "ws-1", userId: "u1" });
+    vi.runAllTimers();
+    expect(seen).toHaveLength(2);
+  });
+});

--- a/web/src/components/workspaces/WorkspaceTree.tsx
+++ b/web/src/components/workspaces/WorkspaceTree.tsx
@@ -265,6 +265,9 @@ const updateTreeWithChildren = (
   });
 };
 
+/** How deep a workspace path sits, so parents can be merged before children. */
+const depthOf = (path: string): number => path.split("/").length;
+
 const shouldLoadChildren = (item: TreeViewItem | undefined): boolean => {
   return Boolean(
     item?.children?.length === 1 && item.children[0].label === "loading..."
@@ -284,6 +287,9 @@ const WorkspaceTree: React.FC = () => {
   const filesRef = useRef<TreeViewItem[]>([]);
   filesRef.current = files;
   const [selectedFilePath, setSelectedFilePath] = useState<string>("");
+  const [expandedItems, setExpandedItems] = useState<string[]>([]);
+  const expandedItemsRef = useRef<string[]>([]);
+  expandedItemsRef.current = expandedItems;
 
   const {
     workspaceId,
@@ -295,6 +301,7 @@ const WorkspaceTree: React.FC = () => {
 
   const {
     data: initialFiles,
+    dataUpdatedAt,
     isLoading: isLoadingFiles,
     refetch: refetchFiles
   } = useQuery({
@@ -305,12 +312,54 @@ const WorkspaceTree: React.FC = () => {
 
   // The query answers with the root listing; lazily-loaded children are merged
   // into this copy as folders expand.
+  //
+  // A refetch replaces the whole tree, which puts a `loading...` placeholder
+  // back under every folder that was open — and nothing would ever replace it,
+  // because MUI keeps its expansion state and so fires no expand event. The
+  // open folders are therefore re-listed here, which is also what makes a file
+  // written into a subfolder appear without collapsing the tree by hand.
   useEffect(() => {
     setFiles(initialFiles ?? []);
-  }, [initialFiles]);
+
+    const wsId = workspaceId;
+    const expanded = expandedItemsRef.current;
+    if (!wsId || !initialFiles || expanded.length === 0) return;
+
+    let cancelled = false;
+    void (async () => {
+      const loaded = await Promise.all(
+        expanded.map(async (itemId) => ({
+          itemId,
+          children: await fetchWorkspaceFiles(wsId, itemId).catch(() => [
+            createErrorItem(itemId)
+          ])
+        }))
+      );
+      if (cancelled) return;
+      // Shallowest first: a child's listing is merged into a parent that has
+      // already been replaced, not into the placeholder it is about to lose.
+      loaded.sort((a, b) => depthOf(a.itemId) - depthOf(b.itemId));
+      setFiles((prev) =>
+        loaded.reduce(
+          (tree, { itemId, children }) =>
+            updateTreeWithChildren(tree, itemId, children),
+          prev
+        )
+      );
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // `dataUpdatedAt`, not just `initialFiles`: TanStack's structural sharing
+    // hands back the identical array when a refetch finds the root unchanged,
+    // and a file written into an open subfolder changes nothing at the root.
+    // Keying on the data alone made that refresh a no-op.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialFiles, dataUpdatedAt, workspaceId]);
 
   useEffect(() => {
     setSelectedFilePath("");
+    setExpandedItems([]);
   }, [workspaceId]);
 
   const loadItemChildren = useCallback(
@@ -476,7 +525,9 @@ const WorkspaceTree: React.FC = () => {
           <div onDoubleClick={handleTreeDoubleClick}>
             <RichTreeView
               onItemClick={handleItemClick}
+              expandedItems={expandedItems}
               onExpandedItemsChange={(_event: React.SyntheticEvent, itemIds: string[]) => {
+                setExpandedItems(itemIds);
                 for (const itemId of itemIds) {
                   loadItemChildren(itemId);
                 }

--- a/web/src/components/workspaces/__tests__/WorkspaceTree.test.tsx
+++ b/web/src/components/workspaces/__tests__/WorkspaceTree.test.tsx
@@ -84,4 +84,39 @@ describe("WorkspaceTree", () => {
       "ws-renders"
     );
   });
+
+  it("re-lists open folders on refresh, so a file written into one appears", async () => {
+    // Root holds a folder; the folder holds one file until the refresh, two
+    // after — the shape of an agent writing into a subfolder while the tree is
+    // open on it.
+    let promptsHasSecondFile = false;
+    listFiles.mockImplementation((input: { path: string }) => {
+      if (input.path === ".") {
+        return Promise.resolve([
+          { name: "prompts", path: "prompts", is_dir: true, size: 0 }
+        ]);
+      }
+      return Promise.resolve(
+        promptsHasSecondFile
+          ? [
+              { name: "one.md", path: "prompts/one.md", is_dir: false, size: 1 },
+              { name: "two.md", path: "prompts/two.md", is_dir: false, size: 1 }
+            ]
+          : [{ name: "one.md", path: "prompts/one.md", is_dir: false, size: 1 }]
+      );
+    });
+
+    renderTree();
+    await userEvent.click(await screen.findByText("prompts"));
+    expect(await screen.findByText("one.md")).toBeInTheDocument();
+
+    promptsHasSecondFile = true;
+    await userEvent.click(screen.getByRole("button", { name: /refresh/i }));
+
+    expect(await screen.findByText("two.md")).toBeInTheDocument();
+    // The open folder keeps its contents rather than falling back to the
+    // placeholder the refetched root carries.
+    expect(screen.getByText("one.md")).toBeInTheDocument();
+    expect(screen.queryByText("loading...")).not.toBeInTheDocument();
+  });
 });

--- a/web/src/stores/__tests__/resourceChangeHandler.test.ts
+++ b/web/src/stores/__tests__/resourceChangeHandler.test.ts
@@ -34,6 +34,32 @@ describe("handleResourceChange", () => {
     setWorkflowResourceReloader(null);
   });
 
+  it("refetches the workspace explorer when a run writes a file", () => {
+    handleResourceChange({
+      type: "resource_change",
+      event: "updated",
+      resource_type: "workspacefile",
+      resource: { id: "ws-1" }
+    } as ResourceChangeUpdate);
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["workspace-files", "ws-1"]
+    });
+  });
+
+  it("refetches every workspace listing when the change names none", () => {
+    handleResourceChange({
+      type: "resource_change",
+      event: "updated",
+      resource_type: "workspacefile",
+      resource: {}
+    } as unknown as ResourceChangeUpdate);
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["workspace-files"]
+    });
+  });
+
   it("invalidates workflow queries on workflow update", () => {
     const update: ResourceChangeUpdate = {
       type: "resource_change",

--- a/web/src/stores/resourceChangeHandler.ts
+++ b/web/src/stores/resourceChangeHandler.ts
@@ -144,6 +144,22 @@ export function handleResourceChange(update: ResourceChangeUpdate): void {
     return;
   }
 
+  // Workspace *files* are not rows, so this arrives from the server's own
+  // emitter rather than ModelObserver. `resource.id` is the workspace the write
+  // landed in; without one, refetch every cached listing.
+  if (resource_type === "workspacefile") {
+    const workspaceId = isString(resource.id) ? resource.id : null;
+    console.info(
+      `[ResourceChange] Invalidating workspace files for ${workspaceId ?? "all workspaces"}`
+    );
+    queryClient.invalidateQueries({
+      queryKey: workspaceId
+        ? ["workspace-files", workspaceId]
+        : ["workspace-files"]
+    });
+    return;
+  }
+
   if (resource_type === "model") {
     console.info("[ResourceChange] Invalidating model queries");
     invalidateQueryKeys(MODEL_QUERY_KEYS);


### PR DESCRIPTION
## What changed

A file an agent writes now shows up in the Workspace Explorer, and the file tools stop reporting a written file as a ghost. Workspace files are not database rows, so `ModelObserver`'s `resource_change` broadcast — what keeps every other panel live — never fired for them, and the explorer showed whatever it happened to fetch when it mounted. A run's workspace now reports its own mutations (`observeWorkspace`), the resolver attaches the workspace row id and user (the `Workspace` interface deliberately carries neither), and the server coalesces a burst of writes into one `resource_change` per workspace per 400 ms; the client invalidates that workspace's listing. The tree also refetched into a dead state — TanStack's structural sharing hands back the identical root array when the root is unchanged, which is exactly what a write into an open subfolder produces — so open folders are re-listed on every fetch, keyed on `dataUpdatedAt`, and no longer fall back to a `loading...` placeholder nothing would replace. Three more fixes cover the "I wrote it, now it's gone" transcript: the read tracker was keyed on the string the model typed, so a file read as `./notes.md` and written as `notes.md` came back "exists but has not been read in this session" (it is keyed on the workspace's own path key now, and `edit_file` registers its read-plus-write like `write_file` does); `exists()` answers true for a directory while `read()` answers null for one, so `write_file` called a folder an unread file while `read_file` called the same path missing, and all three tools now say it is a directory; and a chat turn's workspace no longer moves between messages, because the message's `workflow_id` is whatever the client had when it sent, so a turn sent before the thread list loaded resolved the default workspace instead of the workflow's and the files written a moment earlier read as wiped — the thread's binding fills in when the message omits one.

## Verification

`packages/image-nodes` needs a Vulkan ICD headlessly (documented in AGENTS.md); these runs used `VK_DRIVER_FILES` pointed at lavapipe, and all 231 of its tests pass with it.

- [x] `npm run test:affected` — 110/110 package tasks, web 13,626 tests, electron 684 tests. `mobile` fails on `Preset @react-native/jest-preset not found`: `mobile/node_modules` is not installed in this sandbox (mobile is not a root workspace), and the diff touches no mobile file.
- [x] `npm run typecheck` — web and electron clean. Mobile fails on the same missing dependency tree.
- [x] `npm run lint` — exit 0.
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 12/12 selfchecks passed`.

Each new test was inverted once and observed failing:

- `takes a read under any spelling of the same path` and `says a directory is a directory instead of contradicting itself` — with `trackerKey` returning the raw path and `isDirectory` forced false: `Tests 2 failed | 11 passed (13)`.
- `lets write_file follow edit_file without a re-read` — with `edit_file`'s `markRead` removed: `Tests 1 failed | 12 passed (13)`.
- `re-lists open folders on refresh` — failed on the first run against the `initialFiles`-only dependency, which is what surfaced the structural-sharing problem: `expect(await screen.findByText("two.md"))` timed out.

## Agent capabilities

No capability is added and no declared contract changes — the seven `files` specs keep their names, descriptions, schemas, and permission categories; only their implementations change.

- [x] `npm run capabilities:check` — `capability table is current (224 capabilities)`

## New checks

No check, rule, or audit is added. The new tests are behavior tests, and each was inverted as recorded above.

---
_Generated by [Claude Code](https://claude.ai/code/session_011eWANhPTQP9r9yP4zwerYL)_