### PR TITLE
fix(providers): make a Codex sign-in show as connected and reach the agent

### DIFF
--- a/packages/websocket/src/configured-providers.ts
+++ b/packages/websocket/src/configured-providers.ts
@@ -1,0 +1,79 @@
+/**
+ * The set of providers a user holds credentials for, cached per user for the
+ * chat agent's toolbelt (`find_model`, media generation).
+ *
+ * Building it costs one credential resolution per registered provider, so a
+ * cache is worth having — but a cache that never expires is worse than none:
+ * a provider connected after the first chat turn stays invisible until the
+ * process restarts, which on a dev machine is every file save and on the
+ * production server is never. That is how a Codex sign-in could complete and
+ * leave the agent with no Codex.
+ *
+ * So an entry is good for {@link DEFAULT_TTL_MS} and no longer, and
+ * {@link clearProviderCache} from `@nodetool-ai/runtime` drops it immediately —
+ * credential writes call that, so a sign-in takes effect on the next turn
+ * rather than a minute later.
+ *
+ * The TTL is not belt-and-braces on top of that signal. A cached provider is
+ * built around the bearer it was handed, and the Codex bearer is a
+ * short-lived OAuth access token: the credential row is refreshed in place
+ * with no write this process sees, so only expiry rebuilds the instance.
+ */
+
+import { getProviderCacheVersion } from "@nodetool-ai/runtime";
+import type { BaseProvider } from "@nodetool-ai/runtime";
+
+/** How long a built provider set is reused. Bounds a stale OAuth bearer. */
+export const DEFAULT_TTL_MS = 60_000;
+
+export type ProviderSet = Record<string, BaseProvider>;
+
+interface CacheEntry {
+  providers: ProviderSet;
+  /** Registry credential version the entry was built against. */
+  version: number;
+  builtAt: number;
+}
+
+export interface ConfiguredProviderCacheOptions {
+  /** Builds the provider set for a user. Injected so tests need no registry. */
+  load: (userId: string) => Promise<ProviderSet>;
+  ttlMs?: number;
+  now?: () => number;
+  /** Credential-version reader. Injected only by tests. */
+  version?: () => number;
+}
+
+export class ConfiguredProviderCache {
+  private readonly entries = new Map<string, CacheEntry>();
+  private readonly load: (userId: string) => Promise<ProviderSet>;
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+  private readonly version: () => number;
+
+  constructor(options: ConfiguredProviderCacheOptions) {
+    this.load = options.load;
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.now = options.now ?? Date.now;
+    this.version = options.version ?? getProviderCacheVersion;
+  }
+
+  async get(userId: string): Promise<ProviderSet> {
+    const cached = this.entries.get(userId);
+    if (cached && this.isFresh(cached)) {
+      return cached.providers;
+    }
+    const providers = await this.load(userId);
+    this.entries.set(userId, {
+      providers,
+      version: this.version(),
+      builtAt: this.now()
+    });
+    return providers;
+  }
+
+  private isFresh(entry: CacheEntry): boolean {
+    if (entry.version !== this.version()) return false;
+    return this.now() - entry.builtAt < this.ttlMs;
+  }
+}

--- a/packages/websocket/src/oauth-api.ts
+++ b/packages/websocket/src/oauth-api.ts
@@ -30,6 +30,7 @@ import {
   type OAuthTokens,
   type PendingClaudeCodeLogin
 } from "@nodetool-ai/runtime/oauth";
+import { clearProviderCache } from "@nodetool-ai/runtime";
 import {
   isFiniteNumber,
   isNonEmptyString,
@@ -1097,6 +1098,11 @@ async function persistCodexTokens(
     expires_at:
       tokens.expiresAt != null ? new Date(tokens.expiresAt).toISOString() : null
   });
+  // The chat agent holds a per-user provider set built from the credentials it
+  // could resolve at the time. Without this the sign-in lands in the database
+  // and the agent goes on without Codex until the process restarts — which a
+  // production server does not do.
+  clearProviderCache();
   return accountId;
 }
 
@@ -1182,6 +1188,7 @@ async function handleOpenAIDisconnect(
   for (const credential of credentials) {
     await credential.delete();
   }
+  clearProviderCache();
   return jsonResponse({ success: true, removed: credentials.length });
 }
 

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -7,6 +7,7 @@ import {
 } from "./chat-tool-call-repair.js";
 import { attachChatPredictionForwarder } from "./chat-prediction-forwarder.js";
 import { ApiErrorCode } from "./error-codes.js";
+import { ConfiguredProviderCache } from "./configured-providers.js";
 import { admitSpend, releaseSpend, reserveSpend } from "./credit-gate.js";
 import { JobConcurrencyQueue } from "./job-queue.js";
 import { packWebSocketMessage, unpackWebSocketMessage } from "./messagepack.js";
@@ -2130,8 +2131,9 @@ export class UnifiedWebSocketRunner {
   private apiOptions?: HttpApiOptions;
   private frontendRendererRegistry?: FrontendRendererRegistry;
   private frontendRendererId: string | null = null;
-  private configuredProvidersCache: Map<string, Record<string, BaseProvider>> =
-    new Map();
+  private configuredProvidersCache = new ConfiguredProviderCache({
+    load: (userId) => this.buildConfiguredProviders(userId)
+  });
 
   private sendLock: Promise<void> = Promise.resolve();
   private activeJobs = new Map<string, ActiveJob>();
@@ -5738,7 +5740,7 @@ export class UnifiedWebSocketRunner {
     // only exists on deployments that have a login. Local mode never sees it.
     const googleWorkspace = isGoogleWorkspaceEnabled();
     if (googleWorkspace) registerGoogleWorkspaceTools();
-    const chatProviders = await this.getConfiguredProviders(userId);
+    const chatProviders = await this.configuredProvidersCache.get(userId);
     // The single-node runner is a closure only this package can build, so
     // `run_node` reaches a capability run as a host-supplied capability rather
     // than out of the registry.
@@ -8011,16 +8013,13 @@ export class UnifiedWebSocketRunner {
 
   /**
    * Build the map of configured BaseProvider instances for the given user.
-   * Cached per user — invalidate by clearing `configuredProvidersCache`.
    * Used by MCP tools (`find_model`, media generation) that need provider
-   * access.
+   * access. Called through {@link configuredProvidersCache}, which decides
+   * when a credential connected mid-session forces a rebuild.
    */
-  private async getConfiguredProviders(
+  private async buildConfiguredProviders(
     userId: string
   ): Promise<Record<string, BaseProvider>> {
-    const cached = this.configuredProvidersCache.get(userId);
-    if (cached) return cached;
-
     const providersMod = await import("@nodetool-ai/runtime");
     const { getSecret: getStoredSecret } = await import("@nodetool-ai/models");
     const getSecret = (key: string) =>
@@ -8041,7 +8040,6 @@ export class UnifiedWebSocketRunner {
         }
       })
     );
-    this.configuredProvidersCache.set(userId, result);
     return result;
   }
 

--- a/packages/websocket/tests/configured-providers.test.ts
+++ b/packages/websocket/tests/configured-providers.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import { clearProviderCache } from "@nodetool-ai/runtime";
+import type { BaseProvider } from "@nodetool-ai/runtime";
+import {
+  ConfiguredProviderCache,
+  type ProviderSet
+} from "../src/configured-providers.js";
+
+/** A provider set is only ever read by identity here. */
+const providerSet = (...ids: string[]): ProviderSet =>
+  Object.fromEntries(ids.map((id) => [id, { id } as unknown as BaseProvider]));
+
+describe("ConfiguredProviderCache", () => {
+  it("builds once per user and reuses the set", async () => {
+    const load = vi.fn(async () => providerSet("openai"));
+    const cache = new ConfiguredProviderCache({ load, now: () => 0 });
+
+    const first = await cache.get("user-1");
+    const second = await cache.get("user-1");
+
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+  });
+
+  it("keeps one entry per user", async () => {
+    const load = vi.fn(async (userId: string) => providerSet(userId));
+    const cache = new ConfiguredProviderCache({ load, now: () => 0 });
+
+    expect(Object.keys(await cache.get("user-1"))).toEqual(["user-1"]);
+    expect(Object.keys(await cache.get("user-2"))).toEqual(["user-2"]);
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("rebuilds after a credential write bumps the registry version", async () => {
+    let built = 0;
+    const cache = new ConfiguredProviderCache({
+      load: async () => providerSet(built++ === 0 ? "openai" : "codex"),
+      now: () => 0
+    });
+
+    expect(Object.keys(await cache.get("user-1"))).toEqual(["openai"]);
+    // What an OAuth sign-in does after persisting the credential.
+    clearProviderCache();
+    expect(Object.keys(await cache.get("user-1"))).toEqual(["codex"]);
+  });
+
+  it("rebuilds once the entry is older than the TTL", async () => {
+    let now = 0;
+    const load = vi.fn(async () => providerSet("codex"));
+    const cache = new ConfiguredProviderCache({
+      load,
+      ttlMs: 1000,
+      now: () => now
+    });
+
+    await cache.get("user-1");
+    now = 999;
+    await cache.get("user-1");
+    expect(load).toHaveBeenCalledTimes(1);
+
+    // A cached Codex provider holds a bearer that expires without any write
+    // this process sees, so age alone has to rebuild it.
+    now = 1000;
+    await cache.get("user-1");
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/components/menus/APIKeysTab.tsx
+++ b/web/src/components/menus/APIKeysTab.tsx
@@ -112,9 +112,28 @@ export const ProviderCard = memo(function ProviderCard({
   const validateSecret = useSecretsStore((s) => s.validateSecret);
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<SecretValidation | null>(null);
-  // OAuth-only providers have no stored secret — the sign-in itself is the
-  // connection.
-  const isConnected = meta.oauthOnly ? oauth.isConnected : secret.is_configured;
+  // A card has two ways to be connected and they are independent: a stored
+  // API key, and an OAuth sign-in. Only the key can be tested, managed or
+  // deleted, so the two stay separate rather than collapsing into one flag.
+  const hasKey = secret.is_configured;
+  const isConnected = meta.oauthOnly
+    ? oauth.isConnected
+    : hasKey || oauth.isConnected;
+
+  // The registry providers this card currently holds a credential for. The
+  // sign-in can credential a different provider than the key does — signing in
+  // to OpenAI stores a Codex token, and `codex` is what serves the models — so
+  // asking about `providerId` alone reports an OAuth-connected card as
+  // unconfigured.
+  const credentialedProviderIds = useMemo(() => {
+    const ids = new Set<string>();
+    if (hasKey && meta.providerId) ids.add(meta.providerId);
+    if (oauth.isConnected) {
+      const viaOAuth = meta.oauthProviderId ?? meta.providerId;
+      if (viaOAuth) ids.add(viaOAuth);
+    }
+    return ids;
+  }, [hasKey, oauth.isConnected, meta.providerId, meta.oauthProviderId]);
 
   // A credential says nothing about whether the server offers the provider.
   // A cloud profile prunes the local and OAuth-backed providers, and a build
@@ -122,11 +141,11 @@ export const ProviderCard = memo(function ProviderCard({
   // stays empty. `models.providers` is what the model menu itself reads.
   const { providers, isLoading: providersLoading } = useProviders();
   const isUnavailable = useMemo(() => {
-    if (!isConnected || !meta.providerId) return false;
+    if (credentialedProviderIds.size === 0) return false;
     // Unknown is not absent: while the query is in flight, say nothing.
     if (providersLoading || providers.length === 0) return false;
-    return !providers.some((p) => p.provider === meta.providerId);
-  }, [isConnected, meta.providerId, providers, providersLoading]);
+    return !providers.some((p) => credentialedProviderIds.has(p.provider));
+  }, [credentialedProviderIds, providers, providersLoading]);
 
   const statusTone = isUnavailable ? "warning" : isConnected ? "success" : "error";
   const statusLabel = isUnavailable
@@ -331,12 +350,11 @@ export const ProviderCard = memo(function ProviderCard({
                 textAlign: { xs: "left", sm: "right" }
               }}
             >
-              {meta.oauthOnly ? "Signed in" : "Key stored"}, but this server
-              does not offer {meta.name}. Its models stay out of the model
-              menu.
+              {hasKey ? "Key stored" : "Signed in"}, but this server does not
+              offer {meta.name}. Its models stay out of the model menu.
             </Caption>
           )}
-          {isConnected && !isUnavailable && secret.updated_at && (
+          {hasKey && !isUnavailable && secret.updated_at && (
             <Caption size="smaller" sx={{ opacity: 0.45, whiteSpace: "nowrap" }}>
               Last used{" "}
               {new Date(secret.updated_at).toLocaleDateString()}
@@ -409,7 +427,7 @@ export const ProviderCard = memo(function ProviderCard({
                   </EditorButton>
                 ))}
 
-          {meta.oauthOnly ? null : isConnected ? (
+          {meta.oauthOnly ? null : hasKey ? (
             <>
               <EditorButton
                 density="compact"

--- a/web/src/components/menus/__tests__/ProviderCard.test.tsx
+++ b/web/src/components/menus/__tests__/ProviderCard.test.tsx
@@ -212,6 +212,52 @@ describe("ProviderCard registry availability", () => {
     expect(screen.getByText("Connected")).toBeInTheDocument();
   });
 
+  it("counts an OAuth sign-in as connected on a card that also takes a key", () => {
+    mockUseOAuthConnection.mockReturnValue(
+      oauthState({ label: "OpenAI", isConnected: true, canDisconnect: true })
+    );
+    mockUseProviders.mockReturnValue(registryWith("codex", "groq"));
+
+    // Signing in to OpenAI credentials `codex`, not `openai` — the card used
+    // to read the key alone and call this "Not connected".
+    renderCard({ ...oauthMeta, oauthProviderId: "codex" });
+
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+    expect(screen.queryByText("Not connected")).not.toBeInTheDocument();
+    expect(screen.queryByText("Unavailable")).not.toBeInTheDocument();
+    // No key is stored, so the key actions stay out of the way.
+    expect(
+      screen.getByRole("button", { name: /^connect$/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /manage/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("says Unavailable when the server lacks the provider the sign-in credentials", () => {
+    mockUseOAuthConnection.mockReturnValue(
+      oauthState({ label: "OpenAI", isConnected: true })
+    );
+    mockUseProviders.mockReturnValue(registryWith("openai", "groq"));
+
+    renderCard({ ...oauthMeta, oauthProviderId: "codex" });
+
+    expect(screen.getByText("Unavailable")).toBeInTheDocument();
+    expect(screen.getByText(/Signed in, but this server/i)).toBeInTheDocument();
+  });
+
+  it("stays available when either credential reaches an offered provider", () => {
+    mockUseOAuthConnection.mockReturnValue(
+      oauthState({ label: "OpenAI", isConnected: true })
+    );
+    mockUseProviders.mockReturnValue(registryWith("openai"));
+
+    renderCard({ ...oauthMeta, oauthProviderId: "codex" }, true);
+
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+    expect(screen.queryByText("Unavailable")).not.toBeInTheDocument();
+  });
+
   it("stays quiet for a card with no registry provider behind it", () => {
     mockUseProviders.mockReturnValue(registryWith("openai"));
 

--- a/web/src/components/menus/providerCatalog.ts
+++ b/web/src/components/menus/providerCatalog.ts
@@ -78,6 +78,14 @@ export interface ProviderMeta {
    * provider behind them (web search, GPU rental, tracing) leave this unset.
    */
   providerId?: ProviderId;
+  /**
+   * The registry provider the OAuth sign-in credentials, when it differs from
+   * the one the API key credentials. Signing in to OpenAI stores a ChatGPT
+   * Codex token, which the `codex` provider consumes — `openai` stays
+   * unconfigured until a key is pasted. Left unset when both paths lead to
+   * `providerId`.
+   */
+  oauthProviderId?: ProviderId;
 }
 
 /** Hosted deployments can't finish a same-machine sign-in — hide those cards. */
@@ -87,6 +95,7 @@ export const PROVIDER_META: ProviderMeta[] = [
   {
     key: "OPENAI_API_KEY",
     providerId: PROVIDER_IDS.OPENAI,
+    oauthProviderId: PROVIDER_IDS.CODEX,
     name: "OpenAI",
     description: "GPT models, images, embeddings, and more.",
     section: "popular",


### PR DESCRIPTION
## What changed

Signing in to OpenAI stores a ChatGPT Codex OAuth token, which the `codex` provider consumes — `openai` stays unconfigured until a key is pasted. Two places read the wrong thing, so a completed sign-in produced no Codex. The settings card decided "connected" from `secret.is_configured` alone, so after a successful sign-in it read "Not connected" with "Add your API key to get started", and its "does this server offer the provider" check asked about `openai`, never about the provider the sign-in actually credentials; the card now tracks the key and the sign-in separately (either connects it, availability is checked against every provider it holds a credential for, and Test/Manage/Delete stay tied to a stored key). Separately, the chat agent's per-user provider set was cached for the process lifetime and never invalidated, so a provider connected after the first chat turn stayed invisible until restart — every file save on a dev machine, never on the Fly server; it now rebuilds when `clearProviderCache()` bumps the credential version, which the OAuth connect and disconnect handlers now call, and in any case after 60s, because a cached `CodexProvider` holds a short-lived bearer that is refreshed in the credential row with no write this process sees.

The tRPC `models.providers` path was checked and needed no change: with a stored credential, `isProviderConfigured("codex", …)` already returns true under the cloud profile.

## Verification

- [x] `npm run test:affected` — 684 passed, "All affected suites passed". Also ran the two suites the diff touches directly: `packages/websocket` 229 files / 2542 tests passed, `web/src/components/menus` 9 suites / 67 tests passed.
- [x] `npm run typecheck` — web and electron clean. Mobile fails on `Cannot find module 'react-native'`/`expo` for every file, because `mobile/` is not a root workspace and its dependencies are not installed in this container; unchanged by this diff and untouched by it.
- [x] `npm run lint` — exit 0.
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — "0 selfcheck(s) to run" for these 7 files. It also prints an `edit_script` capability-mapping violation; that reproduces with this commit reverted (`git checkout HEAD~1` → same violation, "No changed files"), so it comes from `main` moving ahead, not from this diff. `npm run capabilities:check` reports the table current at 228 capabilities.

Both new server-side conditions were inverted once and observed failing:

Deleting the version check (`if (entry.version !== this.version()) return false;`):

```
× rebuilds after a credential write bumps the registry version 9ms
 Tests  1 failed | 4 passed
```

Replacing the TTL comparison with `return true`:

```
× rebuilds once the entry is older than the TTL 5ms
 Tests  1 failed | 4 passed
```

And the two new card tests against the old behaviour (`isConnected = hasKey`, `viaOAuth = meta.providerId`):

```
✕ counts an OAuth sign-in as connected on a card that also takes a key
✕ says Unavailable when the server lacks the provider the sign-in credentials
Tests: 2 failed, 10 passed
```

## Agent capabilities

No capability is added and none changes its declared contract.

## New checks

No check, rule, or audit is added — the new tests are unit tests over the changed behaviour, each shown failing above against the code as it was.


---
_Generated by [Claude Code](https://claude.ai/code/session_0197PVP2PiHKMBDKJUXZCvax)_