### PR TITLE
fix(web): align the composer text column and widen the model select

### DIFF
--- a/web/src/components/chat/composer/MediaChatComposer.styles.ts
+++ b/web/src/components/chat/composer/MediaChatComposer.styles.ts
@@ -54,9 +54,10 @@ export const createMediaComposerStyles = (theme: Theme) =>
       minHeight: 36,
       maxHeight: 220,
       margin: 0,
-      // Align the text with the chip row below (card padding + row padding)
-      // instead of floating it in its own 24px inset.
-      padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
+      // The prompt shares one text column with the chip row below: a chip's
+      // own 12px padding insets its icon, so the textarea carries that inset
+      // itself (row padding 4 + chip padding 12 = spacing(4)).
+      padding: `${theme.spacing(2)} ${theme.spacing(4)}`,
       resize: "none",
       background: "transparent",
       color: theme.vars.palette.grey[50],
@@ -80,7 +81,9 @@ export const createMediaComposerStyles = (theme: Theme) =>
       alignItems: "center",
       gap: theme.spacing(1),
       width: "100%",
-      padding: `0 ${theme.spacing(2)}`,
+      // Chips carry their own 12px padding, so the row adds only the
+      // remainder of the shared text column inset.
+      padding: `0 ${theme.spacing(1)}`,
       boxSizing: "border-box",
       // Trailing run actions stay pinned to the right, so the row itself does
       // not wrap. The chip cluster wraps internally instead.
@@ -174,12 +177,14 @@ export const createMediaComposerStyles = (theme: Theme) =>
       }
     },
 
-    ".media-file-preview-row": {
+    // Attachments and entity mentions sit in the same text column as the
+    // prompt, so the card reads as one left edge top to bottom.
+    ".media-file-preview-row, .mentioned-entities": {
       display: "flex",
       flexWrap: "wrap",
       alignItems: "center",
       gap: theme.spacing(1),
-      padding: `0 ${theme.spacing(2)}`,
+      padding: `0 ${theme.spacing(4)}`,
       boxSizing: "border-box"
     },
 
@@ -206,7 +211,9 @@ export const createMediaComposerStyles = (theme: Theme) =>
         gap: theme.spacing(1)
       },
       ".media-compose-card textarea.media-compose-input": {
-        padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+        // The chip row loses its padding here, so the column is the chip's
+        // own 12px inset.
+        padding: `${theme.spacing(1)} ${theme.spacing(3)}`,
         // The keyboard takes most of the screen — cap the growth well below
         // the desktop 220 (matches MOBILE_TEXTAREA_MAX_HEIGHT).
         maxHeight: 140
@@ -215,6 +222,9 @@ export const createMediaComposerStyles = (theme: Theme) =>
         flexWrap: "wrap",
         rowGap: theme.spacing(1),
         padding: 0
+      },
+      ".media-file-preview-row, .mentioned-entities": {
+        padding: `0 ${theme.spacing(3)}`
       },
       // One scrolling strip, never a wrapped block: chips keep their touch
       // size and the row keeps its height whatever the mode puts in it.

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -100,6 +100,10 @@ import { useAutoFocusEnabled } from "../../../hooks/useAutoFocusEnabled";
 const TEXTAREA_MAX_HEIGHT = 220;
 const MOBILE_TEXTAREA_MAX_HEIGHT = 140;
 
+/** The model chip takes the width the other chips in the row leave, up to
+ *  this, rather than truncating at a fixed width while the row runs empty. */
+const MODEL_CHIP_MAX_WIDTH = 320;
+
 interface MediaChatComposerProps {
   isLoading: boolean;
   isStreaming: boolean;
@@ -1031,9 +1035,10 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
                 title={chatProviderLabel}
                 active={languageModelOpen}
                 onClick={() => setLanguageModelOpen(true)}
-                showChevron={false}
+                showChevron={!isMobile}
                 truncate
-                maxWidth={isMobile ? 108 : 140}
+                grow={!isMobile}
+                maxWidth={isMobile ? 108 : MODEL_CHIP_MAX_WIDTH}
               />
               <PermissionSelector threadId={threadId} />
               <LanguageModelMenuDialog
@@ -1058,8 +1063,10 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
                 label={imageParams.model?.name || "Select Model"}
                 active={imageModelOpen}
                 onClick={() => setImageModelOpen(true)}
-                showChevron={false}
+                showChevron={!isMobile}
                 truncate
+                grow={!isMobile}
+                maxWidth={isMobile ? undefined : MODEL_CHIP_MAX_WIDTH}
               />
               <ImageModelMenuDialog
                 open={imageModelOpen}
@@ -1130,7 +1137,9 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
                 active={videoModelOpen}
                 onClick={() => setVideoModelOpen(true)}
                 truncate
-                showChevron={false}
+                grow={!isMobile}
+                maxWidth={isMobile ? undefined : MODEL_CHIP_MAX_WIDTH}
+                showChevron={!isMobile}
               />
               <VideoModelMenuDialog
                 open={videoModelOpen}
@@ -1199,8 +1208,10 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
                 label={imageEditParams.model?.name || "Select Edit Model"}
                 active={imageModelOpen}
                 truncate
+                grow={!isMobile}
+                maxWidth={isMobile ? undefined : MODEL_CHIP_MAX_WIDTH}
                 onClick={() => setImageModelOpen(true)}
-                showChevron={false}
+                showChevron={!isMobile}
               />
               <ImageModelMenuDialog
                 open={imageModelOpen}
@@ -1308,8 +1319,10 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
                 }
                 active={videoModelOpen}
                 onClick={() => setVideoModelOpen(true)}
-                showChevron={false}
+                showChevron={!isMobile}
                 truncate
+                grow={!isMobile}
+                maxWidth={isMobile ? undefined : MODEL_CHIP_MAX_WIDTH}
               />
               <VideoModelMenuDialog
                 open={videoModelOpen}
@@ -1398,8 +1411,10 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
                 label={audioParams.model?.name || "Select TTS Model"}
                 active={ttsModelOpen}
                 onClick={() => setTtsModelOpen(true)}
-                showChevron={false}
+                showChevron={!isMobile}
                 truncate
+                grow={!isMobile}
+                maxWidth={isMobile ? undefined : MODEL_CHIP_MAX_WIDTH}
               />
               <TTSModelMenuDialog
                 open={ttsModelOpen}

--- a/web/src/components/chat/composer/MediaControlChip.tsx
+++ b/web/src/components/chat/composer/MediaControlChip.tsx
@@ -32,7 +32,15 @@ interface MediaControlChipProps {
   emphasis?: "default" | "primary";
   /** Allow this chip to shrink and truncate its label. */
   truncate?: boolean;
-  /** Max width in px when truncating. Defaults to 200. */
+  /**
+   * Let the chip claim the row's leftover width (up to `maxWidth`) instead of
+   * hugging its label. A grown chip also takes a field surface and pins its
+   * caret to the right edge, so the extra width reads as a select rather than
+   * a label with a gap after it. For the one chip in a row that deserves the
+   * space — the model select.
+   */
+  grow?: boolean;
+  /** Max width in px when truncating or growing. Defaults to 200. */
   maxWidth?: number;
   ref?: React.Ref<HTMLButtonElement>;
 }
@@ -43,6 +51,7 @@ const createStyles = (
   emphasis: "default" | "primary",
   active: boolean,
   truncate: boolean,
+  grow: boolean,
   iconOnly: boolean,
   maxWidth: number
 ) =>
@@ -62,7 +71,7 @@ const createStyles = (
     border: "1px solid transparent",
     backgroundColor: active
       ? theme.vars.palette.c_overlay_strong
-      : emphasis === "primary"
+      : emphasis === "primary" || grow
         ? theme.vars.palette.c_overlay
         : "transparent",
     color: theme.vars.palette.grey[100],
@@ -73,10 +82,12 @@ const createStyles = (
     outline: "none",
     transition: `background-color ${MOTION.normal}, border-color ${MOTION.normal}, color ${MOTION.normal}`,
     whiteSpace: "nowrap",
-    flexShrink: truncate ? 1 : 0,
-    minWidth: truncate ? 0 : undefined,
-    maxWidth: truncate ? maxWidth : undefined,
-    overflow: truncate ? "hidden" : undefined,
+    justifyContent: "flex-start",
+    flex: grow ? "1 1 auto" : undefined,
+    flexShrink: grow || truncate ? 1 : 0,
+    minWidth: grow || truncate ? 0 : undefined,
+    maxWidth: grow || truncate ? maxWidth : undefined,
+    overflow: grow || truncate ? "hidden" : undefined,
     "&:hover:not(:disabled)": {
       backgroundColor: theme.vars.palette.c_overlay
     },
@@ -90,14 +101,18 @@ const createStyles = (
     ".media-chip-icon": {
       display: "inline-flex",
       alignItems: "center",
+      flexShrink: 0,
       color: theme.vars.palette.grey[300],
       "& svg": { fontSize: size === "sm" ? 16 : 18 }
     },
     ".media-chip-chevron": {
       display: "inline-flex",
       alignItems: "center",
+      flexShrink: 0,
       opacity: 0.6,
-      marginLeft: 2,
+      // A grown chip pins its caret to the far edge, so the widened pill
+      // reads as a select rather than a label with a gap after it.
+      marginLeft: grow ? "auto" : 2,
       "& svg": { fontSize: 16 }
     }
   });
@@ -119,6 +134,7 @@ const MediaControlChip = memo(function MediaControlChip({
   className,
   emphasis = "default",
   truncate = false,
+  grow = false,
   maxWidth = 200,
   ref
 }: MediaControlChipProps) {
@@ -137,6 +153,7 @@ const MediaControlChip = memo(function MediaControlChip({
         emphasis,
         active,
         truncate,
+        grow,
         !hasLabel,
         maxWidth
       )}
@@ -144,7 +161,11 @@ const MediaControlChip = memo(function MediaControlChip({
       disabled={disabled}
       aria-pressed={active || undefined}
     >
-      <FlexRow align="center" gap={hasLabel ? 1 : 0}>
+      <FlexRow
+        align="center"
+        gap={hasLabel ? 1 : 0}
+        sx={grow || truncate ? { flex: 1, minWidth: 0 } : undefined}
+      >
         {icon && <span className="media-chip-icon">{icon}</span>}
         {hasLabel && (
           <Text
@@ -154,7 +175,8 @@ const MediaControlChip = memo(function MediaControlChip({
             sx={{
               color: "inherit",
               lineHeight: 1.2,
-              ...(truncate && {
+              ...((grow || truncate) && {
+                minWidth: 0,
                 overflow: "hidden",
                 textOverflow: "ellipsis",
                 whiteSpace: "nowrap"


### PR DESCRIPTION
## What changed

The chat composer card had two left edges: the prompt textarea's text sat 8px left of the chip icons in the row below it, and 12px from the card's top border. Every child of the card now shares one text column — the textarea, the attachment preview row, and the entity mention row carry the inset a chip's own 12px padding gives its icon (`spacing(4)` desktop, `spacing(3)` mobile, with the chip row's padding reduced to match), and the textarea's top padding gains a step so the prompt is not hugging the border. Measured in the browser: the placeholder's left edge and the first chip icon are now within 1px (the chip's border), and the prompt sits 17px below the card top.

The model chip truncated at a fixed 140px while the chat row ran ~250px empty — chat mode has no Generate button to fill it. `MediaControlChip` gains a `grow` prop: the chip claims the row's leftover width up to `maxWidth`, takes a field surface, and pins its caret to the right edge, so the extra width reads as a select rather than a stretched label. It is applied to the model chip in every mode (320px cap, desktop only); in media modes the chip absorbs whatever the other chips and the Generate button leave, so the row stays on one line. Truncation also ellipsizes now instead of hard-clipping — the chip's inner flex row could not shrink, so `text-overflow` never applied.

## Verification

Verified visually by replaying a marketing chat cast through the real `ChatView` (`web/demo.html`) in Chromium at 1180px and 390px, in chat mode and image mode, and reading the geometry out of the DOM.

- [x] `npm run test:affected` — 172 suites, 1491 passed, 3 skipped
- [x] `npm run typecheck` — no errors in `web/`, `electron/`, or `mobile/`. The run also reports `Cannot find module '@nodetool-ai/base-nodes' | '@nodetool-ai/model3d' | '@nodetool-ai/automation-nodes'` from `packages/`; those dists are absent in this sandbox and are unrelated to this diff, which touches three files under `web/src/components/chat/composer/`.
- [x] `npm run lint` — exit 0 (only pre-existing `no-unused-vars` warnings)
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — 3 files touch 1 surface (`web-editor`), 0 selfchecks to run

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hK7VtcnuKLWzc9ms4vPrh