### PR TITLE
fix(oauth): finish OpenAI sign-in on a remote server by pasted address

### DIFF
--- a/packages/runtime/src/providers/oauth/README.md
+++ b/packages/runtime/src/providers/oauth/README.md
@@ -236,22 +236,26 @@ The **web app** drives the same Codex flow from the API server, sharing this
 module's protocol layer (`OAuthClient` + PKCE + `LocalCallbackServer`). Because
 the public Codex client only permits the loopback redirect
 `http://localhost:1455/auth/callback`, the redirect cannot bounce through a
-server route — the API process binds the Codex loopback listener itself:
+server route. `localhost` resolves in the *browser's* machine, so the server
+finishes the login one of two ways:
 
 - Backend: `packages/websocket/src/oauth-api.ts` exposes
-  `/api/oauth/openai/{start,tokens,disconnect}`. `start` builds the Codex
-  authorization URL (`createCodexOAuthProvider`'s config — public client id, no
-  secret, Codex scopes/params), binds a one-shot `LocalCallbackServer` on port
-  1455, and returns the auth URL; the code exchange completes in the background
-  and persists tokens through the encrypted `OAuthCredential` model. The
-  published client id is overridable via `CODEX_OAUTH_CLIENT_ID`. Because it
-  binds loopback and relies on the same machine's browser, it is a same-machine
-  flow (desktop / local server).
-- Frontend: the **Settings → Integrations** panel
-  (`web/src/components/menus/RemoteSettingsMenu.tsx`) renders an
-  "OpenAI Authentication" section with **Connect with OpenAI** / **Disconnect**
-  buttons that open the auth URL and poll `/api/oauth/openai/tokens` for
-  completion.
+  `/api/oauth/openai/{start,complete,tokens,disconnect}`. `start` builds the
+  Codex authorization URL (`createCodexOAuthProvider`'s config — public client
+  id, no secret, Codex scopes/params) and records the pending login under its
+  CSRF state for 10 minutes. On a same-machine host it also binds a one-shot
+  `LocalCallbackServer` on port 1455 and completes the exchange in the
+  background. On a shared server — `isAuthEnforced()`, or `?manual=true` — it
+  binds nothing and answers `manual: true`: the browser lands on its own
+  localhost with the code in the address bar, and the user pastes that address
+  to `complete`, which checks the state against the requesting user and
+  exchanges the code server-side. Both paths persist tokens through the
+  encrypted `OAuthCredential` model. The published client id is overridable via
+  `CODEX_OAUTH_CLIENT_ID`.
+- Frontend: the provider cards in **Settings → API Keys** and the onboarding
+  dialog call `useOAuthConnection("openai")`, which opens the auth URL and polls
+  `/api/oauth/openai/tokens`. When `start` answers `manual: true` the card also
+  raises `OAuthManualCompletionDialog` to take the pasted address.
 
 ## Claude Code login (Claude subscription)
 

--- a/packages/websocket/src/oauth-api.ts
+++ b/packages/websocket/src/oauth-api.ts
@@ -7,7 +7,11 @@
  */
 
 import { createHash, randomBytes } from "node:crypto";
-import { createLogger, isGoogleWorkspaceEnabled } from "@nodetool-ai/config";
+import {
+  createLogger,
+  isAuthEnforced,
+  isGoogleWorkspaceEnabled
+} from "@nodetool-ai/config";
 import {
   OAuthCredential,
   storeGoogleCredential,
@@ -23,6 +27,7 @@ import {
   CODEX_CALLBACK_PORT,
   CODEX_CALLBACK_PATH,
   DEFAULT_CODEX_OAUTH_CONFIG,
+  type OAuthTokens,
   type PendingClaudeCodeLogin
 } from "@nodetool-ai/runtime/oauth";
 import {
@@ -49,9 +54,12 @@ const GITHUB_SCOPES = ["user:email", "read:user"];
 // OpenAI OAuth uses the public Codex CLI client (no client secret, no
 // per-deployment registration). The authorization server only accepts the
 // Codex-registered loopback redirect (http://localhost:1455/auth/callback), so
-// the browser is redirected to a local single-shot listener this process binds
-// rather than back to a server route. This is inherently a same-machine flow —
-// the listener must be reachable from the browser that completes the login.
+// the browser is redirected to a local single-shot listener rather than back to
+// a server route. `localhost` resolves in the *browser's* machine, so binding
+// that port here only receives the code when the browser runs on this machine
+// too. On a shared server it does not, and the browser lands on its own
+// localhost with the code sitting in the address bar — so that host skips the
+// listener and the user pastes the address back instead.
 const OPENAI_USERINFO_URL =
   process.env.OPENAI_OAUTH_USERINFO_URL ?? "https://auth.openai.com/userinfo";
 
@@ -856,10 +864,69 @@ async function handleGithubUser(
 //
 // The login uses the public Codex CLI OAuth client. Because the Codex client's
 // only registered redirect is the loopback http://localhost:1455/auth/callback,
-// the flow can't bounce back through a server route: `start` binds a one-shot
-// loopback listener on that port, returns the authorization URL for the UI to
-// open, and finishes the code exchange in the background. The UI reflects
-// success by polling `/api/oauth/openai/tokens`.
+// the flow can't bounce back through a server route. Two ways to finish, both
+// from the one authorization request `start` creates:
+//
+//  - **Loopback** — `start` binds a one-shot listener on port 1455 and finishes
+//    the exchange in the background. Only works when the browser runs on this
+//    machine (desktop, local dev).
+//  - **Manual** — the browser is redirected to its own localhost, where nothing
+//    answers, and the user pastes the address back to `/complete`. The only
+//    option on a shared server, which is what `start` offers there.
+//
+// The UI reflects success by polling `/api/oauth/openai/tokens`.
+
+/** How long a started login stays completable from a pasted address. */
+const CODEX_LOGIN_TTL_MS = 10 * 60 * 1000;
+
+/** Logins awaiting a pasted redirect address, keyed by their CSRF state. */
+export const pendingCodexLogins = new Map<
+  string,
+  { userId: string; codeVerifier: string; createdAt: number }
+>();
+
+function pruneExpiredCodexLogins(): void {
+  const now = Date.now();
+  for (const [state, pending] of pendingCodexLogins) {
+    if (now - pending.createdAt > CODEX_LOGIN_TTL_MS) {
+      pendingCodexLogins.delete(state);
+    }
+  }
+}
+
+/**
+ * Read `code` and `state` out of what the user pastes back — the whole address
+ * the browser was sent to, or just its query string. The state is required: it
+ * is the CSRF check, and a bare code cannot be tied to the login it belongs to.
+ */
+export function parseCodexRedirect(input: string): {
+  code: string;
+  state: string;
+} {
+  let query = input.trim();
+  const questionMark = query.indexOf("?");
+  if (questionMark >= 0) {
+    query = query.slice(questionMark + 1);
+    const hash = query.indexOf("#");
+    if (hash >= 0) query = query.slice(0, hash);
+  }
+  const params = new URLSearchParams(query);
+
+  const error = params.get("error");
+  if (error) {
+    throw new Error(
+      params.get("error_description") || `Sign-in was refused: ${error}`
+    );
+  }
+  const code = params.get("code");
+  const state = params.get("state");
+  if (!code || !state) {
+    throw new Error(
+      "Paste the whole address the browser was sent to — it carries both the code and the state."
+    );
+  }
+  return { code, state };
+}
 
 /** Build the Codex OAuth client (public client id, no secret). */
 function codexOAuthClient(): OAuthClient {
@@ -891,30 +958,51 @@ async function handleOpenAIStart(
   if (request.method !== "GET") return errorResponse(405, "Method not allowed");
 
   const userId = getUserId();
+  const url = new URL(request.url);
   const client = codexOAuthClient();
   const { codeVerifier, codeChallenge } = generatePkcePair();
   const state = generateState();
 
+  // A shared server's users browse from their own machines, where the loopback
+  // redirect lands — so binding it here would receive nothing. The caller can
+  // also ask for the paste flow outright.
+  const manual = url.searchParams.get("manual") === "true" || isAuthEnforced();
+
+  pruneExpiredCodexLogins();
+  pendingCodexLogins.set(state, { userId, codeVerifier, createdAt: Date.now() });
+
   // A new attempt supersedes any listener left over from an abandoned one.
   await closeActiveCodexCallbackServer();
 
-  const server = new LocalCallbackServer({
-    host: "localhost",
-    port: CODEX_CALLBACK_PORT,
-    path: CODEX_CALLBACK_PATH
-  });
-  try {
-    await server.listen();
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return errorResponse(
-      500,
-      `Could not start the OAuth callback listener on port ${CODEX_CALLBACK_PORT}: ${message}`
-    );
-  }
+  if (!manual) {
+    const server = new LocalCallbackServer({
+      host: "localhost",
+      port: CODEX_CALLBACK_PORT,
+      path: CODEX_CALLBACK_PATH
+    });
+    try {
+      await server.listen();
+    } catch (err) {
+      pendingCodexLogins.delete(state);
+      const message = err instanceof Error ? err.message : String(err);
+      return errorResponse(
+        500,
+        `Could not start the OAuth callback listener on port ${CODEX_CALLBACK_PORT}: ${message}`
+      );
+    }
 
-  const abort = new AbortController();
-  activeCodexLogin = { server, abort };
+    const abort = new AbortController();
+    activeCodexLogin = { server, abort };
+    // Finish the exchange off the request path; the UI polls /tokens.
+    void completeCodexLogin({
+      server,
+      client,
+      state,
+      codeVerifier,
+      userId,
+      abort
+    });
+  }
 
   const authUrl = client.buildAuthorizationUrl({
     redirectUri: CODEX_REDIRECT_URI,
@@ -923,10 +1011,11 @@ async function handleOpenAIStart(
     codeChallengeMethod: "S256"
   });
 
-  // Finish the exchange off the request path; the UI polls /tokens for success.
-  void completeCodexLogin({ server, client, state, codeVerifier, userId, abort });
-
-  return jsonResponse({ auth_url: authUrl });
+  return jsonResponse({
+    auth_url: authUrl,
+    manual,
+    redirect_uri: CODEX_REDIRECT_URI
+  });
 }
 
 /** Await the loopback redirect, exchange the code, and persist credentials. */
@@ -953,51 +1042,119 @@ async function completeCodexLogin(args: {
       signal: abort.signal
     });
 
-    // Prefer the ChatGPT account id embedded in the Codex access-token JWT — it
-    // is the stable identity the ChatGPT backend addresses accounts by. Falls
-    // back to the OIDC `sub`, then to an opaque token-derived id.
-    const chatgptAccountId = extractChatGptAccountId(tokens.accessToken);
-    let accountId =
-      chatgptAccountId ?? String(Math.abs(hashCode(tokens.accessToken.slice(0, 24))));
-    // Best-effort OIDC userinfo for a friendly account label.
-    let username: string | null = null;
-    try {
-      const infoRes = await fetch(OPENAI_USERINFO_URL, {
-        headers: { Authorization: `${tokens.tokenType} ${tokens.accessToken}` }
-      });
-      if (infoRes.ok) {
-        const info = (await infoRes.json()) as Record<string, unknown>;
-        username =
-          (info.email as string) ?? (info.name as string) ?? (info.sub as string) ?? null;
-        if (!chatgptAccountId && isNonEmptyString(info.sub)) {
-          accountId = info.sub;
-        }
-      }
-    } catch {
-      // userinfo is optional — keep the fallback account id.
-    }
-
-    await OAuthCredential.upsert({
-      user_id: userId,
-      provider: "openai",
-      account_id: accountId,
-      access_token: tokens.accessToken,
-      refresh_token: tokens.refreshToken,
-      username,
-      token_type: tokens.tokenType,
-      scope: tokens.scope,
-      received_at: new Date(tokens.receivedAt).toISOString(),
-      expires_at:
-        tokens.expiresAt != null ? new Date(tokens.expiresAt).toISOString() : null
-    });
+    const accountId = await persistCodexTokens(tokens, userId);
     logger.info("Codex OAuth login completed", { accountId });
   } catch (err) {
     logger.warn("Codex OAuth login did not complete", {
       error: err instanceof Error ? err.message : String(err)
     });
   } finally {
+    pendingCodexLogins.delete(state);
     await server.close().catch(() => {});
     if (activeCodexLogin?.server === server) activeCodexLogin = null;
+  }
+}
+
+/** Store exchanged Codex tokens against a user; returns the account id used. */
+async function persistCodexTokens(
+  tokens: OAuthTokens,
+  userId: string
+): Promise<string> {
+  // Prefer the ChatGPT account id embedded in the Codex access-token JWT — it
+  // is the stable identity the ChatGPT backend addresses accounts by. Falls
+  // back to the OIDC `sub`, then to an opaque token-derived id.
+  const chatgptAccountId = extractChatGptAccountId(tokens.accessToken);
+  let accountId =
+    chatgptAccountId ?? String(Math.abs(hashCode(tokens.accessToken.slice(0, 24))));
+  // Best-effort OIDC userinfo for a friendly account label.
+  let username: string | null = null;
+  try {
+    const infoRes = await fetch(OPENAI_USERINFO_URL, {
+      headers: { Authorization: `${tokens.tokenType} ${tokens.accessToken}` }
+    });
+    if (infoRes.ok) {
+      const info = (await infoRes.json()) as Record<string, unknown>;
+      username =
+        (info.email as string) ?? (info.name as string) ?? (info.sub as string) ?? null;
+      if (!chatgptAccountId && isNonEmptyString(info.sub)) {
+        accountId = info.sub;
+      }
+    }
+  } catch {
+    // userinfo is optional — keep the fallback account id.
+  }
+
+  await OAuthCredential.upsert({
+    user_id: userId,
+    provider: "openai",
+    account_id: accountId,
+    access_token: tokens.accessToken,
+    refresh_token: tokens.refreshToken,
+    username,
+    token_type: tokens.tokenType,
+    scope: tokens.scope,
+    received_at: new Date(tokens.receivedAt).toISOString(),
+    expires_at:
+      tokens.expiresAt != null ? new Date(tokens.expiresAt).toISOString() : null
+  });
+  return accountId;
+}
+
+/** Complete a started login from the address the browser was redirected to. */
+async function handleOpenAIComplete(
+  request: Request,
+  getUserId: () => string
+): Promise<Response> {
+  if (request.method !== "POST")
+    return errorResponse(405, "Method not allowed");
+
+  let body: { code?: unknown };
+  try {
+    body = (await request.json()) as { code?: unknown };
+  } catch {
+    return errorResponse(400, "Invalid JSON body");
+  }
+  const raw = isString(body.code) ? body.code : "";
+  if (!raw.trim()) return errorResponse(400, "code is required");
+
+  let redirect: { code: string; state: string };
+  try {
+    redirect = parseCodexRedirect(raw);
+  } catch (err) {
+    return errorResponse(400, err instanceof Error ? err.message : String(err));
+  }
+
+  pruneExpiredCodexLogins();
+  const pending = pendingCodexLogins.get(redirect.state);
+  const userId = getUserId();
+  // An unknown state and another user's state are the same answer: this login
+  // is not one we can finish, and saying which it was leaks the difference.
+  if (!pending || pending.userId !== userId) {
+    return errorResponse(
+      400,
+      "That sign-in expired or was never started here. Start it again and paste the new address."
+    );
+  }
+  pendingCodexLogins.delete(redirect.state);
+
+  // The code is spent; any loopback listener still up is waiting for nothing.
+  await closeActiveCodexCallbackServer();
+
+  try {
+    const tokens = await codexOAuthClient().exchangeAuthorizationCode({
+      code: redirect.code,
+      codeVerifier: pending.codeVerifier,
+      redirectUri: CODEX_REDIRECT_URI
+    });
+    const accountId = await persistCodexTokens(tokens, userId);
+    logger.info("Codex OAuth login completed from a pasted address", {
+      accountId
+    });
+    return jsonResponse({ success: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn("Codex OAuth code exchange failed", { error: message });
+    return errorResponse(400, message);
   }
 }
 
@@ -1330,6 +1487,8 @@ export async function handleOAuthRequest(
     // OpenAI (Codex)
     case "/api/oauth/openai/start":
       return handleOpenAIStart(request, getUserId);
+    case "/api/oauth/openai/complete":
+      return handleOpenAIComplete(request, getUserId);
     case "/api/oauth/openai/tokens":
       return handleOpenAITokens(getUserId);
     case "/api/oauth/openai/disconnect":

--- a/packages/websocket/tests/oauth-api.test.ts
+++ b/packages/websocket/tests/oauth-api.test.ts
@@ -1,7 +1,8 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { initTestDb, OAuthCredential } from "@nodetool-ai/models";
 import {
   generatePkcePair,
@@ -9,7 +10,9 @@ import {
   oauthStateStore,
   handleOAuthRequest,
   closeActiveCodexCallbackServer,
-  closeActiveClaudeLogin
+  closeActiveClaudeLogin,
+  parseCodexRedirect,
+  pendingCodexLogins
 } from "../src/oauth-api.js";
 
 function getUserId(): string {
@@ -284,14 +287,49 @@ describe("OAuth API: GitHub endpoints", () => {
   });
 });
 
+describe("parseCodexRedirect", () => {
+  it("reads code and state from the whole redirect address", () => {
+    expect(
+      parseCodexRedirect(
+        "http://localhost:1455/auth/callback?code=ac_abc&scope=openid+profile&state=st_xyz"
+      )
+    ).toEqual({ code: "ac_abc", state: "st_xyz" });
+  });
+
+  it("accepts a bare query string and ignores a fragment", () => {
+    expect(parseCodexRedirect("  ?code=ac_abc&state=st_xyz#done  ")).toEqual({
+      code: "ac_abc",
+      state: "st_xyz"
+    });
+  });
+
+  it("surfaces the provider's own refusal", () => {
+    expect(() =>
+      parseCodexRedirect(
+        "http://localhost:1455/auth/callback?error=access_denied&error_description=User+said+no"
+      )
+    ).toThrow("User said no");
+  });
+
+  it("refuses a code with no state to check it against", () => {
+    expect(() =>
+      parseCodexRedirect("http://localhost:1455/auth/callback?code=ac_abc")
+    ).toThrow(/whole address/);
+    expect(() => parseCodexRedirect("ac_abc")).toThrow(/whole address/);
+  });
+});
+
 describe("OAuth API: OpenAI (Codex) endpoints", () => {
   beforeEach(() => {
     initTestDb();
     oauthStateStore.clear();
+    pendingCodexLogins.clear();
   });
 
   afterEach(async () => {
     await closeActiveCodexCallbackServer();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
   });
 
   it("GET /api/oauth/openai/start returns a Codex PKCE auth_url", async () => {
@@ -321,6 +359,170 @@ describe("OAuth API: OpenAI (Codex) endpoints", () => {
     // Codex-specific authorization params.
     expect(body.auth_url).toContain("codex_cli_simplified_flow=true");
     expect(body.auth_url).toContain("id_token_add_organizations=true");
+  });
+
+  it("GET /api/oauth/openai/start binds no listener on a shared server", async () => {
+    // A shared server's users browse from elsewhere, so localhost:1455 is
+    // theirs, not ours — binding it here would only swallow the port.
+    vi.stubEnv("SUPABASE_URL", "https://project.supabase.co");
+    vi.stubEnv("SUPABASE_KEY", "service-key");
+
+    const response = await handleOAuthRequest(
+      new Request("http://api.example.com/api/oauth/openai/start"),
+      "/api/oauth/openai/start",
+      getUserId
+    );
+
+    expect(response!.status).toBe(200);
+    const body = (await jsonBody(response!)) as {
+      auth_url: string;
+      manual: boolean;
+      redirect_uri: string;
+    };
+    expect(body.manual).toBe(true);
+    expect(body.redirect_uri).toBe("http://localhost:1455/auth/callback");
+    expect(pendingCodexLogins.size).toBe(1);
+
+    // Nothing is listening, so the port is free to bind.
+    const probe = createServer();
+    await new Promise<void>((resolve, reject) => {
+      probe.once("error", reject);
+      probe.listen(1455, "localhost", resolve);
+    });
+    await new Promise<void>((resolve) => probe.close(() => resolve()));
+  });
+
+  it("GET /api/oauth/openai/start?manual=true skips the listener too", async () => {
+    const response = await handleOAuthRequest(
+      new Request("http://localhost:7777/api/oauth/openai/start?manual=true"),
+      "/api/oauth/openai/start",
+      getUserId
+    );
+
+    const body = (await jsonBody(response!)) as { manual: boolean };
+    expect(body.manual).toBe(true);
+  });
+
+  it("POST /api/oauth/openai/complete exchanges a pasted redirect address", async () => {
+    vi.stubEnv("SUPABASE_URL", "https://project.supabase.co");
+    vi.stubEnv("SUPABASE_KEY", "service-key");
+
+    await handleOAuthRequest(
+      new Request("http://api.example.com/api/oauth/openai/start"),
+      "/api/oauth/openai/start",
+      getUserId
+    );
+    const [state] = [...pendingCodexLogins.keys()];
+
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/oauth/token")) {
+        return new Response(
+          JSON.stringify({
+            access_token: "codex-access",
+            refresh_token: "codex-refresh",
+            token_type: "Bearer",
+            expires_in: 3600
+          }),
+          { headers: { "content-type": "application/json" } }
+        );
+      }
+      // userinfo is best-effort; refusing it must not fail the login.
+      return new Response("nope", { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await handleOAuthRequest(
+      new Request("http://api.example.com/api/oauth/openai/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          code: `http://localhost:1455/auth/callback?code=ac_test&state=${state}`
+        })
+      }),
+      "/api/oauth/openai/complete",
+      getUserId
+    );
+
+    expect(response!.status).toBe(200);
+    expect(await jsonBody(response!)).toEqual({ success: true });
+    // The code is single-use; the pending login must not survive it.
+    expect(pendingCodexLogins.size).toBe(0);
+
+    const stored = await OAuthCredential.listForUserAndProvider(
+      "test-user-1",
+      "openai"
+    );
+    expect(stored).toHaveLength(1);
+    expect(await stored[0].getDecryptedAccessToken()).toBe("codex-access");
+
+    const tokenCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).includes("/oauth/token")
+    );
+    const sentBody = String(
+      (tokenCall?.[1] as { body?: unknown } | undefined)?.body ?? ""
+    );
+    expect(sentBody).toContain("code=ac_test");
+    expect(sentBody).toContain(
+      "redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback"
+    );
+  });
+
+  it("POST /api/oauth/openai/complete rejects an unknown state", async () => {
+    const response = await handleOAuthRequest(
+      new Request("http://api.example.com/api/oauth/openai/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          code: "http://localhost:1455/auth/callback?code=ac_test&state=nope"
+        })
+      }),
+      "/api/oauth/openai/complete",
+      getUserId
+    );
+
+    expect(response!.status).toBe(400);
+    expect((await jsonBody(response!)) as { detail: string }).toMatchObject({
+      detail: expect.stringContaining("expired or was never started")
+    });
+  });
+
+  it("POST /api/oauth/openai/complete rejects another user's state", async () => {
+    await handleOAuthRequest(
+      new Request("http://localhost:7777/api/oauth/openai/start?manual=true"),
+      "/api/oauth/openai/start",
+      getUserId
+    );
+    const [state] = [...pendingCodexLogins.keys()];
+
+    const response = await handleOAuthRequest(
+      new Request("http://api.example.com/api/oauth/openai/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          code: `http://localhost:1455/auth/callback?code=ac_test&state=${state}`
+        })
+      }),
+      "/api/oauth/openai/complete",
+      () => "someone-else"
+    );
+
+    expect(response!.status).toBe(400);
+    // The other user's login is still theirs to finish.
+    expect(pendingCodexLogins.has(state)).toBe(true);
+  });
+
+  it("POST /api/oauth/openai/complete rejects a code with no state", async () => {
+    const response = await handleOAuthRequest(
+      new Request("http://api.example.com/api/oauth/openai/complete", {
+        method: "POST",
+        body: JSON.stringify({ code: "ac_just_the_code" })
+      }),
+      "/api/oauth/openai/complete",
+      getUserId
+    );
+
+    expect(response!.status).toBe(400);
+    expect((await jsonBody(response!)) as { detail: string }).toMatchObject({
+      detail: expect.stringContaining("whole address")
+    });
   });
 
   it("GET /api/oauth/openai/tokens returns empty list initially", async () => {

--- a/web/src/components/menus/APIKeysTab.tsx
+++ b/web/src/components/menus/APIKeysTab.tsx
@@ -17,6 +17,7 @@ import useSecretsStore from "../../stores/SecretsStore";
 import type { SecretValidation } from "../../stores/SecretsStore";
 import { useNotificationStore } from "../../stores/NotificationStore";
 import { useOAuthConnection } from "../../hooks/useOAuthConnection";
+import { OAuthManualCompletionDialog } from "../oauth/OAuthManualCompletionDialog";
 import { useProviders } from "../../hooks/useProviders";
 import type { SecretResponse } from "../../stores/ApiTypes";
 import {
@@ -449,6 +450,13 @@ export const ProviderCard = memo(function ProviderCard({
           )}
         </FlexRow>
       </FlexRow>
+      <OAuthManualCompletionDialog
+        prompt={oauth.manualPrompt}
+        label={oauth.label}
+        isSubmitting={oauth.isSubmittingManual}
+        onSubmit={oauth.submitManualCode}
+        onCancel={oauth.cancelManual}
+      />
     </Card>
   );
 });

--- a/web/src/components/menus/__tests__/APIKeysTabContent.test.tsx
+++ b/web/src/components/menus/__tests__/APIKeysTabContent.test.tsx
@@ -66,7 +66,11 @@ describe("APIKeysTabContent on a hosted deployment", () => {
         isConnecting: false,
         canDisconnect: false,
         connect: jest.fn(),
-        disconnect: jest.fn()
+        disconnect: jest.fn(),
+        manualPrompt: null,
+        isSubmittingManual: false,
+        submitManualCode: jest.fn(),
+        cancelManual: jest.fn()
       });
   });
 

--- a/web/src/components/menus/__tests__/ProviderCard.test.tsx
+++ b/web/src/components/menus/__tests__/ProviderCard.test.tsx
@@ -41,6 +41,10 @@ const oauthState = (overrides: Partial<OAuthConnection>): OAuthConnection => ({
   canDisconnect: false,
   connect: jest.fn(),
   disconnect: jest.fn(),
+  manualPrompt: null,
+  isSubmittingManual: false,
+  submitManualCode: jest.fn(),
+  cancelManual: jest.fn(),
   ...overrides
 });
 

--- a/web/src/components/oauth/OAuthManualCompletionDialog.tsx
+++ b/web/src/components/oauth/OAuthManualCompletionDialog.tsx
@@ -1,0 +1,97 @@
+/**
+ * Finishes an OAuth login the server cannot receive a callback for.
+ *
+ * The OpenAI (Codex) client is registered against one redirect —
+ * `http://localhost:1455/auth/callback` — which resolves in the browser's own
+ * machine. When the server runs somewhere else, the browser lands on its own
+ * localhost with nothing listening and the authorization code sitting in the
+ * address bar. This dialog takes that address and hands it back to the server,
+ * which does the code exchange.
+ */
+
+import { useCallback, useState } from "react";
+
+import {
+  Caption,
+  Dialog,
+  FlexColumn,
+  Text,
+  TextInput,
+  TextLink
+} from "../ui_primitives";
+import type { OAuthManualPrompt } from "../../hooks/useOAuthConnection";
+
+interface OAuthManualCompletionDialogProps {
+  /** The pending login, or null when nothing is waiting on a paste. */
+  prompt: OAuthManualPrompt | null;
+  /** Provider label for the copy (e.g. "OpenAI"). */
+  label: string;
+  isSubmitting: boolean;
+  onSubmit: (input: string) => void;
+  onCancel: () => void;
+}
+
+export const OAuthManualCompletionDialog = ({
+  prompt,
+  label,
+  isSubmitting,
+  onSubmit,
+  onCancel
+}: OAuthManualCompletionDialogProps) => {
+  const [value, setValue] = useState("");
+
+  const handleCancel = useCallback(() => {
+    setValue("");
+    onCancel();
+  }, [onCancel]);
+
+  const handleConfirm = useCallback(() => {
+    onSubmit(value);
+    setValue("");
+  }, [onSubmit, value]);
+
+  if (!prompt) {
+    return null;
+  }
+
+  return (
+    <Dialog
+      open
+      onClose={handleCancel}
+      title={`Finish signing in with ${label}`}
+      showActions
+      onConfirm={handleConfirm}
+      onCancel={handleCancel}
+      confirmText={isSubmitting ? "Connecting…" : "Connect"}
+      confirmDisabled={value.trim().length === 0 || isSubmitting}
+      isLoading={isSubmitting}
+      minWidth="520px"
+    >
+      <FlexColumn gap={2}>
+        <Text size="small">
+          {label} sends the browser to{" "}
+          <code>{prompt.redirectUri ?? "a local address"}</code>, which only
+          exists on your own machine — so this server never sees it. Approve the
+          sign-in, then copy the whole address the browser ends up on (an error
+          page is expected) and paste it below.
+        </Text>
+        <TextInput
+          label="Redirect address"
+          placeholder="http://localhost:1455/auth/callback?code=…&state=…"
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          multiline
+          rows={3}
+          autoFocus
+        />
+        <Caption sx={{ opacity: 0.6 }}>
+          Sign-in window closed?{" "}
+          <TextLink href={prompt.authUrl} external>
+            Open it again
+          </TextLink>
+          . The link expires after 10 minutes.
+        </Caption>
+      </FlexColumn>
+    </Dialog>
+  );
+};

--- a/web/src/components/oauth/__tests__/OAuthManualCompletionDialog.test.tsx
+++ b/web/src/components/oauth/__tests__/OAuthManualCompletionDialog.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+import { OAuthManualCompletionDialog } from "../OAuthManualCompletionDialog";
+
+const prompt = {
+  authUrl: "https://auth.openai.com/oauth/authorize?x=1",
+  redirectUri: "http://localhost:1455/auth/callback"
+};
+
+const renderDialog = (
+  overrides: Partial<
+    React.ComponentProps<typeof OAuthManualCompletionDialog>
+  > = {}
+) => {
+  const props = {
+    prompt,
+    label: "OpenAI",
+    isSubmitting: false,
+    onSubmit: jest.fn(),
+    onCancel: jest.fn(),
+    ...overrides
+  };
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <OAuthManualCompletionDialog {...props} />
+    </ThemeProvider>
+  );
+  return props;
+};
+
+describe("OAuthManualCompletionDialog", () => {
+  it("renders nothing when no login is waiting on a paste", () => {
+    renderDialog({ prompt: null });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("names the redirect address the user should look for", () => {
+    renderDialog();
+    expect(
+      screen.getByText("http://localhost:1455/auth/callback")
+    ).toBeInTheDocument();
+  });
+
+  it("hands the pasted address to onSubmit", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderDialog();
+
+    const address = "http://localhost:1455/auth/callback?code=ac_abc&state=st";
+    await user.type(screen.getByLabelText("Redirect address"), address);
+    await user.click(screen.getByRole("button", { name: "Connect" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(address);
+  });
+
+  it("keeps Connect disabled until something is pasted", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    const connect = screen.getByRole("button", { name: "Connect" });
+    expect(connect).toBeDisabled();
+
+    await user.type(screen.getByLabelText("Redirect address"), "x");
+    expect(connect).toBeEnabled();
+  });
+});

--- a/web/src/components/provider_onboarding/ProviderOnboardingCard.tsx
+++ b/web/src/components/provider_onboarding/ProviderOnboardingCard.tsx
@@ -23,6 +23,7 @@ import {
   SPACING
 } from "../ui_primitives";
 import { useOAuthConnection } from "../../hooks/useOAuthConnection";
+import { OAuthManualCompletionDialog } from "../oauth/OAuthManualCompletionDialog";
 import useSecretsStore from "../../stores/SecretsStore";
 import { useNotificationStore } from "../../stores/NotificationStore";
 import type { OnboardingProvider } from "./providerOnboardingCatalog";
@@ -350,6 +351,13 @@ const ProviderOnboardingCard: React.FC<ProviderOnboardingCardProps> = ({
           </FlexColumn>
         )}
       </FlexColumn>
+      <OAuthManualCompletionDialog
+        prompt={oauth.manualPrompt}
+        label={oauth.label}
+        isSubmitting={oauth.isSubmittingManual}
+        onSubmit={oauth.submitManualCode}
+        onCancel={oauth.cancelManual}
+      />
     </Card>
   );
 };

--- a/web/src/components/provider_onboarding/__tests__/ProviderOnboardingCard.test.tsx
+++ b/web/src/components/provider_onboarding/__tests__/ProviderOnboardingCard.test.tsx
@@ -36,6 +36,10 @@ const oauthState = (overrides: Partial<OAuthConnection>): OAuthConnection => ({
   canDisconnect: false,
   connect: jest.fn(),
   disconnect: jest.fn(),
+  manualPrompt: null,
+  isSubmittingManual: false,
+  submitManualCode: jest.fn(),
+  cancelManual: jest.fn(),
   ...overrides
 });
 

--- a/web/src/components/provider_onboarding/__tests__/ProviderOnboardingDialog.test.tsx
+++ b/web/src/components/provider_onboarding/__tests__/ProviderOnboardingDialog.test.tsx
@@ -59,7 +59,11 @@ beforeEach(() => {
     isConnecting: false,
     canDisconnect: false,
     connect: jest.fn(),
-    disconnect: jest.fn()
+    disconnect: jest.fn(),
+    manualPrompt: null,
+    isSubmittingManual: false,
+    submitManualCode: jest.fn(),
+    cancelManual: jest.fn()
   });
   mockUseSecretsStore.mockImplementation(
     <T,>(selector: (s: { updateSecret: jest.Mock }) => T) =>

--- a/web/src/hooks/__tests__/useHasConfiguredProvider.test.tsx
+++ b/web/src/hooks/__tests__/useHasConfiguredProvider.test.tsx
@@ -25,7 +25,11 @@ const oauthState = (isConnected: boolean): OAuthConnection => ({
   isConnecting: false,
   canDisconnect: false,
   connect: jest.fn(),
-  disconnect: jest.fn()
+  disconnect: jest.fn(),
+  manualPrompt: null,
+  isSubmittingManual: false,
+  submitManualCode: jest.fn(),
+  cancelManual: jest.fn()
 });
 
 const withSecrets = (secrets: SecretResponse[]): void => {

--- a/web/src/hooks/__tests__/useOAuthConnection.test.tsx
+++ b/web/src/hooks/__tests__/useOAuthConnection.test.tsx
@@ -135,6 +135,128 @@ describe("useOAuthConnection", () => {
     expect(open).toHaveBeenCalledWith("https://example.com/auth", "_self");
   });
 
+  it("asks for the redirect address when /start answers manual", async () => {
+    mockRestFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/tokens")) return jsonResponse({ tokens: [] });
+      if (url.endsWith("/start"))
+        return jsonResponse({
+          auth_url: "https://example.com/auth",
+          manual: true,
+          redirect_uri: "http://localhost:1455/auth/callback"
+        });
+      return jsonResponse({});
+    });
+
+    const { result } = renderHook(() => useOAuthConnection("openai"), {
+      wrapper: createWrapper()
+    });
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(result.current.manualPrompt).toEqual({
+      authUrl: "https://example.com/auth",
+      redirectUri: "http://localhost:1455/auth/callback"
+    });
+  });
+
+  it("posts a pasted address to /complete and clears the prompt", async () => {
+    let connected = false;
+    mockRestFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/tokens"))
+        return jsonResponse({ tokens: connected ? ["token-1"] : [] });
+      if (url.endsWith("/start"))
+        return jsonResponse({
+          auth_url: "https://example.com/auth",
+          manual: true,
+          redirect_uri: "http://localhost:1455/auth/callback"
+        });
+      if (url.endsWith("/complete")) {
+        connected = true;
+        return jsonResponse({ success: true });
+      }
+      return jsonResponse({});
+    });
+
+    const { result } = renderHook(() => useOAuthConnection("openai"), {
+      wrapper: createWrapper()
+    });
+
+    await act(async () => {
+      await result.current.connect();
+    });
+    await act(async () => {
+      await result.current.submitManualCode(
+        "http://localhost:1455/auth/callback?code=ac_abc&state=st"
+      );
+    });
+
+    expect(mockRestFetch).toHaveBeenCalledWith("/api/oauth/openai/complete", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        code: "http://localhost:1455/auth/callback?code=ac_abc&state=st"
+      })
+    });
+    expect(result.current.manualPrompt).toBeNull();
+    await waitFor(() => expect(result.current.isConnected).toBe(true));
+  });
+
+  it("keeps the prompt open when /complete refuses the address", async () => {
+    mockRestFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/tokens")) return jsonResponse({ tokens: [] });
+      if (url.endsWith("/start"))
+        return jsonResponse({
+          auth_url: "https://example.com/auth",
+          manual: true,
+          redirect_uri: "http://localhost:1455/auth/callback"
+        });
+      if (url.endsWith("/complete"))
+        return jsonResponse({ detail: "That sign-in expired" }, false);
+      return jsonResponse({});
+    });
+
+    const { result } = renderHook(() => useOAuthConnection("openai"), {
+      wrapper: createWrapper()
+    });
+
+    await act(async () => {
+      await result.current.connect();
+    });
+    await act(async () => {
+      await result.current.submitManualCode("garbage");
+    });
+
+    expect(result.current.manualPrompt).not.toBeNull();
+    expect(mockAddNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "That sign-in expired", type: "error" })
+    );
+  });
+
+  it("never prompts for a paste on a provider without a /complete route", async () => {
+    mockRestFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/tokens")) return jsonResponse({ tokens: [] });
+      if (url.endsWith("/start"))
+        return jsonResponse({ auth_url: "https://example.com/auth", manual: true });
+      return jsonResponse({});
+    });
+
+    const { result } = renderHook(() => useOAuthConnection("hf"), {
+      wrapper: createWrapper()
+    });
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(result.current.manualPrompt).toBeNull();
+  });
+
   it("calls the disconnect endpoint for a provider that supports it", async () => {
     mockRestFetch.mockImplementation(async (input) => {
       const url = String(input);

--- a/web/src/hooks/useOAuthConnection.ts
+++ b/web/src/hooks/useOAuthConnection.ts
@@ -11,16 +11,39 @@ interface OAuthProviderConfig {
   label: string;
   /** Whether the backend exposes a disconnect endpoint for this provider. */
   canDisconnect: boolean;
+  /**
+   * Whether `/start` may answer `manual: true`, meaning the provider redirects
+   * somewhere this server cannot receive and the user finishes the login by
+   * pasting the address back to `/complete`.
+   */
+  canCompleteManually: boolean;
 }
 
 const PROVIDER_CONFIG = {
-  openai: { label: "OpenAI", canDisconnect: true },
-  hf: { label: "HuggingFace", canDisconnect: false },
-  claude: { label: "Claude", canDisconnect: true }
+  openai: { label: "OpenAI", canDisconnect: true, canCompleteManually: true },
+  hf: { label: "HuggingFace", canDisconnect: false, canCompleteManually: false },
+  claude: { label: "Claude", canDisconnect: true, canCompleteManually: false }
 } satisfies Record<OAuthProvider, OAuthProviderConfig>;
 
 interface TokensResponse {
   tokens: unknown[];
+}
+
+interface StartResponse {
+  auth_url?: string;
+  /** The redirect can't reach this server — finish with a pasted address. */
+  manual?: boolean;
+  /** The address the provider redirects to, shown so the user recognizes it. */
+  redirect_uri?: string;
+  detail?: string;
+}
+
+/** A login waiting for the user to paste back where the browser was sent. */
+export interface OAuthManualPrompt {
+  /** Authorization URL, in case the pop-up was blocked or closed. */
+  authUrl: string;
+  /** The redirect address to look for in the browser's address bar. */
+  redirectUri: string | null;
 }
 
 /**
@@ -63,6 +86,14 @@ export interface OAuthConnection {
   connect: () => Promise<void>;
   /** Revoke stored tokens (no-op when unsupported). */
   disconnect: () => Promise<void>;
+  /** Set when the login can only be finished by pasting the redirect address. */
+  manualPrompt: OAuthManualPrompt | null;
+  /** True while a pasted address is being exchanged. */
+  isSubmittingManual: boolean;
+  /** Finish the pending login from the pasted address. */
+  submitManualCode: (input: string) => Promise<void>;
+  /** Abandon the pending login. */
+  cancelManual: () => void;
 }
 
 /**
@@ -76,6 +107,10 @@ export const useOAuthConnection = (
   const queryClient = useQueryClient();
   const addNotification = useNotificationStore((state) => state.addNotification);
   const [isConnecting, setIsConnecting] = useState(false);
+  const [manualPrompt, setManualPrompt] = useState<OAuthManualPrompt | null>(
+    null
+  );
+  const [isSubmittingManual, setIsSubmittingManual] = useState(false);
 
   const config = provider ? PROVIDER_CONFIG[provider] : null;
   const tokenQueryKey = useMemo(() => ["oauth-token", provider], [provider]);
@@ -109,6 +144,7 @@ export const useOAuthConnection = (
     }
     if (isConnected) {
       setIsConnecting(false);
+      setManualPrompt(null);
       addNotification({
         content: `Successfully connected to ${config.label}`,
         type: "success",
@@ -142,7 +178,7 @@ export const useOAuthConnection = (
     try {
       const response = await restFetch(`/api/oauth/${provider}/start`);
       const body = (await response.json().catch(() => null)) as
-        | { auth_url?: string; detail?: string }
+        | StartResponse
         | null;
 
       if (!response.ok || !body?.auth_url) {
@@ -150,6 +186,12 @@ export const useOAuthConnection = (
       }
 
       const authUrl = body.auth_url;
+      // The provider will redirect somewhere this server never sees. Ask for
+      // the address the browser lands on instead of waiting for a callback
+      // that cannot arrive.
+      if (body.manual && config.canCompleteManually) {
+        setManualPrompt({ authUrl, redirectUri: body.redirect_uri ?? null });
+      }
       if (useNativeBrowser) {
         await window.api?.shell?.openExternal(authUrl);
       } else if (authWindow) {
@@ -162,6 +204,7 @@ export const useOAuthConnection = (
     } catch (error) {
       authWindow?.close();
       setIsConnecting(false);
+      setManualPrompt(null);
       addNotification({
         content:
           error instanceof Error
@@ -172,6 +215,47 @@ export const useOAuthConnection = (
       });
     }
   }, [provider, config, addNotification]);
+
+  const submitManualCode = useCallback(
+    async (input: string) => {
+      if (!provider || !config) {
+        return;
+      }
+      setIsSubmittingManual(true);
+      try {
+        const response = await restFetch(`/api/oauth/${provider}/complete`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ code: input })
+        });
+        const body = (await response.json().catch(() => null)) as
+          | { detail?: string }
+          | null;
+        if (!response.ok) {
+          throw new Error(body?.detail || "Could not complete the sign-in");
+        }
+        setManualPrompt(null);
+        await queryClient.invalidateQueries({ queryKey: tokenQueryKey });
+      } catch (error) {
+        addNotification({
+          content:
+            error instanceof Error
+              ? error.message
+              : `Could not complete the ${config.label} sign-in`,
+          type: "error",
+          alert: true
+        });
+      } finally {
+        setIsSubmittingManual(false);
+      }
+    },
+    [provider, config, addNotification, queryClient, tokenQueryKey]
+  );
+
+  const cancelManual = useCallback(() => {
+    setManualPrompt(null);
+    setIsConnecting(false);
+  }, []);
 
   const disconnect = useCallback(async () => {
     if (!provider || !config?.canDisconnect) {
@@ -205,6 +289,10 @@ export const useOAuthConnection = (
     isConnecting,
     canDisconnect: config?.canDisconnect ?? false,
     connect,
-    disconnect
+    disconnect,
+    manualPrompt,
+    isSubmittingManual,
+    submitManualCode,
+    cancelManual
   };
 };


### PR DESCRIPTION
## What changed

OpenAI OAuth on the production server left the user stranded at `localhost:1455/auth/callback?code=…`. The Codex client's only registered redirect is `http://localhost:1455/auth/callback`, and `localhost` resolves in the *browser's* machine — so the listener the server bound on that port only ever received the code when the browser ran on the same machine. On a shared host the browser landed on its own localhost, nothing answered, and the login never completed. A shared host (`isAuthEnforced()`, or an explicit `?manual=true`) now binds no listener: `start` records the pending login under its CSRF state for ten minutes and answers `manual: true`, and the new `POST /api/oauth/openai/complete` takes the address the browser was sent to, checks the state against the requesting user, and does the exchange server-side. Local and desktop hosts keep the loopback path unchanged. In the web app a `manual` answer raises `OAuthManualCompletionDialog` from the provider cards, which posts the pasted address and lets the existing token poll report the connection.

## Verification

- [x] `npm run test:affected` — passes except a pre-existing `@nodetool-ai/image-nodes` failure: `No WebGPU adapter available (Node/Dawn)`, the missing-Vulkan-driver environment gap AGENTS.md documents. Unrelated to this diff; CI installs `mesa-vulkan-drivers`. The suites this diff actually touches were run in full: `npm run test --workspace=packages/websocket` (228 files, 2538 tests, all passing) and the web OAuth suites (47 tests).
- [x] `npm run typecheck` — web and electron clean. Mobile fails on unresolved `react-native`/`expo` modules because `mobile/` is not a root workspace and its dependencies are not installed in this sandbox; the diff touches nothing under `mobile/`.
- [x] `npm run lint` — exit 0.
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — `Gate: 4/4 selfchecks passed` (`--base main` has no merge base in this shallow clone).

## New checks

The guard against the original bug is `GET /api/oauth/openai/start binds no listener on a shared server`. It was inverted once by dropping `|| isAuthEnforced()` from the `manual` decision, which reproduced the reported failure:

```
× GET /api/oauth/openai/start binds no listener on a shared server 10ms
Tests  1 failed | 92 passed (93)
```

It asserts positively rather than by absence: after `start`, the test binds port 1455 itself, which only succeeds because the server left it free.

Also added: `parseCodexRedirect` unit cases (whole address, bare query string with a fragment, the provider's own `error=`, and a bare code refused for having no state to check), plus `/complete` cases for an unknown state, another user's state (which must survive the refusal), and a successful exchange asserting the `redirect_uri` sent to the token endpoint. Hook and dialog tests cover the prompt appearing only when `/start` says `manual` and the provider has a `/complete` route.

## Agent capabilities

No capability added or re-declared.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBv1mYaL74Ny1TE4rr4f1F)_