### PR TITLE
feat(fal-nodes): add Meta Muse Image text-to-image and edit nodes

### DIFF
--- a/packages/fal-codegen/src/configs/image-to-image.ts
+++ b/packages/fal-codegen/src/configs/image-to-image.ts
@@ -16,6 +16,39 @@ export const config: ModuleConfig = {
     }
   },
   configs: {
+    "meta/muse-image/edit": {
+      className: "MuseImageEdit",
+      docstring:
+        "Meta Muse Image Edit makes precise edits to one or more reference images from a text instruction, keeping changes coherent with the rest of the image.",
+      tags: ["editing", "image-to-image", "img2img", "meta", "muse"],
+      useCases: [
+        "Edit an image from a written instruction",
+        "Compose a new image from multiple reference images",
+        "Replace or remove objects in a photo",
+        "Restyle an image without redrawing it",
+        "Iterate on a generated image across turns"
+      ],
+      fieldOverrides: {
+        prompt: {
+          description: "The text prompt describing the desired edit"
+        },
+        image_urls: {
+          description:
+            "Reference images used for the edit. Provide between 1 and 10 images"
+        },
+        num_images: {
+          description: "The number of edited images to generate"
+        },
+        aspect_ratio: {
+          description:
+            "The output aspect ratio. If omitted, Muse chooses the dimensions automatically"
+        },
+        output_format: {
+          description: "The format of the generated image"
+        }
+      }
+    },
+
     "fal-ai/flux-2/edit": {
       className: "Flux2Edit",
       docstring:

--- a/packages/fal-codegen/src/configs/text-to-image.ts
+++ b/packages/fal-codegen/src/configs/text-to-image.ts
@@ -16,6 +16,35 @@ export const config: ModuleConfig = {
     }
   },
   configs: {
+    "meta/muse-image/text-to-image": {
+      className: "MuseImageTextToImage",
+      docstring:
+        "Meta Muse Image generates images from text, reasoning about the request before rendering to compose scenes with strong prompt adherence.",
+      tags: ["generation", "text-to-image", "txt2img", "meta", "muse"],
+      useCases: [
+        "Generate photorealistic images from prompts",
+        "Create editorial and marketing visuals",
+        "Produce illustrations with fine detail",
+        "Generate multiple variations from one prompt",
+        "Render images at a chosen aspect ratio"
+      ],
+      fieldOverrides: {
+        prompt: {
+          description: "The text prompt used to generate the image"
+        },
+        num_images: {
+          description: "The number of images to generate"
+        },
+        aspect_ratio: {
+          description:
+            "The output aspect ratio. If omitted, Muse chooses the dimensions automatically"
+        },
+        output_format: {
+          description: "The format of the generated image"
+        }
+      }
+    },
+
     "fal-ai/flux-2": {
       className: "Flux2",
       docstring:

--- a/packages/fal-nodes/src/fal-manifest.json
+++ b/packages/fal-nodes/src/fal-manifest.json
@@ -350079,5 +350079,341 @@
       }
     ],
     "moduleName": "text_to_video"
+  },
+  {
+    "endpointId": "meta/muse-image/edit",
+    "className": "MuseImageEdit",
+    "docstring": "Meta Muse Image Edit makes precise edits to one or more reference images from a text instruction, keeping changes coherent with the rest of the image.",
+    "tags": [
+      "editing",
+      "image-to-image",
+      "img2img",
+      "meta",
+      "muse"
+    ],
+    "useCases": [
+      "Edit an image from a written instruction",
+      "Compose a new image from multiple reference images",
+      "Replace or remove objects in a photo",
+      "Restyle an image without redrawing it",
+      "Iterate on a generated image across turns"
+    ],
+    "inputFields": [
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The text prompt describing the desired edit",
+        "fieldType": "input",
+        "required": true,
+        "min": 1
+      },
+      {
+        "name": "images",
+        "tsType": "image[]",
+        "propType": "list[image]",
+        "default": [],
+        "description": "Reference images used for the edit. Provide between 1 and 10 HTTP(S) or data URLs.",
+        "fieldType": "input",
+        "required": true,
+        "min": 1,
+        "max": 10,
+        "apiParamName": "image_urls"
+      },
+      {
+        "name": "num_images",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "The number of edited images to generate",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": null,
+        "description": "The output aspect ratio. If omitted, Muse chooses the dimensions automatically",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "21:9",
+          "16:9",
+          "4:3",
+          "3:2",
+          "1:1",
+          "2:3",
+          "3:4",
+          "9:16",
+          "9:21"
+        ]
+      },
+      {
+        "name": "sync_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If `True`, the image is returned as a data URI and is not persisted in the request history.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "The format of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpeg",
+          "png",
+          "webp"
+        ]
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "images",
+        "tsType": "Image[]",
+        "propType": "list[Image]",
+        "default": [],
+        "description": "The generated or edited images.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ]
+        ],
+        "description": "The output aspect ratio. Supported values are \"21:9\", \"16:9\", \"4:3\", \"3:2\", \"1:1\", \"2:3\", \"3:4\", \"9:16\", and \"9:21\". If omitted, Muse chooses the output dimensions automatically based on the request."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPEG",
+            "jpeg"
+          ],
+          [
+            "PNG",
+            "png"
+          ],
+          [
+            "WEBP",
+            "webp"
+          ]
+        ],
+        "description": "The format of the generated image."
+      }
+    ],
+    "moduleName": "image_to_image"
+  },
+  {
+    "endpointId": "meta/muse-image/text-to-image",
+    "className": "MuseImageTextToImage",
+    "docstring": "Meta Muse Image generates images from text, reasoning about the request before rendering to compose scenes with strong prompt adherence.",
+    "tags": [
+      "generation",
+      "text-to-image",
+      "txt2img",
+      "meta",
+      "muse"
+    ],
+    "useCases": [
+      "Generate photorealistic images from prompts",
+      "Create editorial and marketing visuals",
+      "Produce illustrations with fine detail",
+      "Generate multiple variations from one prompt",
+      "Render images at a chosen aspect ratio"
+    ],
+    "inputFields": [
+      {
+        "name": "prompt",
+        "tsType": "string",
+        "propType": "str",
+        "default": "",
+        "description": "The text prompt used to generate the image",
+        "fieldType": "input",
+        "required": true,
+        "min": 1
+      },
+      {
+        "name": "num_images",
+        "tsType": "number",
+        "propType": "int",
+        "default": 1,
+        "description": "The number of images to generate",
+        "fieldType": "input",
+        "required": false,
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "aspect_ratio",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": null,
+        "description": "The output aspect ratio. If omitted, Muse chooses the dimensions automatically",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "AspectRatio",
+        "enumValues": [
+          "21:9",
+          "16:9",
+          "4:3",
+          "3:2",
+          "1:1",
+          "2:3",
+          "3:4",
+          "9:16",
+          "9:21"
+        ]
+      },
+      {
+        "name": "sync_mode",
+        "tsType": "boolean",
+        "propType": "bool",
+        "default": false,
+        "description": "If `True`, the image is returned as a data URI and is not persisted in the request history.",
+        "fieldType": "input",
+        "required": false
+      },
+      {
+        "name": "output_format",
+        "tsType": "enum",
+        "propType": "enum",
+        "default": "webp",
+        "description": "The format of the generated image",
+        "fieldType": "input",
+        "required": false,
+        "enumRef": "OutputFormat",
+        "enumValues": [
+          "jpeg",
+          "png",
+          "webp"
+        ]
+      }
+    ],
+    "outputType": "image",
+    "outputFields": [
+      {
+        "name": "images",
+        "tsType": "Image[]",
+        "propType": "list[Image]",
+        "default": [],
+        "description": "The generated or edited images.",
+        "fieldType": "output",
+        "required": true
+      }
+    ],
+    "enums": [
+      {
+        "name": "AspectRatio",
+        "values": [
+          [
+            "RATIO_21_9",
+            "21:9"
+          ],
+          [
+            "RATIO_16_9",
+            "16:9"
+          ],
+          [
+            "RATIO_4_3",
+            "4:3"
+          ],
+          [
+            "RATIO_3_2",
+            "3:2"
+          ],
+          [
+            "RATIO_1_1",
+            "1:1"
+          ],
+          [
+            "RATIO_2_3",
+            "2:3"
+          ],
+          [
+            "RATIO_3_4",
+            "3:4"
+          ],
+          [
+            "RATIO_9_16",
+            "9:16"
+          ],
+          [
+            "RATIO_9_21",
+            "9:21"
+          ]
+        ],
+        "description": "The output aspect ratio. Supported values are \"21:9\", \"16:9\", \"4:3\", \"3:2\", \"1:1\", \"2:3\", \"3:4\", \"9:16\", and \"9:21\". If omitted, Muse chooses the output dimensions automatically based on the request."
+      },
+      {
+        "name": "OutputFormat",
+        "values": [
+          [
+            "JPEG",
+            "jpeg"
+          ],
+          [
+            "PNG",
+            "png"
+          ],
+          [
+            "WEBP",
+            "webp"
+          ]
+        ],
+        "description": "The format of the generated image."
+      }
+    ],
+    "moduleName": "text_to_image"
   }
 ]


### PR DESCRIPTION
## What changed

Adds support for Meta's Muse Image model on the FAL provider: `meta/muse-image/text-to-image` (generation) and `meta/muse-image/edit` (multi-reference-image editing, 1-10 input images). Both configs were added to `packages/fal-codegen/src/configs/` and appended to the generated `fal-nodes/src/fal-manifest.json` via `npx tsx scripts/append-new-endpoints.ts`, which fetched the live OpenAPI schemas from FAL. Node classes for these are built dynamically from the manifest at runtime (no per-node codegen file needed). Pricing catalogs are generated separately and were left untouched — they'll pick up these models on the next `npm run sync:genspend`/FAL pricing sync, per repo convention against hand-editing generated price data.

## Verification

- [x] `npm run test:affected` — passes (one unrelated pre-existing failure in `@nodetool-ai/image-nodes` GPU shader tests due to no Vulkan driver in this sandbox — documented environment gap, not caused by this change)
- [x] `npm run typecheck` — passes for touched packages (unrelated pre-existing mobile workspace errors from its separate, not-installed dependency tree)
- [x] `npm run lint` — `tsc --noEmit` clean for `packages/fal-codegen` and `packages/fal-nodes`
- [x] `npm run dev:nodetool -- harness gate --base main` — 12/12 selfchecks passed, including `provider-codegen` (fal fixtures match)
- [x] `nodetool node run fal.text_to_image.MuseImageTextToImage --no-secrets` and `fal.image_to_image.MuseImageEdit --no-secrets` — both nodes register and run correctly, failing only on missing `FAL_API_KEY` as expected

## Agent capabilities

Skipped — no capability added or changed.

## New checks

Skipped — no new check, rule, or audit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RJKphzZExrar62YQNQKMS4)_