### PR TITLE
docs(plans): project-view plan with mockups

### DIFF
--- a/docs/plans/project-view/PLAN.md
+++ b/docs/plans/project-view/PLAN.md
@@ -10,9 +10,9 @@ center area untouched.
 
 ## Mockups
 
-Four 1440×900 screens in `mockups/` (open in any browser; the `support.js`
-script tag 404s harmlessly — everything is inline styles). Also published as an
-editable canvas: https://claude.ai/code/artifact/9fde1641-9965-4f71-bb23-2543ef4bc4db
+Four 1440×900 screens in `mockups/` (self-contained HTML, inline styles; open
+in any browser). Also published as an editable canvas:
+https://claude.ai/code/artifact/9fde1641-9965-4f71-bb23-2543ef4bc4db
 
 | File | Screen | Referenced by |
 |---|---|---|

--- a/docs/plans/project-view/PLAN.md
+++ b/docs/plans/project-view/PLAN.md
@@ -1,0 +1,239 @@
+# Project View — Implementation Plan
+
+Make the *project* the unit of the workspace instead of the *document*. Every
+document row already carries a `project_id` column (`packages/models/src/db.ts`
+— `timeline_sequences`, `image_documents`, `applications`, and siblings) and
+every creation site hardcodes `projectId: "default"`. This plan spends that
+column: a project is a tab group plus one overview tab inside the existing
+`WorkspaceShell`. No new window, no mode. The fifteen document editors keep the
+center area untouched.
+
+## Mockups
+
+Four 1440×900 screens in `mockups/` (open in any browser; the `support.js`
+script tag 404s harmlessly — everything is inline styles). Also published as an
+editable canvas: https://claude.ai/code/artifact/9fde1641-9965-4f71-bb23-2543ef4bc4db
+
+| File | Screen | Referenced by |
+|---|---|---|
+| `mockups/storyboard-board.html` | Storyboard editor restyled as a shot grid, inside a project tab group | Phase 0, A1–A4; Phase 2, B1–B2; Phase 5, E1 |
+| `mockups/projects-list.html` | Projects list tab | Phase 2, B3; Phase 3, C4 |
+| `mockups/project-overview.html` | Project overview tab, populated (Aurora Launch Spot) | Phase 3, C1–C3; Phase 4 (spend) |
+| `mockups/new-project.html` | Full-view "Start a project" surface | Phase 4, D1–D3 |
+
+The mockups draw the shipped chrome from real values: 40px tab bar
+(`c_app_header` #0A0B0D), 50px full-height rail, 32px bottom strip, `divider`
+rgba(255,255,255,0.08), fonts Inter 22/18/15/13/11 + JetBrains Mono, radii from
+`theme.rounded`. Anything in a mockup that differs from a token in
+`web/src/components/themes/ThemeNodetool.tsx` or `docs/DESIGN.md` — the tokens
+win. Type glyph colors come from `colorForType` in `web/src/config/data_types.ts`
+(the mockups hardcode the same hex values).
+
+Project identity color everywhere: `info.light` cyan `#67E8F9` — rail icon,
+scope chip, group underline, `◆` glyph.
+
+## Ordering
+
+Phase 0 ships alone, first (explicit request: the restyled storyboard is wanted
+regardless of the project layer). Phases 1→5 build on each other; 1 and 0 are
+independent.
+
+Rules that apply to every phase: ui_primitives only (no raw MUI), design tokens
+only (SPACING / BORDER_RADIUS / MOTION / Z_INDEX / `var(--fontSize*)`), media
+through `ResponsiveImage`/`VideoPlayer` with `locator`, and after each phase
+`npm run test:affected && npm run typecheck && npm run lint` must pass.
+
+---
+
+## Phase 0 — Restyle the storyboard board as a shot grid
+
+Reference: `mockups/storyboard-board.html`, center area. Today
+(`web/src/components/storyboard/StoryboardBoard.tsx`) the board is a large
+settings `Panel` (Screenplay + Direction `FormGrid`, then a wide button row)
+followed by a vertical list of `ShotCard`s, each a two-column card
+(`shotCardGridSx`: `minmax(220px, 300px) minmax(0, 1fr)`). The mockup replaces
+that with a dense grid the user approved. Keep all existing behavior (store
+wiring, Direct/re-direct dialog, generate hooks, undo/redo, preview, zip, script
+link); this phase is presentation.
+
+- **A1 — Compact board toolbar.** Collapse the settings `Panel` into one
+  toolbar row at the top of the surface: board title (18px, weight 600), a
+  13px `text.secondary` meta line ("8 shots · night-minimal style · entity:
+  Aurora lamp" — shot count, style field, entity names), then right-aligned
+  actions: `Render stills`, `Render clips` (outlined) and `Assemble timeline`
+  (contained primary). Move the full Screenplay/Direction form (title, brief,
+  style, entities, the three model pickers, aspect ratio, shot count, Direct)
+  into a collapsible section or popover opened from the toolbar — it must stay
+  reachable, but not permanently occupy the top of the board. Undo/redo,
+  Preview, Download ZIP, and ScriptLinkControl move into the same toolbar row
+  or its overflow. Files: `StoryboardBoard.tsx`.
+- **A2 — Shot grid.** Replace the vertical `ShotCard` list with a responsive
+  CSS grid: `repeat(4, minmax(0, 1fr))` at desktop width, collapsing to 3/2/1
+  columns. Each card (restyled `ShotCard.tsx`): thumbnail on top (fixed-height
+  media area, `background.paper` card, 1px `divider` border, `BORDER_RADIUS.lg`),
+  action text below (13px, 1.45 line-height, 2-line clamp), overlays on the
+  thumbnail: top-left `SH NN · Ns` mono label on a scrim, bottom-right status
+  pill. The per-shot detail editing that no longer fits the card (prompt,
+  render mode, takes gallery, per-shot model) moves to a selected-shot
+  inspector or expand-in-place — decide against `ShotCard.tsx`'s current
+  feature list and keep every existing control reachable. Files:
+  `ShotCard.tsx`, `StoryboardBoard.tsx`, tests in
+  `web/src/components/storyboard/__tests__/`.
+- **A3 — Status vocabulary.** Pills are `JetBrains Mono` 11px, pill radius:
+  done = `success.main` #50FA7B on rgba(80,250,123,0.12) with 0.5-alpha border
+  ("clip · 38s"); rendering = video-violet #9460FF border on
+  rgba(148,96,255,0.16) plus a 3px progress bar along the thumbnail's bottom
+  edge, and the whole card takes a 1px #9460FF border (mid-render border, per
+  the app's visual language); still-only/queued = neutral
+  rgba(255,255,255,0.06)/0.15. Selected card: 1px `primary.main` border +
+  1px spread ring, as in the mockup's SH 05.
+- **A4 — Selection footer.** A 44px bar docked under the grid when a shot is
+  selected: `SH NN selected`, then "Appears in" chips (see E1 for where the
+  links come from; in this phase render the chips only for what the board
+  already knows — the linked script line via `ScriptLinkControl` data),
+  right-aligned `Revise take` and `Re-render clip` actions bound to the
+  existing generate hooks. Until E1 lands the timeline chip is omitted, not
+  faked.
+
+Acceptance: board renders 8+ shots as a grid matching the mockup's geometry;
+all pre-existing storyboard tests pass (updated where they assert the old
+layout); no raw MUI imports; `npm run test:affected` green.
+
+## Phase 1 — Projects data layer
+
+No mockup; this is the substrate. Backend only.
+
+- **P1 — `projects` table + model.** `packages/models`: id, user_id, name,
+  kind (free text: "spot", "trailer", "report", …), created_at, updated_at.
+  Follow an existing small model (e.g. `packages/models/src/script.ts`) for
+  shape, migrations in both sqlite and pg schema paths in
+  `packages/models/src/db.ts` / `schema-pg`.
+- **P2 — tRPC router.** `projects.list / get / create / update / delete` plus
+  `projects.documents(id)` — one query per document table filtered on
+  `project_id`, returned as a typed union `{type, ref, name, updated_at}`
+  matching `WorkspaceTabType`. Wire where the other routers live
+  (`packages/websocket`).
+- **P3 — Status + spend rollup.** `projects.get` returns a derived status line
+  and spend. Status from document state: storyboard (shot count, stills n/m,
+  clips n/m), script (lines voiced/stale via `needsVoicing` from
+  `@nodetool-ai/timeline`), timeline (clip count, rendered or not). Spend from
+  the prediction/cost ledger (`nodetool costs` reads it; see
+  `attachRunCostLedger` in `@nodetool-ai/execution`) — requires cost rows to
+  carry a project attribution: add `project_id` to the prediction record where
+  it is written, nullable, backfilled as null. Per-document and per-category
+  (stills/clips/voice/pipeline) sums, as shown in
+  `mockups/project-overview.html`'s spend bar.
+- **P4 — Creation sites take a project.** Replace the hardcoded
+  `projectId: "default"` at every web creation site (grep `projectId:
+  "default"` under `web/src`) with the active project id from the store added
+  in B1, falling back to `"default"` when no project is active. `"default"`
+  remains the loose-documents bucket; no migration of existing rows.
+
+## Phase 2 — Shell: project group, rail entry, projects list
+
+References: `mockups/storyboard-board.html` and `mockups/project-overview.html`
+(tab bar anatomy), `mockups/projects-list.html` (list surface).
+
+- **B1 — Active-project state.** `web/src/stores/WorkspaceTabsStore.ts`: tabs
+  gain an optional `projectId`; store gains `activeProjectId` plus
+  open/close-project actions. Opening a project opens its overview tab and
+  restores its document tabs as one contiguous group.
+- **B2 — Tab bar group rendering.** `WorkspaceTabBar.tsx`: tabs sharing the
+  active `projectId` render contiguously behind a scope chip — `◆ <project
+  name> ▾` on rgba(103,232,249,0.06) with `inset 0 -2px 0 #67E8F9`; grouped
+  tabs carry `inset 0 -2px 0 rgba(103,232,249,0.35)`. The chip's menu:
+  switch project, close group, open overview. Loose tabs render exactly as
+  today. Active tab keeps its existing background treatment.
+- **B3 — Projects rail entry + list tab.** `PanelLeft.tsx`: a Projects section
+  at the top (diamond icon, cyan when a project surface is active). It opens a
+  `project-list` tab rendering `mockups/projects-list.html`'s center: header
+  row (title, search, `+ New project`), 3-column card grid — thumbnail montage
+  from real shot stills (via `ResponsiveImage` + locators), name row with `◆`
+  and relative time, status line and spend from P3, status pill styles as in
+  A3 — then a "Not in a project" strip of loose documents (chips, drag onto a
+  card sets `project_id`). Ghost card opens the D1 surface.
+- **B4 — Tab type registry.** `WorkspaceTabsStore`/`TabContent`/`OpenMenu`
+  glyph+color tables gain the new types (`project-list`, `project`,
+  `project-new`): glyph `◆`, color #67E8F9. Update
+  `SUPPORTS_BOTH_MODES`, `TYPE_GLYPH`, `TYPE_COLOR` in `WorkspaceTabBar.tsx`.
+
+## Phase 3 — Project overview tab
+
+Reference: `mockups/project-overview.html`.
+
+- **C1 — Layout.** New `project` tab type, first tab of its group. Header
+  strip: name + status pill, derived status line, spend block ("$4.12 / so far
+  · provider rates, no markup"), primary next-step action (label derived from
+  status: "Render master", "Render clips", …). Below: 460px left column +
+  fluid right column, split by `divider`.
+- **C2 — Left: the project agent.** The chat thread that built the project
+  (`chat` document bound to the project), rendered compactly: user turns as
+  bubbles, agent turns as text + tool-call chips (mono 11px on `Paper.overlay`),
+  status pills for renders it kicked off. Input box at the bottom feeds the
+  same thread. Reuse the existing chat components where they fit; this is a
+  narrow rendering of an existing thread, not a new chat system.
+- **C3 — Right: document cards.** One card per project document: type-specific
+  thumbnail (storyboard = 4-still strip, script = first lines with
+  voiced/stale dots, timeline = track miniature, workflow = node sketch),
+  name, status pill, meta line with per-document spend. Click opens the
+  document tab in the group. Card geometry per the mockup: 2-column grid,
+  120px media area, 8px radius.
+- **C4 — Spend bar.** Bottom of the right column: stacked bar split by
+  category with a mono legend, totals from P3. Categories and colors:
+  stills #E838FF, clips #9460FF, voice #08B8FF, pipeline #6690d4. Unpriced
+  spend shows as an `unpriced` segment, not dropped (ledger convention).
+
+## Phase 4 — New-project surface
+
+Reference: `mockups/new-project.html`. Full center-view surface, itself a tab
+(`project-new`), opened from `+ New`, the projects list ghost card, and the
+rail.
+
+- **D1 — Layout.** Centered 860px column: "What do you want to make?" (22px),
+  one-line promise (13px secondary), prompt card (`background.paper`, 1px
+  `primary.main` border, 12px radius) with context chips (ref images, voice,
+  entities), cost estimate line ("est. $3–6 · provider rates, no markup" —
+  from the shape preset's historical range, or omitted when unknown; never a
+  made-up number), `Start` primary button. Shape shortcut chips below; the
+  selected shape renders its document chain (Board → Script → Cut → Render
+  pipeline) as a glyph row. Foot of the view: "Blank document" strip — the
+  full existing `OpenMenu` catalog as a 6-column grid, opening loose tabs
+  exactly as today.
+- **D2 — Start wiring.** `Start` creates the project row (P1), opens its group
+  with the overview tab (C1), and posts the prompt as the first turn of the
+  project's agent thread. The agent builds documents through the existing
+  headless tools (`create_storyboard`, `voice_script_lines`,
+  `assemble_storyboard_timeline`, …) with the project id applied via P4.
+- **D3 — OpenMenu demotion.** The `+ New` button keeps its popover for
+  keyboard/muscle-memory flow, but its first item becomes "Start a project…"
+  opening the D1 tab; the document list stays beneath. `OpenMenu.tsx`.
+
+## Phase 5 — Cross-document context
+
+Reference: `mockups/storyboard-board.html`, selection footer.
+
+- **E1 — "Appears in" links.** Given a selected shot, resolve where it lands
+  in sibling documents: timeline placement via `buildStoryboardTimeline`'s
+  shot→clip mapping (`@nodetool-ai/timeline`) against the project's assembled
+  sequence, script line via the existing script↔storyboard link
+  (`get_storyboard` link state). Render as chips (violet ▤ timeline at
+  timecode, sky 🎙 script line); clicking opens the sibling tab and selects
+  the clip/line there. Requires a "select this clip/line on open" param on the
+  timeline and script tab-open paths.
+- **E2 — Reverse direction.** Timeline clip selection shows a "from Board ·
+  SH NN" chip that jumps back. Same mechanism, other direction.
+
+## Out of scope
+
+Mobile (documents open one-per-screen there; project grouping needs its own
+design), Electron-specific chrome, migrating existing `"default"` rows into
+projects, and any change to the fifteen editors beyond Phase 0's storyboard
+restyle and E1/E2's selection deep-links.
+
+## Verification per phase
+
+`npm run test:affected`, `npm run typecheck`, `npm run lint`. Phase 0 also:
+existing storyboard suites updated, `nodetool harness gate --base main` if the
+diff touches surfaces the registry maps. Phases 1–2: model tests beside the
+new table, router tests, `WorkspaceTabsStore` unit tests for grouping. UI
+phases: RTL tests for the new surfaces (behavior, not layout snapshots).

--- a/docs/plans/project-view/mockups/new-project.html
+++ b/docs/plans/project-view/mockups/new-project.html
@@ -3,7 +3,6 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="./support.js"></script>
 </head>
 <body>
 <x-dc>

--- a/docs/plans/project-view/mockups/new-project.html
+++ b/docs/plans/project-view/mockups/new-project.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<!-- Mockup for docs/plans/project-view/PLAN.md — Phase 4 (D1-D3). 1440x900; chrome matches the shipped WorkspaceShell. Editable canvas: https://claude.ai/code/artifact/9fde1641-9965-4f71-bb23-2543ef4bc4db -->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
+  <style>
+    body { margin: 0; background: #08090A; }
+    a { color: #6690d4; } a:hover { color: #7aa0e2; }
+    * { box-sizing: border-box; }
+  </style>
+</helmet>
+<div style="position: relative; width: 1440px; height: 900px; background: #08090A; color: #F7F8F8; font-family: 'Inter', Arial, sans-serif; overflow: hidden;">
+
+  <!-- ===== Tab bar ===== -->
+  <div style="position: absolute; top: 0; left: 0; right: 0; height: 40px; padding-left: 50px; background: #0A0B0D; border-bottom: 1px solid rgba(255,255,255,0.08); display: flex; align-items: stretch;">
+    <div style="display: flex; align-items: center; gap: 6px; padding: 0 16px; border-right: 1px solid rgba(255,255,255,0.08); color: #6690d4; font-size: 13px; font-weight: 500;">
+      <span style="font-size: 15px; line-height: 1;">+</span><span>New</span><span style="font-size: 11px; opacity: 0.75; margin-left: 2px;">▾</span>
+    </div>
+    <!-- The new-project surface is itself a tab, so it can sit beside open work -->
+    <div style="display: flex; align-items: center; gap: 8px; min-width: 150px; max-width: 240px; padding: 0 12px 0 16px; background: #08090A; color: #F7F8F8; border-right: 1px solid rgba(255,255,255,0.08); font-size: 13px;">
+      <span style="color: #67E8F9; font-size: 13px;">◆</span>
+      <span style="flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">New project</span>
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="rgba(247,248,248,0.38)" stroke-width="1.4"><path d="M3.5 3.5l7 7M10.5 3.5l-7 7"/></svg>
+    </div>
+    <div style="flex: 1;"></div>
+    <div style="display: flex; align-items: center; padding-right: 8px;">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="#8A8F98" stroke-width="1.3"><path d="M8 2a4 4 0 0 1 4 4v3l1.2 2H2.8L4 9V6a4 4 0 0 1 4-4z"/><path d="M6.7 13.4a1.5 1.5 0 0 0 2.6 0"/></svg>
+    </div>
+  </div>
+
+  <!-- ===== Left rail ===== -->
+  <div style="position: absolute; top: 0; left: 0; bottom: 0; width: 50px; background: #0A0B0D; border-right: 1px solid rgba(255,255,255,0.08); display: flex; flex-direction: column; align-items: center; padding: 10px 0 12px 0; gap: 4px; z-index: 3;">
+    <svg width="22" height="22" viewBox="0 0 22 22" fill="none" style="margin-bottom: 10px;"><path d="M11 2l7.8 4.5v9L11 20l-7.8-4.5v-9z" stroke="#F7F8F8" stroke-width="1.5"/><circle cx="11" cy="11" r="2.4" fill="#6690d4"/></svg>
+    <div style="width: 34px; height: 34px; border-radius: 6px; background: rgba(255,255,255,0.05); display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#67E8F9" stroke-width="1.5"><path d="M9 2.2l6.8 6.8L9 15.8 2.2 9z"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><rect x="2.5" y="2.5" width="5.4" height="5.4" rx="1"/><rect x="10.1" y="2.5" width="5.4" height="5.4" rx="1"/><rect x="2.5" y="10.1" width="5.4" height="5.4" rx="1"/><rect x="10.1" y="10.1" width="5.4" height="5.4" rx="1"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><path d="M9 2.5l5.6 3.2v6.6L9 15.5l-5.6-3.2V5.7z"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><path d="M3 4.5h12v7.5H8.5L5.5 15v-3H3z"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><path d="M11.5 3.2l3.3 3.3L6.3 15H3v-3.3z"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><path d="M3 5h12M3 9h8M3 13h10"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><rect x="2.5" y="3.5" width="13" height="11" rx="1.5"/><path d="M6.8 3.5v11M11.2 3.5v11"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><circle cx="9" cy="6.4" r="3"/><path d="M3.4 15c.9-2.8 3-4.2 5.6-4.2s4.7 1.4 5.6 4.2"/></svg>
+    </div>
+    <div style="flex: 1;"></div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><circle cx="9" cy="9" r="2.4"/><path d="M9 2.5v2M9 13.5v2M2.5 9h2M13.5 9h2M4.4 4.4l1.4 1.4M12.2 12.2l1.4 1.4M13.6 4.4l-1.4 1.4M5.8 12.2l-1.4 1.4"/></svg>
+    </div>
+  </div>
+
+  <!-- ===== Bottom strip ===== -->
+  <div style="position: absolute; bottom: 0; left: 50px; right: 0; height: 32px; background: #101113; border-top: 1px solid rgba(255,255,255,0.08); display: flex; align-items: center; padding: 0 12px; gap: 16px; font-size: 11px; color: #8A8F98;">
+    <span>Logs</span><span>Queue</span><span>Workers</span><span>Versions</span><span>Trace</span>
+    <div style="flex: 1;"></div>
+    <div style="display: flex; align-items: center; gap: 6px; font-family: 'JetBrains Mono', monospace;"><span style="width: 6px; height: 6px; border-radius: 50%; background: #50FA7B; display: inline-block;"></span><span>worker · local</span></div>
+  </div>
+
+  <!-- ===== Center: full-view new-project surface ===== -->
+  <div style="position: absolute; top: 40px; left: 50px; right: 0; bottom: 32px; overflow: hidden; display: flex; flex-direction: column; align-items: center;">
+
+    <div style="width: 860px; display: flex; flex-direction: column; gap: 20px; padding-top: 96px;">
+      <div style="display: flex; flex-direction: column; gap: 8px; align-items: center; text-align: center;">
+        <div style="font-size: 22px; font-weight: 600; letter-spacing: -0.01em;">What do you want to make?</div>
+        <div style="font-size: 13px; color: #8A8F98; max-width: 560px; line-height: 1.5;">An agent plans the documents — a board, a script, a cut — and builds them while you watch. Everything it makes stays editable.</div>
+      </div>
+
+      <!-- Prompt card -->
+      <div style="background: #101113; border: 1px solid #6690d4; border-radius: 12px; padding: 18px 20px 14px 20px; display: flex; flex-direction: column; gap: 16px;">
+        <div style="font-size: 15px; line-height: 1.55; color: #F7F8F8; min-height: 70px;">A 30-second launch spot for our desk lamp — warm, minimal, night-time mood<span style="display: inline-block; width: 1px; height: 16px; background: #6690d4; vertical-align: text-bottom; margin-left: 1px;"></span></div>
+        <div style="display: flex; align-items: center; gap: 8px;">
+          <span style="height: 26px; padding: 0 10px; border-radius: 9999px; border: 1px solid rgba(255,255,255,0.15); color: #9CA0A8; font-size: 11px; display: inline-flex; align-items: center; gap: 5px;"><span style="color: #E838FF;">▦</span> ref images · 0</span>
+          <span style="height: 26px; padding: 0 10px; border-radius: 9999px; border: 1px solid rgba(255,255,255,0.15); color: #9CA0A8; font-size: 11px; display: inline-flex; align-items: center; gap: 5px;"><span style="color: #08B8FF;">♪</span> voice · Ines</span>
+          <span style="height: 26px; padding: 0 10px; border-radius: 9999px; border: 1px solid rgba(255,255,255,0.15); color: #9CA0A8; font-size: 11px; display: inline-flex; align-items: center; gap: 5px;"><span style="color: #B0F030;">◈</span> entities · none</span>
+          <div style="flex: 1;"></div>
+          <span style="font-size: 11px; color: #5C606A; font-family: 'JetBrains Mono', monospace;">est. $3–6 · provider rates, no markup</span>
+          <span style="display: inline-flex; align-items: center; gap: 6px; height: 32px; padding: 0 18px; background: #6690d4; border-radius: 6px; color: #fff; font-size: 13px; font-weight: 500;">Start</span>
+        </div>
+      </div>
+
+      <!-- Shape shortcuts -->
+      <div style="display: flex; justify-content: center; flex-wrap: wrap; gap: 8px;">
+        <span style="height: 28px; padding: 0 12px; border-radius: 9999px; background: rgba(103,232,249,0.06); border: 1px solid rgba(103,232,249,0.4); color: #67E8F9; font-size: 13px; display: inline-flex; align-items: center;">30s spot</span>
+        <span style="height: 28px; padding: 0 12px; border-radius: 9999px; border: 1px solid rgba(255,255,255,0.15); color: #9CA0A8; font-size: 13px; display: inline-flex; align-items: center;">Trailer</span>
+        <span style="height: 28px; padding: 0 12px; border-radius: 9999px; border: 1px solid rgba(255,255,255,0.15); color: #9CA0A8; font-size: 13px; display: inline-flex; align-items: center;">Music video</span>
+        <span style="height: 28px; padding: 0 12px; border-radius: 9999px; border: 1px solid rgba(255,255,255,0.15); color: #9CA0A8; font-size: 13px; display: inline-flex; align-items: center;">Research report</span>
+        <span style="height: 28px; padding: 0 12px; border-radius: 9999px; border: 1px solid rgba(255,255,255,0.15); color: #9CA0A8; font-size: 13px; display: inline-flex; align-items: center;">Mini app</span>
+        <span style="height: 28px; padding: 0 12px; border-radius: 9999px; border: 1px solid rgba(255,255,255,0.15); color: #9CA0A8; font-size: 13px; display: inline-flex; align-items: center;">Empty project</span>
+      </div>
+
+      <!-- What a project shape sets up, shown for the selected shortcut -->
+      <div style="display: flex; justify-content: center; align-items: center; gap: 10px; font-size: 11px; color: #5C606A;">
+        <span>30s spot sets up</span>
+        <span style="display: inline-flex; align-items: center; gap: 5px; color: #8A8F98;"><span style="color: #9460FF;">▥</span> Board</span>
+        <span style="color: #3A3D44;">→</span>
+        <span style="display: inline-flex; align-items: center; gap: 5px; color: #8A8F98;"><span style="color: #08B8FF;">🎙</span> Script</span>
+        <span style="color: #3A3D44;">→</span>
+        <span style="display: inline-flex; align-items: center; gap: 5px; color: #8A8F98;"><span style="color: #9460FF;">▤</span> Cut</span>
+        <span style="color: #3A3D44;">→</span>
+        <span style="display: inline-flex; align-items: center; gap: 5px; color: #8A8F98;"><span style="color: #A7B1BF;">⬡</span> Render pipeline</span>
+      </div>
+    </div>
+
+    <div style="flex: 1;"></div>
+
+    <!-- Blank documents, demoted to the foot of the view -->
+    <div style="width: 860px; padding-bottom: 28px; display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: baseline; gap: 8px; border-top: 1px solid rgba(255,255,255,0.08); padding-top: 14px;">
+        <div style="font-size: 11px; color: #5C606A; text-transform: uppercase; letter-spacing: 0.08em;">Blank document</div>
+        <div style="font-size: 11px; color: #5C606A;">— opens as a loose tab, outside any project</div>
+      </div>
+      <div style="display: grid; grid-template-columns: repeat(6, minmax(0, 1fr)); gap: 6px;">
+        <div style="display: flex; align-items: center; gap: 8px; height: 32px; padding: 0 10px; border-radius: 6px; font-size: 13px; color: #D4D6DB;"><span style="color: #A7B1BF;">⬡</span> Workflow</div>
+        <div style="display: flex; align-items: center; gap: 8px; height: 32px; padding: 0 10px; border-radius: 6px; font-size: 13px; color: #D4D6DB;"><span style="color: #FFA808;">❝</span> Chat</div>
+        <div style="display: flex; align-items: center; gap: 8px; height: 32px; padding: 0 10px; border-radius: 6px; font-size: 13px; color: #D4D6DB;"><span style="color: #9460FF;">▥</span> Storyboard</div>
+        <div style="display: flex; align-items: center; gap: 8px; height: 32px; padding: 0 10px; border-radius: 6px; font-size: 13px; color: #D4D6DB;"><span style="color: #9460FF;">▤</span> Timeline</div>
+        <div style="display: flex; align-items: center; gap: 8px; height: 32px; padding: 0 10px; border-radius: 6px; font-size: 13px; color: #D4D6DB;"><span style="color: #08B8FF;">🎙</span> Script</div>
+        <div style="display: flex; align-items: center; gap: 8px; height: 32px; padding: 0 10px; border-radius: 6px; font-size: 13px; color: #D4D6DB;"><span style="color: #E838FF;">✎</span> Sketch</div>
+        <div style="display: flex; align-items: center; gap: 8px; height: 32px; padding: 0 10px; border-radius: 6px; font-size: 13px; color: #D4D6DB;"><span style="color: #E838FF;">▦</span> Image</div>
+        <div style="display: flex; align-items: center; gap: 8px; height: 32px; padding: 0 10px; border-radius: 6px; font-size: 13px; color: #D4D6DB;"><span style="color: #08B8FF;">♪</span> Audio</div>
+        <div style="display: flex; align-items: center; gap: 8px; height: 32px; padding: 0 10px; border-radius: 6px; font-size: 13px; color: #D4D6DB;"><span style="color: #B0F030;">◈</span> 3D model</div>
+        <div style="display: flex; align-items: center; gap: 8px; height: 32px; padding: 0 10px; border-radius: 6px; font-size: 13px; color: #D4D6DB;"><span style="color: #FFA808;">{ }</span> JS script</div>
+        <div style="display: flex; align-items: center; gap: 8px; height: 32px; padding: 0 10px; border-radius: 6px; font-size: 13px; color: #D4D6DB;"><span style="color: #A7B1BF;">◧</span> App</div>
+        <div style="display: flex; align-items: center; gap: 8px; height: 32px; padding: 0 10px; border-radius: 6px; font-size: 13px; color: #D4D6DB;"><span style="color: #FFA808;">¶</span> Text ▸</div>
+      </div>
+    </div>
+  </div>
+
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/plans/project-view/mockups/project-overview.html
+++ b/docs/plans/project-view/mockups/project-overview.html
@@ -3,7 +3,6 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="./support.js"></script>
 </head>
 <body>
 <x-dc>

--- a/docs/plans/project-view/mockups/project-overview.html
+++ b/docs/plans/project-view/mockups/project-overview.html
@@ -1,0 +1,285 @@
+<!doctype html>
+<!-- Mockup for docs/plans/project-view/PLAN.md — Phase 3 (C1-C4). 1440x900; chrome matches the shipped WorkspaceShell. Editable canvas: https://claude.ai/code/artifact/9fde1641-9965-4f71-bb23-2543ef4bc4db -->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
+  <style>
+    body { margin: 0; background: #08090A; }
+    a { color: #6690d4; } a:hover { color: #7aa0e2; }
+    * { box-sizing: border-box; }
+  </style>
+</helmet>
+<div style="position: relative; width: 1440px; height: 900px; background: #08090A; color: #F7F8F8; font-family: 'Inter', Arial, sans-serif; overflow: hidden;">
+
+  <!-- ===== Workspace tab bar with the project group ===== -->
+  <div style="position: absolute; top: 0; left: 0; right: 0; height: 40px; padding-left: 50px; background: #0A0B0D; border-bottom: 1px solid rgba(255,255,255,0.08); display: flex; align-items: stretch;">
+    <div style="display: flex; align-items: center; gap: 6px; padding: 0 16px; border-right: 1px solid rgba(255,255,255,0.08); color: #6690d4; font-size: 13px; font-weight: 500;">
+      <span style="font-size: 15px; line-height: 1;">+</span><span>New</span><span style="font-size: 11px; opacity: 0.75; margin-left: 2px;">▾</span>
+    </div>
+    <!-- Project scope chip: collapses the group, carries the project everywhere -->
+    <div style="display: flex; align-items: center; gap: 8px; padding: 0 14px; background: rgba(103,232,249,0.06); border-right: 1px solid rgba(255,255,255,0.08); box-shadow: inset 0 -2px 0 #67E8F9; font-size: 13px; color: #F7F8F8;">
+      <span style="color: #67E8F9;">◆</span><span style="font-weight: 500;">Aurora Launch Spot</span>
+      <span style="font-size: 11px; opacity: 0.6;">▾</span>
+    </div>
+    <!-- Grouped tabs: the project's documents, cyan-tinted underline -->
+    <div style="display: flex; align-items: center; gap: 8px; min-width: 120px; padding: 0 12px 0 16px; background: #08090A; color: #F7F8F8; border-right: 1px solid rgba(255,255,255,0.08); box-shadow: inset 0 -2px 0 rgba(103,232,249,0.35); font-size: 13px;">
+      <span style="color: #67E8F9;">◆</span><span>Overview</span>
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="rgba(247,248,248,0.38)" stroke-width="1.4"><path d="M3.5 3.5l7 7M10.5 3.5l-7 7"/></svg>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; min-width: 110px; padding: 0 12px 0 16px; color: #8A8F98; border-right: 1px solid rgba(255,255,255,0.08); box-shadow: inset 0 -2px 0 rgba(103,232,249,0.35); font-size: 13px;">
+      <span style="color: #9460FF;">▥</span><span>Board</span>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; min-width: 110px; padding: 0 12px 0 16px; color: #8A8F98; border-right: 1px solid rgba(255,255,255,0.08); box-shadow: inset 0 -2px 0 rgba(103,232,249,0.35); font-size: 13px;">
+      <span style="color: #08B8FF;">🎙</span><span>Script</span>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; min-width: 110px; padding: 0 12px 0 16px; color: #8A8F98; border-right: 1px solid rgba(255,255,255,0.08); box-shadow: inset 0 -2px 0 rgba(103,232,249,0.35); font-size: 13px;">
+      <span style="color: #9460FF;">▤</span><span>Cut v2</span>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; min-width: 140px; padding: 0 12px 0 16px; color: #8A8F98; border-right: 1px solid rgba(255,255,255,0.08); box-shadow: inset 0 -2px 0 rgba(103,232,249,0.35); font-size: 13px;">
+      <span style="color: #A7B1BF;">⬡</span><span>Render pipeline</span>
+    </div>
+    <div style="flex: 1;"></div>
+    <div style="display: flex; align-items: center; padding-right: 8px;">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="#8A8F98" stroke-width="1.3"><path d="M8 2a4 4 0 0 1 4 4v3l1.2 2H2.8L4 9V6a4 4 0 0 1 4-4z"/><path d="M6.7 13.4a1.5 1.5 0 0 0 2.6 0"/></svg>
+    </div>
+  </div>
+
+  <!-- ===== Left rail ===== -->
+  <div style="position: absolute; top: 0; left: 0; bottom: 0; width: 50px; background: #0A0B0D; border-right: 1px solid rgba(255,255,255,0.08); display: flex; flex-direction: column; align-items: center; padding: 10px 0 12px 0; gap: 4px; z-index: 3;">
+    <svg width="22" height="22" viewBox="0 0 22 22" fill="none" style="margin-bottom: 10px;"><path d="M11 2l7.8 4.5v9L11 20l-7.8-4.5v-9z" stroke="#F7F8F8" stroke-width="1.5"/><circle cx="11" cy="11" r="2.4" fill="#6690d4"/></svg>
+    <div style="width: 34px; height: 34px; border-radius: 6px; background: rgba(255,255,255,0.05); display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#67E8F9" stroke-width="1.5"><path d="M9 2.2l6.8 6.8L9 15.8 2.2 9z"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><rect x="2.5" y="2.5" width="5.4" height="5.4" rx="1"/><rect x="10.1" y="2.5" width="5.4" height="5.4" rx="1"/><rect x="2.5" y="10.1" width="5.4" height="5.4" rx="1"/><rect x="10.1" y="10.1" width="5.4" height="5.4" rx="1"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><path d="M9 2.5l5.6 3.2v6.6L9 15.5l-5.6-3.2V5.7z"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><path d="M3 4.5h12v7.5H8.5L5.5 15v-3H3z"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><path d="M11.5 3.2l3.3 3.3L6.3 15H3v-3.3z"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><path d="M3 5h12M3 9h8M3 13h10"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><rect x="2.5" y="3.5" width="13" height="11" rx="1.5"/><path d="M6.8 3.5v11M11.2 3.5v11"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><circle cx="9" cy="6.4" r="3"/><path d="M3.4 15c.9-2.8 3-4.2 5.6-4.2s4.7 1.4 5.6 4.2"/></svg>
+    </div>
+    <div style="flex: 1;"></div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><circle cx="9" cy="9" r="2.4"/><path d="M9 2.5v2M9 13.5v2M2.5 9h2M13.5 9h2M4.4 4.4l1.4 1.4M12.2 12.2l1.4 1.4M13.6 4.4l-1.4 1.4M5.8 12.2l-1.4 1.4"/></svg>
+    </div>
+  </div>
+
+  <!-- ===== Bottom strip ===== -->
+  <div style="position: absolute; bottom: 0; left: 50px; right: 0; height: 32px; background: #101113; border-top: 1px solid rgba(255,255,255,0.08); display: flex; align-items: center; padding: 0 12px; gap: 16px; font-size: 11px; color: #8A8F98;">
+    <span>Logs</span><span>Queue</span><span>Workers</span><span>Versions</span><span>Trace</span>
+    <div style="flex: 1;"></div>
+    <div style="display: flex; align-items: center; gap: 6px; font-family: 'JetBrains Mono', monospace;"><span style="width: 6px; height: 6px; border-radius: 50%; background: #9460FF; display: inline-block;"></span><span>1 job running · shot 7 clip · 0:41</span></div>
+  </div>
+
+  <!-- ===== Center: project overview tab ===== -->
+  <div style="position: absolute; top: 40px; left: 50px; right: 0; bottom: 32px; overflow: hidden; display: flex; flex-direction: column;">
+
+    <!-- Header strip -->
+    <div style="display: flex; align-items: center; gap: 16px; padding: 22px 28px 18px 28px; border-bottom: 1px solid rgba(255,255,255,0.08);">
+      <div style="display: flex; flex-direction: column; gap: 6px; flex: 1; min-width: 0;">
+        <div style="display: flex; align-items: center; gap: 10px;">
+          <span style="color: #67E8F9; font-size: 18px;">◆</span>
+          <span style="font-size: 22px; font-weight: 600; letter-spacing: -0.01em;">Aurora Launch Spot</span>
+          <span style="height: 20px; padding: 0 8px; border-radius: 9999px; background: rgba(148,96,255,0.16); border: 1px solid #9460FF; color: #c9adff; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center; gap: 6px;"><span style="width: 6px; height: 6px; border-radius: 50%; background: #9460FF;"></span>rendering shot 7</span>
+        </div>
+        <div style="font-size: 13px; color: #8A8F98;">30-second product launch spot · 8 shots · stills 8/8 · clips 6/8 · script 5/6 voiced · cut assembled, not rendered</div>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: flex-end; gap: 3px; padding-right: 18px; border-right: 1px solid rgba(255,255,255,0.08);">
+        <div style="font-size: 18px; font-family: 'JetBrains Mono', monospace;">$4.12</div>
+        <div style="font-size: 11px; color: #5C606A;">so far · provider rates, no markup</div>
+      </div>
+      <div style="display: flex; align-items: center; gap: 6px; height: 32px; padding: 0 14px; background: #6690d4; border-radius: 6px; color: #fff; font-size: 13px; font-weight: 500;">
+        Render master
+      </div>
+    </div>
+
+    <div style="flex: 1; display: flex; min-height: 0;">
+
+      <!-- Left: the conversation that built it -->
+      <div style="width: 460px; display: flex; flex-direction: column; border-right: 1px solid rgba(255,255,255,0.08); min-height: 0;">
+        <div style="padding: 14px 20px 10px 20px; font-size: 11px; color: #5C606A; text-transform: uppercase; letter-spacing: 0.08em;">Project agent</div>
+        <div style="flex: 1; overflow: hidden; padding: 0 20px; display: flex; flex-direction: column; gap: 14px;">
+          <div style="align-self: flex-end; max-width: 340px; background: #1B1D21; border-radius: 12px 12px 2px 12px; padding: 10px 14px; font-size: 13px; line-height: 1.5; color: #F7F8F8;">Make a 30-second launch spot for the Aurora desk lamp. Warm, minimal, night-time mood. End on the wordmark.</div>
+          <div style="align-self: flex-start; max-width: 400px; display: flex; flex-direction: column; gap: 8px;">
+            <div style="font-size: 13px; line-height: 1.55; color: #D4D6DB;">Broke the spot into 8 shots — macro to lifestyle, ending on the card. Wrote and voiced the 6-line script, rendered stills for every shot, and assembled a first cut with the VO and a music bed.</div>
+            <div style="display: flex; flex-wrap: wrap; gap: 6px;">
+              <span style="height: 20px; padding: 0 8px; border-radius: 4px; background: #17181B; border: 1px solid rgba(255,255,255,0.08); color: #8A8F98; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">create_storyboard</span>
+              <span style="height: 20px; padding: 0 8px; border-radius: 4px; background: #17181B; border: 1px solid rgba(255,255,255,0.08); color: #8A8F98; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">voice_script_lines</span>
+              <span style="height: 20px; padding: 0 8px; border-radius: 4px; background: #17181B; border: 1px solid rgba(255,255,255,0.08); color: #8A8F98; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">render_storyboard_stills</span>
+              <span style="height: 20px; padding: 0 8px; border-radius: 4px; background: #17181B; border: 1px solid rgba(255,255,255,0.08); color: #8A8F98; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">assemble_storyboard_timeline</span>
+            </div>
+          </div>
+          <div style="align-self: flex-end; max-width: 340px; background: #1B1D21; border-radius: 12px 12px 2px 12px; padding: 10px 14px; font-size: 13px; line-height: 1.5; color: #F7F8F8;">Shot 5 feels static — make the light-on moment punchier.</div>
+          <div style="align-self: flex-start; max-width: 400px; display: flex; flex-direction: column; gap: 8px;">
+            <div style="font-size: 13px; line-height: 1.55; color: #D4D6DB;">Re-directed shot 5 as a fast push-in with a bloom on the switch-on, and queued shots 7–8 clips. Shot 7 is rendering now; the cut picks the new take up automatically.</div>
+            <div style="display: flex; align-items: center; gap: 8px;">
+              <span style="height: 20px; padding: 0 8px; border-radius: 9999px; background: rgba(80,250,123,0.12); border: 1px solid rgba(80,250,123,0.5); color: #50FA7B; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">shot 5 · completed in 41s</span>
+              <span style="height: 20px; padding: 0 8px; border-radius: 9999px; background: rgba(148,96,255,0.16); border: 1px solid #9460FF; color: #c9adff; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">shot 7 · rendering</span>
+            </div>
+          </div>
+        </div>
+        <div style="padding: 14px 20px 18px 20px;">
+          <div style="display: flex; align-items: center; gap: 10px; height: 40px; padding: 0 14px; background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; color: #5C606A; font-size: 13px;">
+            Ask for a change to this project…
+            <div style="flex: 1;"></div>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="#6690d4" stroke-width="1.5"><path d="M2.5 8h10M9 4.5L12.5 8 9 11.5"/></svg>
+          </div>
+        </div>
+      </div>
+
+      <!-- Right: documents + cost -->
+      <div style="flex: 1; min-width: 0; display: flex; flex-direction: column; overflow: hidden;">
+        <div style="padding: 14px 24px 10px 24px; display: flex; align-items: baseline;">
+          <div style="font-size: 11px; color: #5C606A; text-transform: uppercase; letter-spacing: 0.08em;">Documents</div>
+          <div style="flex: 1;"></div>
+          <div style="font-size: 11px; color: #5C606A;">everything below opens as a tab in this group</div>
+        </div>
+        <div style="padding: 0 24px; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px;">
+
+          <!-- Storyboard card -->
+          <div style="background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; overflow: hidden; display: flex; flex-direction: column;">
+            <div style="height: 120px; display: grid; grid-template-columns: repeat(4, 1fr); gap: 2px; background: #1B1D21;">
+              <svg viewBox="0 0 120 120" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;"><rect width="120" height="120" fill="#0c0c14"/><circle cx="60" cy="64" r="9" fill="#8f7bff"/><rect x="42" y="92" width="36" height="4" rx="2" fill="#232038"/></svg>
+              <svg viewBox="0 0 120 120" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;"><rect width="120" height="120" fill="#151329"/><rect x="52" y="48" width="10" height="46" rx="4" fill="#2A2740"/><circle cx="57" cy="42" r="14" fill="#8f7bff"/></svg>
+              <svg viewBox="0 0 120 120" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;"><rect width="120" height="120" fill="#241a10"/><path d="M12 96 L52 62 L76 78 L112 50 L112 120 L12 120 Z" fill="#3a2a17"/><circle cx="88" cy="34" r="11" fill="#FFB86C"/></svg>
+              <svg viewBox="0 0 120 120" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;"><rect width="120" height="120" fill="#101d2e"/><circle cx="60" cy="56" r="16" fill="#67E8F9" opacity="0.85"/><rect x="36" y="88" width="48" height="5" rx="2.5" fill="#1c3049"/></svg>
+            </div>
+            <div style="padding: 12px 14px; display: flex; flex-direction: column; gap: 6px;">
+              <div style="display: flex; align-items: center; gap: 8px;">
+                <span style="color: #9460FF;">▥</span><span style="font-size: 13px; font-weight: 500; flex: 1;">Board</span>
+                <span style="height: 18px; padding: 0 7px; border-radius: 9999px; background: rgba(148,96,255,0.16); border: 1px solid #9460FF; color: #c9adff; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">clips 6/8</span>
+              </div>
+              <div style="display: flex; align-items: baseline; gap: 8px; font-size: 11px; color: #8A8F98;">
+                <span>8 shots · stills 8/8</span><div style="flex: 1;"></div><span style="font-family: 'JetBrains Mono', monospace; color: #9CA0A8;">$3.88</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Script card -->
+          <div style="background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; overflow: hidden; display: flex; flex-direction: column;">
+            <div style="height: 120px; background: #17181B; padding: 12px 14px; display: flex; flex-direction: column; gap: 8px;">
+              <div style="display: flex; align-items: center; gap: 8px;"><span style="width: 6px; height: 6px; border-radius: 50%; background: #50FA7B;"></span><span style="font-size: 11px; color: #9CA0A8; font-family: 'JetBrains Mono', monospace;">VO 1</span><span style="font-size: 11px; color: #D4D6DB; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">Late is when ideas show up.</span></div>
+              <div style="display: flex; align-items: center; gap: 8px;"><span style="width: 6px; height: 6px; border-radius: 50%; background: #50FA7B;"></span><span style="font-size: 11px; color: #9CA0A8; font-family: 'JetBrains Mono', monospace;">VO 2</span><span style="font-size: 11px; color: #D4D6DB; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">Aurora keeps the room out of the way.</span></div>
+              <div style="display: flex; align-items: center; gap: 8px;"><span style="width: 6px; height: 6px; border-radius: 50%; background: #FFB86C;"></span><span style="font-size: 11px; color: #9CA0A8; font-family: 'JetBrains Mono', monospace;">VO 3</span><span style="font-size: 11px; color: #D4D6DB; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">One touch. The right light.</span><span style="font-size: 11px; color: #FFB86C; font-family: 'JetBrains Mono', monospace;">stale</span></div>
+              <div style="display: flex; align-items: center; gap: 8px;"><span style="width: 6px; height: 6px; border-radius: 50%; background: #50FA7B;"></span><span style="font-size: 11px; color: #9CA0A8; font-family: 'JetBrains Mono', monospace;">VO 4</span><span style="font-size: 11px; color: #D4D6DB; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">Aurora. Work late, gently.</span></div>
+            </div>
+            <div style="padding: 12px 14px; display: flex; flex-direction: column; gap: 6px;">
+              <div style="display: flex; align-items: center; gap: 8px;">
+                <span style="color: #08B8FF;">🎙</span><span style="font-size: 13px; font-weight: 500; flex: 1;">Script</span>
+                <span style="height: 18px; padding: 0 7px; border-radius: 9999px; background: rgba(255,184,108,0.1); border: 1px solid rgba(255,184,108,0.5); color: #FFB86C; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">1 line stale</span>
+              </div>
+              <div style="display: flex; align-items: baseline; gap: 8px; font-size: 11px; color: #8A8F98;">
+                <span>6 lines · 5 voiced</span><div style="flex: 1;"></div><span style="font-family: 'JetBrains Mono', monospace; color: #9CA0A8;">$0.19</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Timeline card -->
+          <div style="background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; overflow: hidden; display: flex; flex-direction: column;">
+            <div style="height: 120px; background: #0c0d10; padding: 14px; display: flex; flex-direction: column; gap: 6px; justify-content: center;">
+              <div style="display: flex; gap: 3px; align-items: center;">
+                <span style="font-size: 11px; color: #5C606A; width: 30px; font-family: 'JetBrains Mono', monospace;">V1</span>
+                <div style="height: 22px; flex: 1.4; background: #221c38; border: 1px solid #3b3160; border-radius: 4px;"></div>
+                <div style="height: 22px; flex: 1; background: #221c38; border: 1px solid #3b3160; border-radius: 4px;"></div>
+                <div style="height: 22px; flex: 1.8; background: #221c38; border: 1px solid #3b3160; border-radius: 4px;"></div>
+                <div style="height: 22px; flex: 1.1; background: #221c38; border: 1px solid #9460FF; border-radius: 4px;"></div>
+                <div style="height: 22px; flex: 1.3; background: #17131f; border: 1px dashed #3b3160; border-radius: 4px;"></div>
+              </div>
+              <div style="display: flex; gap: 3px; align-items: center;">
+                <span style="font-size: 11px; color: #5C606A; width: 30px; font-family: 'JetBrains Mono', monospace;">A1</span>
+                <div style="height: 16px; flex: 2.2; background: #0e2233; border: 1px solid #1d4258; border-radius: 4px;"></div>
+                <div style="height: 16px; flex: 1.6; background: #0e2233; border: 1px solid #1d4258; border-radius: 4px;"></div>
+                <div style="height: 16px; flex: 1.4; background: #0e2233; border: 1px solid #1d4258; border-radius: 4px;"></div>
+              </div>
+              <div style="display: flex; gap: 3px; align-items: center;">
+                <span style="font-size: 11px; color: #5C606A; width: 30px; font-family: 'JetBrains Mono', monospace;">A2</span>
+                <div style="height: 16px; flex: 5.2; background: #0f2418; border: 1px solid #1e4a2f; border-radius: 4px;"></div>
+              </div>
+            </div>
+            <div style="padding: 12px 14px; display: flex; flex-direction: column; gap: 6px;">
+              <div style="display: flex; align-items: center; gap: 8px;">
+                <span style="color: #9460FF;">▤</span><span style="font-size: 13px; font-weight: 500; flex: 1;">Cut v2</span>
+                <span style="height: 18px; padding: 0 7px; border-radius: 9999px; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.15); color: #9CA0A8; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">not rendered</span>
+              </div>
+              <div style="display: flex; align-items: baseline; gap: 8px; font-size: 11px; color: #8A8F98;">
+                <span>9 clips · VO + music · 0:30</span><div style="flex: 1;"></div><span style="font-family: 'JetBrains Mono', monospace; color: #9CA0A8;">$0.00</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Workflow card -->
+          <div style="background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; overflow: hidden; display: flex; flex-direction: column;">
+            <div style="height: 120px; background: #0c0d10; position: relative;">
+              <svg viewBox="0 0 340 120" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;">
+                <path d="M78 46 C110 46 110 34 142 34" stroke="#3A3D44" stroke-width="1" fill="none"/>
+                <path d="M78 46 C110 46 110 74 142 74" stroke="#3A3D44" stroke-width="1" fill="none"/>
+                <path d="M206 34 C232 34 232 54 258 54" stroke="#3A3D44" stroke-width="1" fill="none"/>
+                <path d="M206 74 C232 74 232 54 258 54" stroke="#3A3D44" stroke-width="1" fill="none"/>
+                <rect x="22" y="32" width="56" height="28" rx="6" fill="#1B1D21" stroke="#27292E"/>
+                <rect x="142" y="20" width="64" height="28" rx="6" fill="#1B1D21" stroke="#27292E"/>
+                <rect x="142" y="60" width="64" height="28" rx="6" fill="#1B1D21" stroke="#27292E"/>
+                <rect x="258" y="40" width="60" height="28" rx="6" fill="#1B1D21" stroke="#27292E"/>
+                <text x="32" y="49" fill="#808590" font-size="9" font-family="JetBrains Mono, monospace">shots</text>
+                <text x="150" y="37" fill="#808590" font-size="9" font-family="JetBrains Mono, monospace">upscale</text>
+                <text x="150" y="77" fill="#808590" font-size="9" font-family="JetBrains Mono, monospace">grade</text>
+                <text x="266" y="57" fill="#808590" font-size="9" font-family="JetBrains Mono, monospace">encode</text>
+              </svg>
+            </div>
+            <div style="padding: 12px 14px; display: flex; flex-direction: column; gap: 6px;">
+              <div style="display: flex; align-items: center; gap: 8px;">
+                <span style="color: #A7B1BF;">⬡</span><span style="font-size: 13px; font-weight: 500; flex: 1;">Render pipeline</span>
+                <span style="height: 18px; padding: 0 7px; border-radius: 9999px; background: rgba(80,250,123,0.12); border: 1px solid rgba(80,250,123,0.5); color: #50FA7B; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">last run 2.1s</span>
+              </div>
+              <div style="display: flex; align-items: baseline; gap: 8px; font-size: 11px; color: #8A8F98;">
+                <span>4 nodes · reusable</span><div style="flex: 1;"></div><span style="font-family: 'JetBrains Mono', monospace; color: #9CA0A8;">$0.05</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Cost breakdown row -->
+        <div style="margin-top: auto; padding: 14px 24px 18px 24px;">
+          <div style="display: flex; align-items: center; gap: 10px; padding: 12px 16px; background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 8px;">
+            <div style="font-size: 11px; color: #5C606A; text-transform: uppercase; letter-spacing: 0.08em;">Spend</div>
+            <div style="flex: 1; height: 6px; border-radius: 3px; overflow: hidden; display: flex; background: #1B1D21;">
+              <div style="width: 31.1%; background: #E838FF;"></div>
+              <div style="width: 63.1%; background: #9460FF;"></div>
+              <div style="width: 4.6%; background: #08B8FF;"></div>
+              <div style="width: 1.2%; background: #6690d4;"></div>
+            </div>
+            <div style="display: flex; gap: 14px; font-size: 11px; color: #8A8F98; font-family: 'JetBrains Mono', monospace;">
+              <span><span style="color: #E838FF;">●</span> stills $1.28</span>
+              <span><span style="color: #9460FF;">●</span> clips $2.60</span>
+              <span><span style="color: #08B8FF;">●</span> voice $0.19</span>
+              <span><span style="color: #6690d4;">●</span> pipeline $0.05</span>
+              <span style="color: #F7F8F8;">$4.12</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/plans/project-view/mockups/projects-list.html
+++ b/docs/plans/project-view/mockups/projects-list.html
@@ -3,7 +3,6 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="./support.js"></script>
 </head>
 <body>
 <x-dc>

--- a/docs/plans/project-view/mockups/projects-list.html
+++ b/docs/plans/project-view/mockups/projects-list.html
@@ -1,0 +1,223 @@
+<!doctype html>
+<!-- Mockup for docs/plans/project-view/PLAN.md — Phase 2 (B3), Phase 3 (C4). 1440x900; chrome matches the shipped WorkspaceShell. Editable canvas: https://claude.ai/code/artifact/9fde1641-9965-4f71-bb23-2543ef4bc4db -->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
+  <style>
+    body { margin: 0; background: #08090A; }
+    a { color: #6690d4; } a:hover { color: #7aa0e2; }
+    * { box-sizing: border-box; }
+  </style>
+</helmet>
+<div style="position: relative; width: 1440px; height: 900px; background: #08090A; color: #F7F8F8; font-family: 'Inter', Arial, sans-serif; overflow: hidden;">
+
+  <!-- ===== Workspace tab bar (40px, shipped chrome) ===== -->
+  <div style="position: absolute; top: 0; left: 0; right: 0; height: 40px; padding-left: 50px; background: #0A0B0D; border-bottom: 1px solid rgba(255,255,255,0.08); display: flex; align-items: stretch;">
+    <div style="display: flex; align-items: center; gap: 6px; padding: 0 16px; border-right: 1px solid rgba(255,255,255,0.08); color: #6690d4; font-size: 13px; font-weight: 500;">
+      <span style="font-size: 15px; line-height: 1;">+</span><span>New</span><span style="font-size: 11px; opacity: 0.75; margin-left: 2px;">▾</span>
+    </div>
+    <!-- Projects opens as a first-class tab, keyed project-list — the center area stays the tab system's -->
+    <div style="display: flex; align-items: center; gap: 8px; min-width: 150px; max-width: 240px; padding: 0 12px 0 16px; background: #08090A; color: #F7F8F8; border-right: 1px solid rgba(255,255,255,0.08); font-size: 13px;">
+      <span style="color: #67E8F9; font-size: 13px;">◆</span>
+      <span style="flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">Projects</span>
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="rgba(247,248,248,0.38)" stroke-width="1.4"><path d="M3.5 3.5l7 7M10.5 3.5l-7 7"/></svg>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; min-width: 150px; max-width: 240px; padding: 0 12px 0 16px; color: #8A8F98; border-right: 1px solid rgba(255,255,255,0.08); font-size: 13px;">
+      <span style="color: #FFA808; font-size: 13px;">❝</span>
+      <span style="flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">Quick question</span>
+    </div>
+    <div style="flex: 1;"></div>
+    <div style="display: flex; align-items: center; padding-right: 8px;">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="#8A8F98" stroke-width="1.3"><path d="M8 2a4 4 0 0 1 4 4v3l1.2 2H2.8L4 9V6a4 4 0 0 1 4-4z"/><path d="M6.7 13.4a1.5 1.5 0 0 0 2.6 0"/></svg>
+    </div>
+  </div>
+
+  <!-- ===== Left rail (50px, full height to top 0) ===== -->
+  <div style="position: absolute; top: 0; left: 0; bottom: 0; width: 50px; background: #0A0B0D; border-right: 1px solid rgba(255,255,255,0.08); display: flex; flex-direction: column; align-items: center; padding: 10px 0 12px 0; gap: 4px; z-index: 3;">
+    <svg width="22" height="22" viewBox="0 0 22 22" fill="none" style="margin-bottom: 10px;"><path d="M11 2l7.8 4.5v9L11 20l-7.8-4.5v-9z" stroke="#F7F8F8" stroke-width="1.5"/><circle cx="11" cy="11" r="2.4" fill="#6690d4"/></svg>
+    <!-- Projects: the one addition to the rail, top slot, active -->
+    <div style="width: 34px; height: 34px; border-radius: 6px; background: rgba(255,255,255,0.05); display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#67E8F9" stroke-width="1.5"><path d="M9 2.2l6.8 6.8L9 15.8 2.2 9z"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><rect x="2.5" y="2.5" width="5.4" height="5.4" rx="1"/><rect x="10.1" y="2.5" width="5.4" height="5.4" rx="1"/><rect x="2.5" y="10.1" width="5.4" height="5.4" rx="1"/><rect x="10.1" y="10.1" width="5.4" height="5.4" rx="1"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><path d="M9 2.5l5.6 3.2v6.6L9 15.5l-5.6-3.2V5.7z"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><path d="M3 4.5h12v7.5H8.5L5.5 15v-3H3z"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><path d="M11.5 3.2l3.3 3.3L6.3 15H3v-3.3z"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><path d="M3 5h12M3 9h8M3 13h10"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><rect x="2.5" y="3.5" width="13" height="11" rx="1.5"/><path d="M6.8 3.5v11M11.2 3.5v11"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><circle cx="9" cy="6.4" r="3"/><path d="M3.4 15c.9-2.8 3-4.2 5.6-4.2s4.7 1.4 5.6 4.2"/></svg>
+    </div>
+    <div style="flex: 1;"></div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><circle cx="9" cy="9" r="2.4"/><path d="M9 2.5v2M9 13.5v2M2.5 9h2M13.5 9h2M4.4 4.4l1.4 1.4M12.2 12.2l1.4 1.4M13.6 4.4l-1.4 1.4M5.8 12.2l-1.4 1.4"/></svg>
+    </div>
+  </div>
+
+  <!-- ===== Bottom strip (32px docked) ===== -->
+  <div style="position: absolute; bottom: 0; left: 50px; right: 0; height: 32px; background: #101113; border-top: 1px solid rgba(255,255,255,0.08); display: flex; align-items: center; padding: 0 12px; gap: 16px; font-size: 11px; color: #8A8F98;">
+    <span>Logs</span><span>Queue</span><span>Workers</span><span>Versions</span><span>Trace</span>
+    <div style="flex: 1;"></div>
+    <div style="display: flex; align-items: center; gap: 6px; font-family: 'JetBrains Mono', monospace;"><span style="width: 6px; height: 6px; border-radius: 50%; background: #50FA7B; display: inline-block;"></span><span>worker · local</span></div>
+  </div>
+
+  <!-- ===== Center: Projects list ===== -->
+  <div style="position: absolute; top: 40px; left: 50px; right: 0; bottom: 32px; overflow: hidden; display: flex; flex-direction: column;">
+    <div style="display: flex; align-items: center; gap: 16px; padding: 28px 32px 4px 32px;">
+      <div style="font-size: 22px; font-weight: 600; letter-spacing: -0.01em;">Projects</div>
+      <div style="font-size: 13px; color: #8A8F98;">One piece of work — the documents an agent built for it, what it cost, where it stands.</div>
+      <div style="flex: 1;"></div>
+      <div style="display: flex; align-items: center; gap: 8px;">
+        <div style="display: flex; align-items: center; gap: 8px; height: 32px; padding: 0 12px; border: 1px solid rgba(255,255,255,0.08); border-radius: 6px; color: #8A8F98; font-size: 13px; min-width: 220px;">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="#5C606A" stroke-width="1.4"><circle cx="6" cy="6" r="3.6"/><path d="M9 9l3 3"/></svg>
+          Search projects
+        </div>
+        <div style="display: flex; align-items: center; gap: 6px; height: 32px; padding: 0 14px; background: #6690d4; border-radius: 6px; color: #fff; font-size: 13px; font-weight: 500;">
+          <span style="font-size: 15px; line-height: 1;">+</span> New project
+        </div>
+      </div>
+    </div>
+
+    <div style="flex: 1; overflow: hidden; padding: 20px 32px 24px 32px;">
+      <div style="display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 20px;">
+
+        <!-- Card 1: Aurora — active, mid-render -->
+        <div style="background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; overflow: hidden;">
+          <div style="position: relative; height: 176px; background: #1B1D21;">
+            <div style="position: absolute; inset: 0; display: grid; grid-template-columns: 2fr 1fr; grid-template-rows: 1fr 1fr; gap: 2px;">
+              <svg viewBox="0 0 240 176" preserveAspectRatio="xMidYMid slice" style="grid-row: span 2; width: 100%; height: 100%; display: block;"><rect width="240" height="176" fill="#151329"/><rect x="96" y="58" width="12" height="62" rx="4" fill="#2A2740"/><circle cx="102" cy="52" r="17" fill="#8f7bff"/><circle cx="102" cy="52" r="30" fill="#8f7bff" opacity="0.16"/><rect x="70" y="120" width="64" height="5" rx="2.5" fill="#232038"/></svg>
+              <svg viewBox="0 0 120 87" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;"><rect width="120" height="87" fill="#241a10"/><path d="M14 66 L52 40 L74 52 L106 30 L106 87 L14 87 Z" fill="#3a2a17"/><circle cx="86" cy="26" r="10" fill="#FFB86C"/></svg>
+              <svg viewBox="0 0 120 87" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;"><rect width="120" height="87" fill="#101d2e"/><rect x="16" y="20" width="40" height="48" rx="3" fill="#1c3049"/><circle cx="84" cy="42" r="12" fill="#67E8F9" opacity="0.85"/></svg>
+            </div>
+            <div style="position: absolute; left: 10px; bottom: 10px; display: flex; align-items: center; gap: 6px; height: 20px; padding: 0 8px; border-radius: 9999px; background: rgba(148,96,255,0.16); border: 1px solid #9460FF; color: #c9adff; font-size: 11px; font-family: 'JetBrains Mono', monospace;">
+              <span style="width: 6px; height: 6px; border-radius: 50%; background: #9460FF; display: inline-block;"></span> rendering shot 7
+            </div>
+            <div style="position: absolute; right: 10px; bottom: 10px; height: 20px; padding: 0 8px; border-radius: 9999px; background: rgba(0,0,0,0.55); color: #F7F8F8; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: flex; align-items: center;">0:30</div>
+          </div>
+          <div style="padding: 14px 16px 16px 16px; display: flex; flex-direction: column; gap: 8px;">
+            <div style="display: flex; align-items: center; gap: 8px;">
+              <span style="color: #67E8F9; font-size: 13px;">◆</span>
+              <span style="font-size: 15px; font-weight: 500; flex: 1;">Aurora Launch Spot</span>
+              <span style="font-size: 11px; color: #8A8F98;">2 min ago</span>
+            </div>
+            <div style="font-size: 13px; color: #8A8F98;">8 shots · stills rendered · clips 6/8 · cut assembled</div>
+            <div style="display: flex; align-items: center; gap: 8px; padding-top: 2px;">
+              <span style="font-size: 11px; display: inline-flex; gap: 5px;"><span style="color: #9460FF;">▥</span><span style="color: #A7B1BF;">⬡</span><span style="color: #08B8FF;">🎙</span><span style="color: #9460FF;">▤</span></span>
+              <div style="flex: 1;"></div>
+              <span style="font-size: 11px; color: #F7F8F8; font-family: 'JetBrains Mono', monospace;">$4.12</span>
+              <span style="font-size: 11px; color: #5C606A;">provider rates</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Card 2: trailer, done -->
+        <div style="background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; overflow: hidden;">
+          <div style="position: relative; height: 176px; background: #1B1D21;">
+            <svg viewBox="0 0 480 176" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;"><rect width="480" height="176" fill="#0d1512"/><path d="M0 140 L110 74 L200 118 L330 44 L480 120 L480 176 L0 176 Z" fill="#16241d"/><path d="M0 156 L150 104 L290 142 L480 92 L480 176 L0 176 Z" fill="#1e3327"/><circle cx="372" cy="46" r="18" fill="#dfe8e3" opacity="0.9"/></svg>
+            <div style="position: absolute; left: 10px; bottom: 10px; height: 20px; padding: 0 8px; border-radius: 9999px; background: rgba(80,250,123,0.12); border: 1px solid rgba(80,250,123,0.5); color: #50FA7B; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: flex; align-items: center;">rendered · 1:42</div>
+          </div>
+          <div style="padding: 14px 16px 16px 16px; display: flex; flex-direction: column; gap: 8px;">
+            <div style="display: flex; align-items: center; gap: 8px;">
+              <span style="color: #67E8F9; font-size: 13px;">◆</span>
+              <span style="font-size: 15px; font-weight: 500; flex: 1;">Meridian — teaser trailer</span>
+              <span style="font-size: 11px; color: #8A8F98;">yesterday</span>
+            </div>
+            <div style="font-size: 13px; color: #8A8F98;">14 shots · voiced · timeline rendered to master</div>
+            <div style="display: flex; align-items: center; gap: 8px; padding-top: 2px;">
+              <span style="font-size: 11px; display: inline-flex; gap: 5px;"><span style="color: #9460FF;">▥</span><span style="color: #08B8FF;">🎙</span><span style="color: #9460FF;">▤</span></span>
+              <div style="flex: 1;"></div>
+              <span style="font-size: 11px; color: #F7F8F8; font-family: 'JetBrains Mono', monospace;">$11.87</span>
+              <span style="font-size: 11px; color: #5C606A;">provider rates</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Card 3: research report -->
+        <div style="background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; overflow: hidden;">
+          <div style="position: relative; height: 176px; background: #1B1D21;">
+            <svg viewBox="0 0 480 176" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;"><rect width="480" height="176" fill="#131417"/><rect x="56" y="28" width="180" height="10" rx="3" fill="#3A3D44"/><rect x="56" y="52" width="290" height="6" rx="3" fill="#27292E"/><rect x="56" y="66" width="270" height="6" rx="3" fill="#27292E"/><rect x="56" y="80" width="284" height="6" rx="3" fill="#27292E"/><rect x="56" y="108" width="60" height="40" fill="#22344e"/><rect x="124" y="96" width="60" height="52" fill="#2c4568"/><rect x="192" y="118" width="60" height="30" fill="#22344e"/><rect x="260" y="86" width="60" height="62" fill="#3f5f8a"/><rect x="360" y="28" width="70" height="120" rx="4" fill="#17181B" stroke="#27292E"/></svg>
+            <div style="position: absolute; left: 10px; bottom: 10px; height: 20px; padding: 0 8px; border-radius: 9999px; background: rgba(255,168,8,0.1); border: 1px solid rgba(255,168,8,0.45); color: #FFA808; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: flex; align-items: center;">draft · 2 sources pending</div>
+          </div>
+          <div style="padding: 14px 16px 16px 16px; display: flex; flex-direction: column; gap: 8px;">
+            <div style="display: flex; align-items: center; gap: 8px;">
+              <span style="color: #67E8F9; font-size: 13px;">◆</span>
+              <span style="font-size: 15px; font-weight: 500; flex: 1;">Q3 battery market brief</span>
+              <span style="font-size: 11px; color: #8A8F98;">3 days ago</span>
+            </div>
+            <div style="font-size: 13px; color: #8A8F98;">report drafted · 4 charts · collection indexed</div>
+            <div style="display: flex; align-items: center; gap: 8px; padding-top: 2px;">
+              <span style="font-size: 11px; display: inline-flex; gap: 5px;"><span style="color: #FFA808;">¶</span><span style="color: #A7B1BF;">⬡</span><span style="color: #FFA808;">❝</span></span>
+              <div style="flex: 1;"></div>
+              <span style="font-size: 11px; color: #F7F8F8; font-family: 'JetBrains Mono', monospace;">$0.94</span>
+              <span style="font-size: 11px; color: #5C606A;">provider rates</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Card 4: brand film, early -->
+        <div style="background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; overflow: hidden;">
+          <div style="position: relative; height: 176px; background: #1B1D21;">
+            <svg viewBox="0 0 480 176" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;"><rect width="480" height="176" fill="#1a1410"/><rect x="150" y="46" width="180" height="104" rx="6" fill="#241c14"/><path d="M150 96 C210 66 270 126 330 92" stroke="#c88a4a" stroke-width="4" fill="none"/><circle cx="240" cy="94" r="7" fill="#e8b071"/></svg>
+            <div style="position: absolute; left: 10px; bottom: 10px; height: 20px; padding: 0 8px; border-radius: 9999px; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.15); color: #9CA0A8; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: flex; align-items: center;">script · 6 shots blocked out</div>
+          </div>
+          <div style="padding: 14px 16px 16px 16px; display: flex; flex-direction: column; gap: 8px;">
+            <div style="display: flex; align-items: center; gap: 8px;">
+              <span style="color: #67E8F9; font-size: 13px;">◆</span>
+              <span style="font-size: 15px; font-weight: 500; flex: 1;">Handmade — brand film</span>
+              <span style="font-size: 11px; color: #8A8F98;">last week</span>
+            </div>
+            <div style="font-size: 13px; color: #8A8F98;">6 shots · stills not rendered · no timeline yet</div>
+            <div style="display: flex; align-items: center; gap: 8px; padding-top: 2px;">
+              <span style="font-size: 11px; display: inline-flex; gap: 5px;"><span style="color: #9460FF;">▥</span><span style="color: #08B8FF;">🎙</span></span>
+              <div style="flex: 1;"></div>
+              <span style="font-size: 11px; color: #F7F8F8; font-family: 'JetBrains Mono', monospace;">$0.31</span>
+              <span style="font-size: 11px; color: #5C606A;">provider rates</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Card 5: new project ghost -->
+        <div style="border: 1px dashed rgba(255,255,255,0.15); border-radius: 8px; min-height: 268px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 10px; color: #8A8F98;">
+          <div style="width: 40px; height: 40px; border-radius: 50%; border: 1px solid rgba(255,255,255,0.15); display: flex; align-items: center; justify-content: center; font-size: 18px; color: #6690d4;">+</div>
+          <div style="font-size: 13px;">Start a project</div>
+          <div style="font-size: 11px; color: #5C606A;">Describe what you want to make — an agent sets it up</div>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- Loose documents, demoted but reachable -->
+    <div style="padding: 0 32px 20px 32px;">
+      <div style="display: flex; align-items: center; gap: 10px; padding: 12px 0 10px 0; border-top: 1px solid rgba(255,255,255,0.08); font-size: 11px; color: #5C606A; text-transform: uppercase; letter-spacing: 0.08em;">Not in a project</div>
+      <div style="display: flex; gap: 10px;">
+        <div style="display: flex; align-items: center; gap: 8px; height: 30px; padding: 0 12px; background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 6px; font-size: 13px; color: #8A8F98;"><span style="color: #A7B1BF;">⬡</span> Scratch workflow</div>
+        <div style="display: flex; align-items: center; gap: 8px; height: 30px; padding: 0 12px; background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 6px; font-size: 13px; color: #8A8F98;"><span style="color: #FFA808;">❝</span> Quick question</div>
+        <div style="display: flex; align-items: center; gap: 8px; height: 30px; padding: 0 12px; background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 6px; font-size: 13px; color: #8A8F98;"><span style="color: #E838FF;">✎</span> Logo sketch</div>
+        <div style="flex: 1;"></div>
+        <div style="display: flex; align-items: center; font-size: 11px; color: #5C606A;">Drag onto a project card to move it in</div>
+      </div>
+    </div>
+  </div>
+
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/plans/project-view/mockups/storyboard-board.html
+++ b/docs/plans/project-view/mockups/storyboard-board.html
@@ -3,7 +3,6 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="./support.js"></script>
 </head>
 <body>
 <x-dc>

--- a/docs/plans/project-view/mockups/storyboard-board.html
+++ b/docs/plans/project-view/mockups/storyboard-board.html
@@ -1,0 +1,217 @@
+<!doctype html>
+<!-- Mockup for docs/plans/project-view/PLAN.md — Phase 0 (A1-A4), Phase 2 (B1-B2), Phase 5 (E1). 1440x900; chrome matches the shipped WorkspaceShell. Editable canvas: https://claude.ai/code/artifact/9fde1641-9965-4f71-bb23-2543ef4bc4db -->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
+  <style>
+    body { margin: 0; background: #08090A; }
+    a { color: #6690d4; } a:hover { color: #7aa0e2; }
+    * { box-sizing: border-box; }
+  </style>
+</helmet>
+<div style="position: relative; width: 1440px; height: 900px; background: #08090A; color: #F7F8F8; font-family: 'Inter', Arial, sans-serif; overflow: hidden;">
+
+  <!-- ===== Tab bar: same project group, Board active ===== -->
+  <div style="position: absolute; top: 0; left: 0; right: 0; height: 40px; padding-left: 50px; background: #0A0B0D; border-bottom: 1px solid rgba(255,255,255,0.08); display: flex; align-items: stretch;">
+    <div style="display: flex; align-items: center; gap: 6px; padding: 0 16px; border-right: 1px solid rgba(255,255,255,0.08); color: #6690d4; font-size: 13px; font-weight: 500;">
+      <span style="font-size: 15px; line-height: 1;">+</span><span>New</span><span style="font-size: 11px; opacity: 0.75; margin-left: 2px;">▾</span>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; padding: 0 14px; background: rgba(103,232,249,0.06); border-right: 1px solid rgba(255,255,255,0.08); box-shadow: inset 0 -2px 0 #67E8F9; font-size: 13px; color: #F7F8F8;">
+      <span style="color: #67E8F9;">◆</span><span style="font-weight: 500;">Aurora Launch Spot</span>
+      <span style="font-size: 11px; opacity: 0.6;">▾</span>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; min-width: 120px; padding: 0 12px 0 16px; color: #8A8F98; border-right: 1px solid rgba(255,255,255,0.08); box-shadow: inset 0 -2px 0 rgba(103,232,249,0.35); font-size: 13px;">
+      <span style="color: #67E8F9;">◆</span><span>Overview</span>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; min-width: 110px; padding: 0 12px 0 16px; background: #08090A; color: #F7F8F8; border-right: 1px solid rgba(255,255,255,0.08); box-shadow: inset 0 -2px 0 rgba(103,232,249,0.35); font-size: 13px;">
+      <span style="color: #9460FF;">▥</span><span>Board</span>
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="rgba(247,248,248,0.38)" stroke-width="1.4"><path d="M3.5 3.5l7 7M10.5 3.5l-7 7"/></svg>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; min-width: 110px; padding: 0 12px 0 16px; color: #8A8F98; border-right: 1px solid rgba(255,255,255,0.08); box-shadow: inset 0 -2px 0 rgba(103,232,249,0.35); font-size: 13px;">
+      <span style="color: #08B8FF;">🎙</span><span>Script</span>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; min-width: 110px; padding: 0 12px 0 16px; color: #8A8F98; border-right: 1px solid rgba(255,255,255,0.08); box-shadow: inset 0 -2px 0 rgba(103,232,249,0.35); font-size: 13px;">
+      <span style="color: #9460FF;">▤</span><span>Cut v2</span>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; min-width: 140px; padding: 0 12px 0 16px; color: #8A8F98; border-right: 1px solid rgba(255,255,255,0.08); box-shadow: inset 0 -2px 0 rgba(103,232,249,0.35); font-size: 13px;">
+      <span style="color: #A7B1BF;">⬡</span><span>Render pipeline</span>
+    </div>
+    <div style="flex: 1;"></div>
+    <div style="display: flex; align-items: center; padding-right: 8px;">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="#8A8F98" stroke-width="1.3"><path d="M8 2a4 4 0 0 1 4 4v3l1.2 2H2.8L4 9V6a4 4 0 0 1 4-4z"/><path d="M6.7 13.4a1.5 1.5 0 0 0 2.6 0"/></svg>
+    </div>
+  </div>
+
+  <!-- ===== Left rail ===== -->
+  <div style="position: absolute; top: 0; left: 0; bottom: 0; width: 50px; background: #0A0B0D; border-right: 1px solid rgba(255,255,255,0.08); display: flex; flex-direction: column; align-items: center; padding: 10px 0 12px 0; gap: 4px; z-index: 3;">
+    <svg width="22" height="22" viewBox="0 0 22 22" fill="none" style="margin-bottom: 10px;"><path d="M11 2l7.8 4.5v9L11 20l-7.8-4.5v-9z" stroke="#F7F8F8" stroke-width="1.5"/><circle cx="11" cy="11" r="2.4" fill="#6690d4"/></svg>
+    <div style="width: 34px; height: 34px; border-radius: 6px; background: rgba(255,255,255,0.05); display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#67E8F9" stroke-width="1.5"><path d="M9 2.2l6.8 6.8L9 15.8 2.2 9z"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><rect x="2.5" y="2.5" width="5.4" height="5.4" rx="1"/><rect x="10.1" y="2.5" width="5.4" height="5.4" rx="1"/><rect x="2.5" y="10.1" width="5.4" height="5.4" rx="1"/><rect x="10.1" y="10.1" width="5.4" height="5.4" rx="1"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><path d="M9 2.5l5.6 3.2v6.6L9 15.5l-5.6-3.2V5.7z"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><path d="M3 4.5h12v7.5H8.5L5.5 15v-3H3z"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><path d="M11.5 3.2l3.3 3.3L6.3 15H3v-3.3z"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><path d="M3 5h12M3 9h8M3 13h10"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><rect x="2.5" y="3.5" width="13" height="11" rx="1.5"/><path d="M6.8 3.5v11M11.2 3.5v11"/></svg>
+    </div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><circle cx="9" cy="6.4" r="3"/><path d="M3.4 15c.9-2.8 3-4.2 5.6-4.2s4.7 1.4 5.6 4.2"/></svg>
+    </div>
+    <div style="flex: 1;"></div>
+    <div style="width: 34px; height: 34px; border-radius: 6px; display: flex; align-items: center; justify-content: center;">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="#8A8F98" stroke-width="1.4"><circle cx="9" cy="9" r="2.4"/><path d="M9 2.5v2M9 13.5v2M2.5 9h2M13.5 9h2M4.4 4.4l1.4 1.4M12.2 12.2l1.4 1.4M13.6 4.4l-1.4 1.4M5.8 12.2l-1.4 1.4"/></svg>
+    </div>
+  </div>
+
+  <!-- ===== Bottom strip ===== -->
+  <div style="position: absolute; bottom: 0; left: 50px; right: 0; height: 32px; background: #101113; border-top: 1px solid rgba(255,255,255,0.08); display: flex; align-items: center; padding: 0 12px; gap: 16px; font-size: 11px; color: #8A8F98;">
+    <span>Logs</span><span>Queue</span><span>Workers</span><span>Versions</span><span>Trace</span>
+    <div style="flex: 1;"></div>
+    <div style="display: flex; align-items: center; gap: 6px; font-family: 'JetBrains Mono', monospace;"><span style="width: 6px; height: 6px; border-radius: 50%; background: #9460FF; display: inline-block;"></span><span>1 job running · shot 7 clip · 0:41</span></div>
+  </div>
+
+  <!-- ===== Center: the storyboard surface, unchanged, full-bleed ===== -->
+  <div style="position: absolute; top: 40px; left: 50px; right: 0; bottom: 32px; overflow: hidden; display: flex; flex-direction: column;">
+
+    <!-- Board toolbar (the surface's own header) -->
+    <div style="display: flex; align-items: center; gap: 12px; padding: 14px 24px 12px 24px;">
+      <span style="font-size: 18px; font-weight: 600;">Board</span>
+      <span style="font-size: 13px; color: #8A8F98;">8 shots · night-minimal style · entity: Aurora lamp</span>
+      <div style="flex: 1;"></div>
+      <div style="display: flex; align-items: center; gap: 6px; height: 28px; padding: 0 12px; border: 1px solid rgba(255,255,255,0.08); border-radius: 6px; color: #8A8F98; font-size: 13px;">Render stills</div>
+      <div style="display: flex; align-items: center; gap: 6px; height: 28px; padding: 0 12px; border: 1px solid rgba(255,255,255,0.08); border-radius: 6px; color: #8A8F98; font-size: 13px;">Render clips</div>
+      <div style="display: flex; align-items: center; gap: 6px; height: 28px; padding: 0 12px; background: #6690d4; border-radius: 6px; color: #fff; font-size: 13px; font-weight: 500;">Assemble timeline</div>
+    </div>
+
+    <!-- Shot grid -->
+    <div style="flex: 1; padding: 4px 24px 16px 24px; overflow: hidden;">
+      <div style="display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 16px;">
+
+        <!-- Shot 1 -->
+        <div style="background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; overflow: hidden;">
+          <div style="position: relative; height: 150px;">
+            <svg viewBox="0 0 320 150" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;"><rect width="320" height="150" fill="#0c0c14"/><circle cx="160" cy="80" r="10" fill="#8f7bff"/><rect x="130" y="112" width="60" height="4" rx="2" fill="#232038"/></svg>
+            <span style="position: absolute; left: 8px; top: 8px; font-size: 11px; font-family: 'JetBrains Mono', monospace; color: #9CA0A8; background: rgba(0,0,0,0.55); border-radius: 4px; padding: 2px 6px;">SH 01 · 3s</span>
+            <span style="position: absolute; right: 8px; bottom: 8px; height: 18px; padding: 0 7px; border-radius: 9999px; background: rgba(80,250,123,0.12); border: 1px solid rgba(80,250,123,0.5); color: #50FA7B; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">clip · 38s</span>
+          </div>
+          <div style="padding: 10px 12px; font-size: 13px; color: #D4D6DB; line-height: 1.45;">Dark room. A single point of light breathes on.</div>
+        </div>
+
+        <!-- Shot 2 -->
+        <div style="background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; overflow: hidden;">
+          <div style="position: relative; height: 150px;">
+            <svg viewBox="0 0 320 150" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;"><rect width="320" height="150" fill="#151329"/><rect x="150" y="58" width="12" height="60" rx="5" fill="#2A2740"/><circle cx="156" cy="50" r="18" fill="#8f7bff"/><circle cx="156" cy="50" r="34" fill="#8f7bff" opacity="0.14"/></svg>
+            <span style="position: absolute; left: 8px; top: 8px; font-size: 11px; font-family: 'JetBrains Mono', monospace; color: #9CA0A8; background: rgba(0,0,0,0.55); border-radius: 4px; padding: 2px 6px;">SH 02 · 3s</span>
+            <span style="position: absolute; right: 8px; bottom: 8px; height: 18px; padding: 0 7px; border-radius: 9999px; background: rgba(80,250,123,0.12); border: 1px solid rgba(80,250,123,0.5); color: #50FA7B; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">clip · 44s</span>
+          </div>
+          <div style="padding: 10px 12px; font-size: 13px; color: #D4D6DB; line-height: 1.45;">Macro on the Aurora head, halo blooming softly.</div>
+        </div>
+
+        <!-- Shot 3 -->
+        <div style="background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; overflow: hidden;">
+          <div style="position: relative; height: 150px;">
+            <svg viewBox="0 0 320 150" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;"><rect width="320" height="150" fill="#12141c"/><rect x="30" y="96" width="260" height="8" rx="3" fill="#1e2230"/><rect x="60" y="60" width="70" height="36" rx="3" fill="#1a1d28"/><rect x="210" y="48" width="12" height="48" rx="4" fill="#2A2740"/><circle cx="216" cy="42" r="12" fill="#8f7bff"/></svg>
+            <span style="position: absolute; left: 8px; top: 8px; font-size: 11px; font-family: 'JetBrains Mono', monospace; color: #9CA0A8; background: rgba(0,0,0,0.55); border-radius: 4px; padding: 2px 6px;">SH 03 · 4s</span>
+            <span style="position: absolute; right: 8px; bottom: 8px; height: 18px; padding: 0 7px; border-radius: 9999px; background: rgba(80,250,123,0.12); border: 1px solid rgba(80,250,123,0.5); color: #50FA7B; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">clip · 51s</span>
+          </div>
+          <div style="padding: 10px 12px; font-size: 13px; color: #D4D6DB; line-height: 1.45;">Wide: the desk at night, laptop closed, lamp waiting.</div>
+        </div>
+
+        <!-- Shot 4 -->
+        <div style="background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; overflow: hidden;">
+          <div style="position: relative; height: 150px;">
+            <svg viewBox="0 0 320 150" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;"><rect width="320" height="150" fill="#241a10"/><path d="M40 150 C90 96 150 110 200 74" stroke="#3a2a17" stroke-width="26" fill="none" stroke-linecap="round"/><circle cx="216" cy="64" r="14" fill="#FFB86C"/></svg>
+            <span style="position: absolute; left: 8px; top: 8px; font-size: 11px; font-family: 'JetBrains Mono', monospace; color: #9CA0A8; background: rgba(0,0,0,0.55); border-radius: 4px; padding: 2px 6px;">SH 04 · 3s</span>
+            <span style="position: absolute; right: 8px; bottom: 8px; height: 18px; padding: 0 7px; border-radius: 9999px; background: rgba(80,250,123,0.12); border: 1px solid rgba(80,250,123,0.5); color: #50FA7B; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">clip · 36s</span>
+          </div>
+          <div style="padding: 10px 12px; font-size: 13px; color: #D4D6DB; line-height: 1.45;">A hand reaches into frame toward the touch ring.</div>
+        </div>
+
+        <!-- Shot 5 — SELECTED -->
+        <div style="background: #101113; border: 1px solid #6690d4; box-shadow: 0 0 0 1px #6690d4; border-radius: 8px; overflow: hidden;">
+          <div style="position: relative; height: 150px;">
+            <svg viewBox="0 0 320 150" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;"><rect width="320" height="150" fill="#0e0c18"/><circle cx="160" cy="72" r="46" fill="#f5edda"/><circle cx="160" cy="72" r="70" fill="#f5edda" opacity="0.12"/><rect x="152" y="104" width="14" height="46" rx="5" fill="#2A2740"/></svg>
+            <span style="position: absolute; left: 8px; top: 8px; font-size: 11px; font-family: 'JetBrains Mono', monospace; color: #9CA0A8; background: rgba(0,0,0,0.55); border-radius: 4px; padding: 2px 6px;">SH 05 · 2s</span>
+            <span style="position: absolute; right: 8px; bottom: 8px; height: 18px; padding: 0 7px; border-radius: 9999px; background: rgba(80,250,123,0.12); border: 1px solid rgba(80,250,123,0.5); color: #50FA7B; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">clip · 41s</span>
+          </div>
+          <div style="padding: 10px 12px; display: flex; flex-direction: column; gap: 8px;">
+            <div style="font-size: 13px; color: #D4D6DB; line-height: 1.45;">Fast push-in: light-on moment, bloom on the switch.</div>
+            <!-- Project context carried into the surface: the shot's place in sibling documents -->
+            <div style="display: flex; flex-wrap: wrap; gap: 6px;">
+              <span style="height: 20px; padding: 0 8px; border-radius: 4px; background: rgba(148,96,255,0.1); border: 1px solid rgba(148,96,255,0.4); color: #c9adff; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center; gap: 5px;">▤ in Cut v2 · 00:12</span>
+              <span style="height: 20px; padding: 0 8px; border-radius: 4px; background: rgba(8,184,255,0.08); border: 1px solid rgba(8,184,255,0.35); color: #7fd6ff; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center; gap: 5px;">🎙 VO 3</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Shot 6 -->
+        <div style="background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; overflow: hidden;">
+          <div style="position: relative; height: 150px;">
+            <svg viewBox="0 0 320 150" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;"><rect width="320" height="150" fill="#101113"/><rect x="0" y="0" width="106" height="150" fill="#2b1a3e"/><rect x="106" y="0" width="107" height="150" fill="#132c3a"/><rect x="213" y="0" width="107" height="150" fill="#3a2517"/><circle cx="53" cy="75" r="12" fill="#b18cff"/><circle cx="160" cy="75" r="12" fill="#67E8F9"/><circle cx="266" cy="75" r="12" fill="#FFB86C"/></svg>
+            <span style="position: absolute; left: 8px; top: 8px; font-size: 11px; font-family: 'JetBrains Mono', monospace; color: #9CA0A8; background: rgba(0,0,0,0.55); border-radius: 4px; padding: 2px 6px;">SH 06 · 4s</span>
+            <span style="position: absolute; right: 8px; bottom: 8px; height: 18px; padding: 0 7px; border-radius: 9999px; background: rgba(80,250,123,0.12); border: 1px solid rgba(80,250,123,0.5); color: #50FA7B; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">clip · 47s</span>
+          </div>
+          <div style="padding: 10px 12px; font-size: 13px; color: #D4D6DB; line-height: 1.45;">Triptych: the ring cycles warm, cool, amber.</div>
+        </div>
+
+        <!-- Shot 7 — MID-RENDER (purple border) -->
+        <div style="background: #101113; border: 1px solid #9460FF; box-shadow: 0 0 0 1px rgba(148,96,255,0.35); border-radius: 8px; overflow: hidden;">
+          <div style="position: relative; height: 150px;">
+            <svg viewBox="0 0 320 150" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;"><rect width="320" height="150" fill="#0d1524"/><rect x="196" y="20" width="90" height="110" rx="4" fill="#13203a"/><circle cx="90" cy="86" r="20" fill="#8f7bff" opacity="0.9"/><rect x="80" y="112" width="20" height="38" rx="6" fill="#1a2338"/></svg>
+            <span style="position: absolute; left: 8px; top: 8px; font-size: 11px; font-family: 'JetBrains Mono', monospace; color: #9CA0A8; background: rgba(0,0,0,0.55); border-radius: 4px; padding: 2px 6px;">SH 07 · 5s</span>
+            <div style="position: absolute; left: 0; right: 0; bottom: 0; height: 3px; background: #1B1D21;"><div style="width: 62%; height: 100%; background: #9460FF;"></div></div>
+            <span style="position: absolute; right: 8px; bottom: 8px; height: 18px; padding: 0 7px; border-radius: 9999px; background: rgba(148,96,255,0.16); border: 1px solid #9460FF; color: #c9adff; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">rendering · 0:41</span>
+          </div>
+          <div style="padding: 10px 12px; font-size: 13px; color: #D4D6DB; line-height: 1.45;">Night lifestyle: reader by the window, city bokeh.</div>
+        </div>
+
+        <!-- Shot 8 — still only -->
+        <div style="background: #101113; border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; overflow: hidden;">
+          <div style="position: relative; height: 150px;">
+            <svg viewBox="0 0 320 150" preserveAspectRatio="xMidYMid slice" style="width: 100%; height: 100%; display: block;"><rect width="320" height="150" fill="#0c0c14"/><rect x="140" y="44" width="10" height="50" rx="4" fill="#2A2740"/><circle cx="145" cy="38" r="13" fill="#8f7bff"/><rect x="118" y="106" width="84" height="8" rx="3" fill="#3A3D44"/><rect x="132" y="122" width="56" height="5" rx="2.5" fill="#27292E"/></svg>
+            <span style="position: absolute; left: 8px; top: 8px; font-size: 11px; font-family: 'JetBrains Mono', monospace; color: #9CA0A8; background: rgba(0,0,0,0.55); border-radius: 4px; padding: 2px 6px;">SH 08 · 6s</span>
+            <span style="position: absolute; right: 8px; bottom: 8px; height: 18px; padding: 0 7px; border-radius: 9999px; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.15); color: #9CA0A8; font-size: 11px; font-family: 'JetBrains Mono', monospace; display: inline-flex; align-items: center;">still · clip queued</span>
+          </div>
+          <div style="padding: 10px 12px; font-size: 13px; color: #D4D6DB; line-height: 1.45;">End card: product and wordmark. Aurora. Work late, gently.</div>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- Selection footer: cross-document jump, the "one thing" mechanism -->
+    <div style="padding: 0 24px 16px 24px;">
+      <div style="display: flex; align-items: center; gap: 12px; height: 44px; padding: 0 16px; background: #17181B; border: 1px solid rgba(255,255,255,0.08); border-radius: 8px;">
+        <span style="font-size: 11px; font-family: 'JetBrains Mono', monospace; color: #9CA0A8;">SH 05 selected</span>
+        <span style="width: 1px; height: 16px; background: rgba(255,255,255,0.08);"></span>
+        <span style="font-size: 13px; color: #8A8F98;">Appears in</span>
+        <span style="display: inline-flex; align-items: center; gap: 6px; height: 24px; padding: 0 10px; border: 1px solid rgba(148,96,255,0.4); border-radius: 6px; color: #c9adff; font-size: 13px;"><span style="color: #9460FF;">▤</span> Cut v2 at 00:12 <span style="color: #5C606A;">→</span></span>
+        <span style="display: inline-flex; align-items: center; gap: 6px; height: 24px; padding: 0 10px; border: 1px solid rgba(8,184,255,0.35); border-radius: 6px; color: #7fd6ff; font-size: 13px;"><span style="color: #08B8FF;">🎙</span> Script, VO 3 <span style="color: #5C606A;">→</span></span>
+        <div style="flex: 1;"></div>
+        <span style="font-size: 13px; color: #8A8F98;">Revise take</span>
+        <span style="display: inline-flex; align-items: center; height: 28px; padding: 0 12px; background: #6690d4; border-radius: 6px; color: #fff; font-size: 13px; font-weight: 500;">Re-render clip</span>
+      </div>
+    </div>
+  </div>
+
+</div>
+</x-dc>
+</body>
+</html>


### PR DESCRIPTION
Adds `docs/plans/project-view/`: an executable plan for making the *project* the unit of the workspace, plus the four pixel-matched mockups it references.

## What's in it

- **PLAN.md** — phased tasks with codes an agent can execute one by one:
  - Phase 0: restyle the storyboard board as a shot grid (compact toolbar, 4-column cards, status pills, mid-render border, selection footer) — ships first, independent of the project layer.
  - Phase 1: `projects` table, tRPC router, status/spend rollup, creation sites stop hardcoding `projectId: "default"`.
  - Phase 2: shell — project tab group with a cyan scope chip in `WorkspaceTabBar`, Projects rail entry, projects-list tab.
  - Phase 3: project overview tab (agent thread + document cards + spend bar).
  - Phase 4: full-view "Start a project" surface; OpenMenu demoted, not removed.
  - Phase 5: cross-document "appears in" links (shot ↔ timeline clip ↔ script line).
- **mockups/** — four 1440×900 HTML screens drawn from the shipped shell's real tokens; each carries a header comment naming the plan phases it backs, and the plan's mockup table points back at each file.

Design rationale in short: every document row already carries `project_id`; the plan spends that column. A project is a tab group plus one overview tab — no new window, no mode, and the fifteen editors keep the center area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AB4DRbuuiDq2KFqFjGmNPB

---
_Generated by [Claude Code](https://claude.ai/code/session_01AB4DRbuuiDq2KFqFjGmNPB)_