### PR TITLE
fix(marketing): update imprint provider to David Bührer

### DIFF
--- a/marketing/src/app/imprint/page.tsx
+++ b/marketing/src/app/imprint/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export const dynamic = "force-static";
 
-const LAST_UPDATED = "2 May 2026";
+const LAST_UPDATED = "27 August 2026";
 
 export default function ImprintPage() {
   return (
@@ -31,70 +31,25 @@ export default function ImprintPage() {
 
           <h2>Provider</h2>
           <p>
-            <strong>NodeTool B.V.</strong>
+            <strong>David Bührer</strong>
             <br />
-            Prinsengracht 263
+            Reichenberger Str. 144
             <br />
-            1016 GV Amsterdam
+            10999 Berlin
             <br />
-            The Netherlands
-          </p>
-
-          <h2>Represented by</h2>
-          <p>
-            Managing Directors: Matti Georgi, David de Vries
+            Germany
           </p>
 
           <h2>Contact</h2>
           <p>
             Email: <a href="mailto:hello@nodetool.ai">hello@nodetool.ai</a>
-            <br />
-            Phone: +31 20 123 4567
-          </p>
-
-          <h2>Commercial register</h2>
-          <p>
-            Registered with the Kamer van Koophandel (Dutch Chamber of
-            Commerce)
-            <br />
-            KvK no.: 87654321
-          </p>
-
-          <h2>VAT identification number</h2>
-          <p>
-            VAT ID pursuant to Art. 214 of Council Directive 2006/112/EC:
-            <br />
-            NL864209876B01
           </p>
 
           <h2>Responsible for content pursuant to § 18 (2) MStV</h2>
           <p>
-            Matti Georgi
+            David Bührer
             <br />
-            c/o NodeTool B.V.
-            <br />
-            Prinsengracht 263, 1016 GV Amsterdam, The Netherlands
-          </p>
-
-          <h2>Data Protection Officer</h2>
-          <p>
-            You can reach our Data Protection Officer at{" "}
-            <a href="mailto:dpo@nodetool.ai">dpo@nodetool.ai</a>.
-          </p>
-
-          <h2>Lead supervisory authority</h2>
-          <p>
-            Autoriteit Persoonsgegevens (Dutch Data Protection Authority)
-            <br />
-            Hoge Nieuwstraat 8, 2514 EL Den Haag, The Netherlands
-            <br />
-            <a
-              href="https://autoriteitpersoonsgegevens.nl"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              autoriteitpersoonsgegevens.nl
-            </a>
+            Reichenberger Str. 144, 10999 Berlin, Germany
           </p>
 
           <h2>EU online dispute resolution</h2>
@@ -112,13 +67,6 @@ export default function ImprintPage() {
             resolution proceedings before a consumer arbitration board.
           </p>
 
-          <h2>Digital Services Act — single point of contact</h2>
-          <p>
-            Pursuant to Art. 11 and Art. 12 of Regulation (EU) 2022/2065 (DSA),
-            authorities and users can contact us in English, German, or Dutch
-            at <a href="mailto:dsa@nodetool.ai">dsa@nodetool.ai</a>.
-          </p>
-
           <p className="text-sm text-slate-400">
             See also our <Link href="/privacy">Privacy Policy</Link> and{" "}
             <Link href="/terms">Terms of Use</Link>.
@@ -129,7 +77,7 @@ export default function ImprintPage() {
       <footer className="relative border-t border-slate-800/50 bg-slate-950 py-8">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="flex flex-col items-center justify-between gap-3 sm:flex-row text-sm text-slate-400">
-            <p>© {new Date().getFullYear()} NodeTool B.V.</p>
+            <p>© {new Date().getFullYear()} David Bührer</p>
             <div className="flex gap-5">
               <Link href="/" className="hover:text-slate-200 transition-colors">
                 Home


### PR DESCRIPTION
## Summary
- Replaces the imprint page's provider details with David Bührer, Reichenberger Str. 144, 10999 Berlin, Germany, dropping the placeholder NodeTool B.V. entity, register, and VAT sections.
- Updates the footer copyright line and last-updated date to match.

## Test plan
- [x] Reviewed rendered `marketing/src/app/imprint/page.tsx` content for correctness
- [ ] Marketing site typecheck/build not run locally (pre-existing missing deps in this environment — `framer-motion`, `@heroicons/react` unrelated to this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KokSfecuA5sS2hyNaJu4z2)_