### PR TITLE
feat(search): image web search on Brave, with previews in chat

### DIFF
--- a/packages/agents/src/capabilities/web.ts
+++ b/packages/agents/src/capabilities/web.ts
@@ -34,6 +34,7 @@ import type {
   SerpProviderType
 } from "../tools/serp-providers/index.js";
 import {
+  SERP_PROVIDER_SEARCH_TYPES,
   createSerpProvider,
   serpProviderConfigured
 } from "../tools/serp-providers/index.js";
@@ -348,10 +349,36 @@ export function webSearchImpl(provider?: SerpProvider): CapabilityImpl {
     ): SearchBackend => ({
       name,
       requires,
-      supports: new Set<SearchType>(["web"]),
+      supports: new Set<SearchType>(SERP_PROVIDER_SEARCH_TYPES[name]),
       isConfigured: (ctx) => serpProviderConfigured(name, ctx),
       run: async (ctx) => {
         const client = await createSerpProvider(name, ctx);
+        if (searchType === "images") {
+          // Routing only offers this backend for images when the table says
+          // its client implements searchImages, so a missing method here is a
+          // table that drifted from the class — say which, rather than
+          // answering an image search with pages.
+          if (!client.searchImages) {
+            throw new Error(
+              `${WEB_SEARCH_TOOL_NAME}: backend "${name}" declares image ` +
+                "search but its client implements none."
+            );
+          }
+          const images = await client.searchImages(effectiveQuery, {
+            numResults
+          });
+          return {
+            success: true,
+            results: keepRecords(
+              images.map((r) => ({
+                title: r.title,
+                link: r.link,
+                original: r.original,
+                thumbnail: r.thumbnail
+              }))
+            )
+          };
+        }
         const results = await client.search(effectiveQuery, { numResults });
         return formatFiltered(
           results.map((r) => ({
@@ -368,8 +395,15 @@ export function webSearchImpl(provider?: SerpProvider): CapabilityImpl {
         name: "serpapi",
         requires: "SERPAPI_API_KEY",
         supports: new Set<SearchType>(["web", "news", "images"]),
+        // The injected client is only consulted on the web path below, and it
+        // is whatever SERP_PROVIDER names — possibly not SerpAPI at all. On
+        // news and images this backend calls serpapi.com directly, so only a
+        // real key makes it configured; otherwise a Brave-backed install
+        // answered an image search with "SERPAPI_API_KEY is not configured"
+        // instead of routing on to Brave.
         isConfigured: async (ctx) =>
-          provider !== undefined || serpApiConfigured(ctx),
+          (provider !== undefined && searchType === "web") ||
+          serpApiConfigured(ctx),
         run: async (ctx) => {
           if (searchType === "news") {
             const data = (await serpApiFetch({

--- a/packages/agents/src/tools/serp-providers/brave-provider.ts
+++ b/packages/agents/src/tools/serp-providers/brave-provider.ts
@@ -7,7 +7,12 @@
  * API docs: https://api-dashboard.search.brave.com/app/documentation/web-search/get-started
  */
 
-import type { SerpProvider, SearchResult, SearchOptions } from "./index.js";
+import type {
+  SerpProvider,
+  SearchResult,
+  SearchOptions,
+  ImageSearchResult
+} from "./index.js";
 
 const API_BASE = "https://api.search.brave.com/res/v1";
 
@@ -21,20 +26,41 @@ interface BraveResponse {
   };
 }
 
+/**
+ * Brave's image endpoint. `url` is the page carrying the image,
+ * `properties.url` the image file, `thumbnail.src` Brave's own preview — the
+ * three things `search_type: "images"` reports.
+ */
+interface BraveImageResponse {
+  results?: Array<{
+    title?: string;
+    url?: string;
+    thumbnail?: { src?: string };
+    properties?: { url?: string };
+  }>;
+}
+
 /** A failed Brave call, with whatever the API said about it. */
 interface BraveError {
   error: string;
   details?: unknown;
 }
 
-async function braveRequest(
+async function braveRequest<T>(
   apiKey: string,
+  path: "web" | "images",
   query: string,
   numResults: number
-): Promise<BraveResponse | BraveError> {
-  const url = new URL(`${API_BASE}/web/search`);
+): Promise<T | BraveError> {
+  const url = new URL(`${API_BASE}/${path}/search`);
   url.searchParams.set("q", query);
-  url.searchParams.set("count", String(numResults));
+  // Brave's image endpoint caps `count` at 100 and rejects anything larger
+  // outright, so an over-large num_results clamps rather than failing the
+  // search. The web endpoint keeps the count it was always sent.
+  url.searchParams.set(
+    "count",
+    String(path === "images" ? Math.min(Math.max(numResults, 1), 100) : numResults)
+  );
 
   try {
     const res = await fetch(url.toString(), {
@@ -57,7 +83,7 @@ async function braveRequest(
       };
     }
 
-    return (await res.json()) as BraveResponse;
+    return (await res.json()) as T;
   } catch (e: unknown) {
     return { error: `Brave Search request failed: ${(e as Error).message}` };
   }
@@ -76,7 +102,12 @@ export class BraveProvider implements SerpProvider {
   ): Promise<SearchResult[]> {
     const numResults = options?.numResults ?? 10;
 
-    const result = await braveRequest(this.apiKey, query, numResults);
+    const result = await braveRequest<BraveResponse>(
+      this.apiKey,
+      "web",
+      query,
+      numResults
+    );
 
     if ("error" in result) {
       throw new Error(result.error);
@@ -97,6 +128,37 @@ export class BraveProvider implements SerpProvider {
     options?: SearchOptions
   ): Promise<BraveResponse | { error: string }> {
     const numResults = options?.numResults ?? 10;
-    return braveRequest(this.apiKey, query, numResults);
+    return braveRequest<BraveResponse>(this.apiKey, "web", query, numResults);
+  }
+
+  /**
+   * Brave's image search. The subscription needs the Image Search plan; a
+   * token without it comes back 401/403, which surfaces as the request error
+   * rather than as an empty result list.
+   */
+  async searchImages(
+    query: string,
+    options?: SearchOptions
+  ): Promise<ImageSearchResult[]> {
+    const numResults = options?.numResults ?? 20;
+
+    const result = await braveRequest<BraveImageResponse>(
+      this.apiKey,
+      "images",
+      query,
+      numResults
+    );
+
+    if ("error" in result) {
+      throw new Error(result.error);
+    }
+
+    return (result.results ?? []).slice(0, numResults).map((r, i) => ({
+      title: r.title ?? null,
+      link: r.url ?? null,
+      original: r.properties?.url ?? null,
+      thumbnail: r.thumbnail?.src ?? null,
+      position: i + 1
+    }));
   }
 }

--- a/packages/agents/src/tools/serp-providers/index.ts
+++ b/packages/agents/src/tools/serp-providers/index.ts
@@ -22,6 +22,24 @@ export interface SearchOptions {
 }
 
 /**
+ * One image search hit, in the shape `web_search`'s `search_type: "images"`
+ * already returns: `link` is the page the image sits on, `original` the image
+ * file itself, `thumbnail` a small preview. Kept identical to the SerpAPI and
+ * DataForSEO image paths in `capabilities/web.ts` so a caller — the chat
+ * result renderer most of all — reads one shape whichever backend answered.
+ */
+export interface ImageSearchResult {
+  title: string | null;
+  link: string | null;
+  original: string | null;
+  thumbnail: string | null;
+  position: number;
+}
+
+/** What kind of search a backend is being asked for. */
+export type SerpSearchType = "web" | "news" | "images";
+
+/**
  * Abstract SERP provider interface.
  *
  * Implementations wrap a specific search API (SerpAPI, DataForSEO, etc.)
@@ -33,6 +51,16 @@ export interface SerpProvider {
 
   /** Perform a web search and return the raw API response. */
   searchRaw(query: string, options?: SearchOptions): Promise<unknown>;
+
+  /**
+   * Image search, on the providers whose API offers one. Absent here means
+   * the service has no image endpoint we call — routing skips the provider
+   * for `search_type: "images"` rather than answering with pages.
+   */
+  searchImages?(
+    query: string,
+    options?: SearchOptions
+  ): Promise<ImageSearchResult[]>;
 }
 
 export type SerpProviderType =
@@ -67,6 +95,26 @@ export const SERP_PROVIDER_SECRETS: Readonly<
   dataforseo: ["DATA_FOR_SEO_LOGIN", "DATA_FOR_SEO_PASSWORD"],
   brave: ["BRAVE_API_KEY"],
   apify: ["APIFY_API_TOKEN", "APIFY_API_KEY"]
+};
+
+/**
+ * The search types each provider's client can answer through
+ * `createSerpProvider`.
+ *
+ * Declared here rather than read off the instance because routing has to know
+ * before it builds a client (building one needs the key). A provider whose
+ * class implements `searchImages` must list `images` here and one that does
+ * not must not: `serp-providers-images.test.ts` instantiates every provider
+ * and checks the two against each other, so an image backend cannot be added
+ * and left invisible to routing.
+ */
+export const SERP_PROVIDER_SEARCH_TYPES: Readonly<
+  Record<SerpProviderType, readonly SerpSearchType[]>
+> = {
+  serpapi: ["web"],
+  dataforseo: ["web"],
+  brave: ["web", "images"],
+  apify: ["web"]
 };
 
 /**

--- a/packages/agents/tests/capabilities-web.test.ts
+++ b/packages/agents/tests/capabilities-web.test.ts
@@ -205,13 +205,13 @@ describe("behaviour through toolFromCapability", () => {
   it("refuses a backend that cannot serve the requested search type", async () => {
     const context = makeContext();
     const tool = asTool(byName("web_search"));
-    // Brave answers web searches only, so pinning it for images must say so
-    // rather than quietly returning pages.
+    // Apify's actor scrapes web results only, so pinning it for images must
+    // say so rather than quietly returning pages.
     await expect(
       tool.process(context, {
         query: "otters",
         search_type: "images",
-        backend: "brave"
+        backend: "apify"
       })
     ).rejects.toThrow(/does not support search_type "images"/);
   });

--- a/packages/agents/tests/search-tools.test.ts
+++ b/packages/agents/tests/search-tools.test.ts
@@ -370,6 +370,64 @@ describe("web_search with search_type: images", () => {
     expect(result.results).toEqual([]);
   });
 
+  it("routes to Brave when it is the only configured backend", async () => {
+    const ctx = makeContext({ BRAVE_API_KEY: "brave-key" });
+    fetchSpy = stubFetch({
+      results: [
+        {
+          title: "A red fox",
+          url: "https://wildlife.example/fox",
+          thumbnail: { src: "https://cdn.example/fox-thumb.jpg" },
+          properties: { url: "https://cdn.example/fox.jpg" }
+        }
+      ]
+    });
+
+    const result = (await tool.process(ctx, {
+      query: "red fox",
+      search_type: "images"
+    })) as Record<string, unknown>;
+
+    expect(result.success).toBe(true);
+    expect(result.results).toEqual([
+      {
+        title: "A red fox",
+        link: "https://wildlife.example/fox",
+        original: "https://cdn.example/fox.jpg",
+        thumbnail: "https://cdn.example/fox-thumb.jpg"
+      }
+    ]);
+    expect(String(fetchSpy.mock.calls[0][0])).toContain("/images/search");
+  });
+
+  it("applies blocked_domains to Brave image results", async () => {
+    const ctx = makeContext({ BRAVE_API_KEY: "brave-key" });
+    fetchSpy = stubFetch({
+      results: [
+        {
+          title: "Keep",
+          url: "https://good.example/a",
+          properties: { url: "https://good.example/a.jpg" }
+        },
+        {
+          title: "Drop",
+          url: "https://spam.com/b",
+          properties: { url: "https://spam.com/b.jpg" }
+        }
+      ]
+    });
+
+    const result = (await tool.process(ctx, {
+      query: "red fox",
+      search_type: "images",
+      blocked_domains: ["spam.com"]
+    })) as Record<string, unknown>;
+
+    const results = result.results as Array<Record<string, unknown>>;
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe("Keep");
+  });
+
   it("has correct provider tool shape", () => {
     const pt = tool.toProviderTool();
     expect(pt.name).toBe("web_search");

--- a/packages/agents/tests/serp-providers-images.test.ts
+++ b/packages/agents/tests/serp-providers-images.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Image search across the SERP providers.
+ *
+ * Two things are checked here. That `SERP_PROVIDER_SEARCH_TYPES` — which
+ * routing reads *before* a client exists — says what the client classes
+ * actually implement, in both directions, so an image backend cannot be added
+ * and left unreachable, nor advertised and then fail at call time. And that
+ * Brave's image endpoint is read into the same `{title, link, original,
+ * thumbnail}` shape SerpAPI and DataForSEO already return.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  SERP_PROVIDER_SEARCH_TYPES,
+  createSerpProvider,
+  type SerpProviderType
+} from "../src/tools/serp-providers/index.js";
+
+const ALL_PROVIDERS = Object.keys(
+  SERP_PROVIDER_SEARCH_TYPES
+) as SerpProviderType[];
+
+/** Every secret any provider asks for, so the factory always builds. */
+const anySecret = { getSecret: async () => "test-key" };
+
+/** Stub global.fetch with one JSON body. */
+function stubFetch(body: unknown, status = 200) {
+  return vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: async () => body,
+    text: async () => JSON.stringify(body)
+  } as Response);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SERP_PROVIDER_SEARCH_TYPES", () => {
+  it("matches which clients implement searchImages", async () => {
+    for (const name of ALL_PROVIDERS) {
+      const client = await createSerpProvider(name, anySecret);
+      expect(
+        { name, images: typeof client.searchImages === "function" },
+        `${name}: the table and the class disagree`
+      ).toEqual({
+        name,
+        images: SERP_PROVIDER_SEARCH_TYPES[name].includes("images")
+      });
+    }
+  });
+
+  it("lists web for every provider", () => {
+    for (const name of ALL_PROVIDERS) {
+      expect(SERP_PROVIDER_SEARCH_TYPES[name]).toContain("web");
+    }
+  });
+});
+
+describe("BraveProvider.searchImages", () => {
+  it("normalises Brave image results", async () => {
+    const fetchSpy = stubFetch({
+      results: [
+        {
+          title: "A red fox",
+          url: "https://wildlife.example/fox",
+          thumbnail: { src: "https://cdn.example/fox-thumb.jpg" },
+          properties: { url: "https://cdn.example/fox.jpg" }
+        },
+        {
+          title: "Fox in snow",
+          url: "https://photos.example/snow-fox",
+          thumbnail: { src: "https://cdn.example/snow-thumb.jpg" },
+          properties: { url: "https://cdn.example/snow.jpg" }
+        }
+      ]
+    });
+
+    const client = await createSerpProvider("brave", anySecret);
+    const results = await client.searchImages!("red fox", { numResults: 5 });
+
+    expect(results).toEqual([
+      {
+        title: "A red fox",
+        link: "https://wildlife.example/fox",
+        original: "https://cdn.example/fox.jpg",
+        thumbnail: "https://cdn.example/fox-thumb.jpg",
+        position: 1
+      },
+      {
+        title: "Fox in snow",
+        link: "https://photos.example/snow-fox",
+        original: "https://cdn.example/snow.jpg",
+        thumbnail: "https://cdn.example/snow-thumb.jpg",
+        position: 2
+      }
+    ]);
+
+    const url = String(fetchSpy.mock.calls[0][0]);
+    expect(url).toContain("/res/v1/images/search");
+    expect(url).toContain("count=5");
+  });
+
+  it("clamps count to the 100 Brave's image endpoint accepts", async () => {
+    const fetchSpy = stubFetch({ results: [] });
+    const client = await createSerpProvider("brave", anySecret);
+    await client.searchImages!("otters", { numResults: 500 });
+    expect(String(fetchSpy.mock.calls[0][0])).toContain("count=100");
+  });
+
+  it("reports a failed request instead of an empty result list", async () => {
+    stubFetch({ message: "Subscription does not include image search" }, 403);
+    const client = await createSerpProvider("brave", anySecret);
+    await expect(client.searchImages!("otters")).rejects.toThrow(
+      /Brave Search request failed \(403\)/
+    );
+  });
+
+  it("survives a result carrying no image url", async () => {
+    stubFetch({ results: [{ title: "Bare" }] });
+    const client = await createSerpProvider("brave", anySecret);
+    expect(await client.searchImages!("bare")).toEqual([
+      {
+        title: "Bare",
+        link: null,
+        original: null,
+        thumbnail: null,
+        position: 1
+      }
+    ]);
+  });
+});

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -1121,7 +1121,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "take_screenshot",
     module: "web",
     impl: "packages/agents/src/capabilities/web.ts",
-    contract: "fae5f5a3d1c0",
+    contract: "6990fdc0a93a",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-web.test.ts",

--- a/web/src/__tests__/mediaResolutionBoundary.test.ts
+++ b/web/src/__tests__/mediaResolutionBoundary.test.ts
@@ -56,6 +56,7 @@ const INVENTORY: Surface[] = [
   { surface: "chat media", file: "components/chat/message/MessageContentRenderer.tsx", via: "resolver" },
   { surface: "chat media", file: "components/chat/message/ChatMarkdown.tsx", via: "resolver" },
   { surface: "chat media", file: "components/chat/composer/FilePreview.tsx", via: "locator" },
+  { surface: "chat media", file: "components/chat/message/toolResults/SearchResults.tsx", via: "locator" },
   // Storyboard cards
   { surface: "storyboard cards", file: "components/storyboard/ShotCard.tsx", via: "locator" },
   { surface: "storyboard cards", file: "components/storyboard/ShotTakesGallery.tsx", via: "locator" },
@@ -90,7 +91,7 @@ describe("media resolution boundary", () => {
         "app builder media"
       ])
     );
-    expect(INVENTORY.length).toBeGreaterThanOrEqual(13);
+    expect(INVENTORY.length).toBeGreaterThanOrEqual(14);
   });
 
   it.each(INVENTORY)("$file reaches the boundary via $via", ({ file, via }) => {

--- a/web/src/components/chat/message/toolResults/SearchResults.tsx
+++ b/web/src/components/chat/message/toolResults/SearchResults.tsx
@@ -1,6 +1,15 @@
 import React from "react";
-import { FlexColumn, FlexRow, Text } from "../../../ui_primitives";
+import {
+  BORDER_RADIUS,
+  FlexColumn,
+  FlexRow,
+  ResponsiveImage,
+  Text
+} from "../../../ui_primitives";
 import type { SearchResultItem } from "./parseSearchResults";
+
+/** Edge of the preview an image search result renders, in px. */
+const THUMBNAIL_SIZE = 56;
 
 interface SearchResultsProps {
   items: SearchResultItem[];
@@ -30,6 +39,17 @@ const SearchResultsBase: React.FC<SearchResultsProps> = ({ items }) => (
         >
           {String(index + 1).padStart(2, "0")}
         </Text>
+        {item.imageUrl && (
+          <ResponsiveImage
+            locator={item.imageUrl}
+            alt={item.title}
+            aspectRatio="1/1"
+            fit="cover"
+            borderRadius={BORDER_RADIUS.sm}
+            className="tool-search-thumbnail"
+            sx={{ width: THUMBNAIL_SIZE, flexShrink: 0 }}
+          />
+        )}
         <FlexColumn gap={0.5} sx={{ minWidth: 0, flex: 1 }}>
           <FlexRow gap={1} justify="space-between" align="baseline" sx={{ minWidth: 0 }}>
             {item.url ? (

--- a/web/src/components/chat/message/toolResults/__tests__/parseSearchResults.test.ts
+++ b/web/src/components/chat/message/toolResults/__tests__/parseSearchResults.test.ts
@@ -64,6 +64,46 @@ describe("normalizeSearchResults", () => {
     expect(items![0].title).toBe("T");
   });
 
+  test("carries an image search result's preview", () => {
+    const items = normalizeSearchResults({
+      success: true,
+      results: [
+        {
+          title: "A red fox",
+          link: "https://wildlife.example/fox",
+          original: "https://cdn.example/fox.jpg",
+          thumbnail: "https://cdn.example/fox-thumb.jpg"
+        }
+      ]
+    });
+    expect(items).toHaveLength(1);
+    expect(items![0]).toMatchObject({
+      title: "A red fox",
+      url: "https://wildlife.example/fox",
+      imageUrl: "https://cdn.example/fox-thumb.jpg"
+    });
+  });
+
+  test("falls back to the image itself when a backend sends no thumbnail", () => {
+    const items = normalizeSearchResults({
+      results: [
+        {
+          title: "Bare",
+          link: "https://wildlife.example/fox",
+          original: "https://cdn.example/fox.jpg"
+        }
+      ]
+    });
+    expect(items![0].imageUrl).toBe("https://cdn.example/fox.jpg");
+  });
+
+  test("leaves imageUrl unset on results with no picture", () => {
+    const items = normalizeSearchResults([
+      { title: "T", url: "https://e.com", snippet: "s" }
+    ]);
+    expect(items![0].imageUrl).toBeUndefined();
+  });
+
   test("returns null for non-search content", () => {
     expect(normalizeSearchResults(null)).toBeNull();
     expect(normalizeSearchResults("")).toBeNull();

--- a/web/src/components/chat/message/toolResults/parseSearchResults.ts
+++ b/web/src/components/chat/message/toolResults/parseSearchResults.ts
@@ -5,6 +5,8 @@ import { isObjectLike, isString } from "../../../../utils/typePredicates";
  * three different forms:
  *
  *  - `web_search` with search_type news/images: `{ results: [{ title, link, snippet, ... }] }`
+ *    — image results additionally carry `original` (the image file) and
+ *      `thumbnail` (a preview), which become `imageUrl`
  *  - SERP-style providers: a bare array of result objects
  *  - `google_search`: a numbered plain-text block (`"1. Title\n   url\n   snippet"`)
  *
@@ -18,6 +20,12 @@ export interface SearchResultItem {
   snippet?: string;
   source?: string;
   date?: string;
+  /**
+   * A picture of the result, for image searches. The preview when the backend
+   * offers one, else the image itself — every image backend returns at least
+   * one of the two, so a result that has neither is not an image result.
+   */
+  imageUrl?: string;
 }
 
 function domainFromUrl(url: string): string | undefined {
@@ -61,7 +69,8 @@ function itemFromObject(obj: Record<string, unknown>): SearchResultItem | null {
     url,
     snippet,
     source: normalizeSource(obj, url),
-    date: pickString(obj, "date", "published", "published_at")
+    date: pickString(obj, "date", "published", "published_at"),
+    imageUrl: pickString(obj, "thumbnail", "original", "image_url")
   };
 }
 


### PR DESCRIPTION
## What changed

`web_search` has served `search_type: "images"` on SerpAPI and DataForSEO, but the two SERP-factory backends were declared web-only, so an install whose only key is `BRAVE_API_KEY` could not search for an image at all — and worse, it did not fall through: the injected SERP client made the `serpapi` backend look configured whatever `SERP_PROVIDER` actually named, so a Brave-backed install answered an image search with `SERPAPI_API_KEY is not configured` instead of routing on. This adds `SerpProvider.searchImages`, implements it against Brave's `/res/v1/images/search`, routes `search_type: "images"` through it, and fixes the injected-client check so it is only consulted on the web path it serves. Backends now declare their search types in `SERP_PROVIDER_SEARCH_TYPES`, which routing reads before a client exists; a test instantiates every provider and checks the table against the class in both directions, so an image backend cannot be added and left unreachable, nor advertised and then fail at call time. Result records keep the exact `{title, link, original, thumbnail}` shape the two existing image paths return, so a caller reads one shape whichever backend answered — and the chat result renderer now carries each result's preview and shows it, so an image search reads as pictures rather than a list of links.

## Verification

- [x] `npm run test:affected` — all affected suites passed (19 packages, web, electron). The `base-nodes` shader tests needed `mesa-vulkan-drivers` installed first, per AGENTS.md § WebGPU on a headless machine.
- [x] `npm run typecheck` — web and electron clean. Mobile fails on `Cannot find module 'react-native'` etc. because `mobile/node_modules` does not exist in this container (mobile is not a root workspace); no file in this diff is under `mobile/`.
- [x] `npm run lint` — exit 0.
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — 3/3 selfchecks passed.

The routing table's drift guard was inverted once and observed failing. With `apify: ["web", "images"]` in `SERP_PROVIDER_SEARCH_TYPES` while `ApifyProvider` implements no `searchImages`:

```
× matches which clients implement searchImages 10ms
AssertionError: apify: the table and the class disagree:
  expected { name: 'apify', images: false } to deeply equal { name: 'apify', images: true }
Tests  1 failed | 5 passed (6)
```

Restored, and the suite is green.

## Agent capabilities

No capability is added and no declared contract changes — `webSearchSpec`'s name, description, input schema and category are untouched; only which backend answers a `search_type` it already advertised.

`npm run capabilities:check` was **already failing on the merge base** (7e6cc5f4): `take_screenshot`'s recorded contract fingerprint no longer matched its spec, from a change that landed earlier. Since it gates `harness gate`, the one-command regeneration is ported here as its own commit rather than left red. Nothing in this branch touches that capability.

## New checks

- [x] `SERP_PROVIDER_SEARCH_TYPES` vs. the provider classes was inverted once and observed failing; the output is in **Verification** above.
- [x] The check enumerates `Object.keys(SERP_PROVIDER_SEARCH_TYPES)` and asserts per provider, so it cannot pass by matching nothing; a second case asserts every provider still lists `web`.
- [x] `web/src/__tests__/mediaResolutionBoundary.test.ts` gains the new rendering surface and its minimum-inventory count rises to 14, so the row cannot be silently dropped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2MHgJjeWUQ5EvYXspTyma)_