### PR TITLE
docs(brand): add brand and verbal guidelines, anchor them repo-wide

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -124,6 +124,7 @@ Non-negotiable ([electron/src/AGENTS.md](../../../electron/src/AGENTS.md) § Sec
 - `package.json` script or dependency changes: check the lockfile moved with it, and that the sandboxed-install caveats (AGENTS.md § Common Pitfalls) still hold.
 - Changes to commands, architecture, or rules documented in `AGENTS.md`: the doc must move in the same PR — that's a written rule, cite it.
 - Prose follows [docs/WRITING_STYLE.md](../../../docs/WRITING_STYLE.md); flag slop words but leave the full prose pass to `unslop`.
+- User-facing copy (marketing site, product strings, release notes, node and workflow descriptions) also follows [docs/BRAND.md](../../../docs/BRAND.md): outcome before mechanism, no `credits`/`tokens` as billing, no `chatbot` for the agent, no `powered by AI` where a model name fits.
 
 ## Smell baseline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,7 @@ Everything else in the document is downstream of these.
 - **[Scripts](scripts/AGENTS.md)** — Build and release scripts
 - **[URL Egress Inventory](docs/url-egress-inventory.md)** — Every surface that fetches a caller-provided URL, the one address table, and the SSRF policy each surface applies
 - **[Writing Style](docs/WRITING_STYLE.md)** — Anti-slop prose rules and the forbidden-expressions list for all docs and Markdown
+- **[Brand & Verbal Guidelines](docs/BRAND.md)** — Positioning, voice, messaging pillars, and product lexicon for anything user-facing
 
 ---
 
@@ -2663,11 +2664,12 @@ These three areas have full sections in the central standards doc:
 
 ## Writing & Docs
 
-> Full guide: [docs/WRITING_STYLE.md](docs/WRITING_STYLE.md). Comment/README rules: [DEVELOPMENT_STANDARDS §19](docs/DEVELOPMENT_STANDARDS.md#19-documentation--comments).
+> Full guide: [docs/WRITING_STYLE.md](docs/WRITING_STYLE.md). Brand voice and messaging: [docs/BRAND.md](docs/BRAND.md). Comment/README rules: [DEVELOPMENT_STANDARDS §19](docs/DEVELOPMENT_STANDARDS.md#19-documentation--comments).
 
 - Write prose — docs, READMEs, this file, PR descriptions, comments — concise and concrete. Cut any sentence that survives deletion without losing meaning.
 - **No AI slop.** Forbidden: `leverage`, `utilize`, `seamless`, `robust`, `powerful`, `comprehensive`, `cutting-edge`, `unlock`, `empower`, `streamline`, `it's worth noting`, `dive into`, rule-of-three padding, "it's not just X, it's Y", emoji decoration, and the rest of the [forbidden list](docs/WRITING_STYLE.md#forbidden-expressions).
 - Bold-label bullets must add information beyond the label. Claims are concrete: numbers, names, paths — not adjectives.
+- **User-facing copy also follows [docs/BRAND.md](docs/BRAND.md).** Lead with the outcome, not the node graph. Never `credits`/`tokens` for billing (say `provider rates`, `at cost`), never `chatbot` for the agent, never `powered by AI` where a model name fits. Full lexicon: [BRAND.md § Lexicon](docs/BRAND.md#5-lexicon).
 - When you edit a Markdown file, fix slop you pass in the same change. For code, use the `unslop` skill.
 
 ## Technologies

--- a/docs/BRAND.md
+++ b/docs/BRAND.md
@@ -1,0 +1,154 @@
+---
+layout: page
+title: "Brand & Verbal Guidelines"
+permalink: /brand
+description: "NodeTool brand and verbal guidelines — positioning, voice, messaging pillars, lexicon, and feature-to-benefit framing."
+---
+
+# NodeTool Brand & Verbal Guidelines
+
+**Navigation**: [Root AGENTS.md](../AGENTS.md) | [Writing Style](WRITING_STYLE.md) → **Brand & Verbal Guidelines**
+
+What NodeTool says about itself, and in whose voice. [WRITING_STYLE.md](WRITING_STYLE.md)
+governs prose mechanics — the words that are banned and the sentences that get
+cut. This file governs the message: positioning, pillars, lexicon, and how a
+feature becomes a benefit. Both apply to the marketing site, product copy,
+docs, release notes, node and workflow descriptions, and social posts.
+
+When copy and this file disagree, one of them is wrong. Fix both in the same
+change.
+
+## 1. Identity and positioning
+
+- **Mission.** Give creators and developers control over multi-modal AI
+  orchestration without platform lock-in, credit markups, or lost context.
+- **Elevator pitch.** NodeTool is the open canvas for multi-modal AI. It
+  connects image, video, audio, and language models into repeatable workflows
+  that run in the cloud, locally on your own hardware, or headless over MCP.
+- **What we are against.** The five-tab workflow: brand context lost in chat
+  threads, prompts and seeds stranded between tools, and a markup on every
+  generation.
+
+The pitch above is the general-purpose one — README, docs, conference blurb,
+app store listing. The marketing homepage runs a narrower, filmmaker-first
+line; [marketing/NARRATIVE.md](../marketing/NARRATIVE.md) owns that hero and
+wins on nodetool.ai. The two must not contradict each other: both say the
+creator directs and keeps the project file.
+
+## 2. Voice
+
+NodeTool speaks like a senior technical director: capable, practical,
+transparent, unpretentious.
+
+- **Pragmatic, not hyperbolic.** No "magic", "wizardry", "mind-blowing". We
+  talk about orchestration, pipelines, and execution. The efficiency is the
+  story.
+- **Direct.** Active voice, second person, the user in the director's chair.
+  "You hold the keys. You own the canvas."
+- **Transparent.** Costs, API limits, and model tradeoffs are stated, not
+  buried. Complexity is tamed in the open, never hidden.
+
+## 3. Messaging pillars
+
+Every claim advances one of these four. A sentence that advances none is cut.
+
+### Pillar 1 — Outcome before mechanism
+
+People come to build a product video, a trailer, or an ad pipeline, not to play
+with nodes. Lead with the finished asset; reveal the canvas that made it second.
+
+> "Turn one product brief into a finished campaign" (outcome) → "One canvas to
+> write, generate, and edit" (mechanism).
+
+### Pillar 2 — Radical ownership
+
+The user owns the data, the keys, and the infrastructure. This is the position
+closed platforms cannot copy.
+
+Vocabulary: your keys, at cost, open source, local-first, MLX / Ollama /
+llama.cpp, no markups.
+
+### Pillar 3 — Persistent context
+
+Chat interfaces forget. The canvas is a workspace that holds the brief, the
+references, and the takes across sessions, so nobody re-types a brand brief on
+the fourth variant.
+
+Vocabulary: stateful, global references, persistent context, repeatable.
+
+### Pillar 4 — Built to integrate
+
+NodeTool is an engine inside someone's stack, not a destination that holds them.
+Developer interoperability is a headline feature, not a footer link.
+
+Vocabulary: MCP server, headless execution, API endpoints, CLI, spec-driven.
+
+## 4. Dos and don'ts
+
+| Do | Don't | Why |
+|---|---|---|
+| "The agent wires the studio." | "Chat with our AI." | Chatbot implies text in, text out. The agent edits the canvas and connects nodes. |
+| "Your keys, at cost." | "500 credits / month." | Credits imply a markup and lock-in. Provider list price is the product. |
+| "Local-first and cloud." | "The web app." | MLX, Ollama, and llama.cpp support is the differentiator for privacy-bound users. |
+| "Repeatable workflows." | "Generate a video." | Anyone generates one video. NodeTool builds the system that generates a hundred. |
+| "Connect the models you want." | "Powered by AI." | Name the models — Flux, Veo, Kling, Claude, Gemini — to show we are model-agnostic. |
+| "A Seedance run that costs $0.18 on KIE costs $0.18 here." | "No markup." | Concrete beats categorical. |
+
+## 5. Lexicon
+
+**Use.**
+
+| Term | Means |
+|---|---|
+| Canvas | The visual workspace where the work happens. |
+| Orchestrate / wire | Connecting models and steps. |
+| Pipeline / workflow | The repeatable system the user builds. |
+| Agent | The built-in assistant that configures the canvas. |
+| Open-weight / local-first | Models running on the user's own MacBook or NVIDIA box. |
+| Provider rates | What the user pays. No middleman. |
+| Brief / context | The input a creator supplies. |
+
+**Avoid.**
+
+| Term | Instead |
+|---|---|
+| Prompt engineering | brief, context, direction |
+| Magic box / black box | name the mechanism |
+| Credits / gems / coins / tokens (as billing) | provider rates, at cost, list price |
+| Chatbot (for the agent) | agent |
+| Powered by AI | name the models |
+| Users (in creator-facing copy) | creators, directors, filmmakers, developers |
+
+The banned words in [WRITING_STYLE.md § Forbidden expressions](WRITING_STYLE.md#forbidden-expressions)
+apply on top of this table.
+
+## 6. Feature to benefit
+
+Ship the benefit; the feature is the evidence.
+
+| Feature | Benefit |
+|---|---|
+| Multi-modal node graph | Stop juggling five browser tabs to make one video. |
+| Bring your own API keys | Never pay a marked-up credit subscription again. |
+| MCP server export | Call your NodeTool pipelines from Cursor or Claude Code. |
+| Cost-aware agent rendering | See what a generation costs across four providers before you click run. |
+| Local model support (MLX, Ollama, llama.cpp) | Work that never leaves the machine, and costs nothing after the download. |
+| Headless CLI and API | Run the same pipeline in CI that you built on the canvas. |
+
+## 7. Checklist
+
+Before shipping copy:
+
+- [ ] The lead is an outcome, not a mechanism.
+- [ ] No term from the avoid table, and none from the forbidden list.
+- [ ] Cost and ownership stated as fact, not as a pitch.
+- [ ] Model and provider names where a reader is checking for a specific one.
+- [ ] Claims are concrete: a number, a model name, a price, a path.
+
+## Related
+
+- [WRITING_STYLE.md](WRITING_STYLE.md) — prose mechanics and the forbidden-expressions list
+- [marketing/NARRATIVE.md](../marketing/NARRATIVE.md) — what nodetool.ai says, in what order
+- [marketing/PRODUCT.md](../marketing/PRODUCT.md) — users, brand personality, design principles
+- [marketing/POSITIONING_PLAN.md](../marketing/POSITIONING_PLAN.md) — competitive positioning and launch plan
+- [DEVELOPMENT_STANDARDS §19](DEVELOPMENT_STANDARDS.md#19-documentation--comments) — documentation rules

--- a/docs/DEVELOPMENT_STANDARDS.md
+++ b/docs/DEVELOPMENT_STANDARDS.md
@@ -512,6 +512,8 @@ We use **OpenTelemetry** for tracing across agents and workflows (`workflow.run`
 
 All prose — docs, READMEs, AGENTS.md files, PR descriptions, comments — follows [WRITING_STYLE.md](WRITING_STYLE.md): concise, concrete, no AI filler. It carries the forbidden-expressions list (no `leverage`, `seamless`, `robust`, `comprehensive`, `it's worth noting`, rule-of-three padding, etc.). Agents editing a Markdown file fix violations they pass.
 
+User-facing copy — the marketing site, product strings, release notes, node and workflow descriptions — also follows [BRAND.md](BRAND.md), which covers positioning, voice, the four messaging pillars, and the product lexicon (no `credits` for billing, no `chatbot` for the agent, no `powered by AI` where a model name fits).
+
 ### target
 
 - Every exported function in `@nodetool-ai/agents`, `@nodetool-ai/kernel`, `@nodetool-ai/runtime`, `@nodetool-ai/node-sdk` has JSDoc.

--- a/docs/WRITING_STYLE.md
+++ b/docs/WRITING_STYLE.md
@@ -5,9 +5,11 @@ permalink: /writing-style
 description: "How to write docs, READMEs, and AGENTS.md files for NodeTool — concise, direct, no AI slop."
 ---
 
-**Navigation**: [Root AGENTS.md](../AGENTS.md) | [DEVELOPMENT_STANDARDS §19](DEVELOPMENT_STANDARDS.md#19-documentation--comments) → **Writing Style**
+**Navigation**: [Root AGENTS.md](../AGENTS.md) | [DEVELOPMENT_STANDARDS §19](DEVELOPMENT_STANDARDS.md#19-documentation--comments) | [Brand & Verbal Guidelines](BRAND.md) → **Writing Style**
 
 How to write prose in this repo: docs, READMEs, AGENTS.md files, PR descriptions, comments. The goal is text a reader trusts — concrete, short, free of the filler that marks machine-generated copy.
+
+This file covers mechanics: which words are banned and which sentences get cut. [BRAND.md](BRAND.md) covers the message — positioning, voice, pillars, and the product lexicon. Anything user-facing follows both.
 
 This applies to humans and agents alike. When an agent edits a Markdown file, it follows these rules and fixes violations it passes.
 
@@ -43,6 +45,12 @@ Don't open sentences with these out of habit: `Furthermore` · `Moreover` · `Ad
 
 `gone are the days` · `say goodbye to` · `look no further` · `the possibilities are endless` · `whether you're a beginner or an expert` · `unlock the power of` · `take it to the next level` · `at your fingertips` · `with just a few clicks` · `out of the box` (prefer "by default") · `and much more` / `and more!` · `wide range of` / `rich set of` (say the number or the list)
 
+### Off-brand product terms
+
+These are wrong about NodeTool, not just inflated. Full table with replacements in [BRAND.md § Lexicon](BRAND.md#5-lexicon).
+
+`credits` / `gems` / `coins` / `tokens` (as billing — say `provider rates`, `at cost`, `list price`) · `chatbot` (for the agent — say `agent`) · `powered by AI` (name the models) · `prompt engineering` (say `brief`, `context`, `direction`) · `magic` / `magic box` / `black box` (name the mechanism) · `users` in creator-facing copy (say `creators`, `directors`, `developers`)
+
 ### Banned patterns
 
 - **The "it's not just X, it's Y" frame.** "NodeTool isn't just a tool, it's a workspace." Cut it. State what it is.
@@ -75,11 +83,11 @@ Before committing prose, scan for:
 - [ ] Claims are concrete: numbers, names, file paths — not "powerful" or "wide range".
 - [ ] At most one em-dash per paragraph.
 - [ ] No opening throat-clear and no closing summary that repeats the body.
+- [ ] For user-facing copy: no off-brand product term, and the lead is an outcome (see [BRAND.md](BRAND.md)).
 
 ## Related
 
+- [BRAND.md](BRAND.md) — brand and verbal guidelines: positioning, voice, messaging pillars, lexicon
 - [DEVELOPMENT_STANDARDS §19 Documentation & Comments](DEVELOPMENT_STANDARDS.md#19-documentation--comments) — comment and README rules
 - [Root AGENTS.md](../AGENTS.md) — repo rules for agents and contributors
 - The `unslop` skill (`.claude/skills/`) — the equivalent pass for code
-</content>
-</invoke>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -182,6 +182,7 @@ exclude:
   # but NOT published to docs.nodetool.ai. These are not user-facing.
   - README.md
   - AGENTS.md
+  - BRAND.md
   - DESIGN.md
   - DEVELOPMENT_STANDARDS.md
   - WRITING_STYLE.md

--- a/marketing/NARRATIVE.md
+++ b/marketing/NARRATIVE.md
@@ -1,10 +1,16 @@
 # Narrative
 
-What the site says, in what order, and why. `PRODUCT.md` covers brand, users, and
-design principles; this file covers the message; `POSITIONING_PLAN.md` covers
-the competitive positioning, landing-page blueprint, and launch plan. When
-homepage copy and this file disagree, one of them is wrong — fix both in the
-same change.
+What the site says, in what order, and why. [docs/BRAND.md](../docs/BRAND.md)
+carries the repo-wide brand and verbal guidelines (mission, voice, the four
+messaging pillars, lexicon); `PRODUCT.md` covers brand, users, and design
+principles; this file covers the message; `POSITIONING_PLAN.md` covers the
+competitive positioning, landing-page blueprint, and launch plan. When homepage
+copy and this file disagree, one of them is wrong — fix both in the same change.
+
+This file is the homepage's narrower cut of `BRAND.md`, not a second standard.
+The positioning line below wins on nodetool.ai; `BRAND.md`'s elevator pitch
+covers everywhere else (README, docs, listings). Both say the same thing: the
+creator directs and keeps the project file.
 
 ## Positioning line
 
@@ -86,7 +92,8 @@ better than a manufactured superlative.
 
 ## Phrasing rules
 
-Beyond [docs/WRITING_STYLE.md](../docs/WRITING_STYLE.md), which applies here too:
+Beyond [docs/WRITING_STYLE.md](../docs/WRITING_STYLE.md) and
+[docs/BRAND.md § Lexicon](../docs/BRAND.md#5-lexicon), which apply here too:
 
 - "Studio" or "canvas", not "workflow builder" — the latter undersells the
   editors and puts us in the n8n bracket.
@@ -99,5 +106,7 @@ Beyond [docs/WRITING_STYLE.md](../docs/WRITING_STYLE.md), which applies here too
   providers where a reader is checking for a specific one (pricing, model pages).
 - Concrete over categorical: "a Seedance run that costs $0.18 on KIE costs $0.18
   here" beats "no markup".
+- Never "credits", "gems", or "tokens" as billing units, and never "chatbot" for
+  the agent. See the avoid table in `BRAND.md`.
 - No "magic", "revolutionary", "seamless", "powerful", "unlock", "empower". If a
   sentence survives its own deletion, delete it.

--- a/marketing/POSITIONING_PLAN.md
+++ b/marketing/POSITIONING_PLAN.md
@@ -3,8 +3,13 @@
 Consolidated from the positioning, use-case, landing-page, asset, and rollout
 work sessions (August 2026). This is the single reference for how NodeTool is
 positioned, who it is for, what the website says, and what ships in the next
-two weeks. Companion docs: [NARRATIVE.md](NARRATIVE.md) (brand voice),
-[PRODUCT.md](PRODUCT.md) (product facts), [docs/SEO_STRATEGY.md](../docs/SEO_STRATEGY.md).
+two weeks. Companion docs: [docs/BRAND.md](../docs/BRAND.md) (brand and verbal
+guidelines — voice, messaging pillars, lexicon), [NARRATIVE.md](NARRATIVE.md)
+(site message and hero), [PRODUCT.md](PRODUCT.md) (product facts),
+[docs/SEO_STRATEGY.md](../docs/SEO_STRATEGY.md).
+
+Every headline, tagline, and matrix row below is subject to `BRAND.md`: lead
+with the outcome, name the models, and never price the product in credits.
 
 > Every dollar figure in this document (SaaS stack totals, per-asset costs,
 > savings percentages) is illustrative and must be re-verified against current

--- a/marketing/PRODUCT.md
+++ b/marketing/PRODUCT.md
@@ -18,21 +18,23 @@ Success looks like a creator downloading it, wiring their first multi-model work
 
 ## Brand Personality
 
-**Powerful creative studio.** Confident, vivid, capable. Three words: *capable, open, vivid.*
+**A creative studio that behaves like a pro tool.** Three words: *capable, open, vivid.*
 
-The voice is a pro tool that respects the user's intelligence — it shows the canvas and the work rather than over-explaining. Underneath the studio confidence runs a current of honesty: BYOK, no markup, you own it. That transparency is substance, not a slogan, so it should read as quiet fact, not as a pitch. Aspirational but never breathless.
+The voice is a senior technical director: it shows the canvas and the work rather than over-explaining, and it respects the reader's intelligence. Underneath the studio confidence runs a current of honesty: BYOK, no markup, you own it. That transparency is substance, not a slogan, so it should read as quiet fact, not as a pitch. Aspirational but never breathless.
+
+Voice rules, messaging pillars, and the product lexicon live in [docs/BRAND.md](../docs/BRAND.md). This section covers how the brand feels; that file covers what it says.
 
 ## Anti-references
 
 - **Generic SaaS / template.** No cream backgrounds, no identical icon-heading-text card grids repeated down the page, no hero-metric template (big number + small label + gradient), no AI-slop landing aesthetic.
 - **Enterprise / corporate.** No stiff navy-and-gray, no stock photography, no jargon, no IBM/Salesforce stiffness.
-- **Crypto / hype.** No neon-on-black, no gradient overload, no breathless "revolutionary" copy. The product is genuinely powerful; let the work say so.
+- **Crypto / hype.** No neon-on-black, no gradient overload, no breathless "revolutionary" copy. The product does the work; let the output say so.
 
 ## Design Principles
 
 1. **Show the work.** The canvas, the nodes, real product screenshots carry the message. Lead with what the tool makes possible, not adjectives about it.
 2. **Honesty as a feature.** "Your keys, your canvas, pay providers directly" is a differentiator. State it plainly and let it land without overselling.
-3. **Studio confidence.** Vivid, committed, capable. Match the visual ambition to a pro creative tool, not a generic SaaS funnel.
+3. **Studio confidence.** Vivid, committed, capable. Match the visual ambition to a pro creative tool, not a generic SaaS funnel. Pragmatic, never hyperbolic: the efficiency is the story, not the adjectives.
 4. **Creators first.** The homepage speaks to makers. Technical depth and business framing live on their own tracks, reachable but not crowding the front door.
 5. **Earn every section.** No filler, no repeated card grids, no restated headings. Each section advances a distinct reason to download.
 

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -4,12 +4,13 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 Copy and positioning decisions live next to the site code:
 
+- [docs/BRAND.md](../docs/BRAND.md) — brand and verbal guidelines: mission, voice, the four messaging pillars, lexicon, feature-to-benefit table. Applies to every surface, not just this site
 - [NARRATIVE.md](NARRATIVE.md) — what the site says, in what order, and why; holds the current hero line
 - [PRODUCT.md](PRODUCT.md) — brand, users, and design principles
 - [POSITIONING_PLAN.md](POSITIONING_PLAN.md) — competitive positioning, landing-page blueprint, asset checklist, and launch plan
 - [VIDEO_SCRIPT.md](VIDEO_SCRIPT.md) — the product video script
 
-When homepage copy and these docs disagree, fix both in the same change.
+When homepage copy and these docs disagree, fix both in the same change. `BRAND.md` is the wider standard; where it and `NARRATIVE.md` differ on the homepage hero, `NARRATIVE.md` wins for nodetool.ai.
 
 ## Getting Started
 

--- a/marketing/src/data/providerCatalog.generated.ts
+++ b/marketing/src/data/providerCatalog.generated.ts
@@ -31,13 +31,13 @@ export interface ProviderCatalog {
 export const providerCatalog: Record<string, ProviderCatalog> = {
   "fal_ai": {
     "id": "fal_ai",
-    "total": 1554,
+    "total": 1560,
     "counts": {
       "3d": 60,
-      "image": 734,
+      "image": 736,
       "audio": 127,
       "text": 18,
-      "video": 615
+      "video": 619
     },
     "topTags": [
       "generation",
@@ -48,8 +48,8 @@ export const providerCatalog: Record<string, ProviderCatalog> = {
       "transformation",
       "video to video",
       "text to image",
-      "vid2vid",
       "image to video",
+      "vid2vid",
       "txt2img",
       "lora"
     ],
@@ -1466,11 +1466,11 @@ export const providerCatalog: Record<string, ProviderCatalog> = {
   },
   "replicate": {
     "id": "replicate",
-    "total": 655,
+    "total": 662,
     "counts": {
-      "image": 310,
-      "text": 127,
-      "video": 156,
+      "image": 312,
+      "text": 128,
+      "video": 160,
       "audio": 62
     },
     "topTags": [],
@@ -1508,6 +1508,20 @@ export const providerCatalog: Record<string, ProviderCatalog> = {
         "name": "Alexgenovese Upscaler",
         "kind": "image",
         "desc": "GFPGAN aims at developing Practical Algorithms for Real-world Face and Object Restoration",
+        "tags": []
+      },
+      {
+        "id": "alibaba/qwen-image-3",
+        "name": "Qwen Image 3",
+        "kind": "image",
+        "desc": "Qwen-Image-3.0 generates and edits images with accurate text rendering, complex layouts, and photographic detail.",
+        "tags": []
+      },
+      {
+        "id": "alibaba/qwen-image-3-pro",
+        "name": "Qwen Image 3 Pro",
+        "kind": "image",
+        "desc": "Qwen-Image-3.0-Pro generates and edits images with dense, accurate text rendering, complex multi-element layouts, and photographic detail.",
         "tags": []
       },
       {
@@ -1742,20 +1756,6 @@ export const providerCatalog: Record<string, ProviderCatalog> = {
         "tags": []
       },
       {
-        "id": "black-forest-labs/flux-schnell-lora",
-        "name": "Flux Schnell Lora",
-        "kind": "image",
-        "desc": "The fastest image generation model tailored for fine-tuned use",
-        "tags": []
-      },
-      {
-        "id": "bria/eraser",
-        "name": "Bria Eraser",
-        "kind": "image",
-        "desc": "SOTA Object removal, enables precise removal of unwanted objects from images while maintaining high-quality outputs.",
-        "tags": []
-      },
-      {
         "id": "alibaba/happyhorse-1.0",
         "name": "Happy Horse 1",
         "kind": "video",
@@ -1767,6 +1767,20 @@ export const providerCatalog: Record<string, ProviderCatalog> = {
         "name": "Happyhorse 1 1",
         "kind": "video",
         "desc": "Alibaba's Happy Horse 1.1 generates videos from text, animates a single image, or builds a video from multiple reference images.",
+        "tags": []
+      },
+      {
+        "id": "alibaba/wan-3",
+        "name": "Wan 3",
+        "kind": "video",
+        "desc": "Wan 3.0 generates video from a text prompt, with cinematic motion and support for 480p, 720p, and 1080p output.",
+        "tags": []
+      },
+      {
+        "id": "alibaba/wan-3-prime",
+        "name": "Wan 3 Prime",
+        "kind": "video",
+        "desc": "Generate videos from text prompts using Alibaba's Wan 3.0 Prime model.",
         "tags": []
       },
       {
@@ -1795,6 +1809,13 @@ export const providerCatalog: Record<string, ProviderCatalog> = {
         "name": "Robust Video Matting",
         "kind": "video",
         "desc": "extract foreground of a video",
+        "tags": []
+      },
+      {
+        "id": "black-forest-labs/flux-video-upscale",
+        "name": "Flux Video Upscale",
+        "kind": "video",
+        "desc": "Upscale videos to higher resolution with FLUX super-resolution.",
         "tags": []
       },
       {
@@ -1893,6 +1914,13 @@ export const providerCatalog: Record<string, ProviderCatalog> = {
         "name": "Seedance 2 0 Mini",
         "kind": "video",
         "desc": "A lower-cost variant of Seedance 2.0 for high-volume video generation with multimodal inputs and native audio.",
+        "tags": []
+      },
+      {
+        "id": "bytedance/seedance-2.5",
+        "name": "Seedance 2 5",
+        "kind": "video",
+        "desc": "ByteDance's flagship multimodal video model with native audio, native 30-second generation, and large multimodal reference sets.",
         "tags": []
       },
       {
@@ -2005,34 +2033,6 @@ export const providerCatalog: Record<string, ProviderCatalog> = {
         "name": "Veo 3 1 Fast",
         "kind": "video",
         "desc": "New and improved version of Veo 3 Fast, with higher-fidelity video, context-aware audio and last frame support",
-        "tags": []
-      },
-      {
-        "id": "google/veo-3.1-lite",
-        "name": "Veo 3 1 Lite",
-        "kind": "video",
-        "desc": "Google's cost-efficient video generation model with native audio, optimized for high-volume applications",
-        "tags": []
-      },
-      {
-        "id": "heygen/avatar-iv",
-        "name": "Avatar Iv",
-        "kind": "video",
-        "desc": "Create realistic talking avatar videos from text with HeyGen's Avatar IV engine",
-        "tags": []
-      },
-      {
-        "id": "heygen/avatar-v",
-        "name": "Avatar V",
-        "kind": "video",
-        "desc": "Create realistic talking avatar videos from text with HeyGen's Avatar V engine — the newest, highest-quality avatar engine with cross-reference-driven animat…",
-        "tags": []
-      },
-      {
-        "id": "heygen/lipsync-precision",
-        "name": "Hey Gen Lipsync Precision",
-        "kind": "video",
-        "desc": "High-accuracy lip-sync: replace or dub audio on any video with avatar-inference lip sync",
         "tags": []
       },
       {


### PR DESCRIPTION
## What changed

Adds `docs/BRAND.md` as the canonical message standard — mission, elevator pitch, voice, four messaging pillars (outcome before mechanism, radical ownership, persistent context, built to integrate), a do/don't table, the product lexicon, and feature-to-benefit framing — and threads it into every doc that governs copy. The split is that `WRITING_STYLE.md` keeps prose mechanics (which words are banned, which sentences get cut) and `BRAND.md` carries the message; anything user-facing follows both. `WRITING_STYLE.md` gains an off-brand product terms list (`credits`/`gems`/`tokens` as billing, `chatbot` for the agent, `powered by AI`, `prompt engineering`, `magic box`) plus a checklist item. Anchor links go into `AGENTS.md` (nav entry and a Writing & Docs rule), `DEVELOPMENT_STANDARDS.md` §19, the `code-review` skill's config/CI/docs checks, and the four marketing strategy docs. `NARRATIVE.md` records the precedence explicitly: its filmmaker-first hero wins on nodetool.ai, `BRAND.md`'s elevator pitch covers every other surface. `PRODUCT.md`'s brand personality drops "Powerful" — a word `WRITING_STYLE.md` already forbids — for the senior-technical-director voice. `BRAND.md` is excluded from the published docs site alongside the other contributor docs.

Two things in the diff that are not the docs work:

1. **`marketing/src/data/providerCatalog.generated.ts` regenerated** (`0139effa`). `npm run seo:provider-catalog -- --check` was already failing on `origin/main`, reproduced in a clean worktree at `404506b3` with none of these changes present: the fal and replicate manifests gained models without the marketing catalog being regenerated (fal 1554 → 1560, replicate 655 → 662). Ported here so this PR's CI can pass; it no-ops once `main` carries the same regeneration. Generated by the repo's own tooling, no hand edits.
2. **A stray tool-call artifact removed** from the end of `WRITING_STYLE.md` — two leaked XML-ish closing tags, in a file this change already touches. The same artifact sits in five other Markdown files (`docs/use-cases.md`, `docs/use-cases/movie-trailer.md`, `docs/use-cases/movie-poster.md`, `docs/use-cases/product-video.md`, `docs/worker-deployment.md`), left alone to keep the diff scoped. Three of those are published pages, so it renders live — worth a follow-up.

## Verification

- [x] `npm run test:affected -- --dry-run` → `nothing — no workspace owns the changed files.`
- [x] Every relative link added across the nine touched docs resolves on disk (script over `[…](…)` targets: `broken: 0`), and the `BRAND.md#5-lexicon` anchor target exists. CI's **Markdown link check (relative links)** agrees
- [x] `docs/_config.yml` still parses as YAML after adding `BRAND.md` to the site exclude list
- [x] `docs/BRAND.md` scanned against the `WRITING_STYLE.md` forbidden list — no matches
- [x] For the regenerated catalog, all four steps of the `Typecheck, lint & build` job run locally in `marketing/`: generated-template check clean, `npm run seo:check` up to date, `npx tsc --noEmit` exit 0, `npm run lint` exit 0 (two pre-existing warnings), `npx next build` exit 0
- [x] Root `npm run typecheck` / `npm run lint` — not run, and not applicable: the only non-Markdown file is a `// @ts-nocheck` generated data file under `marketing/`, which is not a root workspace and is covered by the marketing job above
- [ ] `npm run dev:nodetool -- harness gate --base main` — not run: the diff touches no product surface in the harness registry

All 24 checks are green on `0139effa`, including the `Typecheck, lint & build` job that failed on the first head.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added. The off-brand terms list is prose guidance in `WRITING_STYLE.md`, not a lint rule — nothing enforces it mechanically today.