### PR TITLE
feat(agents): ship immutable system skills, and fix three headless gaps

### DIFF
--- a/electron/src/__tests__/verifyBackendBundle.test.ts
+++ b/electron/src/__tests__/verifyBackendBundle.test.ts
@@ -67,6 +67,7 @@ function writeValidBundle(dir: string): void {
     "x"
   );
   writeShippedSandboxPacks(dir);
+  writeShippedSystemSkills(dir);
   fs.mkdirSync(path.join(dir, "js-sandbox-worker"), { recursive: true });
   fs.writeFileSync(
     path.join(dir, "js-sandbox-worker", "worker-entry.js"),
@@ -95,6 +96,15 @@ const SANDBOX_PACKS_DIR = path.join(
   "..",
   "packages",
   "sandbox-packs"
+);
+
+const SYSTEM_SKILLS_DIR = path.join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "packages",
+  "system-skills"
 );
 
 /**
@@ -127,6 +137,22 @@ function writeShippedSandboxPacks(dir: string): void {
       })
     );
     fs.writeFileSync(path.join(packDir, "sandbox", "index.js"), "export default 1;");
+  }
+}
+
+/**
+ * Stage every system skill the repo ships.
+ *
+ * Same reason as the packs above: the script cross-checks the staged set
+ * against `packages/system-skills/` whenever it runs inside a checkout, so a
+ * fixture staging none of them is an incomplete bundle, not a minimal one.
+ */
+function writeShippedSystemSkills(dir: string): void {
+  for (const entry of fs.readdirSync(SYSTEM_SKILLS_DIR)) {
+    if (!fs.existsSync(path.join(SYSTEM_SKILLS_DIR, entry, "SKILL.md"))) continue;
+    const skillDir = path.join(dir, "_skills", entry);
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, "SKILL.md"), "---\nname: x\n---\n");
   }
 }
 
@@ -329,6 +355,32 @@ describe("verify-backend-bundle", () => {
     const { status, output } = runVerify(tempDir);
     expect(status).toBe(1);
     expect(output).toContain("nodetool.sandboxModules");
+  });
+
+  it("fails when a shipped system skill is not staged", () => {
+    // The failing branch is what the docker leg would have hit: it referenced
+    // an accumulator that does not exist, so a missing skill crashed the
+    // verifier instead of being reported. Only inverting the check found it.
+    const skills = fs
+      .readdirSync(path.join(tempDir, "_skills"))
+      .sort();
+    expect(skills.length).toBeGreaterThan(0);
+    fs.rmSync(path.join(tempDir, "_skills", skills[0]), {
+      recursive: true,
+      force: true,
+    });
+    const { status, output } = runVerify(tempDir);
+    expect(status).toBe(1);
+    expect(output).toContain("System skill(s) not staged under _skills/");
+    expect(output).toContain(skills[0]);
+  });
+
+  it("reports the shipped system skills it found", () => {
+    const { status, output } = runVerify(tempDir);
+    expect(status).toBe(0);
+    // Asserting a count, so the check cannot pass by having matched nothing.
+    const staged = fs.readdirSync(path.join(tempDir, "_skills")).length;
+    expect(output).toContain(`system skills staged: ${staged}`);
   });
 
   it("fails when server.mjs itself is missing", () => {

--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -2042,8 +2042,33 @@ Steps can enforce structured output via JSON schema:
 
 ### Skills System
 
-Skills are user-scoped records in the `skills` database table. Each record has
-`name`, `description`, and markdown `content` columns. Agent discovery reads
+Skills come in two tiers.
+
+A **user skill** is a row in the `skills` table — `name`, `description`, and
+markdown `content` — that someone wrote and can rewrite.
+
+A **system skill** ships with the build: a `SKILL.md` under
+`packages/system-skills/<name>/`, frontmatter naming it, and it is **read-only
+at runtime**. The tier exists because the two properties a user row cannot have
+both matter: every install has the skill on day one with no seeding migration to
+drift per machine, and nothing — including an agent acting on its own
+mis-read instructions — can edit or delete the document it is working from.
+`system-skills.ts` reads them (cached per process) from `_skills/` beside the
+bundled `server.mjs`, else `packages/system-skills` on the way up from the
+module, else `NODETOOL_SYSTEM_SKILLS_DIR` — the same two-root shape as the
+sandbox packs, and for the same reason: nothing imports them, so they are not
+workspaces and npm links nothing. `bundle-backend.mjs` stages them and
+`verify-backend-bundle.mjs` fails a build that ships none.
+
+Both tiers share one catalog. `list_skills` and `load_skill` serve either, each
+answer carrying `system: true|false`; `create_skill`, `update_skill` and
+`delete_skill` refuse a shipped name, including a rename onto one. A user row
+that *already* held the name predates the reservation, so it wins and the
+shipped skill is not listed twice — reserving names stops new collisions, not
+old ones. A malformed `SKILL.md` is skipped rather than fatal: one bad shipped
+file must not cost a user every other skill.
+
+Each record has `name`, `description`, and markdown `content` columns. Agent discovery reads
 the current user's records through the models layer and merges trusted
 sandbox-pack skills supplied for the session.
 

--- a/packages/agents/src/capabilities/entities.ts
+++ b/packages/agents/src/capabilities/entities.ts
@@ -352,8 +352,11 @@ const saveEntityAsset = async (
   };
   await asset.save();
   const entity = entityFromAsset(asset);
+  // `entity_id` and `id` alongside the record: an entity IS its asset, so the
+  // id was always the `asset_id` the caller passed in — but the result carried
+  // it only nested, and a caller reading `.id` got `undefined` and passed it on.
   return entity
-    ? { entity }
+    ? { entity, entity_id: asset.id, id: asset.id }
     : { error: "The entity marker was not readable after saving." };
 };
 

--- a/packages/agents/src/capabilities/skills.ts
+++ b/packages/agents/src/capabilities/skills.ts
@@ -6,6 +6,12 @@
  * turn's prompt (`skill-prompt.ts`), so discovery costs nothing; `load_skill`
  * is how the body reaches the model, and the other three are authoring.
  *
+ * Two tiers share these names. A **user skill** is a row someone wrote and can
+ * rewrite. A **system skill** ships with the build (`system-skills.ts`) and is
+ * read-only: `list_skills` and `load_skill` serve both, and the three authoring
+ * calls refuse a shipped name so nothing can edit or delete one. A user row that
+ * already held the name predates the reservation and still wins.
+ *
  * `@nodetool-ai/models` is imported inside each implementation, so loading this
  * module never opens a database.
  */
@@ -21,6 +27,11 @@ import {
   deleteSkillSpec
 } from "./skills.specs.js";
 import { isString } from "../utils/type-guards.js";
+import {
+  findSystemSkill,
+  isSystemSkillName,
+  loadSystemSkills
+} from "../system-skills.js";
 
 function requireUser(
   context: ProcessingContext
@@ -37,6 +48,18 @@ function errorMessage(e: unknown): string {
 /** Normalize a name the model may have typed with its leading slash. */
 function skillName(value: unknown): string {
   return isString(value) ? value.trim().replace(/^\//, "").toLowerCase() : "";
+}
+
+/**
+ * The refusal a shipped name earns. Immutability is the point of the tier: an
+ * agent that mis-reads its own instructions must not be able to edit the
+ * document those instructions came from.
+ */
+function reservedNameError(name: string, verb: string): string {
+  return (
+    `"${name}" is a system skill that ships with NodeTool and cannot be ` +
+    `${verb}. Pick another name; load_skill still reads it.`
+  );
 }
 
 async function findSkill(userId: string, name: string) {
@@ -59,17 +82,30 @@ const listSkills: CapabilityExport = {
       const query = isString(params.query)
         ? params.query.trim().toLowerCase()
         : "";
-      const skills = rows
-        .filter(
-          (row) =>
-            !query ||
-            `${row.name} ${row.description}`.toLowerCase().includes(query)
-        )
-        .map((row) => ({
+      const taken = new Set(rows.map((row) => row.name.toLowerCase()));
+      const merged = [
+        ...rows.map((row) => ({
           name: row.name,
           description: row.description,
-          updated_at: row.updated_at
-        }));
+          updated_at: row.updated_at,
+          system: false
+        })),
+        // A shipped skill whose name a user row already holds is shadowed by
+        // that row and is not listed twice.
+        ...loadSystemSkills()
+          .filter((skill) => !taken.has(skill.name))
+          .map((skill) => ({
+            name: skill.name,
+            description: skill.description,
+            updated_at: null,
+            system: true
+          }))
+      ];
+      const skills = merged.filter(
+        (skill) =>
+          !query ||
+          `${skill.name} ${skill.description}`.toLowerCase().includes(query)
+      );
       return { success: true, count: skills.length, skills };
     } catch (e) {
       return { success: false, error: errorMessage(e) };
@@ -90,17 +126,28 @@ const loadSkill: CapabilityExport = {
     if (!name) return { success: false, error: "name is required" };
     try {
       const skill = await findSkill(scope.userId, name);
-      if (!skill) {
+      if (skill) {
         return {
-          success: false,
-          error: `No skill named "${name}". Call list_skills to see what exists.`
+          success: true,
+          name: skill.name,
+          description: skill.description,
+          instructions: skill.content,
+          system: false
+        };
+      }
+      const shipped = findSystemSkill(name);
+      if (shipped) {
+        return {
+          success: true,
+          name: shipped.name,
+          description: shipped.description,
+          instructions: shipped.content,
+          system: true
         };
       }
       return {
-        success: true,
-        name: skill.name,
-        description: skill.description,
-        instructions: skill.content
+        success: false,
+        error: `No skill named "${name}". Call list_skills to see what exists.`
       };
     } catch (e) {
       return { success: false, error: errorMessage(e) };
@@ -127,6 +174,9 @@ const createSkill: CapabilityExport = {
         success: false,
         error: "name, description and content are all required"
       };
+    }
+    if (isSystemSkillName(name)) {
+      return { success: false, error: reservedNameError(name, "overwritten") };
     }
     try {
       if (await findSkill(scope.userId, name)) {
@@ -162,10 +212,23 @@ const updateSkill: CapabilityExport = {
     if (!name) return { success: false, error: "name is required" };
     try {
       const skill = await findSkill(scope.userId, name);
-      if (!skill) return { success: false, error: `No skill named "${name}"` };
+      if (!skill) {
+        // A shipped name with no user row behind it is the immutable tier, and
+        // says so — rather than the "no such skill" a plain lookup would give.
+        if (isSystemSkillName(name)) {
+          return { success: false, error: reservedNameError(name, "edited") };
+        }
+        return { success: false, error: `No skill named "${name}"` };
+      }
 
       const newName = skillName(params.new_name);
       if (newName && newName !== name) {
+        if (isSystemSkillName(newName)) {
+          return {
+            success: false,
+            error: reservedNameError(newName, "renamed over")
+          };
+        }
         if (await findSkill(scope.userId, newName)) {
           return {
             success: false,
@@ -199,7 +262,12 @@ const deleteSkill: CapabilityExport = {
     if (!name) return { success: false, error: "name is required" };
     try {
       const skill = await findSkill(scope.userId, name);
-      if (!skill) return { success: false, error: `No skill named "${name}"` };
+      if (!skill) {
+        if (isSystemSkillName(name)) {
+          return { success: false, error: reservedNameError(name, "deleted") };
+        }
+        return { success: false, error: `No skill named "${name}"` };
+      }
       await skill.delete();
       return { success: true, name };
     } catch (e) {

--- a/packages/agents/src/capabilities/storyboards.specs.ts
+++ b/packages/agents/src/capabilities/storyboards.specs.ts
@@ -180,8 +180,11 @@ export const EDIT_STORYBOARD_SCHEMA: JsonSchema = {
         "location_id?, notes?, index?}, " +
         "update_shot {target, ...same fields}, remove_shot {target}, " +
         "reorder_shot {target, index}, set_board {brief?, style?, " +
-        "aspect_ratio?, entity_ids?}. `target` is a shot id, its 0-based " +
-        "index, or its slug.",
+        "aspect_ratio?, entity_ids?, image_model?, video_model?}. " +
+        "`target` is a shot id, its 0-based index, or its slug. " +
+        "image_model/video_model take a model object from find_model and " +
+        "become the board's defaults for render_storyboard_stills and " +
+        "render_storyboard_clips.",
       items: { type: "object" }
     }
   },

--- a/packages/agents/src/capabilities/storyboards.ts
+++ b/packages/agents/src/capabilities/storyboards.ts
@@ -475,6 +475,10 @@ function createdBoardSummary(row: Storyboard) {
   return {
     ok: true as const,
     storyboard_id: row.id,
+    // The same value under the key a caller reaches for first. Reading `.id`
+    // off this result and passing the `undefined` onward is what a create/edit
+    // pair actually did, and the edit blamed a missing argument two calls later.
+    id: row.id,
     name: row.name,
     project_id: row.project_id,
     shots: doc.shots.length,
@@ -1303,6 +1307,33 @@ function assertKnownShotFields(op: string, args: Record<string, unknown>): void 
   );
 }
 
+/** The board fields `set_board` may set. */
+const BOARD_EDIT_FIELDS = new Set([
+  "brief",
+  "style",
+  "aspect_ratio",
+  "entity_ids",
+  "image_model",
+  "video_model"
+]);
+
+/**
+ * The board-level twin of {@link assertKnownShotFields}.
+ *
+ * `set_board` used to keep whatever it was handed and act on the keys it knew,
+ * so `{op: "set_board", image_model: …}` reported success and left the board's
+ * model null — and the render then refused for want of a model the caller had
+ * just set.
+ */
+function assertKnownBoardFields(args: Record<string, unknown>): void {
+  const unknown = Object.keys(args).filter((key) => !BOARD_EDIT_FIELDS.has(key));
+  if (unknown.length === 0) return;
+  throw new Error(
+    `set_board does not take ${unknown.map((k) => `\`${k}\``).join(", ")}. ` +
+      `Accepted: ${[...BOARD_EDIT_FIELDS].join(", ")}.`
+  );
+}
+
 /** The shot fields an edit may set. Media and status stay the render tools'. */
 function applyShotFields(shot: Shot, args: Record<string, unknown>): Shot {
   const next: Shot = { ...shot };
@@ -1422,6 +1453,7 @@ function applyBoardOp(
     }
 
     case "set_board": {
+      assertKnownBoardFields(args);
       if (args["brief"] !== undefined) doc.brief = String(args["brief"]);
       if (args["style"] !== undefined) doc.style = String(args["style"]);
       if (args["aspect_ratio"] !== undefined) {
@@ -1430,11 +1462,40 @@ function applyBoardOp(
       if (Array.isArray(args["entity_ids"])) {
         doc.entityIds = args["entity_ids"].map(String);
       }
+      // The board's default models. Without these the only way to set one was
+      // the editor, so a headless caller passed them here, saw the op succeed,
+      // and then had `render_storyboard_stills` refuse for want of a model —
+      // the keys were being dropped silently.
+      const model = (key: "image_model" | "video_model") => {
+        const value = args[key];
+        if (value === null) return null;
+        return isRecord(value) ? (value as Record<string, unknown>) : undefined;
+      };
+      const imageModel = model("image_model");
+      if (args["image_model"] !== undefined) {
+        if (imageModel === undefined) {
+          throw new Error(
+            "set_board: image_model must be a model object (use find_model) or null"
+          );
+        }
+        doc.imageModel = imageModel;
+      }
+      const videoModel = model("video_model");
+      if (args["video_model"] !== undefined) {
+        if (videoModel === undefined) {
+          throw new Error(
+            "set_board: video_model must be a model object (use find_model) or null"
+          );
+        }
+        doc.videoModel = videoModel;
+      }
       return {
         brief: doc.brief,
         style: doc.style,
         aspect_ratio: doc.aspectRatio,
-        entity_ids: doc.entityIds
+        entity_ids: doc.entityIds,
+        image_model: doc.imageModel,
+        video_model: doc.videoModel
       };
     }
   }

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -437,6 +437,19 @@ export {
   formatSkillCatalogForPrompt,
   formatInvokedSkillsForPrompt
 } from "./skill-prompt.js";
+
+// The skills that ship with the build, and the merge that puts them in the
+// same catalog as the user's own rows.
+export {
+  loadSystemSkills,
+  findSystemSkill,
+  isSystemSkillName,
+  mergeSystemSkills,
+  systemSkillsDir,
+  parseSkillMarkdown,
+  clearSystemSkillCache,
+  type SystemSkill
+} from "./system-skills.js";
 export type {
   SkillCatalogEntry,
   SkillInstructions

--- a/packages/agents/src/sandbox-media.ts
+++ b/packages/agents/src/sandbox-media.ts
@@ -440,11 +440,59 @@ export function sniffImageFormat(bytes: Uint8Array): string {
   return "unknown";
 }
 
+/**
+ * Structural check before the native decoder sees the bytes.
+ *
+ * `@napi-rs/canvas` does not merely fail on a truncated image — on linux-x64 it
+ * **segfaults the process**, and on other builds it reports "Invalid SVG image"
+ * for bytes whose own magic number says PNG, which sends the reader hunting for
+ * an SVG that was never involved. Both are reachable from guest code with
+ * nothing but a short read, so the check belongs here rather than in whichever
+ * caller happened to produce a partial buffer.
+ *
+ * This is a terminator check, not a validation: it proves the byte stream ends
+ * where its container says it should. A corrupt middle still reaches the
+ * decoder, which is the decoder's job.
+ */
+function assertDecodable(bytes: Uint8Array, label: string): void {
+  const format = sniffImageFormat(bytes);
+  const fail = (why: string): never => {
+    throw new Error(
+      `${label}: the ${format} data is incomplete (${why}). ` +
+        `Got ${bytes.length} bytes — the source was likely truncated.`
+    );
+  };
+  if (format === "png") {
+    // 8-byte signature + at least one chunk, ending in IEND.
+    if (bytes.length < 57) fail("shorter than the smallest possible PNG");
+    const end = bytes.subarray(bytes.length - 8);
+    const iend = [0x49, 0x45, 0x4e, 0x44];
+    if (!iend.every((b, i) => end[i] === b)) fail("no IEND chunk at the end");
+    return;
+  }
+  if (format === "jpeg") {
+    if (bytes.length < 4) fail("shorter than the smallest possible JPEG");
+    const last = bytes.length - 1;
+    // EOI marker FFD9. Some encoders pad after it, so scan the tail.
+    let found = false;
+    for (let i = last; i >= Math.max(0, last - 32) && !found; i--) {
+      if (bytes[i - 1] === 0xff && bytes[i] === 0xd9) found = true;
+    }
+    if (!found) fail("no EOI marker at the end");
+    return;
+  }
+  if (format === "gif") {
+    if (bytes.length < 14) fail("shorter than the smallest possible GIF");
+    if (bytes[bytes.length - 1] !== 0x3b) fail("no trailer byte at the end");
+  }
+}
+
 async function decodeImage(
   bytes: Uint8Array,
   label: string
 ): Promise<{ backend: MediaBackend; image: MediaImage }> {
   assertInputSize(bytes, label);
+  assertDecodable(bytes, label);
   const backend = await getMediaBackend();
   let image: MediaImage;
   try {

--- a/packages/agents/src/system-skills.ts
+++ b/packages/agents/src/system-skills.ts
@@ -1,0 +1,166 @@
+/**
+ * System skills — the instruction documents that ship with NodeTool.
+ *
+ * A user skill is a row someone wrote and can rewrite. A system skill is a
+ * `SKILL.md` in the build: same shape in the prompt, but **immutable**, so a
+ * workflow the product depends on cannot be edited away by an agent that
+ * mis-read its own instructions, and every install has it on day one without a
+ * seeding migration that then drifts per machine.
+ *
+ * Nothing imports these files, so they are not a workspace and npm links
+ * nothing. Discovery mirrors the sandbox packs (`shippedPackSearchPaths`):
+ * `_skills/` beside the bundled `server.mjs`, else `packages/system-skills` on
+ * the way up from this module, else `NODETOOL_SYSTEM_SKILLS_DIR`.
+ *
+ * Their names are **reserved**: `create_skill` and `update_skill` refuse them,
+ * so a user row can never shadow one going forward.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  SHIPPED_SYSTEM_SKILLS_BUNDLE_DIR,
+  SHIPPED_SYSTEM_SKILLS_SOURCE_DIR
+} from "@nodetool-ai/config";
+import { isValidSkillDescription, isValidSkillName } from "@nodetool-ai/protocol";
+
+/** One shipped skill, as the catalog and `load_skill` both see it. */
+export interface SystemSkill {
+  readonly name: string;
+  readonly description: string;
+  readonly content: string;
+  /** Always true — the field exists so a merged list stays self-describing. */
+  readonly system: true;
+}
+
+/** The directory holding the shipped skills, or null when this build has none. */
+export function systemSkillsDir(): string | null {
+  const override = process.env["NODETOOL_SYSTEM_SKILLS_DIR"];
+  if (override) return existsSync(override) ? override : null;
+
+  const here = dirname(fileURLToPath(import.meta.url));
+  const bundled = join(here, SHIPPED_SYSTEM_SKILLS_BUNDLE_DIR);
+  if (existsSync(bundled)) return bundled;
+
+  const segments = SHIPPED_SYSTEM_SKILLS_SOURCE_DIR.split("/");
+  let dir = here;
+  for (;;) {
+    const candidate = join(dir, ...segments);
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
+ * Split a `SKILL.md` into its frontmatter fields and body.
+ *
+ * Deliberately not a YAML parse: the frontmatter is two scalar fields, and
+ * pulling js-yaml into the host to read them would buy nothing. A file whose
+ * frontmatter is missing or malformed yields null and is skipped rather than
+ * failing the whole catalog — one bad shipped file must not cost a user every
+ * other skill.
+ */
+export function parseSkillMarkdown(text: string): {
+  name: string;
+  description: string;
+  content: string;
+} | null {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(text);
+  if (!match) return null;
+  const [, front, body] = match;
+  const field = (key: string): string => {
+    const line = new RegExp(`^${key}:\\s*(.*)$`, "m").exec(front ?? "");
+    return (line?.[1] ?? "").trim().replace(/^["']|["']$/g, "");
+  };
+  const name = field("name").toLowerCase();
+  const description = field("description");
+  const content = (body ?? "").trim();
+  if (!name || !description || !content) return null;
+  if (!isValidSkillName(name) || !isValidSkillDescription(description)) {
+    return null;
+  }
+  return { name, description, content };
+}
+
+let cache: readonly SystemSkill[] | null = null;
+
+/**
+ * Every shipped skill, read once per process.
+ *
+ * Cached because the files are part of the build and cannot change under a
+ * running server; `clearSystemSkillCache` exists for tests that stage a
+ * directory of their own.
+ */
+export function loadSystemSkills(): readonly SystemSkill[] {
+  if (cache) return cache;
+  cache = readSystemSkills();
+  return cache;
+}
+
+/** Drop the cache. Tests only. */
+export function clearSystemSkillCache(): void {
+  cache = null;
+}
+
+function readSystemSkills(): readonly SystemSkill[] {
+  const root = systemSkillsDir();
+  if (!root) return [];
+  let entries: string[];
+  try {
+    entries = readdirSync(root);
+  } catch {
+    return [];
+  }
+  const skills: SystemSkill[] = [];
+  const seen = new Set<string>();
+  for (const entry of entries.sort()) {
+    const file = join(root, entry, "SKILL.md");
+    try {
+      if (!statSync(join(root, entry)).isDirectory()) continue;
+      if (!existsSync(file)) continue;
+      const parsed = parseSkillMarkdown(readFileSync(file, "utf8"));
+      if (!parsed) continue;
+      // The directory names the skill. A frontmatter name that disagrees is a
+      // packaging mistake, and taking the directory keeps `/name` matching what
+      // a reader sees on disk.
+      if (parsed.name !== entry.toLowerCase()) continue;
+      if (seen.has(parsed.name)) continue;
+      seen.add(parsed.name);
+      skills.push({ ...parsed, system: true });
+    } catch {
+      // A skill that cannot be read is skipped, never fatal.
+    }
+  }
+  return skills;
+}
+
+/** Whether `name` belongs to a shipped skill, and is therefore not writable. */
+export function isSystemSkillName(name: string): boolean {
+  const wanted = name.trim().replace(/^\//, "").toLowerCase();
+  return loadSystemSkills().some((skill) => skill.name === wanted);
+}
+
+/** One shipped skill by name, or null. */
+export function findSystemSkill(name: string): SystemSkill | null {
+  const wanted = name.trim().replace(/^\//, "").toLowerCase();
+  return loadSystemSkills().find((skill) => skill.name === wanted) ?? null;
+}
+
+/**
+ * The catalog a prompt or `list_skills` should show: the user's rows, plus every
+ * shipped skill the user has not already taken the name of.
+ *
+ * A pre-existing user row wins on a collision. Reserving the names only stops
+ * *new* ones, so a row written before a skill shipped keeps working — and the
+ * person who wrote it gets what they wrote.
+ */
+export function mergeSystemSkills<T extends { name: string; description: string }>(
+  userSkills: readonly T[]
+): (T | SystemSkill)[] {
+  const taken = new Set(userSkills.map((skill) => skill.name.toLowerCase()));
+  const shipped = loadSystemSkills().filter((skill) => !taken.has(skill.name));
+  return [...userSkills, ...shipped];
+}

--- a/packages/agents/tests/capabilities-skills.test.ts
+++ b/packages/agents/tests/capabilities-skills.test.ts
@@ -7,6 +7,10 @@ import {
   formatInvokedSkillsForPrompt,
   formatSkillCatalogForPrompt
 } from "../src/skill-prompt.js";
+import { clearSystemSkillCache } from "../src/system-skills.js";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 function ctx(userId: string | null = "u1") {
   return { userId } as unknown as ProcessingContext;
@@ -19,8 +23,24 @@ function call(name: string, args: Record<string, unknown>, user = "u1") {
 }
 
 describe("skills capabilities", () => {
-  beforeEach(() => initTestDb());
-  afterEach(() => ModelObserver.clear());
+  // These cases are about the user's own rows, so they run against an empty
+  // shipped-skill directory — otherwise every count here also counts whatever
+  // `packages/system-skills` happens to hold.
+  let emptySkillsDir: string;
+
+  beforeEach(() => {
+    initTestDb();
+    emptySkillsDir = mkdtempSync(join(tmpdir(), "nodetool-noskills-"));
+    process.env["NODETOOL_SYSTEM_SKILLS_DIR"] = emptySkillsDir;
+    clearSystemSkillCache();
+  });
+
+  afterEach(() => {
+    delete process.env["NODETOOL_SYSTEM_SKILLS_DIR"];
+    clearSystemSkillCache();
+    ModelObserver.clear();
+    rmSync(emptySkillsDir, { recursive: true, force: true });
+  });
 
   it("creates, lists, loads, updates and deletes a skill", async () => {
     const created = await call("create_skill", {
@@ -155,5 +175,107 @@ describe("skill prompt blocks", () => {
     expect(block).toContain("### /release-notes");
     expect(block).toContain("Lead with what changed.");
     expect(formatInvokedSkillsForPrompt([])).toBe("");
+  });
+});
+
+describe("system skills are immutable", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    initTestDb();
+    dir = mkdtempSync(join(tmpdir(), "nodetool-sysskill-"));
+    mkdirSync(join(dir, "launch-commercial"));
+    writeFileSync(
+      join(dir, "launch-commercial", "SKILL.md"),
+      "---\nname: launch-commercial\ndescription: Ship a launch spot.\n---\n\nDo the thing.\n"
+    );
+    process.env["NODETOOL_SYSTEM_SKILLS_DIR"] = dir;
+    clearSystemSkillCache();
+  });
+
+  afterEach(() => {
+    delete process.env["NODETOOL_SYSTEM_SKILLS_DIR"];
+    clearSystemSkillCache();
+    ModelObserver.clear();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("lists a shipped skill beside the user's own, flagged as system", async () => {
+    await call("create_skill", {
+      name: "mine",
+      description: "Mine.",
+      content: "body"
+    });
+    const listed = await call("list_skills", {});
+    const skills = listed.skills as Array<{ name: string; system: boolean }>;
+    expect(skills.map((s) => s.name).sort()).toEqual([
+      "launch-commercial",
+      "mine"
+    ]);
+    expect(skills.find((s) => s.name === "launch-commercial")?.system).toBe(true);
+    expect(skills.find((s) => s.name === "mine")?.system).toBe(false);
+  });
+
+  it("loads a shipped skill body", async () => {
+    const loaded = await call("load_skill", { name: "launch-commercial" });
+    expect(loaded.success).toBe(true);
+    expect(loaded.instructions).toContain("Do the thing.");
+    expect(loaded.system).toBe(true);
+  });
+
+  it("refuses to create a skill over a shipped name", async () => {
+    const created = await call("create_skill", {
+      name: "launch-commercial",
+      description: "Mine now.",
+      content: "hijacked"
+    });
+    expect(created.success).toBe(false);
+    expect(String(created.error)).toMatch(/system skill/i);
+    // And the shipped body is untouched.
+    const loaded = await call("load_skill", { name: "launch-commercial" });
+    expect(loaded.instructions).toContain("Do the thing.");
+  });
+
+  it("refuses to edit, rename over, or delete a shipped skill", async () => {
+    const updated = await call("update_skill", {
+      name: "launch-commercial",
+      content: "hijacked"
+    });
+    expect(updated.success).toBe(false);
+    expect(String(updated.error)).toMatch(/system skill/i);
+
+    const deleted = await call("delete_skill", { name: "launch-commercial" });
+    expect(deleted.success).toBe(false);
+    expect(String(deleted.error)).toMatch(/system skill/i);
+
+    await call("create_skill", {
+      name: "mine",
+      description: "Mine.",
+      content: "body"
+    });
+    const renamed = await call("update_skill", {
+      name: "mine",
+      new_name: "launch-commercial"
+    });
+    expect(renamed.success).toBe(false);
+    expect(String(renamed.error)).toMatch(/system skill/i);
+  });
+
+  it("lets a user row that already holds the name win, listed once", async () => {
+    // Written directly: create_skill would now refuse the reserved name, which
+    // is the point — this row is one that predates the skill shipping.
+    await Skill.create({
+      user_id: "u1",
+      name: "launch-commercial",
+      description: "The user's own.",
+      content: "user body"
+    });
+    const listed = await call("list_skills", {});
+    const skills = listed.skills as Array<{ name: string }>;
+    expect(skills.filter((s) => s.name === "launch-commercial")).toHaveLength(1);
+
+    const loaded = await call("load_skill", { name: "launch-commercial" });
+    expect(loaded.instructions).toBe("user body");
+    expect(loaded.system).toBe(false);
   });
 });

--- a/packages/agents/tests/capabilities-storyboards.test.ts
+++ b/packages/agents/tests/capabilities-storyboards.test.ts
@@ -246,6 +246,85 @@ describe("storyboards capability behaviour", () => {
   beforeEach(() => initTestDb());
   afterEach(() => ModelObserver.clear());
 
+  it("returns the new board id under `id` as well as `storyboard_id`", async () => {
+    const created = (await run(ctx()).invoke("create_storyboard", {
+      name: "Ids"
+    })) as { storyboard_id: string; id: string };
+    // Reading `.id` off this result and passing the undefined onward is what a
+    // create/edit pair actually did; the edit then blamed a missing argument.
+    expect(created.id).toBe(created.storyboard_id);
+    expect(typeof created.id).toBe("string");
+  });
+
+  it("set_board stores the board's image and video models", async () => {
+    const context = ctx();
+    const created = (await run(context).invoke("create_storyboard", {
+      name: "Models"
+    })) as { storyboard_id: string };
+
+    const imageModel = {
+      type: "image_model",
+      provider: "atlascloud",
+      id: "openai/gpt-image-2/text-to-image"
+    };
+    const edited = (await run(context).invoke("edit_storyboard", {
+      storyboard_id: created.storyboard_id,
+      ops: [{ op: "set_board", image_model: imageModel }]
+    })) as { applied: number };
+    expect(edited.applied).toBe(1);
+
+    const read = (await run(context).invoke("get_storyboard", {
+      storyboard_id: created.storyboard_id
+    })) as { image_model: Record<string, unknown> | null };
+    // Before this the keys were dropped silently: the op reported success and
+    // the render then refused for want of a model.
+    expect(read.image_model).toMatchObject({
+      provider: "atlascloud",
+      id: "openai/gpt-image-2/text-to-image"
+    });
+  });
+
+  it("set_board clears a model when passed null", async () => {
+    const context = ctx();
+    const created = (await run(context).invoke("create_storyboard", {
+      name: "Clear"
+    })) as { storyboard_id: string };
+    await run(context).invoke("edit_storyboard", {
+      storyboard_id: created.storyboard_id,
+      ops: [{ op: "set_board", video_model: { provider: "fal_ai", id: "x" } }]
+    });
+    await run(context).invoke("edit_storyboard", {
+      storyboard_id: created.storyboard_id,
+      ops: [{ op: "set_board", video_model: null }]
+    });
+    const read = (await run(context).invoke("get_storyboard", {
+      storyboard_id: created.storyboard_id
+    })) as { video_model: unknown };
+    expect(read.video_model).toBeNull();
+  });
+
+  it("refuses an op key it does not know instead of dropping it", async () => {
+    const context = ctx();
+    const created = (await run(context).invoke("create_storyboard", {
+      name: "Unknown keys"
+    })) as { storyboard_id: string };
+
+    const refused = (await run(context).invoke("edit_storyboard", {
+      storyboard_id: created.storyboard_id,
+      // `set_entities` is the op name a caller reached for; it does not exist,
+      // and passing its argument to set_board used to succeed and change nothing.
+      ops: [{ op: "set_board", entities: ["a", "b"] }]
+    })) as {
+      applied: number;
+      failed: number;
+      ops: Array<{ error?: string }>;
+    };
+    expect(refused.applied).toBe(0);
+    expect(refused.failed).toBe(1);
+    expect(refused.ops[0].error).toContain("`entities`");
+    expect(refused.ops[0].error).toContain("entity_ids");
+  });
+
   it("sets a shot's duration source, and refuses an unknown one", async () => {
     const context = ctx();
     const created = (await run(context).invoke("create_storyboard", {

--- a/packages/agents/tests/sandbox-media-truncation.test.ts
+++ b/packages/agents/tests/sandbox-media-truncation.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Truncated image bytes must be refused, not handed to the native decoder.
+ *
+ * `@napi-rs/canvas` segfaults the host process on a truncated PNG (linux-x64)
+ * and reports "Invalid SVG image" for it elsewhere — both reachable from guest
+ * code, so `decodeImage` checks the container terminator first.
+ */
+import { describe, expect, it } from "vitest";
+import { createCanvas } from "@napi-rs/canvas";
+import { imageOps } from "../src/sandbox-media.js";
+
+async function png(): Promise<Uint8Array> {
+  const canvas = createCanvas(8, 8);
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = "#ff0000";
+  ctx.fillRect(0, 0, 8, 8);
+  return new Uint8Array(await canvas.encode("png"));
+}
+
+describe("image decode guards", () => {
+  it("reads a whole PNG", async () => {
+    const info = (await imageOps.info(await png())) as {
+      width: number;
+      height: number;
+    };
+    expect(info.width).toBe(8);
+    expect(info.height).toBe(8);
+  });
+
+  it("refuses a truncated PNG instead of decoding it", async () => {
+    const bytes = await png();
+    await expect(
+      imageOps.info(bytes.subarray(0, Math.floor(bytes.length / 2)))
+    ).rejects.toThrow(/incomplete/i);
+  });
+
+  it("refuses a PNG that is only its magic number", async () => {
+    const bytes = (await png()).subarray(0, 8);
+    await expect(imageOps.info(bytes)).rejects.toThrow(/incomplete/i);
+  });
+
+  it("names the truncation rather than blaming SVG", async () => {
+    const bytes = await png();
+    await expect(
+      imageOps.info(bytes.subarray(0, bytes.length - 4))
+    ).rejects.toThrow(/IEND/);
+  });
+});

--- a/packages/agents/tests/system-skills.test.ts
+++ b/packages/agents/tests/system-skills.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The immutable skill tier: read from disk, merged into one catalog, and
+ * refused by every authoring call.
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearSystemSkillCache,
+  findSystemSkill,
+  isSystemSkillName,
+  loadSystemSkills,
+  mergeSystemSkills,
+  parseSkillMarkdown
+} from "../src/system-skills.js";
+
+let dir: string;
+
+function writeSkill(name: string, body: string): void {
+  mkdirSync(join(dir, name), { recursive: true });
+  writeFileSync(join(dir, name, "SKILL.md"), body);
+}
+
+const wellFormed = (name: string): string =>
+  `---\nname: ${name}\ndescription: What ${name} is for\n---\n\n# ${name}\n\nDo the thing.\n`;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "nodetool-skills-"));
+  process.env["NODETOOL_SYSTEM_SKILLS_DIR"] = dir;
+  clearSystemSkillCache();
+});
+
+afterEach(() => {
+  delete process.env["NODETOOL_SYSTEM_SKILLS_DIR"];
+  clearSystemSkillCache();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("parseSkillMarkdown", () => {
+  it("reads name, description and body", () => {
+    const parsed = parseSkillMarkdown(wellFormed("alpha"));
+    expect(parsed).toMatchObject({
+      name: "alpha",
+      description: "What alpha is for"
+    });
+    expect(parsed?.content).toContain("Do the thing.");
+    // The frontmatter must not survive into the body the model reads.
+    expect(parsed?.content).not.toContain("description:");
+  });
+
+  it("rejects a file with no frontmatter, an empty field, or a bad name", () => {
+    expect(parseSkillMarkdown("# Just a heading")).toBeNull();
+    expect(parseSkillMarkdown("---\nname: a\n---\n\nbody")).toBeNull();
+    expect(parseSkillMarkdown("---\nname: a\ndescription: d\n---\n\n")).toBeNull();
+    expect(
+      parseSkillMarkdown("---\nname: Not A Name\ndescription: d\n---\n\nbody")
+    ).toBeNull();
+  });
+});
+
+describe("loadSystemSkills", () => {
+  it("reads every well-formed skill in the directory", () => {
+    writeSkill("alpha", wellFormed("alpha"));
+    writeSkill("beta", wellFormed("beta"));
+    expect(loadSystemSkills().map((s) => s.name)).toEqual(["alpha", "beta"]);
+  });
+
+  it("skips a malformed skill without losing the others", () => {
+    writeSkill("alpha", wellFormed("alpha"));
+    writeSkill("broken", "no frontmatter here");
+    expect(loadSystemSkills().map((s) => s.name)).toEqual(["alpha"]);
+  });
+
+  it("skips a skill whose frontmatter name disagrees with its directory", () => {
+    writeSkill("alpha", wellFormed("somethingelse"));
+    expect(loadSystemSkills()).toEqual([]);
+  });
+
+  it("reports an empty list when no directory exists", () => {
+    process.env["NODETOOL_SYSTEM_SKILLS_DIR"] = join(dir, "nope");
+    clearSystemSkillCache();
+    expect(loadSystemSkills()).toEqual([]);
+  });
+});
+
+describe("reservation and merge", () => {
+  beforeEach(() => {
+    writeSkill("alpha", wellFormed("alpha"));
+    clearSystemSkillCache();
+  });
+
+  it("recognizes a shipped name, with or without a leading slash", () => {
+    expect(isSystemSkillName("alpha")).toBe(true);
+    expect(isSystemSkillName("/alpha")).toBe(true);
+    expect(isSystemSkillName("ALPHA")).toBe(true);
+    expect(isSystemSkillName("mine")).toBe(false);
+  });
+
+  it("finds a shipped skill body by name", () => {
+    expect(findSystemSkill("alpha")?.content).toContain("Do the thing.");
+    expect(findSystemSkill("mine")).toBeNull();
+  });
+
+  it("appends shipped skills to the user's own", () => {
+    const merged = mergeSystemSkills([
+      { name: "mine", description: "mine" }
+    ]);
+    expect(merged.map((s) => s.name)).toEqual(["mine", "alpha"]);
+  });
+
+  it("lets a pre-existing user row of the same name win, listed once", () => {
+    const merged = mergeSystemSkills([
+      { name: "alpha", description: "the user's own alpha" }
+    ]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.description).toBe("the user's own alpha");
+  });
+});

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -2020,7 +2020,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "edit_storyboard",
     module: "storyboards",
     impl: "packages/agents/src/capabilities/storyboards.ts",
-    contract: "f4d8b3cedbae",
+    contract: "9b3c1f3f93a1",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-storyboards.test.ts",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -57,6 +57,8 @@ export {
   PACKAGE_RUNTIME_ASSETS,
   SHIPPED_SANDBOX_PACKS_SOURCE_DIR,
   SHIPPED_SANDBOX_PACKS_BUNDLE_DIR,
+  SHIPPED_SYSTEM_SKILLS_SOURCE_DIR,
+  SHIPPED_SYSTEM_SKILLS_BUNDLE_DIR,
   findPackageAsset,
   type PackageAssetRef
 } from "./package-asset-registry.js";

--- a/packages/config/src/package-asset-registry.ts
+++ b/packages/config/src/package-asset-registry.ts
@@ -64,6 +64,20 @@ export const SHIPPED_SANDBOX_PACKS_SOURCE_DIR = "packages/sandbox-packs";
 /** The staged copy's directory name, relative to the bundled `server.mjs`. */
 export const SHIPPED_SANDBOX_PACKS_BUNDLE_DIR = "_sandbox";
 
+/**
+ * The system skills that ship with NodeTool.
+ *
+ * A system skill is a `SKILL.md` — frontmatter naming it, Markdown body — under
+ * a directory of its own, read-only at runtime. Same two-root shape as the
+ * sandbox packs above and for the same reason: nothing imports them, so npm
+ * links nothing, and each host reads them from where its own build put them.
+ * `NODETOOL_SYSTEM_SKILLS_DIR` overrides both.
+ */
+export const SHIPPED_SYSTEM_SKILLS_SOURCE_DIR = "packages/system-skills";
+
+/** The staged copy's directory name, relative to the bundled `server.mjs`. */
+export const SHIPPED_SYSTEM_SKILLS_BUNDLE_DIR = "_skills";
+
 /** Registry lookup by exact pkg + path. */
 export function findPackageAsset(
   pkg: string,

--- a/packages/system-skills/commercial-beat-sheet/SKILL.md
+++ b/packages/system-skills/commercial-beat-sheet/SKILL.md
@@ -1,0 +1,313 @@
+---
+name: commercial-beat-sheet
+description: Write a shootable, precisely timed commercial beat sheet and store it as a NodeTool storyboard, with a consistent entity roster behind every shot. Use when someone needs ad structure — hooks, beats, timecodes, VO — rather than a finished render.
+---
+
+You are a single agent. Your job: take a product brief and produce a complete, shootable commercial beat sheet as a NodeTool storyboard. You do not build a workflow. You do not run a pipeline. You call the storyboard and entity capabilities directly.
+
+---
+
+## Role
+
+You are a senior commercial director and advertising dramaturg. You write shootable, precisely timed commercial beat sheets optimized for retention. The first 3 seconds matter most. You escalate one problem. You demonstrate mechanisms, not benefits. You close every loop you open. You never invent brand facts — you write `[CLIENT INPUT NEEDED]` instead. You obey the runtime budget on every word. And you keep the visual language consistent: the can looks the same in beat 2 and beat 8, the protagonist's face reads the same across every shot they appear in, the room is the same room in the open and the close.
+
+---
+
+## Entities (production consistency)
+
+Every recurring subject — the protagonist, the product, the pack, the location, the brand mark — is an **entity**: a named production asset with a **reference image** (the source of truth) and a **descriptor** (prose describing exactly what that image shows). The model uses descriptor + reference to keep the subject identical across shots.
+
+| Kind | Use for | Extra fields |
+| --- | --- | --- |
+| `character` | Anyone appearing in two or more shots | `voice_id` for VO casting |
+| `location` | The recurring environment | — |
+| `style` | A look that must hold across shots | `palette` (hex), `lora` |
+| `prop` | The product, the pack, the hero object | — |
+
+Never generate a storyboard before the roster is resolved. Without entities, beat 2's can and beat 8's can drift, the protagonist's face changes between hook and CTA, and the briefed style is a suggestion the model may ignore.
+
+**Headless tool names.** `list_entities`, `get_entity`, `apply_entities`, `create_entity`, `update_entity`, `delete_entity` from `@nodetool-ai/sandbox-nodetool/entities`. The `ui_entity_*` tools need a browser with the document open — do not reach for them here.
+
+**Ids.** `create_entity` returns `{entity}`; an entity's id **is the asset id you passed in**. Do not read `.id` off the result.
+
+---
+
+## Brief (collect from the user, never invent)
+
+```text
+PRODUCT / SERVICE:
+BRAND:                  [name + 3 personality traits]
+CATEGORY:
+TARGET AUDIENCE:
+CORE PAIN:
+USP:
+PROOF ASSETS:
+CTA:
+TOTAL RUNTIME:          [15s / 30s / 60s / 90s / 180s]
+PLATFORM:
+TONE:
+ENTITIES:               [characters / locations / props / style]
+MANDATORIES:
+FORBIDDEN:
+```
+
+A fact that cannot be known is `[CLIENT INPUT NEEDED]` in the storyboard, never a guess.
+
+---
+
+## Entity discovery (between brief and beat sheet)
+
+Three sources, in priority order:
+
+1. **User-provided** — use verbatim, do not regenerate.
+2. **Existing in the library** — `await list_entities({})` before creating anything. A re-cut of a spot already has its can, its pack, its logo and probably its protagonist. Reuse is almost always what the user wants.
+3. **Generate the rest** — a reference still per missing entity, promoted with `create_entity`.
+
+**Style first, always.** Create or fetch the style entity before anything else, then generate every other entity with it applied. Drift from one visual register to another is the most common consistency failure, and the style entity is what stops it.
+
+```js
+import { create_entity } from "@nodetool-ai/sandbox-nodetool/entities";
+import { apply_entities } from "@nodetool-ai/sandbox-nodetool/entities";
+
+const seasoned = styleId
+  ? await apply_entities({ text: "<the entity, on a neutral background>", entity_ids: [styleId] })
+  : { prompt: "<the entity, on a neutral background>" };
+
+const still = await nodetool.media.generateImage(
+  seasoned.prompt,
+  await nodetool.models.pick("text_to_image")
+);
+
+await create_entity({
+  asset_id: still.asset_id,
+  kind: "character" | "location" | "style" | "prop",
+  name: "<Entity Name>",
+  descriptor: "<one to two dense sentences describing the reference image>",
+  description: "<longer notes for future shots>",
+  tags: ["brand", "..."],
+  palette: null,        // style only: ["#000000", "#00f0ff", ...]
+  lora: null
+});
+const entityId = still.asset_id;   // the entity IS its asset
+```
+
+**The descriptor is the most important field** — it is injected into every prompt that names the entity. Write it as a visual specification:
+
+- **Character** — age range, build, hair, skin, distinguishing features, signature wardrobe. "Late-20s East Asian creative director, sharp jaw, undercut black hair, matte black technical bomber with a single cyan seam down the sleeve."
+- **Location** — layout, materials, lighting, signature features. "Windowless after-hours studio, four 4K monitors, exposed concrete pillar, single cyan rim light from the left, carbon-fiber desk, no windows."
+- **Prop** — exact geometry, materials, branding marks, condition. "Matte black slim 12oz aluminum can, 155mm tall, laser-etched angular wordmark mid-can, cyan glyph above it, 0g sugar callout at the base, chilled condensation beads."
+- **Style** — medium, palette, lighting, lens signature. "Cyber-utilitarian commercial look, matte black backgrounds, cyan (#00F0FF) rim light only, no warm tones, hard specular highlights, shallow depth of field at f/1.8."
+
+A 30s spot usually needs 4–6 entities: 1 style, 1–2 characters, 0–1 location, 1–2 props. A 15s spot may need 3. More than 8 is over-engineered.
+
+Show the roster before drafting beats. Once a beat sheet cites an entity, its reference image is the source of truth, and changing it later means re-rendering every shot that uses it.
+
+---
+
+## Beat budget
+
+Compute timecodes from the runtime, rounded to the nearest 0.5s.
+
+| Beat | % of runtime |
+| --- | --- |
+| **Hook** | 0–4% |
+| **Brand landing** | 4–10% |
+| **Problem** | 10–30% |
+| **Solution / USP** | 30–55% |
+| **Proof** | 55–72% |
+| **CTA** | 72–85% |
+| **Reiteration** | 85–93% |
+| **Closing** | 93–100% |
+
+Pattern interrupts at every 5s boundary and at 25%, 50%, 75%. Total VO ≤ `runtime × 2.5` words. One deliberate silence immediately before the CTA.
+
+---
+
+## Deliverables, in order
+
+1. **Three hooks + a recommendation** — three different archetypes, plus a ≤2-sentence recommendation.
+2. **The full beat sheet** — every beat in the block format below.
+3. **The entity roster** — id, kind, descriptor summary, and which beats reference each. This is the audit trail for visual consistency.
+
+---
+
+## Hook format
+
+```text
+ARCHETYPE: <one of the 8>
+0:00–0:03: <shot by shot, max 3 shots>
+LOOP OPENED: <the question this forces the viewer to answer>
+SCROLL-STOP REASON: <why a thumb stops>
+RISK: <what could feel off or alienating>
+ENTITIES REFERENCED: <entity names visible in the hook>
+```
+
+**Archetypes** — pick three that are not the category default: Cold Contradiction · In Media Res Failure · Cost Reveal · Visual Impossibility · Interrupted Confession · Result First · Anti-Ad · Ticking Clock.
+
+**Hook rules.** Start mid-action; no fade, logo, or establishing shot. The brand appears no earlier than 0:03 and never in the hook. One idea per hook. Visuals work muted, audio works without visuals. If the first three seconds would work for a competitor, rewrite.
+
+---
+
+## Beat sheet format
+
+```text
+─────────────────────────────────────
+BEAT [#] — [NAME]
+TIMECODE:        0:00–0:00 (0.0s)
+DRAMATURGIC JOB: [one line]
+
+SHOT 1
+  FRAMING:
+  VISUAL:
+  ACTION:
+  ENTITIES: [entity names visible in this shot]
+SHOT 2 ...
+
+VOICE-OVER:      "[verbatim, max 2.5 words/sec]"
+DIALOGUE:        "[verbatim]"
+ON-SCREEN TEXT:  [exact wording, max 5 words]
+SOUND DESIGN:
+MUSIC:
+TRANSITION OUT:
+
+WHY IT HOLDS:    [one sentence]
+─────────────────────────────────────
+```
+
+The `ENTITIES:` line is the consistency contract: every entity named must exist in the roster, and every one must be applied to that shot's generation prompt.
+
+---
+
+## Craft rules
+
+* Demonstrate mechanisms instead of claiming benefits.
+* Concrete numbers and behavior over adjectives.
+* One idea per shot.
+* Verbs in VO, nouns on screen. Never duplicate.
+* Escalate one problem. Never list multiple pains.
+* Proof sits immediately after the claim it validates.
+* One CTA only.
+* The closing line pays off, ideally echoes, the hook.
+* **Every shot's prompt applies every entity visible in that shot.**
+
+---
+
+## Execution
+
+### 1. Collect the brief
+
+Ask for any missing required field. Confirm the runtime is one of `15`, `30`, `60`, `90`, `180`.
+
+### 2. Resolve the entity roster
+
+A hard gate — do not move on until it is complete. Look in the library, reuse what is there, generate only what is missing, style first. Show the roster.
+
+### 3. Compute the beat budget
+
+Timecodes rounded to 0.5s; mark every 5s boundary and 25/50/75% as pattern-interrupt points.
+
+### 4. Draft three hooks
+
+Three different archetypes, each in the hook format. Recommend one in ≤2 sentences.
+
+### 5. Draft the full beat sheet
+
+For the chosen hook, every beat in the block format, matching step 3's timecodes, with a pattern interrupt on every flagged timecode, one deliberate silence before the CTA, and a closing line that echoes the hook.
+
+### 6. Create the storyboard
+
+```js
+import { create_storyboard, edit_storyboard } from "@nodetool-ai/sandbox-nodetool/storyboards";
+
+const board = await create_storyboard({
+  name: `${brand} — ${product} (${runtime}s)`,
+  brief: fullBriefIncludingEntities,
+  style: oneLineToneSummary,
+  aspect_ratio: runtime <= 30 ? "9:16" : "16:9"
+});
+const boardId = board.storyboard_id;   // NOT board.id
+```
+
+### 7. Attach the roster
+
+`edit_storyboard` takes exactly five ops: `add_shot`, `update_shot`, `remove_shot`, `reorder_shot`, `set_board`. **There is no `set_entities`** — the roster goes on `set_board`, which accepts `{brief?, style?, aspect_ratio?, entity_ids?}` and drops anything else silently.
+
+```js
+await edit_storyboard({
+  storyboard_id: boardId,
+  ops: [{ op: "set_board", entity_ids: roster }]
+});
+```
+
+The render pipeline reads that list and applies the relevant descriptors per shot, so you do not pass them again.
+
+### 8. Add one shot per beat
+
+```js
+await edit_storyboard({
+  storyboard_id: boardId,
+  ops: [{
+    op: "add_shot",
+    action: "<DRAMATURGIC JOB> — <shot summary, entity names in brackets>",
+    camera: { framing: "...", lens: "...", angle: "...", movement: "..." },
+    motion: "<what moves, how>",
+    duration_seconds: <beat length, rounded to 0.5>
+  }]
+});
+```
+
+`action` is the board's first-class content: pack the dramaturgic job, the shots, VO and on-screen text into one dense line under 400 characters, naming entities in brackets.
+
+```
+HOOK (0:00–0:01.5): In media res failure. ECU of [Protagonist]'s hand trembling over a mechanical keyboard, spilling cheap neon soda. Text: YOUR ENERGY IS BROKEN.
+```
+
+Set `render_mode` per shot: `"keyframe"` (default) where a subject must hold steady, `"direct"` for a heavy-motion shot where first-frame conditioning renders stiff.
+
+### 9. Season a prompt outside the board
+
+The board's render pipeline applies its `entity_ids` automatically. For a test frame or an extra generated outside it, build the prompt the same way:
+
+```js
+import { apply_entities } from "@nodetool-ai/sandbox-nodetool/entities";
+
+const seasoned = await apply_entities({
+  text: shotAction.replace(/\[([^\]]+)\]/g, "").trim(),
+  entity_ids: entityIdsForThisShot
+});
+// seasoned.prompt ends with a "Consistency references:" block;
+// seasoned.reference_asset_ids are the images to pass as image inputs.
+```
+
+### 10. Render (only on request)
+
+The default path stops at the planned board. When asked, keyframes first — they cost cents, and you look at them:
+
+```js
+import { render_storyboard_stills, render_storyboard_clips } from "@nodetool-ai/sandbox-nodetool/storyboards";
+
+await render_storyboard_stills({ storyboard_id: boardId, provider, model });
+```
+
+**Pass `provider` and `model` on every render call.** The board has `image_model` / `video_model` fields, and if this build's `set_board` cannot write them, an unset board fails the render outright — never silently picks something.
+
+A still that violates entity consistency (wrong face, wrong can, wrong look) is fixed at the **entity**: revise its reference and re-render every shot using it. Never paper over drift in one shot's prompt. A clip wrong where its keyframe was right is a **motion** problem: one `revise_storyboard_clip`.
+
+### 11. Assemble (only on request)
+
+```js
+import { assemble_storyboard_timeline } from "@nodetool-ai/sandbox-nodetool/storyboards";
+
+const timeline = await assemble_storyboard_timeline({
+  storyboard_id: boardId,
+  name: `${brand} — ${product} (${runtime}s) Cut`
+});
+```
+
+From here the normal timeline tools take over: audio, music, color, captions.
+
+---
+
+## When the user has no brand assets yet
+
+If the brief is "an energy drink called WARP" with no logo, no can render and no protagonist photo, you still build the board. Entity discovery *is* the generation of those assets: the reference stills double as mood-board frames the client can sign off, and the descriptors you write become the brand guidelines the next production pass inherits.

--- a/packages/system-skills/launch-commercial/SKILL.md
+++ b/packages/system-skills/launch-commercial/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: launch-commercial
+description: Turn a product page URL into a finished launch commercial — research, storyboard, rendered stills and clips, voice, music, an assembled timeline — delivered as an editable NodeTool project with the real cost. Use when someone asks for an ad, a launch spot, a promo or a commercial from a product page or website.
+---
+
+# Product Page → Launch Commercial Agent
+
+You are a single agent. Your job: take a product page URL and deliver a finished launch commercial — rendered clips, voice, music, an assembled cut — as an **editable NodeTool project** (storyboard + script + timeline), plus the real cost of making it. You do not build a workflow. You do not run a pipeline. You call the capability modules directly.
+
+This skill owns the outer loop: research → brief → entities → board → renders → voice → music → cut → cost report. The dramaturgy inside the board — hooks, beat budget, timecodes, VO discipline — belongs to the **Commercial Beat Sheet → Storyboard Agent** skill. Load it at phase 3 and follow it there. Do not duplicate its rules; do not skip it.
+
+---
+
+## Role
+
+You are a senior integrated producer and commercial director. You turn a URL and a runtime into a shot spot. You research before you write, and you never invent a brand fact — everything the spot claims comes from the page or is marked `[CLIENT INPUT NEEDED]`. You spend money in ascending order: research is free, stills are cheap, clips are expensive, and nothing expensive renders before the cheap version was looked at *critically*. You end every run with the deliverables, where to open them, and what they cost.
+
+---
+
+## The contract
+
+The user gives you at minimum:
+
+```text
+PRODUCT PAGE URL:   [required]
+RUNTIME:            [15s / 30s / 60s — default 30s]
+PLATFORM:           [default: 9:16 for ≤30s, 16:9 above]
+```
+
+Everything else — brand, category, audience, pain, USP, proof, tone, CTA — you **derive from the page** and present back as a brief for sign-off. A field the page cannot answer is `[CLIENT INPUT NEEDED]`, never a guess.
+
+The user gets back: a **storyboard** (still + clip on every shot), a **script** (every line voiced), a **timeline** that validates, and a **cost report** from the ledger. All four persist. The render is not the deliverable; the editable project is.
+
+---
+
+## Tool contract — read this before writing any code
+
+These are the exact shapes. Getting them wrong cost a previous run six failed actions and two orphaned boards.
+
+**Headless only.** `ui_*` tools need a browser with that document open. From this skill you are headless: use `list_entities` / `apply_entities`, never `ui_entity_list` / `ui_entity_apply`.
+
+**Return shapes do not use `.id`.**
+
+| Call | Returns | The id you want |
+| --- | --- | --- |
+| `create_storyboard` | `{ok, storyboard_id, name, shots, updated_at}` | `.storyboard_id` |
+| `create_entity` | `{entity: {...}}` | **the `asset_id` you passed in** — an entity *is* its asset |
+| `generateImage` | `{asset_id, asset_uri, url, uri, bytes, mime_type}` | `.asset_id` |
+
+Never write `result.id || result.asset_id` and proceed. If an id is `undefined`, stop and read it back with `list_*` — do not pass it onward.
+
+**`edit_storyboard` ops are exactly five:** `add_shot`, `update_shot`, `remove_shot`, `reorder_shot`, `set_board`. There is no `set_entities`. `set_board` takes `{brief?, style?, aspect_ratio?, entity_ids?}` — **and nothing else**. Keys it does not know are dropped silently.
+
+**The board cannot hold a model.** `set_board` has no `image_model` / `video_model`, so passing them appears to work and leaves the board's fields null. **Pass `provider` + `model` explicitly to every `render_storyboard_stills` and `render_storyboard_clips` call.** Do not rely on a board default; there isn't one.
+
+**`image.*` cannot read an `asset://` uri here.** `image.info` / `image.resize` on a stored PNG fails with "could not decode the image (png) — Invalid SVG image". So: no contact sheets, and **no programmatic dimension check**. You grade frames with `view_image` and `score_image_adherence`, and you standardize aspect at assembly rather than measuring it now.
+
+**`take_screenshot` needs a configured remote browser.** Without `BROWSER_URL` it fails with a message saying exactly that. Treat it as a **setup gap, not a flake**: report it once, in the user's own terms — "screenshots need `BROWSER_URL` set on the server; set it and I'll capture the live page" — and fall back to downloading the page's own images meanwhile. Do not silently work around it and do not retry on a timer; retry when the user says it is set. A screenshot is the best style anchor a page can give you, so it is worth one clear ask.
+
+---
+
+## Spend gates
+
+| Gate | After | You show | Money spent |
+| --- | --- | --- | --- |
+| **G1 Brief** | Research | Derived brief, entity plan | $0 |
+| **G2 Stills** | Keyframes + your own adversarial grade | Every keyframe, defects named | cents |
+| **G3 Cut** | Clips + voice + music + assembly | Timeline, validation, ledger cost | the real number |
+
+Never render clips before G2 is approved. Never pick a model silently. If the user says "run it end to end", G1/G2 become progress reports; the cost report is never optional.
+
+---
+
+## Phase 1 — Research the page
+
+```js
+import { browser, take_screenshot, download_file } from "@nodetool-ai/sandbox-nodetool/web";
+
+const page = await browser({ url: productPageUrl });
+```
+
+Extract into the brief:
+
+- **Facts** — name, what it does, price, materials, claims. Verbatim or `[CLIENT INPUT NEEDED]`.
+- **Voice** — how the brand writes. The VO inherits it.
+- **Visual identity** — read hex values out of the raw HTML (design tokens beat eyeballing a screenshot), plus a live screenshot when `take_screenshot` is configured.
+- **Product imagery** — download the hero photos. They become the prop entity's reference. The real product is the one thing the model must not reimagine.
+- **The one pain** — pages list five benefits; the spot escalates one. Take the one the page leads with.
+
+Then fill the beat-sheet skill's brief format and present it at **G1** with the entity plan.
+
+---
+
+## Phase 2 — Entities from the page
+
+Follow the beat-sheet skill's entity rules (kinds, descriptors, style-first, roster size). What this skill adds:
+
+**Priority per entity:** library (`list_entities`) → page asset → generated.
+
+**The style entity comes from the page whenever the page has a look.** A screenshot of the real site beats a generated mood frame, and for a software product it is not close — the product *is* the interface. Capture it if `take_screenshot` works; otherwise use the best downloaded hero image. Only generate a style entity when the product is physical and the page's photography cannot carry the look.
+
+**But a screenshot style anchor has one failure mode, and it is severe.** Anchored on a website screenshot, the image model will draw *the website* — navbar, hero headline, buttons, marketing paragraphs — into shots that were supposed to be scenes. This happened on four of eight plates in a real run, and every one baked legible marketing copy the spot was supposed to keep in an editable text layer. So the descriptor separates look from content, and **every scene prompt carries hard negatives**:
+
+```text
+ABSOLUTELY NO website page, NO navbar, NO marketing headline, NO gradient
+title text, NO buttons, NO paragraphs, NO wordmark or logo. No readable
+text of any kind.
+```
+
+Two shot classes, prompted differently:
+
+- **Product shots** (the mechanism, the proof) — the interface *is* the subject, edge to edge, no page around it. UI chrome (a status pill, a label) is fine; marketing copy is not.
+- **Scene shots** (hook, problem, CTA, closing) — describe the scene only. Never say "match the homepage" in a scene prompt; that phrase is what makes the model draw the homepage.
+
+Entity ids: pass `asset_id`, and use that same asset id as the entity id afterward.
+
+```js
+import { create_entity, list_entities } from "@nodetool-ai/sandbox-nodetool/entities";
+
+const styleAssetId = shot.asset_id;           // the screenshot
+await create_entity({ asset_id: styleAssetId, kind: "style", name: "...", descriptor: "...", palette: [...] });
+const styleId = styleAssetId;                 // entity id === asset id
+```
+
+---
+
+## Phase 3 — Beat sheet and board
+
+Load the **commercial-beat-sheet** skill and run its execution path with the phase-1 brief and phase-2 roster: three hooks, a recommendation, the full beat sheet. Then:
+
+```js
+import { create_storyboard, edit_storyboard } from "@nodetool-ai/sandbox-nodetool/storyboards";
+
+const board = await create_storyboard({ name, brief, style, aspect_ratio });
+const boardId = board.storyboard_id;          // NOT board.id
+
+await edit_storyboard({
+  storyboard_id: boardId,
+  ops: [{ op: "set_board", entity_ids: roster }]   // set_board, not set_entities
+});
+for (const shot of shots) {
+  await edit_storyboard({ storyboard_id: boardId, ops: [{ op: "add_shot", ...shot }] });
+}
+```
+
+Set `render_mode` per shot: `"keyframe"` where the product or a face must hold steady, `"direct"` for the one or two heavy-motion shots. A launch spot usually has exactly one direct shot.
+
+Resolve the model slate now with `nodetool.models.pick` / `find_model`, name what you picked, and **carry provider+model in variables** — you will pass them to every render call.
+
+---
+
+## Phase 4 — Stills, then grade them adversarially (G2)
+
+```js
+import { render_storyboard_stills, get_storyboard } from "@nodetool-ai/sandbox-nodetool/storyboards";
+
+await render_storyboard_stills({
+  storyboard_id: boardId,
+  provider,                   // required — the board holds no model
+  model
+});
+```
+
+Then grade. **This is the step most likely to fail, and it fails as flattery.** A previous run called its frames "astonishing" and "pixel-perfect", presented them for approval, and only found a blank-blob card, an unfinished-looking end frame, and a non-uniform aspect ratio after the user asked "did you look at the stills?".
+
+The discipline:
+
+1. **Look at every frame with `view_image`, one question per frame, asking what is *wrong*.** "Critique honestly: what is crude, off-brand, or unfinished here?" — never "does this look good?".
+2. **Score adherence** with `score_image_adherence({image, prompt})` where the shot prompt is specific enough to score against.
+3. **Compare frames to each other**, not just to their prompts. The defect that killed two frames in the real run was only visible next to a third that got it right.
+4. **Report per frame: keep, or the specific defect.** Banned words in a grade: stunning, astonishing, gorgeous, perfect, night-and-day. If you cannot name a defect, write "checked: card fidelity, baked text, palette, framing — none found".
+5. **Never claim a property you did not verify.** You cannot measure dimensions (`image.info` fails on `asset://`), so do not state the aspect ratio. Say it is unverified and will be standardized at assembly.
+
+Two failure classes, two different fixes — never confuse them:
+
+- **Entity drift** (wrong product, wrong face, off-palette) → fix the *entity*: sharpen its descriptor or replace its reference, then re-render every shot using it.
+- **Shot failure** (composition, unreadable action, baked marketing copy) → fix the *shot*: rewrite its action line, re-render that shot.
+
+Present all keyframes at G2 with the per-clip cost of phase 5.
+
+---
+
+## Phase 5 — Clips
+
+```js
+await render_storyboard_clips({ storyboard_id: boardId, provider, model });
+```
+
+A clip wrong where its keyframe was right is a **motion** problem: one `revise_storyboard_clip`, never a board-wide re-render. Cap at one revision per shot before flagging.
+
+---
+
+## Phase 6 — Voice
+
+```js
+import { extract_script_from_storyboard } from "@nodetool-ai/sandbox-nodetool/storyboards";
+import { get_script, voice_script_lines } from "@nodetool-ai/sandbox-nodetool/scripts";
+
+const script = await extract_script_from_storyboard({ storyboard_id: boardId });
+await voice_script_lines({ script_id: script.script_id ?? script.id });
+const voiced = await get_script({ script_id: ... });
+```
+
+Every line must come back `voiced`. A `stale` or `no_voice` line is a defect, not a warning. If a voiced line overruns its beat, cut the line — never speed the read.
+
+---
+
+## Phase 7 — Assemble the cut
+
+```js
+import { assemble_storyboard_timeline } from "@nodetool-ai/sandbox-nodetool/storyboards";
+import { edit_timeline, validate_timeline } from "@nodetool-ai/sandbox-nodetool/timelines";
+import { generate_music } from "@nodetool-ai/sandbox-nodetool/media";
+```
+
+1. Assemble the clips.
+2. **Standardize aspect here** — this is where mixed plate ratios get resolved. Pad the black-heavy minimal frames, crop the full-bleed ones. Say which you did to which.
+3. Voice track, aligned to beats.
+4. Music bed at the spot's exact runtime, ducked under VO, with the beat sheet's deliberate pre-CTA silence kept silent.
+5. **Overrun check.** Video models overshoot requested durations. If the cut runs long, trim the **last** clip — trimming an earlier one opens a gap and leaves the runtime unchanged.
+6. `validate_timeline` must come back ok. Fix and re-validate.
+
+---
+
+## Phase 8 — Report (G3)
+
+```js
+import { get_cost_summary } from "@nodetool-ai/sandbox-nodetool/costs";
+```
+
+```text
+DELIVERED
+  Storyboard / Script / Timeline — each openable and editable
+
+COST  (from the ledger, not an estimate)
+  Stills / Clips / Voice / Music / Agent / TOTAL
+
+OPEN QUESTIONS
+  Every [CLIENT INPUT NEEDED] still in the project
+```
+
+**Estimates during the run are labeled estimates, and never sourced from the brand's own page.** Quoting the client's published prices back as your production forecast reads as a real quote and is not one.
+
+---
+
+## Craft rules (on top of the beat-sheet skill's)
+
+* Every claim in VO or on-screen text traces to the page, or is `[CLIENT INPUT NEEDED]`.
+* The product on screen is the page's product. Drift is fixed at the entity.
+* The palette is the page's palette, read from its own tokens.
+* **No lettering the model must invent.** Claims live in the text layer; brand marks come from downloaded assets or stay out of frame. Generated legible marketing copy is a defect even when it looks good.
+* Spend ascending: read → still → clip → revision.
+* Name what was wrong before spending to fix it.
+
+---
+
+## When it goes wrong
+
+* **Page unreachable or thin** → report what you could and could not read, fill the brief with `[CLIENT INPUT NEEDED]`, stop at G1. Never fabricate a product from the URL's words.
+* **A capability errors on argument shape** → re-read the tool contract above before retrying. Two consecutive failures on the same call means read the state back with `list_*` / `get_*` and work from what actually exists, not from what you think you created.
+* **A partial action left orphans** (a board with no shots, an entity with no roster) → find them with `list_*` and finish or delete them. Do not create a second one alongside.
+* **A model is unavailable or unpriced** → say so at the gate it blocks, with alternatives. Never substitute silently.
+* **A shot will not converge** (three renders, still failing adherence) → stop spending, show the best take with what is wrong, offer: accept, rewrite, or change `render_mode`.
+* **Budget cap set** → check the ledger before each render phase and stop at the gate before the cap would be crossed, with the remaining work priced.

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -213,6 +213,7 @@ import {
   findInvokedSkillNames,
   formatInvokedSkillsForPrompt,
   formatSkillCatalogForPrompt,
+  mergeSystemSkills,
   formatMemoriesForPrompt
 } from "@nodetool-ai/agents";
 import { RunNodeTool } from "./agent/run-node-tool.js";
@@ -2106,6 +2107,13 @@ type RawGraphData = {
   nodes: Array<Record<string, unknown>>;
   edges: Array<Record<string, unknown>>;
 };
+
+/** What the prompt needs from a skill, whichever tier it came from. */
+interface SkillEntry {
+  name: string;
+  description: string;
+  content: string;
+}
 
 export class UnifiedWebSocketRunner {
   websocket: WebSocketConnection | null = null;
@@ -5159,19 +5167,31 @@ export class UnifiedWebSocketRunner {
    * Best-effort like the memory block: a DB hiccup costs the skills, not the
    * turn.
    */
-  private async loadUserSkills(userId: string): Promise<Skill[]> {
+  private async loadUserSkills(userId: string): Promise<SkillEntry[]> {
+    let rows: Skill[] = [];
     try {
-      return await Skill.listByUser(userId);
+      rows = await Skill.listByUser(userId);
     } catch (err) {
       log.warn("Failed to load user skills", {
         error: err instanceof Error ? err.message : String(err)
       });
-      return [];
     }
+    // The shipped skills ride in the same catalog. They come off disk rather
+    // than the table, so a DB hiccup costs the user's own rows and not these.
+    return mergeSystemSkills(
+      rows.map((row) => ({
+        name: row.name,
+        description: row.description,
+        content: row.content
+      }))
+    );
   }
 
   /** The bodies of the skills this turn's message named with `/<name>`. */
-  private invokedSkillsSection(skills: readonly Skill[], userText: string): string {
+  private invokedSkillsSection(
+    skills: readonly SkillEntry[],
+    userText: string
+  ): string {
     const invoked = findInvokedSkillNames(
       userText,
       skills.map((skill) => skill.name)

--- a/scripts/bundle-backend.mjs
+++ b/scripts/bundle-backend.mjs
@@ -480,6 +480,44 @@ async function dirSize(dir) {
  * change here. These packages are not workspaces (no host code may import
  * them), which is why the directory is read by path instead of resolved.
  */
+/**
+ * Stage the system skills under `_skills/<name>/SKILL.md`, next to `server.mjs`.
+ *
+ * Same shape and same reason as the sandbox packs above: nothing imports them,
+ * so they are not workspaces and must be copied by path. The directory listing
+ * is the manifest — a skill added to the source tree ships with no change here
+ * — and an empty source directory fails the build, because a bundle that
+ * silently ships no skills is exactly what this staging prevents.
+ */
+async function stageSystemSkills(sourceDirRel) {
+  console.log("\nStaging the system skills NodeTool ships...");
+  const sourceDir = path.join(ROOT_DIR, sourceDirRel);
+  let entries;
+  try {
+    entries = await fsp.readdir(sourceDir, { withFileTypes: true });
+  } catch {
+    throw new Error(`System skills directory not found: ${sourceDir}`);
+  }
+
+  let staged = 0;
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const src = path.join(sourceDir, entry.name, "SKILL.md");
+    if (!fs.existsSync(src)) continue;
+    const destDir = path.join(BUNDLE_DIR, "_skills", entry.name);
+    await fsp.mkdir(destDir, { recursive: true });
+    await fsp.copyFile(src, path.join(destDir, "SKILL.md"));
+    staged += 1;
+    console.log(`  Staged skill ${entry.name}`);
+  }
+  if (staged === 0) {
+    throw new Error(
+      `No system skills staged from ${sourceDir} — every directory must hold a SKILL.md.`
+    );
+  }
+  return staged;
+}
+
 async function stageShippedSandboxPacks(sourceDirRel) {
   console.log("\nStaging the sandbox packs NodeTool ships...");
   const sourceDir = path.join(ROOT_DIR, sourceDirRel);
@@ -1036,7 +1074,11 @@ async function main() {
     "dist",
     "package-asset-registry.js"
   );
-  const { PACKAGE_RUNTIME_ASSETS, SHIPPED_SANDBOX_PACKS_SOURCE_DIR } = await import(
+  const {
+    PACKAGE_RUNTIME_ASSETS,
+    SHIPPED_SANDBOX_PACKS_SOURCE_DIR,
+    SHIPPED_SYSTEM_SKILLS_SOURCE_DIR
+  } = await import(
     pathToFileURL(registryPath).href
   );
 
@@ -1080,6 +1122,7 @@ async function main() {
   // unaffected: they resolve through the optional-node root at runtime, and
   // shadow the shipped copy when they carry the same name.
   await stageShippedSandboxPacks(SHIPPED_SANDBOX_PACKS_SOURCE_DIR);
+  await stageSystemSkills(SHIPPED_SYSTEM_SKILLS_SOURCE_DIR);
 
   // Cross-check: any *-manifest.json in a package's dist/ that is NOT in the
   // registry is almost certainly a new provider manifest someone forgot to

--- a/scripts/verify-backend-bundle.mjs
+++ b/scripts/verify-backend-bundle.mjs
@@ -97,9 +97,11 @@ function listShippedSystemSkillNames() {
   if (entries === null) return null;
   const names = [];
   for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    if (!fs.existsSync(path.join(sourceDir, entry.name, "SKILL.md"))) continue;
-    names.push(entry.name);
+    // `listFiles` is a bare `readdirSync`, so an entry is a name, not a
+    // Dirent. Holding a SKILL.md is also the directory test: `existsSync`
+    // under a plain file is false.
+    if (!existsSync(path.join(sourceDir, entry, "SKILL.md"))) continue;
+    names.push(entry);
   }
   return names;
 }
@@ -350,11 +352,12 @@ export function verifyBackendBundle(bundleDir, { requireWebgpu = true } = {}) {
   const shippedSkills = listShippedSystemSkillNames();
   if (shippedSkills !== null && shippedSkills.length > 0) {
     const missingSkills = shippedSkills.filter(
-      (name) => !fs.existsSync(path.join(bundleDir, "_skills", name, "SKILL.md"))
+      (name) => !existsSync(path.join(bundleDir, "_skills", name, "SKILL.md"))
     );
     if (missingSkills.length > 0) {
-      problems.push(
-        `System skill(s) not staged under _skills/: ${missingSkills.join(", ")}.`
+      errors.push(
+        `System skill(s) not staged under _skills/: ${missingSkills.join(", ")}. ` +
+          "Check stageSystemSkills in bundle-backend.mjs."
       );
     } else {
       summary.push(`system skills staged: ${shippedSkills.length}`);

--- a/scripts/verify-backend-bundle.mjs
+++ b/scripts/verify-backend-bundle.mjs
@@ -81,6 +81,30 @@ function listStagedSandboxPacks(bundleDir) {
 }
 
 /**
+ * Skill names this repo ships, or null when the source directory is absent —
+ * the artifact can be verified outside a checkout.
+ *
+ * The path repeats SHIPPED_SYSTEM_SKILLS_SOURCE_DIR for the same reason the
+ * pack list above does: no build tree is required beside the bundle.
+ */
+function listShippedSystemSkillNames() {
+  const sourceDir = path.join(
+    path.dirname(path.dirname(fileURLToPath(import.meta.url))),
+    "packages",
+    "system-skills"
+  );
+  const entries = listFiles(sourceDir);
+  if (entries === null) return null;
+  const names = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (!fs.existsSync(path.join(sourceDir, entry.name, "SKILL.md"))) continue;
+    names.push(entry.name);
+  }
+  return names;
+}
+
+/**
  * Package names of the sandbox packs this repo ships, or null when the source
  * directory is absent — the artifact can be verified outside a checkout.
  *
@@ -318,6 +342,22 @@ export function verifyBackendBundle(bundleDir, { requireWebgpu = true } = {}) {
         `sandbox pack ${pack} staged: ${declared.length} module(s), ` +
           `${new Set(files).size} declared file(s)`
       );
+    }
+  }
+
+  // 3c. System skills staged under _skills/. A build that ships none leaves
+  //     every install with an empty skill catalog, which is invisible at boot.
+  const shippedSkills = listShippedSystemSkillNames();
+  if (shippedSkills !== null && shippedSkills.length > 0) {
+    const missingSkills = shippedSkills.filter(
+      (name) => !fs.existsSync(path.join(bundleDir, "_skills", name, "SKILL.md"))
+    );
+    if (missingSkills.length > 0) {
+      problems.push(
+        `System skill(s) not staged under _skills/: ${missingSkills.join(", ")}.`
+      );
+    } else {
+      summary.push(`system skills staged: ${shippedSkills.length}`);
     }
   }
 


### PR DESCRIPTION
## What changed

A live `/launch-commercial` run against nodetool.ai spent six actions on contract mismatches and left two orphaned boards; the skill it was running had nowhere to live but a user row. This adds a **system skill** tier — a `SKILL.md` under `packages/system-skills/<name>/` is a read-only skill in the same catalog as the user's rows — and fixes the three real gaps the run exposed. The tier exists for the two properties a row cannot have: every install has the skill on day one with no seeding migration to drift per machine, and nothing (including an agent acting on its own mis-read instructions) can edit or delete the document it is working from. `list_skills` / `load_skill` serve both tiers with a `system` flag; `create_skill` / `update_skill` / `delete_skill` refuse a shipped name, rename included. A row that already holds the name predates the reservation, so it wins and the shipped skill is not listed twice — reserving names stops new collisions, not old ones. Discovery, staging (`_skills/`) and bundle verification mirror the sandbox packs, since nothing imports these files either. Two skills ship: `launch-commercial` and the `commercial-beat-sheet` it defers to.

The three fixes: **`set_board` can set the board's models** — it has `image_model`/`video_model` fields, no op wrote them, and passing them looked like it worked until `render_storyboard_stills` refused for want of a model; unknown `set_board` keys now throw the way unknown shot fields already did. **Creation results carry a canonical `id`** — `create_storyboard` answered only `storyboard_id` and `create_entity` only a nested `{entity}`, so reading `.id` gave `undefined` and the *next* call blamed a missing argument. **Truncated images are refused before the native decoder** — `@napi-rs/canvas` segfaults the host process on a truncated PNG (linux-x64) and reports "Invalid SVG image" for the same bytes elsewhere, both reachable from guest code with a short read.

## Verification

- [x] `npm run test:affected` — the diff touches `scripts/`, so the plan is everything. Ran `npm run test:packages`: **3461 passed** in `packages/agents` (229 files). Two pre-existing environment failures, both confirmed identical on a clean stash: `packages/agents` model3d (5 tests, `Cannot find package '@nodetool-ai/model3d'`) and `packages/protocol` (2 suites, `Cannot find package 'ajv/dist/2020.js'`). Neither is touched by this diff.
- [x] `npm run typecheck` — exit 0. The 9 `TS2307` errors in `packages/agents` / `packages/websocket` are unbuilt-dependency noise and are byte-identical before and after this change (verified via `git stash`).
- [x] `npm run lint` — exit 0.
- [ ] `npm run dev:nodetool -- harness gate --base main` — not run; the CLI's decorator fixtures need a full `dist` this container could not complete. CI's gate leg covers it.

Inverting the new decode guard, as the template asks:

```
$ sed -i 's/^  assertDecodable/  \/\/ assertDecodable/' packages/agents/src/sandbox-media.ts
$ npm run test --workspace=packages/agents -- sandbox-media-truncation
[vitest-pool]: Timeout terminating forks worker for test files .../sandbox-media-truncation.test.ts
npm error Lifecycle script `test` failed with error: code 1
```

The worker does not fail — it dies. That segfault is the bug the guard closes. Restored, the same four tests pass.

## Agent capabilities

- [x] `npm run capabilities:check` passes — `capability table is current (228 capabilities)`
- [x] One contract fingerprint moved, `edit_storyboard` (`f4d8b3cedbae` → `9b3c1f3f93a1`), from the new `set_board` fields. It keeps its existing `capability-suites` selfcheck, and `packages/agents/tests/capabilities-storyboards.test.ts` gains four cases covering the re-declared contract: models stored, models cleared with `null`, an unknown key refused per-op, and the canonical `id` on the create result.

## New checks

- [x] The decode guard was inverted once and observed failing; the output is in **Verification** above.
- [x] `verify-backend-bundle.mjs` asserts it found its targets: it reads the shipped skill names off disk and fails on any that is not staged, and `bundle-backend.mjs` throws when the source directory yields zero skills — so neither can pass by matching nothing.
- [x] `packages/agents/tests/system-skills.test.ts` (10 cases) covers the loader's refusals directly: no frontmatter, an empty field, an invalid name, and a frontmatter name disagreeing with its directory are each skipped without costing the other skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyRs56kk5KsiYBRQgVXG2t)_