### PR TITLE
feat(storyboard): restyle the board as a shot grid (project view, phase 0)

### DIFF
--- a/web/src/components/storyboard/ShotCard.tsx
+++ b/web/src/components/storyboard/ShotCard.tsx
@@ -1,97 +1,55 @@
 /**
  * ShotCard
  *
- * One shot in the storyboard, laid out as a full-width row: the keyframe
- * still or rendered clip on the left, and the shot's text, camera line,
- * cast, takes browser, and actions in the wide column beside it. There is
- * no approval step: the selected still (see {@link ShotTakesGallery}) is
- * what the clip render uses, so a shot is ready for video as soon as it
- * has a still.
+ * One cell of the storyboard's shot grid: the rendered clip or selected still
+ * on top, the action line under it. The card carries only what reads at a
+ * glance — the shot number and length, a status pill, a render's progress —
+ * and clicking it selects the shot, which opens {@link ShotInspector} under
+ * the grid with the shot's prompt, takes, cast, and per-shot actions.
  */
 
-import React, { memo, useCallback, useMemo, useState } from "react";
-import { keyframes } from "@emotion/react";
-import type { Theme } from "@mui/material/styles";
+import React, { memo, useCallback, useState } from "react";
 import { useTheme } from "@mui/material/styles";
-import type { ImageRef, Shot, ShotStatus, VideoRef } from "@nodetool-ai/protocol";
-import { shotRenderMode } from "@nodetool-ai/protocol";
-import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
-import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
-import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import type { ImageRef, Shot, VideoRef } from "@nodetool-ai/protocol";
 import FullscreenIcon from "@mui/icons-material/Fullscreen";
-import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
 
 import {
   Box,
   Card,
   Caption,
-  Chip,
-  Dialog,
-  EditorButton,
-  EditorMenu,
-  EditorMenuItem,
   FlexColumn,
-  FlexRow,
-  HoverActionGroup,
-  StatusIndicator,
+  ProgressBar,
   Text,
-  TextInput,
   ToolbarIconButton,
   VideoPlayer,
   BORDER_RADIUS,
-  MOTION,
   SPACING,
-  reducedMotion,
-  type StatusType
+  TYPOGRAPHY
 } from "../ui_primitives";
 import ImageRefPreview from "../node/ImageRefPreview";
 import ShotMediaViewer from "./ShotMediaViewer";
-import ShotTakesGallery from "./ShotTakesGallery";
-import ShotScriptPanel from "./ShotScriptPanel";
-import {
-  sameMediaRef,
-  useStoryboardStore
-} from "../../stores/storyboard/StoryboardStore";
-import { entitiesForShot } from "../../stores/storyboard/shotEntities";
-import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
+import ShotStatusPill, {
+  CLIP_COLOR,
+  isShotGenerating
+} from "./ShotStatusPill";
 import { useStoryboardGenerationStore } from "../../stores/storyboard/StoryboardGenerationStore";
 import { useShotDuration } from "../../hooks/storyboard/useShotDuration";
-import { useEntities } from "../../serverState/useEntities";
-import {
-  getEntityChipSx,
-  getEntityKindDotSx
-} from "../entities/entityKind";
 import { useResolvedMediaUri } from "../../hooks/useResolvedMediaUri";
 
 interface ShotCardProps {
   boardId: string;
   shot: Shot;
-  readOnly?: boolean;
-  /** True when this is the first shot on the board (disables "move up"). */
-  isFirst?: boolean;
-  /** True when this is the last shot on the board (disables "move down"). */
-  isLast?: boolean;
+  /** True when this card is the board's selected shot. */
+  selected?: boolean;
+  /** Selects (or, on the selected card, deselects) this shot. */
+  onSelect?: (shotId: string) => void;
 }
 
-const STATUS_META: Record<
-  ShotStatus,
-  { status: StatusType; label: string; pulse?: boolean }
-> = {
-  planned: { status: "default", label: "Planned" },
-  keyframe_generating: { status: "pending", label: "Generating still…", pulse: true },
-  keyframe_ready: { status: "info", label: "Still ready" },
-  // Legacy status from the removed approval step; same meaning as a ready still.
-  approved: { status: "info", label: "Still ready" },
-  clip_generating: { status: "pending", label: "Rendering…", pulse: true },
-  rendered: { status: "success", label: "Rendered" },
-  failed: { status: "error", label: "Failed" }
-};
-
-const previewSx = {
+/** The thumbnail: a fixed 16:9 media area every card in the grid shares. */
+const mediaSx = {
   position: "relative",
   width: "100%",
   aspectRatio: "16 / 9",
-  borderRadius: BORDER_RADIUS.sm,
   overflow: "hidden",
   bgcolor: "c_overlay_subtle",
   display: "flex",
@@ -104,143 +62,50 @@ const previewSx = {
   }
 } as const;
 
-const cardGridSx = {
-  display: "grid",
-  gridTemplateColumns: "minmax(220px, 300px) minmax(0, 1fr)",
-  gap: SPACING.lg,
-  alignItems: "start",
-  "@media (max-width: 720px)": {
-    gridTemplateColumns: "minmax(0, 1fr)"
-  }
-} as const;
-
-/**
- * Secondary actions read as text rather than as a row of equal accent links;
- * only the step the shot has not taken yet keeps the accent.
- */
-const quietActionSx = {
+/** The `SH 01 · 3s` label, on a scrim so it reads over any still. */
+const shotLabelSx = {
+  position: "absolute",
+  left: SPACING.md,
+  top: SPACING.md,
+  px: SPACING.sm,
+  py: SPACING.micro,
+  borderRadius: BORDER_RADIUS.xs,
+  bgcolor: "c_scrim_soft",
   color: "text.secondary",
-  "&:hover": { color: "text.primary", bgcolor: "c_overlay_subtle" }
+  ...TYPOGRAPHY.mono.caption
 } as const;
 
-/** Metadata chips carry no status color — the label is the whole signal. */
-const quietChipSx = {
-  borderRadius: BORDER_RADIUS.pill,
-  color: "text.secondary",
-  borderColor: "divider"
-} as const;
+/** The render bar sits on the thumbnail's bottom edge, 3px per the design. */
+const RENDER_BAR_HEIGHT = 3;
 
-/** The glow that travels around the frame while a still or clip renders. */
-const borderOrbit = keyframes`
-  0% { background-position: 0% 0%; }
-  25% { background-position: 100% 0%; }
-  50% { background-position: 100% 100%; }
-  75% { background-position: 0% 100%; }
-  100% { background-position: 0% 0%; }
-`;
-
-/**
- * Animated border for a shot whose still or clip is rendering: the card's
- * own border goes transparent and a pseudo-element paints a two-layer
- * background — paper over the interior, a radial-gradient tile above the
- * border ring. The tile is larger than the card, and the orbit keyframes
- * move it corner to corner, so the glow circles the frame.
- */
-const generatingSx = (theme: Theme): Record<string, unknown> => ({
-  position: "relative",
-  outline: "none",
-  border: "1px solid transparent",
-  "&::before": {
-    content: '""',
-    position: "absolute",
-    inset: 0,
-    borderRadius: "inherit",
-    pointerEvents: "none",
-    backgroundImage: `linear-gradient(${theme.vars.palette.background.paper}, ${theme.vars.palette.background.paper}), radial-gradient(
-      circle closest-side,
-      ${theme.vars.palette.primary.light} 0%,
-      ${theme.vars.palette.primary.main} 45%,
-      transparent 100%
-    )`,
-    backgroundSize: "auto, 250% 250%",
-    backgroundRepeat: "no-repeat",
-    backgroundOrigin: "border-box",
-    backgroundClip: "padding-box, border-box",
-    animation: `${borderOrbit.name} ${MOTION.pulse} infinite`
-  },
-  ...reducedMotion({
-    "&::before": { animation: "none" }
-  })
-});
-
-const cameraLine = (shot: Shot): string =>
-  [
-    shot.camera?.framing,
-    shot.camera?.lens,
-    shot.camera?.angle,
-    shot.camera?.movement
-  ]
-    .filter((p): p is string => !!p && p.trim().length > 0)
-    .join(" · ");
-
-const EMPTY_IDS: string[] = [];
+const shotNumber = (shot: Shot): string =>
+  `SH ${String(shot.index + 1).padStart(2, "0")}`;
 
 const ShotCardInner: React.FC<ShotCardProps> = ({
   boardId,
   shot,
-  readOnly,
-  isFirst,
-  isLast
+  selected,
+  onSelect
 }) => {
-  const toggleShotEntity = useStoryboardStore((state) => state.toggleShotEntity);
-  const updateShot = useStoryboardStore((state) => state.updateShot);
-  const moveShot = useStoryboardStore((state) => state.moveShot);
-  const removeShot = useStoryboardStore((state) => state.removeShot);
-  const removeKeyframeVersion = useStoryboardStore(
-    (state) => state.removeKeyframeVersion
-  );
-  const removeClipVersion = useStoryboardStore(
-    (state) => state.removeClipVersion
-  );
-  const boardEntityIds = useStoryboardStore(
-    (state) => state.boards[boardId]?.entityIds ?? EMPTY_IDS
-  );
-  const { data: allEntities } = useEntities();
-  const { generateKeyframe, generateClip, generateRevisedClip } =
-    useGenerateShot();
-
-  const { boardEntities, appliedIds } = useMemo(() => {
-    const idSet = new Set(boardEntityIds);
-    const board = (allEntities ?? []).filter((e) => idSet.has(e.id));
-    return {
-      boardEntities: board,
-      appliedIds: entitiesForShot(shot, board).map((e) => e.id)
-    };
-  }, [allEntities, boardEntityIds, shot]);
-
-  const [reviseOpen, setReviseOpen] = useState(false);
-  // Anchor for the overflow menu holding the destructive take actions; null
-  // when it is closed.
-  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
-  const [reviseText, setReviseText] = useState("");
-  const [confirmDelete, setConfirmDelete] = useState(false);
+  const theme = useTheme();
   // The still or clip the fullscreen viewer shows; null when it is closed.
   const [viewerMedia, setViewerMedia] = useState<ImageRef | VideoRef | null>(
     null
   );
 
-  const meta = STATUS_META[shot.status];
-  const theme = useTheme();
   // Why the last still or clip failed. Kept on the shot's job state until the
-  // next attempt registers, so the card can say more than "Failed".
+  // next attempt registers, so the card can say more than "failed".
   const renderError = useStoryboardGenerationStore((state) => {
     const job = state.shotJobs[shot.id];
     return job?.status === "failed" ? job.errorMessage : undefined;
   });
+  const progress = useStoryboardGenerationStore(
+    (state) => state.shotJobs[shot.id]?.progress
+  );
+
   const failed = shot.status === "failed";
-  const isGenerating =
-    shot.status === "keyframe_generating" || shot.status === "clip_generating";
-  const camera = cameraLine(shot);
+  const isGenerating = isShotGenerating(shot);
+  const duration = useShotDuration(boardId, shot);
   // Whether there is a clip to show at all: the player itself resolves the
   // `asset://` locator, but the card renders the keyframe when it cannot.
   const clipUri = useResolvedMediaUri(shot.clip);
@@ -250,144 +115,71 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
   const previewMedia: ImageRef | VideoRef | null = clipUri
     ? (shot.clip as VideoRef)
     : (shot.keyframe ?? null);
-  const handleOpenViewer = useCallback(() => {
-    if (previewMedia) {
-      setViewerMedia(previewMedia);
-    }
-  }, [previewMedia]);
-  const handleCloseViewer = useCallback(() => setViewerMedia(null), []);
 
-  // A start that throws records its reason on the shot's job state (and
-  // toasts it), which is what `renderError` above shows — so the rejection is
-  // already reported and only needs to not go unhandled.
-  const handleGenerateStill = useCallback(() => {
-    void generateKeyframe(boardId, shot).catch(() => undefined);
-  }, [generateKeyframe, boardId, shot]);
-
-  const handleGenerateClip = useCallback(() => {
-    void generateClip(boardId, shot).catch(() => undefined);
-  }, [generateClip, boardId, shot]);
-
-  const handleReviseConfirm = useCallback(() => {
-    const instruction = reviseText.trim();
-    if (instruction.length > 0) {
-      void generateRevisedClip(boardId, shot, instruction).catch(
-        () => undefined
-      );
-    }
-    setReviseOpen(false);
-    setReviseText("");
-  }, [reviseText, generateRevisedClip, boardId, shot]);
-
-  const handleMoveUp = useCallback(() => {
-    moveShot(boardId, shot.id, "up");
-  }, [moveShot, boardId, shot.id]);
-
-  const handleMoveDown = useCallback(() => {
-    moveShot(boardId, shot.id, "down");
-  }, [moveShot, boardId, shot.id]);
-
-  // A shot covering script lines is timed by the takes under it unless the
-  // user pins it; the chip says which, and clicking it switches.
-  const duration = useShotDuration(boardId, shot);
-  const linksLines = (shot.script_line_ids?.length ?? 0) > 0;
-  const durationLabel =
-    duration.seconds != null
-      ? `${duration.seconds}s · ${duration.source === "audio" ? "from takes" : "manual"}`
-      : "model default";
-  // Camera and cost share one quiet line under the action text; neither is
-  // worth a chip of its own.
-  const metaLine = [
-    camera.length > 0 ? camera : null,
-    shot.cost_estimate != null ? `~$${shot.cost_estimate.toFixed(2)}` : null
-  ]
-    .filter((p): p is string => p !== null)
-    .join(" · ");
-
-  const handleToggleDurationSource = useCallback(() => {
-    updateShot(boardId, shot.id, {
-      duration_source: shot.duration_source === "manual" ? "audio" : "manual"
-    });
-  }, [updateShot, boardId, shot.id, shot.duration_source]);
-
-  const handleOpenMenu = useCallback(
-    (event: React.MouseEvent<HTMLElement>) => setMenuAnchor(event.currentTarget),
-    []
+  const handleOpenViewer = useCallback(
+    (event?: React.SyntheticEvent) => {
+      // The card itself selects on click; opening the viewer is its own action.
+      event?.stopPropagation();
+      if (previewMedia) {
+        setViewerMedia(previewMedia);
+      }
+    },
+    [previewMedia]
   );
-  const handleCloseMenu = useCallback(() => setMenuAnchor(null), []);
-
-  const handleDelete = useCallback(() => {
-    removeShot(boardId, shot.id);
-    setConfirmDelete(false);
-  }, [removeShot, boardId, shot.id]);
-
-  const handleRemoveStill = useCallback(() => {
-    setMenuAnchor(null);
-    const versions =
-      shot.keyframe_versions ?? (shot.keyframe ? [shot.keyframe] : []);
-    if (versions.length === 0 || !shot.keyframe) {
-      return;
-    }
-    const selected = versions.findIndex((v) =>
-      sameMediaRef(v, shot.keyframe as ImageRef)
-    );
-    const index = selected >= 0 ? selected : 0;
-    removeKeyframeVersion(boardId, shot.id, index);
-  }, [
-    shot.keyframe,
-    shot.keyframe_versions,
-    removeKeyframeVersion,
-    boardId,
-    shot.id
-  ]);
-
-  const handleRemoveClip = useCallback(() => {
-    setMenuAnchor(null);
-    const versions = shot.clip_versions ?? (shot.clip ? [shot.clip] : []);
-    if (versions.length === 0 || !shot.clip) {
-      return;
-    }
-    const selected = versions.findIndex((v) =>
-      sameMediaRef(v, shot.clip as VideoRef)
-    );
-    const index = selected >= 0 ? selected : 0;
-    removeClipVersion(boardId, shot.id, index);
-  }, [shot.clip, shot.clip_versions, removeClipVersion, boardId, shot.id]);
+  const handleCloseViewer = useCallback(() => setViewerMedia(null), []);
+  const handleSelect = useCallback(() => {
+    onSelect?.(shot.id);
+  }, [onSelect, shot.id]);
 
   return (
     <Card
       variant="outlined"
-      padding="compact"
+      padding="none"
+      clickable={!!onSelect}
+      onClick={handleSelect}
       className="shot-card"
+      aria-label={shotName}
+      aria-pressed={onSelect ? !!selected : undefined}
       data-generating={isGenerating ? "true" : undefined}
+      data-selected={selected ? "true" : undefined}
       sx={{
-        ...cardGridSx,
-        ...(isGenerating ? generatingSx(theme) : undefined)
+        overflow: "hidden",
+        borderRadius: BORDER_RADIUS.lg,
+        borderColor: isGenerating
+          ? CLIP_COLOR
+          : selected
+            ? "primary.main"
+            : "divider",
+        boxShadow: isGenerating
+          ? `0 0 0 1px ${CLIP_COLOR}`
+          : selected
+            ? `0 0 0 1px ${theme.palette.primary.main}`
+            : undefined
       }}
     >
-      <Box sx={previewSx} onDoubleClick={previewMedia ? handleOpenViewer : undefined}>
+      <Box sx={mediaSx} onDoubleClick={previewMedia ? handleOpenViewer : undefined}>
         {clipUri ? (
           <VideoPlayer locator={shot.clip} />
         ) : (
           <ImageRefPreview
             value={shot.keyframe}
             placeholder={
-              <Caption
-                color="muted"
-                sx={{ textAlign: "center", p: SPACING.md }}
-              >
+              <Caption color="muted" sx={{ textAlign: "center", p: SPACING.md }}>
                 No still yet
               </Caption>
             }
           />
         )}
+        <Box sx={shotLabelSx}>
+          {duration.seconds != null
+            ? `${shotNumber(shot)} · ${duration.seconds}s`
+            : shotNumber(shot)}
+        </Box>
         {previewMedia && !isGenerating && (
           <ToolbarIconButton
             icon={<FullscreenIcon sx={{ fontSize: "1em" }} />}
             tooltip="View fullscreen (double-click)"
-            ariaLabel={
-              clipUri ? "View clip fullscreen" : "View still fullscreen"
-            }
+            ariaLabel={clipUri ? "View clip fullscreen" : "View still fullscreen"}
             onClick={handleOpenViewer}
             sx={{
               position: "absolute",
@@ -402,89 +194,32 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
             }}
           />
         )}
-        {failed && !isGenerating && !shot.keyframe && !shot.clip && (
-          <FlexColumn
-            align="center"
-            justify="center"
-            sx={{
-              position: "absolute",
-              inset: 0,
-              bgcolor: "c_scrim_soft",
-              p: SPACING.sm
-            }}
-          >
-            <Caption sx={{ color: "error.main", textAlign: "center" }}>
-              Render failed
-            </Caption>
-          </FlexColumn>
-        )}
+        <ShotStatusPill
+          shot={shot}
+          durationSeconds={duration.seconds}
+          sx={{
+            position: "absolute",
+            right: SPACING.md,
+            bottom: SPACING.md
+          }}
+        />
         {isGenerating && (
-          <FlexColumn
-            align="center"
-            justify="center"
-            gap={SPACING.sm}
-            sx={{
-              position: "absolute",
-              inset: 0,
-              bgcolor: "c_scrim_soft"
-            }}
-          >
-            <Caption>
-              {shot.status === "clip_generating"
-                ? "Rendering clip…"
-                : "Generating still…"}
-            </Caption>
-          </FlexColumn>
+          <Box sx={{ position: "absolute", left: 0, right: 0, bottom: 0 }}>
+            <ProgressBar
+              value={progress ?? 0}
+              progressVariant={progress == null ? "indeterminate" : "determinate"}
+              showValue={false}
+              sx={{
+                height: RENDER_BAR_HEIGHT,
+                backgroundColor: "c_overlay_subtle",
+                "& .MuiLinearProgress-bar": { backgroundColor: CLIP_COLOR }
+              }}
+            />
+          </Box>
         )}
       </Box>
 
-      <FlexColumn gap={SPACING.sm} sx={{ minWidth: 0 }}>
-        <FlexRow align="center" justify="space-between" gap={SPACING.sm}>
-          <Text size="small" truncate sx={{ minWidth: 0 }}>
-            {shotName}
-          </Text>
-          <FlexRow align="center" gap={SPACING.xs} sx={{ flexShrink: 0 }}>
-            <StatusIndicator
-              status={meta.status}
-              label={meta.label}
-              pulse={meta.pulse}
-              labelTone={failed ? "status" : "muted"}
-            />
-            {!readOnly && (
-              <HoverActionGroup
-                triggerSelector=".shot-card:hover"
-                gap={0}
-                // Touch devices can't hover; keep the row actions (reorder,
-                // delete) visible there instead of hiding behind the reveal.
-                sx={{ "@media (pointer: coarse)": { opacity: 1 } }}
-              >
-                <ToolbarIconButton
-                  icon={<ArrowUpwardIcon sx={{ fontSize: "1em" }} />}
-                  tooltip="Move up"
-                  ariaLabel="Move shot up"
-                  onClick={handleMoveUp}
-                  disabled={isFirst}
-                />
-                <ToolbarIconButton
-                  icon={<ArrowDownwardIcon sx={{ fontSize: "1em" }} />}
-                  tooltip="Move down"
-                  ariaLabel="Move shot down"
-                  onClick={handleMoveDown}
-                  disabled={isLast}
-                />
-                <ToolbarIconButton
-                  icon={<DeleteOutlineIcon sx={{ fontSize: "1em" }} />}
-                  tooltip="Delete shot"
-                  ariaLabel="Delete shot"
-                  variant="error"
-                  onClick={() => setConfirmDelete(true)}
-                  disabled={isGenerating}
-                />
-              </HoverActionGroup>
-            )}
-          </FlexRow>
-        </FlexRow>
-
+      <FlexColumn gap={SPACING.xs} sx={{ p: SPACING.lg, minWidth: 0 }}>
         {failed && (
           <Caption
             role="alert"
@@ -494,174 +229,11 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
             {renderError ?? "The render failed. Try again."}
           </Caption>
         )}
-
-        <Text lineClamp={3} sx={{ lineHeight: 1.6 }}>
+        <Text size="small" weight={400} lineClamp={2} sx={{ lineHeight: 1.45 }}>
           {shot.action}
         </Text>
-
-        {(metaLine.length > 0 || linksLines) && (
-          <FlexRow align="center" gap={SPACING.sm} wrap>
-            {metaLine.length > 0 && (
-              <Caption color="secondary" noWrap>
-                {metaLine}
-              </Caption>
-            )}
-            {linksLines && (
-              <Chip
-                compact
-                variant="outlined"
-                label={durationLabel}
-                sx={quietChipSx}
-                title={
-                  duration.source === "audio"
-                    ? "Length comes from the takes of the lines this shot covers. Click to pin it to the shot's own duration."
-                    : "Length is pinned to the shot's own duration. Click to take it from the lines this shot covers."
-                }
-                onClick={readOnly ? undefined : handleToggleDurationSource}
-              />
-            )}
-          </FlexRow>
-        )}
-
-        {boardEntities.length > 0 && (
-          <FlexRow gap={SPACING.micro} wrap>
-            {boardEntities.map((entity) => {
-              const applied = appliedIds.includes(entity.id);
-              return (
-                <Chip
-                  key={entity.id}
-                  compact
-                  label={entity.name || "Untitled"}
-                  variant="outlined"
-                  icon={<Box sx={getEntityKindDotSx(entity.kind, applied)} />}
-                  sx={getEntityChipSx(applied)}
-                  title={
-                    applied
-                      ? `${entity.descriptor || entity.name}: click to exclude from this shot`
-                      : `Click to include ${entity.name} in this shot`
-                  }
-                  onClick={
-                    readOnly
-                      ? undefined
-                      : () =>
-                          toggleShotEntity(boardId, shot.id, entity.id, appliedIds)
-                  }
-                />
-              );
-            })}
-          </FlexRow>
-        )}
-
-        <ShotTakesGallery boardId={boardId} shot={shot} readOnly={readOnly} />
-
-        <ShotScriptPanel boardId={boardId} shot={shot} readOnly={readOnly} />
-
-        {!readOnly && (
-          <FlexRow
-            gap={SPACING.xs}
-            align="center"
-            wrap
-            sx={{ mt: SPACING.xs }}
-          >
-            <EditorButton
-              onClick={handleGenerateStill}
-              disabled={isGenerating}
-              sx={shot.keyframe ? quietActionSx : undefined}
-            >
-              {shot.keyframe ? "New still" : "Generate still"}
-            </EditorButton>
-            <EditorButton
-              onClick={handleGenerateClip}
-              disabled={
-                isGenerating ||
-                (!shot.keyframe && shotRenderMode(shot) !== "direct")
-              }
-              sx={shot.clip ? quietActionSx : undefined}
-              title={
-                shot.keyframe
-                  ? "Animate the selected still into a clip"
-                  : shotRenderMode(shot) === "direct"
-                    ? "Render a clip straight from the prompt"
-                    : "Generate a still first, or set render mode to direct"
-              }
-            >
-              {shot.clip ? "New clip" : "Generate clip"}
-            </EditorButton>
-            {shot.clip && (
-              <EditorButton
-                onClick={() => setReviseOpen(true)}
-                disabled={isGenerating}
-                sx={quietActionSx}
-              >
-                Revise clip
-              </EditorButton>
-            )}
-            {(shot.keyframe || shot.clip) && (
-              <ToolbarIconButton
-                icon={<MoreHorizIcon sx={{ fontSize: "1em" }} />}
-                tooltip="More actions"
-                ariaLabel="More shot actions"
-                onClick={handleOpenMenu}
-                disabled={isGenerating}
-              />
-            )}
-          </FlexRow>
-        )}
       </FlexColumn>
 
-      <EditorMenu
-        open={menuAnchor !== null}
-        anchorEl={menuAnchor}
-        onClose={handleCloseMenu}
-      >
-        {shot.keyframe && (
-          <EditorMenuItem onClick={handleRemoveStill}>
-            Remove still
-          </EditorMenuItem>
-        )}
-        {shot.clip && (
-          <EditorMenuItem onClick={handleRemoveClip}>
-            Remove clip
-          </EditorMenuItem>
-        )}
-      </EditorMenu>
-
-      <Dialog
-        open={reviseOpen}
-        onClose={() => setReviseOpen(false)}
-        title="Revise clip"
-        onConfirm={handleReviseConfirm}
-        confirmText="Revise"
-        confirmDisabled={reviseText.trim().length === 0}
-      >
-        <FlexColumn gap={SPACING.xs}>
-          <Caption color="secondary">
-            Describe the change to make. The current clip is re-rendered with
-            your note applied.
-          </Caption>
-          <TextInput
-            value={reviseText}
-            placeholder="e.g. make it darker, add rain"
-            onChange={(e) => setReviseText(e.target.value)}
-            multiline
-            rows={3}
-            autoFocus
-          />
-        </FlexColumn>
-      </Dialog>
-
-      <Dialog
-        open={confirmDelete}
-        onClose={() => setConfirmDelete(false)}
-        title="Delete shot?"
-        onConfirm={handleDelete}
-        confirmText="Delete"
-        destructive
-      >
-        <Text>
-          {`Remove “${shotName}” from the board. Generated stills and clips stay in your asset library.`}
-        </Text>
-      </Dialog>
       <ShotMediaViewer media={viewerMedia} onClose={handleCloseViewer} />
     </Card>
   );

--- a/web/src/components/storyboard/ShotInspector.tsx
+++ b/web/src/components/storyboard/ShotInspector.tsx
@@ -1,0 +1,554 @@
+/**
+ * ShotInspector
+ *
+ * The selected shot's detail, docked under the shot grid. Its top bar is the
+ * selection footer — which shot is selected, where it appears in the
+ * project's sibling documents, and the two actions that re-render it. Below
+ * that sits everything the grid card no longer shows: the action line, the
+ * camera and cost meta, the cast chips, the takes browser, the script lines
+ * the shot covers, and the reorder/delete controls.
+ */
+
+import React, { memo, useCallback, useMemo, useState } from "react";
+import type { ImageRef, Shot, ShotStatus, VideoRef } from "@nodetool-ai/protocol";
+import { shotRenderMode } from "@nodetool-ai/protocol";
+import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
+
+import {
+  Box,
+  Caption,
+  Chip,
+  CloseButton,
+  Dialog,
+  Divider,
+  EditorButton,
+  EditorMenu,
+  EditorMenuItem,
+  FlexColumn,
+  FlexRow,
+  Panel,
+  StatusIndicator,
+  Text,
+  TextInput,
+  ToolbarIconButton,
+  BORDER_RADIUS,
+  CONTROL,
+  SPACING,
+  TYPOGRAPHY,
+  type StatusType
+} from "../ui_primitives";
+import ShotTakesGallery from "./ShotTakesGallery";
+import ShotScriptPanel from "./ShotScriptPanel";
+import {
+  sameMediaRef,
+  useStoryboardStore
+} from "../../stores/storyboard/StoryboardStore";
+import { entitiesForShot } from "../../stores/storyboard/shotEntities";
+import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
+import {
+  useBoardScriptLines,
+  useShotDuration
+} from "../../hooks/storyboard/useShotDuration";
+import { useEntities } from "../../serverState/useEntities";
+import { getEntityChipSx, getEntityKindDotSx } from "../entities/entityKind";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import { isShotGenerating } from "./ShotStatusPill";
+import { colorForType } from "../../config/data_types";
+import { hexToRgba } from "../../utils/ColorUtils";
+
+interface ShotInspectorProps {
+  boardId: string;
+  shot: Shot;
+  readOnly?: boolean;
+  /** True when the shot is first on the board (disables "move up"). */
+  isFirst?: boolean;
+  /** True when the shot is last on the board (disables "move down"). */
+  isLast?: boolean;
+  /** Clears the board's selection. */
+  onClose?: () => void;
+}
+
+const STATUS_META: Record<
+  ShotStatus,
+  { status: StatusType; label: string; pulse?: boolean }
+> = {
+  planned: { status: "default", label: "Planned" },
+  keyframe_generating: {
+    status: "pending",
+    label: "Generating still…",
+    pulse: true
+  },
+  keyframe_ready: { status: "info", label: "Still ready" },
+  // Legacy status from the removed approval step; same meaning as a ready still.
+  approved: { status: "info", label: "Still ready" },
+  clip_generating: { status: "pending", label: "Rendering…", pulse: true },
+  rendered: { status: "success", label: "Rendered" },
+  failed: { status: "error", label: "Failed" }
+};
+
+/** Sky — the app's colour for anything script- or voice-shaped. */
+const SCRIPT_COLOR = colorForType("audio");
+
+/**
+ * Secondary actions read as text rather than as a row of equal accent links;
+ * only the step the shot has not taken yet keeps the accent.
+ */
+const quietActionSx = {
+  color: "text.secondary",
+  "&:hover": { color: "text.primary", bgcolor: "c_overlay_subtle" }
+} as const;
+
+/** Metadata chips carry no status color — the label is the whole signal. */
+const quietChipSx = {
+  borderRadius: BORDER_RADIUS.pill,
+  color: "text.secondary",
+  borderColor: "divider"
+} as const;
+
+/** A cross-document link chip, tinted by the document type it points at. */
+const linkChipSx = {
+  height: `${CONTROL.height.xs}px`,
+  borderRadius: BORDER_RADIUS.md,
+  borderColor: hexToRgba(SCRIPT_COLOR, 0.35),
+  color: SCRIPT_COLOR
+} as const;
+
+const cameraLine = (shot: Shot): string =>
+  [
+    shot.camera?.framing,
+    shot.camera?.lens,
+    shot.camera?.angle,
+    shot.camera?.movement
+  ]
+    .filter((p): p is string => !!p && p.trim().length > 0)
+    .join(" · ");
+
+const EMPTY_IDS: string[] = [];
+
+const ShotInspectorInner: React.FC<ShotInspectorProps> = ({
+  boardId,
+  shot,
+  readOnly,
+  isFirst,
+  isLast,
+  onClose
+}) => {
+  const toggleShotEntity = useStoryboardStore((state) => state.toggleShotEntity);
+  const updateShot = useStoryboardStore((state) => state.updateShot);
+  const moveShot = useStoryboardStore((state) => state.moveShot);
+  const removeShot = useStoryboardStore((state) => state.removeShot);
+  const removeKeyframeVersion = useStoryboardStore(
+    (state) => state.removeKeyframeVersion
+  );
+  const removeClipVersion = useStoryboardStore(
+    (state) => state.removeClipVersion
+  );
+  const boardEntityIds = useStoryboardStore(
+    (state) => state.boards[boardId]?.entityIds ?? EMPTY_IDS
+  );
+  const scriptId = useStoryboardStore(
+    (state) => state.boards[boardId]?.screenplay?.script_id ?? null
+  );
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const { data: allEntities } = useEntities();
+  const { generateKeyframe, generateClip, generateRevisedClip } =
+    useGenerateShot();
+
+  const { boardEntities, appliedIds } = useMemo(() => {
+    const idSet = new Set(boardEntityIds);
+    const board = (allEntities ?? []).filter((e) => idSet.has(e.id));
+    return {
+      boardEntities: board,
+      appliedIds: entitiesForShot(shot, board).map((e) => e.id)
+    };
+  }, [allEntities, boardEntityIds, shot]);
+
+  const [reviseOpen, setReviseOpen] = useState(false);
+  // Anchor for the overflow menu holding the destructive take actions; null
+  // when it is closed.
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [reviseText, setReviseText] = useState("");
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const meta = STATUS_META[shot.status];
+  const isGenerating = isShotGenerating(shot);
+  const camera = cameraLine(shot);
+  const shotName = `${shot.index + 1}. ${shot.slug ?? "Untitled shot"}`;
+  const shotNumber = `SH ${String(shot.index + 1).padStart(2, "0")}`;
+
+  // A start that throws records its reason on the shot's job state (and
+  // toasts it), which is what the card's error line shows — so the rejection
+  // is already reported and only needs to not go unhandled.
+  const handleGenerateStill = useCallback(() => {
+    void generateKeyframe(boardId, shot).catch(() => undefined);
+  }, [generateKeyframe, boardId, shot]);
+
+  const handleGenerateClip = useCallback(() => {
+    void generateClip(boardId, shot).catch(() => undefined);
+  }, [generateClip, boardId, shot]);
+
+  const handleReviseConfirm = useCallback(() => {
+    const instruction = reviseText.trim();
+    if (instruction.length > 0) {
+      void generateRevisedClip(boardId, shot, instruction).catch(
+        () => undefined
+      );
+    }
+    setReviseOpen(false);
+    setReviseText("");
+  }, [reviseText, generateRevisedClip, boardId, shot]);
+
+  const handleMoveUp = useCallback(() => {
+    moveShot(boardId, shot.id, "up");
+  }, [moveShot, boardId, shot.id]);
+
+  const handleMoveDown = useCallback(() => {
+    moveShot(boardId, shot.id, "down");
+  }, [moveShot, boardId, shot.id]);
+
+  // A shot covering script lines is timed by the takes under it unless the
+  // user pins it; the chip says which, and clicking it switches.
+  const duration = useShotDuration(boardId, shot);
+  const linksLines = (shot.script_line_ids?.length ?? 0) > 0;
+  const durationLabel =
+    duration.seconds != null
+      ? `${duration.seconds}s · ${duration.source === "audio" ? "from takes" : "manual"}`
+      : "model default";
+  // Camera and cost share one quiet line under the action text; neither is
+  // worth a chip of its own.
+  const metaLine = [
+    camera.length > 0 ? camera : null,
+    shot.cost_estimate != null ? `~$${shot.cost_estimate.toFixed(2)}` : null
+  ]
+    .filter((p): p is string => p !== null)
+    .join(" · ");
+
+  // Where this shot lands in the project's other documents. Only the script
+  // link exists today; the timeline chip arrives with the timeline mapping.
+  const scriptLines = useBoardScriptLines(boardId);
+  const scriptLinkLabel = useMemo(() => {
+    const ids = shot.script_line_ids ?? [];
+    if (!scriptId || ids.length === 0) {
+      return null;
+    }
+    const order = [...scriptLines.keys()];
+    const position = ids
+      .map((id) => order.indexOf(id))
+      .filter((i) => i >= 0)
+      .sort((a, b) => a - b)[0];
+    return position == null ? "Script" : `Script · line ${position + 1}`;
+  }, [scriptId, scriptLines, shot.script_line_ids]);
+
+  const handleOpenScript = useCallback(() => {
+    if (scriptId) {
+      openTab({ type: "script", ref: scriptId, mode: "edit", title: "Script" });
+    }
+  }, [openTab, scriptId]);
+
+  const handleToggleDurationSource = useCallback(() => {
+    updateShot(boardId, shot.id, {
+      duration_source: shot.duration_source === "manual" ? "audio" : "manual"
+    });
+  }, [updateShot, boardId, shot.id, shot.duration_source]);
+
+  const handleOpenMenu = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => setMenuAnchor(event.currentTarget),
+    []
+  );
+  const handleCloseMenu = useCallback(() => setMenuAnchor(null), []);
+
+  const handleDelete = useCallback(() => {
+    removeShot(boardId, shot.id);
+    setConfirmDelete(false);
+  }, [removeShot, boardId, shot.id]);
+
+  const handleRemoveStill = useCallback(() => {
+    setMenuAnchor(null);
+    const versions =
+      shot.keyframe_versions ?? (shot.keyframe ? [shot.keyframe] : []);
+    if (versions.length === 0 || !shot.keyframe) {
+      return;
+    }
+    const selected = versions.findIndex((v) =>
+      sameMediaRef(v, shot.keyframe as ImageRef)
+    );
+    const index = selected >= 0 ? selected : 0;
+    removeKeyframeVersion(boardId, shot.id, index);
+  }, [
+    shot.keyframe,
+    shot.keyframe_versions,
+    removeKeyframeVersion,
+    boardId,
+    shot.id
+  ]);
+
+  const handleRemoveClip = useCallback(() => {
+    setMenuAnchor(null);
+    const versions = shot.clip_versions ?? (shot.clip ? [shot.clip] : []);
+    if (versions.length === 0 || !shot.clip) {
+      return;
+    }
+    const selected = versions.findIndex((v) =>
+      sameMediaRef(v, shot.clip as VideoRef)
+    );
+    const index = selected >= 0 ? selected : 0;
+    removeClipVersion(boardId, shot.id, index);
+  }, [shot.clip, shot.clip_versions, removeClipVersion, boardId, shot.id]);
+
+  return (
+    <Panel padding="none" className="shot-inspector">
+      <FlexRow
+        align="center"
+        gap={SPACING.lg}
+        wrap
+        sx={{
+          minHeight: `${CONTROL.height.xl}px`,
+          px: SPACING.xl,
+          py: SPACING.md
+        }}
+      >
+        <Box sx={{ ...TYPOGRAPHY.mono.caption, color: "text.secondary" }}>
+          {`${shotNumber} selected`}
+        </Box>
+        <Divider orientation="vertical" flexItem />
+        <Caption color="secondary">Appears in</Caption>
+        {scriptLinkLabel ? (
+          <Chip
+            compact
+            variant="outlined"
+            label={scriptLinkLabel}
+            sx={linkChipSx}
+            onClick={handleOpenScript}
+            title="Open the script this shot's lines come from"
+          />
+        ) : (
+          <Caption color="muted">nothing yet</Caption>
+        )}
+        <Box sx={{ flex: 1 }} />
+        {!readOnly && (
+          <>
+            <EditorButton
+              onClick={() => setReviseOpen(true)}
+              disabled={isGenerating || !shot.clip}
+              sx={quietActionSx}
+              title={
+                shot.clip
+                  ? "Re-render this clip with a note applied"
+                  : "Render a clip first"
+              }
+            >
+              Revise take
+            </EditorButton>
+            <EditorButton
+              variant="contained"
+              color="primary"
+              onClick={handleGenerateClip}
+              disabled={
+                isGenerating ||
+                (!shot.keyframe && shotRenderMode(shot) !== "direct")
+              }
+              title={
+                shot.keyframe
+                  ? "Animate the selected still into a clip"
+                  : shotRenderMode(shot) === "direct"
+                    ? "Render a clip straight from the prompt"
+                    : "Generate a still first, or set render mode to direct"
+              }
+            >
+              {shot.clip ? "Re-render clip" : "Render clip"}
+            </EditorButton>
+          </>
+        )}
+        {onClose && (
+          <CloseButton onClick={onClose} tooltip="Clear shot selection" />
+        )}
+      </FlexRow>
+
+      <Divider />
+
+      <FlexColumn gap={SPACING.md} sx={{ p: SPACING.xl, minWidth: 0 }}>
+        <FlexRow align="center" justify="space-between" gap={SPACING.sm}>
+          <Text size="small" truncate sx={{ minWidth: 0 }}>
+            {shotName}
+          </Text>
+          <FlexRow align="center" gap={SPACING.xs} sx={{ flexShrink: 0 }}>
+            <StatusIndicator
+              status={meta.status}
+              label={meta.label}
+              pulse={meta.pulse}
+              labelTone={shot.status === "failed" ? "status" : "muted"}
+            />
+            {!readOnly && (
+              <>
+                <ToolbarIconButton
+                  icon={<ArrowUpwardIcon sx={{ fontSize: "1em" }} />}
+                  tooltip="Move up"
+                  ariaLabel="Move shot up"
+                  onClick={handleMoveUp}
+                  disabled={isFirst}
+                />
+                <ToolbarIconButton
+                  icon={<ArrowDownwardIcon sx={{ fontSize: "1em" }} />}
+                  tooltip="Move down"
+                  ariaLabel="Move shot down"
+                  onClick={handleMoveDown}
+                  disabled={isLast}
+                />
+                <ToolbarIconButton
+                  icon={<DeleteOutlineIcon sx={{ fontSize: "1em" }} />}
+                  tooltip="Delete shot"
+                  ariaLabel="Delete shot"
+                  variant="error"
+                  onClick={() => setConfirmDelete(true)}
+                  disabled={isGenerating}
+                />
+              </>
+            )}
+          </FlexRow>
+        </FlexRow>
+
+        <Text lineClamp={3} sx={{ lineHeight: 1.6 }}>
+          {shot.action}
+        </Text>
+
+        {(metaLine.length > 0 || linksLines) && (
+          <FlexRow align="center" gap={SPACING.sm} wrap>
+            {metaLine.length > 0 && (
+              <Caption color="secondary" noWrap>
+                {metaLine}
+              </Caption>
+            )}
+            {linksLines && (
+              <Chip
+                compact
+                variant="outlined"
+                label={durationLabel}
+                sx={quietChipSx}
+                title={
+                  duration.source === "audio"
+                    ? "Length comes from the takes of the lines this shot covers. Click to pin it to the shot's own duration."
+                    : "Length is pinned to the shot's own duration. Click to take it from the lines this shot covers."
+                }
+                onClick={readOnly ? undefined : handleToggleDurationSource}
+              />
+            )}
+          </FlexRow>
+        )}
+
+        {boardEntities.length > 0 && (
+          <FlexRow gap={SPACING.micro} wrap>
+            {boardEntities.map((entity) => {
+              const applied = appliedIds.includes(entity.id);
+              return (
+                <Chip
+                  key={entity.id}
+                  compact
+                  label={entity.name || "Untitled"}
+                  variant="outlined"
+                  icon={<Box sx={getEntityKindDotSx(entity.kind, applied)} />}
+                  sx={getEntityChipSx(applied)}
+                  title={
+                    applied
+                      ? `${entity.descriptor || entity.name}: click to exclude from this shot`
+                      : `Click to include ${entity.name} in this shot`
+                  }
+                  onClick={
+                    readOnly
+                      ? undefined
+                      : () =>
+                          toggleShotEntity(boardId, shot.id, entity.id, appliedIds)
+                  }
+                />
+              );
+            })}
+          </FlexRow>
+        )}
+
+        <ShotTakesGallery boardId={boardId} shot={shot} readOnly={readOnly} />
+
+        <ShotScriptPanel boardId={boardId} shot={shot} readOnly={readOnly} />
+
+        {!readOnly && (
+          <FlexRow gap={SPACING.xs} align="center" wrap>
+            <EditorButton
+              onClick={handleGenerateStill}
+              disabled={isGenerating}
+              sx={shot.keyframe ? quietActionSx : undefined}
+            >
+              {shot.keyframe ? "New still" : "Generate still"}
+            </EditorButton>
+            {(shot.keyframe || shot.clip) && (
+              <ToolbarIconButton
+                icon={<MoreHorizIcon sx={{ fontSize: "1em" }} />}
+                tooltip="More actions"
+                ariaLabel="More shot actions"
+                onClick={handleOpenMenu}
+                disabled={isGenerating}
+              />
+            )}
+          </FlexRow>
+        )}
+      </FlexColumn>
+
+      <EditorMenu
+        open={menuAnchor !== null}
+        anchorEl={menuAnchor}
+        onClose={handleCloseMenu}
+      >
+        {shot.keyframe && (
+          <EditorMenuItem onClick={handleRemoveStill}>
+            Remove still
+          </EditorMenuItem>
+        )}
+        {shot.clip && (
+          <EditorMenuItem onClick={handleRemoveClip}>Remove clip</EditorMenuItem>
+        )}
+      </EditorMenu>
+
+      <Dialog
+        open={reviseOpen}
+        onClose={() => setReviseOpen(false)}
+        title="Revise clip"
+        onConfirm={handleReviseConfirm}
+        confirmText="Revise"
+        confirmDisabled={reviseText.trim().length === 0}
+      >
+        <FlexColumn gap={SPACING.xs}>
+          <Caption color="secondary">
+            Describe the change to make. The current clip is re-rendered with
+            your note applied.
+          </Caption>
+          <TextInput
+            value={reviseText}
+            placeholder="e.g. make it darker, add rain"
+            onChange={(e) => setReviseText(e.target.value)}
+            multiline
+            rows={3}
+            autoFocus
+          />
+        </FlexColumn>
+      </Dialog>
+
+      <Dialog
+        open={confirmDelete}
+        onClose={() => setConfirmDelete(false)}
+        title="Delete shot?"
+        onConfirm={handleDelete}
+        confirmText="Delete"
+        destructive
+      >
+        <Text>
+          {`Remove “${shotName}” from the board. Generated stills and clips stay in your asset library.`}
+        </Text>
+      </Dialog>
+    </Panel>
+  );
+};
+
+export const ShotInspector = memo(ShotInspectorInner);
+ShotInspector.displayName = "ShotInspector";
+
+export default ShotInspector;

--- a/web/src/components/storyboard/ShotStatusPill.tsx
+++ b/web/src/components/storyboard/ShotStatusPill.tsx
@@ -1,0 +1,152 @@
+/**
+ * ShotStatusPill
+ *
+ * The one status vocabulary the shot grid speaks, rendered as a mono pill in
+ * the thumbnail's bottom-right corner. Four tones: a rendered clip (success
+ * green), a render in flight (video violet, matching the card's border and
+ * the progress bar under the thumbnail), a shot waiting on its next step
+ * (neutral), and a failed render (error).
+ */
+
+import { memo } from "react";
+import type { SxProps, Theme } from "@mui/material/styles";
+import { useTheme } from "@mui/material/styles";
+import type { Shot } from "@nodetool-ai/protocol";
+
+import {
+  Box,
+  BORDER_RADIUS,
+  CONTROL,
+  SPACING,
+  TYPOGRAPHY
+} from "../ui_primitives";
+import { colorForType } from "../../config/data_types";
+import { hexToRgba } from "../../utils/ColorUtils";
+import { brighten, toHex } from "../../utils/colorMath";
+
+/** Video violet — the app's colour for anything clip-shaped. */
+export const CLIP_COLOR = colorForType("video");
+/** The same violet, lifted off the tinted background it sits on. */
+const CLIP_TEXT = toHex(brighten(CLIP_COLOR, 1.4));
+
+export type ShotPillTone = "done" | "rendering" | "neutral" | "failed";
+
+export interface ShotPill {
+  tone: ShotPillTone;
+  label: string;
+}
+
+/** True while the shot is waiting on a still or a clip render. */
+export const isShotGenerating = (shot: Shot): boolean =>
+  shot.status === "keyframe_generating" || shot.status === "clip_generating";
+
+/**
+ * What the pill says about a shot: the step it is on, and — once there is a
+ * clip — how long that clip runs.
+ */
+export const shotPill = (
+  shot: Shot,
+  durationSeconds?: number | null
+): ShotPill => {
+  if (isShotGenerating(shot)) {
+    return {
+      tone: "rendering",
+      label: shot.status === "clip_generating" ? "rendering clip" : "rendering still"
+    };
+  }
+  if (shot.status === "failed") {
+    return { tone: "failed", label: "failed" };
+  }
+  if (shot.clip) {
+    return {
+      tone: "done",
+      label: durationSeconds != null ? `clip · ${durationSeconds}s` : "clip"
+    };
+  }
+  if (shot.keyframe) {
+    return { tone: "neutral", label: "still · clip queued" };
+  }
+  return { tone: "neutral", label: "planned" };
+};
+
+/** Border and background for a tone, shared with the card's own border. */
+export const toneColors = (
+  tone: ShotPillTone,
+  theme: Theme
+): { color: string; border: string; background: string } => {
+  switch (tone) {
+    case "done": {
+      const green = theme.palette.success.main;
+      return {
+        color: green,
+        border: hexToRgba(green, 0.5),
+        background: hexToRgba(green, 0.12)
+      };
+    }
+    case "rendering":
+      return {
+        color: CLIP_TEXT,
+        border: CLIP_COLOR,
+        background: hexToRgba(CLIP_COLOR, 0.16)
+      };
+    case "failed": {
+      const red = theme.palette.error.main;
+      return {
+        color: red,
+        border: hexToRgba(red, 0.5),
+        background: hexToRgba(red, 0.12)
+      };
+    }
+    default:
+      return {
+        color: theme.palette.text.secondary,
+        border: theme.palette.divider,
+        background: hexToRgba(theme.palette.common.white, 0.06)
+      };
+  }
+};
+
+interface ShotStatusPillProps {
+  shot: Shot;
+  /** The shot's effective length, shown once it has a clip. */
+  durationSeconds?: number | null;
+  sx?: SxProps<Theme>;
+}
+
+const ShotStatusPillInner = ({
+  shot,
+  durationSeconds,
+  sx
+}: ShotStatusPillProps) => {
+  const theme = useTheme();
+  const pill = shotPill(shot, durationSeconds);
+  const colors = toneColors(pill.tone, theme);
+
+  return (
+    <Box
+      data-testid="shot-status-pill"
+      data-tone={pill.tone}
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        height: `${CONTROL.height.xs}px`,
+        px: SPACING.sm,
+        borderRadius: BORDER_RADIUS.pill,
+        border: "1px solid",
+        borderColor: colors.border,
+        backgroundColor: colors.background,
+        color: colors.color,
+        whiteSpace: "nowrap",
+        ...TYPOGRAPHY.mono.caption,
+        ...sx
+      }}
+    >
+      {pill.label}
+    </Box>
+  );
+};
+
+export const ShotStatusPill = memo(ShotStatusPillInner);
+ShotStatusPill.displayName = "ShotStatusPill";
+
+export default ShotStatusPill;

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -1,18 +1,23 @@
 /**
  * StoryboardBoard
  *
- * The board header (title, brief, style, aspect ratio, shot count, and a
- * "Direct" trigger) plus a list of {@link ShotCard}s. The Direct button
- * forwards to an `onDirect` callback so a parent can wire it to a Director run.
+ * A compact toolbar over a grid of {@link ShotCard}s. The toolbar carries the
+ * board's name, a one-line summary, and the three actions that move the board
+ * forward (render stills, render clips, assemble the timeline); the
+ * Screenplay/Direction form — including *Direct* — folds into a collapsible
+ * section behind *Board settings*, open by default while the board has no
+ * shots. Selecting a card opens {@link ShotInspector} under the grid.
  */
 
 import React, { memo, useCallback, useMemo, useState } from "react";
 import { shotRenderMode } from "@nodetool-ai/protocol";
+import TuneIcon from "@mui/icons-material/Tune";
 
 import {
   Box,
   Card,
   Caption,
+  Collapse,
   Dialog,
   Divider,
   EditorButton,
@@ -50,9 +55,11 @@ import { useInStudio } from "../../studio/StudioContext";
 import ImageModelSelect from "../properties/ImageModelSelect";
 import VideoModelSelect from "../properties/VideoModelSelect";
 import { useNotificationStore } from "../../stores/NotificationStore";
+import { useEntities } from "../../serverState/useEntities";
 import { exportStoryboardZip } from "../../utils/storyboardZip";
 import ScriptLinkControl from "./ScriptLinkControl";
 import ShotCard from "./ShotCard";
+import ShotInspector from "./ShotInspector";
 import StoryboardEntitiesField from "./StoryboardEntitiesField";
 
 // The preview mounts the timeline compositor; keep it out of the board bundle.
@@ -109,12 +116,19 @@ const settingsRailSx = {
   }
 } as const;
 
-const shotCardGridSx = {
+/** Four cards across at desktop width, down to one on a phone. */
+const shotGridSx = {
   display: "grid",
-  gridTemplateColumns: "minmax(220px, 300px) minmax(0, 1fr)",
-  gap: SPACING.md,
+  gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+  gap: SPACING.xl,
   alignItems: "start",
-  "@media (max-width: 720px)": {
+  "@media (max-width: 1280px)": {
+    gridTemplateColumns: "repeat(3, minmax(0, 1fr))"
+  },
+  "@media (max-width: 960px)": {
+    gridTemplateColumns: "repeat(2, minmax(0, 1fr))"
+  },
+  "@media (max-width: 600px)": {
     gridTemplateColumns: "minmax(0, 1fr)"
   }
 } as const;
@@ -138,7 +152,8 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
     directorModel,
     imageModel,
     videoModel,
-    shots
+    shots,
+    activeShotId
   } = useBoard(boardId);
 
   const inStudio = useInStudio();
@@ -149,6 +164,7 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   const setDirectorModel = useStoryboardStore((state) => state.setDirectorModel);
   const setImageModel = useStoryboardStore((state) => state.setImageModel);
   const setVideoModel = useStoryboardStore((state) => state.setVideoModel);
+  const selectShot = useStoryboardStore((state) => state.selectShot);
   const undo = useStoryboardStore((state) => state.undo);
   const redo = useStoryboardStore((state) => state.redo);
   const canUndo = useStoryboardCanUndo(boardId);
@@ -163,6 +179,25 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   const [downloading, setDownloading] = useState(false);
 
   const hasShots = shots.length > 0;
+
+  // A board with no shots is a board being set up: the form is the surface.
+  // Once shots exist the grid is, and the form folds behind the toolbar.
+  const [settingsOpen, setSettingsOpen] = useState(!hasShots);
+  const toggleSettings = useCallback(
+    () => setSettingsOpen((open) => !open),
+    []
+  );
+
+  const handleSelectShot = useCallback(
+    (shotId: string) => selectShot(boardId, shotId),
+    [selectShot, boardId]
+  );
+  const clearSelection = useCallback(
+    () => selectShot(boardId, null),
+    [selectShot, boardId]
+  );
+  const activeShotIndex = shots.findIndex((s) => s.id === activeShotId);
+  const activeShot = activeShotIndex >= 0 ? shots[activeShotIndex] : undefined;
 
   // Entity reference images only reach generation through an editing model;
   // warn when entities are attached but the still model can't take them.
@@ -225,6 +260,23 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
     [shots]
   );
 
+  // The toolbar's one-line summary: how big the board is, how it looks, and
+  // who is in it — the fields the folded form would otherwise hide.
+  const { data: allEntities } = useEntities();
+  const summary = useMemo(() => {
+    const entityNames = (allEntities ?? [])
+      .filter((e) => entityIds.includes(e.id))
+      .map((e) => e.name)
+      .filter((name): name is string => !!name);
+    return [
+      `${shots.length} shot${shots.length === 1 ? "" : "s"}`,
+      style.trim().length > 0 ? `${style.trim()} style` : null,
+      entityNames.length > 0 ? `entity: ${entityNames.join(", ")}` : null
+    ]
+      .filter((part): part is string => part !== null)
+      .join(" · ");
+  }, [shots.length, style, entityIds, allEntities]);
+
   const { generateKeyframe, generateClip } = useGenerateShot();
   // A shot that cannot start records the reason on itself (its card shows it,
   // and it is toasted), so one failure must not stop the rest of the batch.
@@ -270,249 +322,278 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
           }
         }}
       >
-      {!readOnly && (
-        <Panel padding={SPACING.xl} sx={{ maxWidth: "1100px" }}>
-          <FlexColumn gap={SPACING.xl}>
-            <FormGrid stackBelow={FORM_STACK_BELOW}>
-              <FormSection label="Screenplay">
-                <FormField label="Title">
-                  <TextInput
-                    value={title}
-                    placeholder="Untitled film"
-                    onChange={(e) => setTitle(boardId, e.target.value)}
-                  />
-                </FormField>
-                <FormField label="Brief">
-                  <TextInput
-                    value={brief}
-                    placeholder="Your film in one or two sentences"
-                    onChange={(e) => setBrief(boardId, e.target.value)}
-                    multiline
-                    rows={3}
-                  />
-                </FormField>
-                <FormField label="Style">
-                  <TextInput
-                    value={style}
-                    placeholder="Palette, light, lens, texture"
-                    onChange={(e) => setStyle(boardId, e.target.value)}
-                  />
-                </FormField>
-                <FormField label="Entities">
-                  <StoryboardEntitiesField
-                    boardId={boardId}
-                    entityIds={entityIds}
-                  />
-                </FormField>
-              </FormSection>
-
-              <FormSection label="Direction" sx={settingsRailSx}>
-                {/* The Studio shell pins the director model — a beginner
-                    picks what the film looks like, not which LLM writes it. */}
-                {!inStudio && (
-                  <FormField label="Screenplay model" sx={modelFieldSx}>
-                    <LanguageModelSelect
-                      value={directorModel?.id ?? ""}
-                      onChange={(value) => setDirectorModel(boardId, value)}
-                    />
-                  </FormField>
-                )}
-                <FormField label="Still model" sx={modelFieldSx}>
-                  <ImageModelSelect
-                    value={imageModel?.id ?? ""}
-                    task={STILL_MODEL_TASKS}
-                    onChange={(value) => setImageModel(boardId, value)}
-                  />
-                  {entitiesNeedEditModel && (
-                    <Caption color="warning">
-                      Entities carry reference images, but this model only
-                      takes text. Pick an image-to-image model to use them.
-                    </Caption>
-                  )}
-                </FormField>
-                <FormField label="Clip model" sx={modelFieldSx}>
-                  <VideoModelSelect
-                    value={videoModel?.id ?? ""}
-                    task="image_to_video"
-                    onChange={(value) => setVideoModel(boardId, value)}
-                  />
-                </FormField>
-                <FormField label="Aspect ratio">
-                  <SelectField
-                    label="Aspect ratio"
-                    value={aspectRatio}
-                    onChange={(value) => setAspectRatio(boardId, value)}
-                    options={ASPECT_OPTIONS}
-                  />
-                </FormField>
-                <FormField label="Shots">
-                  <SelectField
-                    label="Shots"
-                    value={shotCount}
-                    onChange={(value) => setShotCount(Number(value))}
-                    options={SHOT_COUNT_OPTIONS}
-                  />
-                </FormField>
-              </FormSection>
-            </FormGrid>
-
-            <Divider />
-
-            <FlexRow
-              gap={SPACING.md}
-              align="center"
-              justify="space-between"
-              wrap
-            >
-              <Caption
-                color={directError || assembleError ? "error" : "secondary"}
+        <FlexRow align="center" gap={SPACING.lg} wrap>
+          <Text size="big">{title || "Untitled film"}</Text>
+          <Caption color="secondary">{summary}</Caption>
+          <Box sx={{ flex: 1 }} />
+          {!readOnly && (
+            <FlexRow align="center" gap={SPACING.md} wrap>
+              <UndoRedoButtons
+                canUndo={canUndo}
+                canRedo={canRedo}
+                onUndo={onUndo}
+                onRedo={onRedo}
+                undoTooltip="Undo (⌘Z)"
+                redoTooltip="Redo (⌘⇧Z)"
+              />
+              <ScriptLinkControl boardId={boardId} disabled={directing} />
+              <EditorButton
+                variant="outlined"
+                onClick={togglePreview}
+                disabled={!hasPlayableShot}
               >
-                {directError ??
-                  assembleError ??
-                  (hasShots
-                    ? "Re-directing rewrites the screenplay and replaces every shot."
-                    : "Direct writes the screenplay and seeds your shots.")}
-              </Caption>
-              <FlexRow gap={SPACING.md} align="center" wrap>
-                <UndoRedoButtons
-                  canUndo={canUndo}
-                  canRedo={canRedo}
-                  onUndo={onUndo}
-                  onRedo={onRedo}
-                  undoTooltip="Undo (⌘Z)"
-                  redoTooltip="Redo (⌘⇧Z)"
-                />
-                <EditorButton
-                  variant="outlined"
-                  onClick={handleGenerateAllStills}
-                  disabled={pendingStills.length === 0 || directing}
-                >
-                  {`Generate all stills${pendingStills.length > 0 ? ` (${pendingStills.length})` : ""}`}
-                </EditorButton>
-                <EditorButton
-                  variant="outlined"
-                  onClick={handleGenerateAllClips}
-                  disabled={pendingClips.length === 0 || directing}
-                >
-                  {`Generate all clips${pendingClips.length > 0 ? ` (${pendingClips.length})` : ""}`}
-                </EditorButton>
-                <ScriptLinkControl boardId={boardId} disabled={directing} />
-                <EditorButton
-                  variant="outlined"
-                  onClick={togglePreview}
-                  disabled={!hasPlayableShot}
-                >
-                  {previewOpen ? "Hide preview" : "Preview"}
-                </EditorButton>
-                <EditorButton
-                  variant="outlined"
-                  onClick={handleDownloadZip}
-                  disabled={!hasShots || downloading}
-                >
-                  {downloading ? "Preparing…" : "Download ZIP"}
-                </EditorButton>
-                <EditorButton
-                  variant="outlined"
-                  onClick={onAssemble}
-                  disabled={!onAssemble || assembling || !hasRenderedShot}
-                >
-                  {assembling ? "Assembling…" : "Assemble timeline"}
-                </EditorButton>
-                <EditorButton
-                  variant="contained"
-                  color="primary"
-                  onClick={handleDirect}
-                  disabled={!onDirect || directing}
-                >
-                  {directing ? "Directing…" : hasShots ? "Re-direct" : "Direct"}
-                </EditorButton>
-              </FlexRow>
+                {previewOpen ? "Hide preview" : "Preview"}
+              </EditorButton>
+              <EditorButton
+                variant="outlined"
+                onClick={handleDownloadZip}
+                disabled={!hasShots || downloading}
+              >
+                {downloading ? "Preparing…" : "Download ZIP"}
+              </EditorButton>
+              <EditorButton
+                variant="outlined"
+                startIcon={<TuneIcon fontSize="small" />}
+                onClick={toggleSettings}
+                aria-expanded={settingsOpen}
+              >
+                Board settings
+              </EditorButton>
+              <EditorButton
+                variant="outlined"
+                onClick={handleGenerateAllStills}
+                disabled={pendingStills.length === 0 || directing}
+              >
+                {`Render stills${pendingStills.length > 0 ? ` (${pendingStills.length})` : ""}`}
+              </EditorButton>
+              <EditorButton
+                variant="outlined"
+                onClick={handleGenerateAllClips}
+                disabled={pendingClips.length === 0 || directing}
+              >
+                {`Render clips${pendingClips.length > 0 ? ` (${pendingClips.length})` : ""}`}
+              </EditorButton>
+              <EditorButton
+                variant="contained"
+                color="primary"
+                onClick={onAssemble}
+                disabled={!onAssemble || assembling || !hasRenderedShot}
+              >
+                {assembling ? "Assembling…" : "Assemble timeline"}
+              </EditorButton>
             </FlexRow>
-          </FlexColumn>
-        </Panel>
-      )}
+          )}
+        </FlexRow>
 
-      <Dialog
-        open={confirmRedirect}
-        onClose={() => setConfirmRedirect(false)}
-        title="Re-direct this storyboard?"
-        onConfirm={handleConfirmRedirect}
-        confirmText="Re-direct"
-        destructive
-      >
-        <FlexColumn gap={SPACING.xs}>
-          <Text>
-            {`Directing writes a new screenplay and replaces all ${shots.length} current shot${shots.length === 1 ? "" : "s"}.`}
-          </Text>
-          <Caption color="secondary">
-            Generated stills and clips stay in your asset library, but the
-            shots on this board are rebuilt from scratch.
-          </Caption>
-        </FlexColumn>
-      </Dialog>
+        {!readOnly && (
+          <Collapse in={settingsOpen} timeout="auto" unmountOnExit>
+            <Panel padding={SPACING.xl} sx={{ maxWidth: "1100px" }}>
+              <FlexColumn gap={SPACING.xl}>
+                <FormGrid stackBelow={FORM_STACK_BELOW}>
+                  <FormSection label="Screenplay">
+                    <FormField label="Title">
+                      <TextInput
+                        value={title}
+                        placeholder="Untitled film"
+                        onChange={(e) => setTitle(boardId, e.target.value)}
+                      />
+                    </FormField>
+                    <FormField label="Brief">
+                      <TextInput
+                        value={brief}
+                        placeholder="Your film in one or two sentences"
+                        onChange={(e) => setBrief(boardId, e.target.value)}
+                        multiline
+                        rows={3}
+                      />
+                    </FormField>
+                    <FormField label="Style">
+                      <TextInput
+                        value={style}
+                        placeholder="Palette, light, lens, texture"
+                        onChange={(e) => setStyle(boardId, e.target.value)}
+                      />
+                    </FormField>
+                    <FormField label="Entities">
+                      <StoryboardEntitiesField
+                        boardId={boardId}
+                        entityIds={entityIds}
+                      />
+                    </FormField>
+                  </FormSection>
 
-      {previewOpen && (
-        <React.Suspense
-          fallback={<LoadingSpinner size="small" text="Loading preview" />}
+                  <FormSection label="Direction" sx={settingsRailSx}>
+                    {/* The Studio shell pins the director model — a beginner
+                        picks what the film looks like, not which LLM writes it. */}
+                    {!inStudio && (
+                      <FormField label="Screenplay model" sx={modelFieldSx}>
+                        <LanguageModelSelect
+                          value={directorModel?.id ?? ""}
+                          onChange={(value) => setDirectorModel(boardId, value)}
+                        />
+                      </FormField>
+                    )}
+                    <FormField label="Still model" sx={modelFieldSx}>
+                      <ImageModelSelect
+                        value={imageModel?.id ?? ""}
+                        task={STILL_MODEL_TASKS}
+                        onChange={(value) => setImageModel(boardId, value)}
+                      />
+                      {entitiesNeedEditModel && (
+                        <Caption color="warning">
+                          Entities carry reference images, but this model only
+                          takes text. Pick an image-to-image model to use them.
+                        </Caption>
+                      )}
+                    </FormField>
+                    <FormField label="Clip model" sx={modelFieldSx}>
+                      <VideoModelSelect
+                        value={videoModel?.id ?? ""}
+                        task="image_to_video"
+                        onChange={(value) => setVideoModel(boardId, value)}
+                      />
+                    </FormField>
+                    <FormField label="Aspect ratio">
+                      <SelectField
+                        label="Aspect ratio"
+                        value={aspectRatio}
+                        onChange={(value) => setAspectRatio(boardId, value)}
+                        options={ASPECT_OPTIONS}
+                      />
+                    </FormField>
+                    <FormField label="Shots">
+                      <SelectField
+                        label="Shots"
+                        value={shotCount}
+                        onChange={(value) => setShotCount(Number(value))}
+                        options={SHOT_COUNT_OPTIONS}
+                      />
+                    </FormField>
+                  </FormSection>
+                </FormGrid>
+
+                <Divider />
+
+                <FlexRow
+                  gap={SPACING.md}
+                  align="center"
+                  justify="space-between"
+                  wrap
+                >
+                  <Caption
+                    color={directError || assembleError ? "error" : "secondary"}
+                  >
+                    {directError ??
+                      assembleError ??
+                      (hasShots
+                        ? "Re-directing rewrites the screenplay and replaces every shot."
+                        : "Direct writes the screenplay and seeds your shots.")}
+                  </Caption>
+                  <EditorButton
+                    variant="contained"
+                    color="primary"
+                    onClick={handleDirect}
+                    disabled={!onDirect || directing}
+                  >
+                    {directing
+                      ? "Directing…"
+                      : hasShots
+                        ? "Re-direct"
+                        : "Direct"}
+                  </EditorButton>
+                </FlexRow>
+              </FlexColumn>
+            </Panel>
+          </Collapse>
+        )}
+
+        <Dialog
+          open={confirmRedirect}
+          onClose={() => setConfirmRedirect(false)}
+          title="Re-direct this storyboard?"
+          onConfirm={handleConfirmRedirect}
+          confirmText="Re-direct"
+          destructive
         >
-          <LazyStoryboardPreview boardId={boardId} />
-        </React.Suspense>
-      )}
+          <FlexColumn gap={SPACING.xs}>
+            <Text>
+              {`Directing writes a new screenplay and replaces all ${shots.length} current shot${shots.length === 1 ? "" : "s"}.`}
+            </Text>
+            <Caption color="secondary">
+              Generated stills and clips stay in your asset library, but the
+              shots on this board are rebuilt from scratch.
+            </Caption>
+          </FlexColumn>
+        </Dialog>
 
-      {directing ? (
-        <FlexColumn gap={SPACING.md}>
-          <Caption color="primary">
-            The director is writing your screenplay.
-          </Caption>
-          {Array.from({ length: shotCount }).map((_, i) => (
-            <Card key={i} variant="outlined" padding="compact">
-              <Box sx={shotCardGridSx}>
-                <Skeleton
-                  variant="rectangular"
-                  animation="wave"
-                  sx={{
-                    width: "100%",
-                    aspectRatio: "16 / 9",
-                    height: "auto",
-                    borderRadius: BORDER_RADIUS.sm
-                  }}
-                />
-                <FlexColumn gap={SPACING.sm}>
-                  <Skeleton preset="text" width="40%" />
-                  <Skeleton preset="text" width="85%" />
-                  <Skeleton preset="text" width="60%" />
-                </FlexColumn>
-              </Box>
-            </Card>
-          ))}
-        </FlexColumn>
-      ) : shots.length === 0 ? (
-        <EmptyState
-          variant="empty"
-          title="No shots yet"
-          description={
-            readOnly
-              ? "This storyboard has no shots."
-              : "Write a brief and press Direct to generate a screenplay of shots."
-          }
-        />
-      ) : (
-        <FlexColumn gap={SPACING.md}>
-          <Caption color="secondary">
-            {`${shots.length} shot${shots.length === 1 ? "" : "s"}`}
-          </Caption>
-          {shots.map((shot, i) => (
-            <ShotCard
-              key={shot.id}
-              boardId={boardId}
-              shot={shot}
-              readOnly={readOnly}
-              isFirst={i === 0}
-              isLast={i === shots.length - 1}
-            />
-          ))}
-        </FlexColumn>
-      )}
+        {previewOpen && (
+          <React.Suspense
+            fallback={<LoadingSpinner size="small" text="Loading preview" />}
+          >
+            <LazyStoryboardPreview boardId={boardId} />
+          </React.Suspense>
+        )}
+
+        {directing ? (
+          <FlexColumn gap={SPACING.md}>
+            <Caption color="primary">
+              The director is writing your screenplay.
+            </Caption>
+            <Box sx={shotGridSx}>
+              {Array.from({ length: shotCount }).map((_, i) => (
+                <Card key={i} variant="outlined" padding="none">
+                  <Skeleton
+                    variant="rectangular"
+                    animation="wave"
+                    sx={{
+                      width: "100%",
+                      aspectRatio: "16 / 9",
+                      height: "auto",
+                      borderRadius: BORDER_RADIUS.lg
+                    }}
+                  />
+                  <FlexColumn gap={SPACING.xs} sx={{ p: SPACING.lg }}>
+                    <Skeleton preset="text" width="85%" />
+                    <Skeleton preset="text" width="60%" />
+                  </FlexColumn>
+                </Card>
+              ))}
+            </Box>
+          </FlexColumn>
+        ) : shots.length === 0 ? (
+          <EmptyState
+            variant="empty"
+            title="No shots yet"
+            description={
+              readOnly
+                ? "This storyboard has no shots."
+                : "Write a brief and press Direct to generate a screenplay of shots."
+            }
+          />
+        ) : (
+          <Box sx={shotGridSx}>
+            {shots.map((shot) => (
+              <ShotCard
+                key={shot.id}
+                boardId={boardId}
+                shot={shot}
+                selected={shot.id === activeShotId}
+                onSelect={handleSelectShot}
+              />
+            ))}
+          </Box>
+        )}
+
+        {activeShot && (
+          <ShotInspector
+            boardId={boardId}
+            shot={activeShot}
+            readOnly={readOnly}
+            isFirst={activeShotIndex === 0}
+            isLast={activeShotIndex === shots.length - 1}
+            onClose={clearSelection}
+          />
+        )}
       </FlexColumn>
     </ScrollArea>
   );

--- a/web/src/components/storyboard/__tests__/ShotCard.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotCard.test.tsx
@@ -1,13 +1,10 @@
 import React from "react";
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 import type { Shot, ShotStatus } from "@nodetool-ai/protocol";
 import mockTheme from "../../../__mocks__/themeMock";
 
-// Keep the card's generation hook and image ladder out of the render — this test
-// only asserts the card's presentation and button gating, not generation.
-const generateRevisedClipMock = jest.fn(async () => undefined);
 // Media sources resolve through TanStack Query; these suites render no
 // QueryClientProvider, so use the manual mock (resolution itself is covered
 // by hooks/__tests__/useResolvedMediaUri.test.tsx).
@@ -22,91 +19,22 @@ jest.mock("../../assets/AssetViewer", () => ({
   )
 }));
 
-jest.mock("../../../hooks/storyboard/useGenerateShot", () => ({
-  useGenerateShot: () => ({
-    generateKeyframe: jest.fn(async () => undefined),
-    generateClip: jest.fn(async () => undefined),
-    generateRevisedClip: generateRevisedClipMock
-  })
-}));
-
-const moveShotMock = jest.fn();
-const removeShotMock = jest.fn();
-const updateShotMock = jest.fn();
-const removeKeyframeVersionMock = jest.fn();
-const removeClipVersionMock = jest.fn();
-/** Script the board links, if any — set per test before rendering. */
-let linkedScriptId: string | null = null;
+// The card reads the board only to time a shot against the linked script.
 jest.mock("../../../stores/storyboard/StoryboardStore", () => {
   const actual = jest.requireActual(
     "../../../stores/storyboard/StoryboardStore"
   );
   return {
     ...actual,
-    // Serve the actions the card reads via selectors; keep sameMediaRef and the
-    // other real exports (the nested takes gallery uses them).
     useStoryboardStore: <T,>(selector: (s: unknown) => T) =>
-      selector({
-        toggleShotEntity: jest.fn(),
-        moveShot: moveShotMock,
-        removeShot: removeShotMock,
-        updateShot: updateShotMock,
-        selectKeyframeVersion: jest.fn(),
-        selectClipVersion: jest.fn(),
-        removeKeyframeVersion: removeKeyframeVersionMock,
-        removeClipVersion: removeClipVersionMock,
-        boards: {
-          "board-1": {
-            screenplay: linkedScriptId ? { script_id: linkedScriptId } : null
-          }
-        }
-      })
+      selector({ boards: { "board-1": { screenplay: null } } })
   };
 });
 
-/** The linked script: one line, voiced with a 3.4 s take plus 250 ms silence. */
-let lineIsVoiced = true;
 jest.mock("../../../trpc/client", () => ({
   trpc: {
     scripts: {
-      get: {
-        useQuery: (_input: { id: string }, options?: { enabled?: boolean }) =>
-          options?.enabled
-            ? {
-                data: {
-                  document: {
-                    cast: [],
-                    sections: [
-                      {
-                        id: "sec1",
-                        lines: [
-                          {
-                            id: "line-1",
-                            text: "We are closed.",
-                            pauseAfterMs: 250,
-                            currentTakeId: lineIsVoiced ? "take-1" : null,
-                            takes: lineIsVoiced
-                              ? [
-                                  {
-                                    id: "take-1",
-                                    assetId: "audio-1",
-                                    durationMs: 3400,
-                                    words: [],
-                                    textSnapshot: "We are closed.",
-                                    voiceSnapshot: null,
-                                    createdAt: "2026-01-01T00:00:00.000Z"
-                                  }
-                                ]
-                              : []
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            : { data: undefined }
-      }
+      get: { useQuery: () => ({ data: undefined }) }
     }
   },
   trpcClient: {}
@@ -117,12 +45,6 @@ jest.mock("../../node/ImageRefPreview", () => ({
   default: ({ placeholder }: { placeholder?: React.ReactNode }) => (
     <div data-testid="image-preview">{placeholder}</div>
   )
-}));
-
-// The entity chips resolve the library through React Query; an empty library
-// keeps them out of these presentation tests.
-jest.mock("../../../serverState/useEntities", () => ({
-  useEntities: () => ({ data: [] })
 }));
 
 import ShotCard from "../ShotCard";
@@ -138,7 +60,10 @@ const makeShot = (overrides: Partial<Shot> = {}): Shot => ({
   ...overrides
 });
 
-const renderCard = (shot: Shot, props: Partial<React.ComponentProps<typeof ShotCard>> = {}) =>
+const renderCard = (
+  shot: Shot,
+  props: Partial<React.ComponentProps<typeof ShotCard>> = {}
+) =>
   render(
     <ThemeProvider theme={mockTheme}>
       <ShotCard boardId="board-1" shot={shot} {...props} />
@@ -146,36 +71,39 @@ const renderCard = (shot: Shot, props: Partial<React.ComponentProps<typeof ShotC
   );
 
 describe("ShotCard", () => {
-  beforeEach(() => {
-    moveShotMock.mockClear();
-    removeShotMock.mockClear();
-    updateShotMock.mockClear();
-    removeKeyframeVersionMock.mockClear();
-    removeClipVersionMock.mockClear();
-    linkedScriptId = null;
-    lineIsVoiced = true;
+  it("shows the shot number, its length, and the action line", () => {
+    renderCard(makeShot({ index: 4, duration_seconds: 3 }));
+    expect(screen.getByText("SH 05 · 3s")).toBeInTheDocument();
+    expect(screen.getByText("A lighthouse at dusk")).toBeInTheDocument();
+  });
+
+  it("drops the length from the label when the shot has none", () => {
+    renderCard(makeShot());
+    expect(screen.getByText("SH 01")).toBeInTheDocument();
   });
 
   it("shows why the last render failed", () => {
     // Seed the job state directly: this suite mocks the storyboard store, so
     // the action that would write it has nothing to write to.
-    useStoryboardGenerationStore.setState({
-      shotJobs: {
-        "shot-1": {
-          shotId: "shot-1",
-          boardId: "board-1",
-          jobId: "req-1",
-          kind: "keyframe",
-          status: "failed",
-          errorMessage: "Out of credits"
+    act(() =>
+      useStoryboardGenerationStore.setState({
+        shotJobs: {
+          "shot-1": {
+            shotId: "shot-1",
+            boardId: "board-1",
+            jobId: "req-1",
+            kind: "keyframe",
+            status: "failed",
+            errorMessage: "Out of credits"
+          }
         }
-      }
-    });
+      })
+    );
     renderCard(makeShot({ status: "failed" }));
     expect(screen.getByTestId("shot-render-error")).toHaveTextContent(
       "Out of credits"
     );
-    useStoryboardGenerationStore.setState({ shotJobs: {} });
+    act(() => useStoryboardGenerationStore.setState({ shotJobs: {} }));
   });
 
   it("falls back to a generic reason when the job state is gone", () => {
@@ -184,109 +112,70 @@ describe("ShotCard", () => {
       "The render failed. Try again."
     );
   });
+});
 
-  it("renders the shot action and status label", () => {
+describe("ShotCard status pill", () => {
+  const pill = () => screen.getByTestId("shot-status-pill");
+
+  it("reads planned before anything is generated", () => {
     renderCard(makeShot());
-    expect(screen.getByText("A lighthouse at dusk")).toBeInTheDocument();
-    expect(screen.getByText("Planned")).toBeInTheDocument();
-    expect(screen.getByText("1. Opening")).toBeInTheDocument();
+    expect(pill()).toHaveTextContent("planned");
+    expect(pill()).toHaveAttribute("data-tone", "neutral");
   });
 
-  it("gates buttons for a planned shot with no keyframe", () => {
-    renderCard(makeShot({ status: "planned" }));
-    expect(
-      screen.getByRole("button", { name: "Generate still" })
-    ).toBeEnabled();
-    expect(
-      screen.getByRole("button", { name: "Generate clip" })
-    ).toBeDisabled();
-  });
-
-  it("enables Generate clip as soon as a still is ready", () => {
-    const shot = makeShot({
-      status: "keyframe_ready",
-      keyframe: { type: "image", uri: "http://example.com/still.png" }
-    });
-    renderCard(shot);
-    // With a keyframe present, the still button offers another take.
-    expect(screen.getByRole("button", { name: "New still" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Generate clip" })).toBeEnabled();
-  });
-
-  it("treats the legacy approved status as a ready still", () => {
-    const shot = makeShot({
-      status: "approved",
-      keyframe: { type: "image", uri: "http://example.com/still.png" }
-    });
-    renderCard(shot);
-    expect(screen.getByText("Still ready")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Generate clip" })).toBeEnabled();
-  });
-
-  it("shows Revise clip only once a clip exists and collects an instruction in a dialog", async () => {
-    generateRevisedClipMock.mockClear();
-    // No clip yet: the revise affordance is absent.
-    const { unmount } = renderCard(makeShot({ status: "keyframe_ready" }));
-    expect(
-      screen.queryByRole("button", { name: "Revise clip" })
-    ).not.toBeInTheDocument();
-    unmount();
-
-    const shot = makeShot({
-      status: "rendered",
-      clip: { type: "video", uri: "http://example.com/clip.mp4" }
-    });
-    renderCard(shot);
-    await userEvent.click(screen.getByRole("button", { name: "Revise clip" }));
-
-    // The dialog opens; confirm is gated until an instruction is typed.
-    const dialog = await screen.findByRole("dialog");
-    const confirm = within(dialog).getByRole("button", { name: "Revise" });
-    expect(confirm).toBeDisabled();
-
-    await userEvent.type(
-      within(dialog).getByRole("textbox"),
-      "make it darker, add rain"
+  it("reads still · clip queued once the shot has a still", () => {
+    renderCard(
+      makeShot({
+        status: "keyframe_ready",
+        keyframe: { type: "image", uri: "http://example.com/still.png" }
+      })
     );
-    expect(confirm).toBeEnabled();
-    await userEvent.click(confirm);
+    expect(pill()).toHaveTextContent("still · clip queued");
+  });
 
-    expect(generateRevisedClipMock).toHaveBeenCalledWith(
-      "board-1",
-      shot,
-      "make it darker, add rain"
+  it("reads the clip's length once it is rendered", () => {
+    renderCard(
+      makeShot({
+        status: "rendered",
+        duration_seconds: 4,
+        clip: { type: "video", uri: "http://example.com/clip.mp4" }
+      })
+    );
+    expect(pill()).toHaveTextContent("clip · 4s");
+    expect(pill()).toHaveAttribute("data-tone", "done");
+  });
+
+  it("takes the render tone while a clip is in flight", () => {
+    renderCard(makeShot({ status: "clip_generating" }));
+    expect(pill()).toHaveTextContent("rendering clip");
+    expect(pill()).toHaveAttribute("data-tone", "rendering");
+  });
+
+  it("takes the failed tone after a failed render", () => {
+    renderCard(makeShot({ status: "failed" }));
+    expect(pill()).toHaveAttribute("data-tone", "failed");
+  });
+});
+
+describe("ShotCard selection", () => {
+  it("selects the shot when the card is clicked", async () => {
+    const onSelect = jest.fn();
+    renderCard(makeShot(), { onSelect });
+
+    await userEvent.click(screen.getByRole("button", { name: "1. Opening" }));
+    expect(onSelect).toHaveBeenCalledWith("shot-1");
+  });
+
+  it("marks the selected card pressed", () => {
+    renderCard(makeShot(), { onSelect: jest.fn(), selected: true });
+    expect(screen.getByRole("button", { name: "1. Opening" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
     );
   });
+});
 
-  it("reorders a shot with the move controls", async () => {
-    renderCard(makeShot(), { isFirst: false, isLast: false });
-    await userEvent.click(screen.getByRole("button", { name: "Move shot up" }));
-    expect(moveShotMock).toHaveBeenCalledWith("board-1", "shot-1", "up");
-    await userEvent.click(
-      screen.getByRole("button", { name: "Move shot down" })
-    );
-    expect(moveShotMock).toHaveBeenCalledWith("board-1", "shot-1", "down");
-  });
-
-  it("disables move-up on the first shot and move-down on the last", () => {
-    renderCard(makeShot(), { isFirst: true, isLast: true });
-    expect(screen.getByRole("button", { name: "Move shot up" })).toBeDisabled();
-    expect(
-      screen.getByRole("button", { name: "Move shot down" })
-    ).toBeDisabled();
-  });
-
-  it("deletes a shot only after confirming", async () => {
-    renderCard(makeShot());
-    await userEvent.click(screen.getByRole("button", { name: "Delete shot" }));
-    // Nothing removed until the confirmation is accepted.
-    expect(removeShotMock).not.toHaveBeenCalled();
-
-    const dialog = await screen.findByRole("dialog");
-    await userEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
-    expect(removeShotMock).toHaveBeenCalledWith("board-1", "shot-1");
-  });
-
+describe("ShotCard media viewer", () => {
   it("opens the still fullscreen from the preview", async () => {
     renderCard(
       makeShot({
@@ -329,70 +218,25 @@ describe("ShotCard", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("keeps the destructive take actions in the overflow menu", async () => {
+  it("does not select the shot when the viewer is opened", async () => {
+    const onSelect = jest.fn();
     renderCard(
       makeShot({
-        status: "rendered",
-        keyframe: { type: "image", uri: "http://example.com/still.png" },
-        clip: { type: "video", uri: "http://example.com/clip.mp4" }
-      })
-    );
-
-    // The action row stays short: removals live behind the overflow.
-    expect(
-      screen.queryByRole("menuitem", { name: "Remove still" })
-    ).not.toBeInTheDocument();
-
-    await userEvent.click(
-      screen.getByRole("button", { name: "More shot actions" })
-    );
-    await userEvent.click(
-      await screen.findByRole("menuitem", { name: "Remove still" })
-    );
-    expect(removeKeyframeVersionMock).toHaveBeenCalledWith(
-      "board-1",
-      "shot-1",
-      0
+        status: "keyframe_ready",
+        keyframe: { type: "image", uri: "asset://img-9", asset_id: "img-9" }
+      }),
+      { onSelect }
     );
 
     await userEvent.click(
-      screen.getByRole("button", { name: "More shot actions" })
+      screen.getByRole("button", { name: "View still fullscreen" })
     );
-    await userEvent.click(
-      await screen.findByRole("menuitem", { name: "Remove clip" })
-    );
-    expect(removeClipVersionMock).toHaveBeenCalledWith("board-1", "shot-1", 0);
+    expect(onSelect).not.toHaveBeenCalled();
   });
+});
 
-  it("offers no overflow menu before a shot has any media", () => {
-    renderCard(makeShot());
-    expect(
-      screen.queryByRole("button", { name: "More shot actions" })
-    ).not.toBeInTheDocument();
-  });
-
-  it("hides the management controls in read-only mode", () => {
-    renderCard(makeShot(), { readOnly: true });
-    expect(
-      screen.queryByRole("button", { name: "Move shot up" })
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Delete shot" })
-    ).not.toBeInTheDocument();
-  });
-
-  it("disables the still button while generating", () => {
-    const statuses: ShotStatus[] = ["keyframe_generating", "clip_generating"];
-    for (const status of statuses) {
-      const { unmount } = renderCard(makeShot({ status }));
-      expect(
-        screen.getByRole("button", { name: /Generate still|New still/ })
-      ).toBeDisabled();
-      unmount();
-    }
-  });
-
-  it("marks the card as generating so the animated border renders", () => {
+describe("ShotCard render state", () => {
+  it("marks the card as generating so the render border renders", () => {
     const statuses: ShotStatus[] = [
       "planned",
       "keyframe_generating",
@@ -410,51 +254,13 @@ describe("ShotCard", () => {
       unmount();
     }
   });
-});
 
-describe("ShotCard duration source", () => {
-  const linkedShot = (overrides: Partial<Shot> = {}): Shot =>
-    makeShot({ duration_seconds: 8, script_line_ids: ["line-1"], ...overrides });
+  it("shows a progress bar only while a render is in flight", () => {
+    const { unmount } = renderCard(makeShot({ status: "clip_generating" }));
+    expect(screen.getAllByRole("progressbar").length).toBeGreaterThan(0);
+    unmount();
 
-  beforeEach(() => {
-    updateShotMock.mockClear();
-    linkedScriptId = "script-1";
-    lineIsVoiced = true;
-  });
-
-  it("shows the audio-derived length for a linked, voiced shot", () => {
-    renderCard(linkedShot());
-    // 3400 ms + 250 ms of silence, rounded up to whole seconds.
-    expect(screen.getByText("4s · from takes")).toBeInTheDocument();
-  });
-
-  it("shows the shot's own length when it is pinned to manual", () => {
-    renderCard(linkedShot({ duration_source: "manual" }));
-    expect(screen.getByText("8s · manual")).toBeInTheDocument();
-  });
-
-  it("falls back to the shot's own length while the line is unvoiced", () => {
-    lineIsVoiced = false;
-    renderCard(linkedShot());
-    expect(screen.getByText("8s · manual")).toBeInTheDocument();
-  });
-
-  it("shows nothing for a shot that covers no script lines", () => {
-    renderCard(makeShot({ duration_seconds: 8 }));
-    expect(screen.queryByText(/from takes|manual/)).not.toBeInTheDocument();
-  });
-
-  it("toggles the source through the store", async () => {
-    renderCard(linkedShot());
-    await userEvent.click(screen.getByText("4s · from takes"));
-    expect(updateShotMock).toHaveBeenCalledWith("board-1", "shot-1", {
-      duration_source: "manual"
-    });
-  });
-
-  it("does not toggle in read-only mode", async () => {
-    renderCard(linkedShot(), { readOnly: true });
-    await userEvent.click(screen.getByText("4s · from takes"));
-    expect(updateShotMock).not.toHaveBeenCalled();
+    renderCard(makeShot());
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/storyboard/__tests__/ShotInspector.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotInspector.test.tsx
@@ -1,0 +1,397 @@
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import type { Shot } from "@nodetool-ai/protocol";
+import mockTheme from "../../../__mocks__/themeMock";
+
+const generateKeyframeMock = jest.fn(async () => undefined);
+const generateClipMock = jest.fn(async () => undefined);
+const generateRevisedClipMock = jest.fn(async () => undefined);
+jest.mock("../../../hooks/storyboard/useGenerateShot", () => ({
+  useGenerateShot: () => ({
+    generateKeyframe: generateKeyframeMock,
+    generateClip: generateClipMock,
+    generateRevisedClip: generateRevisedClipMock
+  })
+}));
+
+const moveShotMock = jest.fn();
+const removeShotMock = jest.fn();
+const updateShotMock = jest.fn();
+const removeKeyframeVersionMock = jest.fn();
+const removeClipVersionMock = jest.fn();
+/** Script the board links, if any — set per test before rendering. */
+let linkedScriptId: string | null = null;
+jest.mock("../../../stores/storyboard/StoryboardStore", () => {
+  const actual = jest.requireActual(
+    "../../../stores/storyboard/StoryboardStore"
+  );
+  return {
+    ...actual,
+    // Serve the actions the inspector reads via selectors; keep sameMediaRef
+    // and the other real exports.
+    useStoryboardStore: <T,>(selector: (s: unknown) => T) =>
+      selector({
+        toggleShotEntity: jest.fn(),
+        moveShot: moveShotMock,
+        removeShot: removeShotMock,
+        updateShot: updateShotMock,
+        removeKeyframeVersion: removeKeyframeVersionMock,
+        removeClipVersion: removeClipVersionMock,
+        boards: {
+          "board-1": {
+            entityIds: [],
+            screenplay: linkedScriptId ? { script_id: linkedScriptId } : null
+          }
+        }
+      })
+  };
+});
+
+/** The linked script: one line, voiced with a 3.4 s take plus 250 ms silence. */
+let lineIsVoiced = true;
+jest.mock("../../../trpc/client", () => ({
+  trpc: {
+    scripts: {
+      get: {
+        useQuery: (_input: { id: string }, options?: { enabled?: boolean }) =>
+          options?.enabled
+            ? {
+                data: {
+                  document: {
+                    cast: [],
+                    sections: [
+                      {
+                        id: "sec1",
+                        lines: [
+                          {
+                            id: "line-1",
+                            text: "We are closed.",
+                            pauseAfterMs: 250,
+                            currentTakeId: lineIsVoiced ? "take-1" : null,
+                            takes: lineIsVoiced
+                              ? [
+                                  {
+                                    id: "take-1",
+                                    assetId: "audio-1",
+                                    durationMs: 3400,
+                                    words: [],
+                                    textSnapshot: "We are closed.",
+                                    voiceSnapshot: null,
+                                    createdAt: "2026-01-01T00:00:00.000Z"
+                                  }
+                                ]
+                              : []
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            : { data: undefined }
+      }
+    }
+  },
+  trpcClient: {}
+}));
+
+// The entity chips resolve the library through React Query; an empty library
+// keeps them out of these tests.
+jest.mock("../../../serverState/useEntities", () => ({
+  useEntities: () => ({ data: [] })
+}));
+
+// Both have their own suites and reach further into the script store than
+// this one needs.
+const stub = (name: string) => ({
+  __esModule: true,
+  default: () => <div data-testid={name} />
+});
+jest.mock("../ShotTakesGallery", () => stub("takes-gallery"));
+jest.mock("../ShotScriptPanel", () => stub("script-panel"));
+
+import ShotInspector from "../ShotInspector";
+import { useWorkspaceTabsStore } from "../../../stores/WorkspaceTabsStore";
+
+const makeShot = (overrides: Partial<Shot> = {}): Shot => ({
+  type: "shot",
+  id: "shot-1",
+  index: 0,
+  slug: "Opening",
+  action: "A lighthouse at dusk",
+  status: "planned",
+  ...overrides
+});
+
+const renderInspector = (
+  shot: Shot,
+  props: Partial<React.ComponentProps<typeof ShotInspector>> = {}
+) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ShotInspector boardId="board-1" shot={shot} {...props} />
+    </ThemeProvider>
+  );
+
+describe("ShotInspector", () => {
+  beforeEach(() => {
+    moveShotMock.mockClear();
+    removeShotMock.mockClear();
+    updateShotMock.mockClear();
+    removeKeyframeVersionMock.mockClear();
+    removeClipVersionMock.mockClear();
+    generateClipMock.mockClear();
+    linkedScriptId = null;
+    lineIsVoiced = true;
+  });
+
+  it("names the selected shot and shows its status", () => {
+    renderInspector(makeShot({ index: 4 }));
+    expect(screen.getByText("SH 05 selected")).toBeInTheDocument();
+    expect(screen.getByText("5. Opening")).toBeInTheDocument();
+    expect(screen.getByText("Planned")).toBeInTheDocument();
+    expect(screen.getByText("A lighthouse at dusk")).toBeInTheDocument();
+  });
+
+  it("treats the legacy approved status as a ready still", () => {
+    renderInspector(
+      makeShot({
+        status: "approved",
+        keyframe: { type: "image", uri: "http://example.com/still.png" }
+      })
+    );
+    expect(screen.getByText("Still ready")).toBeInTheDocument();
+  });
+
+  it("gates the clip render until the shot has a still", () => {
+    const { unmount } = renderInspector(makeShot());
+    expect(screen.getByRole("button", { name: "Render clip" })).toBeDisabled();
+    unmount();
+
+    renderInspector(
+      makeShot({
+        status: "keyframe_ready",
+        keyframe: { type: "image", uri: "http://example.com/still.png" }
+      })
+    );
+    expect(screen.getByRole("button", { name: "Render clip" })).toBeEnabled();
+  });
+
+  it("re-renders the clip from the selection footer", async () => {
+    const shot = makeShot({
+      status: "rendered",
+      keyframe: { type: "image", uri: "http://example.com/still.png" },
+      clip: { type: "video", uri: "http://example.com/clip.mp4" }
+    });
+    renderInspector(shot);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Re-render clip" })
+    );
+    expect(generateClipMock).toHaveBeenCalledWith("board-1", shot);
+  });
+
+  it("offers another still once one exists", () => {
+    renderInspector(
+      makeShot({
+        status: "keyframe_ready",
+        keyframe: { type: "image", uri: "http://example.com/still.png" }
+      })
+    );
+    expect(screen.getByRole("button", { name: "New still" })).toBeEnabled();
+  });
+
+  it("collects a revise instruction in a dialog, and only with a clip", async () => {
+    generateRevisedClipMock.mockClear();
+    const { unmount } = renderInspector(makeShot({ status: "keyframe_ready" }));
+    expect(screen.getByRole("button", { name: "Revise take" })).toBeDisabled();
+    unmount();
+
+    const shot = makeShot({
+      status: "rendered",
+      clip: { type: "video", uri: "http://example.com/clip.mp4" }
+    });
+    renderInspector(shot);
+    await userEvent.click(screen.getByRole("button", { name: "Revise take" }));
+
+    // The dialog opens; confirm is gated until an instruction is typed.
+    const dialog = await screen.findByRole("dialog");
+    const confirm = within(dialog).getByRole("button", { name: "Revise" });
+    expect(confirm).toBeDisabled();
+
+    await userEvent.type(
+      within(dialog).getByRole("textbox"),
+      "make it darker, add rain"
+    );
+    expect(confirm).toBeEnabled();
+    await userEvent.click(confirm);
+
+    expect(generateRevisedClipMock).toHaveBeenCalledWith(
+      "board-1",
+      shot,
+      "make it darker, add rain"
+    );
+  });
+
+  it("reorders a shot with the move controls", async () => {
+    renderInspector(makeShot(), { isFirst: false, isLast: false });
+    await userEvent.click(screen.getByRole("button", { name: "Move shot up" }));
+    expect(moveShotMock).toHaveBeenCalledWith("board-1", "shot-1", "up");
+    await userEvent.click(
+      screen.getByRole("button", { name: "Move shot down" })
+    );
+    expect(moveShotMock).toHaveBeenCalledWith("board-1", "shot-1", "down");
+  });
+
+  it("disables move-up on the first shot and move-down on the last", () => {
+    renderInspector(makeShot(), { isFirst: true, isLast: true });
+    expect(screen.getByRole("button", { name: "Move shot up" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Move shot down" })
+    ).toBeDisabled();
+  });
+
+  it("deletes a shot only after confirming", async () => {
+    renderInspector(makeShot());
+    await userEvent.click(screen.getByRole("button", { name: "Delete shot" }));
+    // Nothing removed until the confirmation is accepted.
+    expect(removeShotMock).not.toHaveBeenCalled();
+
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Delete" })
+    );
+    expect(removeShotMock).toHaveBeenCalledWith("board-1", "shot-1");
+  });
+
+  it("keeps the destructive take actions in the overflow menu", async () => {
+    renderInspector(
+      makeShot({
+        status: "rendered",
+        keyframe: { type: "image", uri: "http://example.com/still.png" },
+        clip: { type: "video", uri: "http://example.com/clip.mp4" }
+      })
+    );
+
+    // The action row stays short: removals live behind the overflow.
+    expect(
+      screen.queryByRole("menuitem", { name: "Remove still" })
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "More shot actions" })
+    );
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: "Remove still" })
+    );
+    expect(removeKeyframeVersionMock).toHaveBeenCalledWith(
+      "board-1",
+      "shot-1",
+      0
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "More shot actions" })
+    );
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: "Remove clip" })
+    );
+    expect(removeClipVersionMock).toHaveBeenCalledWith("board-1", "shot-1", 0);
+  });
+
+  it("offers no overflow menu before a shot has any media", () => {
+    renderInspector(makeShot());
+    expect(
+      screen.queryByRole("button", { name: "More shot actions" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the management controls in read-only mode", () => {
+    renderInspector(makeShot(), { readOnly: true });
+    expect(
+      screen.queryByRole("button", { name: "Move shot up" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Delete shot" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Re-render clip" })
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("ShotInspector cross-document links", () => {
+  beforeEach(() => {
+    linkedScriptId = null;
+    lineIsVoiced = true;
+    useWorkspaceTabsStore.setState({ tabs: [], activeTabId: null });
+  });
+
+  it("says nothing appears elsewhere for an unlinked shot", () => {
+    renderInspector(makeShot());
+    expect(screen.getByText("nothing yet")).toBeInTheDocument();
+  });
+
+  it("links to the script line the shot covers", async () => {
+    linkedScriptId = "script-1";
+    renderInspector(makeShot({ script_line_ids: ["line-1"] }));
+
+    const chip = screen.getByText("Script · line 1");
+    await userEvent.click(chip);
+
+    const tabs = useWorkspaceTabsStore.getState().tabs;
+    expect(tabs.some((t) => t.type === "script" && t.ref === "script-1")).toBe(
+      true
+    );
+  });
+});
+
+describe("ShotInspector duration source", () => {
+  const linkedShot = (overrides: Partial<Shot> = {}): Shot =>
+    makeShot({ duration_seconds: 8, script_line_ids: ["line-1"], ...overrides });
+
+  beforeEach(() => {
+    updateShotMock.mockClear();
+    linkedScriptId = "script-1";
+    lineIsVoiced = true;
+  });
+
+  it("shows the audio-derived length for a linked, voiced shot", () => {
+    renderInspector(linkedShot());
+    // 3400 ms + 250 ms of silence, rounded up to whole seconds.
+    expect(screen.getByText("4s · from takes")).toBeInTheDocument();
+  });
+
+  it("shows the shot's own length when it is pinned to manual", () => {
+    renderInspector(linkedShot({ duration_source: "manual" }));
+    expect(screen.getByText("8s · manual")).toBeInTheDocument();
+  });
+
+  it("falls back to the shot's own length while the line is unvoiced", () => {
+    lineIsVoiced = false;
+    renderInspector(linkedShot());
+    expect(screen.getByText("8s · manual")).toBeInTheDocument();
+  });
+
+  it("shows nothing for a shot that covers no script lines", () => {
+    linkedScriptId = null;
+    renderInspector(makeShot({ duration_seconds: 8 }));
+    expect(screen.queryByText(/from takes|manual/)).not.toBeInTheDocument();
+  });
+
+  it("toggles the source through the store", async () => {
+    renderInspector(linkedShot());
+    await userEvent.click(screen.getByText("4s · from takes"));
+    expect(updateShotMock).toHaveBeenCalledWith("board-1", "shot-1", {
+      duration_source: "manual"
+    });
+  });
+
+  it("does not toggle in read-only mode", async () => {
+    renderInspector(linkedShot(), { readOnly: true });
+    await userEvent.click(screen.getByText("4s · from takes"));
+    expect(updateShotMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
+++ b/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
@@ -5,6 +5,8 @@ import type { Shot } from "@nodetool-ai/protocol";
 import mockTheme from "../../../__mocks__/themeMock";
 
 let mockShots: Shot[] = [];
+/** The board's selected shot id, driving the inspector's presence. */
+let activeShot: string | null = null;
 jest.mock("../../../stores/storyboard/StoryboardStore", () => ({
   useBoard: () => ({
     title: "My film",
@@ -15,7 +17,8 @@ jest.mock("../../../stores/storyboard/StoryboardStore", () => ({
     directorModel: { id: "model-1" },
     imageModel: null,
     videoModel: null,
-    shots: mockShots
+    shots: mockShots,
+    activeShotId: activeShot
   }),
   useStoryboardStore: <T,>(
     selector: (s: {
@@ -28,6 +31,7 @@ jest.mock("../../../stores/storyboard/StoryboardStore", () => ({
       setVideoModel: jest.Mock;
       undo: jest.Mock;
       redo: jest.Mock;
+      selectShot: jest.Mock;
     }) => T
   ) =>
     selector({
@@ -39,7 +43,8 @@ jest.mock("../../../stores/storyboard/StoryboardStore", () => ({
       setImageModel: jest.fn(),
       setVideoModel: jest.fn(),
       undo: jest.fn(),
-      redo: jest.fn()
+      redo: jest.fn(),
+      selectShot: jest.fn()
     }),
   useStoryboardCanUndo: () => false,
   useStoryboardCanRedo: () => false
@@ -63,6 +68,12 @@ jest.mock("../../../hooks/useModelsByProvider", () => ({
   useImageModelsByProvider: () => ({ models: [] })
 }));
 
+// The toolbar's summary line names the board's entities; the library itself
+// resolves through React Query, which these tests do not mount.
+jest.mock("../../../serverState/useEntities", () => ({
+  useEntities: () => ({ data: [] })
+}));
+
 const stub = (name: string) => ({
   __esModule: true,
   default: () => <div data-testid={name} />
@@ -71,6 +82,9 @@ jest.mock("../../properties/LanguageModelSelect", () => stub("lang-model"));
 jest.mock("../../properties/ImageModelSelect", () => stub("image-model"));
 jest.mock("../../properties/VideoModelSelect", () => stub("video-model"));
 jest.mock("../ShotCard", () => stub("shot-card"));
+// The inspector reads the real store, the entity library and the linked
+// script; it has its own suite (ShotInspector.test.tsx).
+jest.mock("../ShotInspector", () => stub("shot-inspector"));
 // The real preview mounts the timeline compositor — not viable under jsdom.
 jest.mock("../StoryboardPreview", () => stub("storyboard-preview"));
 jest.mock("../StoryboardEntitiesField", () => stub("entities"));
@@ -129,6 +143,8 @@ describe("StoryboardBoard direct guard", () => {
     const user = userEvent.setup();
     renderBoard(onDirect);
 
+    // With shots on the board the form is folded behind the toolbar.
+    await user.click(screen.getByRole("button", { name: /Board settings/ }));
     // The button relabels once shots exist.
     await user.click(screen.getByRole("button", { name: "Re-direct" }));
 
@@ -208,5 +224,55 @@ describe("StoryboardBoard download", () => {
     await user.click(screen.getByRole("button", { name: "Download ZIP" }));
 
     expect(mockExportStoryboardZip).toHaveBeenCalledWith("board-1", "My film");
+  });
+});
+
+describe("StoryboardBoard toolbar", () => {
+  it("summarises the board and folds the form away once it has shots", async () => {
+    mockShots = [makeShot("s1"), makeShot("s2")];
+    const user = userEvent.setup();
+    renderBoard(jest.fn());
+
+    expect(screen.getByText("My film")).toBeInTheDocument();
+    expect(screen.getByText("2 shots")).toBeInTheDocument();
+    // Folded: the screenplay fields are out of the DOM until asked for.
+    expect(screen.queryByTestId("lang-model")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Board settings/ }));
+    expect(await screen.findByTestId("lang-model")).toBeInTheDocument();
+  });
+
+  it("keeps the form open while the board has no shots", () => {
+    mockShots = [];
+    renderBoard(jest.fn());
+
+    expect(screen.getByTestId("lang-model")).toBeInTheDocument();
+    expect(screen.getByText("0 shots")).toBeInTheDocument();
+  });
+
+  it("renders the render actions on the toolbar", () => {
+    mockShots = [makeShot("s1")];
+    renderBoard(jest.fn());
+
+    expect(
+      screen.getByRole("button", { name: "Render stills (1)" })
+    ).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Render clips" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Assemble timeline" })
+    ).toBeDisabled();
+  });
+});
+
+describe("StoryboardBoard selection", () => {
+  it("opens the inspector for the selected shot", () => {
+    mockShots = [makeShot("s1")];
+    renderBoard(jest.fn());
+    expect(screen.queryByTestId("shot-inspector")).not.toBeInTheDocument();
+
+    activeShot = "s1";
+    renderBoard(jest.fn());
+    expect(screen.getAllByTestId("shot-inspector").length).toBeGreaterThan(0);
+    activeShot = null;
   });
 });


### PR DESCRIPTION
## What changed

Phase 0 of `docs/plans/project-view/PLAN.md` (A1–A4), matching `docs/plans/project-view/mockups/storyboard-board.html`. The board was a full settings `Panel` over a vertical list of two-column shot cards; it is now a compact toolbar over a responsive 4-column grid, with a selection inspector docked under it. Behaviour is unchanged — store wiring, the Direct/re-direct guard, the generate hooks, undo/redo, preview, ZIP export and the script link all keep working — this is presentation plus a new home for the per-shot controls.

`ShotCard` now carries only what reads at a glance: the clip or selected still in a 16:9 media area, a mono `SH NN · Ns` label on a scrim, a status pill, and the action line clamped to two lines. Clicking it selects the shot through the store's existing `selectShot`/`activeShotId`, which had no UI before. Everything the old card held beyond that — camera and cost meta, the duration-source chip, cast chips, the takes browser, the script lines, reorder, delete, and the take overflow — moves into the new `ShotInspector`, whose top bar is the plan's 44px selection footer: which shot is selected, where it appears in sibling documents, and the *Revise take* / *Re-render clip* actions. The Screenplay/Direction form, *Direct* included, folds behind a *Board settings* toggle in the toolbar, open by default while the board has no shots, so a fresh board still opens on its form.

`ShotStatusPill` holds the one status vocabulary the grid speaks: a rendered clip in `success.main` with its length, a render in flight in video violet (`colorForType("video")`, the same colour as the card's border and the 3px progress bar on the thumbnail's bottom edge), a shot waiting on its next step neutral, and a failed render in error red. The "appears in" chips claim only what the board already knows — the linked script line, opening the script tab. The timeline chip waits for Phase 5's shot→clip mapping rather than being faked.

Not in this diff, and worth knowing: `web/src/demo/doc/DocDemoPlayer.tsx` replays the SCRAPHEART cast through this board read-only, so `marketing/public/surface-storyboard.*` shows the old layout until someone re-runs `npm run render:surfaces`.

## Verification

- [x] `npm run test:affected` — 4 suites, 54 tests, all passing (`ShotCard`, `ShotInspector`, `StoryboardBoard`, `DocumentSurfaceLoading`). The whole `web/src/components/storyboard` suite is green too: 10 suites, 99 tests.
- [x] `npm run typecheck` — `web` and `electron` exit 0. `mobile` fails on `Cannot find module 'react-native'` and siblings because `mobile/node_modules` is not installed in this container; the diff touches no mobile file.
- [x] `npm run lint` — exit 0 (only pre-existing warnings elsewhere in the repo).
- [x] `harness gate` — the CLI cannot compute a diff here (`fatal: main...HEAD: no merge base`, shallow clone), so the storyboard surface's selfchecks were run directly: `npm run test --workspace=packages/protocol -- script-link` (26 passed), `npm run test --workspace=packages/timeline -- script-link linked` (25 passed), `npm run test --workspace=packages/execution -- linked-timeline-validate` (1 passed), and `npm run validate:examples` (255/255 graphs, including the three shipped storyboards).

An earlier `npx tsc --noEmit | head -40` reported exit 0 while tsc itself was failing — `head`'s status, not tsc's. The exit codes above are the command's own, and the unbuilt-package errors it was hiding went away after `npm run build:packages`.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added. The moved behaviour keeps its assertions: the tests that covered the old card's controls now live in `__tests__/ShotInspector.test.tsx` against the same mocks, and `ShotCard.test.tsx` covers what the card kept (the number/length label, each pill tone, selection, the fullscreen viewer, the render border and bar).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdguJznxAJ33V3ziRB7aQk)_