### PR TITLE
feat(storyboard): quiet the shot card's color and tighten its layout

### DIFF
--- a/web/src/components/entities/entityKind.ts
+++ b/web/src/components/entities/entityKind.ts
@@ -10,7 +10,7 @@ import PlaceOutlinedIcon from "@mui/icons-material/PlaceOutlined";
 import PaletteOutlinedIcon from "@mui/icons-material/PaletteOutlined";
 import CategoryOutlinedIcon from "@mui/icons-material/CategoryOutlined";
 import type { EntityKind } from "@nodetool-ai/protocol";
-import { BORDER_RADIUS } from "../ui_primitives";
+import { BORDER_RADIUS, SPACING } from "../ui_primitives";
 
 /** ui_primitives Chip color per entity kind. */
 export const ENTITY_KIND_COLOR = {
@@ -48,3 +48,36 @@ export const ENTITY_KIND_ICON = {
   style: PaletteOutlinedIcon,
   prop: CategoryOutlinedIcon
 } satisfies Record<EntityKind, SvgIconComponent>;
+
+/**
+ * Quiet chip styling for surfaces that show many entity chips at once (the
+ * storyboard shot card). The chip body stays neutral so it reads as metadata
+ * next to the shot text; the kind is carried by the dot the caller renders as
+ * the chip icon, and inclusion in the shot by the text and border strength.
+ */
+export const getEntityChipSx = (applied: boolean) =>
+  ({
+    borderRadius: BORDER_RADIUS.pill,
+    backgroundColor: "transparent",
+    color: applied ? "text.secondary" : "text.disabled",
+    borderColor: applied ? "divider" : "transparent",
+    "& .MuiChip-icon": {
+      marginLeft: SPACING.sm,
+      marginRight: -SPACING.micro
+    }
+  }) as const;
+
+/** The kind dot rendered as an entity chip's icon on quiet chip surfaces. */
+export const getEntityKindDotSx = (kind: EntityKind, applied: boolean) =>
+  ({
+    width: 6,
+    height: 6,
+    borderRadius: BORDER_RADIUS.circle,
+    flexShrink: 0,
+    backgroundColor: applied
+      ? `var(--palette-${ENTITY_KIND_COLOR[kind]}-main)`
+      : "transparent",
+    border: applied
+      ? "none"
+      : `1px solid rgba(var(--palette-${ENTITY_KIND_COLOR[kind]}-mainChannel) / 0.5)`
+  }) as const;

--- a/web/src/components/storyboard/ShotCard.tsx
+++ b/web/src/components/storyboard/ShotCard.tsx
@@ -18,6 +18,7 @@ import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import FullscreenIcon from "@mui/icons-material/Fullscreen";
+import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
 
 import {
   Box,
@@ -26,6 +27,8 @@ import {
   Chip,
   Dialog,
   EditorButton,
+  EditorMenu,
+  EditorMenuItem,
   FlexColumn,
   FlexRow,
   HoverActionGroup,
@@ -53,7 +56,10 @@ import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
 import { useStoryboardGenerationStore } from "../../stores/storyboard/StoryboardGenerationStore";
 import { useShotDuration } from "../../hooks/storyboard/useShotDuration";
 import { useEntities } from "../../serverState/useEntities";
-import { getEntityKindChipSx } from "../entities/entityKind";
+import {
+  getEntityChipSx,
+  getEntityKindDotSx
+} from "../entities/entityKind";
 import { useResolvedMediaUri } from "../../hooks/useResolvedMediaUri";
 
 interface ShotCardProps {
@@ -100,11 +106,27 @@ const previewSx = {
 const cardGridSx = {
   display: "grid",
   gridTemplateColumns: "minmax(220px, 300px) minmax(0, 1fr)",
-  gap: SPACING.md,
+  gap: SPACING.lg,
   alignItems: "start",
   "@media (max-width: 720px)": {
     gridTemplateColumns: "minmax(0, 1fr)"
   }
+} as const;
+
+/**
+ * Secondary actions read as text rather than as a row of equal accent links;
+ * only the step the shot has not taken yet keeps the accent.
+ */
+const quietActionSx = {
+  color: "text.secondary",
+  "&:hover": { color: "text.primary", bgcolor: "c_overlay_subtle" }
+} as const;
+
+/** Metadata chips carry no status color — the label is the whole signal. */
+const quietChipSx = {
+  borderRadius: BORDER_RADIUS.pill,
+  color: "text.secondary",
+  borderColor: "divider"
 } as const;
 
 /** The glow that travels around the frame while a still or clip renders. */
@@ -196,6 +218,9 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
   }, [allEntities, boardEntityIds, shot]);
 
   const [reviseOpen, setReviseOpen] = useState(false);
+  // Anchor for the overflow menu holding the destructive take actions; null
+  // when it is closed.
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const [reviseText, setReviseText] = useState("");
   const [confirmDelete, setConfirmDelete] = useState(false);
   // The still or clip the fullscreen viewer shows; null when it is closed.
@@ -269,11 +294,26 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
     duration.seconds != null
       ? `${duration.seconds}s · ${duration.source === "audio" ? "from takes" : "manual"}`
       : "model default";
+  // Camera and cost share one quiet line under the action text; neither is
+  // worth a chip of its own.
+  const metaLine = [
+    camera.length > 0 ? camera : null,
+    shot.cost_estimate != null ? `~$${shot.cost_estimate.toFixed(2)}` : null
+  ]
+    .filter((p): p is string => p !== null)
+    .join(" · ");
+
   const handleToggleDurationSource = useCallback(() => {
     updateShot(boardId, shot.id, {
       duration_source: shot.duration_source === "manual" ? "audio" : "manual"
     });
   }, [updateShot, boardId, shot.id, shot.duration_source]);
+
+  const handleOpenMenu = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => setMenuAnchor(event.currentTarget),
+    []
+  );
+  const handleCloseMenu = useCallback(() => setMenuAnchor(null), []);
 
   const handleDelete = useCallback(() => {
     removeShot(boardId, shot.id);
@@ -281,6 +321,7 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
   }, [removeShot, boardId, shot.id]);
 
   const handleRemoveStill = useCallback(() => {
+    setMenuAnchor(null);
     const versions =
       shot.keyframe_versions ?? (shot.keyframe ? [shot.keyframe] : []);
     if (versions.length === 0 || !shot.keyframe) {
@@ -300,6 +341,7 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
   ]);
 
   const handleRemoveClip = useCallback(() => {
+    setMenuAnchor(null);
     const versions = shot.clip_versions ?? (shot.clip ? [shot.clip] : []);
     if (versions.length === 0 || !shot.clip) {
       return;
@@ -396,37 +438,16 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
       </Box>
 
       <FlexColumn gap={SPACING.sm} sx={{ minWidth: 0 }}>
-        <FlexRow align="center" justify="space-between" gap={SPACING.xs} wrap>
-          <Text size="small" truncate>
+        <FlexRow align="center" justify="space-between" gap={SPACING.sm}>
+          <Text size="small" truncate sx={{ minWidth: 0 }}>
             {shotName}
           </Text>
-          <FlexRow align="center" gap={SPACING.xs}>
-            {shot.cost_estimate != null && (
-              <Chip
-                compact
-                color="info"
-                label={`~$${shot.cost_estimate.toFixed(2)}`}
-              />
-            )}
-            {linksLines && (
-              <Chip
-                compact
-                color={duration.source === "audio" ? "info" : "default"}
-                variant={duration.source === "audio" ? "filled" : "outlined"}
-                label={durationLabel}
-                sx={{ borderRadius: BORDER_RADIUS.pill }}
-                title={
-                  duration.source === "audio"
-                    ? "Length comes from the takes of the lines this shot covers. Click to pin it to the shot's own duration."
-                    : "Length is pinned to the shot's own duration. Click to take it from the lines this shot covers."
-                }
-                onClick={readOnly ? undefined : handleToggleDurationSource}
-              />
-            )}
+          <FlexRow align="center" gap={SPACING.xs} sx={{ flexShrink: 0 }}>
             <StatusIndicator
               status={meta.status}
               label={meta.label}
               pulse={meta.pulse}
+              labelTone={failed ? "status" : "muted"}
             />
             {!readOnly && (
               <HoverActionGroup
@@ -473,12 +494,32 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
           </Caption>
         )}
 
-        <Text lineClamp={3}>{shot.action}</Text>
+        <Text lineClamp={3} sx={{ lineHeight: 1.6 }}>
+          {shot.action}
+        </Text>
 
-        {camera.length > 0 && (
-          <Caption color="secondary" noWrap>
-            {camera}
-          </Caption>
+        {(metaLine.length > 0 || linksLines) && (
+          <FlexRow align="center" gap={SPACING.sm} wrap>
+            {metaLine.length > 0 && (
+              <Caption color="secondary" noWrap>
+                {metaLine}
+              </Caption>
+            )}
+            {linksLines && (
+              <Chip
+                compact
+                variant="outlined"
+                label={durationLabel}
+                sx={quietChipSx}
+                title={
+                  duration.source === "audio"
+                    ? "Length comes from the takes of the lines this shot covers. Click to pin it to the shot's own duration."
+                    : "Length is pinned to the shot's own duration. Click to take it from the lines this shot covers."
+                }
+                onClick={readOnly ? undefined : handleToggleDurationSource}
+              />
+            )}
+          </FlexRow>
         )}
 
         {boardEntities.length > 0 && (
@@ -491,14 +532,8 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
                   compact
                   label={entity.name || "Untitled"}
                   variant="outlined"
-                  sx={
-                    applied
-                      ? getEntityKindChipSx(entity.kind)
-                      : {
-                          borderRadius: BORDER_RADIUS.pill,
-                          opacity: 0.55
-                        }
-                  }
+                  icon={<Box sx={getEntityKindDotSx(entity.kind, applied)} />}
+                  sx={getEntityChipSx(applied)}
                   title={
                     applied
                       ? `${entity.descriptor || entity.name}: click to exclude from this shot`
@@ -521,16 +556,23 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
         <ShotScriptPanel boardId={boardId} shot={shot} readOnly={readOnly} />
 
         {!readOnly && (
-          <FlexRow gap={SPACING.micro} wrap>
+          <FlexRow
+            gap={SPACING.xs}
+            align="center"
+            wrap
+            sx={{ mt: SPACING.xs }}
+          >
             <EditorButton
               onClick={handleGenerateStill}
               disabled={isGenerating}
+              sx={shot.keyframe ? quietActionSx : undefined}
             >
               {shot.keyframe ? "New still" : "Generate still"}
             </EditorButton>
             <EditorButton
               onClick={handleGenerateClip}
               disabled={isGenerating || !shot.keyframe}
+              sx={shot.clip ? quietActionSx : undefined}
               title={
                 shot.keyframe
                   ? "Animate the selected still into a clip"
@@ -543,31 +585,40 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
               <EditorButton
                 onClick={() => setReviseOpen(true)}
                 disabled={isGenerating}
+                sx={quietActionSx}
               >
                 Revise clip
               </EditorButton>
             )}
-            {shot.keyframe && (
-              <EditorButton
-                onClick={handleRemoveStill}
+            {(shot.keyframe || shot.clip) && (
+              <ToolbarIconButton
+                icon={<MoreHorizIcon sx={{ fontSize: "1em" }} />}
+                tooltip="More actions"
+                ariaLabel="More shot actions"
+                onClick={handleOpenMenu}
                 disabled={isGenerating}
-                title="Remove the selected still from this shot"
-              >
-                Remove still
-              </EditorButton>
-            )}
-            {shot.clip && (
-              <EditorButton
-                onClick={handleRemoveClip}
-                disabled={isGenerating}
-                title="Remove the selected clip from this shot"
-              >
-                Remove clip
-              </EditorButton>
+              />
             )}
           </FlexRow>
         )}
       </FlexColumn>
+
+      <EditorMenu
+        open={menuAnchor !== null}
+        anchorEl={menuAnchor}
+        onClose={handleCloseMenu}
+      >
+        {shot.keyframe && (
+          <EditorMenuItem onClick={handleRemoveStill}>
+            Remove still
+          </EditorMenuItem>
+        )}
+        {shot.clip && (
+          <EditorMenuItem onClick={handleRemoveClip}>
+            Remove clip
+          </EditorMenuItem>
+        )}
+      </EditorMenu>
 
       <Dialog
         open={reviseOpen}

--- a/web/src/components/storyboard/ShotTakesGallery.tsx
+++ b/web/src/components/storyboard/ShotTakesGallery.tsx
@@ -44,7 +44,7 @@ interface ShotTakesGalleryProps {
 }
 
 const takeThumbSx = {
-  width: getSpacingPx(24),
+  width: getSpacingPx(20),
   aspectRatio: "16 / 9",
   p: 0,
   overflow: "hidden",
@@ -62,9 +62,13 @@ const takeThumbSx = {
     objectFit: "cover",
     display: "block"
   },
+  // Unselected takes sit back; the selected one is the only lit thumbnail,
+  // marked by a border rather than a glow.
+  opacity: 0.6,
+  "&:hover": { opacity: 1 },
   "&[aria-pressed='true']": {
-    borderColor: "primary.main",
-    boxShadow: "0 0 0 1px var(--palette-primary-main)"
+    opacity: 1,
+    borderColor: "primary.main"
   },
   "&:disabled": {
     cursor: "default"
@@ -200,9 +204,15 @@ const ShotTakesGalleryInner: React.FC<ShotTakesGalleryProps> = ({
 
   return (
     <FlexColumn gap={SPACING.xs} className="takes">
-      <FlexRow align="center" justify="space-between" gap={SPACING.xs}>
+      <FlexRow align="center" gap={SPACING.xs}>
         <Caption color="secondary">{`Takes: ${countLabel}`}</Caption>
-        <EditorButton onClick={handleToggle}>
+        <EditorButton
+          onClick={handleToggle}
+          sx={{
+            color: "text.secondary",
+            "&:hover": { color: "text.primary", bgcolor: "c_overlay_subtle" }
+          }}
+        >
           {expanded ? "Hide takes" : "View takes"}
         </EditorButton>
       </FlexRow>
@@ -263,8 +273,13 @@ const ShotTakesGalleryInner: React.FC<ShotTakesGalleryProps> = ({
               <Chip
                 compact
                 clickable={!readOnly}
-                color={i === selectedClip ? "primary" : "default"}
+                variant="outlined"
                 label={`Take ${i + 1}`}
+                sx={{
+                  borderRadius: BORDER_RADIUS.pill,
+                  color: i === selectedClip ? "text.primary" : "text.secondary",
+                  borderColor: i === selectedClip ? "primary.main" : "divider"
+                }}
                 onClick={readOnly ? undefined : () => handleSelectClip(i)}
               />
               {!readOnly && (

--- a/web/src/components/storyboard/__tests__/ShotCard.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotCard.test.tsx
@@ -33,6 +33,8 @@ jest.mock("../../../hooks/storyboard/useGenerateShot", () => ({
 const moveShotMock = jest.fn();
 const removeShotMock = jest.fn();
 const updateShotMock = jest.fn();
+const removeKeyframeVersionMock = jest.fn();
+const removeClipVersionMock = jest.fn();
 /** Script the board links, if any — set per test before rendering. */
 let linkedScriptId: string | null = null;
 jest.mock("../../../stores/storyboard/StoryboardStore", () => {
@@ -51,6 +53,8 @@ jest.mock("../../../stores/storyboard/StoryboardStore", () => {
         updateShot: updateShotMock,
         selectKeyframeVersion: jest.fn(),
         selectClipVersion: jest.fn(),
+        removeKeyframeVersion: removeKeyframeVersionMock,
+        removeClipVersion: removeClipVersionMock,
         boards: {
           "board-1": {
             screenplay: linkedScriptId ? { script_id: linkedScriptId } : null
@@ -146,6 +150,8 @@ describe("ShotCard", () => {
     moveShotMock.mockClear();
     removeShotMock.mockClear();
     updateShotMock.mockClear();
+    removeKeyframeVersionMock.mockClear();
+    removeClipVersionMock.mockClear();
     linkedScriptId = null;
     lineIsVoiced = true;
   });
@@ -320,6 +326,48 @@ describe("ShotCard", () => {
     renderCard(makeShot());
     expect(
       screen.queryByRole("button", { name: /fullscreen/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the destructive take actions in the overflow menu", async () => {
+    renderCard(
+      makeShot({
+        status: "rendered",
+        keyframe: { type: "image", uri: "http://example.com/still.png" },
+        clip: { type: "video", uri: "http://example.com/clip.mp4" }
+      })
+    );
+
+    // The action row stays short: removals live behind the overflow.
+    expect(
+      screen.queryByRole("menuitem", { name: "Remove still" })
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "More shot actions" })
+    );
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: "Remove still" })
+    );
+    expect(removeKeyframeVersionMock).toHaveBeenCalledWith(
+      "board-1",
+      "shot-1",
+      0
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "More shot actions" })
+    );
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: "Remove clip" })
+    );
+    expect(removeClipVersionMock).toHaveBeenCalledWith("board-1", "shot-1", 0);
+  });
+
+  it("offers no overflow menu before a shot has any media", () => {
+    renderCard(makeShot());
+    expect(
+      screen.queryByRole("button", { name: "More shot actions" })
     ).not.toBeInTheDocument();
   });
 

--- a/web/src/components/ui_primitives/StatusIndicator.tsx
+++ b/web/src/components/ui_primitives/StatusIndicator.tsx
@@ -47,6 +47,12 @@ export interface StatusIndicatorProps {
   filledIcon?: boolean;
   /** Pulse animation for pending/active states */
   pulse?: boolean;
+  /**
+   * Label color. "status" tints the label like the dot; "muted" keeps the
+   * label in secondary text so a wall of indicators stays quiet and only the
+   * dot carries the color.
+   */
+  labelTone?: "status" | "muted";
   /** Optional tooltip */
   tooltip?: string;
   /** Size */
@@ -70,6 +76,7 @@ const StatusIndicatorInternal: React.FC<StatusIndicatorProps> = ({
   showIcon = true,
   filledIcon = false,
   pulse = false,
+  labelTone = "status",
   tooltip,
   size = "small",
   className
@@ -108,7 +115,7 @@ const StatusIndicatorInternal: React.FC<StatusIndicatorProps> = ({
           color: statusColors[status]
         },
         ".status-label": {
-          color: statusColors[status],
+          color: labelTone === "muted" ? "text.secondary" : statusColors[status],
           fontSize: size === "small" ? 12 : 14
         }
       }}


### PR DESCRIPTION
## What changed

A storyboard shot card put color on nearly everything: entity chips tinted per kind, an info-colored cost chip, a status-tinted status label, a glow ring on the selected take, and five equally weighted accent buttons — so the still and the action text competed with their own metadata. Color now carries one signal per surface. Entity chips are neutral with a 6px kind dot, so four entities read as a row of labels rather than a paint chart. Cost joins the camera line as plain text. The status label drops to secondary and only the dot keeps the status color (`StatusIndicator` gains a `labelTone` prop). Take thumbnails sit at 0.6 opacity with the selected one lit and outlined instead of glowing. The action row keeps the step the shot has not taken yet in accent, drops the rest to text, and moves **Remove still** / **Remove clip** into an overflow menu — which is what makes the row short enough to read at a glance. Column gap goes 8px → 12px and the action row gets a 4px lead so the card groups instead of stacking evenly.

Verified visually by rendering the real `ShotCard` (three shots: planned, rendered with takes, still-ready) against the running dev server and comparing with the reported screenshot; the temporary preview page was removed before committing.

## Verification

- [x] `npm run test:affected` — the diff's own suites pass. The full run selected everything (the clone's `origin/main` was stale) and the only failure was `@nodetool-ai/image-nodes`, which fails in this sandbox with `No WebGPU adapter available (Node/Dawn)` — the missing-Vulkan-driver gap AGENTS.md documents, unrelated to a web-only diff. Ran `npx jest --findRelatedTests` over the four changed source files instead: **369 suites passed, 3095 tests passed, 3 skipped.**
- [x] `npm run typecheck` — web and electron pass. `typecheck:mobile` fails on `Cannot find module 'expo'` / `'react-native'`: `mobile/node_modules` is not installed in this sandbox and no mobile file is touched.
- [x] `npm run lint` — clean (exit 0), plus the four design-token CSS linters.
- [x] `npm run dev:nodetool -- harness gate --base HEAD~1` — **3/3 selfchecks passed** over the 3 surfaces this diff touches. (`--base main` was run first against the stale `origin/main`, which selected 1028 unrelated files; after fetching, the branch is one commit ahead.)

## Agent capabilities

No capability added and no declared contract changed.

## New checks

No check, rule, or audit added. Two tests pin the behavior change: the overflow menu holds the removals and calls through to the store, and it is absent before a shot has any media.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MhFz5vynBzcWrqtAAyVG9V

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhFz5vynBzcWrqtAAyVG9V)_