### PR TITLE
perf(websocket): load bundled workflows concurrently on export

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -105,3 +105,6 @@
 ## 2026-05-25 - N+1 query optimization in pruneOldAutosaves
 **Learning:** Found an N+1 query bottleneck in `packages/models/src/workflow-version.ts` where `v.delete()` was called inside a loop over the oldest autosave versions. For workflows with many excess autosaves (e.g. 1500), doing 1500 sequential `DELETE` queries took ~392ms.
 **Action:** Replaced the sequential deletes with batched `DELETE WHERE id IN (...)` queries (using `inArray` from Drizzle) grouped in chunks of 500 to satisfy SQLite query limits. This reduced the time to prune 1500 versions to ~18ms, a significant speedup.
+## 2026-08-26 - Concurrent workflow bundle export
+**Learning:** `handleWorkflowsExportBundle` in `packages/websocket/src/http-api.ts` awaited `loadBundledWorkflow` sequentially for each requested workflow ID, making export latency scale O(N) with the number of workflows even though each load is an independent IO read.
+**Action:** Replaced the sequential loop with `Promise.all(ids.map(...))` to resolve all loads concurrently, then iterate the results to check for per-workflow errors and build the bundle.

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -1419,9 +1419,11 @@ export async function handleWorkflowsExportBundle(
   if (ids.length === 0) {
     return errorResponse(400, "workflow_ids (non-empty array) is required");
   }
+  const loadedResults = await Promise.all(
+    ids.map((id) => loadBundledWorkflow(id, userId))
+  );
   const workflows: BundledWorkflow[] = [];
-  for (const id of ids) {
-    const loaded = await loadBundledWorkflow(id, userId);
+  for (const loaded of loadedResults) {
     if ("error" in loaded) {
       return loaded.error;
     }


### PR DESCRIPTION
## What changed

`handleWorkflowsExportBundle` (`packages/websocket/src/http-api.ts`) awaited `loadBundledWorkflow` sequentially for each workflow ID in a bundle export, so latency scaled O(N) with the bundle size even though each load is an independent DB/asset read. Resolves them concurrently with `Promise.all` instead, then walks the results in order to preserve the existing per-workflow error handling and output ordering.

This supersedes #5293, which had the same intent but bit-rotted against `main`: it carried a merge conflict, reverted unrelated `package-lock.json` entries, deleted most of `.jules/bolt.md`'s history instead of appending to it, and added two stray debug scripts (`benchmark.cjs`, `test-concurrent.cjs`) that shouldn't ship. This PR rebases the actual fix onto current `main`, appends a single learnings entry to `.jules/bolt.md` instead of truncating it, and drops the debug scripts and lockfile noise. No review comments needed addressing beyond that (PR #5293 only had Jules bot's automated intro comment).

## Verification

- [x] `npm run test --workspace=packages/websocket` — 226 test files / 2513 tests passed
- [x] `npm run typecheck` — web and electron clean (mobile has pre-existing unrelated errors from its dependency tree not being installed, per AGENTS.md)
- [x] `npm run lint` — clean (pre-existing warnings only, unrelated to this diff)
- [x] `npm run dev:nodetool -- harness gate --base main` — 0 selfchecks required for this diff

## Agent capabilities

N/A — no capability added or changed.

## New checks

N/A — no new check, rule, or audit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LfS2jdqBPR9xt9oh4EqA1v)_