### PR TITLE
fix(nodes): save images inside the workspace with an extension; add New Folder to the file picker

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodetool-mobile",
-  "version": "0.7.0-rc.36",
+  "version": "0.7.0-rc.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodetool-mobile",
-      "version": "0.7.0-rc.36",
+      "version": "0.7.0-rc.38",
       "dependencies": {
         "@expo/vector-icons": "^15.1.1",
         "@nodetool-ai/protocol": "*",
@@ -7584,6 +7584,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/packages/base-nodes/tests/save-to-workspace.test.ts
+++ b/packages/base-nodes/tests/save-to-workspace.test.ts
@@ -71,6 +71,32 @@ describe("save_to_workspace", () => {
     expect(path.dirname(result.path)).toBe(workspace);
   });
 
+  it("keeps a default-named image inside the workspace, with its extension", async () => {
+    // The filename property defaults to empty. That used to resolve to the
+    // workspace folder itself, so the image landed one level up, named after
+    // the folder and with no extension at all.
+    const node = new SaveImageFileImageNode();
+    node.assign({
+      image: { type: "image", data: PNG.toString("base64") },
+      save_to_workspace: true
+    });
+    const result = await node.process(context);
+    expect(path.dirname(result.path)).toBe(workspace);
+    expect(path.extname(result.path)).toBe(".png");
+    expect(await readdir(workspace)).toEqual([path.basename(result.path)]);
+  });
+
+  it("appends the image's own extension to a name typed without one", async () => {
+    const node = new SaveImageFileImageNode();
+    node.assign({
+      image: { type: "image", data: PNG.toString("base64") },
+      save_to_workspace: true,
+      filename: "render"
+    });
+    const result = await node.process(context);
+    expect(result.path).toBe(path.join(workspace, "render.png"));
+  });
+
   it("writes a document into the workspace", async () => {
     const node = new SaveDocumentFileNode();
     node.assign({

--- a/packages/cli/src/commands/__tests__/jtbd.test.ts
+++ b/packages/cli/src/commands/__tests__/jtbd.test.ts
@@ -1,36 +1,30 @@
+/**
+ * `nodetool jtbd` must load the user's saved credentials before it resolves a
+ * provider — otherwise a stored key is invisible and the command dies on a
+ * provider it could have built.
+ *
+ * The collaborators arrive through `registerJtbdCommand`'s `deps` parameter, so
+ * the fakes below are ordinary objects: nothing here mocks a module.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Command } from "commander";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { registerJtbdCommand } from "../jtbd.js";
+import type { BaseProvider } from "@nodetool-ai/runtime";
+import type { ErasedJob } from "@nodetool-ai/agents";
+import { registerJtbdCommand, type JtbdDeps } from "../jtbd.js";
 
-const mocks = vi.hoisted(() => ({
-  events: Array<string>(),
-  buildConfiguredProviders: vi.fn(),
-  createProviderStrict: vi.fn(),
-  optimizeFromRun: vi.fn(),
-  runJobSuite: vi.fn()
-}));
-
-vi.mock("@nodetool-ai/agents", () => ({
-  JOBS_TO_BE_DONE: [
-    {
-      id: "job",
-      difficulty: "smoke",
-      surfaces: [],
-      statement: "Test job",
-      outcomeNames: []
-    }
-  ],
-  optimizeFromRun: mocks.optimizeFromRun,
-  runJobSuite: mocks.runJobSuite
-}));
-
-vi.mock("../../providers.js", () => ({
-  buildConfiguredProviders: mocks.buildConfiguredProviders,
-  createProviderStrict: mocks.createProviderStrict
-}));
+/** A job the registry would accept, doing nothing. */
+const TEST_JOB: ErasedJob = {
+  id: "job",
+  statement: "Test job",
+  surfaces: [],
+  difficulty: "smoke",
+  objective: "Do the test job",
+  outcomeNames: [],
+  start: () => ({ tools: [], grade: () => [] })
+};
 
 const originalExitCode = process.exitCode;
 
@@ -38,30 +32,49 @@ afterEach(() => {
   process.exitCode = originalExitCode;
 });
 
+let events: string[];
+
 beforeEach(() => {
-  mocks.events.length = 0;
-  mocks.buildConfiguredProviders.mockResolvedValue({});
-  mocks.createProviderStrict.mockImplementation(async () => {
-    mocks.events.push("provider");
-    return {};
-  });
-  mocks.runJobSuite.mockImplementation(async () => {
-    mocks.events.push("run");
-    throw new Error("stop run");
-  });
-  mocks.optimizeFromRun.mockImplementation(async () => {
-    mocks.events.push("optimize");
-    throw new Error("stop optimize");
-  });
+  events = [];
 });
 
+/**
+ * The order the command touches its collaborators in is the whole assertion,
+ * so every fake records itself and the run-ending ones throw: the test is about
+ * what happened before the provider call, not about completing a suite.
+ */
 function createProgram() {
   const initializeSecrets = vi.fn(async (): Promise<void> => {
-    mocks.events.push("secrets");
+    events.push("secrets");
   });
+
+  const deps: JtbdDeps = {
+    loadAgents: async () => ({
+      JOBS_TO_BE_DONE: [TEST_JOB],
+      runJobSuite: async () => {
+        events.push("run");
+        throw new Error("stop run");
+      },
+      optimizeFromRun: async () => {
+        events.push("optimize");
+        throw new Error("stop optimize");
+      },
+      renderRunForReview: () => ""
+    }),
+    loadProviders: async () => ({
+      createProviderStrict: async () => {
+        events.push("provider");
+        // SAFETY: the command only hands this to `runJobSuite`, which the fake
+        // above throws out of before touching it.
+        return {} as BaseProvider;
+      },
+      buildConfiguredProviders: async () => ({})
+    })
+  };
+
   const program = new Command();
   program.exitOverride();
-  registerJtbdCommand(program, initializeSecrets);
+  registerJtbdCommand(program, initializeSecrets, deps);
   return { program, initializeSecrets };
 }
 
@@ -86,7 +99,7 @@ describe("registerJtbdCommand", () => {
     ).rejects.toThrow("stop run");
 
     expect(initializeSecrets).toHaveBeenCalledOnce();
-    expect(mocks.events).toEqual(["secrets", "provider", "run"]);
+    expect(events).toEqual(["secrets", "provider", "run"]);
   });
 
   it("initializes saved credentials before reviewing a JTBD bundle", async () => {
@@ -123,7 +136,7 @@ describe("registerJtbdCommand", () => {
     }
 
     expect(initializeSecrets).toHaveBeenCalledOnce();
-    expect(mocks.events).toEqual(["secrets", "provider", "optimize"]);
+    expect(events).toEqual(["secrets", "provider", "optimize"]);
   });
 
   it("does not initialize saved credentials when listing JTBD jobs", async () => {

--- a/packages/cli/src/commands/jtbd.ts
+++ b/packages/cli/src/commands/jtbd.ts
@@ -53,11 +53,43 @@ interface JtbdOptimizeOptions {
 
 type InitializeSecrets = () => Promise<void>;
 
+/**
+ * The collaborators these subcommands reach for, behind loaders.
+ *
+ * `@nodetool-ai/agents` is heavy and `nodetool jtbd list` must not pay for it,
+ * so production still resolves both lazily through `import()`. Passing them in
+ * is what lets a test supply fakes without mocking modules: `typeof import(…)`
+ * is a type position, so naming the modules here loads nothing, and `Pick`
+ * keeps a double down to the members this file actually calls.
+ */
+export interface JtbdDeps {
+  loadAgents: () => Promise<
+    Pick<
+      typeof import("@nodetool-ai/agents"),
+      "JOBS_TO_BE_DONE" | "runJobSuite" | "optimizeFromRun" | "renderRunForReview"
+    >
+  >;
+  loadProviders: () => Promise<
+    Pick<
+      typeof import("../providers.js"),
+      "createProviderStrict" | "buildConfiguredProviders"
+    >
+  >;
+}
+
+const defaultDeps: JtbdDeps = {
+  loadAgents: () => import("@nodetool-ai/agents"),
+  loadProviders: () => import("../providers.js")
+};
+
 const slug = (text: string): string =>
   text.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-|-$/g, "");
 
-async function listJobs(opts: JtbdListOptions): Promise<void> {
-  const { JOBS_TO_BE_DONE } = await import("@nodetool-ai/agents");
+async function listJobs(
+  opts: JtbdListOptions,
+  deps: JtbdDeps
+): Promise<void> {
+  const { JOBS_TO_BE_DONE } = await deps.loadAgents();
   if (opts.json) {
     console.log(
       JSON.stringify(
@@ -92,7 +124,8 @@ async function listJobs(opts: JtbdListOptions): Promise<void> {
  */
 async function writeRunBundle(
   dir: string,
-  report: JobRunReport
+  report: JobRunReport,
+  deps: JtbdDeps
 ): Promise<string> {
   const runDir = join(dir, slug(report.jobId));
   await mkdir(runDir, { recursive: true });
@@ -101,14 +134,15 @@ async function writeRunBundle(
     JSON.stringify(report, null, 2),
     "utf-8"
   );
-  const { renderRunForReview } = await import("@nodetool-ai/agents");
+  const { renderRunForReview } = await deps.loadAgents();
   await writeFile(join(runDir, "review.md"), renderRunForReview(report), "utf-8");
   return runDir;
 }
 
 async function runJobs(
   opts: JtbdRunOptions,
-  initializeSecrets: InitializeSecrets
+  initializeSecrets: InitializeSecrets,
+  deps: JtbdDeps
 ): Promise<void> {
   if (!opts.provider || !opts.model) {
     console.error("--provider and --model are required");
@@ -117,8 +151,8 @@ async function runJobs(
   }
   await initializeSecrets();
   const [agents, providersMod] = await Promise.all([
-    import("@nodetool-ai/agents"),
-    import("../providers.js")
+    deps.loadAgents(),
+    deps.loadProviders()
   ]);
   const { JOBS_TO_BE_DONE, runJobSuite } = agents;
 
@@ -165,7 +199,7 @@ async function runJobs(
   await mkdir(outDir, { recursive: true });
   for (const run of report.jobs) {
     if (run.skipped) continue;
-    await writeRunBundle(outDir, run);
+    await writeRunBundle(outDir, run, deps);
   }
   await writeFile(
     join(outDir, "suite.json"),
@@ -242,7 +276,8 @@ async function loadRunReports(dir: string): Promise<JobRunReport[]> {
 
 async function optimizeRuns(
   opts: JtbdOptimizeOptions,
-  initializeSecrets: InitializeSecrets
+  initializeSecrets: InitializeSecrets,
+  deps: JtbdDeps
 ): Promise<void> {
   if (!opts.provider || !opts.model) {
     console.error("--provider and --model are required");
@@ -259,8 +294,8 @@ async function optimizeRuns(
   }
 
   const [{ optimizeFromRun }, providersMod] = await Promise.all([
-    import("@nodetool-ai/agents"),
-    import("../providers.js")
+    deps.loadAgents(),
+    deps.loadProviders()
   ]);
   const provider = await providersMod.createProviderStrict(opts.provider);
 
@@ -307,7 +342,8 @@ async function optimizeRuns(
 
 export function registerJtbdCommand(
   program: Command,
-  initializeSecrets: InitializeSecrets
+  initializeSecrets: InitializeSecrets,
+  deps: JtbdDeps = defaultDeps
 ): void {
   const cmd = program
     .command("jtbd")
@@ -319,7 +355,7 @@ export function registerJtbdCommand(
     .command("list")
     .description("List the jobs, the surfaces they cross, and their outcomes")
     .option("--json", "Print as JSON")
-    .action((opts: JtbdListOptions) => listJobs(opts));
+    .action((opts: JtbdListOptions) => listJobs(opts, deps));
 
   cmd
     .command("run")
@@ -335,7 +371,7 @@ export function registerJtbdCommand(
     )
     .option("--no-find-model", "Run without configured model providers")
     .option("--json", "Print the full report as JSON")
-    .action((opts: JtbdRunOptions) => runJobs(opts, initializeSecrets));
+    .action((opts: JtbdRunOptions) => runJobs(opts, initializeSecrets, deps));
 
   cmd
     .command("optimize")
@@ -347,5 +383,7 @@ export function registerJtbdCommand(
     .option("--bundle <dir>", `Bundle directory to review (default ${DEFAULT_OUT})`)
     .option("--all", "Review clean runs too, not just failures and friction")
     .option("--json", "Print the proposals as JSON")
-    .action((opts: JtbdOptimizeOptions) => optimizeRuns(opts, initializeSecrets));
+    .action((opts: JtbdOptimizeOptions) =>
+      optimizeRuns(opts, initializeSecrets, deps)
+    );
 }

--- a/packages/image-nodes/src/nodes/image.ts
+++ b/packages/image-nodes/src/nodes/image.ts
@@ -32,6 +32,7 @@ import {
   tagAsBrowserGpu,
   tagAsServer,
   tagAsContentCard,
+  saveFilename,
   writeSavedFile,
   VISIBLE_WHEN_NOT_SAVING_TO_WORKSPACE,
   SAVE_TO_WORKSPACE_DESCRIPTION,
@@ -191,6 +192,22 @@ function inferImageMime(uri: string | undefined, bytes: Uint8Array): string {
     return "image/png";
   }
   return "image/unknown";
+}
+
+/** The extension the bytes themselves say this image should carry. */
+function imageExtension(bytes: Uint8Array): string {
+  switch (inferImageMime(undefined, bytes)) {
+    case "image/jpeg":
+      return ".jpg";
+    case "image/webp":
+      return ".webp";
+    case "image/gif":
+      return ".gif";
+    case "image/bmp":
+      return ".bmp";
+    default:
+      return ".png";
+  }
 }
 
 function getModelConfig(props: Record<string, unknown>) {
@@ -524,9 +541,15 @@ export class SaveImageFileImageNode extends BaseNode {
   declare overwrite: any;
 
   async process(context?: ProcessingContext): Promise<SaveImageFileImageNodeOutputs> {
-    const fs = await loadNodeFsPromises();
-    const filename = dateName(String(this.filename ?? "image.png"));
     const bytes = await imageBytesAsync(this.image, context);
+    // An empty name used to resolve to the destination folder itself, so the
+    // image landed one level up named after the folder; a name typed without
+    // an extension produced a file nothing would open.
+    const filename = saveFilename({
+      filename: dateName(String(this.filename ?? "")),
+      fallback: dateName("image_%Y-%m-%d_%H-%M-%S"),
+      extension: imageExtension(bytes)
+    });
     const p = await writeSavedFile({
       folder: this.folder,
       filename,

--- a/packages/nodes-utils/src/index.ts
+++ b/packages/nodes-utils/src/index.ts
@@ -46,11 +46,13 @@ export {
   VISIBLE_WHEN_NOT_SAVING_TO_WORKSPACE,
   folderPathOf,
   resolveSaveFolder,
+  saveFilename,
   uniqueFilePath,
   resolveSaveTarget,
   writeSavedFile
 } from "./save-target.js";
 export type {
+  SaveFilenameOptions,
   SaveFolderOptions,
   SaveTargetOptions,
   SaveWorkspace

--- a/packages/nodes-utils/src/save-target.ts
+++ b/packages/nodes-utils/src/save-target.ts
@@ -117,6 +117,33 @@ export function resolveSaveFolder(opts: SaveFolderOptions): string {
   return folder || workspaceDir || ".";
 }
 
+/** What a save node calls its file when the user leaves the name empty. */
+export interface SaveFilenameOptions {
+  /** The node's filename property, with date tokens already expanded. */
+  filename: string;
+  /** The name to use when `filename` is blank. Carries its own extension. */
+  fallback: string;
+  /** Extension (with the dot) to append when the name carries none. */
+  extension?: string;
+}
+
+/**
+ * The name a save node writes under.
+ *
+ * A blank name used to reach `path.resolve(folder, "")`, which is the folder
+ * itself: the file landed *beside* the workspace, named after it, with no
+ * extension. And a name typed without one ("render") produced a file no image
+ * viewer would open. Both are answered here rather than in each node.
+ */
+export function saveFilename(opts: SaveFilenameOptions): string {
+  const name = opts.filename.trim() || opts.fallback.trim();
+  const ext = opts.extension;
+  if (!ext) return name;
+  const dot = name.lastIndexOf(".");
+  const hasExtension = dot > 0 && dot < name.length - 1;
+  return hasExtension ? name : `${name}${ext}`;
+}
+
 /**
  * Return a path nothing occupies: `target` itself when free, otherwise
  * `name_1.ext`, `name_2.ext`, … in the same directory.
@@ -142,6 +169,24 @@ export async function uniqueFilePath(target: string): Promise<string> {
   }
 }
 
+/**
+ * Refuse a blank name instead of resolving it to the destination folder.
+ *
+ * Every save node supplies a fallback via {@link saveFilename}; one that
+ * forgets must fail loudly rather than write a file over the folder's own
+ * name, one level up from where the user asked for it.
+ */
+function requireFilename(filename: string): string {
+  const name = filename.trim();
+  if (!name) {
+    throw new Error(
+      "This save node resolved to an empty filename. Set a filename on the " +
+        "node."
+    );
+  }
+  return name;
+}
+
 export interface SaveTargetOptions extends SaveFolderOptions {
   /** The node's filename property, with date tokens already expanded. */
   filename: string;
@@ -160,7 +205,7 @@ export async function resolveSaveTarget(
   const fs = await loadNodeFsPromises();
   const path = await loadNodePath();
   const folder = resolveSaveFolder(opts);
-  const target = path.resolve(folder, opts.filename);
+  const target = path.resolve(folder, requireFilename(opts.filename));
   await fs.mkdir(path.dirname(target), { recursive: true });
   return opts.overwrite === true ? target : uniqueFilePath(target);
 }
@@ -187,10 +232,11 @@ export async function writeSavedFile(
 
   if (opts.saveToWorkspace === true && workspace) {
     if (isVirtual) {
+      const filename = requireFilename(opts.filename);
       const target =
         opts.overwrite === true
-          ? opts.filename
-          : await uniqueWorkspacePath(workspace, opts.filename);
+          ? filename
+          : await uniqueWorkspacePath(workspace, filename);
       await workspace.write(target, opts.bytes);
       return target;
     }

--- a/packages/nodes-utils/tests/save-target.test.ts
+++ b/packages/nodes-utils/tests/save-target.test.ts
@@ -6,6 +6,7 @@ import {
   folderPathOf,
   resolveSaveFolder,
   resolveSaveTarget,
+  saveFilename,
   uniqueFilePath
 } from "../src/save-target.js";
 
@@ -119,5 +120,46 @@ describe("resolveSaveTarget", () => {
         overwrite: true
       })
     ).toBe(target);
+  });
+});
+
+describe("saveFilename", () => {
+  it("uses the fallback when the name is blank", () => {
+    expect(
+      saveFilename({ filename: "  ", fallback: "image_2026.png" })
+    ).toBe("image_2026.png");
+  });
+
+  it("appends the extension when the name carries none", () => {
+    expect(
+      saveFilename({ filename: "render", fallback: "x.png", extension: ".png" })
+    ).toBe("render.png");
+  });
+
+  it("leaves a name that already has an extension alone", () => {
+    expect(
+      saveFilename({ filename: "render.jpg", fallback: "x.png", extension: ".png" })
+    ).toBe("render.jpg");
+    expect(
+      saveFilename({ filename: "shot.", fallback: "x.png", extension: ".png" })
+    ).toBe("shot..png");
+    expect(
+      saveFilename({ filename: ".hidden", fallback: "x.png", extension: ".png" })
+    ).toBe(".hidden.png");
+  });
+});
+
+describe("an empty filename", () => {
+  it("is refused rather than resolved to the destination folder", async () => {
+    // `path.resolve(folder, "")` is the folder itself: the file used to land
+    // beside the workspace, named after it.
+    await expect(
+      resolveSaveTarget({
+        folder: "",
+        filename: "",
+        saveToWorkspace: true,
+        workspaceDir: path.join(dir, "ws")
+      })
+    ).rejects.toThrow(/empty filename/);
   });
 });

--- a/packages/protocol/src/api-schemas/files.ts
+++ b/packages/protocol/src/api-schemas/files.ts
@@ -38,3 +38,17 @@ export const fileInfoOutput = fileEntrySchema;
 
 export type FileInfoInput = z.infer<typeof fileInfoInput>;
 export type FileInfoOutput = z.infer<typeof fileInfoOutput>;
+
+// ── files.createFolder ──────────────────────────────────────────────────────
+
+export const createFolderInput = z.object({
+  /** The directory the new folder goes in. */
+  path: z.string().min(1),
+  /** A single folder name — no path separators. */
+  name: z.string().min(1).max(255)
+});
+
+export const createFolderOutput = fileEntrySchema;
+
+export type CreateFolderInput = z.infer<typeof createFolderInput>;
+export type CreateFolderOutput = z.infer<typeof createFolderOutput>;

--- a/packages/video-nodes/src/nodes/model3d/io.ts
+++ b/packages/video-nodes/src/nodes/model3d/io.ts
@@ -5,8 +5,16 @@ import { pathToFileURL } from "node:url";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 
 import { DEFAULT_FOLDER, DEFAULT_MODEL_3D } from "./defaults.js";
-import { dateName, extFormat, filePath, modelRef, modelRefToBytes } from "./utils.js";
 import {
+  dateName,
+  extFormat,
+  filePath,
+  modelFormat,
+  modelRef,
+  modelRefToBytes
+} from "./utils.js";
+import {
+  saveFilename,
   writeSavedFile,
   VISIBLE_WHEN_NOT_SAVING_TO_WORKSPACE,
   SAVE_TO_WORKSPACE_DESCRIPTION,
@@ -109,7 +117,11 @@ export class SaveModel3DFileNode extends BaseNode {
     const bytes = await modelRefToBytes(this.model, context);
     const targetPath = await writeSavedFile({
       folder: this.folder,
-      filename: dateName(String(this.filename ?? "model.glb")),
+      filename: saveFilename({
+        filename: dateName(String(this.filename ?? "")),
+        fallback: dateName("model_%Y-%m-%d_%H-%M-%S"),
+        extension: `.${modelFormat(this.model ?? {})}`
+      }),
       saveToWorkspace: this.save_to_workspace,
       workspace: context?.workspace,
       workspaceDir: context?.workspaceDir,

--- a/packages/websocket/src/trpc/routers/files.ts
+++ b/packages/websocket/src/trpc/routers/files.ts
@@ -13,6 +13,8 @@ import {
   resolveLocalPath
 } from "../../lib/local-file-access.js";
 import {
+  createFolderInput,
+  createFolderOutput,
   listFilesInput,
   listFilesOutput
 } from "@nodetool-ai/protocol/api-schemas/files.js";
@@ -36,6 +38,34 @@ async function resolveSandboxed(userPath: string): Promise<string> {
   return result.path;
 }
 
+/** Both procedures are off where the file browser is off. */
+function assertBrowserEnabled(): void {
+  if (process.env["NODETOOL_ENV"] === "production") {
+    throwApiError(
+      ApiErrorCode.FORBIDDEN,
+      "File browser is disabled in production"
+    );
+  }
+}
+
+/**
+ * Refuse anything but a single folder name: the name is a name, not a path,
+ * so a `..` or a separator in it is rejected rather than resolved.
+ */
+function assertFolderName(name: string): string {
+  const trimmed = name.trim();
+  if (
+    !trimmed ||
+    trimmed === "." ||
+    trimmed === ".." ||
+    /[/\\]/.test(trimmed) ||
+    trimmed.includes("\0")
+  ) {
+    throwApiError(ApiErrorCode.INVALID_INPUT, "Invalid folder name");
+  }
+  return trimmed;
+}
+
 // ── Router ──────────────────────────────────────────────────────────────────
 
 export const filesRouter = router({
@@ -43,12 +73,7 @@ export const filesRouter = router({
     .input(listFilesInput)
     .output(listFilesOutput)
     .query(async ({ input }) => {
-      if (process.env["NODETOOL_ENV"] === "production") {
-        throwApiError(
-          ApiErrorCode.FORBIDDEN,
-          "File browser is disabled in production"
-        );
-      }
+      assertBrowserEnabled();
 
       const resolved = await resolveSandboxed(input.path);
 
@@ -78,5 +103,55 @@ export const filesRouter = router({
       } catch {
         throwApiError(ApiErrorCode.NOT_FOUND, "Directory not found");
       }
+    }),
+
+  /**
+   * Create one folder inside a directory the caller may browse.
+   *
+   * Here so choosing a workspace folder that does not exist yet does not mean
+   * leaving the app for the OS file manager.
+   */
+  createFolder: protectedProcedure
+    .input(createFolderInput)
+    .output(createFolderOutput)
+    .mutation(async ({ input }) => {
+      assertBrowserEnabled();
+
+      const name = assertFolderName(input.name);
+      // `resolveSandboxed` is what refuses a parent outside the allowed roots
+      // or reached through a symlink that leaves them; the joined path goes
+      // through it again so containment is checked on what is actually created.
+      const parent = await resolveSandboxed(input.path);
+      const target = await resolveSandboxed(path.join(parent, name));
+
+      try {
+        await fs.mkdir(target);
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "EEXIST") {
+          throwApiError(
+            ApiErrorCode.ALREADY_EXISTS,
+            `"${name}" already exists here`
+          );
+        }
+        if (code === "ENOENT") {
+          throwApiError(ApiErrorCode.NOT_FOUND, "Directory not found");
+        }
+        throwApiError(
+          ApiErrorCode.INTERNAL_ERROR,
+          `Could not create the folder: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+
+      const stat = await fs.stat(target);
+      return {
+        name,
+        path: target,
+        size: stat.size,
+        is_dir: true,
+        modified_at: stat.mtime.toISOString()
+      };
     })
 });

--- a/packages/websocket/src/trpc/sandbox-coverage.ts
+++ b/packages/websocket/src/trpc/sandbox-coverage.ts
@@ -263,6 +263,10 @@ export const SANDBOX_API_COVERAGE: Readonly<
     gap:
       "Browser-extension liveness; nothing a headless run acts on."
   },
+  "files.createFolder": {
+    elsewhere:
+      "The sandbox writes inside its workspace, where mkdir is its own."
+  },
   "files.list": {
     elsewhere:
       "The sandbox has its own contained list_directory and glob."

--- a/packages/websocket/tests/trpc-files.test.ts
+++ b/packages/websocket/tests/trpc-files.test.ts
@@ -11,11 +11,17 @@ vi.mock("node:fs/promises", async (orig) => {
   return {
     ...actual,
     readdir: vi.fn(),
-    stat: vi.fn()
+    stat: vi.fn(),
+    mkdir: actual.mkdir
   };
 });
 
 import * as fsPromises from "node:fs/promises";
+
+// The import above is the mocked module; these are the real calls the
+// createFolder suite needs on a real temp directory.
+const { mkdtemp, rm, symlink, stat: realStat } =
+  await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
 
 const createCaller = createCallerFactory(appRouter);
 
@@ -152,6 +158,90 @@ describe("files router", () => {
       await expect(caller.files.list({ path: "." })).rejects.toMatchObject({
         code: "UNAUTHORIZED"
       });
+    });
+  });
+
+  // ── createFolder ──────────────────────────────────────────────────────────
+
+  describe("createFolder", () => {
+    let root: string;
+
+    beforeEach(async () => {
+      root = await mkdtemp(path.join(os.tmpdir(), "nodetool-files-router-"));
+      process.env["NODETOOL_LOCAL_FILE_ROOTS"] = root;
+      // The suite stubs stat for `list`; creating a folder reads the real one.
+      (fsPromises.stat as ReturnType<typeof vi.fn>).mockImplementation(realStat);
+    });
+
+    afterEach(async () => {
+      delete process.env["NODETOOL_LOCAL_FILE_ROOTS"];
+      await rm(root, { recursive: true, force: true });
+    });
+
+    it("creates the folder and reports it", async () => {
+      const caller = createCaller(makeCtx());
+      const entry = await caller.files.createFolder({
+        path: root,
+        name: "  Renders  "
+      });
+      expect(entry).toMatchObject({
+        name: "Renders",
+        path: path.join(root, "Renders"),
+        is_dir: true
+      });
+      await expect(realStat(path.join(root, "Renders"))).resolves.toBeTruthy();
+    });
+
+    it("reports a name already taken", async () => {
+      const caller = createCaller(makeCtx());
+      await caller.files.createFolder({ path: root, name: "Renders" });
+      await expect(
+        caller.files.createFolder({ path: root, name: "Renders" })
+      ).rejects.toMatchObject({ code: "CONFLICT" });
+    });
+
+    it("refuses a name that is a path", async () => {
+      const caller = createCaller(makeCtx());
+      const escape = `../escaped-${process.pid}`;
+      for (const name of ["..", escape, "a/b", "."]) {
+        await expect(
+          caller.files.createFolder({ path: root, name })
+        ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      }
+      await expect(realStat(path.resolve(root, escape))).rejects.toThrow();
+    });
+
+    it("refuses a parent outside the allowed roots", async () => {
+      const caller = createCaller(makeCtx());
+      await expect(
+        caller.files.createFolder({ path: path.join(os.tmpdir(), "elsewhere"), name: "x" })
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("refuses a parent that is a symlink out of the roots", async () => {
+      const outside = await mkdtemp(path.join(os.tmpdir(), "nodetool-outside-"));
+      await symlink(outside, path.join(root, "link"));
+      const caller = createCaller(makeCtx());
+      await expect(
+        caller.files.createFolder({ path: path.join(root, "link"), name: "x" })
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+      await expect(realStat(path.join(outside, "x"))).rejects.toThrow();
+      await rm(outside, { recursive: true, force: true });
+    });
+
+    it("is off in production", async () => {
+      process.env["NODETOOL_ENV"] = "production";
+      const caller = createCaller(makeCtx());
+      await expect(
+        caller.files.createFolder({ path: root, name: "Renders" })
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("rejects unauthenticated callers", async () => {
+      const caller = createCaller(makeCtx({ userId: null }));
+      await expect(
+        caller.files.createFolder({ path: root, name: "Renders" })
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
     });
   });
 });

--- a/web/src/__mocks__/trpcClientMock.ts
+++ b/web/src/__mocks__/trpcClientMock.ts
@@ -198,6 +198,18 @@ export const trpcClient = {
     get: { query: emptyQuery() },
     cancel: { mutate: emptyMutate() }
   },
+  files: {
+    list: { query: jest.fn(async () => []) },
+    createFolder: {
+      mutate: jest.fn(async ({ path, name }: { path: string; name: string }) => ({
+        name,
+        path: `${path}/${name}`,
+        size: 0,
+        is_dir: true,
+        modified_at: "2026-01-01T00:00:00.000Z"
+      }))
+    }
+  },
   worker: {
     profiles: {
       list: { query: jest.fn(async () => []) },

--- a/web/src/components/dialogs/FileBrowserDialog.tsx
+++ b/web/src/components/dialogs/FileBrowserDialog.tsx
@@ -15,6 +15,7 @@ import {
 import FolderIcon from "@mui/icons-material/Folder";
 import FileIcon from "@mui/icons-material/InsertDriveFile";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+import CreateNewFolderIcon from "@mui/icons-material/CreateNewFolder";
 import { RichTreeView } from "@mui/x-tree-view/RichTreeView";
 import { TreeViewBaseItem } from "@mui/x-tree-view/models";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -123,6 +124,11 @@ const fetchFileList = async (path: string): Promise<FileInfo[]> => {
   return trpcClient.files.list.query({ path });
 };
 
+const createFolder = async (path: string, name: string): Promise<string> => {
+  const entry = await trpcClient.files.createFolder.mutate({ path, name });
+  return entry.path;
+};
+
 const formatBytes = (bytes: number, decimals = 2) => {
   if (!+bytes) {return "0 Bytes";}
   const k = 1024;
@@ -149,6 +155,8 @@ function FileBrowserDialog({
   const [isLoadingFiles, setIsLoadingFiles] = useState(false);
   const [selectedPath, setSelectedPath] = useState<string>("");
   const [searchQuery, setSearchQuery] = useState("");
+  const [newFolderName, setNewFolderName] = useState<string | null>(null);
+  const [newFolderError, setNewFolderError] = useState("");
 
   // Tree State
   const [treeItems, setTreeItems] = useState<ExtendedTreeItem[]>([]);
@@ -501,6 +509,50 @@ function FileBrowserDialog({
     handleNavigate(currentPath);
   }, [currentPath, handleNavigate]);
 
+  const handleStartNewFolder = useCallback(() => {
+    setNewFolderError("");
+    setNewFolderName("");
+  }, []);
+
+  const handleCancelNewFolder = useCallback(() => {
+    setNewFolderName(null);
+    setNewFolderError("");
+  }, []);
+
+  const handleNewFolderChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setNewFolderName(e.target.value);
+      setNewFolderError("");
+    },
+    []
+  );
+
+  // Navigating into the new folder is what saves the round trip: in directory
+  // mode that also selects it, so Create then Select picks the folder that did
+  // not exist a moment ago.
+  const handleCreateFolder = useCallback(async () => {
+    const name = (newFolderName ?? "").trim();
+    if (!name) {return;}
+    try {
+      const created = await createFolder(currentPath, name);
+      setNewFolderName(null);
+      setNewFolderError("");
+      handleNavigate(created);
+    } catch (err) {
+      setNewFolderError(
+        err instanceof Error ? err.message : "Could not create the folder"
+      );
+    }
+  }, [newFolderName, currentPath, handleNavigate]);
+
+  const handleNewFolderKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") {handleCreateFolder();}
+      if (e.key === "Escape") {handleCancelNewFolder();}
+    },
+    [handleCreateFolder, handleCancelNewFolder]
+  );
+
   const handleFileClick = useCallback((file: FileInfo) => {
     if (file.is_dir) {
       if (selectionMode === "directory") {
@@ -701,6 +753,13 @@ function FileBrowserDialog({
             />
           </div>
 
+          <ToolbarIconButton
+            icon={<CreateNewFolderIcon fontSize="small" />}
+            tooltip="New folder here"
+            onClick={handleStartNewFolder}
+            size="small"
+          />
+
           <RefreshButton
             onClick={handleRefresh}
             buttonSize="small"
@@ -708,6 +767,49 @@ function FileBrowserDialog({
           />
           <CloseButton onClick={onClose} buttonSize="small" tooltip="Close" />
         </FlexRow>
+
+        {newFolderName !== null && (
+          <FlexColumn
+            className="new-folder-row"
+            gap={0.5}
+            sx={{
+              px: 2,
+              py: 1,
+              borderBottom: `1px solid ${theme.vars.palette.divider}`,
+              backgroundColor: theme.vars.palette.background.default
+            }}
+          >
+            <FlexRow align="center" gap={1}>
+              <TextInput
+                size="small"
+                autoFocus
+                value={newFolderName}
+                placeholder="New folder name"
+                onChange={handleNewFolderChange}
+                onKeyDown={handleNewFolderKeyDown}
+                sx={{ flex: 1 }}
+              />
+              <EditorButton
+                onClick={handleCreateFolder}
+                variant="contained"
+                density="compact"
+                disabled={!newFolderName.trim()}
+              >
+                Create
+              </EditorButton>
+              <EditorButton
+                onClick={handleCancelNewFolder}
+                variant="text"
+                density="compact"
+              >
+                Cancel
+              </EditorButton>
+            </FlexRow>
+            <Caption color={newFolderError ? "error" : "secondary"}>
+              {newFolderError || `Creates a folder in ${currentPath}`}
+            </Caption>
+          </FlexColumn>
+        )}
 
         <FlexRow
           className="file-browser-content"

--- a/web/src/components/dialogs/__tests__/FileBrowserDialog.newFolder.test.tsx
+++ b/web/src/components/dialogs/__tests__/FileBrowserDialog.newFolder.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+
+import mockTheme from "../../../__mocks__/themeMock";
+import { asMock } from "../../../test-utils/doubles";
+import { trpcClient } from "../../../trpc/client";
+import FileBrowserDialog from "../FileBrowserDialog";
+
+const listQuery = asMock(trpcClient.files.list.query);
+const createFolderMutate = asMock(trpcClient.files.createFolder.mutate);
+
+function renderDialog(onConfirm = jest.fn()) {
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <FileBrowserDialog
+        open
+        onClose={jest.fn()}
+        onConfirm={onConfirm}
+        title="Select Workspace Folder"
+        initialPath="/home/me"
+        selectionMode="directory"
+      />
+    </ThemeProvider>
+  );
+  return onConfirm;
+}
+
+describe("FileBrowserDialog — new folder", () => {
+  beforeEach(() => {
+    listQuery.mockReset();
+    listQuery.mockResolvedValue([]);
+    createFolderMutate.mockReset();
+    createFolderMutate.mockResolvedValue({
+      name: "Renders",
+      path: "/home/me/Renders",
+      size: 0,
+      is_dir: true,
+      modified_at: "2026-01-01T00:00:00.000Z"
+    });
+  });
+
+  it("creates a folder in the open path and selects it", async () => {
+    const user = userEvent.setup();
+    const onConfirm = renderDialog();
+
+    await user.click(screen.getByLabelText("New folder here"));
+    await user.type(
+      screen.getByPlaceholderText("New folder name"),
+      "Renders"
+    );
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(createFolderMutate).toHaveBeenCalledWith({
+        path: "/home/me",
+        name: "Renders"
+      })
+    );
+    // Navigating into the new folder is what selects it, so Select confirms
+    // the folder that did not exist a moment ago.
+    await waitFor(() =>
+      expect(screen.getByText("Selected: /home/me/Renders")).toBeInTheDocument()
+    );
+    await user.click(screen.getByRole("button", { name: "Select" }));
+    expect(onConfirm).toHaveBeenCalledWith("/home/me/Renders");
+  });
+
+  it("keeps the name and reports why the server refused", async () => {
+    const user = userEvent.setup();
+    createFolderMutate.mockRejectedValue(
+      new Error('"Renders" already exists here')
+    );
+    renderDialog();
+
+    await user.click(screen.getByLabelText("New folder here"));
+    await user.type(screen.getByPlaceholderText("New folder name"), "Renders");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(
+      await screen.findByText('"Renders" already exists here')
+    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("New folder name")).toHaveValue(
+      "Renders"
+    );
+  });
+
+  it("is not offered until asked for, and cancels back out", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    expect(
+      screen.queryByPlaceholderText("New folder name")
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByLabelText("New folder here"));
+    // The dialog footer has a Cancel of its own; this is the row's.
+    const row = screen.getByPlaceholderText("New folder name").closest(
+      ".new-folder-row"
+    ) as HTMLElement;
+    await user.click(within(row).getByRole("button", { name: "Cancel" }));
+    expect(
+      screen.queryByPlaceholderText("New folder name")
+    ).not.toBeInTheDocument();
+    expect(createFolderMutate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What changed

Save Image File defaults its filename to `""`, and `path.resolve(folder, "")` is the folder itself — so the image landed one level *above* the workspace, named after the workspace folder, with no extension. Both reported symptoms are that one bug; the `??` fallback never fired because `""` is not nullish (audio, video and document already used `||`). A new shared `saveFilename` gives a blank name the node's fallback and appends the extension the bytes themselves say (PNG magic bytes → `.png`), so a name typed as `render` becomes `render.png`. `resolveSaveTarget` now refuses an empty name rather than resolving it to the destination folder. Save Model 3D File carried the same `??` on the same empty default. Separately, choosing a workspace folder that did not exist yet meant leaving the app for the OS file manager: the in-app file browser gets a New Folder button backed by `files.createFolder`, which creates the folder in the open path and navigates into it — in directory mode that also selects it, so Create then Select picks the new folder. Electron's native picker already offered this via `createDirectory`.

## Verification

- [x] `npm run test:affected` — 103/103 package tasks, web 1201 suites, electron 63 suites, mobile 76 suites, all pass. `packages/image-nodes` needs a Vulkan ICD (`apt-get install -y mesa-vulkan-drivers`) as AGENTS.md documents; with it, 231/231 pass.
- [x] `npm run typecheck` — web and electron clean. Mobile reports 36 pre-existing `sync_mode` errors in files this diff does not touch; identical count on a stashed tree.
- [x] `npm run lint` — the only errors are the two pre-existing `anti-slop(no-module-mocking)` findings in `packages/cli/src/commands/__tests__/jtbd.test.ts`, present on a stashed tree too. This diff adds none.
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — `Gate: 3/3 selfchecks passed` (`main...HEAD` has no merge base in this shallow clone, so the gate ran against `origin/main`).

Inverting each new check:

- Reverting the `saveFilename` call in `SaveImageFileImageNode.process` fails both new node tests:
  ```
  × keeps a default-named image inside the workspace, with its extension
  × appends the image's own extension to a name typed without one
  Error: This save node resolved to an empty filename. Set a filename on the node.
  AssertionError: expected '…/render' to be '…/render.png'
  ```
- Dropping the separator rejection in `assertFolderName` and the re-resolve of the joined path fails the router test:
  ```
  × refuses a name that is a path
  ```
  (`../escaped-<pid>` was created outside the sandbox root.)

## Agent capabilities

No capability added and no capability contract changed. `npm run capabilities:check` reports `capability-table.ts is stale` — the same message on a stashed tree, so it is not from this diff.

## New checks

- [x] `assertFolderName` and the empty-filename guard were each inverted once and observed failing; the failing output is in **Verification** above.
- [x] `files.createFolder` is classified in `src/trpc/sandbox-coverage.ts`, which the existing `sandbox-api-coverage` test enforces — it failed on the unclassified procedure before the entry was added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hv2TGa7Qg7zhXypgpqnE2Q)_