### PR TITLE
fix(storyboard): allow rendering clips for direct-mode shots without a still

### DIFF
--- a/web/src/components/storyboard/ShotCard.tsx
+++ b/web/src/components/storyboard/ShotCard.tsx
@@ -14,6 +14,7 @@ import { keyframes } from "@emotion/react";
 import type { Theme } from "@mui/material/styles";
 import { useTheme } from "@mui/material/styles";
 import type { ImageRef, Shot, ShotStatus, VideoRef } from "@nodetool-ai/protocol";
+import { shotRenderMode } from "@nodetool-ai/protocol";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
@@ -571,12 +572,17 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
             </EditorButton>
             <EditorButton
               onClick={handleGenerateClip}
-              disabled={isGenerating || !shot.keyframe}
+              disabled={
+                isGenerating ||
+                (!shot.keyframe && shotRenderMode(shot) !== "direct")
+              }
               sx={shot.clip ? quietActionSx : undefined}
               title={
                 shot.keyframe
                   ? "Animate the selected still into a clip"
-                  : "Generate a still first"
+                  : shotRenderMode(shot) === "direct"
+                    ? "Render a clip straight from the prompt"
+                    : "Generate a still first, or set render mode to direct"
               }
             >
               {shot.clip ? "New clip" : "Generate clip"}

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, { memo, useCallback, useMemo, useState } from "react";
+import { shotRenderMode } from "@nodetool-ai/protocol";
 
 import {
   Box,
@@ -216,7 +217,7 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
     () =>
       shots.filter(
         (s) =>
-          !!s.keyframe &&
+          (!!s.keyframe || shotRenderMode(s) === "direct") &&
           !s.clip &&
           s.status !== "keyframe_generating" &&
           s.status !== "clip_generating"

--- a/web/src/hooks/storyboard/useGenerateShot.ts
+++ b/web/src/hooks/storyboard/useGenerateShot.ts
@@ -22,7 +22,7 @@
 
 import { useCallback } from "react";
 import type { Entity, Shot } from "@nodetool-ai/protocol";
-import { injectEntities } from "@nodetool-ai/protocol";
+import { injectEntities, shotRenderMode } from "@nodetool-ai/protocol";
 import {
   globalWebSocketManager
 } from "../../lib/websocket/GlobalWebSocketManager";
@@ -101,6 +101,23 @@ const clipPrompt = (shot: Shot): string =>
   [shot.motion, shot.action]
     .filter((p) => !!p && p.trim().length > 0)
     .join(", ");
+
+/**
+ * Direct-mode clip prompt. No still carries the look into the render, so the
+ * prompt has to: framing and board style ride along with the action and the
+ * motion (mirrors the headless `render_storyboard_clips` tool).
+ */
+const directClipPrompt = (shot: Shot, style: string): string => {
+  const parts: (string | undefined)[] = [shot.action];
+  if (shot.camera?.framing) {
+    parts.push(`${shot.camera.framing} shot`);
+  }
+  parts.push(shot.motion, style);
+  return parts
+    .filter((p): p is string => !!p && p.trim().length > 0)
+    .map((p) => p.trim())
+    .join(", ");
+};
 
 /** Entity mentions on their own line; the server seasons the prompt with them. */
 const entityTokenSuffix = (entities: Entity[]): string =>
@@ -252,18 +269,22 @@ export const useGenerateShot = (): UseGenerateShotResult => {
 
   const generateClip = useCallback(
     async (boardId: string, shot: Shot): Promise<void> => {
-      if (!shot.keyframe) {
-        throw new Error(
-          "Shot has no keyframe to animate. Generate a still first."
-        );
-      }
-      const sourceAssetId = assetIdFromRef(shot.keyframe);
-      if (!sourceAssetId) {
-        throw new Error(
-          "The shot's still has no stored asset to animate. Generate a still first."
-        );
-      }
       const board = useStoryboardStore.getState().getBoard(boardId);
+      const isDirect = shotRenderMode(shot) === "direct";
+      let sourceAssetId: string | undefined;
+      if (!isDirect) {
+        if (!shot.keyframe) {
+          throw new Error(
+            "Shot has no keyframe to animate. Generate a still first, or set its render mode to direct."
+          );
+        }
+        sourceAssetId = assetIdFromRef(shot.keyframe);
+        if (!sourceAssetId) {
+          throw new Error(
+            "The shot's still has no stored asset to animate. Generate a still first."
+          );
+        }
+      }
       const aspectRatio = board?.aspectRatio ?? "16:9";
       // A board linked to a script renders each shot as long as the takes it
       // covers, so the clip holds its voiceover (design §2.3).
@@ -271,16 +292,21 @@ export const useGenerateShot = (): UseGenerateShotResult => {
         board?.screenplay?.script_id,
         shot
       );
+      const prompt = isDirect
+        ? directClipPrompt(shot, board?.style ?? "")
+        : clipPrompt(shot);
       const data: Record<string, unknown> = {
         mode: "video",
-        prompt: `${clipPrompt(shot)}${entityTokenSuffix(
+        prompt: `${prompt}${entityTokenSuffix(
           entitiesForShot(shot, boardEntities(board?.entityIds))
         )}`,
-        source_asset_id: sourceAssetId,
         aspect_ratio: aspectRatio,
         resolution: CLIP_RESOLUTION,
         variations: 1
       };
+      if (sourceAssetId) {
+        data.source_asset_id = sourceAssetId;
+      }
       if (durationSeconds !== undefined) {
         data.duration = durationSeconds;
       }


### PR DESCRIPTION
## What changed

The headless `render_storyboard_clips` agent tool already supports a shot's
`render_mode: "direct"` (render the clip straight from the prompt with
`text_to_video`, no still needed), but the web UI's clip-render path did not:
`useGenerateShot.generateClip` unconditionally required `shot.keyframe`,
`ShotCard`'s "Generate clip" button was disabled without one, and
`StoryboardBoard`'s batch "pending clips" selection skipped these shots
entirely. This change branches all three on `shotRenderMode(shot)` (from
`@nodetool-ai/protocol`) so a direct-mode shot renders its clip from the
prompt in the browser too, matching the agent tool's existing behavior. Also
added a `directClipPrompt` helper mirroring the one already used by
`render_storyboard_clips`, so the composed prompt carries framing and style
that a still would otherwise have anchored.

## Verification

- [x] `npm run test:affected` — 4 suites, 49 tests passed
- [x] `npm run typecheck` — one new error from this diff (an inferred
      `string | undefined` in the array literal fed to `directClipPrompt`)
      was fixed; remaining errors are pre-existing (unbuilt
      `@nodetool-ai/node-sdk`/`core-nodes`/etc. — confirmed identical on a
      clean-stash baseline run)
- [x] `npm run lint` (oxlint on the three changed files) — clean
- [ ] `npm run dev:nodetool -- harness gate --base main` — not run (no backend
      build available in this environment)

## Agent capabilities

Skipped — this diff adds no capability and changes no capability's declared
contract.

## New checks

Skipped — this diff adds no check, rule, or audit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UJKxtHcDFuzcQ7KXf3RXTx)_