### PR TITLE
scripts: a script tool that cannot take a call says so

### DIFF
--- a/packages/agents/src/capabilities/scripts.specs.ts
+++ b/packages/agents/src/capabilities/scripts.specs.ts
@@ -122,7 +122,10 @@ export const EDIT_SCRIPT_SCHEMA: JsonSchema = {
         "library (list_entities) — when set the speaker is that character/entity " +
         "and storyboard renders can season prompts with it. A line `target` is " +
         "its id, its 0-based index across the script, or its exact text; a " +
-        "speaker `target` is its id or name.",
+        "speaker `target` is its id or name. `set_speaker` renames a cast " +
+      "member; the op that gives a LINE its speaker is `set_line_speaker`. An " +
+      "argument an op does not take is refused rather than ignored, so a " +
+      "misspelled key is reported instead of silently dropping its value.",
       items: { type: "object" }
     }
   },

--- a/packages/agents/src/capabilities/scripts.ts
+++ b/packages/agents/src/capabilities/scripts.ts
@@ -646,10 +646,39 @@ const voiceScriptLines: CapabilityExport = {
     });
     if (isError(selected)) return selected;
     if (selected.length === 0) {
+      // "Every line with a voice is already up to date" was true of a script
+      // whose lines have no voice at all — vacuously, since there were none to
+      // be out of date. Read as written it says the work is done, and a chat
+      // that had just written eight unvoiced lines took it that way. The reason
+      // nothing was selected is the useful half, so it is the half reported.
+      const withText = lines.filter((line) => line.text.trim().length > 0);
+      const voiceless = withText.filter(
+        (line) => !(override ?? effectiveVoice(line, doc.cast))
+      );
+      if (withText.length === 0) {
+        return {
+          voiced: 0,
+          results: [],
+          note: "This script has no line with text in it yet. Write lines with edit_script, then voice them."
+        };
+      }
+      if (voiceless.length > 0) {
+        return {
+          voiced: 0,
+          results: [],
+          skipped_without_voice: voiceless.length,
+          note:
+            `${voiceless.length} of ${withText.length} lines have no voice, so nothing could be voiced` +
+            (voiceless.length < withText.length
+              ? "; the rest are already up to date. "
+              : ". ") +
+            'Give each speaker a voice with edit_script {"op": "set_speaker_voice", "target": "<speaker>", provider, model, voice} — find_model with capability=text_to_speech resolves one — or pass provider, model and voice to this call to override them all.'
+        };
+      }
       return {
         voiced: 0,
         results: [],
-        note: "No line needs voicing. Every line with a voice is already up to date; name lines explicitly with `targets` to re-voice them."
+        note: `All ${withText.length} lines are voiced and up to date. Name lines explicitly with \`targets\` to re-voice them.`
       };
     }
     if (selected.length > MAX_LINES_PER_CALL) {
@@ -950,11 +979,115 @@ interface ParsedScriptOp {
   args: Record<string, unknown>;
 }
 
+/**
+ * Every argument each op reads. An op used to take whatever object it was
+ * handed and read the keys it knew, so a key it did not know was dropped in
+ * silence: `add_line {text, speaker_id}` — the field name `get_script`
+ * *reports* a line's speaker under — added the line with no speaker at all and
+ * reported `ok`. A chat wrote eight lines that way, read them back unattributed,
+ * and spent the rest of the session rebuilding the script twice trying to
+ * work out which call had not taken. A key no op reads is now refused, by name.
+ */
+const OP_KEYS: Record<ScriptOpName, readonly string[]> = {
+  add_speaker: [
+    "name",
+    "color",
+    "provider",
+    "model",
+    "voice",
+    "settings",
+    "entityId",
+    "entity_id"
+  ],
+  set_speaker: ["target", "name", "color", "entityId", "entity_id"],
+  set_speaker_voice: ["target", "provider", "model", "voice", "settings"],
+  remove_speaker: ["target"],
+  add_section: ["title"],
+  add_line: [
+    "text",
+    "speaker",
+    "section",
+    "direction",
+    "pause_after_ms",
+    "index"
+  ],
+  set_line_text: ["target", "text"],
+  set_line_speaker: ["target", "speaker"],
+  remove_line: ["target"]
+};
+
+/**
+ * Spellings that mean one of an op's own keys. These are the names the rest of
+ * the surface already uses for the same thing: `get_script` answers with `id`,
+ * `speaker_id` and `line_id`, and reading a script then editing it by the
+ * field names it just reported is consistency, not a mistake. Translating them
+ * costs nothing; a spelling that would collide with a key already present is
+ * refused rather than guessed at.
+ */
+const OP_ALIASES: Record<ScriptOpName, Readonly<Record<string, string>>> = {
+  add_speaker: { speaker: "name", speaker_name: "name" },
+  set_speaker: { id: "target", speaker: "target", speaker_id: "target" },
+  set_speaker_voice: {
+    id: "target",
+    speaker: "target",
+    speaker_id: "target"
+  },
+  remove_speaker: { id: "target", speaker: "target", speaker_id: "target" },
+  add_section: { name: "title" },
+  add_line: { speaker_id: "speaker", section_id: "section" },
+  set_line_text: { id: "target", line: "target", line_id: "target" },
+  set_line_speaker: {
+    id: "target",
+    line: "target",
+    line_id: "target",
+    speaker_id: "speaker"
+  },
+  remove_line: { id: "target", line: "target", line_id: "target" }
+};
+
+/**
+ * One op's arguments, with the known aliases translated, or the reason it
+ * cannot be applied as written.
+ */
+function normalizeOpArgs(
+  op: ScriptOpName,
+  index: number,
+  raw: Record<string, unknown>
+): Record<string, unknown> | ToolError {
+  const known = OP_KEYS[op];
+  const aliases = OP_ALIASES[op];
+  const args: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (known.includes(key)) {
+      args[key] = value;
+      continue;
+    }
+    const alias = aliases[key];
+    if (alias === undefined) {
+      return {
+        error: `ops[${index}] (${op}) has no argument "${key}"; it takes ${known.join(", ")}.`
+      };
+    }
+    if (raw[alias] !== undefined) {
+      return {
+        error: `ops[${index}] (${op}) passes both "${key}" and "${alias}", which mean the same argument. Pass one.`
+      };
+    }
+    args[alias] = value;
+  }
+  return args;
+}
+
 function parseScriptOps(raw: unknown): ParsedScriptOp[] | ToolError {
   if (!Array.isArray(raw) || raw.length === 0) {
     return {
+      // The ops are listed here as well as in the spec: a caller that reached
+      // this message was already guessing, and one that has to guess again
+      // spends a turn calling edit_script with a made-up op just to read the
+      // list off the rejection.
       error:
-        'ops must be a non-empty array, e.g. [{"op": "add_line", "text": "Hello."}].'
+        'ops must be a non-empty array, e.g. [{"op": "add_line", "text": "Hello."}]. ' +
+        `The ops are: ${SCRIPT_OPS.join(", ")}.`
     };
   }
   if (raw.length > MAX_SCRIPT_OPS) {
@@ -967,13 +1100,16 @@ function parseScriptOps(raw: unknown): ParsedScriptOp[] | ToolError {
     if (!isRecord(entry)) {
       return { error: `ops[${index}] must be an object.` };
     }
-    const { op, ...args } = entry;
+    const { op, ...rest } = entry;
     if (!isString(op) || !isScriptOpName(op.trim())) {
       return {
         error: `ops[${index}] names "${String(op)}"; expected one of ${SCRIPT_OPS.join(", ")}.`
       };
     }
-    parsed.push({ op: op.trim() as ScriptOpName, args });
+    const name = op.trim() as ScriptOpName;
+    const args = normalizeOpArgs(name, index, rest);
+    if (isError(args)) return args;
+    parsed.push({ op: name, args });
   }
   return parsed;
 }
@@ -986,6 +1122,27 @@ function findSpeakerIndex(doc: ScriptDocument, target: unknown): number {
   const name = raw.toLowerCase();
   return doc.cast.findIndex(
     (speaker) => speaker.name.trim().toLowerCase() === name
+  );
+}
+
+/**
+ * Why a speaker op found no speaker. A speaker op whose `target` is a line id
+ * is the same confusion twice over — the cast and the lines both answer to
+ * `target`, and `set_speaker` reads as "set this line's speaker" — so the one
+ * mistake worth naming is named.
+ */
+function noSpeaker(doc: ScriptDocument, target: unknown): Error {
+  const raw = isString(target) ? target.trim() : String(target);
+  const cast = doc.cast.map((speaker) => `${speaker.id} (${speaker.name})`);
+  const looksLikeLine = /^line[_-]?\d+$/i.test(raw);
+  return new Error(
+    `No speaker matches "${raw}".` +
+      (looksLikeLine
+        ? ' That is a line id — to give a line a speaker use {"op": "set_line_speaker", "target": "<line>", "speaker": "<speaker>"}.'
+        : "") +
+      (cast.length > 0
+        ? ` The cast is: ${cast.join(", ")}.`
+        : " This script has no cast yet; add one with add_speaker.")
   );
 }
 
@@ -1100,8 +1257,7 @@ function applyScriptOp(
 
     case "set_speaker": {
       const index = findSpeakerIndex(doc, args["target"]);
-      if (index < 0)
-        throw new Error(`No speaker matches "${String(args["target"])}".`);
+      if (index < 0) throw noSpeaker(doc, args["target"]);
       const speaker = { ...doc.cast[index] };
       if (args["name"] !== undefined) speaker.name = String(args["name"]);
       if (args["color"] !== undefined) speaker.color = String(args["color"]);
@@ -1113,8 +1269,7 @@ function applyScriptOp(
 
     case "set_speaker_voice": {
       const index = findSpeakerIndex(doc, args["target"]);
-      if (index < 0)
-        throw new Error(`No speaker matches "${String(args["target"])}".`);
+      if (index < 0) throw noSpeaker(doc, args["target"]);
       const voice = parseVoiceBinding(args);
       if (!voice) {
         throw new Error(
@@ -1129,8 +1284,7 @@ function applyScriptOp(
 
     case "remove_speaker": {
       const index = findSpeakerIndex(doc, args["target"]);
-      if (index < 0)
-        throw new Error(`No speaker matches "${String(args["target"])}".`);
+      if (index < 0) throw noSpeaker(doc, args["target"]);
       const [removed] = doc.cast.splice(index, 1);
       for (const section of doc.sections) {
         section.lines = section.lines.map((line) =>
@@ -1159,9 +1313,7 @@ function applyScriptOp(
       let speakerId: string | null = null;
       if (args["speaker"] !== undefined) {
         const index = findSpeakerIndex(doc, args["speaker"]);
-        if (index < 0) {
-          throw new Error(`No speaker matches "${String(args["speaker"])}".`);
-        }
+        if (index < 0) throw noSpeaker(doc, args["speaker"]);
         speakerId = doc.cast[index].id;
       }
       const used = new Set(scriptLines(doc.sections).map((line) => line.id));
@@ -1204,9 +1356,7 @@ function applyScriptOp(
       const line = findLine(scriptLines(doc.sections), target);
       if (!line) throw new Error(`No line matches "${target}".`);
       const index = findSpeakerIndex(doc, args["speaker"]);
-      if (index < 0) {
-        throw new Error(`No speaker matches "${String(args["speaker"])}".`);
-      }
+      if (index < 0) throw noSpeaker(doc, args["speaker"]);
       line.speakerId = doc.cast[index].id;
       return { id: line.id, speaker_id: line.speakerId };
     }

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -207,6 +207,32 @@ const nodetool = (() => {
   const __merge = (a, b) => Object.assign({}, a || {}, b || {});
 
   /**
+   * A \`create(name, opts)\` call's arguments, however the caller spelled them.
+   * The documented form passes the name first, but a caller holding an options
+   * bag reaches for \`create({name, ...})\` — and that used to arrive at the tool
+   * as \`name: {name: "..."}\`, refused as "name is required and must be a
+   * non-empty string". The message described the argument, not the call, so
+   * there was nothing to correct against: a chat retried the same object shape
+   * three times before falling back to the positional form by accident. Both
+   * spellings are the same call, so both are accepted, and a name that is
+   * genuinely missing is named as the caller's own argument.
+   */
+  const __named = (nameOrOpts, opts, method) => {
+    const args =
+      nameOrOpts && typeof nameOrOpts === "object"
+        ? __merge(nameOrOpts, opts)
+        : __merge(opts, { name: nameOrOpts });
+    if (typeof args.name !== "string" || args.name.trim() === "") {
+      throw new Error(
+        "nodetool." + method + ": a name is required. Pass it first — " +
+        'nodetool.' + method + '("My name", {...}) — or in the options ' +
+        'object as {name: "My name"}.'
+      );
+    }
+    return args;
+  };
+
+  /**
    * A job id from either an id or a job/receipt object. \`start()\` answers with
    * a record, and reaching for the wrong field on it used to reach the tool as
    * \`job_id: undefined\`, which came back as "Job undefined was not found" —
@@ -603,7 +629,13 @@ const nodetool = (() => {
       get: (id) => __need("get_workflow")({ workflow_id: id }),
       create: (name, graph, opts) =>
         __need("create_workflow")(
-          __merge(opts, { name: name, graph: __graphJson(graph) })
+          __merge(__named(name, opts, "workflows.create"), {
+            graph: __graphJson(
+              graph === undefined && name && typeof name === "object"
+                ? name.graph
+                : graph
+            )
+          })
         ),
       versions: (id, opts) =>
         __need("list_workflow_versions")(__merge(opts, { workflow_id: id })),
@@ -1059,7 +1091,8 @@ const nodetool = (() => {
       list: (opts) => __need("list_apps")(__merge(opts)),
       get: (id) => __need("get_app")({ application_id: id }),
       /** Create an empty app and get its id back. */
-      create: (name, opts) => __need("create_app")(__merge(opts, { name: name })),
+      create: (name, opts) =>
+        __need("create_app")(__named(name, opts, "apps.create")),
       /** Apply App Builder steps to a saved app, then save it. */
       edit: (id, steps, opts) =>
         __need("edit_app")(
@@ -1073,7 +1106,7 @@ const nodetool = (() => {
     timelines: {
       list: (opts) => __need("list_timelines")(__merge(opts)),
       create: (name, opts) =>
-        __need("create_timeline")(__merge(opts, { name: name })),
+        __need("create_timeline")(__named(name, opts, "timelines.create")),
       get: (id) => __need("get_timeline")({ timeline_id: id }),
       versions: (id, opts) =>
         __need("list_timeline_versions")(__merge(opts, { timeline_id: id })),
@@ -1103,7 +1136,7 @@ const nodetool = (() => {
       list: (opts) => __need("list_sketches")(__merge(opts)),
       /** Create a blank sketch. Pass {width, height} for the canvas size. */
       create: (name, opts) =>
-        __need("create_sketch")(__merge(opts, { name: name })),
+        __need("create_sketch")(__named(name, opts, "sketches.create")),
       get: (id) => __need("get_sketch")({ image_document_id: id }),
       versions: (id, opts) =>
         __need("list_sketch_versions")(
@@ -1141,7 +1174,7 @@ const nodetool = (() => {
       list: (opts) => __need("list_scripts")(__merge(opts)),
       /** Create an empty script. Pass {project_id} to place it. */
       create: (name, opts) =>
-        __need("create_script")(__merge(opts, { name: name })),
+        __need("create_script")(__named(name, opts, "scripts.create")),
       get: (id) => __need("get_script")({ script_id: id }),
       voice: (id, opts) =>
         __need("voice_script_lines")(__merge(opts, { script_id: id })),
@@ -1155,7 +1188,7 @@ const nodetool = (() => {
       list: (opts) => __need("list_storyboards")(__merge(opts)),
       /** Create a blank storyboard. Pass {brief, style, aspect_ratio} for board settings. */
       create: (name, opts) =>
-        __need("create_storyboard")(__merge(opts, { name: name })),
+        __need("create_storyboard")(__named(name, opts, "storyboards.create")),
       get: (id) => __need("get_storyboard")({ storyboard_id: id }),
       renderStills: (id, opts) =>
         __need("render_storyboard_stills")(
@@ -1179,7 +1212,98 @@ const nodetool = (() => {
       edit: (id, ops) => __need("edit_storyboard")({ storyboard_id: id, ops: ops })
     }
   };
-  return api;
+
+  /**
+   * What a member that does not exist answers with: callable, and a namespace
+   * all the way down, so \`nodetool.script.list()\` reports the typo in
+   * \`script\` rather than bottoming out one hop later as
+   * \`TypeError: not a function\` — the message the whole guard exists to
+   * replace.
+   */
+  const __missing = (message) =>
+    new Proxy(function () {}, {
+      apply() {
+        throw new Error(message);
+      },
+      get(target, prop) {
+        if (typeof prop !== "string" || prop === "then") return target[prop];
+        return __missing(message);
+      }
+    });
+
+  /**
+   * The nearest member name to one that does not exist, comparing on letters
+   * and digits alone: \`find_model\` finds \`find\`, \`assemble_timeline\` finds
+   * \`assembleTimeline\`, \`create_script\` finds \`create\`.
+   */
+  const __nearest = (prop, names) => {
+    const flatten = (s) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
+    const want = flatten(prop);
+    let best = null;
+    for (const name of names) {
+      const have = flatten(name);
+      if (have === want) return name;
+      if (have.length === 0) continue;
+      const near = want.indexOf(have) === 0 || have.indexOf(want) === 0;
+      if (near && (best === null || have.length > flatten(best).length)) {
+        best = name;
+      }
+    }
+    return best;
+  };
+
+  /**
+   * Every namespace is guarded, so a member that does not exist answers with
+   * its own name instead of QuickJS's \`TypeError: not a function\`.
+   *
+   * The name a capability has on the belt is not the name it has here — the
+   * object model curates: \`find_model\` is \`nodetool.models.find\`,
+   * \`create_script\` is \`nodetool.scripts.create\`. A caller reaching for the
+   * belt spelling got a message that named neither the call it made nor the
+   * one it meant, and a bare \`TypeError\` reads like the sandbox is broken
+   * rather than like a typo: one chat took it as "models are unavailable here"
+   * and abandoned the namespace. An unknown member answers with a thrower
+   * rather than \`undefined\` — the shape \`tools.<name>\` already uses — so the
+   * report lands at the call, where the mistake is, and reads the same whether
+   * the missing half is the method or the namespace.
+   */
+  const __guard = (path, obj) =>
+    new Proxy(obj, {
+      get(target, prop) {
+        // Symbols, everything that really is there, and the handful of names
+        // the language itself reaches for pass straight through: \`then\` so
+        // awaiting a namespace cannot mistake it for a thenable, \`toJSON\` and
+        // \`inspect\` so logging one still prints it instead of throwing.
+        if (
+          typeof prop !== "string" ||
+          prop === "then" ||
+          prop === "toJSON" ||
+          prop === "inspect" ||
+          prop in target
+        ) {
+          return target[prop];
+        }
+        const names = Object.keys(target).sort();
+        const nearest = __nearest(prop, names);
+        return __missing(
+          path + "." + prop + " does not exist" +
+            (nearest ? ". Did you mean " + path + "." + nearest + "?" : ".") +
+            " " + path + " has: " + names.join(", ") + "." +
+            (path === "nodetool"
+              ? ""
+              : ' nodetool.searchTools("' + prop + '") finds the tool ' +
+                "behind a name if it is one.")
+        );
+      }
+    });
+
+  for (const key of Object.keys(api)) {
+    const value = api[key];
+    if (value && typeof value === "object") {
+      api[key] = __guard("nodetool." + key, value);
+    }
+  }
+  return __guard("nodetool", api);
 })();
 `;
 

--- a/packages/agents/tests/capabilities-scripts.test.ts
+++ b/packages/agents/tests/capabilities-scripts.test.ts
@@ -290,7 +290,11 @@ describe("scripts capability behaviour", () => {
       script_id: row.id
     })) as { voiced: number; note?: string };
     expect(again).toMatchObject({ voiced: 0 });
-    expect(again.note).toContain("No line needs voicing");
+    // Both lines really are up to date, so the note says so — and counts them,
+    // because the wording that used to cover this case ("every line with a
+    // voice is already up to date") was also what a script with no voices at
+    // all got back.
+    expect(again.note).toContain("All 2 lines are voiced and up to date");
   });
 
   it("refuses a half-specified voice override", async () => {
@@ -401,5 +405,76 @@ describe("scripts capability behaviour", () => {
     })) as { failed: number; ops: Array<{ error?: string }> };
     expect(result.failed).toBe(1);
     expect(result.ops[0].error).toContain('No line matches "nope"');
+  });
+
+  // A chat wrote eight lines with `add_line {text, speaker_id}` — the key
+  // `get_script` reports a line's speaker under. Every op returned ok and every
+  // line came back unattributed, because an argument no op reads was dropped
+  // rather than refused. These pin both halves of the fix: the spelling that
+  // means something is translated, and the one that means nothing is reported.
+  it("reads a line's speaker from speaker_id as well as speaker", async () => {
+    const row = await makeScript([]);
+    const result = (await run(ctx().context).invoke("edit_script", {
+      script_id: row.id,
+      ops: [
+        { op: "add_line", text: "First", speaker_id: "sp1" },
+        { op: "add_line", text: "Second", speaker: "Narrator" }
+      ]
+    })) as {
+      applied: number;
+      failed: number;
+      lines: Array<{ speaker_id: string | null }>;
+    };
+    expect(result).toMatchObject({ applied: 2, failed: 0 });
+    expect(result.lines.map((l) => l.speaker_id)).toEqual(["sp1", "sp1"]);
+  });
+
+  it("refuses an argument the op does not take, naming the ones it does", async () => {
+    const row = await makeScript([line({ id: "l1", speakerId: "sp1" })]);
+    const result = (await run(ctx().context).invoke("edit_script", {
+      script_id: row.id,
+      ops: [{ op: "add_line", text: "First", speeker: "sp1" }]
+    })) as { error?: string };
+    expect(result.error).toContain('has no argument "speeker"');
+    expect(result.error).toContain("text, speaker, section");
+  });
+
+  it("refuses an op that spells the same argument twice", async () => {
+    const row = await makeScript([line({ id: "l1", speakerId: "sp1" })]);
+    const result = (await run(ctx().context).invoke("edit_script", {
+      script_id: row.id,
+      ops: [
+        { op: "set_line_speaker", target: "l1", line_id: "l1", speaker: "sp1" }
+      ]
+    })) as { error?: string };
+    expect(result.error).toContain('both "line_id" and "target"');
+  });
+
+  it("points a speaker op aimed at a line id at set_line_speaker", async () => {
+    const row = await makeScript([line({ id: "line_1", speakerId: null })]);
+    const result = (await run(ctx().context).invoke("edit_script", {
+      script_id: row.id,
+      ops: [{ op: "set_speaker", target: "line_1", name: "Host" }]
+    })) as { failed: number; ops: Array<{ error?: string }> };
+    expect(result.failed).toBe(1);
+    expect(result.ops[0].error).toContain("set_line_speaker");
+    expect(result.ops[0].error).toContain("sp1 (Narrator)");
+  });
+
+  // "Every line with a voice is already up to date" was also what a script
+  // with no voice anywhere got back — true only because there was nothing to
+  // be out of date, and read by a chat as "the voicing worked".
+  it("says why nothing was voiced when no line has a voice", async () => {
+    const row = await makeScript(
+      [line({ id: "l1", speakerId: "sp1" }), line({ id: "l2", speakerId: "sp1" })],
+      [{ id: "sp1", name: "Narrator", voice: null }] as never
+    );
+    const result = (await run(ctx().context).invoke("voice_script_lines", {
+      script_id: row.id
+    })) as { voiced: number; skipped_without_voice?: number; note?: string };
+    expect(result).toMatchObject({ voiced: 0, skipped_without_voice: 2 });
+    expect(result.note).toContain("2 of 2 lines have no voice");
+    expect(result.note).toContain("set_speaker_voice");
+    expect(result.note).not.toContain("already up to date");
   });
 });

--- a/packages/agents/tests/nodetool-api-media-docs.test.ts
+++ b/packages/agents/tests/nodetool-api-media-docs.test.ts
@@ -286,17 +286,22 @@ describe("generate → image.adjust → nodetool.media.toImage", () => {
          "a clockmaker", { provider: "fal_ai", model_id: "fal-ai/flux/schnell" });
        const grey = await image.adjust(img, { grayscale: true });
        const saved = await nodetool.media.toImage(grey);
-       return {
-         uri: saved.asset_uri,
-         handle: grey.uri,
-         hasBytes: typeof nodetool.media.bytes
-       };`
+       let bytes = "none";
+       try {
+         await nodetool.media.bytes(grey);
+         bytes = "returned";
+       } catch (e) { bytes = e.message; }
+       return { uri: saved.asset_uri, handle: grey.uri, bytes: bytes };`
     );
     expect(obs.ok).toBe(true);
-    expect(obs.result).toMatchObject({
-      uri: "asset://grey1.png",
-      hasBytes: "undefined"
-    });
+    // There is no way to pull the bytes into the guest: they stay host-side
+    // and the guest only ever sees the handle. The namespace guard answers for
+    // the method that is not there, so the refusal names `nodetool.media`
+    // rather than arriving as `TypeError: not a function`.
+    expect(obs.result).toMatchObject({ uri: "asset://grey1.png" });
+    const bytes = String((obs.result as { bytes?: string }).bytes);
+    expect(bytes).toContain("nodetool.media.bytes does not exist");
+    expect(bytes).not.toContain("not a function");
     expect(String((obs.result as { handle?: string }).handle)).toMatch(
       /^sandbox:\/\/media\//
     );

--- a/packages/agents/tests/sandbox-belt-reach.test.ts
+++ b/packages/agents/tests/sandbox-belt-reach.test.ts
@@ -51,6 +51,28 @@ async function run(
   });
 }
 
+/** The same, plus the arguments every call carried, in order. */
+async function runRecording(code: string, names: readonly string[] = []) {
+  const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+  const result = await runInSandbox({
+    code: `${PRELUDE}\n${code}`,
+    context: {} as never,
+    globals: {
+      __toolNames: [...names],
+      __toolModules: {},
+      __callTool: async (name: unknown, args: unknown) => {
+        calls.push({
+          name: String(name),
+          args: JSON.parse(String(args)) as Record<string, unknown>
+        });
+        return { ok: true, result: { called: name } };
+      }
+    },
+    timeoutMs: 20000
+  });
+  return { result, calls };
+}
+
 describe("the sandbox toolbelt", () => {
   it("carries the Apify and SerpAPI capabilities", () => {
     const names = new Set(assembleSandboxToolbelt().map((tool) => tool.name));
@@ -217,5 +239,99 @@ describe("the retired tools.<name> global", () => {
       ["list_workflows", "run_workflow"]
     );
     expect(result.result).toEqual({ keys: [], then: "undefined" });
+  }, 60_000);
+});
+
+/**
+ * Two dead ends the object model used to leave a caller in, both of them a
+ * message that described something other than the call that produced it.
+ */
+describe("the nodetool object model's own errors", () => {
+  /**
+   * `create({name})` used to reach the tool as `name: {name: "..."}` and come
+   * back as "name is required and must be a non-empty string" — a sentence
+   * about the argument, true of a call that had passed one. A chat retried the
+   * same object three times, then found the positional form by accident.
+   */
+  it("takes a create name positionally or in the options object", async () => {
+    const { calls } = await runRecording(
+      `await nodetool.scripts.create("Positional", { project_id: "p1" });
+       await nodetool.scripts.create({ name: "In options", project_id: "p2" });
+       await nodetool.storyboards.create({ name: "A board", style: "noir" });
+       return "ok";`,
+      ["create_script", "create_storyboard"]
+    );
+    expect(calls.map((c) => c.args["name"])).toEqual([
+      "Positional",
+      "In options",
+      "A board"
+    ]);
+    expect(calls[1].args["project_id"]).toBe("p2");
+    expect(calls[2].args["style"]).toBe("noir");
+  });
+
+  it("names the call when a create really has no name", async () => {
+    const result = await run(
+      `try {
+         await nodetool.scripts.create({ project_id: "p1" });
+         return "no throw";
+       } catch (e) {
+         return String(e.message);
+       }`,
+      ["create_script"]
+    );
+    expect(result.result).toContain("nodetool.scripts.create");
+    expect(result.result).toContain("{name:");
+  }, 60_000);
+
+  /**
+   * The belt spelling is not the object model's spelling — `find_model` is
+   * `nodetool.models.find`. Reaching for the belt name answered with QuickJS's
+   * `TypeError: not a function`, which names neither the call nor the method
+   * that would have worked, and reads like the sandbox is broken rather than
+   * like a typo.
+   */
+  it("names the nearest method instead of TypeError: not a function", async () => {
+    const result = await run(
+      `try {
+         await nodetool.models.find_model({ capability: "text_to_speech" });
+         return "no throw";
+       } catch (e) {
+         return String(e.message);
+       }`,
+      ["find_model"]
+    );
+    expect(result.result).toContain("nodetool.models.find_model does not exist");
+    expect(result.result).toContain("Did you mean nodetool.models.find?");
+    expect(result.result).toContain("forProvider");
+    expect(result.result).not.toContain("not a function");
+  }, 60_000);
+
+  it("names the namespaces when the namespace itself is the typo", async () => {
+    const result = await run(
+      `try {
+         await nodetool.script.list();
+         return "no throw";
+       } catch (e) {
+         return String(e.message);
+       }`,
+      ["list_scripts"]
+    );
+    expect(result.result).toContain("Did you mean nodetool.scripts?");
+    expect(result.result).not.toContain("not a function");
+  }, 60_000);
+
+  it("leaves what is really there, awaiting, and logging a namespace alone", async () => {
+    const result = await run(
+      `const ns = await nodetool.scripts;
+       return typeof ns.list + "," + typeof ns.voice + "," +
+         Object.keys(nodetool.models).sort().join("/") + "," +
+         JSON.stringify(nodetool.scripts);`,
+      ["list_scripts"]
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBe(
+      "function,function,find/forProvider/list/pick,{}"
+    );
   }, 60_000);
 });

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -1895,7 +1895,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "edit_script",
     module: "scripts",
     impl: "packages/agents/src/capabilities/scripts.ts",
-    contract: "62385ab44f70",
+    contract: "0d3075938411",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-scripts.test.ts",


### PR DESCRIPTION
## What changed

A chat asked for a script and spent forty minutes not getting one. Four messages along the way each described something other than the call that produced them, and this fixes all four. `nodetool.scripts.create({name})` reached the tool as `name: {name: "..."}` and came back as "name is required and must be a non-empty string" — a sentence about the argument, true of a call that had passed one — so every `create(name, opts)` in the object model now takes the name first or in the options bag, since both spell the same call. `nodetool.models.find_model`, the belt's name for `nodetool.models.find`, was `TypeError: not a function`, which names neither the call made nor the one meant and reads like the sandbox is broken; every namespace is guarded now, and an unknown member reports its own path, the nearest real method and the ones that exist, one hop deep so `nodetool.script.list()` blames `script` rather than `list`. `edit_script`'s ops read the keys they knew and dropped the rest in silence, so `add_line {text, speaker_id}` — the field `get_script` reports a speaker under — added a line with no speaker and reported ok, eight times; each op now declares its arguments, the spellings the rest of the surface already uses are translated, and a key no op reads is refused by name. And `voice_script_lines` answered a script with no voice anywhere with "every line with a voice is already up to date" — vacuously true, and read as "the voicing worked" — where it now reports how many lines have no voice and how to give them one.

## Verification

- [x] `npm run test:affected` — passes except `packages/base-nodes` `tests/image-examples-run.test.ts` and `tests/image-processing-examples-run.test.ts` (14 tests), which fail identically on `main` in this container: the image pipeline's native deps are not built here.
- [x] `packages/agents` full suite: 3408 passed, 4 failed — `tests/capabilities-flow.test.ts` (2) and `tests/host-modules.test.ts` sandbox-fabric (2), both failing identically on `main` here for the same reason.
- [x] `npx tsc --noEmit` in `packages/agents` (the package's own `lint` script) — clean. Root `npm run typecheck` (web/electron/mobile) not run; the diff touches neither.
- [x] `npx oxlint packages/agents/src` and `--config .oxlintrc.anti-slop-enforced.json` — 137 warnings, byte-identical to the count on `main`; no new ones.
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 3/3 selfchecks passed`.

Each fix is pinned by a test that fails without it, in `tests/capabilities-scripts.test.ts` and `tests/sandbox-belt-reach.test.ts`. Two existing assertions moved rather than being deleted, and both moved because the surface genuinely answers differently now: the "no line needs voicing" note is asserted in the case it is actually true of, and `typeof nodetool.media.bytes === "undefined"` became a call that must throw and name `nodetool.media` — the same invariant (bytes never reach the guest), stated where the guard now answers.

## Agent capabilities

- [x] `npm run capabilities:check` passes. `edit_script`'s description gained a sentence about arguments being refused rather than ignored, which moved its contract hash; the resync is its own commit.
- [x] `edit_script` keeps its existing suites in `capability-table.ts` — `tests/capabilities-scripts.test.ts` and `tests/document-edit-tools.test.ts` — and the four new cases land in the first of them. No capability is added.

## New checks

No check, rule, or audit is added — the strictness lives in the capability, not in a lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VV7ChFbRjEAGdUJnAgqXD

---
_Generated by [Claude Code](https://claude.ai/code/session_017VV7ChFbRjEAGdUJnAgqXD)_