### PR TITLE
feat(web): fold the mobile app menu into the browse sheet

### DIFF
--- a/web/src/components/panels/AppPagesList.tsx
+++ b/web/src/components/panels/AppPagesList.tsx
@@ -1,0 +1,93 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import React, { useMemo } from "react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import { useShallow } from "zustand/react/shallow";
+
+import { useAppHeaderStore } from "../../stores/AppHeaderStore";
+import Help from "../content/Help/Help";
+import { useAppMenuActions } from "./useAppMenuActions";
+import {
+  Caption,
+  Divider,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
+
+const styles = (theme: Theme) =>
+  css({
+    paddingBottom: getSpacingPx(SPACING.xl),
+    "& .page-row": {
+      minHeight: "44px",
+      gap: getSpacingPx(SPACING.md),
+      paddingLeft: getSpacingPx(SPACING.xl),
+      paddingRight: getSpacingPx(SPACING.xl)
+    },
+    "& .row-icon": {
+      display: "flex",
+      flexShrink: 0,
+      color: theme.vars.palette.text.secondary,
+      "& svg": {
+        fontSize: "var(--fontSizeBig)"
+      }
+    }
+  });
+
+interface AppPagesListProps {
+  /** Dismisses the sheet so the opened destination isn't hidden behind it. */
+  onAction: () => void;
+}
+
+/**
+ * The app-level destinations (Dashboard, Settings, Help, Downloads, …) as rows
+ * in the mobile browse sheet. On desktop the same list is the logo popover
+ * (RailAppMenu); mobile folds it into the one sheet the hamburger opens rather
+ * than carrying a second menu button in the top row.
+ */
+const AppPagesList: React.FC<AppPagesListProps> = ({ onAction }) => {
+  const theme = useTheme();
+  const listStyles = useMemo(() => styles(theme), [theme]);
+  const actions = useAppMenuActions(onAction);
+
+  // RailAppMenu owns the Help dialog on desktop and is not mounted here.
+  const { helpOpen, handleCloseHelp } = useAppHeaderStore(
+    useShallow((state) => ({
+      helpOpen: state.helpOpen,
+      handleCloseHelp: state.handleCloseHelp
+    }))
+  );
+
+  return (
+    <div css={listStyles}>
+      <List dense disablePadding>
+        {actions.map((action) => (
+          <React.Fragment key={action.key}>
+            <ListItem disablePadding>
+              <ListItemButton className="page-row" onClick={action.onClick}>
+                <span className="row-icon" aria-hidden>
+                  {action.icon}
+                </span>
+                <ListItemText primary={action.label} />
+                {action.secondary && (
+                  <Caption color="secondary">{action.secondary}</Caption>
+                )}
+              </ListItemButton>
+            </ListItem>
+            {action.dividerAfter && <Divider />}
+          </React.Fragment>
+        ))}
+      </List>
+
+      <Help open={helpOpen} handleClose={handleCloseHelp} />
+    </div>
+  );
+};
+
+AppPagesList.displayName = "AppPagesList";
+
+export default AppPagesList;

--- a/web/src/components/panels/MobileRailLauncher.tsx
+++ b/web/src/components/panels/MobileRailLauncher.tsx
@@ -12,7 +12,6 @@ import {
   SPACING,
   getSpacingPx
 } from "../ui_primitives";
-import RailAppMenu from "./RailAppMenu";
 
 const styles = (theme: Theme) =>
   css({
@@ -24,12 +23,6 @@ const styles = (theme: Theme) =>
     padding: `0 ${getSpacingPx(SPACING.xs)}`,
     borderRight: `1px solid ${theme.vars.palette.divider}`,
 
-    "& .rail-app-logo": {
-      width: "40px",
-      height: "40px",
-      margin: 0,
-      opacity: 1
-    },
     "& .panel-left-mobile-launcher": {
       width: "40px",
       height: "40px",
@@ -49,25 +42,21 @@ const styles = (theme: Theme) =>
     }
   });
 
-interface MobileRailLauncherProps {
-  /** Renders the logo/app menu alongside the panel toggle. */
-  showAppMenu?: boolean;
-}
-
 /**
- * The app menu (logo) and left-panel toggle as the leading cell of the mobile
- * top row. On desktop these live in the vertical rail, which mobile doesn't
- * render — the top row carries them instead so they share the app chrome rather
- * than floating over the content.
+ * The left-panel toggle as the leading cell of the mobile top row. On desktop
+ * it lives in the vertical rail, which mobile doesn't render — the top row
+ * carries it instead so it shares the app chrome rather than floating over the
+ * content.
+ *
+ * The sheet it opens is mobile's single navigation surface: document
+ * categories plus the app pages the desktop logo menu holds, so there is no
+ * second menu button beside it.
  */
-const MobileRailLauncher: React.FC<MobileRailLauncherProps> = ({
-  showAppMenu = false
-}) => {
+const MobileRailLauncher: React.FC = () => {
   const theme = useTheme();
   const isVisible = usePanelStore((state) => state.panel.isVisible);
   const setVisibility = usePanelStore((state) => state.setVisibility);
 
-  const close = useCallback(() => setVisibility(false), [setVisibility]);
   const toggle = useCallback(
     () => setVisibility(!isVisible),
     [setVisibility, isVisible]
@@ -75,7 +64,6 @@ const MobileRailLauncher: React.FC<MobileRailLauncherProps> = ({
 
   return (
     <div css={styles(theme)} className="mobile-rail-launcher">
-      {showAppMenu && <RailAppMenu onAction={close} />}
       <ToolbarIconButton
         className={`panel-left-mobile-launcher ${isVisible ? "active" : ""}`}
         onClick={toggle}

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -22,7 +22,7 @@ import {
 } from "../ui_primitives";
 import { useResizePanel } from "../../hooks/handlers/useResizePanel";
 import isEqual from "../../utils/isEqual";
-import { memo, useCallback, useEffect, useMemo } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import AssetGrid from "../assets/AssetGrid";
 import {
@@ -57,6 +57,7 @@ import FavoritesTiles from "../node_menu/FavoritesTiles";
 import QuickAccessSidebar from "../node_menu/QuickAccessSidebar";
 import NodeLibrary from "../node_menu/NodeLibrary";
 import RailAppMenu from "./RailAppMenu";
+import AppPagesList from "./AppPagesList";
 import WorkspaceTree from "../workspaces/WorkspaceTree";
 
 import {
@@ -86,6 +87,7 @@ import ThemeToggle from "../ui/ThemeToggle";
 import PanelHeadline from "../ui/PanelHeadline";
 import MenuIcon from "@mui/icons-material/Menu";
 import CodeIcon from "@mui/icons-material/Code";
+import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
 
 import Fullscreen from "@mui/icons-material/Fullscreen";
 
@@ -285,9 +287,7 @@ const VerticalToolbar = memo(function VerticalToolbar({
 
   return (
     <div className="vertical-toolbar">
-      {showAppMenu && (
-        <RailAppMenu />
-      )}
+      {showAppMenu && <RailAppMenu />}
       <QuickAccessSidebar
         activeCategory={renderedActive}
         onCategoryClick={onViewChange}
@@ -868,13 +868,27 @@ const MobilePanelLeft: React.FC<{
   hideLauncher = false
 }) => {
   const theme = useTheme();
+  // The app pages (Settings, Help, Downloads, …) are a section of this sheet
+  // rather than a second menu in the top row, so the sheet has two modes:
+  // browse a document category, or pick an app page.
+  const [appPagesOpen, setAppPagesOpen] = useState(false);
 
   const handleSheetViewChange = useCallback(
     (view: LeftPanelView) => {
+      setAppPagesOpen(false);
       onViewChange(view);
     },
     [onViewChange]
   );
+
+  const showAppPages = useCallback(() => setAppPagesOpen(true), []);
+
+  // Reopening the sheet lands on the documents it was browsing, not on More.
+  useEffect(() => {
+    if (!isVisible) {
+      setAppPagesOpen(false);
+    }
+  }, [isVisible]);
 
   const categoryGroups = useMemo(
     () =>
@@ -887,9 +901,13 @@ const MobilePanelLeft: React.FC<{
     [hiddenViews]
   );
 
-  const CreateAction = MOBILE_CREATE_ACTIONS[activeView];
+  const CreateAction = appPagesOpen
+    ? undefined
+    : MOBILE_CREATE_ACTIONS[activeView];
 
-  const launcherTitle = getTopLevelCategory(activeView).label;
+  const launcherTitle = appPagesOpen
+    ? "More"
+    : getTopLevelCategory(activeView).label;
 
   return (
     <>
@@ -941,6 +959,22 @@ const MobilePanelLeft: React.FC<{
               </FlexRow>
             ))}
 
+            <FlexRow className="mobile-tab-group" gap={SPACING.xs}>
+              <Tooltip
+                title="More"
+                placement="bottom"
+                delay={TOOLTIP_ENTER_DELAY}
+              >
+                <ToolbarIconButton
+                  className={`tab-button ${appPagesOpen ? "active" : ""}`}
+                  onClick={showAppPages}
+                  ariaLabel="More"
+                  tabIndex={-1}
+                  icon={<MoreHorizIcon />}
+                />
+              </Tooltip>
+            </FlexRow>
+
             <Box sx={{ flex: 1 }} />
             {CreateAction && <CreateAction />}
           </div>
@@ -952,16 +986,22 @@ const MobilePanelLeft: React.FC<{
             overflow: "hidden"
           }}
         >
-          <ContextMenuProvider>
-            <ContextMenus />
-            <PanelContent
-              activeView={activeView}
-              activeNodeCategory={activeNodeCategory}
-              setActiveNodeCategory={setActiveNodeCategory}
-              handlePanelToggle={handlePanelToggle}
-              isMobile
-            />
-          </ContextMenuProvider>
+          {appPagesOpen ? (
+            <ScrollArea>
+              <AppPagesList onAction={onClose} />
+            </ScrollArea>
+          ) : (
+            <ContextMenuProvider>
+              <ContextMenus />
+              <PanelContent
+                activeView={activeView}
+                activeNodeCategory={activeNodeCategory}
+                setActiveNodeCategory={setActiveNodeCategory}
+                handlePanelToggle={handlePanelToggle}
+                isMobile
+              />
+            </ContextMenuProvider>
+          )}
         </FlexColumn>
       </MobileBottomSheet>
     </>

--- a/web/src/components/panels/RailAppMenu.tsx
+++ b/web/src/components/panels/RailAppMenu.tsx
@@ -2,31 +2,24 @@
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import React, { useCallback, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import React, { useCallback, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
-import SettingsIcon from "@mui/icons-material/Settings";
-import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
-import DownloadIcon from "@mui/icons-material/Download";
-import SpaceDashboardOutlinedIcon from "@mui/icons-material/SpaceDashboardOutlined";
-import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
-import SchoolOutlinedIcon from "@mui/icons-material/SchoolOutlined";
-import PaidOutlinedIcon from "@mui/icons-material/PaidOutlined";
-import ViewInArOutlinedIcon from "@mui/icons-material/ViewInArOutlined";
-import Inventory2OutlinedIcon from "@mui/icons-material/Inventory2Outlined";
-import LibraryBooksOutlinedIcon from "@mui/icons-material/LibraryBooksOutlined";
-import FolderSpecialOutlinedIcon from "@mui/icons-material/FolderSpecialOutlined";
 
-import { isProduction } from "../../lib/env";
 import { useCombo } from "../../stores/KeyPressedStore";
 import { useAppHeaderStore } from "../../stores/AppHeaderStore";
-import { useModelDownloadStore } from "../../stores/ModelDownloadStore";
-import { openPageTab, openSettingsTab } from "../workspace/openPageTab";
-import { type PageTabKey } from "../workspace/pageTabs";
-import PermMediaOutlinedIcon from "@mui/icons-material/PermMediaOutlined";
+import { openSettingsTab } from "../workspace/openPageTab";
 import Help from "../content/Help/Help";
 import Logo from "../Logo";
-import { Popover, MenuItemPrimitive, Tooltip, MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
+import { useAppMenuActions } from "./useAppMenuActions";
+import {
+  Popover,
+  MenuItemPrimitive,
+  Tooltip,
+  MOTION,
+  BORDER_RADIUS,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
 
 const logoButtonStyles = (theme: Theme) =>
   css({
@@ -72,10 +65,12 @@ interface RailAppMenuProps {
  * The app menu docked at the top of the workspace rail. The logo opens a menu
  * carrying the global actions that used to live in the old header's right cluster:
  * Settings, Help, and Downloads (with live progress when active).
+ *
+ * Desktop only — on mobile the same destinations are the More section of the
+ * browse sheet (AppPagesList), so the top row carries one menu, not two.
  */
 const RailAppMenu: React.FC<RailAppMenuProps> = ({ onAction }) => {
   const theme = useTheme();
-  const navigate = useNavigate();
   const anchorRef = useRef<HTMLButtonElement>(null);
   const [open, setOpen] = useState(false);
 
@@ -113,58 +108,8 @@ const RailAppMenu: React.FC<RailAppMenuProps> = ({ onAction }) => {
     setOpen(false);
     onAction?.();
   }, [onAction]);
-  // Open an app page (Settings, Costs, …) as a workspace tab and focus the
-  // workspace, instead of navigating to a dedicated route.
-  const openPage = useCallback(
-    (key: PageTabKey) => {
-      openPageTab(key);
-      finish();
-    },
-    [finish]
-  );
 
-  const goDashboard = useCallback(() => {
-    navigate("/dashboard");
-    finish();
-  }, [navigate, finish]);
-
-  const goExamples = useCallback(() => openPage("examples"), [openPage]);
-  const goTutorials = useCallback(() => openPage("tutorials"), [openPage]);
-  const goCosts = useCallback(() => openPage("costs"), [openPage]);
-  const goModels = useCallback(() => openPage("models"), [openPage]);
-  const goPackages = useCallback(() => openPage("packages"), [openPage]);
-  const goCollections = useCallback(() => openPage("collections"), [openPage]);
-  const goAssets = useCallback(() => openPage("assets"), [openPage]);
-  const goWorkspaces = useCallback(() => openPage("workspaces"), [openPage]);
-  const goSettings = useCallback(() => openPage("settings"), [openPage]);
-
-  const openHelp = useCallback(() => {
-    handleOpenHelp();
-    finish();
-  }, [handleOpenHelp, finish]);
-
-  const { downloads, openDownloadsDialog } = useModelDownloadStore(
-    useShallow((state) => ({
-      downloads: state.downloads,
-      openDownloadsDialog: state.openDialog
-    }))
-  );
-
-  // Aggregate percent across in-flight downloads; null when nothing is running.
-  const downloadProgress = useMemo(() => {
-    const active = Object.values(downloads).filter(
-      (download) => download.status === "progress"
-    );
-    if (active.length === 0) return null;
-    const total = active.reduce((sum, d) => sum + d.totalBytes, 0);
-    const done = active.reduce((sum, d) => sum + d.downloadedBytes, 0);
-    return total > 0 ? Math.round((done / total) * 100) : 0;
-  }, [downloads]);
-
-  const openDownloads = useCallback(() => {
-    openDownloadsDialog();
-    finish();
-  }, [openDownloadsDialog, finish]);
+  const actions = useAppMenuActions(finish);
 
   return (
     <>
@@ -196,73 +141,16 @@ const RailAppMenu: React.FC<RailAppMenuProps> = ({ onAction }) => {
         placement="bottom-left"
       >
         <div css={menuStyles()} role="menu">
-          <MenuItemPrimitive
-            label="Dashboard"
-            icon={<SpaceDashboardOutlinedIcon />}
-            onClick={goDashboard}
-          />
-          <MenuItemPrimitive
-            label="Tutorials"
-            icon={<SchoolOutlinedIcon />}
-            onClick={goTutorials}
-          />
-          <MenuItemPrimitive
-            label="Examples"
-            icon={<AutoAwesomeOutlinedIcon />}
-            onClick={goExamples}
-          />
-          <MenuItemPrimitive
-            label="Costs"
-            icon={<PaidOutlinedIcon />}
-            onClick={goCosts}
-            dividerAfter
-          />
-          <MenuItemPrimitive
-            label="Model Manager"
-            icon={<ViewInArOutlinedIcon />}
-            onClick={goModels}
-          />
-          {!isProduction && (
+          {actions.map((action) => (
             <MenuItemPrimitive
-              label="Package Manager"
-              icon={<Inventory2OutlinedIcon />}
-              onClick={goPackages}
+              key={action.key}
+              label={action.label}
+              icon={action.icon}
+              onClick={action.onClick}
+              secondary={action.secondary}
+              dividerAfter={action.dividerAfter}
             />
-          )}
-          <MenuItemPrimitive
-            label="Assets"
-            icon={<PermMediaOutlinedIcon />}
-            onClick={goAssets}
-          />
-          <MenuItemPrimitive
-            label="Collections"
-            icon={<LibraryBooksOutlinedIcon />}
-            onClick={goCollections}
-          />
-          <MenuItemPrimitive
-            label="Workspaces"
-            icon={<FolderSpecialOutlinedIcon />}
-            onClick={goWorkspaces}
-            dividerAfter
-          />
-          <MenuItemPrimitive
-            label="Settings"
-            icon={<SettingsIcon />}
-            onClick={goSettings}
-          />
-          <MenuItemPrimitive
-            label="Help"
-            icon={<HelpOutlineIcon />}
-            onClick={openHelp}
-          />
-          <MenuItemPrimitive
-            label="Downloads"
-            icon={<DownloadIcon />}
-            onClick={openDownloads}
-            secondary={
-              downloadProgress != null ? `${downloadProgress}%` : undefined
-            }
-          />
+          ))}
         </div>
       </Popover>
 

--- a/web/src/components/panels/__tests__/MobileRailLauncher.test.tsx
+++ b/web/src/components/panels/__tests__/MobileRailLauncher.test.tsx
@@ -1,9 +1,10 @@
 /**
  * MobileRailLauncher tests
  *
- * On mobile the vertical rail isn't rendered, so the app menu (logo) and the
- * left-panel toggle ride in the workspace top row. These tests assert both
- * buttons are present and that the toggle flips the shared panel visibility.
+ * On mobile the vertical rail isn't rendered, so the left-panel toggle rides in
+ * the workspace top row. The sheet it opens is the one navigation surface
+ * mobile has — the logo/app menu is a section inside it, not a second button
+ * here.
  */
 
 import { render, screen } from "@testing-library/react";
@@ -14,34 +15,10 @@ import MobileRailLauncher from "../MobileRailLauncher";
 import mockTheme from "../../../__mocks__/themeMock";
 import { usePanelStore } from "../../../stores/PanelStore";
 
-jest.mock("react-router-dom", () => ({
-  useNavigate: () => jest.fn()
-}));
-
-jest.mock("../../content/Help/Help", () => () => null);
-jest.mock("../../Logo", () => () => <span data-testid="logo" />);
-
-jest.mock("../../../stores/KeyPressedStore", () => ({
-  useCombo: jest.fn()
-}));
-
-jest.mock("../../../stores/AppHeaderStore", () => ({
-  useAppHeaderStore: () => ({
-    helpOpen: false,
-    handleCloseHelp: jest.fn(),
-    handleOpenHelp: jest.fn(),
-    setHelpIndex: jest.fn()
-  })
-}));
-
-jest.mock("../../../stores/ModelDownloadStore", () => ({
-  useModelDownloadStore: () => ({ downloads: {}, openDialog: jest.fn() })
-}));
-
-const renderLauncher = (showAppMenu = true) =>
+const renderLauncher = () =>
   render(
     <ThemeProvider theme={mockTheme}>
-      <MobileRailLauncher showAppMenu={showAppMenu} />
+      <MobileRailLauncher />
     </ThemeProvider>
   );
 
@@ -49,18 +26,11 @@ beforeEach(() => {
   usePanelStore.getState().setVisibility(false);
 });
 
-it("renders the app menu next to the panel toggle", () => {
+it("renders the panel toggle and no app menu", () => {
   renderLauncher();
 
-  expect(screen.getByLabelText("Open app menu")).toBeInTheDocument();
   expect(screen.getByLabelText("Open left panel")).toBeInTheDocument();
-});
-
-it("omits the app menu when showAppMenu is false", () => {
-  renderLauncher(false);
-
   expect(screen.queryByLabelText("Open app menu")).not.toBeInTheDocument();
-  expect(screen.getByLabelText("Open left panel")).toBeInTheDocument();
 });
 
 it("toggles panel visibility", async () => {

--- a/web/src/components/panels/__tests__/PanelLeftMobile.test.tsx
+++ b/web/src/components/panels/__tests__/PanelLeftMobile.test.tsx
@@ -70,6 +70,7 @@ jest.mock("../../node_menu/FavoritesTiles", () => () => (
   <div data-testid="favorites-tiles" />
 ));
 jest.mock("../RailAppMenu", () => () => <div data-testid="rail-app-menu" />);
+jest.mock("../../content/Help/Help", () => () => null);
 jest.mock("../../ui/ThemeToggle", () => () => (
   <div data-testid="theme-toggle" />
 ));
@@ -142,7 +143,7 @@ it("keeps the visible desktop groups in the mobile tab row", () => {
   renderPanel();
 
   const groups = Array.from(document.querySelectorAll(".mobile-tab-group"));
-  expect(groups).toHaveLength(4);
+  expect(groups).toHaveLength(5);
   expect(
     groups.map((group) =>
       Array.from(group.querySelectorAll("button")).map((button) =>
@@ -153,8 +154,28 @@ it("keeps the visible desktop groups in the mobile tab row", () => {
     ["Workflows", "Apps", "Chats"],
     ["Sketches", "Scripts", "Storyboards", "Entities", "Timelines"],
     ["JS Scripts", "Skills"],
-    ["Workspace", "Assets", "Library"]
+    ["Workspace", "Assets", "Library"],
+    ["More"]
   ]);
+});
+
+it("reaches the app pages through More, not a second menu button", async () => {
+  const user = userEvent.setup();
+  renderPanel();
+
+  await user.click(screen.getByLabelText("More"));
+
+  // The destinations the desktop logo menu carries.
+  expect(screen.getByText("Settings")).toBeInTheDocument();
+  expect(screen.getByText("Dashboard")).toBeInTheDocument();
+  expect(screen.getByText("Downloads")).toBeInTheDocument();
+  expect(screen.queryByTestId("workflow-list")).not.toBeInTheDocument();
+  expect(screen.queryByTestId("create-workflow")).not.toBeInTheDocument();
+
+  // A category tab takes the sheet back to browsing documents.
+  await user.click(screen.getByLabelText("Chats"));
+  expect(screen.getByTestId("chat-list")).toBeInTheDocument();
+  expect(screen.queryByText("Downloads")).not.toBeInTheDocument();
 });
 
 it("switches the sheet to the view whose tab was tapped", async () => {

--- a/web/src/components/panels/useAppMenuActions.tsx
+++ b/web/src/components/panels/useAppMenuActions.tsx
@@ -1,0 +1,176 @@
+import React, { useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { useShallow } from "zustand/react/shallow";
+import SettingsIcon from "@mui/icons-material/Settings";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
+import DownloadIcon from "@mui/icons-material/Download";
+import SpaceDashboardOutlinedIcon from "@mui/icons-material/SpaceDashboardOutlined";
+import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
+import SchoolOutlinedIcon from "@mui/icons-material/SchoolOutlined";
+import PaidOutlinedIcon from "@mui/icons-material/PaidOutlined";
+import ViewInArOutlinedIcon from "@mui/icons-material/ViewInArOutlined";
+import Inventory2OutlinedIcon from "@mui/icons-material/Inventory2Outlined";
+import LibraryBooksOutlinedIcon from "@mui/icons-material/LibraryBooksOutlined";
+import FolderSpecialOutlinedIcon from "@mui/icons-material/FolderSpecialOutlined";
+import PermMediaOutlinedIcon from "@mui/icons-material/PermMediaOutlined";
+
+import { isProduction } from "../../lib/env";
+import { useAppHeaderStore } from "../../stores/AppHeaderStore";
+import { useModelDownloadStore } from "../../stores/ModelDownloadStore";
+import { openPageTab } from "../workspace/openPageTab";
+import { type PageTabKey } from "../workspace/pageTabs";
+
+export interface AppMenuAction {
+  key: string;
+  label: string;
+  icon: React.ReactNode;
+  onClick: () => void;
+  /** Trailing text, e.g. live download progress. */
+  secondary?: string;
+  /** Group separator after this entry. */
+  dividerAfter?: boolean;
+}
+
+/**
+ * The app-level destinations behind the logo: page tabs, Help, and Downloads.
+ * Shared by the desktop rail's popover (RailAppMenu) and the mobile browse
+ * sheet's More section (AppPagesList) so the two cannot drift.
+ *
+ * Callers own the Help dialog: render `<Help>` against `useAppHeaderStore`,
+ * since the Downloads dialog and page tabs mount themselves but Help does not.
+ */
+export const useAppMenuActions = (onFinish?: () => void): AppMenuAction[] => {
+  const navigate = useNavigate();
+  const handleOpenHelp = useAppHeaderStore((state) => state.handleOpenHelp);
+  const { downloads, openDownloadsDialog } = useModelDownloadStore(
+    useShallow((state) => ({
+      downloads: state.downloads,
+      openDownloadsDialog: state.openDialog
+    }))
+  );
+
+  const finish = useCallback(() => onFinish?.(), [onFinish]);
+
+  const openPage = useCallback(
+    (key: PageTabKey) => {
+      openPageTab(key);
+      finish();
+    },
+    [finish]
+  );
+
+  // Aggregate percent across in-flight downloads; null when nothing is running.
+  const downloadProgress = useMemo(() => {
+    const active = Object.values(downloads).filter(
+      (download) => download.status === "progress"
+    );
+    if (active.length === 0) return null;
+    const total = active.reduce((sum, d) => sum + d.totalBytes, 0);
+    const done = active.reduce((sum, d) => sum + d.downloadedBytes, 0);
+    return total > 0 ? Math.round((done / total) * 100) : 0;
+  }, [downloads]);
+
+  return useMemo(() => {
+    const actions: AppMenuAction[] = [
+      {
+        key: "dashboard",
+        label: "Dashboard",
+        icon: <SpaceDashboardOutlinedIcon />,
+        onClick: () => {
+          navigate("/dashboard");
+          finish();
+        }
+      },
+      {
+        key: "tutorials",
+        label: "Tutorials",
+        icon: <SchoolOutlinedIcon />,
+        onClick: () => openPage("tutorials")
+      },
+      {
+        key: "examples",
+        label: "Examples",
+        icon: <AutoAwesomeOutlinedIcon />,
+        onClick: () => openPage("examples")
+      },
+      {
+        key: "costs",
+        label: "Costs",
+        icon: <PaidOutlinedIcon />,
+        onClick: () => openPage("costs"),
+        dividerAfter: true
+      },
+      {
+        key: "models",
+        label: "Model Manager",
+        icon: <ViewInArOutlinedIcon />,
+        onClick: () => openPage("models")
+      }
+    ];
+
+    if (!isProduction) {
+      actions.push({
+        key: "packages",
+        label: "Package Manager",
+        icon: <Inventory2OutlinedIcon />,
+        onClick: () => openPage("packages")
+      });
+    }
+
+    actions.push(
+      {
+        key: "assets",
+        label: "Assets",
+        icon: <PermMediaOutlinedIcon />,
+        onClick: () => openPage("assets")
+      },
+      {
+        key: "collections",
+        label: "Collections",
+        icon: <LibraryBooksOutlinedIcon />,
+        onClick: () => openPage("collections")
+      },
+      {
+        key: "workspaces",
+        label: "Workspaces",
+        icon: <FolderSpecialOutlinedIcon />,
+        onClick: () => openPage("workspaces"),
+        dividerAfter: true
+      },
+      {
+        key: "settings",
+        label: "Settings",
+        icon: <SettingsIcon />,
+        onClick: () => openPage("settings")
+      },
+      {
+        key: "help",
+        label: "Help",
+        icon: <HelpOutlineIcon />,
+        onClick: () => {
+          handleOpenHelp();
+          finish();
+        }
+      },
+      {
+        key: "downloads",
+        label: "Downloads",
+        icon: <DownloadIcon />,
+        onClick: () => {
+          openDownloadsDialog();
+          finish();
+        },
+        secondary: downloadProgress != null ? `${downloadProgress}%` : undefined
+      }
+    );
+
+    return actions;
+  }, [
+    navigate,
+    openPage,
+    finish,
+    handleOpenHelp,
+    openDownloadsDialog,
+    downloadProgress
+  ]);
+};

--- a/web/src/components/workspace/OpenMenu.tsx
+++ b/web/src/components/workspace/OpenMenu.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useMediaQuery } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
 import AddRoundedIcon from "@mui/icons-material/AddRounded";
 import ArticleOutlinedIcon from "@mui/icons-material/ArticleOutlined";
 import ImageOutlinedIcon from "@mui/icons-material/ImageOutlined";
@@ -152,9 +154,15 @@ const TEXT_FILE_TEMPLATES: readonly TextFileTemplate[] = [
 /**
  * The `[+]` menu for the workspace tab bar: create a new workflow, or open an
  * existing workflow or asset as a tab. A lightweight stand-in for the deferred
- * home/launcher screen — the only way to open existing documents until then.
+ * home/launcher screen.
+ *
+ * On mobile it creates only — the browse sheet behind the hamburger lists
+ * every document by category, so the "Open …" entries put the same lists
+ * behind a second button in a top row with room for neither.
  */
 const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const [view, setView] = useState<MenuView>("root");
   const autoFocusEnabled = useAutoFocusEnabled();
   const [assetQuery, setAssetQuery] = useState("");
@@ -555,23 +563,27 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
               icon={<ViewInArOutlinedIcon fontSize="small" />}
               onClick={() => void handleNewModel()}
               disabled={creating !== null}
-              dividerAfter
+              dividerAfter={!isMobile}
             />
-            <MenuItemPrimitive
-              label="Open workflow…"
-              hasSubmenu
-              onClick={() => setView("workflows")}
-            />
-            <MenuItemPrimitive
-              label="Open asset…"
-              hasSubmenu
-              onClick={() => setView("assets")}
-            />
-            <MenuItemPrimitive
-              label="Open chat…"
-              hasSubmenu
-              onClick={() => setView("chats")}
-            />
+            {!isMobile && (
+              <>
+                <MenuItemPrimitive
+                  label="Open workflow…"
+                  hasSubmenu
+                  onClick={() => setView("workflows")}
+                />
+                <MenuItemPrimitive
+                  label="Open asset…"
+                  hasSubmenu
+                  onClick={() => setView("assets")}
+                />
+                <MenuItemPrimitive
+                  label="Open chat…"
+                  hasSubmenu
+                  onClick={() => setView("chats")}
+                />
+              </>
+            )}
           </>
         )}
 

--- a/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -574,9 +574,11 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
 
   return (
     <div css={tabBarStyles} className="workspace-tabbar">
-      {/* Mobile has no vertical rail, so the app menu and panel toggle ride
-        along in the top row instead of floating over the content. */}
-      {isMobile && <MobileRailLauncher showAppMenu />}
+      {/* Mobile has no vertical rail, so the panel toggle rides along in the
+        top row instead of floating over the content. The sheet it opens is
+        mobile's one navigation surface — document categories plus the app
+        pages the desktop logo menu holds. */}
+      {isMobile && <MobileRailLauncher />}
       <button
         ref={newTabButtonRef}
         type="button"

--- a/web/src/components/workspace/__tests__/OpenMenuMobile.test.tsx
+++ b/web/src/components/workspace/__tests__/OpenMenuMobile.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * The `[+]` menu at phone width creates only. The browse sheet behind the
+ * hamburger already lists every document by category, so "Open workflow… /
+ * asset… / chat…" here put the same lists behind a second button in a top row
+ * that has room for neither.
+ */
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+let matchesMobile = true;
+jest.mock("@mui/material/useMediaQuery", () => ({
+  __esModule: true,
+  default: () => matchesMobile
+}));
+
+jest.mock("../../../hooks/storyboard/useStoryboards", () => ({
+  useCreateStoryboard: () => ({ mutateAsync: jest.fn() }),
+  useExampleStoryboards: () => ({ data: undefined, isLoading: false }),
+  useInstallExampleStoryboard: () => ({ mutateAsync: jest.fn() })
+}));
+jest.mock("../../../stores/WorkspaceTabsStore", () => ({
+  useWorkspaceTabsStore: <T,>(selector: (s: { openTab: jest.Mock }) => T) =>
+    selector({ openTab: jest.fn() })
+}));
+jest.mock("../../../stores/NotificationStore", () => ({
+  useNotificationStore: <T,>(
+    selector: (s: { addNotification: jest.Mock }) => T
+  ) => selector({ addNotification: jest.fn() })
+}));
+jest.mock("../../../stores/AssetStore", () => ({
+  useAssetStore: <T,>(selector: (s: { createAsset: jest.Mock }) => T) =>
+    selector({ createAsset: jest.fn() })
+}));
+jest.mock("../../../contexts/WorkflowManagerContext", () => ({
+  useWorkflowManager: <T,>(selector: (s: { createNew: jest.Mock }) => T) =>
+    selector({ createNew: jest.fn() })
+}));
+jest.mock("../../../stores/GlobalChatStore", () => ({
+  __esModule: true,
+  default: <T,>(selector: (s: { createNewThread: jest.Mock }) => T) =>
+    selector({ createNewThread: jest.fn() })
+}));
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: undefined, isLoading: false, isFetching: false })
+}));
+jest.mock("../../../trpc/client", () => ({ trpcClient: {} }));
+jest.mock("../../../serverState/useAssetSearch", () => ({
+  useAssetSearch: () => ({ searchAssets: jest.fn() })
+}));
+jest.mock("../../../hooks/useTimelineSequence", () => ({
+  useCreateTimeline: () => ({ mutateAsync: jest.fn() })
+}));
+jest.mock("../../../hooks/useApplications", () => ({
+  useCreateApplication: () => ({ mutateAsync: jest.fn() })
+}));
+jest.mock("../../../hooks/script/useScripts", () => ({
+  useCreateScript: () => ({ mutateAsync: jest.fn() })
+}));
+jest.mock("../../../hooks/jsScript/useJsScripts", () => ({
+  useCreateJsScript: () => ({ mutateAsync: jest.fn() })
+}));
+jest.mock("../../../hooks/useAutoFocusEnabled", () => ({
+  useAutoFocusEnabled: () => false
+}));
+
+import OpenMenu from "../OpenMenu";
+
+const renderMenu = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <OpenMenu anchorEl={document.body} open onClose={jest.fn()} />
+    </ThemeProvider>
+  );
+
+const OPEN_ITEMS = ["Open workflow…", "Open asset…", "Open chat…"];
+
+describe("OpenMenu at phone width", () => {
+  it("keeps the creators and drops the open-existing entries", () => {
+    matchesMobile = true;
+    renderMenu();
+
+    expect(screen.getByText("New workflow")).toBeInTheDocument();
+    expect(screen.getByText("New chat")).toBeInTheDocument();
+    for (const label of OPEN_ITEMS) {
+      expect(screen.queryByText(label)).not.toBeInTheDocument();
+    }
+  });
+
+  it("still offers them on desktop", () => {
+    matchesMobile = false;
+    renderMenu();
+
+    for (const label of OPEN_ITEMS) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+});


### PR DESCRIPTION
## What changed

The mobile top bar carried four disclosure surfaces in 48px — the logo menu, the hamburger panel, the `+` menu and the document selector — and three of them opened the same nouns: the logo menu's Assets/Collections/Workspaces and the `+` menu's "Open workflow… / asset… / chat…" are lists the browse sheet already shows. Mobile now has two menus. The app pages (Dashboard, Tutorials, Examples, Costs, Model Manager, Package Manager, Assets, Collections, Workspaces, Settings, Help, Downloads) become a **More** section of the sheet the hamburger opens, so the logo drops out of the top row and the document title takes the width it freed; the `+` menu creates only. The destinations live in one place (`useAppMenuActions`) rendered two ways — the desktop rail's popover and the sheet's 44px rows — so the two surfaces cannot drift. `RailAppMenu` is desktop-only now and keeps the Cmd+, / Cmd+/ shortcuts and the Help dialog it owned. Desktop is unchanged: the "Open …" entries are hidden below the `sm` breakpoint only.

## Verification

- [x] `npm run test:affected` — 5 suites, 18 tests, all passed
- [x] `npm run typecheck` — web and electron clean. Mobile fails on `Cannot find module 'react-native'` and the implicit-any cascade behind it: `mobile/` is not a root workspace and its dependencies are not installed in this container. No mobile file is in the diff.
- [x] `npm run lint` — exit 0; the 108 warnings are pre-existing and none is in a touched file
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — exit 0; 10 changed files touch 1 surface (`web-editor`), 0 selfchecks to run. (`--base main` fails with `no merge base` here — the checkout is shallow.)

Two new checks, each inverted once and observed failing before being kept:

```
# OpenMenu.tsx: {!isMobile && ( → {isMobile && (
✕ keeps the creators and drops the open-existing entries
✕ still offers them on desktop
Tests: 2 failed, 2 total

# PanelLeft.tsx: {appPagesOpen ? ( → {false ? (
✕ reaches the app pages through More, not a second menu button
Tests: 1 failed, 4 passed, 5 total
```

## Agent capabilities

No capability added or re-declared.

## New checks

- [x] Both new tests were inverted once and observed failing; the output is in **Verification** above
- [x] Neither is an audit that scans files, so there is nothing that could pass by matching nothing — each asserts named items are present and named items are absent

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuoqyqYnazNWPFUWZLoLjj)_