### PR TITLE
feat(web): move workspace browser to left panel with file tabs

### DIFF
--- a/docs/editor-panels.md
+++ b/docs/editor-panels.md
@@ -12,7 +12,7 @@ The NodeTool [Workflow Editor]({{ '/workflow-editor' | relative_url }}) is surro
 
 ## Left Panel
 
-Opens from the icons down the left edge. It's a tabbed drawer — click an icon to expand, click the same icon to collapse. The top-level views are: **Nodes**, **Workflows**, **Chats**, **Sketches**, **Timelines**, **Storyboards**, **Scripts**, **Apps**, **Settings**, **History**, **Favorites**, **Assets**, and **Library**.
+Opens from the icons down the left edge. It's a tabbed drawer — click an icon to expand, click the same icon to collapse. The top-level views are: **Nodes**, **Workflows**, **Chats**, **Sketches**, **Timelines**, **Storyboards**, **Scripts**, **Apps**, **Settings**, **History**, **Favorites**, **Workspace**, **Assets**, and **Library**.
 
 ![Left Panel](assets/screenshots/editor-left-panel.png)
 
@@ -58,6 +58,12 @@ Your starred nodes for quick access.
 
 ![Left Panel — Favorites](assets/screenshots/editor-left-panel-favorites.png)
 
+### Workspace Tab
+
+File hierarchy of the backing workspace (on local installs) or the assigned
+workspace (on server installs). Pick the workspace from the dropdown;
+double-click a file to open it as a workspace tab.
+
 ### Assets Tab
 
 Folder tree plus file grid. Drag a file onto the canvas to instantly create the matching input node.
@@ -74,7 +80,7 @@ Your Mini Apps. Click one to open it as a workspace tab; the two header icons cr
 
 ## Right Panel (Inspector)
 
-Press `i` or click the icon in the top right to toggle. The right panel hosts only the **Inspector** — its contents switch based on what's selected on the canvas. (Logs, Queue, Trace, Version History, and Workspace are not here — they live in the [Bottom Panel](#bottom-panel).)
+Press `i` or click the icon in the top right to toggle. The right panel hosts only the **Inspector** — its contents switch based on what's selected on the canvas. (Logs, Queue, Trace, and Version History are not here — they live in the [Bottom Panel](#bottom-panel).)
 
 ![Right Panel](assets/screenshots/editor-right-panel.png)
 
@@ -97,7 +103,7 @@ When no node is selected, the Inspector shows workflow-level metadata: title, de
 The bottom panel docks runtime diagnostics and secondary workflow tools. Drag its top edge to resize. Its views are grouped:
 
 - **Run** — Logs, Queue, Sandboxes, Workers
-- **Workflow** — Versions, Workspace
+- **Workflow** — Versions
 - **Debug** — Trace
 
 ![Bottom Panel](assets/screenshots/editor-bottom-panel.png)
@@ -132,12 +138,6 @@ The code-runner sandboxes and worker processes backing the current run.
 Every save is versioned. Review past versions and roll back.
 
 ![Version History](assets/screenshots/editor-bottom-panel-versions.png)
-
-### Workspace
-
-File hierarchy of the backing workspace (on local installs) or the assigned workspace (on server installs).
-
-![Workspace Tree](assets/screenshots/editor-bottom-panel-workspace.png)
 
 ### Trace
 

--- a/packages/protocol/src/api-schemas/workspace.ts
+++ b/packages/protocol/src/api-schemas/workspace.ts
@@ -93,3 +93,48 @@ export type ListFilesInput = z.infer<typeof listFilesInput>;
 
 export const listFilesOutput = z.array(fileEntry);
 export type ListFilesOutput = z.infer<typeof listFilesOutput>;
+
+// ── readFile / writeFile (text view + editor) ────────────────────
+/**
+ * Largest text payload the read/write procedures carry, in bytes.
+ *
+ * These are for viewing and editing a file as text in the editor, not for
+ * moving data: a read past this cap returns the first 2 MiB with
+ * `truncated: true`, and a write past it is refused. Binary transfer stays on
+ * `GET /api/workspaces/:id/download/:path`.
+ */
+export const MAX_TEXT_FILE_BYTES = 2 * 1024 * 1024;
+
+export const readFileInput = z.object({
+  id: z.string().min(1),
+  /** Workspace-relative. Absolute paths and traversal are refused. */
+  path: z.string().min(1)
+});
+export type ReadFileInput = z.infer<typeof readFileInput>;
+
+export const readFileOutput = z.object({
+  /**
+   * The file decoded as UTF-8. When `truncated` is true this is only the first
+   * {@link MAX_TEXT_FILE_BYTES} bytes, so a multi-byte character straddling the
+   * cut decodes to U+FFFD.
+   */
+  content: z.string(),
+  /** Full size of the file on disk, not the length of `content`. */
+  size: z.number(),
+  modified_at: z.string(),
+  truncated: z.boolean()
+});
+export type ReadFileOutput = z.infer<typeof readFileOutput>;
+
+export const writeFileInput = z.object({
+  id: z.string().min(1),
+  /** Workspace-relative. Absolute paths and traversal are refused. */
+  path: z.string().min(1),
+  /** UTF-8 text. Refused when it encodes to more than {@link MAX_TEXT_FILE_BYTES}. */
+  content: z.string()
+});
+export type WriteFileInput = z.infer<typeof writeFileInput>;
+
+/** The entry as it stands after the write. */
+export const writeFileOutput = fileEntry;
+export type WriteFileOutput = z.infer<typeof writeFileOutput>;

--- a/packages/websocket/src/trpc/routers/workspace.ts
+++ b/packages/websocket/src/trpc/routers/workspace.ts
@@ -15,7 +15,7 @@
 
 import { stat, access } from "node:fs/promises";
 import { existsSync, constants } from "node:fs";
-import { isAbsolute } from "node:path";
+import { isAbsolute, basename } from "node:path";
 import { Workspace } from "@nodetool-ai/models";
 import type { WorkspaceEntry } from "@nodetool-ai/runtime";
 import { workspaceFromRow } from "../../lib/workflow-workspace.js";
@@ -33,9 +33,15 @@ import {
   deleteOutput,
   listFilesInput,
   listFilesOutput,
+  readFileInput,
+  readFileOutput,
+  writeFileInput,
+  writeFileOutput,
+  MAX_TEXT_FILE_BYTES,
   type WorkspaceResponse,
   type FileEntry
 } from "@nodetool-ai/protocol/api-schemas/workspace.js";
+import type { Workspace as RunWorkspace } from "@nodetool-ai/runtime";
 import { isObjectLike } from "../../lib/wire-values.js";
 
 function toWorkspaceResponse(ws: Workspace): WorkspaceResponse {
@@ -113,6 +119,54 @@ async function validateWorkspacePath(candidate: string): Promise<void> {
   } catch {
     throwApiError(ApiErrorCode.INVALID_INPUT, "Path is not writable");
   }
+}
+
+/**
+ * Ceiling on what `readFile` will pull into memory to slice a text preview
+ * from. The workspace interface has no ranged read, so a file past this is
+ * refused rather than loaded and cut.
+ */
+const MAX_READABLE_BYTES = 32 * 1024 * 1024;
+
+/**
+ * Resolve the row a file procedure addresses, applying the same guards
+ * `listFiles` applies: the row must exist, be readable in this deployment, and
+ * the path must be workspace-relative.
+ */
+async function resolveFileTarget(
+  userId: string,
+  id: string,
+  path: string
+): Promise<{ row: Workspace; workspace: RunWorkspace }> {
+  const row = await Workspace.find(userId, id);
+  if (!row) {
+    throwApiError(ApiErrorCode.NOT_FOUND, "Workspace not found");
+  }
+  requireReadable(row);
+
+  if (path.startsWith("/")) {
+    throwApiError(
+      ApiErrorCode.INVALID_INPUT,
+      "Absolute paths not allowed, use relative paths"
+    );
+  }
+
+  const workspace = workspaceFromRow(row);
+  if (!workspace) {
+    throwApiError(
+      ApiErrorCode.INTERNAL_ERROR,
+      "Workspace storage is not configured"
+    );
+  }
+  return { row, workspace };
+}
+
+/** Containment is the workspace's own rule; surface its refusal as a 403. */
+function rethrowTraversal(err: unknown): never {
+  if (err instanceof Error && err.name === "WorkspacePathError") {
+    throwApiError(ApiErrorCode.FORBIDDEN, "Path traversal not allowed");
+  }
+  throw err;
 }
 
 export const workspaceRouter = router({
@@ -273,5 +327,99 @@ export const workspaceRouter = router({
         modified_at: new Date(entry.modifiedAt).toISOString()
       }));
       return files;
+    }),
+
+  /**
+   * Read one workspace file as UTF-8 text, for the editor's file viewer.
+   *
+   * Files larger than `MAX_TEXT_FILE_BYTES` come back cut to that many bytes
+   * with `truncated: true`; `size` always reports the whole file. Past
+   * `MAX_READABLE_BYTES` nothing is read at all — slicing 2 MiB off a
+   * multi-gigabyte file would still load the whole thing into memory first.
+   */
+  readFile: protectedProcedure
+    .input(readFileInput)
+    .output(readFileOutput)
+    .query(async ({ ctx, input }) => {
+      const { workspace } = await resolveFileTarget(
+        ctx.userId,
+        input.id,
+        input.path
+      );
+
+      const info = await workspace.stat(input.path).catch(rethrowTraversal);
+      if (!info) {
+        throwApiError(ApiErrorCode.NOT_FOUND, "File not found");
+      }
+      if (info.isDirectory) {
+        throwApiError(ApiErrorCode.INVALID_INPUT, "Path is a directory");
+      }
+      if (info.size > MAX_READABLE_BYTES) {
+        throwApiError(
+          ApiErrorCode.INVALID_INPUT,
+          "File is too large to open as text"
+        );
+      }
+
+      const bytes = await workspace.read(input.path).catch(rethrowTraversal);
+      if (!bytes) {
+        throwApiError(ApiErrorCode.NOT_FOUND, "File not found");
+      }
+
+      const truncated = bytes.byteLength > MAX_TEXT_FILE_BYTES;
+      const slice = truncated
+        ? bytes.subarray(0, MAX_TEXT_FILE_BYTES)
+        : bytes;
+      return {
+        content: new TextDecoder().decode(slice),
+        size: info.size,
+        modified_at: new Date(info.modifiedAt).toISOString(),
+        truncated
+      };
+    }),
+
+  /**
+   * Write UTF-8 text to a workspace file, creating it when absent.
+   *
+   * Guarded exactly like the read paths — a workspace this deployment refuses
+   * to list is a workspace it refuses to write — plus the accessibility check,
+   * since a row whose folder has gone missing would otherwise recreate it.
+   */
+  writeFile: protectedProcedure
+    .input(writeFileInput)
+    .output(writeFileOutput)
+    .mutation(async ({ ctx, input }) => {
+      const { row, workspace } = await resolveFileTarget(
+        ctx.userId,
+        input.id,
+        input.path
+      );
+      if (!row.isAccessible()) {
+        throwApiError(ApiErrorCode.FORBIDDEN, "Workspace is not accessible");
+      }
+
+      if (Buffer.byteLength(input.content, "utf8") > MAX_TEXT_FILE_BYTES) {
+        throwApiError(ApiErrorCode.INVALID_INPUT, "File content is too large");
+      }
+
+      const existing = await workspace.stat(input.path).catch(rethrowTraversal);
+      if (existing?.isDirectory) {
+        throwApiError(ApiErrorCode.INVALID_INPUT, "Path is a directory");
+      }
+
+      await workspace
+        .write(input.path, input.content, "text/plain; charset=utf-8")
+        .catch(rethrowTraversal);
+
+      const info = await workspace.stat(input.path);
+      const size = info?.size ?? Buffer.byteLength(input.content, "utf8");
+      const modifiedAt = info?.modifiedAt ?? Date.now();
+      return {
+        name: basename(input.path),
+        path: input.path,
+        size,
+        is_dir: false,
+        modified_at: new Date(modifiedAt).toISOString()
+      };
     })
 });

--- a/packages/websocket/src/trpc/sandbox-coverage.ts
+++ b/packages/websocket/src/trpc/sandbox-coverage.ts
@@ -1001,6 +1001,20 @@ export const SANDBOX_API_COVERAGE: Readonly<
       "sandbox has its own workspace API, contained to the run's " +
       "directory, which is the point of it."
   },
+  "workspace.readFile": {
+    withheld:
+      "A workspace names an absolute path on the host filesystem, so " +
+      "reading a file out of one is host-path read. The sandbox has its " +
+      "own workspace API, contained to the run's directory, which is the " +
+      "point of it."
+  },
+  "workspace.writeFile": {
+    withheld:
+      "A workspace names an absolute path on the host filesystem, so " +
+      "writing a file into one is host-path write. The sandbox has its " +
+      "own workspace API, contained to the run's directory, which is the " +
+      "point of it."
+  },
   "workspace.update": {
     withheld:
       "A workspace names an absolute path on the host filesystem, so " +

--- a/packages/websocket/tests/trpc-workspace-files.test.ts
+++ b/packages/websocket/tests/trpc-workspace-files.test.ts
@@ -1,0 +1,315 @@
+/**
+ * `workspace.readFile` / `workspace.writeFile` — the text view and editor the
+ * Workspace Explorer opens a file with.
+ *
+ * These run against a real temp directory: the procedures read and write
+ * through the run's `Workspace`, so mocking `node:fs` would test nothing they
+ * still call. Only the model lookup is stubbed.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { appRouter } from "../src/trpc/router.js";
+import { createCallerFactory } from "../src/trpc/index.js";
+import type { Context } from "../src/trpc/context.js";
+import { MAX_TEXT_FILE_BYTES } from "@nodetool-ai/protocol/api-schemas/workspace.js";
+
+vi.mock("@nodetool-ai/models", async (orig) => {
+  const actual = await orig<typeof import("@nodetool-ai/models")>();
+  return {
+    ...actual,
+    Workspace: {
+      ...actual.Workspace,
+      find: vi.fn()
+    }
+  };
+});
+
+import { Workspace } from "@nodetool-ai/models";
+import {
+  mkdtemp,
+  mkdir,
+  rm,
+  writeFile,
+  readFile as readFileFromDisk
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const createCaller = createCallerFactory(appRouter);
+
+function makeCtx(overrides: Partial<Context> = {}): Context {
+  return {
+    userId: "user-1",
+    registry: {} as never,
+    apiOptions: { metadataRoots: [], registry: {} as never } as never,
+    pythonBridge: {} as never,
+    getPythonBridgeReady: () => false,
+    ...overrides
+  };
+}
+
+function makeRow(opts: {
+  path: string;
+  is_managed?: boolean;
+  is_accessible?: boolean;
+}) {
+  return {
+    id: "w1",
+    user_id: "user-1",
+    name: "My Workspace",
+    path: opts.path,
+    is_default: true,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    isAccessible: vi.fn().mockReturnValue(opts.is_accessible ?? true),
+    isManaged: vi.fn().mockReturnValue(opts.is_managed ?? false),
+    isVirtual: vi.fn().mockReturnValue(false),
+    save: vi.fn(),
+    delete: vi.fn()
+  };
+}
+
+const findMock = () => Workspace.find as ReturnType<typeof vi.fn>;
+
+describe("workspace file read/write", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    delete process.env.NODETOOL_ENV;
+    dir = await mkdtemp(join(tmpdir(), "trpc-ws-files-"));
+    findMock().mockResolvedValue(makeRow({ path: dir }));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  // ── readFile ────────────────────────────────────────────────────
+  describe("readFile", () => {
+    it("reads an existing file as UTF-8", async () => {
+      await writeFile(join(dir, "notes.md"), "# héllo\nworld\n", "utf8");
+
+      const caller = createCaller(makeCtx());
+      const result = await caller.workspace.readFile({
+        id: "w1",
+        path: "notes.md"
+      });
+      expect(result.content).toBe("# héllo\nworld\n");
+      expect(result.size).toBe(Buffer.byteLength("# héllo\nworld\n", "utf8"));
+      expect(result.truncated).toBe(false);
+      expect(Number.isNaN(Date.parse(result.modified_at))).toBe(false);
+    });
+
+    it("reads a file in a subdirectory", async () => {
+      await mkdir(join(dir, "sub"), { recursive: true });
+      await writeFile(join(dir, "sub", "inner.txt"), "inner", "utf8");
+
+      const caller = createCaller(makeCtx());
+      const result = await caller.workspace.readFile({
+        id: "w1",
+        path: "sub/inner.txt"
+      });
+      expect(result.content).toBe("inner");
+    });
+
+    it("truncates a file past the 2 MiB cap and reports the full size", async () => {
+      const big = "a".repeat(MAX_TEXT_FILE_BYTES + 1024);
+      await writeFile(join(dir, "big.log"), big, "utf8");
+
+      const caller = createCaller(makeCtx());
+      const result = await caller.workspace.readFile({
+        id: "w1",
+        path: "big.log"
+      });
+      expect(result.truncated).toBe(true);
+      expect(result.content).toHaveLength(MAX_TEXT_FILE_BYTES);
+      expect(result.size).toBe(MAX_TEXT_FILE_BYTES + 1024);
+    });
+
+    it("does not truncate a file exactly at the cap", async () => {
+      await writeFile(join(dir, "exact.log"), "a".repeat(MAX_TEXT_FILE_BYTES));
+
+      const caller = createCaller(makeCtx());
+      const result = await caller.workspace.readFile({
+        id: "w1",
+        path: "exact.log"
+      });
+      expect(result.truncated).toBe(false);
+      expect(result.content).toHaveLength(MAX_TEXT_FILE_BYTES);
+    });
+
+    it("throws NOT_FOUND for a missing file", async () => {
+      const caller = createCaller(makeCtx());
+      await expect(
+        caller.workspace.readFile({ id: "w1", path: "nope.txt" })
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    });
+
+    it("throws INVALID_INPUT when the path is a directory", async () => {
+      await mkdir(join(dir, "sub"), { recursive: true });
+      await writeFile(join(dir, "sub", "inner.txt"), "x");
+
+      const caller = createCaller(makeCtx());
+      await expect(
+        caller.workspace.readFile({ id: "w1", path: "sub" })
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    it("rejects absolute paths", async () => {
+      const caller = createCaller(makeCtx());
+      await expect(
+        caller.workspace.readFile({ id: "w1", path: "/etc/passwd" })
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    it("rejects path traversal", async () => {
+      const caller = createCaller(makeCtx());
+      await expect(
+        caller.workspace.readFile({ id: "w1", path: "../x" })
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("throws NOT_FOUND when the workspace does not exist", async () => {
+      findMock().mockResolvedValue(null);
+      const caller = createCaller(makeCtx());
+      await expect(
+        caller.workspace.readFile({ id: "missing", path: "a.txt" })
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    });
+
+    it("refuses an unmanaged workspace in production", async () => {
+      process.env.NODETOOL_ENV = "production";
+      await writeFile(join(dir, "notes.md"), "x");
+      const caller = createCaller(makeCtx());
+      await expect(
+        caller.workspace.readFile({ id: "w1", path: "notes.md" })
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("rejects unauthenticated callers", async () => {
+      const caller = createCaller(makeCtx({ userId: null }));
+      await expect(
+        caller.workspace.readFile({ id: "w1", path: "a.txt" })
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+  });
+
+  // ── writeFile ───────────────────────────────────────────────────
+  describe("writeFile", () => {
+    it("creates a file and returns its entry", async () => {
+      const caller = createCaller(makeCtx());
+      const entry = await caller.workspace.writeFile({
+        id: "w1",
+        path: "new.txt",
+        content: "hello"
+      });
+      expect(entry.name).toBe("new.txt");
+      expect(entry.path).toBe("new.txt");
+      expect(entry.is_dir).toBe(false);
+      expect(entry.size).toBe(5);
+      expect(await readFileFromDisk(join(dir, "new.txt"), "utf8")).toBe("hello");
+    });
+
+    it("round-trips through readFile", async () => {
+      const caller = createCaller(makeCtx());
+      await caller.workspace.writeFile({
+        id: "w1",
+        path: "sub/round.md",
+        content: "# round\ntrip é\n"
+      });
+      const result = await caller.workspace.readFile({
+        id: "w1",
+        path: "sub/round.md"
+      });
+      expect(result.content).toBe("# round\ntrip é\n");
+      expect(result.truncated).toBe(false);
+    });
+
+    it("overwrites an existing file", async () => {
+      await writeFile(join(dir, "over.txt"), "old", "utf8");
+      const caller = createCaller(makeCtx());
+      await caller.workspace.writeFile({
+        id: "w1",
+        path: "over.txt",
+        content: "new"
+      });
+      expect(await readFileFromDisk(join(dir, "over.txt"), "utf8")).toBe("new");
+    });
+
+    it("refuses content past the 2 MiB cap and writes nothing", async () => {
+      const caller = createCaller(makeCtx());
+      await expect(
+        caller.workspace.writeFile({
+          id: "w1",
+          path: "huge.txt",
+          content: "a".repeat(MAX_TEXT_FILE_BYTES + 1)
+        })
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      await expect(
+        readFileFromDisk(join(dir, "huge.txt"), "utf8")
+      ).rejects.toThrow();
+    });
+
+    it("rejects absolute paths", async () => {
+      const caller = createCaller(makeCtx());
+      await expect(
+        caller.workspace.writeFile({
+          id: "w1",
+          path: "/etc/evil",
+          content: "x"
+        })
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    it("rejects path traversal and writes nothing outside the root", async () => {
+      const caller = createCaller(makeCtx());
+      await expect(
+        caller.workspace.writeFile({ id: "w1", path: "../x", content: "x" })
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+      await expect(
+        readFileFromDisk(join(dir, "..", "x"), "utf8")
+      ).rejects.toThrow();
+    });
+
+    it("refuses to overwrite a directory", async () => {
+      await mkdir(join(dir, "sub"), { recursive: true });
+      const caller = createCaller(makeCtx());
+      await expect(
+        caller.workspace.writeFile({ id: "w1", path: "sub", content: "x" })
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    it("refuses an unmanaged workspace in production", async () => {
+      process.env.NODETOOL_ENV = "production";
+      const caller = createCaller(makeCtx());
+      await expect(
+        caller.workspace.writeFile({ id: "w1", path: "a.txt", content: "x" })
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("refuses a workspace whose folder is gone", async () => {
+      findMock().mockResolvedValue(
+        makeRow({ path: dir, is_accessible: false })
+      );
+      const caller = createCaller(makeCtx());
+      await expect(
+        caller.workspace.writeFile({ id: "w1", path: "a.txt", content: "x" })
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("throws NOT_FOUND when the workspace does not exist", async () => {
+      findMock().mockResolvedValue(null);
+      const caller = createCaller(makeCtx());
+      await expect(
+        caller.workspace.writeFile({ id: "gone", path: "a.txt", content: "x" })
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    });
+
+    it("rejects unauthenticated callers", async () => {
+      const caller = createCaller(makeCtx({ userId: null }));
+      await expect(
+        caller.workspace.writeFile({ id: "w1", path: "a.txt", content: "x" })
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+  });
+});

--- a/web/src/components/node_menu/__tests__/QuickAccessSidebar.test.tsx
+++ b/web/src/components/node_menu/__tests__/QuickAccessSidebar.test.tsx
@@ -51,7 +51,7 @@ describe("QuickAccessSidebar", () => {
       within(bottom)
         .getAllByRole("button")
         .map((button) => button.getAttribute("aria-label"))
-    ).toEqual(["Workflow Settings", "Assets", "Library"]);
+    ).toEqual(["Workflow Settings", "Workspace", "Assets", "Library"]);
     expect(within(top).getAllByRole("separator")).toHaveLength(3);
   });
 
@@ -80,7 +80,7 @@ describe("QuickAccessSidebar", () => {
       within(bottom)
         .getAllByRole("button")
         .map((button) => button.getAttribute("aria-label"))
-    ).toEqual(["Assets", "Library"]);
+    ).toEqual(["Workspace", "Assets", "Library"]);
   });
 
   it("selects a view from any group", async () => {

--- a/web/src/components/panels/PanelBottom.tsx
+++ b/web/src/components/panels/PanelBottom.tsx
@@ -5,7 +5,6 @@ import type { Theme } from "@mui/material/styles";
 
 import {
   Tooltip,
-  Box,
   FlexColumn,
   MOTION,
   BORDER_RADIUS,
@@ -27,7 +26,6 @@ import LogPanel from "./LogPanel";
 import QueuePanel from "./jobs/QueuePanel";
 import WorkersPanel from "../workers/WorkersPanel";
 import WorkerStatusIndicator from "../workers/WorkerStatusIndicator";
-import WorkspaceTree from "../workspaces/WorkspaceTree";
 import { VersionHistoryPanel } from "../version";
 import PanelHeadline from "../ui/PanelHeadline";
 import { useCombo } from "../../stores/KeyPressedStore";
@@ -46,7 +44,6 @@ import type { NodeStoreState } from "../../stores/NodeStore";
 import TimelineIcon from "@mui/icons-material/Timeline";
 import ArticleIcon from "@mui/icons-material/Article";
 import HistoryIcon from "@mui/icons-material/History";
-import FolderIcon from "@mui/icons-material/Folder";
 import PlaylistPlayIcon from "@mui/icons-material/PlaylistPlay";
 import MemoryIcon from "@mui/icons-material/Memory";
 
@@ -122,7 +119,6 @@ const VIEW_SPECS = {
   queue: { id: "queue", label: "Queue", icon: <PlaylistPlayIcon /> },
   workers: { id: "workers", label: "Workers", icon: <MemoryIcon /> },
   versions: { id: "versions", label: "Versions", icon: <HistoryIcon /> },
-  workspace: { id: "workspace", label: "Workspace", icon: <FolderIcon /> },
   trace: { id: "trace", label: "Trace", icon: <TimelineIcon /> }
 } satisfies Record<BottomPanelView, ViewSpec>;
 
@@ -433,15 +429,6 @@ const PanelBodyContent = memo(function PanelBodyContent({
           onClose={closeView}
         />
       ) : null;
-    case "workspace":
-      return (
-        <Box
-          className="workspace-panel"
-          sx={{ width: "100%", height: "100%", overflow: "hidden" }}
-        >
-          <WorkspaceTree />
-        </Box>
-      );
     case "trace":
       return <TracePanel />;
     default:

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -55,6 +55,7 @@ import FavoritesTiles from "../node_menu/FavoritesTiles";
 import QuickAccessSidebar from "../node_menu/QuickAccessSidebar";
 import NodeLibrary from "../node_menu/NodeLibrary";
 import RailAppMenu from "./RailAppMenu";
+import WorkspaceTree from "../workspaces/WorkspaceTree";
 
 import {
   LeftPanelView,
@@ -467,6 +468,18 @@ const PanelContent = memo(function PanelContent({
           <AssetGridStoreProvider persistKey={LIBRARY_ASSET_GRID_STORE_KEY}>
             <AssetGrid maxItemSize={5} isMobile={isMobile} forceGlobalAssets />
           </AssetGridStoreProvider>
+        </FlexColumn>
+      )}
+      {activeView === "workspace-files" && (
+        <FlexColumn
+          className="workspace-files-container"
+          fullWidth
+          fullHeight
+          sx={{
+            overflow: "hidden"
+          }}
+        >
+          <WorkspaceTree />
         </FlexColumn>
       )}
       {activeView === "workflows" && (

--- a/web/src/components/panels/__tests__/PanelLeftMobile.test.tsx
+++ b/web/src/components/panels/__tests__/PanelLeftMobile.test.tsx
@@ -153,7 +153,7 @@ it("keeps the visible desktop groups in the mobile tab row", () => {
     ["Workflows", "Apps", "Chats"],
     ["Sketches", "Scripts", "Storyboards", "Entities", "Timelines"],
     ["JS Scripts"],
-    ["Assets", "Library"]
+    ["Workspace", "Assets", "Library"]
   ]);
 });
 

--- a/web/src/components/workspace/TabContent.tsx
+++ b/web/src/components/workspace/TabContent.tsx
@@ -21,6 +21,9 @@ const JsScriptSurface = React.lazy(() => import("./JsScriptSurface"));
 const ApplicationSurface = React.lazy(() => import("./ApplicationSurface"));
 const ChatSurface = React.lazy(() => import("./ChatSurface"));
 const PageSurface = React.lazy(() => import("./PageSurface"));
+const WorkspaceFileSurface = React.lazy(
+  () => import("./WorkspaceFileSurface")
+);
 
 interface TabContentProps {
   tab: WorkspaceTab;
@@ -52,6 +55,14 @@ const surfaceFor = (tab: WorkspaceTab, active: boolean) => {
     case "jsscript":
       return (
         <JsScriptSurface refId={tab.ref} mode={tab.mode} active={active} />
+      );
+    case "workspace-file":
+      return (
+        <WorkspaceFileSurface
+          refId={tab.ref}
+          mode={tab.mode}
+          active={active}
+        />
       );
     case "application":
       return <ApplicationSurface refId={tab.ref} />;

--- a/web/src/components/workspace/WorkspaceFileSurface.tsx
+++ b/web/src/components/workspace/WorkspaceFileSurface.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useMemo } from "react";
+
+import { BASE_URL } from "../../stores/BASE_URL";
+import { useAssetDownload } from "../../hooks/assets/useAssetDownload";
+import {
+  useWorkspaceTabsStore,
+  type WorkspaceTabMode
+} from "../../stores/WorkspaceTabsStore";
+import ImageViewer from "../asset_viewer/ImageViewer";
+import AudioViewer from "../asset_viewer/AudioViewer";
+import VideoViewer from "../asset_viewer/VideoViewer";
+import LazyPDFViewer from "../asset_viewer/LazyPDFViewer";
+import LazyModel3DViewer from "../asset_viewer/LazyModel3DViewer";
+import {
+  Button,
+  Caption,
+  FlexColumn,
+  SPACING,
+  Text
+} from "../ui_primitives";
+import WorkspaceFileText from "./WorkspaceFileText";
+import { isTextKind, workspaceFileKind } from "./workspaceFileKind";
+import {
+  parseWorkspaceFileRef,
+  workspaceFileDownloadPath,
+  workspaceFileName
+} from "./workspaceFileRef";
+
+interface WorkspaceFileSurfaceProps {
+  /** `${workspaceId}::${path}` — see workspaceFileRef.ts. */
+  refId: string;
+  mode: WorkspaceTabMode;
+  active: boolean;
+}
+
+const BinaryFallback = ({ name, url }: { name: string; url: string }) => {
+  const { handleDownload } = useAssetDownload({ url });
+  return (
+    <FlexColumn
+      fullWidth
+      fullHeight
+      align="center"
+      justify="center"
+      gap={SPACING.md}
+    >
+      <Text size="normal" weight={600}>
+        {name}
+      </Text>
+      <Caption>No preview available for this file type.</Caption>
+      <Button variant="outlined" size="small" onClick={handleDownload}>
+        Download
+      </Button>
+    </FlexColumn>
+  );
+};
+
+/**
+ * The document surface for a workspace file tab. The ref carries the workspace
+ * id and the workspace-relative path; the filename picks the viewer. Media, PDF
+ * and 3D files stream from the REST download endpoint; text files are read and
+ * written through the `workspace` tRPC router (see WorkspaceFileText).
+ */
+const WorkspaceFileSurface = ({ refId, mode }: WorkspaceFileSurfaceProps) => {
+  const setTabTitle = useWorkspaceTabsStore((state) => state.setTitle);
+  const parsed = useMemo(() => parseWorkspaceFileRef(refId), [refId]);
+  const name = parsed ? workspaceFileName(parsed.path) : "";
+
+  useEffect(() => {
+    if (name) {
+      setTabTitle(refId, "workspace-file", name);
+    }
+  }, [name, refId, setTabTitle]);
+
+  if (!parsed) {
+    return (
+      <FlexColumn fullWidth fullHeight align="center" justify="center">
+        <Text size="normal" weight={600}>
+          Invalid workspace file reference
+        </Text>
+      </FlexColumn>
+    );
+  }
+
+  const { workspaceId, path } = parsed;
+  const kind = workspaceFileKind(name);
+  const url = `${BASE_URL}${workspaceFileDownloadPath(workspaceId, path)}`;
+
+  if (isTextKind(kind)) {
+    return (
+      <WorkspaceFileText
+        workspaceId={workspaceId}
+        path={path}
+        kind={kind}
+        mode={mode}
+      />
+    );
+  }
+
+  switch (kind) {
+    case "image":
+      return <ImageViewer url={url} />;
+    case "audio":
+      return <AudioViewer url={url} />;
+    case "video":
+      return <VideoViewer url={url} />;
+    case "pdf":
+      return <LazyPDFViewer url={url} />;
+    case "model3d":
+      return <LazyModel3DViewer url={url} />;
+    default:
+      return <BinaryFallback name={name} url={url} />;
+  }
+};
+
+export default WorkspaceFileSurface;

--- a/web/src/components/workspace/WorkspaceFileText.tsx
+++ b/web/src/components/workspace/WorkspaceFileText.tsx
@@ -1,0 +1,325 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import SaveIcon from "@mui/icons-material/Save";
+
+import { trpcClient } from "../../trpc/client";
+import { useNotificationStore } from "../../stores/NotificationStore";
+import { languageFromAsset } from "../../utils/assetLanguage";
+import { csvDelimiterFor, parseCsvToDataframe } from "../../utils/csvDataframe";
+import MarkdownRenderer from "../../utils/MarkdownRenderer";
+import MonacoPane from "./MonacoPane";
+import { workspaceFileName } from "./workspaceFileRef";
+import type { WorkspaceFileKind } from "./workspaceFileKind";
+import type { WorkspaceTabMode } from "../../stores/WorkspaceTabsStore";
+import {
+  AlertBanner,
+  BORDER_RADIUS,
+  Caption,
+  CopyButton,
+  DataTable,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  LoadingSpinner,
+  ScrollArea,
+  Text
+} from "../ui_primitives";
+
+interface WorkspaceFileTextProps {
+  workspaceId: string;
+  path: string;
+  kind: WorkspaceFileKind;
+  mode: WorkspaceTabMode;
+}
+
+/** Cap CSV/TSV rows so a huge file can't lock up the table render. */
+const MAX_CSV_ROWS = 2000;
+
+export const workspaceFileTextKey = (workspaceId: string, path: string) =>
+  ["workspaceFile", workspaceId, path] as const;
+
+const styles = (theme: Theme) =>
+  css({
+    width: "100%",
+    height: "100%",
+    backgroundColor: theme.vars.palette.grey[900],
+    ".file-header": {
+      flex: "0 0 auto",
+      height: "2.5em",
+      padding: "0 0.5em 0 0.75em",
+      borderBottom: `1px solid ${theme.vars.palette.divider}`,
+      backgroundColor: theme.vars.palette.grey[800]
+    },
+    ".filename": {
+      color: theme.vars.palette.text.primary,
+      fontWeight: 500
+    },
+    ".kind-tag": {
+      textTransform: "uppercase",
+      letterSpacing: "0.05em"
+    },
+    ".file-body": {
+      flex: 1,
+      minHeight: 0
+    },
+    ".dirty-dot": {
+      width: 8,
+      height: 8,
+      borderRadius: BORDER_RADIUS.circle,
+      backgroundColor: theme.vars.palette.warning.main,
+      flex: "0 0 auto"
+    },
+    ".csv-note": {
+      padding: "0.5em 1.25em"
+    },
+    ".status": {
+      width: "100%",
+      height: "100%",
+      alignItems: "center",
+      justifyContent: "center"
+    }
+  });
+
+const CsvTableView = ({ text, name }: { text: string; name: string }) => {
+  const { columns, rows, truncated } = useMemo(() => {
+    const df = parseCsvToDataframe(text, csvDelimiterFor(name));
+    const cols = (df.columns ?? []).map((c, i) => ({
+      key: String(i),
+      label: c.name
+    }));
+    const allRows = df.data ?? [];
+    const mapped = allRows
+      .slice(0, MAX_CSV_ROWS)
+      .map((row) =>
+        Object.fromEntries(
+          row.map((cell, i) => [String(i), cell as React.ReactNode])
+        )
+      );
+    return {
+      columns: cols,
+      rows: mapped,
+      truncated: allRows.length > MAX_CSV_ROWS
+    };
+  }, [text, name]);
+
+  if (columns.length === 0) {
+    return (
+      <FlexColumn className="status">
+        <Caption>Empty table</Caption>
+      </FlexColumn>
+    );
+  }
+
+  return (
+    <ScrollArea direction="both" sx={{ width: "100%", height: "100%" }}>
+      <DataTable columns={columns} rows={rows} compact bordered stickyHeader />
+      {truncated && (
+        <Caption className="csv-note">
+          Showing first {MAX_CSV_ROWS} rows.
+        </Caption>
+      )}
+    </ScrollArea>
+  );
+};
+
+/**
+ * The text half of a `workspace-file` tab: reads the file through
+ * `workspace.readFile`, renders it per kind in view mode (markdown rendered,
+ * CSV/TSV as a table, everything else in read-only Monaco) and edits it in
+ * Monaco in edit mode, saving through `workspace.writeFile` on Cmd/Ctrl+S or
+ * the toolbar button.
+ *
+ * A file the backend truncated is read-only: saving would write the prefix
+ * back over the whole file.
+ */
+const WorkspaceFileText = ({
+  workspaceId,
+  path,
+  kind,
+  mode
+}: WorkspaceFileTextProps) => {
+  const theme = useTheme();
+  const paneStyles = useMemo(() => styles(theme), [theme]);
+  const queryClient = useQueryClient();
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification
+  );
+
+  const name = workspaceFileName(path);
+  const language = useMemo(
+    () => languageFromAsset({ name }) ?? "plaintext",
+    [name]
+  );
+
+  const queryKey = workspaceFileTextKey(workspaceId, path);
+  const { data, isLoading, error } = useQuery({
+    queryKey,
+    queryFn: () => trpcClient.workspace.readFile.query({ id: workspaceId, path })
+  });
+
+  const loadedText = data?.content;
+  const truncated = data?.truncated ?? false;
+
+  const [content, setContent] = useState<string | null>(null);
+  const [savedContent, setSavedContent] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (loadedText === undefined) {
+      return;
+    }
+    setContent((current) => (current === null ? loadedText : current));
+    setSavedContent((current) => (current === null ? loadedText : current));
+  }, [loadedText]);
+
+  // Re-derive when the tab is pointed at a different file. Guarded by a ref so
+  // it cannot run in the same flush as the seed above and blank a cache hit.
+  const previousFile = useRef(`${workspaceId}::${path}`);
+  useEffect(() => {
+    const current = `${workspaceId}::${path}`;
+    if (previousFile.current === current) {
+      return;
+    }
+    previousFile.current = current;
+    setContent(null);
+    setSavedContent(null);
+  }, [workspaceId, path]);
+
+  const saveMutation = useMutation({
+    mutationFn: (text: string) =>
+      trpcClient.workspace.writeFile.mutate({
+        id: workspaceId,
+        path,
+        content: text
+      }),
+    onSuccess: (_entry, text) => {
+      setSavedContent(text);
+      queryClient.setQueryData(queryKey, (previous) =>
+        previous ? { ...previous, content: text } : previous
+      );
+      addNotification({
+        type: "success",
+        alert: true,
+        content: `Saved ${name}`,
+        dismissable: false
+      });
+    },
+    onError: (saveError: Error) => {
+      addNotification({
+        type: "error",
+        alert: true,
+        content: `Failed to save ${name}: ${saveError.message}`,
+        dismissable: false
+      });
+    }
+  });
+
+  const isSaving = saveMutation.isPending;
+  const isDirty = content !== null && content !== savedContent;
+  const canSave = isDirty && !isSaving && !truncated;
+
+  const handleSave = useCallback(() => {
+    if (content === null || content === savedContent || isSaving || truncated) {
+      return;
+    }
+    saveMutation.mutate(content);
+  }, [content, savedContent, isSaving, truncated, saveMutation]);
+
+  const body = () => {
+    if (error) {
+      return (
+        <FlexColumn className="status">
+          <Text size="normal" weight={600} sx={{ color: "error.main" }}>
+            Failed to load {name}
+          </Text>
+        </FlexColumn>
+      );
+    }
+    if (isLoading || content === null) {
+      return (
+        <FlexColumn className="status">
+          <LoadingSpinner />
+        </FlexColumn>
+      );
+    }
+
+    if (mode === "edit") {
+      return (
+        <MonacoPane
+          value={content}
+          language={language}
+          readOnly={truncated}
+          onChange={setContent}
+          onSave={handleSave}
+        />
+      );
+    }
+
+    switch (kind) {
+      case "markdown":
+        return (
+          <ScrollArea
+            direction="vertical"
+            sx={{ width: "100%", height: "100%" }}
+          >
+            <MarkdownRenderer content={content} fillContainer />
+          </ScrollArea>
+        );
+      case "csv":
+        return <CsvTableView text={content} name={name} />;
+      default:
+        return <MonacoPane value={content} language={language} readOnly />;
+    }
+  };
+
+  return (
+    <FlexColumn css={paneStyles} sx={{ width: "100%", height: "100%" }}>
+      <FlexRow
+        className="file-header"
+        align="center"
+        justify="space-between"
+        gap={1}
+      >
+        <FlexRow align="center" gap={1} sx={{ minWidth: 0 }}>
+          <Text className="filename" size="small">
+            {name}
+          </Text>
+          <Caption className="kind-tag">{kind}</Caption>
+        </FlexRow>
+        <FlexRow align="center" gap={0.5}>
+          {content !== null && (
+            <CopyButton value={content} buttonSize="small" />
+          )}
+          {mode === "edit" && (
+            <>
+              {isDirty && (
+                <span className="dirty-dot" aria-label="Unsaved changes" />
+              )}
+              <EditorButton
+                variant="contained"
+                size="small"
+                startIcon={<SaveIcon />}
+                disabled={!canSave}
+                onClick={handleSave}
+              >
+                {isSaving ? "Saving…" : "Save"}
+              </EditorButton>
+            </>
+          )}
+        </FlexRow>
+      </FlexRow>
+      {truncated && (
+        <AlertBanner severity="warning" compact>
+          Showing the first part of this file only — it is too large to load in
+          full, so editing is disabled.
+        </AlertBanner>
+      )}
+      <div className="file-body">{body()}</div>
+    </FlexColumn>
+  );
+};
+
+export default WorkspaceFileText;

--- a/web/src/components/workspace/WorkspaceFileText.tsx
+++ b/web/src/components/workspace/WorkspaceFileText.tsx
@@ -46,13 +46,13 @@ const styles = (theme: Theme) =>
   css({
     width: "100%",
     height: "100%",
-    backgroundColor: theme.vars.palette.grey[900],
+    backgroundColor: theme.vars.palette.background.default,
     ".file-header": {
       flex: "0 0 auto",
       height: "2.5em",
       padding: "0 0.5em 0 0.75em",
       borderBottom: `1px solid ${theme.vars.palette.divider}`,
-      backgroundColor: theme.vars.palette.grey[800]
+      backgroundColor: theme.vars.palette.background.paper
     },
     ".filename": {
       color: theme.vars.palette.text.primary,

--- a/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -47,6 +47,7 @@ const SUPPORTS_BOTH_MODES = {
   model3d: true,
   text: true,
   audio: true,
+  "workspace-file": true,
   chat: false,
   application: false,
   page: false
@@ -63,6 +64,7 @@ const TYPE_GLYPH = {
   model3d: "◈",
   audio: "♪",
   text: "¶",
+  "workspace-file": "🗎",
   chat: "❝",
   application: "◧",
   page: "☰"
@@ -80,6 +82,7 @@ const TYPE_COLOR = {
   model3d: colorForType("model_3d"),
   audio: colorForType("audio"),
   text: colorForType("text"),
+  "workspace-file": colorForType("file"),
   chat: colorForType("str"),
   application: colorForType("any"),
   page: colorForType("any")

--- a/web/src/components/workspace/__tests__/workspaceFileKind.test.ts
+++ b/web/src/components/workspace/__tests__/workspaceFileKind.test.ts
@@ -25,10 +25,18 @@ describe("workspaceFileKind", () => {
     expect(workspaceFileKind(".gitignore")).toBe("text");
   });
 
+  it("treats conventional extension-less names as text", () => {
+    expect(workspaceFileKind("LICENSE")).toBe("text");
+    expect(workspaceFileKind("docs/README")).toBe("text");
+    expect(workspaceFileKind("Makefile")).toBe("text");
+    // Dockerfile already resolves to a Monaco language upstream.
+    expect(workspaceFileKind("Dockerfile")).toBe("code");
+  });
+
   it("falls back to binary for unknown and extension-less files", () => {
     expect(workspaceFileKind("model.bin")).toBe("binary");
     expect(workspaceFileKind("archive.zip")).toBe("binary");
-    expect(workspaceFileKind("LICENSE")).toBe("binary");
+    expect(workspaceFileKind("somebinary")).toBe("binary");
   });
 
   it("marks exactly the text-rendered kinds as text", () => {

--- a/web/src/components/workspace/__tests__/workspaceFileKind.test.ts
+++ b/web/src/components/workspace/__tests__/workspaceFileKind.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment node
+ */
+import { isTextKind, workspaceFileKind } from "../workspaceFileKind";
+
+describe("workspaceFileKind", () => {
+  it("routes media, PDF and 3D files to their viewers", () => {
+    expect(workspaceFileKind("a.png")).toBe("image");
+    expect(workspaceFileKind("out/a.JPEG")).toBe("image");
+    expect(workspaceFileKind("a.svg")).toBe("image");
+    expect(workspaceFileKind("a.mp3")).toBe("audio");
+    expect(workspaceFileKind("a.mp4")).toBe("video");
+    expect(workspaceFileKind("a.pdf")).toBe("pdf");
+    expect(workspaceFileKind("a.glb")).toBe("model3d");
+  });
+
+  it("classifies text files by how they render", () => {
+    expect(workspaceFileKind("README.md")).toBe("markdown");
+    expect(workspaceFileKind("data.csv")).toBe("csv");
+    expect(workspaceFileKind("data.tsv")).toBe("csv");
+    expect(workspaceFileKind("main.ts")).toBe("code");
+    expect(workspaceFileKind("config.json")).toBe("code");
+    expect(workspaceFileKind("notes.txt")).toBe("text");
+    expect(workspaceFileKind("run.log")).toBe("text");
+    expect(workspaceFileKind(".gitignore")).toBe("text");
+  });
+
+  it("falls back to binary for unknown and extension-less files", () => {
+    expect(workspaceFileKind("model.bin")).toBe("binary");
+    expect(workspaceFileKind("archive.zip")).toBe("binary");
+    expect(workspaceFileKind("LICENSE")).toBe("binary");
+  });
+
+  it("marks exactly the text-rendered kinds as text", () => {
+    expect(isTextKind("markdown")).toBe(true);
+    expect(isTextKind("csv")).toBe(true);
+    expect(isTextKind("code")).toBe(true);
+    expect(isTextKind("text")).toBe(true);
+    expect(isTextKind("image")).toBe(false);
+    expect(isTextKind("binary")).toBe(false);
+  });
+});

--- a/web/src/components/workspace/__tests__/workspaceFileRef.test.ts
+++ b/web/src/components/workspace/__tests__/workspaceFileRef.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment node
+ */
+import {
+  buildWorkspaceFileRef,
+  parseWorkspaceFileRef,
+  workspaceFileDownloadPath,
+  workspaceFileName
+} from "../workspaceFileRef";
+
+describe("workspace file refs", () => {
+  it("round-trips a nested path", () => {
+    const ref = buildWorkspaceFileRef("ws1", "out/images/a b.png");
+    expect(ref).toBe("ws1::out/images/a b.png");
+    expect(parseWorkspaceFileRef(ref)).toEqual({
+      workspaceId: "ws1",
+      path: "out/images/a b.png"
+    });
+  });
+
+  it("splits on the first separator only, so a path may contain '::'", () => {
+    expect(parseWorkspaceFileRef("ws1::odd::name.txt")).toEqual({
+      workspaceId: "ws1",
+      path: "odd::name.txt"
+    });
+  });
+
+  it("normalizes leading './' and '/' so one file yields one ref", () => {
+    expect(buildWorkspaceFileRef("ws1", "./a.txt")).toBe("ws1::a.txt");
+    expect(buildWorkspaceFileRef("ws1", "/a.txt")).toBe("ws1::a.txt");
+    expect(parseWorkspaceFileRef("ws1::/a.txt")?.path).toBe("a.txt");
+  });
+
+  it("rejects malformed refs", () => {
+    expect(parseWorkspaceFileRef("no-separator")).toBeNull();
+    expect(parseWorkspaceFileRef("::a.txt")).toBeNull();
+    expect(parseWorkspaceFileRef("ws1::")).toBeNull();
+  });
+
+  it("reads the basename off a path", () => {
+    expect(workspaceFileName("out/images/a.png")).toBe("a.png");
+    expect(workspaceFileName("a.png")).toBe("a.png");
+  });
+
+  it("encodes each download path segment but keeps the separators", () => {
+    expect(workspaceFileDownloadPath("ws 1", "out dir/a b.png")).toBe(
+      "/api/workspaces/ws%201/download/out%20dir/a%20b.png"
+    );
+  });
+});

--- a/web/src/components/workspace/workspaceFileKind.ts
+++ b/web/src/components/workspace/workspaceFileKind.ts
@@ -60,6 +60,21 @@ const EXTENSION_KIND: Record<string, WorkspaceFileKind> = {
   usdz: "model3d"
 };
 
+/** Extensionless filenames that are conventionally text. */
+const TEXT_BASENAMES = new Set([
+  "license",
+  "licence",
+  "readme",
+  "changelog",
+  "authors",
+  "contributing",
+  "notice",
+  "copying",
+  "makefile",
+  "dockerfile",
+  "procfile"
+]);
+
 const extensionOf = (filename: string): string => {
   const base = filename.split("/").pop() ?? filename;
   const dot = base.lastIndexOf(".");
@@ -88,9 +103,13 @@ export const workspaceFileKind = (filename: string): WorkspaceFileKind => {
   }
   const ext = extensionOf(filename);
   const base = filename.split("/").pop()?.toLowerCase() ?? "";
-  // Plain text only when the name says so: ".txt"/".log", or a dotfile
-  // (".gitignore", ".env") which carries no extension at all.
-  return ext === "txt" || ext === "log" || base.startsWith(".")
+  // Plain text only when the name says so: ".txt"/".log", a dotfile
+  // (".gitignore", ".env") which carries no extension at all, or a
+  // conventional extensionless name (LICENSE, README, Makefile).
+  return ext === "txt" ||
+    ext === "log" ||
+    base.startsWith(".") ||
+    TEXT_BASENAMES.has(base)
     ? "text"
     : "binary";
 };

--- a/web/src/components/workspace/workspaceFileKind.ts
+++ b/web/src/components/workspace/workspaceFileKind.ts
@@ -1,0 +1,96 @@
+// workspaceFileKind.ts
+// -----------------------------------------------------------------
+// Decides which viewer/editor a workspace file opens in, from its
+// filename alone — the download endpoint's own content-type guess
+// (packages/websocket/src/workspace-api.ts) works the same way.
+// Pure, so the dispatch is testable without mounting the surface.
+// -----------------------------------------------------------------
+
+import { previewKind } from "../../utils/assetLanguage";
+
+export type WorkspaceFileKind =
+  | "image"
+  | "audio"
+  | "video"
+  | "pdf"
+  | "model3d"
+  | "markdown"
+  | "csv"
+  | "code"
+  | "text"
+  | "binary";
+
+const EXTENSION_KIND: Record<string, WorkspaceFileKind> = {
+  png: "image",
+  jpg: "image",
+  jpeg: "image",
+  gif: "image",
+  webp: "image",
+  bmp: "image",
+  avif: "image",
+  ico: "image",
+  tif: "image",
+  tiff: "image",
+  svg: "image",
+
+  mp3: "audio",
+  wav: "audio",
+  ogg: "audio",
+  oga: "audio",
+  flac: "audio",
+  m4a: "audio",
+  aac: "audio",
+  opus: "audio",
+
+  mp4: "video",
+  webm: "video",
+  mov: "video",
+  m4v: "video",
+  mkv: "video",
+  avi: "video",
+
+  pdf: "pdf",
+
+  glb: "model3d",
+  gltf: "model3d",
+  obj: "model3d",
+  fbx: "model3d",
+  stl: "model3d",
+  ply: "model3d",
+  usdz: "model3d"
+};
+
+const extensionOf = (filename: string): string => {
+  const base = filename.split("/").pop() ?? filename;
+  const dot = base.lastIndexOf(".");
+  return dot > 0 ? base.slice(dot + 1).toLowerCase() : "";
+};
+
+/** Whether the kind is rendered as text (Monaco / markdown / table). */
+export const isTextKind = (kind: WorkspaceFileKind): boolean =>
+  kind === "markdown" || kind === "csv" || kind === "code" || kind === "text";
+
+/**
+ * Classify a workspace file by name. Media and 3D formats go to their viewer,
+ * every known text format to the text pane, and anything else is binary — a
+ * file-info panel with a download link.
+ */
+export const workspaceFileKind = (filename: string): WorkspaceFileKind => {
+  const media = EXTENSION_KIND[extensionOf(filename)];
+  if (media) {
+    return media;
+  }
+  // previewKind returns "text" for anything it cannot place, so ask it for a
+  // language first: no language means the file is not text at all.
+  const kind = previewKind({ name: filename });
+  if (kind !== "text") {
+    return kind;
+  }
+  const ext = extensionOf(filename);
+  const base = filename.split("/").pop()?.toLowerCase() ?? "";
+  // Plain text only when the name says so: ".txt"/".log", or a dotfile
+  // (".gitignore", ".env") which carries no extension at all.
+  return ext === "txt" || ext === "log" || base.startsWith(".")
+    ? "text"
+    : "binary";
+};

--- a/web/src/components/workspace/workspaceFileRef.ts
+++ b/web/src/components/workspace/workspaceFileRef.ts
@@ -1,0 +1,58 @@
+// workspaceFileRef.ts
+// -----------------------------------------------------------------
+// The `ref` of a `workspace-file` tab is `${workspaceId}::${path}`.
+// The path is workspace-relative and may contain "/", so only the
+// FIRST separator splits the ref — a path is never re-split.
+// -----------------------------------------------------------------
+
+const SEPARATOR = "::";
+
+export interface WorkspaceFileRef {
+  workspaceId: string;
+  /** Workspace-relative path, no leading slash, "/" separated. */
+  path: string;
+}
+
+/** Strip leading "./" and "/" so one file always yields one ref. */
+const normalizePath = (path: string): string =>
+  path.replace(/^\.\//, "").replace(/^\/+/, "");
+
+export const buildWorkspaceFileRef = (
+  workspaceId: string,
+  path: string
+): string => `${workspaceId}${SEPARATOR}${normalizePath(path)}`;
+
+/** Parse a ref, or `null` when it is not a well-formed workspace-file ref. */
+export const parseWorkspaceFileRef = (
+  ref: string
+): WorkspaceFileRef | null => {
+  const index = ref.indexOf(SEPARATOR);
+  if (index <= 0) {
+    return null;
+  }
+  const workspaceId = ref.slice(0, index);
+  const path = normalizePath(ref.slice(index + SEPARATOR.length));
+  if (path.length === 0) {
+    return null;
+  }
+  return { workspaceId, path };
+};
+
+/** The basename of a workspace-relative path. */
+export const workspaceFileName = (path: string): string =>
+  path.split("/").filter(Boolean).pop() ?? path;
+
+/**
+ * The REST download endpoint for a workspace file. Each path segment is
+ * encoded on its own so the "/" separators survive.
+ */
+export const workspaceFileDownloadPath = (
+  workspaceId: string,
+  path: string
+): string =>
+  `/api/workspaces/${encodeURIComponent(workspaceId)}/download/${normalizePath(
+    path
+  )
+    .split("/")
+    .map(encodeURIComponent)
+    .join("/")}`;

--- a/web/src/components/workspaces/WorkspaceTree.tsx
+++ b/web/src/components/workspaces/WorkspaceTree.tsx
@@ -12,8 +12,10 @@ import type { Theme } from "@mui/material/styles";
 import FolderOpenIcon from "@mui/icons-material/FolderOpen";
 import AddIcon from "@mui/icons-material/Add";
 import NavigateNextIcon from "@mui/icons-material/NavigateNext";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { RefreshButton, SettingsButton } from "../ui_primitives";
 import { openPageTab } from "../workspace/openPageTab";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
 import { useWorkspaceExplorer } from "../../hooks/useWorkspaceExplorer";
 import WorkspaceSelect from "./WorkspaceSelect";
 import PanelHeadline from "../ui/PanelHeadline";
@@ -291,6 +293,8 @@ const WorkspaceTree: React.FC = () => {
   const expandedItemsRef = useRef<string[]>([]);
   expandedItemsRef.current = expandedItems;
 
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+
   const {
     workspaceId,
     setWorkspaceId,
@@ -390,14 +394,35 @@ const WorkspaceTree: React.FC = () => {
     [loadItemChildren]
   );
 
+  // Double-click opens the file as a workspace tab. Handing it to the OS is a
+  // secondary action on the selected file ("Open Externally"), Electron only.
   const handleItemDoubleClick = useCallback(
-    async (event: React.MouseEvent, itemId: string) => {
-      if (window.api?.shell?.openPath) {
-        await window.api.shell.openPath(itemId);
+    async (_event: React.MouseEvent, itemId: string) => {
+      const wsId = workspaceIdRef.current;
+      if (!wsId || itemId.endsWith("/loading") || itemId.endsWith("/error")) {
+        return;
       }
+      const item = findItemInTree(filesRef.current, itemId);
+      if (item?.treeItemProps?.className === "folder-item") {
+        await loadItemChildren(itemId);
+        return;
+      }
+      openTab({
+        type: "workspace-file",
+        ref: `${wsId}::${itemId}`,
+        mode: "view",
+        title: item?.label ?? itemId.split("/").pop() ?? itemId
+      });
     },
-    []
+    [loadItemChildren, openTab]
   );
+
+  const handleOpenExternally = useCallback(async () => {
+    if (!selectedFilePath) { return; }
+    if (window.api?.shell?.openPath) {
+      await window.api.shell.openPath(selectedFilePath);
+    }
+  }, [selectedFilePath]);
 
   const handleOpenInFolder = useCallback(async () => {
     if (!selectedFilePath) { return; }
@@ -489,6 +514,16 @@ const WorkspaceTree: React.FC = () => {
           >
             Open in Folder
           </EditorButton>
+          {Boolean(window.api?.shell?.openPath) && (
+            <EditorButton
+              className="open-folder-button"
+              variant="outlined"
+              startIcon={<OpenInNewIcon />}
+              onClick={handleOpenExternally}
+            >
+              Open Externally
+            </EditorButton>
+          )}
         </div>
       )}
 

--- a/web/src/components/workspaces/__tests__/WorkspaceTree.test.tsx
+++ b/web/src/components/workspaces/__tests__/WorkspaceTree.test.tsx
@@ -7,6 +7,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import mockTheme from "../../../__mocks__/themeMock";
 import WorkspaceTree from "../WorkspaceTree";
 import { useWorkspaceExplorerStore } from "../../../stores/WorkspaceExplorerStore";
+import { useWorkspaceTabsStore } from "../../../stores/WorkspaceTabsStore";
 
 const defaultWorkspace = {
   id: "ws-default",
@@ -62,6 +63,7 @@ describe("WorkspaceTree", () => {
       { name: "notes.md", path: "notes.md", is_dir: false, size: 12 }
     ]);
     useWorkspaceExplorerStore.getState().setBrowsedWorkspaceId(null);
+    useWorkspaceTabsStore.setState({ tabs: [], activeTabId: null });
   });
 
   it("lists the default workspace's files with no workflow open", async () => {
@@ -83,6 +85,21 @@ describe("WorkspaceTree", () => {
     expect(useWorkspaceExplorerStore.getState().browsedWorkspaceId).toBe(
       "ws-renders"
     );
+  });
+
+  it("opens a double-clicked file as a workspace-file tab", async () => {
+    renderTree();
+    await userEvent.dblClick(await screen.findByText("notes.md"));
+
+    const tab = useWorkspaceTabsStore
+      .getState()
+      .tabs.find((t) => t.type === "workspace-file");
+    expect(tab).toMatchObject({
+      type: "workspace-file",
+      ref: "ws-default::notes.md",
+      mode: "view",
+      title: "notes.md"
+    });
   });
 
   it("re-lists open folders on refresh, so a file written into one appears", async () => {

--- a/web/src/config/__tests__/quickAccessCategories.test.ts
+++ b/web/src/config/__tests__/quickAccessCategories.test.ts
@@ -33,7 +33,7 @@ const idsIn = (category: NodeCategoryId, all: NodeMetadata[]): string[] =>
   );
 
 describe("quickAccessCategories", () => {
-  it("ships fifteen top-level views in order", () => {
+  it("ships sixteen top-level views in order", () => {
     const ids = LEFT_PANEL_TOP_LEVEL.map((c) => c.id);
     expect(ids).toEqual([
       "nodes",
@@ -49,6 +49,7 @@ describe("quickAccessCategories", () => {
       "timelines",
       "jsscripts",
       "settings",
+      "workspace-files",
       "assets",
       "library"
     ]);
@@ -91,7 +92,7 @@ describe("quickAccessCategories", () => {
       {
         id: "workflow-context",
         placement: "bottom",
-        views: ["settings", "assets", "library"]
+        views: ["settings", "workspace-files", "assets", "library"]
       }
     ]);
   });

--- a/web/src/config/quickAccessCategories.tsx
+++ b/web/src/config/quickAccessCategories.tsx
@@ -36,6 +36,7 @@ import PermMediaOutlinedIcon from "@mui/icons-material/PermMediaOutlined";
 import CollectionsOutlinedIcon from "@mui/icons-material/CollectionsOutlined";
 import ForumOutlinedIcon from "@mui/icons-material/ForumOutlined";
 import PersonOutlineOutlinedIcon from "@mui/icons-material/PersonOutlineOutlined";
+import FolderOutlinedIcon from "@mui/icons-material/FolderOutlined";
 
 import type { NodeMetadata } from "../stores/ApiTypes";
 import {
@@ -196,6 +197,13 @@ const LEFT_PANEL_CATEGORY_BY_ID: Readonly<
     docsTopic: "assets",
     icon: <PermMediaOutlinedIcon />
   },
+  "workspace-files": {
+    id: "workspace-files",
+    label: "Workspace",
+    description: "Browse the files in the selected workspace folder.",
+    docsTopic: "workspaces",
+    icon: <FolderOutlinedIcon />
+  },
   library: {
     id: "library",
     label: "Library",
@@ -250,6 +258,7 @@ export const LEFT_PANEL_GROUPS: readonly LeftPanelGroup[] = [
     placement: "bottom",
     categories: [
       LEFT_PANEL_CATEGORY_BY_ID.settings,
+      LEFT_PANEL_CATEGORY_BY_ID["workspace-files"],
       LEFT_PANEL_CATEGORY_BY_ID.assets,
       LEFT_PANEL_CATEGORY_BY_ID.library
     ]

--- a/web/src/stores/BottomPanelStore.ts
+++ b/web/src/stores/BottomPanelStore.ts
@@ -6,8 +6,11 @@ import { isBoolean, isNumber } from "../utils/typePredicates";
  * Bottom panel hosts secondary workflow tools that used to live in PanelRight.
  * Grouped into:
  *  - "run":      logs, jobs
- *  - "workflow": versions, workspace
+ *  - "workflow": versions
  *  - "debug":    trace
+ *
+ * The workspace file browser moved to the left panel (LeftPanelView
+ * "workspace-files"); a stored activeView of "workspace" falls back to "logs".
  *
  * Workflow settings live in the left panel (LeftPanelView "settings"). Chat
  * now lives in the draggable canvas dock (FloatingToolBar), not a left-panel
@@ -18,7 +21,6 @@ export type BottomPanelView =
   | "queue"
   | "workers"
   | "versions"
-  | "workspace"
   | "trace";
 
 type BottomPanelGroup = "run" | "workflow" | "debug";
@@ -32,7 +34,7 @@ export const BOTTOM_PANEL_GROUPS: ReadonlyArray<{
   {
     id: "workflow",
     label: "Workflow",
-    views: ["versions", "workspace"]
+    views: ["versions"]
   },
   { id: "debug", label: "Debug", views: ["trace"] }
 ];
@@ -40,6 +42,12 @@ export const BOTTOM_PANEL_GROUPS: ReadonlyArray<{
 const ALL_BOTTOM_VIEWS: BottomPanelView[] = BOTTOM_PANEL_GROUPS.flatMap(
   (g) => [...g.views]
 );
+
+function isPersistedShape(
+  value: unknown
+): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 function isBottomPanelView(value: unknown): value is BottomPanelView {
   return typeof value === "string" && (ALL_BOTTOM_VIEWS as readonly string[]).includes(value);
@@ -160,7 +168,23 @@ export const useBottomPanelStore = create<ResizePanelState>()(
     }),
     {
       name: "bottom-panel-storage",
-      version: 2,
+      version: 3,
+      // v3 removed the "workspace" view — the file browser lives in the left
+      // panel now. A persisted selection of it would leave the panel showing
+      // nothing, so it falls back to the default view.
+      migrate: (persistedState, _version) => {
+        if (!isPersistedShape(persistedState)) {
+          return persistedState;
+        }
+        const panel = persistedState.panel;
+        if (!isPersistedShape(panel) || panel.activeView !== "workspace") {
+          return persistedState;
+        }
+        return {
+          ...persistedState,
+          panel: { ...panel, activeView: "logs" }
+        };
+      },
       partialize: (state: ResizePanelState) => ({
         panel: {
           panelSize: state.panel.panelSize,

--- a/web/src/stores/PanelStore.ts
+++ b/web/src/stores/PanelStore.ts
@@ -26,6 +26,7 @@ export type LeftPanelView =
   | "favorites"
   | "assets"
   | "library"
+  | "workspace-files"
   | "nodes";
 export type PanelView = LeftPanelView;
 
@@ -87,6 +88,7 @@ const VALID_VIEWS: LeftPanelView[] = [
   "favorites",
   "assets",
   "library",
+  "workspace-files",
   "nodes"
 ];
 

--- a/web/src/stores/WorkspaceTabsStore.ts
+++ b/web/src/stores/WorkspaceTabsStore.ts
@@ -30,6 +30,9 @@ export type WorkspaceTabType =
   | "application"
   // Chat conversations. `ref` is a chat thread id (GlobalChatStore).
   | "chat"
+  // Files inside a run workspace. `ref` is `${workspaceId}::${path}` — see
+  // components/workspace/workspaceFileRef.ts.
+  | "workspace-file"
   // App pages (Settings, Costs, Model Manager, …) opened from the logo menu.
   // `ref` is a PageTabKey; these have no edit mode.
   | "page";

--- a/web/src/stores/__tests__/BottomPanelStore.test.ts
+++ b/web/src/stores/__tests__/BottomPanelStore.test.ts
@@ -20,6 +20,33 @@ describe("BottomPanelStore", () => {
     });
   });
 
+  describe("persist migration", () => {
+    const getMigrate = () => {
+      const { migrate } = useBottomPanelStore.persist.getOptions();
+      if (!migrate) {
+        throw new Error("BottomPanelStore declares no migrate function");
+      }
+      return migrate;
+    };
+
+    it("falls back to logs when the removed workspace view was stored", () => {
+      const migrated = getMigrate()(
+        { panel: { activeView: "workspace", panelSize: 300, isVisible: true } },
+        2
+      ) as { panel: { activeView: string; panelSize: number } };
+      expect(migrated.panel.activeView).toBe("logs");
+      expect(migrated.panel.panelSize).toBe(300);
+    });
+
+    it("leaves a still-valid view alone", () => {
+      const migrated = getMigrate()(
+        { panel: { activeView: "trace" } },
+        2
+      ) as { panel: { activeView: string } };
+      expect(migrated.panel.activeView).toBe("trace");
+    });
+  });
+
   describe("setSize", () => {
     it("should set size within valid range", () => {
       useBottomPanelStore.getState().setSize(400);

--- a/web/src/stores/__tests__/PanelStore.merge.test.ts
+++ b/web/src/stores/__tests__/PanelStore.merge.test.ts
@@ -56,6 +56,12 @@ describe("PanelStore merge (legacy migration)", () => {
     expect(result.panel.activeView).toBe("assets");
   });
 
+  it("keeps the workspace file browser view", () => {
+    const cs = currentState();
+    const result = merge({ panel: { activeView: "workspace-files" } }, cs);
+    expect(result.panel.activeView).toBe("workspace-files");
+  });
+
   it("clamps panelSize to min 60", () => {
     const cs = currentState();
     const result = merge({ panel: { panelSize: 10, activeView: "workflows" } }, cs);

--- a/web/tests/benchmarks/screenshots.spec.ts
+++ b/web/tests/benchmarks/screenshots.spec.ts
@@ -1075,7 +1075,6 @@ if (process.env.JEST_WORKER_ID) {
       { view: "queue", filename: "editor-bottom-panel-queue.png" },
       { view: "sandboxes", filename: "editor-bottom-panel-sandboxes.png" },
       { view: "versions", filename: "editor-bottom-panel-versions.png" },
-      { view: "workspace", filename: "editor-bottom-panel-workspace.png" },
       { view: "trace", filename: "editor-bottom-panel-trace.png" }
     ];
 


### PR DESCRIPTION
## What changed

Moves the workspace file browser from the bottom panel to the left panel and makes workspace files openable as editor tabs. The left panel gains a "Workspace" view (workspace selector + lazy-loading file tree); the bottom panel's workspace tab is removed with a persisted-state migration (`activeView: "workspace"` → `"logs"`). A new `workspace-file` tab type (`ref = workspaceId::path`) renders a `WorkspaceFileSurface` that reuses the existing asset viewers (image/audio/video/PDF/3D) via the REST download URL, and Monaco/Markdown/DataTable for text — edit mode saves through new `workspace.readFile`/`workspace.writeFile` tRPC procedures, which apply the same guards as `listFiles` (relative paths only, traversal → 403, production managed-only) plus a 2 MiB text cap (truncated reads are forced read-only so a partial save can't clobber the file). Double-click in the tree opens the tab; Electron shell-open moved to a secondary button.

## Verification

- [x] `npm run test:affected` — one non-reproducing failure in `@nodetool-ai/text-nodes` during the parallel turbo run; the package passes standalone (241/241), unrelated to this diff (it touches no text-nodes code)
- [x] `npm run typecheck` — exit 0 (web + electron clean; mobile module-resolution errors are the known uninstalled-Expo sandbox gap)
- [x] `npm run lint` — exit 0
- [x] `npm run dev:nodetool -- harness gate --base main` — 3/3 selfchecks, all 5 Ring 0 reliability journeys pass

New backend tests (22, real temp dir) were mutation-proved: disabling the absolute-path guard, read truncation, write size cap, directory guard, traversal mapping, and the `isAccessible()` guard each failed the corresponding tests; source restored and re-verified.

## Agent capabilities

No capability added or re-declared — the new tRPC procedures are classified `withheld` in sandbox coverage (host-path read/write; the sandbox has its own contained workspace API).

## New checks

No new check, rule, or audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SU4zg36j1hCdNSGHwfNKZh