### PR TITLE
feat(chat): record a voice message from the composer

### DIFF
--- a/web/src/components/chat/composer/ActionButtons.tsx
+++ b/web/src/components/chat/composer/ActionButtons.tsx
@@ -16,6 +16,8 @@ interface ActionButtonsProps {
   onNewChat?: () => void;
   isDisabled: boolean;
   hasContent: boolean;
+  /** Rendered before the send/stop button (e.g. the voice input mic). */
+  leadingAction?: React.ReactNode;
 }
 
 const styles = (_theme: Theme) =>
@@ -38,7 +40,8 @@ export const ActionButtons: React.FC<ActionButtonsProps> = memo(({
   onSend,
   onStop,
   isDisabled,
-  hasContent
+  hasContent,
+  leadingAction
 }) => {
   const showStopButton = (isLoading || isStreaming) && onStop;
   const theme = useTheme();
@@ -50,6 +53,7 @@ export const ActionButtons: React.FC<ActionButtonsProps> = memo(({
 
   return (
     <div className="chat-action-buttons" css={cssStyles}>
+      {leadingAction}
       {showStopButton && (
         <Tooltip delay={TOOLTIP_ENTER_DELAY} title="Stop Generation">
           <span className="button-wrapper">

--- a/web/src/components/chat/composer/ChatComposer.tsx
+++ b/web/src/components/chat/composer/ChatComposer.tsx
@@ -16,6 +16,7 @@ import { MessageContent } from "../../../stores/ApiTypes";
 import { FilePreview } from "./FilePreview";
 import { MessageInput } from "./MessageInput";
 import { ActionButtons } from "./ActionButtons";
+import { VoiceInputControl } from "./voice/VoiceInputControl";
 import { useFileHandling } from "../hooks/useFileHandling";
 import { useDragAndDrop } from "../hooks/useDragAndDrop";
 import { usePromptHistory } from "../hooks/usePromptHistory";
@@ -45,6 +46,7 @@ const ChatComposer: React.FC<ChatComposerProps> = memo(({
   const styles = useMemo(() => createStyles(theme), [theme]);
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const composeCardRef = useRef<HTMLDivElement>(null);
   const [prompt, setPrompt] = useState("");
 
   const { droppedFiles, addFiles, removeFile, clearFiles, getFileContents, addDroppedFiles } =
@@ -76,28 +78,44 @@ const ChatComposer: React.FC<ChatComposerProps> = memo(({
     [resetHistoryNavigation]
   );
 
+  const submitPrompt = useCallback(
+    (text: string) => {
+      // Allow attachment-only sends; a whitespace-only prompt with no files
+      // is not a message. Trim so a spaces-only prompt never sends a text part.
+      if (text.trim().length === 0 && droppedFiles.length === 0) {
+        return;
+      }
+
+      const content: MessageContent[] = [];
+      if (text.trim().length > 0) {
+        content.push({ type: "text", text });
+      }
+      const fileContents = getFileContents();
+      const fullContent = [...content, ...fileContents];
+
+      // Only clear the input when the message was actually sent or queued;
+      // a dropped message (one already queued) keeps its text and attachments.
+      if (sendMessage(fullContent, text)) {
+        recordHistory(text);
+        setPrompt("");
+        clearFiles();
+      }
+    },
+    [droppedFiles, getFileContents, sendMessage, clearFiles, recordHistory]
+  );
+
   const handleSend = useCallback(() => {
-    // Allow attachment-only sends; a whitespace-only prompt with no files
-    // is not a message. Trim so a spaces-only prompt never sends a text part.
-    if (prompt.trim().length === 0 && droppedFiles.length === 0) {
-      return;
-    }
+    submitPrompt(prompt);
+  }, [prompt, submitPrompt]);
 
-    const content: MessageContent[] = [];
-    if (prompt.trim().length > 0) {
-      content.push({ type: "text", text: prompt });
-    }
-    const fileContents = getFileContents();
-    const fullContent = [...content, ...fileContents];
-
-    // Only clear the input when the message was actually sent or queued;
-    // a dropped message (one already queued) keeps its text and attachments.
-    if (sendMessage(fullContent, prompt)) {
-      recordHistory(prompt);
-      setPrompt("");
-      clearFiles();
-    }
-  }, [prompt, droppedFiles, getFileContents, sendMessage, clearFiles, recordHistory]);
+  // An accepted recording sends straight away, appended to whatever was typed.
+  const handleVoiceTranscript = useCallback(
+    (transcript: string) => {
+      const typed = prompt.trim();
+      submitPrompt(typed.length > 0 ? `${typed} ${transcript}` : transcript);
+    },
+    [prompt, submitPrompt]
+  );
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -198,6 +216,7 @@ const ChatComposer: React.FC<ChatComposerProps> = memo(({
       </Collapse>
 
       <div
+        ref={composeCardRef}
         className={`compose-message ${isDragging ? "dragging" : ""}`}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
@@ -229,6 +248,13 @@ const ChatComposer: React.FC<ChatComposerProps> = memo(({
           <div className="composer-footer">
             {toolbarNode}
             <ActionButtons
+              leadingAction={
+                <VoiceInputControl
+                  onTranscript={handleVoiceTranscript}
+                  overlayHost={composeCardRef}
+                  disabled={disabled}
+                />
+              }
               isLoading={isLoading}
               isStreaming={isStreaming}
               onSend={handleSend}

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -77,6 +77,7 @@ import { assetToUri } from "../../node_types/editing/promptComposer/promptTokens
 import { useTextareaAssetMention } from "./useTextareaAssetMention";
 import { useTextareaSkillMention } from "./useTextareaSkillMention";
 import { MentionedEntities } from "./MentionedEntities";
+import { VoiceInputControl } from "./voice/VoiceInputControl";
 import { FilePreview } from "./FilePreview";
 import { useFileHandling } from "../hooks/useFileHandling";
 import { useDragAndDrop } from "../hooks/useDragAndDrop";
@@ -184,6 +185,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const styles = useMemo(() => createMediaComposerStyles(theme), [theme]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const composeCardRef = useRef<HTMLDivElement>(null);
   const autoFocusEnabled = useAutoFocusEnabled();
   const [prompt, setPrompt] = useState("");
 
@@ -571,46 +573,68 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
 
   const canGenerate = prompt.trim().length > 0 || droppedFiles.length > 0;
 
+  const submitPrompt = useCallback(
+    (text: string) => {
+      if (text.trim().length === 0 && droppedFiles.length === 0) {
+        return;
+      }
+      // No configured provider can serve this mode — sending would only fail on
+      // the server. Keep the prompt and guide the user through provider setup.
+      if (providerSetup.needsSetup) {
+        providerSetup.openSetup();
+        return;
+      }
+      // Nothing is picked for this mode. The server rejects such a turn, so keep
+      // the prompt and open the picker instead of sending.
+      if (needsModel) {
+        modelGate?.open();
+        return;
+      }
+      const content: MessageContent[] = [];
+      if (text.trim().length > 0) {
+        content.push({ type: "text", text });
+      }
+      const fileContents = getFileContents();
+      const fullContent = [...content, ...fileContents];
+      // Only clear the input when the message was actually sent or queued; a
+      // dropped message (one already queued) keeps its text and attachments.
+      if (sendMessage(fullContent, text)) {
+        recordHistory(text);
+        setPrompt("");
+        clearFiles();
+      }
+    },
+    [
+      droppedFiles,
+      getFileContents,
+      sendMessage,
+      clearFiles,
+      recordHistory,
+      providerSetup,
+      needsModel,
+      modelGate
+    ]
+  );
+
   const handleSend = useCallback(() => {
-    if (!canGenerate) {
-      return;
-    }
-    // No configured provider can serve this mode — sending would only fail on
-    // the server. Keep the prompt and guide the user through provider setup.
-    if (providerSetup.needsSetup) {
-      providerSetup.openSetup();
-      return;
-    }
-    // Nothing is picked for this mode. The server rejects such a turn, so keep
-    // the prompt and open the picker instead of sending.
-    if (needsModel) {
-      modelGate?.open();
-      return;
-    }
-    const content: MessageContent[] = [];
-    if (prompt.trim().length > 0) {
-      content.push({ type: "text", text: prompt });
-    }
-    const fileContents = getFileContents();
-    const fullContent = [...content, ...fileContents];
-    // Only clear the input when the message was actually sent or queued; a
-    // dropped message (one already queued) keeps its text and attachments.
-    if (sendMessage(fullContent, prompt)) {
-      recordHistory(prompt);
-      setPrompt("");
-      clearFiles();
-    }
-  }, [
-    prompt,
-    canGenerate,
-    getFileContents,
-    sendMessage,
-    clearFiles,
-    recordHistory,
-    providerSetup,
-    needsModel,
-    modelGate
-  ]);
+    submitPrompt(prompt);
+  }, [prompt, submitPrompt]);
+
+  const handleVoiceTranscript = useCallback(
+    (transcript: string) => {
+      const typed = prompt.trim();
+      const text = typed.length > 0 ? `${typed} ${transcript}` : transcript;
+      // A chat turn sends straight away. A media mode bills for the run it
+      // would start, so a dictated prompt lands in the box for review instead.
+      if (isMediaMode) {
+        setPrompt(text);
+        textareaRef.current?.focus();
+        return;
+      }
+      submitPrompt(text);
+    },
+    [prompt, submitPrompt, isMediaMode]
+  );
 
   const handlePaste = useCallback(
     (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
@@ -889,6 +913,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
   return (
     <div css={styles} className="media-chat-composer">
       <div
+        ref={composeCardRef}
         className={`media-compose-card${isDragging ? " dragging" : ""}`}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
@@ -1493,6 +1518,11 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
               the chips, so it joins the workflow action buttons on one line
               when the row wraps. */}
           <div className="media-primary-action">
+            <VoiceInputControl
+              onTranscript={handleVoiceTranscript}
+              overlayHost={composeCardRef}
+              disabled={disabled}
+            />
             {isBusy ? (
               onStop && <StopGenerationButton onClick={onStop} />
             ) : isMediaMode ? (

--- a/web/src/components/chat/composer/voice/RecordingWaveform.tsx
+++ b/web/src/components/chat/composer/voice/RecordingWaveform.tsx
@@ -1,0 +1,91 @@
+import React, { memo, useEffect, useRef } from "react";
+import { useTheme } from "@mui/material/styles";
+import { LEVEL_BUFFER_SIZE } from "../../../../hooks/browser/useMicrophoneRecorder";
+
+interface RecordingWaveformProps {
+  /** Amplitudes in [0,1], oldest first. Read per frame, never via state. */
+  levelsRef: React.MutableRefObject<Float32Array>;
+  height?: number;
+}
+
+const BAR_WIDTH = 2;
+const BAR_GAP = 2;
+const MIN_BAR_HEIGHT = 2;
+
+/**
+ * The live input meter: one bar per amplitude sample, newest at the right, the
+ * whole wave sliding left as the buffer shifts.
+ */
+export const RecordingWaveform = memo(function RecordingWaveform({
+  levelsRef,
+  height = 28
+}: RecordingWaveformProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const theme = useTheme();
+  const barColor = theme.vars.palette.primary.main;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+    const context = canvas.getContext("2d");
+    if (!context) {
+      return;
+    }
+
+    const draw = () => {
+      const ratio = window.devicePixelRatio || 1;
+      const width = canvas.clientWidth;
+      if (
+        canvas.width !== Math.round(width * ratio) ||
+        canvas.height !== Math.round(height * ratio)
+      ) {
+        canvas.width = Math.round(width * ratio);
+        canvas.height = Math.round(height * ratio);
+      }
+      context.setTransform(ratio, 0, 0, ratio, 0, 0);
+      context.clearRect(0, 0, width, height);
+      context.fillStyle = barColor;
+
+      const levels = levelsRef.current;
+      const step = BAR_WIDTH + BAR_GAP;
+      const barCount = Math.min(
+        LEVEL_BUFFER_SIZE,
+        Math.max(1, Math.floor(width / step))
+      );
+      const middle = height / 2;
+      for (let i = 0; i < barCount; i++) {
+        // The right edge is the newest sample, so read the buffer backwards.
+        const level = levels[levels.length - barCount + i] ?? 0;
+        const barHeight = Math.max(MIN_BAR_HEIGHT, level * height);
+        const x = width - (barCount - i) * step;
+        context.fillRect(x, middle - barHeight / 2, BAR_WIDTH, barHeight);
+      }
+    };
+
+    const loop = () => {
+      draw();
+      frameRef.current = requestAnimationFrame(loop);
+    };
+
+    frameRef.current = requestAnimationFrame(loop);
+
+    return () => {
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current);
+        frameRef.current = null;
+      }
+    };
+  }, [barColor, height, levelsRef]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="recording-waveform"
+      role="presentation"
+      style={{ width: "100%", height, display: "block" }}
+    />
+  );
+});

--- a/web/src/components/chat/composer/voice/VoiceInputControl.tsx
+++ b/web/src/components/chat/composer/voice/VoiceInputControl.tsx
@@ -1,0 +1,86 @@
+import React, { memo, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import MicNoneRoundedIcon from "@mui/icons-material/MicNoneRounded";
+import { ToolbarIconButton } from "../../../ui_primitives";
+import ASRModelMenuDialog from "../../../model_menu/ASRModelMenuDialog";
+import { VoiceRecordingBar } from "./VoiceRecordingBar";
+import { useVoiceInput } from "./useVoiceInput";
+
+interface VoiceInputControlProps {
+  /** Called with the transcript once a recording is accepted. */
+  onTranscript: (text: string) => void;
+  /**
+   * The composer card the recording bar covers. The bar is portalled into it
+   * so the button can sit anywhere in the footer without the bar inheriting
+   * the footer's own positioning context.
+   */
+  overlayHost: React.RefObject<HTMLElement | null>;
+  disabled?: boolean;
+}
+
+/**
+ * The composer's mic: the button, the recording bar that takes over the
+ * composer while recording, and the model picker shown when no speech-to-text
+ * default is pinned.
+ */
+export const VoiceInputControl = memo(function VoiceInputControl({
+  onTranscript,
+  overlayHost,
+  disabled = false
+}: VoiceInputControlProps) {
+  const micRef = useRef<HTMLButtonElement>(null);
+  // Read after mount: refs are still null on the first render pass, and the
+  // bar can be active on the very next one.
+  const [overlayElement, setOverlayElement] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setOverlayElement(overlayHost.current);
+  }, [overlayHost]);
+  const {
+    phase,
+    durationMs,
+    levelsRef,
+    startRecording,
+    confirmRecording,
+    cancelRecording,
+    isConfigOpen,
+    closeConfig,
+    selectModel
+  } = useVoiceInput({ onTranscript });
+
+  const isActive = phase !== "idle";
+
+  return (
+    <>
+      {isActive &&
+        overlayElement &&
+        createPortal(
+          <VoiceRecordingBar
+            levelsRef={levelsRef}
+            durationMs={durationMs}
+            isTranscribing={phase === "transcribing"}
+            onConfirm={confirmRecording}
+            onCancel={cancelRecording}
+          />,
+          overlayElement
+        )}
+      <ToolbarIconButton
+        ref={micRef}
+        className="voice-input-button"
+        aria-label="Record voice message"
+        tooltip="Record voice message"
+        icon={<MicNoneRoundedIcon fontSize="small" />}
+        onClick={startRecording}
+        disabled={disabled || isActive}
+        nodrag={false}
+      />
+      <ASRModelMenuDialog
+        open={isConfigOpen}
+        anchorEl={isConfigOpen ? micRef.current : null}
+        onClose={closeConfig}
+        onModelChange={selectModel}
+      />
+    </>
+  );
+});
+
+export default VoiceInputControl;

--- a/web/src/components/chat/composer/voice/VoiceRecordingBar.tsx
+++ b/web/src/components/chat/composer/voice/VoiceRecordingBar.tsx
@@ -1,0 +1,140 @@
+/** @jsxImportSource @emotion/react */
+import { css, keyframes } from "@emotion/react";
+import type { Theme } from "@mui/material/styles";
+import { useTheme } from "@mui/material/styles";
+import React, { memo, useMemo } from "react";
+import CheckRoundedIcon from "@mui/icons-material/CheckRounded";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import {
+  BORDER_RADIUS,
+  FlexRow,
+  LoadingSpinner,
+  MOTION,
+  SPACING,
+  Text,
+  ToolbarIconButton,
+  Z_INDEX,
+  reducedMotion
+} from "../../../ui_primitives";
+import { RecordingWaveform } from "./RecordingWaveform";
+
+interface VoiceRecordingBarProps {
+  levelsRef: React.MutableRefObject<Float32Array>;
+  durationMs: number;
+  isTranscribing: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function formatDuration(durationMs: number): string {
+  const totalSeconds = Math.floor(Math.max(0, durationMs) / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+const pulse = keyframes`
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.25; }
+`;
+
+const styles = (theme: Theme) =>
+  css({
+    position: "absolute",
+    inset: 0,
+    zIndex: Z_INDEX.raised,
+    display: "flex",
+    alignItems: "center",
+    gap: theme.spacing(SPACING.sm),
+    padding: `0 ${theme.spacing(SPACING.sm)}`,
+    borderRadius: BORDER_RADIUS.pill,
+    backgroundColor: theme.vars.palette.c_overlay_strong,
+    backdropFilter: "blur(10px)",
+
+    ".recording-dot": {
+      width: 8,
+      height: 8,
+      flexShrink: 0,
+      borderRadius: BORDER_RADIUS.circle,
+      backgroundColor: theme.vars.palette.error.main,
+      animation: `${pulse} ${MOTION.pulse} infinite`,
+      ...reducedMotion({ animation: "none" })
+    },
+    ".wave-slot": {
+      flex: 1,
+      minWidth: 0,
+      overflow: "hidden"
+    },
+    ".duration": {
+      fontVariantNumeric: "tabular-nums",
+      flexShrink: 0
+    }
+  });
+
+/**
+ * What the composer becomes while a voice message is being taken: a live input
+ * meter between two decisions — discard on the left, accept on the right.
+ */
+export const VoiceRecordingBar = memo(function VoiceRecordingBar({
+  levelsRef,
+  durationMs,
+  isTranscribing,
+  onConfirm,
+  onCancel
+}: VoiceRecordingBarProps) {
+  const theme = useTheme();
+  const cssStyles = useMemo(() => styles(theme), [theme]);
+
+  if (isTranscribing) {
+    // The take is already accepted and the run cannot be called back, so the
+    // bar holds no controls here — only what the composer is waiting on.
+    return (
+      <div
+        css={cssStyles}
+        className="voice-recording-bar"
+        role="status"
+        aria-label="Transcribing recording"
+      >
+        <FlexRow className="wave-slot" gap={1} align="center">
+          <LoadingSpinner variant="circular" size={16} />
+          <Text size="small" color="secondary">
+            Transcribing…
+          </Text>
+        </FlexRow>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      css={cssStyles}
+      className="voice-recording-bar"
+      role="group"
+      aria-label="Voice recording"
+    >
+      <ToolbarIconButton
+        className="voice-cancel"
+        aria-label="Discard recording"
+        tooltip="Discard recording"
+        icon={<CloseRoundedIcon fontSize="small" />}
+        onClick={onCancel}
+        variant="error"
+      />
+      <div className="wave-slot">
+        <RecordingWaveform levelsRef={levelsRef} />
+      </div>
+      <span className="recording-dot" aria-hidden />
+      <Text size="small" className="duration">
+        {formatDuration(durationMs)}
+      </Text>
+      <ToolbarIconButton
+        className="voice-confirm"
+        aria-label="Accept recording"
+        tooltip="Accept recording"
+        icon={<CheckRoundedIcon fontSize="small" />}
+        onClick={onConfirm}
+        variant="primary"
+      />
+    </div>
+  );
+});

--- a/web/src/components/chat/composer/voice/__tests__/VoiceInputControl.test.tsx
+++ b/web/src/components/chat/composer/voice/__tests__/VoiceInputControl.test.tsx
@@ -1,0 +1,85 @@
+import React, { useRef } from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+
+import { VoiceInputControl } from "../VoiceInputControl";
+import type { VoiceInputPhase } from "../useVoiceInput";
+import mockTheme from "../../../../../__mocks__/themeMock";
+
+const startRecording = jest.fn();
+const confirmRecording = jest.fn();
+const cancelRecording = jest.fn();
+let phase: VoiceInputPhase = "idle";
+
+jest.mock("../useVoiceInput", () => ({
+  useVoiceInput: () => ({
+    phase,
+    durationMs: 2_000,
+    levelsRef: { current: new Float32Array(8) },
+    startRecording,
+    confirmRecording,
+    cancelRecording,
+    isConfigOpen: false,
+    closeConfig: jest.fn(),
+    selectModel: jest.fn()
+  })
+}));
+
+jest.mock("../../../../model_menu/ASRModelMenuDialog", () => ({
+  __esModule: true,
+  default: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="asr-dialog" /> : null
+}));
+
+// The composer card the recording bar is portalled into.
+function Host() {
+  const cardRef = useRef<HTMLDivElement>(null);
+  return (
+    <div ref={cardRef} data-testid="compose-card">
+      <div data-testid="footer">
+        <VoiceInputControl onTranscript={jest.fn()} overlayHost={cardRef} />
+      </div>
+    </div>
+  );
+}
+
+const renderControl = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <Host />
+    </ThemeProvider>
+  );
+
+describe("VoiceInputControl", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    phase = "idle";
+  });
+
+  it("starts a recording from the mic button", async () => {
+    renderControl();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Record voice message" })
+    );
+    expect(startRecording).toHaveBeenCalled();
+  });
+
+  it("shows no recording bar while idle", () => {
+    renderControl();
+    expect(screen.queryByRole("group", { name: "Voice recording" })).toBeNull();
+  });
+
+  it("covers the composer card with the bar while recording", () => {
+    phase = "recording";
+    renderControl();
+    const bar = screen.getByRole("group", { name: "Voice recording" });
+    // The bar belongs to the card, not to the footer the button sits in.
+    expect(screen.getByTestId("compose-card")).toContainElement(bar);
+    expect(screen.getByTestId("footer")).not.toContainElement(bar);
+    expect(
+      screen.getByRole("button", { name: "Record voice message" })
+    ).toBeDisabled();
+  });
+});

--- a/web/src/components/chat/composer/voice/__tests__/VoiceRecordingBar.test.tsx
+++ b/web/src/components/chat/composer/voice/__tests__/VoiceRecordingBar.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+
+import { VoiceRecordingBar, formatDuration } from "../VoiceRecordingBar";
+import mockTheme from "../../../../../__mocks__/themeMock";
+
+const levelsRef = { current: new Float32Array(8) };
+
+const renderBar = (
+  props: Partial<React.ComponentProps<typeof VoiceRecordingBar>> = {}
+) => {
+  const onConfirm = jest.fn();
+  const onCancel = jest.fn();
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <VoiceRecordingBar
+        levelsRef={levelsRef}
+        durationMs={0}
+        isTranscribing={false}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        {...props}
+      />
+    </ThemeProvider>
+  );
+  return { onConfirm, onCancel };
+};
+
+describe("formatDuration", () => {
+  it("renders mm:ss", () => {
+    expect(formatDuration(0)).toBe("0:00");
+    expect(formatDuration(9_400)).toBe("0:09");
+    expect(formatDuration(65_000)).toBe("1:05");
+  });
+});
+
+describe("VoiceRecordingBar", () => {
+  it("offers accept and discard while recording", async () => {
+    const { onConfirm, onCancel } = renderBar({ durationMs: 3_000 });
+    expect(screen.getByText("0:03")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Accept recording" }));
+    expect(onConfirm).toHaveBeenCalled();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Discard recording" })
+    );
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("shows only the transcription status once the take is accepted", () => {
+    renderBar({ isTranscribing: true });
+    expect(screen.getByText("Transcribing…")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Accept recording" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Discard recording" })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/chat/composer/voice/__tests__/useVoiceInput.test.tsx
+++ b/web/src/components/chat/composer/voice/__tests__/useVoiceInput.test.tsx
@@ -1,0 +1,180 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ASRModel } from "../../../../../stores/ApiTypes";
+import useModelPreferencesStore from "../../../../../stores/ModelPreferencesStore";
+import { useNotificationStore } from "../../../../../stores/NotificationStore";
+import { ASR_MODEL_PREFERENCE, useVoiceInput } from "../useVoiceInput";
+
+const mockStart = jest.fn<Promise<string | null>, []>();
+const mockConfirm = jest.fn<Promise<Blob | null>, []>();
+const mockCancel = jest.fn();
+const levelsRef = { current: new Float32Array(4) };
+
+jest.mock("../../../../../hooks/browser/useMicrophoneRecorder", () => ({
+  LEVEL_BUFFER_SIZE: 4,
+  useMicrophoneRecorder: () => ({
+    status: "idle",
+    isRecording: false,
+    error: null,
+    durationMs: 0,
+    levelsRef,
+    start: mockStart,
+    confirm: mockConfirm,
+    cancel: mockCancel
+  })
+}));
+
+const mockUploadAsset = jest.fn();
+jest.mock("../../../../../serverState/useAssetUpload", () => ({
+  useAssetUpload: {
+    getState: () => ({ uploadAsset: mockUploadAsset })
+  }
+}));
+
+const mockRpcRequest = jest.fn();
+jest.mock("../../../../../lib/websocket/rpcRequest", () => ({
+  rpcRequest: (command: string, data: Record<string, unknown>) =>
+    mockRpcRequest(command, data)
+}));
+
+const whisper: ASRModel = {
+  type: "asr_model",
+  id: "whisper-1",
+  name: "Whisper",
+  provider: "openai" as ASRModel["provider"]
+};
+
+function pinDefaultModel() {
+  useModelPreferencesStore.getState().setDefault(ASR_MODEL_PREFERENCE, {
+    provider: "openai",
+    id: "whisper-1",
+    name: "Whisper"
+  });
+}
+
+describe("useVoiceInput", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useModelPreferencesStore.setState({ defaults: {} });
+    useNotificationStore.setState({ notifications: [] });
+    mockStart.mockResolvedValue(null);
+    mockUploadAsset.mockImplementation(
+      ({ onCompleted }: { onCompleted: (asset: { id: string }) => void }) => {
+        onCompleted({ id: "asset-1" });
+      }
+    );
+    mockRpcRequest.mockResolvedValue({ text: "  hello there  " });
+  });
+
+  it("asks for a model instead of recording when no default is pinned", () => {
+    const { result } = renderHook(() =>
+      useVoiceInput({ onTranscript: jest.fn() })
+    );
+
+    act(() => {
+      result.current.startRecording();
+    });
+
+    expect(result.current.isConfigOpen).toBe(true);
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("pins the picked model as the default and starts recording", async () => {
+    const { result } = renderHook(() =>
+      useVoiceInput({ onTranscript: jest.fn() })
+    );
+
+    act(() => {
+      result.current.startRecording();
+    });
+    await act(async () => {
+      result.current.selectModel(whisper);
+    });
+
+    expect(
+      useModelPreferencesStore.getState().defaults[ASR_MODEL_PREFERENCE]
+    ).toEqual({ provider: "openai", id: "whisper-1", name: "Whisper" });
+    expect(result.current.isConfigOpen).toBe(false);
+    expect(mockStart).toHaveBeenCalled();
+  });
+
+  it("records straight away once a default is pinned", () => {
+    pinDefaultModel();
+    const { result } = renderHook(() =>
+      useVoiceInput({ onTranscript: jest.fn() })
+    );
+
+    act(() => {
+      result.current.startRecording();
+    });
+
+    expect(result.current.isConfigOpen).toBe(false);
+    expect(mockStart).toHaveBeenCalled();
+  });
+
+  it("uploads the take and transcribes it with the default model", async () => {
+    pinDefaultModel();
+    const onTranscript = jest.fn();
+    mockConfirm.mockResolvedValue(new Blob(["audio"], { type: "audio/webm" }));
+
+    const { result } = renderHook(() => useVoiceInput({ onTranscript }));
+    await act(async () => {
+      result.current.confirmRecording();
+    });
+
+    await waitFor(() => expect(onTranscript).toHaveBeenCalledWith("hello there"));
+    expect(mockRpcRequest).toHaveBeenCalledWith("transcribe_audio", {
+      provider: "openai",
+      model: "whisper-1",
+      asset_id: "asset-1"
+    });
+  });
+
+  it("does not transcribe a discarded recording", async () => {
+    pinDefaultModel();
+    const onTranscript = jest.fn();
+    mockConfirm.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useVoiceInput({ onTranscript }));
+    await act(async () => {
+      result.current.confirmRecording();
+    });
+
+    expect(mockRpcRequest).not.toHaveBeenCalled();
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+
+  it("reports a failed transcription and sends nothing", async () => {
+    pinDefaultModel();
+    const onTranscript = jest.fn();
+    mockConfirm.mockResolvedValue(new Blob(["audio"], { type: "audio/webm" }));
+    mockRpcRequest.mockRejectedValue(new Error("provider unavailable"));
+
+    const { result } = renderHook(() => useVoiceInput({ onTranscript }));
+    await act(async () => {
+      result.current.confirmRecording();
+    });
+
+    await waitFor(() =>
+      expect(useNotificationStore.getState().notifications).toHaveLength(1)
+    );
+    expect(useNotificationStore.getState().notifications[0].content).toContain(
+      "provider unavailable"
+    );
+    expect(onTranscript).not.toHaveBeenCalled();
+    await waitFor(() => expect(result.current.phase).toBe("idle"));
+  });
+
+  it("cancelling discards the take", () => {
+    pinDefaultModel();
+    const { result } = renderHook(() =>
+      useVoiceInput({ onTranscript: jest.fn() })
+    );
+
+    act(() => {
+      result.current.cancelRecording();
+    });
+
+    expect(mockCancel).toHaveBeenCalled();
+    expect(mockRpcRequest).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/chat/composer/voice/useVoiceInput.ts
+++ b/web/src/components/chat/composer/voice/useVoiceInput.ts
@@ -1,0 +1,208 @@
+import { useCallback, useRef, useState } from "react";
+import type { ASRModel, Asset } from "../../../../stores/ApiTypes";
+import { useAssetUpload } from "../../../../serverState/useAssetUpload";
+import useModelPreferencesStore from "../../../../stores/ModelPreferencesStore";
+import { useNotificationStore } from "../../../../stores/NotificationStore";
+import { rpcRequest } from "../../../../lib/websocket/rpcRequest";
+import { isString } from "../../../../utils/typePredicates";
+import { useMicrophoneRecorder } from "../../../../hooks/browser/useMicrophoneRecorder";
+
+/** The `defaults` key holding the speech-to-text model (Settings → Default Models). */
+export const ASR_MODEL_PREFERENCE = "asr_model";
+
+const MIME_EXTENSIONS: Record<string, string> = {
+  "audio/webm": "webm",
+  "audio/ogg": "ogg",
+  "audio/mp4": "m4a",
+  "audio/mpeg": "mp3",
+  "audio/wav": "wav"
+};
+
+function recordingFileName(mimeType: string): string {
+  const base = mimeType.split(";")[0];
+  return `voice-message-${Date.now()}.${MIME_EXTENSIONS[base] ?? "webm"}`;
+}
+
+function uploadRecording(blob: Blob): Promise<Asset> {
+  const mimeType = blob.type || "audio/webm";
+  const file = new File([blob], recordingFileName(mimeType), {
+    type: mimeType
+  });
+  return new Promise((resolve, reject) => {
+    useAssetUpload.getState().uploadAsset({
+      file,
+      onCompleted: resolve,
+      onFailed: (error: string) => reject(new Error(error))
+    });
+  });
+}
+
+export type VoiceInputPhase = "idle" | "recording" | "transcribing";
+
+interface UseVoiceInputOptions {
+  /** Receives the transcript once the recording is accepted and transcribed. */
+  onTranscript: (text: string) => void;
+}
+
+interface UseVoiceInputReturn {
+  phase: VoiceInputPhase;
+  durationMs: number;
+  levelsRef: React.MutableRefObject<Float32Array>;
+  /** Mic button: starts recording, or asks for a model when none is set. */
+  startRecording: () => void;
+  /** Accept: stop, transcribe, hand the text to the composer. */
+  confirmRecording: () => void;
+  /** Discard: stop and throw the audio away. */
+  cancelRecording: () => void;
+  isConfigOpen: boolean;
+  closeConfig: () => void;
+  selectModel: (model: ASRModel) => void;
+}
+
+/**
+ * The chat composer's voice input: record → confirm → transcribe with the
+ * default speech-to-text model.
+ *
+ * The model is the one pinned in Settings → Default Models. With none pinned
+ * there is nothing to transcribe with, so the mic opens the model picker
+ * instead of recording, and what the user picks becomes the default.
+ */
+export function useVoiceInput({
+  onTranscript
+}: UseVoiceInputOptions): Readonly<UseVoiceInputReturn> {
+  const recorder = useMicrophoneRecorder();
+  const [isTranscribing, setIsTranscribing] = useState(false);
+  const [isConfigOpen, setIsConfigOpen] = useState(false);
+  const pendingBlobRef = useRef<Blob | null>(null);
+  const addNotification = useNotificationStore((state) => state.addNotification);
+  const setDefault = useModelPreferencesStore((state) => state.setDefault);
+  const asrDefault = useModelPreferencesStore(
+    (state) => state.defaults[ASR_MODEL_PREFERENCE]
+  );
+
+  const reportError = useCallback(
+    (message: string) => {
+      addNotification({
+        type: "error",
+        alert: true,
+        content: message,
+        dedupeKey: "voice-input-error",
+        replaceExisting: true
+      });
+    },
+    [addNotification]
+  );
+
+  const transcribe = useCallback(
+    async (blob: Blob, model: { provider: string; id: string }) => {
+      setIsTranscribing(true);
+      try {
+        const asset = await uploadRecording(blob);
+        const result = await rpcRequest("transcribe_audio", {
+          provider: model.provider,
+          model: model.id,
+          asset_id: asset.id
+        });
+        const text = isString(result.text) ? result.text.trim() : "";
+        if (text.length === 0) {
+          reportError("Nothing was transcribed from that recording.");
+          return;
+        }
+        onTranscript(text);
+      } catch (err) {
+        reportError(
+          `Transcription failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      } finally {
+        setIsTranscribing(false);
+      }
+    },
+    [onTranscript, reportError]
+  );
+
+  const startRecording = useCallback(() => {
+    // Recording without a model would only strand the audio at the confirm
+    // step, so the picker comes first.
+    if (!asrDefault) {
+      setIsConfigOpen(true);
+      return;
+    }
+    void recorder.start().then((failure) => {
+      if (failure) {
+        reportError(failure);
+      }
+    });
+  }, [asrDefault, recorder, reportError]);
+
+  const confirmRecording = useCallback(() => {
+    void recorder.confirm().then((blob) => {
+      if (!blob) {
+        return;
+      }
+      const model = useModelPreferencesStore.getState().defaults[
+        ASR_MODEL_PREFERENCE
+      ];
+      if (!model) {
+        // The default was cleared while recording; hold the take and ask.
+        pendingBlobRef.current = blob;
+        setIsConfigOpen(true);
+        return;
+      }
+      void transcribe(blob, model);
+    });
+  }, [recorder, transcribe]);
+
+  const cancelRecording = useCallback(() => {
+    pendingBlobRef.current = null;
+    recorder.cancel();
+  }, [recorder]);
+
+  const closeConfig = useCallback(() => {
+    setIsConfigOpen(false);
+    pendingBlobRef.current = null;
+  }, []);
+
+  const selectModel = useCallback(
+    (model: ASRModel) => {
+      const chosen = {
+        provider: model.provider,
+        id: model.id,
+        name: model.name || model.id
+      };
+      setDefault(ASR_MODEL_PREFERENCE, chosen);
+      setIsConfigOpen(false);
+      const pending = pendingBlobRef.current;
+      pendingBlobRef.current = null;
+      if (pending) {
+        void transcribe(pending, chosen);
+        return;
+      }
+      void recorder.start().then((failure) => {
+        if (failure) {
+          reportError(failure);
+        }
+      });
+    },
+    [recorder, reportError, setDefault, transcribe]
+  );
+
+  const phase: VoiceInputPhase = isTranscribing
+    ? "transcribing"
+    : recorder.isRecording
+      ? "recording"
+      : "idle";
+
+  return {
+    phase,
+    durationMs: recorder.durationMs,
+    levelsRef: recorder.levelsRef,
+    startRecording,
+    confirmRecording,
+    cancelRecording,
+    isConfigOpen,
+    closeConfig,
+    selectModel
+  };
+}

--- a/web/src/hooks/browser/__tests__/useMicrophoneRecorder.test.ts
+++ b/web/src/hooks/browser/__tests__/useMicrophoneRecorder.test.ts
@@ -1,0 +1,138 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useMicrophoneRecorder } from "../useMicrophoneRecorder";
+
+type RecorderHandlers = {
+  ondataavailable: ((event: { data: Blob }) => void) | null;
+  onstop: (() => void) | null;
+};
+
+class FakeMediaRecorder implements RecorderHandlers {
+  static instances: FakeMediaRecorder[] = [];
+  static isTypeSupported = (type: string) => type === "audio/webm;codecs=opus";
+
+  state: "inactive" | "recording" = "inactive";
+  mimeType = "audio/webm;codecs=opus";
+  ondataavailable: ((event: { data: Blob }) => void) | null = null;
+  onstop: (() => void) | null = null;
+
+  constructor(public stream: MediaStream) {
+    FakeMediaRecorder.instances.push(this);
+  }
+
+  start() {
+    this.state = "recording";
+  }
+
+  stop() {
+    this.state = "inactive";
+    this.ondataavailable?.({ data: new Blob(["audio"], { type: this.mimeType }) });
+    this.onstop?.();
+  }
+}
+
+const stopTrack = jest.fn();
+const mockGetUserMedia = jest.fn();
+
+function installMediaStack() {
+  (global as unknown as { MediaRecorder: unknown }).MediaRecorder =
+    FakeMediaRecorder;
+  Object.defineProperty(global.navigator, "mediaDevices", {
+    value: { getUserMedia: mockGetUserMedia },
+    writable: true,
+    configurable: true
+  });
+  mockGetUserMedia.mockResolvedValue({
+    getTracks: () => [{ stop: stopTrack }]
+  } as unknown as MediaStream);
+}
+
+describe("useMicrophoneRecorder", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    FakeMediaRecorder.instances = [];
+    installMediaStack();
+  });
+
+  it("starts idle", () => {
+    const { result } = renderHook(() => useMicrophoneRecorder());
+    expect(result.current.status).toBe("idle");
+    expect(result.current.isRecording).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("records after start", async () => {
+    const { result } = renderHook(() => useMicrophoneRecorder());
+    await act(async () => {
+      await result.current.start();
+    });
+    expect(mockGetUserMedia).toHaveBeenCalledWith({ audio: true });
+    await waitFor(() => expect(result.current.status).toBe("recording"));
+  });
+
+  it("confirm resolves the recorded audio and releases the microphone", async () => {
+    const { result } = renderHook(() => useMicrophoneRecorder());
+    await act(async () => {
+      await result.current.start();
+    });
+
+    let blob: Blob | null = null;
+    await act(async () => {
+      blob = await result.current.confirm();
+    });
+
+    expect(blob).toBeInstanceOf(Blob);
+    expect(stopTrack).toHaveBeenCalled();
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("cancel throws the recording away", async () => {
+    const { result } = renderHook(() => useMicrophoneRecorder());
+    await act(async () => {
+      await result.current.start();
+    });
+
+    const stopped = new Promise<Blob | null>((resolve) => {
+      // `cancel` fires and forgets, so watch the recorder's own settle path.
+      const recorder = FakeMediaRecorder.instances[0];
+      const originalOnStop = recorder.onstop;
+      recorder.onstop = () => {
+        originalOnStop?.();
+        resolve(null);
+      };
+    });
+
+    await act(async () => {
+      result.current.cancel();
+      await stopped;
+    });
+
+    expect(stopTrack).toHaveBeenCalled();
+    await waitFor(() => expect(result.current.status).toBe("idle"));
+  });
+
+  it("reports a denied microphone instead of throwing", async () => {
+    const denied = new Error("Permission denied");
+    denied.name = "NotAllowedError";
+    mockGetUserMedia.mockRejectedValueOnce(denied);
+
+    const { result } = renderHook(() => useMicrophoneRecorder());
+    let failure: string | null = null;
+    await act(async () => {
+      failure = await result.current.start();
+    });
+
+    expect(failure).toContain("Microphone access was denied");
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("reports unsupported browsers", async () => {
+    (global as unknown as { MediaRecorder?: unknown }).MediaRecorder =
+      undefined;
+    const { result } = renderHook(() => useMicrophoneRecorder());
+    let failure: string | null = null;
+    await act(async () => {
+      failure = await result.current.start();
+    });
+    expect(failure).toBe("Recording is not supported in this browser.");
+  });
+});

--- a/web/src/hooks/browser/useMicrophoneRecorder.ts
+++ b/web/src/hooks/browser/useMicrophoneRecorder.ts
@@ -1,0 +1,272 @@
+import {
+  type MutableRefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from "react";
+
+export type MicrophoneRecorderStatus =
+  | "idle"
+  | "starting"
+  | "recording"
+  | "stopping";
+
+/** Samples kept for the scrolling waveform (~8s at SAMPLE_INTERVAL_MS). */
+export const LEVEL_BUFFER_SIZE = 240;
+
+/** How often the analyser writes one amplitude sample into the buffer. */
+const SAMPLE_INTERVAL_MS = 33;
+
+/** How often the elapsed-time readout re-renders. */
+const TICK_INTERVAL_MS = 100;
+
+interface UseMicrophoneRecorderReturn {
+  status: MicrophoneRecorderStatus;
+  isRecording: boolean;
+  error: string | null;
+  durationMs: number;
+  /** Amplitudes in [0,1], oldest first — the waveform reads this per frame. */
+  levelsRef: MutableRefObject<Float32Array>;
+  /** Begins capture. Resolves with a reason when it could not start. */
+  start: () => Promise<string | null>;
+  /** Stops and resolves the recorded audio, or null when nothing was captured. */
+  confirm: () => Promise<Blob | null>;
+  /** Stops and throws the recording away. */
+  cancel: () => void;
+}
+
+/** The first container the browser will actually record into. */
+function pickMimeType(): string | undefined {
+  const candidates = [
+    "audio/webm;codecs=opus",
+    "audio/webm",
+    "audio/ogg;codecs=opus",
+    "audio/mp4"
+  ];
+  if (typeof MediaRecorder.isTypeSupported !== "function") {
+    return undefined;
+  }
+  return candidates.find((type) => MediaRecorder.isTypeSupported(type));
+}
+
+function describeStartError(err: unknown): string {
+  const name = err instanceof Error ? err.name : "";
+  if (name === "NotAllowedError" || name === "SecurityError") {
+    return "Microphone access was denied. Allow it in your browser settings to record.";
+  }
+  if (name === "NotFoundError" || name === "OverconstrainedError") {
+    return "No microphone was found.";
+  }
+  return err instanceof Error ? err.message : "Could not start recording.";
+}
+
+/**
+ * Microphone capture for the chat composer: one take, confirmed or discarded.
+ *
+ * Amplitudes land in a ref rather than state — the waveform draws them on its
+ * own animation frame, so a recording re-renders React ten times a second for
+ * the timer instead of sixty times a second for the wave.
+ */
+export function useMicrophoneRecorder(): Readonly<UseMicrophoneRecorderReturn> {
+  const [status, setStatus] = useState<MicrophoneRecorderStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [durationMs, setDurationMs] = useState(0);
+
+  const levelsRef = useRef<Float32Array>(new Float32Array(LEVEL_BUFFER_SIZE));
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startedAtRef = useRef<number>(0);
+  const lastSampleAtRef = useRef<number>(0);
+  const discardRef = useRef<boolean>(false);
+  const settleRef = useRef<((blob: Blob | null) => void) | null>(null);
+
+  const releaseCapture = useCallback(() => {
+    if (frameRef.current !== null) {
+      cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
+    if (tickRef.current !== null) {
+      clearInterval(tickRef.current);
+      tickRef.current = null;
+    }
+    streamRef.current?.getTracks().forEach((track) => track.stop());
+    streamRef.current = null;
+    analyserRef.current = null;
+    const audioContext = audioContextRef.current;
+    audioContextRef.current = null;
+    if (audioContext && audioContext.state !== "closed") {
+      // Closing is async and nothing waits on it; a failure here only leaks a
+      // suspended context, so the rejection is dropped on purpose.
+      audioContext.close().catch(() => undefined);
+    }
+  }, []);
+
+  const sampleLevels = useCallback(() => {
+    const analyser = analyserRef.current;
+    if (!analyser) {
+      return;
+    }
+    frameRef.current = requestAnimationFrame(sampleLevels);
+    const now = performance.now();
+    if (now - lastSampleAtRef.current < SAMPLE_INTERVAL_MS) {
+      return;
+    }
+    lastSampleAtRef.current = now;
+
+    const samples = new Uint8Array(analyser.fftSize);
+    analyser.getByteTimeDomainData(samples);
+    let sumSquares = 0;
+    for (let i = 0; i < samples.length; i++) {
+      const centered = (samples[i] - 128) / 128;
+      sumSquares += centered * centered;
+    }
+    const rms = Math.sqrt(sumSquares / samples.length);
+    const levels = levelsRef.current;
+    levels.copyWithin(0, 1);
+    // Speech sits low in the RMS range; scale so a normal voice fills the bar.
+    levels[levels.length - 1] = Math.min(1, rms * 3);
+  }, []);
+
+  const attachAnalyser = useCallback(
+    (stream: MediaStream) => {
+      const AudioContextCtor =
+        typeof window === "undefined"
+          ? undefined
+          : window.AudioContext ??
+            (window as { webkitAudioContext?: typeof AudioContext })
+              .webkitAudioContext;
+      if (!AudioContextCtor) {
+        return;
+      }
+      const audioContext = new AudioContextCtor();
+      const analyser = audioContext.createAnalyser();
+      analyser.fftSize = 1024;
+      audioContext.createMediaStreamSource(stream).connect(analyser);
+      audioContextRef.current = audioContext;
+      analyserRef.current = analyser;
+      lastSampleAtRef.current = 0;
+      frameRef.current = requestAnimationFrame(sampleLevels);
+    },
+    [sampleLevels]
+  );
+
+  const start = useCallback(async (): Promise<string | null> => {
+    if (recorderRef.current) {
+      return null;
+    }
+    if (
+      typeof MediaRecorder === "undefined" ||
+      !navigator.mediaDevices?.getUserMedia
+    ) {
+      const reason = "Recording is not supported in this browser.";
+      setError(reason);
+      return reason;
+    }
+
+    setError(null);
+    setStatus("starting");
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      const mimeType = pickMimeType();
+      const recorder = new MediaRecorder(
+        stream,
+        mimeType ? { mimeType } : undefined
+      );
+      chunksRef.current = [];
+      discardRef.current = false;
+      recorder.ondataavailable = (event: BlobEvent) => {
+        if (event.data && event.data.size > 0) {
+          chunksRef.current.push(event.data);
+        }
+      };
+      recorder.onstop = () => {
+        const settle = settleRef.current;
+        settleRef.current = null;
+        const chunks = chunksRef.current;
+        chunksRef.current = [];
+        const blob =
+          discardRef.current || chunks.length === 0
+            ? null
+            : new Blob(chunks, { type: recorder.mimeType || "audio/webm" });
+        recorderRef.current = null;
+        releaseCapture();
+        levelsRef.current = new Float32Array(LEVEL_BUFFER_SIZE);
+        setStatus("idle");
+        setDurationMs(0);
+        settle?.(blob);
+      };
+      recorderRef.current = recorder;
+      recorder.start();
+      attachAnalyser(stream);
+
+      startedAtRef.current = Date.now();
+      setDurationMs(0);
+      tickRef.current = setInterval(() => {
+        setDurationMs(Date.now() - startedAtRef.current);
+      }, TICK_INTERVAL_MS);
+      setStatus("recording");
+      return null;
+    } catch (err) {
+      releaseCapture();
+      recorderRef.current = null;
+      setStatus("idle");
+      const reason = describeStartError(err);
+      setError(reason);
+      return reason;
+    }
+  }, [attachAnalyser, releaseCapture]);
+
+  const stop = useCallback(
+    (discard: boolean): Promise<Blob | null> => {
+      const recorder = recorderRef.current;
+      if (!recorder || recorder.state === "inactive") {
+        return Promise.resolve(null);
+      }
+      discardRef.current = discard;
+      setStatus("stopping");
+      return new Promise<Blob | null>((resolve) => {
+        settleRef.current = resolve;
+        recorder.stop();
+      });
+    },
+    []
+  );
+
+  const confirm = useCallback(() => stop(false), [stop]);
+
+  const cancel = useCallback(() => {
+    void stop(true);
+  }, [stop]);
+
+  useEffect(
+    () => () => {
+      const recorder = recorderRef.current;
+      recorderRef.current = null;
+      settleRef.current = null;
+      if (recorder && recorder.state !== "inactive") {
+        discardRef.current = true;
+        recorder.stop();
+      }
+      releaseCapture();
+    },
+    [releaseCapture]
+  );
+
+  return {
+    status,
+    isRecording: status === "recording" || status === "starting",
+    error,
+    durationMs,
+    levelsRef,
+    start,
+    confirm,
+    cancel
+  };
+}


### PR DESCRIPTION
## What changed

The chat composer gets a mic button that takes one recording: a live scrolling waveform while it runs, discard on the left, accept on the right, elapsed time between them. Accepting uploads the take as an asset, transcribes it through the existing `transcribe_audio` RPC with the speech-to-text model pinned in **Settings → Default Models**, and sends the transcript as the turn. With no default pinned there is nothing to transcribe with, so the mic opens the ASR model picker instead of recording and what the user picks becomes the default — including when the default is cleared mid-take, where the audio is held until a model is chosen.

`useMicrophoneRecorder` drives `getUserMedia` + `MediaRecorder` for a single take, with an `AnalyserNode` writing amplitudes into a ref. The waveform canvas reads that ref on its own animation frame, so a recording re-renders React ten times a second for the timer rather than sixty times for the wave. Both composers extract `submitPrompt(text)` out of `handleSend`, so a transcript passes the same provider/model gates a typed prompt does. One deliberate difference in `MediaChatComposer`: in a media mode the transcript lands in the prompt box instead of sending, because that turn bills for a generation and deserves a look first.

New files under `web/src/components/chat/composer/voice/` plus `web/src/hooks/browser/useMicrophoneRecorder.ts`; `ActionButtons` gains a `leadingAction` slot. The recording bar is portalled into the composer card so the mic button can live in the footer without the bar inheriting the footer's positioning context.

## Verification

- [x] `npm run test:affected` — 175 suites, 1507 passed, 3 skipped. 13 of those tests are new (recorder start/confirm/cancel/denied-permission, the model gate and transcription path, the bar's two states, the portal wiring).
- [x] `npm run typecheck` — 14 errors, all `TS2307` module-resolution in packages this diff does not touch. Confirmed pre-existing: the same 14 appear with the branch stashed. Zero in the changed or added files.
- [x] `npm run lint` — exit 0.
- [x] `npm run dev:nodetool -- harness gate --base HEAD~1` — 12 files touch one surface (`web-editor`), 0 selfchecks to run; the two manual harnesses it lists (`debug`, `docker-smoke`) need a running server or workflow target and are unrelated to this diff. `--base main` cannot run in this session's shallow clone ("no merge base").

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRoRP9jXsHp4m9GwtyorUn)_