### PR TITLE
feat(projects): add the projects data layer

### DIFF
--- a/packages/execution/src/cost-ledger.ts
+++ b/packages/execution/src/cost-ledger.ts
@@ -78,6 +78,10 @@ export interface GenerationSpend {
   nodeId?: string;
   nodeType?: string;
   workflowId?: string | null;
+  /** The project this run belongs to, when it has one. */
+  projectId?: string | null;
+  /** The project document this run is producing, when it names one. */
+  documentId?: string | null;
   durationMs?: number | null;
 }
 
@@ -161,6 +165,8 @@ export async function recordGenerationSpend(
       node_id: spend.nodeId ?? "",
       node_type: spend.nodeType ?? "",
       workflow_id: spend.workflowId ?? null,
+      project_id: spend.projectId ?? null,
+      document_id: spend.documentId ?? null,
       status: "completed",
       cost: priced ? priced.cost : null,
       billing_unit: priced ? priced.billing_unit : (spend.capability ?? null),
@@ -187,6 +193,10 @@ export interface NodeCostSpend {
   nodeId: string;
   nodeType: string;
   workflowId: string | null;
+  /** The project this run belongs to, when it has one. */
+  projectId?: string | null;
+  /** The project document this run is producing, when it names one. */
+  documentId?: string | null;
   /** Resolves the provider API key used to look the actual charge up, when one exists. */
   resolveSecret?: (key: string) => Promise<string | null | undefined>;
 }
@@ -211,6 +221,8 @@ export async function recordNodeProviderCost(
       node_type: spend.nodeType,
       node_id: spend.nodeId,
       workflow_id: spend.workflowId,
+      project_id: spend.projectId ?? null,
+      document_id: spend.documentId ?? null,
       status: "completed",
       cost: cost.amount,
       currency: cost.currency ?? cost.unit ?? null,
@@ -269,6 +281,14 @@ async function reconcileProviderCost(
 export interface RunCostLedgerOptions {
   userId: string;
   workflowId: string | null;
+  /**
+   * The project this run belongs to. Left unset outside a project, and the row
+   * then carries a null rather than being attributed to the loose bucket — a
+   * project's total counts only what named it.
+   */
+  projectId?: string | null;
+  /** The project document this run is producing, when the host names one. */
+  documentId?: string | null;
   /** Node type for a node id, so a row names the node that spent the money. */
   nodeType?: (nodeId: string) => string;
   resolveSecret?: (key: string) => Promise<string | null | undefined>;
@@ -324,6 +344,8 @@ export async function recordFromMessage(
       nodeId: msg.node_id,
       nodeType: msg.node_type || options.nodeType?.(msg.node_id) || "",
       workflowId: options.workflowId,
+      projectId: options.projectId,
+      documentId: options.documentId,
       resolveSecret: options.resolveSecret
     });
     return;
@@ -343,6 +365,8 @@ export async function recordFromMessage(
     nodeId: msg.node_id,
     nodeType: options.nodeType?.(msg.node_id) ?? "",
     workflowId: options.workflowId,
+    projectId: options.projectId,
+    documentId: options.documentId,
     durationMs: msg.duration ?? null
   });
 }

--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -870,6 +870,8 @@ function getCreateSchemaSql(): string {
       "provider" text NOT NULL DEFAULT '',
       "model" text NOT NULL DEFAULT '',
       "workflow_id" text,
+      "project_id" text,
+      "document_id" text,
       "error" text,
       "logs" text,
       "status" text NOT NULL DEFAULT 'pending',
@@ -898,6 +900,7 @@ function getCreateSchemaSql(): string {
     CREATE INDEX IF NOT EXISTS "idx_predictions_user_provider" ON "nodetool_predictions" ("user_id", "provider");
     CREATE INDEX IF NOT EXISTS "idx_prediction_created_at" ON "nodetool_predictions" ("created_at");
     CREATE INDEX IF NOT EXISTS "idx_prediction_user_model" ON "nodetool_predictions" ("user_id", "model");
+    CREATE INDEX IF NOT EXISTS "idx_prediction_user_project" ON "nodetool_predictions" ("user_id", "project_id");
 
     CREATE TABLE IF NOT EXISTS "run_events" (
       "id" text PRIMARY KEY NOT NULL,
@@ -1221,6 +1224,17 @@ function getCreateSchemaSql(): string {
       "created_at" text NOT NULL,
       "updated_at" text NOT NULL
     );
+
+    CREATE TABLE IF NOT EXISTS "projects" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL,
+      "name" text NOT NULL,
+      "kind" text NOT NULL DEFAULT '',
+      "created_at" text NOT NULL,
+      "updated_at" text NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS "idx_project_user" ON "projects" ("user_id");
+    CREATE INDEX IF NOT EXISTS "idx_project_updated" ON "projects" ("updated_at");
 
     CREATE TABLE IF NOT EXISTS "scripts" (
       "id" text PRIMARY KEY NOT NULL,

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -34,6 +34,7 @@ export {
   workflowVersions,
   oauthCredentials,
   predictions,
+  projects,
   runEvents,
   teamTasks,
   appSettings,
@@ -216,6 +217,31 @@ export type {
   Reservation,
   ReserveInput
 } from "./application-budget.js";
+export { Project, LOOSE_PROJECT_ID } from "./project.js";
+export type { ProjectResponse } from "./project.js";
+export {
+  listProjectDocuments,
+  scriptStatus,
+  spendCategory,
+  storyboardStatus,
+  summarizeProject,
+  summarizeSpend,
+  timelineStatus
+} from "./project-summary.js";
+export type {
+  CategorySpend,
+  ProjectDocumentRef,
+  ProjectDocumentStatus,
+  ProjectDocumentSummary,
+  ProjectDocumentType,
+  ProjectSpend,
+  ProjectSummary,
+  ScriptStatus,
+  SpendCategory,
+  SpendRow,
+  StoryboardStatus,
+  TimelineStatus
+} from "./project-summary.js";
 export {
   Script,
   ScriptConflictError,

--- a/packages/models/src/migrations/versions.ts
+++ b/packages/models/src/migrations/versions.ts
@@ -2997,6 +2997,72 @@ export const migrations: MigrationDef[] = [
         ON nodetool_thread_memories (user_id)
       `);
     }
+  },
+
+  // ── Create projects ──────────────────────────────────────────────────
+  // The project is the unit of the workspace. Every document table already
+  // carries `project_id`; this is the row it points at. `"default"` stays the
+  // loose-documents bucket and gets no row — nothing is migrated into one.
+  {
+    version: "20260829_000000",
+    name: "create_projects",
+    createsTables: ["projects"],
+    modifiesTables: [],
+    async up(db) {
+      await db.execute(`
+        CREATE TABLE IF NOT EXISTS projects (
+          id TEXT PRIMARY KEY,
+          user_id TEXT NOT NULL,
+          name TEXT NOT NULL,
+          kind TEXT NOT NULL DEFAULT '',
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        )
+      `);
+      await db.execute(`
+        CREATE INDEX IF NOT EXISTS idx_project_user ON projects (user_id)
+      `);
+      await db.execute(`
+        CREATE INDEX IF NOT EXISTS idx_project_updated ON projects (updated_at)
+      `);
+    },
+    async down(db) {
+      await db.execute("DROP INDEX IF EXISTS idx_project_updated");
+      await db.execute("DROP INDEX IF EXISTS idx_project_user");
+      await db.execute("DROP TABLE IF EXISTS projects");
+    }
+  },
+
+  // ── Attribute ledger rows to a project and a document ────────────────
+  // A project's spend is the sum of the prediction rows that name it. Both
+  // columns are nullable and every existing row keeps a null: a run outside a
+  // project has no project, and saying so beats inventing one.
+  {
+    version: "20260829_000001",
+    name: "add_prediction_project_attribution",
+    createsTables: [],
+    modifiesTables: ["nodetool_predictions"],
+    async up(db) {
+      if (!(await db.columnExists("nodetool_predictions", "project_id"))) {
+        await db.execute(
+          "ALTER TABLE nodetool_predictions ADD COLUMN project_id TEXT"
+        );
+      }
+      if (!(await db.columnExists("nodetool_predictions", "document_id"))) {
+        await db.execute(
+          "ALTER TABLE nodetool_predictions ADD COLUMN document_id TEXT"
+        );
+      }
+      await db.execute(`
+        CREATE INDEX IF NOT EXISTS idx_prediction_user_project
+        ON nodetool_predictions (user_id, project_id)
+      `);
+    },
+    async down(db) {
+      await db.execute("DROP INDEX IF EXISTS idx_prediction_user_project");
+      // SQLite before 3.35 cannot drop a column, and the data in these two is
+      // attribution nothing else reads. Leaving them is the safe direction.
+    }
   }
 ];
 

--- a/packages/models/src/prediction.ts
+++ b/packages/models/src/prediction.ts
@@ -117,6 +117,8 @@ export class Prediction extends DBModel {
   declare provider: string;
   declare model: string;
   declare workflow_id: string | null;
+  declare project_id: string | null;
+  declare document_id: string | null;
   declare error: string | null;
   declare logs: string | null;
   declare status: string;
@@ -152,6 +154,8 @@ export class Prediction extends DBModel {
     this.model ??= "";
     this.status ??= "pending";
     this.workflow_id ??= null;
+    this.project_id ??= null;
+    this.document_id ??= null;
     this.error ??= null;
     this.logs ??= null;
     this.cost ??= null;
@@ -178,6 +182,32 @@ export class Prediction extends DBModel {
   /** Find a prediction by ID. */
   static async find(predictionId: string): Promise<Prediction | null> {
     return Prediction.get<Prediction>(predictionId);
+  }
+
+  /**
+   * Every ledger row attributed to one project, newest first. Rows written
+   * before the run knew a project carry a null `project_id` and are not here —
+   * the project's total is a lower bound in exactly that case, which is the
+   * same convention an unpriced row already sets.
+   */
+  static async listByProject(
+    userId: string,
+    projectId: string,
+    limit = 1000
+  ): Promise<Prediction[]> {
+    const db = getDb();
+    const rows = await db
+      .select()
+      .from(predictions)
+      .where(
+        and(
+          eq(predictions.user_id, userId),
+          eq(predictions.project_id, projectId)
+        )
+      )
+      .orderBy(desc(predictions.created_at))
+      .limit(limit);
+    return rows.map((r: Record<string, unknown>) => new Prediction(r));
   }
 
   static async paginate(

--- a/packages/models/src/project-summary.ts
+++ b/packages/models/src/project-summary.ts
@@ -1,0 +1,370 @@
+/**
+ * What a project is made of, and what it cost.
+ *
+ * A project row carries a name and nothing else, so the overview reads its
+ * documents: one query per document table filtered on `project_id`, each row
+ * reduced to what a card shows. Status is derived from the stored document
+ * every time it is asked for — a board that gained a still is behind by
+ * exactly one read, never by a stale counter nobody remembered to bump.
+ *
+ * Spend comes from the prediction ledger, filtered on the same project id.
+ * Rows with no price are counted rather than summed as zero, so a total is a
+ * lower bound the caller can say so about (the `nodetool costs` convention).
+ */
+
+import {
+  effectiveVoice,
+  needsVoicing,
+  currentTake,
+  scriptLines
+} from "@nodetool-ai/timeline";
+import type {
+  ScriptLine as ProtocolScriptLine,
+  ScriptSection as ProtocolScriptSection,
+  Speaker as ProtocolSpeaker
+} from "@nodetool-ai/protocol/api-schemas/scripts.js";
+import { Application } from "./application.js";
+import { ImageDocument } from "./image-document.js";
+import { JsScript } from "./js-script.js";
+import { Prediction } from "./prediction.js";
+import { Script, type ScriptDocument } from "./script.js";
+import { Storyboard, type StoryboardDocument } from "./storyboard.js";
+import { TimelineSequence } from "./timeline-sequence.js";
+
+/**
+ * The document kinds a project groups, spelled as the workspace tab type that
+ * opens each one — `web`'s `WorkspaceTabType`, so a ref opens a tab with no
+ * translation table in between.
+ */
+export type ProjectDocumentType =
+  | "storyboard"
+  | "script"
+  | "timeline"
+  | "sketch"
+  | "application"
+  | "jsscript";
+
+/** One document in a project, as a tab-open needs it. */
+export interface ProjectDocumentRef {
+  type: ProjectDocumentType;
+  /** The document id — what a tab's `ref` carries. */
+  ref: string;
+  name: string;
+  updatedAt: string;
+}
+
+export interface StoryboardStatus {
+  kind: "storyboard";
+  shots: number;
+  /** Shots with a selected still. */
+  stills: number;
+  /** Shots with a selected clip. */
+  clips: number;
+}
+
+export interface ScriptStatus {
+  kind: "script";
+  lines: number;
+  /** Lines whose current take matches their text and voice. */
+  voiced: number;
+  /** Lines with a take that drifted from the text or voice it was voiced from. */
+  stale: number;
+}
+
+/**
+ * A cut's size. Whether it has been *rendered* is not recorded anywhere on the
+ * sequence row, so it is not reported — an omitted fact beats an invented one.
+ */
+export interface TimelineStatus {
+  kind: "timeline";
+  clips: number;
+  durationMs: number;
+}
+
+export type ProjectDocumentStatus =
+  | StoryboardStatus
+  | ScriptStatus
+  | TimelineStatus;
+
+/** A document card: the tab-open ref, what it shows, and what it cost. */
+export interface ProjectDocumentSummary extends ProjectDocumentRef {
+  status: ProjectDocumentStatus | null;
+  /** Priced spend attributed to this document, in USD. */
+  spendUsd: number;
+  /** Calls attributed to it that no catalog priced. */
+  unpricedCount: number;
+}
+
+/** What a run paid for, in the categories the spend bar is split by. */
+export type SpendCategory = "stills" | "clips" | "voice" | "pipeline";
+
+export interface CategorySpend {
+  category: SpendCategory;
+  usd: number;
+  unpricedCount: number;
+}
+
+export interface ProjectSpend {
+  /** Sum of every priced row. A lower bound when `unpricedCount` is non-zero. */
+  totalUsd: number;
+  unpricedCount: number;
+  byCategory: CategorySpend[];
+}
+
+export interface ProjectSummary {
+  documents: ProjectDocumentSummary[];
+  spend: ProjectSpend;
+}
+
+// ── Status ───────────────────────────────────────────────────────────────────
+
+export function storyboardStatus(doc: StoryboardDocument): StoryboardStatus {
+  return {
+    kind: "storyboard",
+    shots: doc.shots.length,
+    stills: doc.shots.filter((shot) => shot.keyframe != null).length,
+    clips: doc.shots.filter((shot) => shot.clip != null).length
+  };
+}
+
+export function scriptStatus(doc: ScriptDocument): ScriptStatus {
+  const cast = doc.cast as ProtocolSpeaker[];
+  const lines = scriptLines(doc.sections as ProtocolScriptSection[]);
+  let voiced = 0;
+  let stale = 0;
+  for (const line of lines as ProtocolScriptLine[]) {
+    if (!needsVoicing(line, effectiveVoice(line, cast))) {
+      voiced += 1;
+    } else if (currentTake(line)) {
+      stale += 1;
+    }
+  }
+  return { kind: "script", lines: lines.length, voiced, stale };
+}
+
+export function timelineStatus(
+  clipCount: number,
+  durationMs: number
+): TimelineStatus {
+  return { kind: "timeline", clips: clipCount, durationMs };
+}
+
+// ── Spend ────────────────────────────────────────────────────────────────────
+
+const CAPABILITY_CATEGORY: Record<string, SpendCategory> = {
+  text_to_image: "stills",
+  image_to_image: "stills",
+  inpainting: "stills",
+  upscale_image: "stills",
+  remove_background: "stills",
+  relight_image: "stills",
+  vectorize_image: "stills",
+  text_to_video: "clips",
+  image_to_video: "clips",
+  video_to_video: "clips",
+  lip_sync: "clips",
+  text_to_speech: "voice",
+  text_to_music: "voice",
+  automatic_speech_recognition: "voice"
+};
+
+/** The fields of a ledger row the category is read off. */
+export interface SpendRow {
+  cost: number | null;
+  /** The project document the charge belongs to, when the caller named one. */
+  document_id?: string | null;
+  node_type?: string | null;
+  billing_unit?: string | null;
+  metadata?: unknown;
+}
+
+const capabilityOf = (row: SpendRow): string | null => {
+  const metadata = row.metadata;
+  if (metadata && typeof metadata === "object") {
+    // SAFETY: `metadata` is a non-null object; the assertion only declares
+    // `capability` optional and `unknown`, and the read is re-checked below.
+    const capability = (metadata as { capability?: unknown }).capability;
+    if (typeof capability === "string" && capability.length > 0) {
+      return capability;
+    }
+  }
+  // An unpriced generation records its capability as the billing unit, since
+  // no catalog answered with a real one.
+  return row.billing_unit ?? null;
+};
+
+/**
+ * Which slice of the spend bar a ledger row belongs to. A capability answers
+ * directly; a node-reported charge that carries none is read off the node
+ * type, which names its own medium. Everything else is pipeline — the LLM
+ * calls that planned the work, and any node that spent without saying on what.
+ */
+export function spendCategory(row: SpendRow): SpendCategory {
+  const capability = capabilityOf(row);
+  const byCapability = capability
+    ? CAPABILITY_CATEGORY[capability]
+    : undefined;
+  if (byCapability) return byCapability;
+
+  const nodeType = (row.node_type ?? "").toLowerCase();
+  if (nodeType.includes("video")) return "clips";
+  if (nodeType.includes("image")) return "stills";
+  if (nodeType.includes("speech") || nodeType.includes("audio")) return "voice";
+  return "pipeline";
+}
+
+const CATEGORY_ORDER: SpendCategory[] = [
+  "stills",
+  "clips",
+  "voice",
+  "pipeline"
+];
+
+/** Roll a project's ledger rows up into the bar's four segments. */
+export function summarizeSpend(rows: SpendRow[]): ProjectSpend {
+  const usd = new Map<SpendCategory, number>();
+  const unpriced = new Map<SpendCategory, number>();
+  for (const row of rows) {
+    const category = spendCategory(row);
+    if (row.cost == null) {
+      unpriced.set(category, (unpriced.get(category) ?? 0) + 1);
+    } else {
+      usd.set(category, (usd.get(category) ?? 0) + row.cost);
+    }
+  }
+  const byCategory = CATEGORY_ORDER.map((category) => ({
+    category,
+    usd: usd.get(category) ?? 0,
+    unpricedCount: unpriced.get(category) ?? 0
+  }));
+  return {
+    totalUsd: byCategory.reduce((sum, entry) => sum + entry.usd, 0),
+    unpricedCount: byCategory.reduce(
+      (sum, entry) => sum + entry.unpricedCount,
+      0
+    ),
+    byCategory
+  };
+}
+
+// ── Gathering ────────────────────────────────────────────────────────────────
+
+interface ProjectDocumentRows {
+  storyboards: Storyboard[];
+  scripts: Script[];
+  timelines: TimelineSequence[];
+  sketches: ImageDocument[];
+  applications: Application[];
+  jsScripts: JsScript[];
+}
+
+/**
+ * One query per document table — the tables share only the column, so there is
+ * no join to make here.
+ */
+async function loadProjectDocuments(
+  userId: string,
+  projectId: string
+): Promise<ProjectDocumentRows> {
+  const [storyboards, scripts, timelines, sketches, applications, jsScripts] =
+    await Promise.all([
+      Storyboard.listByProject(projectId, userId),
+      Script.listByProject(projectId, userId),
+      TimelineSequence.listByProject(projectId, userId),
+      ImageDocument.listByProject(projectId, userId),
+      Application.listByProject(projectId, userId),
+      JsScript.listByProject(projectId, userId)
+    ]);
+  return { storyboards, scripts, timelines, sketches, applications, jsScripts };
+}
+
+const toRef = (
+  type: ProjectDocumentType,
+  row: { id: string; name: string; updated_at: string }
+): ProjectDocumentRef => ({
+  type,
+  ref: row.id,
+  name: row.name,
+  updatedAt: row.updated_at
+});
+
+const newestFirst = <T extends ProjectDocumentRef>(refs: T[]): T[] =>
+  refs.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+
+/** Every document naming this project, newest first. */
+export async function listProjectDocuments(
+  userId: string,
+  projectId: string
+): Promise<ProjectDocumentRef[]> {
+  const rows = await loadProjectDocuments(userId, projectId);
+  return newestFirst([
+    ...rows.storyboards.map((row) => toRef("storyboard", row)),
+    ...rows.scripts.map((row) => toRef("script", row)),
+    ...rows.timelines.map((row) => toRef("timeline", row)),
+    ...rows.sketches.map((row) => toRef("sketch", row)),
+    ...rows.applications.map((row) => toRef("application", row)),
+    ...rows.jsScripts.map((row) => toRef("jsscript", row))
+  ]);
+}
+
+/** Priced spend and unpriced calls per document id. */
+function spendByDocument(
+  ledger: SpendRow[]
+): Map<string, { usd: number; unpriced: number }> {
+  const perDocument = new Map<string, { usd: number; unpriced: number }>();
+  for (const row of ledger) {
+    const documentId = row.document_id;
+    if (!documentId) continue;
+    const entry = perDocument.get(documentId) ?? { usd: 0, unpriced: 0 };
+    if (row.cost == null) entry.unpriced += 1;
+    else entry.usd += row.cost;
+    perDocument.set(documentId, entry);
+  }
+  return perDocument;
+}
+
+/**
+ * The overview's payload: every document with its derived status and its share
+ * of the ledger, plus the project's spend split by category.
+ */
+export async function summarizeProject(
+  userId: string,
+  projectId: string
+): Promise<ProjectSummary> {
+  const rows = await loadProjectDocuments(userId, projectId);
+  const ledger = await Prediction.listByProject(userId, projectId);
+  const perDocument = spendByDocument(ledger);
+
+  const summarize = (
+    ref: ProjectDocumentRef,
+    status: ProjectDocumentStatus | null
+  ): ProjectDocumentSummary => {
+    const spend = perDocument.get(ref.ref);
+    return {
+      ...ref,
+      status,
+      spendUsd: spend?.usd ?? 0,
+      unpricedCount: spend?.unpriced ?? 0
+    };
+  };
+
+  const documents = newestFirst<ProjectDocumentSummary>([
+    ...rows.storyboards.map((row) =>
+      summarize(toRef("storyboard", row), storyboardStatus(row.toDocument()))
+    ),
+    ...rows.scripts.map((row) =>
+      summarize(toRef("script", row), scriptStatus(row.toDocument()))
+    ),
+    ...rows.timelines.map((row) =>
+      summarize(
+        toRef("timeline", row),
+        timelineStatus(row.toDocument().clips.length, row.duration_ms)
+      )
+    ),
+    ...rows.sketches.map((row) => summarize(toRef("sketch", row), null)),
+    ...rows.applications.map((row) => summarize(toRef("application", row), null)),
+    ...rows.jsScripts.map((row) => summarize(toRef("jsscript", row), null))
+  ]);
+
+  return { documents, spend: summarizeSpend(ledger) };
+}

--- a/packages/models/src/project.ts
+++ b/packages/models/src/project.ts
@@ -1,0 +1,111 @@
+/**
+ * Project model — the unit of the workspace.
+ *
+ * Every document table already carries `project_id`; a project row is what
+ * that column points at. A project owns nothing on its own: its documents,
+ * status and spend are derived by reading the rows that name it
+ * (`project-summary.ts`).
+ *
+ * `"default"` stays the loose-documents bucket. It has no row here, and
+ * nothing migrates into one.
+ */
+
+import { eq, desc, and } from "drizzle-orm";
+import { DBModel, createTimeOrderedUuid } from "./base-model.js";
+import { getDb } from "./db.js";
+import { projects } from "./schema/projects.js";
+
+/** The bucket documents land in when no project is active. */
+export const LOOSE_PROJECT_ID = "default";
+
+export interface ProjectResponse {
+  id: string;
+  name: string;
+  /** Free text — "spot", "trailer", "report". Not an enum on purpose. */
+  kind: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export class Project extends DBModel {
+  static override table = projects;
+
+  declare id: string;
+  declare user_id: string;
+  declare name: string;
+  declare kind: string;
+  declare created_at: string;
+  declare updated_at: string;
+
+  constructor(data: Record<string, unknown>) {
+    super(data);
+    const now = new Date().toISOString();
+    this.id ??= createTimeOrderedUuid();
+    this.name ??= "Untitled project";
+    this.kind ??= "";
+    this.created_at ??= now;
+    this.updated_at ??= now;
+  }
+
+  override beforeSave(): void {
+    this.updated_at = new Date().toISOString();
+  }
+
+  toResponse(): ProjectResponse {
+    return {
+      id: this.id,
+      name: this.name,
+      kind: this.kind,
+      createdAt: this.created_at,
+      updatedAt: this.updated_at
+    };
+  }
+
+  static async findById(id: string): Promise<Project | null> {
+    return Project.get<Project>(id);
+  }
+
+  static async findOwned(userId: string, id: string): Promise<Project | null> {
+    const row = await Project.findById(id);
+    return row && row.user_id === userId ? row : null;
+  }
+
+  static async listByUser(userId: string, limit = 100): Promise<Project[]> {
+    const db = getDb();
+    const rows = await db
+      .select()
+      .from(projects)
+      .where(eq(projects.user_id, userId))
+      .orderBy(desc(projects.updated_at))
+      .limit(limit);
+    return rows.map((r: Record<string, unknown>) => new Project(r));
+  }
+
+  /**
+   * Delete a project the caller owns. Its documents are left where they are —
+   * they keep pointing at a project id that no longer resolves, which reads as
+   * loose rather than as data loss. Missing and not-yours answer the same, so
+   * a caller cannot probe ids.
+   */
+  static async deleteOwned(userId: string, id: string): Promise<boolean> {
+    const row = await Project.findOwned(userId, id);
+    if (!row) return false;
+    await row.delete();
+    return true;
+  }
+
+  static async updateOwned(
+    userId: string,
+    id: string,
+    fields: Partial<{ name: string; kind: string }>
+  ): Promise<Project | null> {
+    const db = getDb();
+    const rows = await db
+      .update(projects)
+      .set({ ...fields, updated_at: new Date().toISOString() })
+      .where(and(eq(projects.id, id), eq(projects.user_id, userId)))
+      .returning();
+    const row = rows[0];
+    return row ? new Project(row) : null;
+  }
+}

--- a/packages/models/src/schema-pg/index.ts
+++ b/packages/models/src/schema-pg/index.ts
@@ -23,6 +23,7 @@ export {
   applicationBudgets,
   applicationInvocations
 } from "./application-budgets.js";
+export { projects } from "./projects.js";
 export { scripts } from "./scripts.js";
 export { jsScripts } from "./js-scripts.js";
 export { skills } from "./skills.js";

--- a/packages/models/src/schema-pg/predictions.ts
+++ b/packages/models/src/schema-pg/predictions.ts
@@ -11,6 +11,13 @@ export const predictions = pgTable(
     provider: text("provider").notNull().default(""),
     model: text("model").notNull().default(""),
     workflow_id: text("workflow_id"),
+    /**
+     * The project the spend belongs to, when the run knew one. Null on every
+     * row written before projects existed, and on any run outside a project.
+     */
+    project_id: text("project_id"),
+    /** The project document the spend belongs to, when the run named one. */
+    document_id: text("document_id"),
     error: text("error"),
     logs: text("logs"),
     status: text("status").notNull().default("pending"),
@@ -43,6 +50,7 @@ export const predictions = pgTable(
     index("idx_predictions_user_id").on(table.user_id),
     index("idx_predictions_user_provider").on(table.user_id, table.provider),
     index("idx_prediction_created_at").on(table.created_at),
-    index("idx_prediction_user_model").on(table.user_id, table.model)
+    index("idx_prediction_user_model").on(table.user_id, table.model),
+    index("idx_prediction_user_project").on(table.user_id, table.project_id)
   ]
 );

--- a/packages/models/src/schema-pg/projects.ts
+++ b/packages/models/src/schema-pg/projects.ts
@@ -1,0 +1,18 @@
+import { pgTable, text, index } from "drizzle-orm/pg-core";
+
+export const projects = pgTable(
+  "projects",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    name: text("name").notNull(),
+    /** Free text — "spot", "trailer", "report", whatever the user calls it. */
+    kind: text("kind").notNull().default(""),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull()
+  },
+  (table) => [
+    index("idx_project_user").on(table.user_id),
+    index("idx_project_updated").on(table.updated_at)
+  ]
+);

--- a/packages/models/src/schema/index.ts
+++ b/packages/models/src/schema/index.ts
@@ -23,6 +23,7 @@ export {
   applicationBudgets,
   applicationInvocations
 } from "./application-budgets.js";
+export { projects } from "./projects.js";
 export { scripts } from "./scripts.js";
 export { jsScripts } from "./js-scripts.js";
 export { skills } from "./skills.js";

--- a/packages/models/src/schema/predictions.ts
+++ b/packages/models/src/schema/predictions.ts
@@ -17,6 +17,13 @@ export const predictions = sqliteTable(
     provider: text("provider").notNull().default(""),
     model: text("model").notNull().default(""),
     workflow_id: text("workflow_id"),
+    /**
+     * The project the spend belongs to, when the run knew one. Null on every
+     * row written before projects existed, and on any run outside a project.
+     */
+    project_id: text("project_id"),
+    /** The project document the spend belongs to, when the run named one. */
+    document_id: text("document_id"),
     error: text("error"),
     logs: text("logs"),
     status: text("status").notNull().default("pending"),
@@ -49,6 +56,7 @@ export const predictions = sqliteTable(
     index("idx_predictions_user_id").on(table.user_id),
     index("idx_predictions_user_provider").on(table.user_id, table.provider),
     index("idx_prediction_created_at").on(table.created_at),
-    index("idx_prediction_user_model").on(table.user_id, table.model)
+    index("idx_prediction_user_model").on(table.user_id, table.model),
+    index("idx_prediction_user_project").on(table.user_id, table.project_id)
   ]
 );

--- a/packages/models/src/schema/projects.ts
+++ b/packages/models/src/schema/projects.ts
@@ -1,0 +1,18 @@
+import { sqliteTable, text, index } from "drizzle-orm/sqlite-core";
+
+export const projects = sqliteTable(
+  "projects",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    name: text("name").notNull(),
+    /** Free text — "spot", "trailer", "report", whatever the user calls it. */
+    kind: text("kind").notNull().default(""),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull()
+  },
+  (table) => [
+    index("idx_project_user").on(table.user_id),
+    index("idx_project_updated").on(table.updated_at)
+  ]
+);

--- a/packages/models/tests/migrations.test.ts
+++ b/packages/models/tests/migrations.test.ts
@@ -423,7 +423,7 @@ describe("MigrationRunner", () => {
 // ── Built-in migrations smoke test ───────────────────────────────────
 
 describe("Built-in migrations", () => {
-  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 69;
+  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 71;
 
   it("should have correct count of migrations", () => {
     expect(migrations.length).toBe(EXPECTED_BUILT_IN_MIGRATION_COUNT);
@@ -471,6 +471,15 @@ describe("Built-in migrations", () => {
       await adapter.tableExists("nodetool_workflow_collaborators")
     ).toBe(true);
     expect(await adapter.tableExists("nodetool_workflow_shares")).toBe(true);
+    expect(await adapter.tableExists("projects")).toBe(true);
+
+    // Ledger rows carry the project (and document) they were spent on.
+    expect(
+      await adapter.columnExists("nodetool_predictions", "project_id")
+    ).toBe(true);
+    expect(
+      await adapter.columnExists("nodetool_predictions", "document_id")
+    ).toBe(true);
 
     // The provider_session continuation token column is added by migration.
     expect(

--- a/packages/models/tests/project.test.ts
+++ b/packages/models/tests/project.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Tests for the Project model and the summary it derives.
+ *
+ * Covers: ownership on read/update/delete, the document gather across the six
+ * tables that carry `project_id`, the per-document status derivations, and the
+ * spend rollup — including that an unpriced row is counted rather than summed
+ * as zero.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { initTestDb } from "../src/db.js";
+import { Project } from "../src/project.js";
+import {
+  listProjectDocuments,
+  scriptStatus,
+  spendCategory,
+  storyboardStatus,
+  summarizeProject,
+  summarizeSpend,
+  timelineStatus,
+  type SpendRow
+} from "../src/project-summary.js";
+import { Prediction } from "../src/prediction.js";
+import { Script, type ScriptDocument } from "../src/script.js";
+import { Storyboard, type StoryboardDocument } from "../src/storyboard.js";
+import { TimelineSequence } from "../src/timeline-sequence.js";
+import type { Shot } from "@nodetool-ai/protocol";
+
+const shot = (id: string, over: Partial<Shot> = {}): Shot => ({
+  type: "shot",
+  id,
+  index: 0,
+  action: "a shot",
+  status: "draft",
+  ...over
+});
+
+const storyboardDoc = (shots: Shot[]): StoryboardDocument => ({
+  screenplay: null,
+  shots,
+  brief: "",
+  style: "",
+  entityIds: [],
+  aspectRatio: "16:9",
+  directorModel: null,
+  imageModel: null,
+  videoModel: null
+});
+
+describe("Project model", () => {
+  beforeEach(() => initTestDb());
+
+  it("creates with defaults and lists by user", async () => {
+    await Project.create<Project>({ user_id: "u1", name: "Aurora", kind: "spot" });
+    await Project.create<Project>({ user_id: "u2", name: "Someone else's" });
+
+    const mine = await Project.listByUser("u1");
+    expect(mine).toHaveLength(1);
+    expect(mine[0].toResponse()).toMatchObject({ name: "Aurora", kind: "spot" });
+  });
+
+  it("answers not-found the same for a missing project and another user's", async () => {
+    const other = await Project.create<Project>({ user_id: "u2", name: "Theirs" });
+    expect(await Project.findOwned("u1", other.id)).toBeNull();
+    expect(await Project.findOwned("u1", "no-such-id")).toBeNull();
+    expect(await Project.deleteOwned("u1", other.id)).toBe(false);
+    expect(await Project.updateOwned("u1", other.id, { name: "Mine now" })).toBeNull();
+    expect((await Project.findById(other.id))?.name).toBe("Theirs");
+  });
+
+  it("updates name and kind and moves updated_at forward", async () => {
+    const project = await Project.create<Project>({
+      user_id: "u1",
+      name: "Aurora",
+      updated_at: "2020-01-01T00:00:00.000Z"
+    });
+    const updated = await Project.updateOwned("u1", project.id, {
+      name: "Aurora Launch Spot",
+      kind: "spot"
+    });
+    expect(updated?.name).toBe("Aurora Launch Spot");
+    expect(updated?.kind).toBe("spot");
+    expect(updated!.updated_at > "2020-01-01T00:00:00.000Z").toBe(true);
+  });
+
+  it("deletes the project and leaves its documents where they are", async () => {
+    const project = await Project.create<Project>({ user_id: "u1", name: "Aurora" });
+    const board = await Storyboard.create<Storyboard>({
+      user_id: "u1",
+      project_id: project.id,
+      name: "Board"
+    });
+    expect(await Project.deleteOwned("u1", project.id)).toBe(true);
+    expect(await Project.findById(project.id)).toBeNull();
+    expect((await Storyboard.findById(board.id))?.project_id).toBe(project.id);
+  });
+});
+
+describe("project documents", () => {
+  beforeEach(() => initTestDb());
+
+  it("gathers every table that carries the project id, newest first", async () => {
+    // Saves stamp their own `updated_at`, so the order is creation order —
+    // spaced out so the assertion is about the sort, not about clock ties.
+    const tick = () => new Promise((resolve) => setTimeout(resolve, 2));
+    await Storyboard.create<Storyboard>({
+      user_id: "u1",
+      project_id: "p1",
+      name: "Board"
+    });
+    await tick();
+    await TimelineSequence.create<TimelineSequence>({
+      user_id: "u1",
+      project_id: "p1",
+      name: "Cut"
+    });
+    await tick();
+    await Script.create<Script>({
+      user_id: "u1",
+      project_id: "p1",
+      name: "VO"
+    });
+    // Another project and another user must not leak in.
+    await Script.create<Script>({ user_id: "u1", project_id: "p2", name: "Other" });
+    await Script.create<Script>({ user_id: "u2", project_id: "p1", name: "Theirs" });
+
+    const docs = await listProjectDocuments("u1", "p1");
+    expect(docs.map((d) => [d.type, d.name])).toEqual([
+      ["script", "VO"],
+      ["timeline", "Cut"],
+      ["storyboard", "Board"]
+    ]);
+  });
+});
+
+describe("document status", () => {
+  it("counts a board's shots, stills and clips", () => {
+    const status = storyboardStatus(
+      storyboardDoc([
+        shot("a", { keyframe: { type: "image", uri: "asset://1" }, clip: { type: "video", uri: "asset://2" } }),
+        shot("b", { keyframe: { type: "image", uri: "asset://3" } }),
+        shot("c")
+      ])
+    );
+    expect(status).toEqual({ kind: "storyboard", shots: 3, stills: 2, clips: 1 });
+  });
+
+  it("separates a voiced line from one whose take drifted", () => {
+    const voice = { provider: "p", model: "m", voice: "v" };
+    const doc: ScriptDocument = {
+      cast: [{ id: "s1", name: "Narrator", voice }],
+      sections: [
+        {
+          id: "sec",
+          lines: [
+            {
+              id: "voiced",
+              speakerId: "s1",
+              text: "hello",
+              currentTakeId: "t1",
+              takes: [
+                {
+                  id: "t1",
+                  assetId: "a1",
+                  durationMs: 1000,
+                  words: [],
+                  textSnapshot: "hello",
+                  voiceSnapshot: voice,
+                  createdAt: "2026-01-01T00:00:00.000Z"
+                }
+              ]
+            },
+            {
+              id: "stale",
+              speakerId: "s1",
+              text: "rewritten",
+              currentTakeId: "t2",
+              takes: [
+                {
+                  id: "t2",
+                  assetId: "a2",
+                  durationMs: 1000,
+                  words: [],
+                  textSnapshot: "the old words",
+                  voiceSnapshot: voice,
+                  createdAt: "2026-01-01T00:00:00.000Z"
+                }
+              ]
+            },
+            { id: "never", speakerId: "s1", text: "unvoiced", takes: [] }
+          ]
+        }
+      ]
+    };
+    expect(scriptStatus(doc)).toEqual({
+      kind: "script",
+      lines: 3,
+      voiced: 1,
+      stale: 1
+    });
+  });
+
+  it("reports a cut's size", () => {
+    expect(timelineStatus(9, 30_000)).toEqual({
+      kind: "timeline",
+      clips: 9,
+      durationMs: 30_000
+    });
+  });
+});
+
+describe("spend rollup", () => {
+  const row = (over: Partial<SpendRow> = {}): SpendRow => ({
+    cost: 1,
+    ...over
+  });
+
+  it("routes a row by capability, then by node type, then to pipeline", () => {
+    expect(spendCategory(row({ metadata: { capability: "text_to_image" } }))).toBe("stills");
+    expect(spendCategory(row({ metadata: { capability: "image_to_video" } }))).toBe("clips");
+    expect(spendCategory(row({ metadata: { capability: "text_to_speech" } }))).toBe("voice");
+    // An unpriced generation records its capability as the billing unit.
+    expect(spendCategory(row({ billing_unit: "lip_sync" }))).toBe("clips");
+    // A node-reported charge naming no capability is read off the node type.
+    expect(spendCategory(row({ node_type: "fal.video.Kling", billing_unit: "seconds" }))).toBe("clips");
+    expect(spendCategory(row({ node_type: "fal.image.Flux", billing_unit: "megapixels" }))).toBe("stills");
+    expect(spendCategory(row({ node_type: "nodetool.agents.Agent" }))).toBe("pipeline");
+  });
+
+  it("counts an unpriced row instead of summing it as zero", () => {
+    const spend = summarizeSpend([
+      row({ cost: 1.28, metadata: { capability: "text_to_image" } }),
+      row({ cost: 2.6, metadata: { capability: "image_to_video" } }),
+      row({ cost: null, metadata: { capability: "image_to_video" } }),
+      row({ cost: 0.19, metadata: { capability: "text_to_speech" } }),
+      row({ cost: 0.05, node_type: "nodetool.agents.Agent" })
+    ]);
+    expect(spend.totalUsd).toBeCloseTo(4.12, 6);
+    expect(spend.unpricedCount).toBe(1);
+    expect(spend.byCategory).toEqual([
+      { category: "stills", usd: 1.28, unpricedCount: 0 },
+      { category: "clips", usd: 2.6, unpricedCount: 1 },
+      { category: "voice", usd: 0.19, unpricedCount: 0 },
+      { category: "pipeline", usd: 0.05, unpricedCount: 0 }
+    ]);
+  });
+});
+
+describe("summarizeProject", () => {
+  beforeEach(() => initTestDb());
+
+  it("attaches each document's status and its share of the ledger", async () => {
+    const board = await Storyboard.create<Storyboard>({
+      user_id: "u1",
+      project_id: "p1",
+      name: "Board",
+      document: JSON.stringify(
+        storyboardDoc([
+          shot("a", { keyframe: { type: "image", uri: "asset://1" } }),
+          shot("b")
+        ])
+      )
+    });
+    await Prediction.create<Prediction>({
+      user_id: "u1",
+      project_id: "p1",
+      document_id: board.id,
+      cost: 0.5,
+      metadata: { capability: "text_to_image" }
+    });
+    // A charge on the project that names no document still counts in the total.
+    await Prediction.create<Prediction>({
+      user_id: "u1",
+      project_id: "p1",
+      cost: 0.25,
+      node_type: "nodetool.agents.Agent"
+    });
+    // Another project's row must not reach this one.
+    await Prediction.create<Prediction>({
+      user_id: "u1",
+      project_id: "p2",
+      cost: 99
+    });
+
+    const summary = await summarizeProject("u1", "p1");
+    expect(summary.documents).toHaveLength(1);
+    expect(summary.documents[0]).toMatchObject({
+      type: "storyboard",
+      ref: board.id,
+      spendUsd: 0.5,
+      unpricedCount: 0,
+      status: { kind: "storyboard", shots: 2, stills: 1, clips: 0 }
+    });
+    expect(summary.spend.totalUsd).toBeCloseTo(0.75, 6);
+  });
+});

--- a/packages/protocol/src/api-schemas/index.ts
+++ b/packages/protocol/src/api-schemas/index.ts
@@ -14,6 +14,7 @@ export * as mcpConfig from "./mcp-config.js";
 export * as messages from "./messages.js";
 export * as models from "./models.js";
 export * as nodes from "./nodes.js";
+export * as projects from "./projects.js";
 export * as scripts from "./scripts.js";
 export * as sdkV1 from "./sdk-v1.js";
 export * as sdkV1Operations from "./sdk-v1-operations.js";

--- a/packages/protocol/src/api-schemas/projects.ts
+++ b/packages/protocol/src/api-schemas/projects.ts
@@ -1,0 +1,115 @@
+import { z } from "zod";
+
+// ── Project ──────────────────────────────────────────────────────────────────
+// A project is a name over documents that already carry `project_id`. `kind` is
+// free text ("spot", "trailer", "report") rather than an enum: the taxonomy is
+// the user's, not ours.
+
+export const projectResponse = z.object({
+  id: z.string(),
+  name: z.string(),
+  kind: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string()
+});
+export type ProjectResponse = z.infer<typeof projectResponse>;
+
+export const createProjectInput = z.object({
+  id: z.string().optional(),
+  name: z.string().min(1).max(200),
+  kind: z.string().max(64).default("")
+});
+export type CreateProjectInput = z.infer<typeof createProjectInput>;
+
+export const patchProjectInput = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    kind: z.string().max(64).optional()
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "At least one field must be provided"
+  });
+export type PatchProjectInput = z.infer<typeof patchProjectInput>;
+
+// ── Documents ────────────────────────────────────────────────────────────────
+// Spelled as the workspace tab type that opens each one, so a ref opens a tab
+// with no translation table in between.
+
+export const projectDocumentType = z.enum([
+  "storyboard",
+  "script",
+  "timeline",
+  "sketch",
+  "application",
+  "jsscript"
+]);
+export type ProjectDocumentType = z.infer<typeof projectDocumentType>;
+
+export const projectDocumentRef = z.object({
+  type: projectDocumentType,
+  ref: z.string(),
+  name: z.string(),
+  updatedAt: z.string()
+});
+export type ProjectDocumentRef = z.infer<typeof projectDocumentRef>;
+
+/**
+ * Derived from the stored document on every read. A timeline reports its size
+ * but not whether it has been rendered — nothing on the sequence row records
+ * that, and an omitted fact beats an invented one.
+ */
+export const projectDocumentStatus = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("storyboard"),
+    shots: z.number(),
+    stills: z.number(),
+    clips: z.number()
+  }),
+  z.object({
+    kind: z.literal("script"),
+    lines: z.number(),
+    voiced: z.number(),
+    stale: z.number()
+  }),
+  z.object({
+    kind: z.literal("timeline"),
+    clips: z.number(),
+    durationMs: z.number()
+  })
+]);
+export type ProjectDocumentStatus = z.infer<typeof projectDocumentStatus>;
+
+export const projectDocumentSummary = projectDocumentRef.extend({
+  status: projectDocumentStatus.nullable(),
+  spendUsd: z.number(),
+  unpricedCount: z.number()
+});
+export type ProjectDocumentSummary = z.infer<typeof projectDocumentSummary>;
+
+// ── Spend ────────────────────────────────────────────────────────────────────
+
+export const spendCategory = z.enum(["stills", "clips", "voice", "pipeline"]);
+export type SpendCategory = z.infer<typeof spendCategory>;
+
+export const categorySpend = z.object({
+  category: spendCategory,
+  usd: z.number(),
+  /** Calls in this category no catalog priced. They are not summed as zero. */
+  unpricedCount: z.number()
+});
+export type CategorySpend = z.infer<typeof categorySpend>;
+
+export const projectSpend = z.object({
+  /** A lower bound whenever `unpricedCount` is non-zero. */
+  totalUsd: z.number(),
+  unpricedCount: z.number(),
+  byCategory: z.array(categorySpend)
+});
+export type ProjectSpend = z.infer<typeof projectSpend>;
+
+export const projectDetail = z.object({
+  project: projectResponse,
+  documents: z.array(projectDocumentSummary),
+  spend: projectSpend
+});
+export type ProjectDetail = z.infer<typeof projectDetail>;

--- a/packages/websocket/src/trpc/router.ts
+++ b/packages/websocket/src/trpc/router.ts
@@ -18,6 +18,7 @@ import { messagesRouter } from "./routers/messages.js";
 import { modelsRouter } from "./routers/models.js";
 import { nodesRouter } from "./routers/nodes.js";
 import { packsRouter } from "./routers/packs.js";
+import { projectsRouter } from "./routers/projects.js";
 import { scriptsRouter } from "./routers/scripts.js";
 import { settingsRouter } from "./routers/settings.js";
 import { fontsRouter } from "./routers/fonts.js";
@@ -58,6 +59,7 @@ export const appRouter = router({
   models: modelsRouter,
   nodes: nodesRouter,
   packs: packsRouter,
+  projects: projectsRouter,
   scripts: scriptsRouter,
   settings: settingsRouter,
   sketch: sketchRouter,

--- a/packages/websocket/src/trpc/routers/projects.ts
+++ b/packages/websocket/src/trpc/routers/projects.ts
@@ -1,0 +1,116 @@
+/**
+ * Projects router — tRPC.
+ *
+ * A project is the unit of the workspace: a name over the documents that
+ * already carry its `project_id`. It owns no content of its own, so `get`
+ * reads the documents back and derives what the overview shows — per-document
+ * status, per-document spend, and the project's spend split by category.
+ *
+ * Procedures:
+ *   list      (query)    — ProjectResponse[]
+ *   get       (query)    — ProjectDetail (project + documents + spend)
+ *   documents (query)    — ProjectDocumentRef[]
+ *   create    (mutation) — ProjectResponse
+ *   update    (mutation) — ProjectResponse
+ *   delete    (mutation) — { ok: true }
+ */
+
+import { z } from "zod";
+import { Project, listProjectDocuments, summarizeProject } from "@nodetool-ai/models";
+import {
+  createProjectInput,
+  patchProjectInput,
+  projectDetail,
+  projectDocumentRef,
+  projectResponse
+} from "@nodetool-ai/protocol/api-schemas/projects.js";
+import { ApiErrorCode } from "../../error-codes.js";
+import { router } from "../index.js";
+import { protectedProcedure } from "../middleware.js";
+import { throwApiError } from "../error-formatter.js";
+
+const listInput = z.object({});
+const idInput = z.object({ id: z.string() });
+const updateInput = patchProjectInput.and(z.object({ id: z.string() }));
+const okOutput = z.object({ ok: z.literal(true) });
+
+async function loadOwned(userId: string, id: string): Promise<Project> {
+  const project = await Project.findOwned(userId, id);
+  if (!project) throwApiError(ApiErrorCode.NOT_FOUND, "Project not found");
+  return project;
+}
+
+export const projectsRouter = router({
+  list: protectedProcedure
+    .input(listInput)
+    .output(z.array(projectResponse))
+    .query(async ({ ctx }) => {
+      const items = await Project.listByUser(ctx.userId);
+      return items.map((item) => item.toResponse());
+    }),
+
+  get: protectedProcedure
+    .input(idInput)
+    .output(projectDetail)
+    .query(async ({ ctx, input }) => {
+      const project = await loadOwned(ctx.userId, input.id);
+      const summary = await summarizeProject(ctx.userId, project.id);
+      return projectDetail.parse({
+        project: project.toResponse(),
+        documents: summary.documents,
+        spend: summary.spend
+      });
+    }),
+
+  documents: protectedProcedure
+    .input(idInput)
+    .output(z.array(projectDocumentRef))
+    .query(async ({ ctx, input }) => {
+      await loadOwned(ctx.userId, input.id);
+      return listProjectDocuments(ctx.userId, input.id);
+    }),
+
+  create: protectedProcedure
+    .input(createProjectInput)
+    .output(projectResponse)
+    .mutation(async ({ ctx, input }) => {
+      if (input.id) {
+        const existing = await Project.findById(input.id);
+        if (existing) {
+          if (existing.user_id !== ctx.userId) {
+            throwApiError(ApiErrorCode.NOT_FOUND, "Project not found");
+          }
+          return projectResponse.parse(existing.toResponse());
+        }
+      }
+      const project = await Project.create<Project>({
+        id: input.id,
+        user_id: ctx.userId,
+        name: input.name,
+        kind: input.kind
+      });
+      return projectResponse.parse(project.toResponse());
+    }),
+
+  update: protectedProcedure
+    .input(updateInput)
+    .output(projectResponse)
+    .mutation(async ({ ctx, input }) => {
+      await loadOwned(ctx.userId, input.id);
+      const fields: { name?: string; kind?: string } = {};
+      if (input.name !== undefined) fields.name = input.name;
+      if (input.kind !== undefined) fields.kind = input.kind;
+      const updated = await Project.updateOwned(ctx.userId, input.id, fields);
+      if (!updated) throwApiError(ApiErrorCode.NOT_FOUND, "Project not found");
+      return projectResponse.parse(updated.toResponse());
+    }),
+
+  delete: protectedProcedure
+    .input(idInput)
+    .output(okOutput)
+    .mutation(async ({ ctx, input }) => {
+      await loadOwned(ctx.userId, input.id);
+      await Project.deleteOwned(ctx.userId, input.id);
+      return { ok: true as const };
+    })
+});

--- a/packages/websocket/src/trpc/sandbox-coverage.ts
+++ b/packages/websocket/src/trpc/sandbox-coverage.ts
@@ -588,6 +588,37 @@ export const SANDBOX_API_COVERAGE: Readonly<
       "rather than as untrusted text. A run that could grant itself " +
       "trust could escalate a prompt injection into executed code."
   },
+  "projects.create": {
+    gap:
+      "A project groups documents that already carry its id, and a run " +
+      "reaches every one of those documents by its own capability. What " +
+      "is missing is the grouping itself — creating one, and reading the " +
+      "status and spend rollup `projects.get` derives. Work, not a " +
+      "boundary: nothing here is a credential, another tenant, or host " +
+      "control."
+  },
+  "projects.delete": {
+    gap:
+      "Same grouping surface as `projects.create`. Deleting a project " +
+      "leaves its documents in place, so this loses a name, not content."
+  },
+  "projects.documents": {
+    gap:
+      "Lists the documents in a project. A run enumerates each kind " +
+      "through its own `list_*` capability today; what it cannot do is " +
+      "ask which of them belong together."
+  },
+  "projects.get": {
+    gap:
+      "Same grouping surface as `projects.create`. Carries the derived " +
+      "status and the spend rollup, both over rows the caller owns."
+  },
+  "projects.list": {
+    gap: "Same grouping surface as `projects.create`."
+  },
+  "projects.update": {
+    gap: "Same grouping surface as `projects.create`. Renames a project."
+  },
   "resources.create": {
     elsewhere:
       "One envelope over assets, timelines, storyboards and image " +

--- a/packages/websocket/tests/trpc-projects.test.ts
+++ b/packages/websocket/tests/trpc-projects.test.ts
@@ -1,0 +1,141 @@
+/**
+ * projects router — ownership, the document gather, and the derived rollup.
+ *
+ * Real DB, real models: a project is a name over rows that already carry its
+ * id, so what `get` returns is only as good as the read-back it derives.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  initTestDb,
+  ModelObserver,
+  Prediction,
+  Storyboard
+} from "@nodetool-ai/models";
+import { appRouter } from "../src/trpc/router.js";
+import { createCallerFactory } from "../src/trpc/index.js";
+import type { Context } from "../src/trpc/context.js";
+
+const createCallerFor = createCallerFactory(appRouter);
+
+function makeCtx(userId: string): Context {
+  return {
+    userId,
+    registry: {} as never,
+    apiOptions: { metadataRoots: [], registry: {} as never } as never,
+    pythonBridge: {} as never,
+    getPythonBridgeReady: () => false
+  } as Context;
+}
+
+const caller = (userId = "user-1") => createCallerFor(makeCtx(userId));
+
+describe("projects router", () => {
+  beforeEach(() => initTestDb());
+  afterEach(() => ModelObserver.clear());
+
+  it("creates, lists, updates and deletes", async () => {
+    const created = await caller().projects.create({
+      name: "Aurora Launch Spot",
+      kind: "spot"
+    });
+    expect(created.name).toBe("Aurora Launch Spot");
+
+    expect((await caller().projects.list({})).map((p) => p.id)).toEqual([
+      created.id
+    ]);
+
+    const renamed = await caller().projects.update({
+      id: created.id,
+      name: "Aurora"
+    });
+    expect(renamed.name).toBe("Aurora");
+    expect(renamed.kind).toBe("spot");
+
+    await caller().projects.delete({ id: created.id });
+    expect(await caller().projects.list({})).toEqual([]);
+  });
+
+  it("hides another user's project behind not-found", async () => {
+    const theirs = await caller("user-2").projects.create({
+      name: "Theirs",
+      kind: ""
+    });
+    await expect(caller().projects.get({ id: theirs.id })).rejects.toThrow(
+      /not found/i
+    );
+    await expect(
+      caller().projects.update({ id: theirs.id, name: "Mine" })
+    ).rejects.toThrow(/not found/i);
+    await expect(
+      caller().projects.delete({ id: theirs.id })
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it("returns each document with its status and the project's spend", async () => {
+    const project = await caller().projects.create({ name: "Aurora", kind: "spot" });
+    const board = await Storyboard.create<Storyboard>({
+      user_id: "user-1",
+      project_id: project.id,
+      name: "Board",
+      document: JSON.stringify({
+        screenplay: null,
+        shots: [
+          {
+            type: "shot",
+            id: "a",
+            index: 0,
+            action: "wide",
+            status: "draft",
+            keyframe: { type: "image", uri: "asset://1" }
+          },
+          { type: "shot", id: "b", index: 1, action: "close", status: "draft" }
+        ],
+        brief: "",
+        style: "",
+        entityIds: [],
+        aspectRatio: "16:9",
+        directorModel: null,
+        imageModel: null,
+        videoModel: null
+      })
+    });
+    await Prediction.create<Prediction>({
+      user_id: "user-1",
+      project_id: project.id,
+      document_id: board.id,
+      cost: 0.5,
+      metadata: { capability: "text_to_image" }
+    });
+
+    const detail = await caller().projects.get({ id: project.id });
+    expect(detail.project.name).toBe("Aurora");
+    expect(detail.documents).toEqual([
+      {
+        type: "storyboard",
+        ref: board.id,
+        name: "Board",
+        updatedAt: board.updated_at,
+        status: { kind: "storyboard", shots: 2, stills: 1, clips: 0 },
+        spendUsd: 0.5,
+        unpricedCount: 0
+      }
+    ]);
+    expect(detail.spend.totalUsd).toBeCloseTo(0.5, 6);
+    expect(detail.spend.byCategory).toContainEqual({
+      category: "stills",
+      usd: 0.5,
+      unpricedCount: 0
+    });
+
+    const refs = await caller().projects.documents({ id: project.id });
+    expect(refs).toEqual([
+      {
+        type: "storyboard",
+        ref: board.id,
+        name: "Board",
+        updatedAt: board.updated_at
+      }
+    ]);
+  });
+});

--- a/web/src/components/applications/ApplicationListPanel.tsx
+++ b/web/src/components/applications/ApplicationListPanel.tsx
@@ -15,7 +15,10 @@ import {
 } from "../../hooks/useApplications";
 import { useNotificationStore } from "../../stores/NotificationStore";
 import { usePanelStore } from "../../stores/PanelStore";
-import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import {
+  useWorkspaceTabsStore,
+  creationProjectId
+} from "../../stores/WorkspaceTabsStore";
 import type { SidebarDocumentItem } from "../../stores/SidebarDocumentActionsStore";
 import { useSidebarDocumentMenu } from "../../hooks/useSidebarDocumentMenu";
 import { trpc } from "../../trpc/client";
@@ -90,7 +93,7 @@ export const CreateApplicationButton = memo(function CreateApplicationButton() {
       const created = await createApplication.mutateAsync({
         name: UNTITLED,
         description: "",
-        projectId: "default"
+        projectId: creationProjectId()
       });
       openApplication(created.id, created.name);
     } catch (error) {
@@ -133,7 +136,7 @@ export const CreateApplicationFromWorkflowButton = memo(
           const created = await createApplication.mutateAsync({
             name: workflowName || UNTITLED,
             description: "",
-            projectId: "default",
+            projectId: creationProjectId(),
             fromWorkflowId: workflowId
           });
           openApplication(created.id, created.name);

--- a/web/src/components/applications/__tests__/ApplicationListPanel.test.tsx
+++ b/web/src/components/applications/__tests__/ApplicationListPanel.test.tsx
@@ -85,6 +85,7 @@ jest.mock("../../../trpc/client", () => ({
 const openTab = jest.fn();
 jest.mock("../../../stores/WorkspaceTabsStore", () => ({
   tabId: (type: string, ref: string) => `${type}:${ref}`,
+  creationProjectId: () => "default",
   useWorkspaceTabsStore: <T,>(
     selector: (s: { openTab: jest.Mock; activeTabId: string }) => T
   ) => selector({ openTab, activeTabId: "application:app-1" })

--- a/web/src/components/jsScript/JsScriptListPanel.tsx
+++ b/web/src/components/jsScript/JsScriptListPanel.tsx
@@ -7,7 +7,10 @@ import { useLocation, useNavigate } from "react-router-dom";
 
 import { useCreateJsScript, useJsScripts } from "../../hooks/jsScript/useJsScripts";
 import { usePanelStore } from "../../stores/PanelStore";
-import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import {
+  useWorkspaceTabsStore,
+  creationProjectId
+} from "../../stores/WorkspaceTabsStore";
 import { notifyMutationError } from "../../utils/notifyMutationError";
 import CategorySearchBar from "../node_menu/CategorySearchBar";
 import {
@@ -36,7 +39,7 @@ export const CreateJsScriptButton = memo(function CreateJsScriptButton() {
     try {
       const created = await createJsScript.mutateAsync({
         name: DEFAULT_NAME,
-        projectId: "default"
+        projectId: creationProjectId()
       });
       openTab({
         type: "jsscript",

--- a/web/src/components/script/ScriptListPanel.tsx
+++ b/web/src/components/script/ScriptListPanel.tsx
@@ -5,7 +5,10 @@ import { useLocation, useNavigate } from "react-router-dom";
 
 import { useCreateScript, useScripts } from "../../hooks/script/useScripts";
 import { usePanelStore } from "../../stores/PanelStore";
-import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import {
+  useWorkspaceTabsStore,
+  creationProjectId
+} from "../../stores/WorkspaceTabsStore";
 import type { SidebarDocumentItem } from "../../stores/SidebarDocumentActionsStore";
 import { useSidebarDocumentMenu } from "../../hooks/useSidebarDocumentMenu";
 import { trpc } from "../../trpc/client";
@@ -29,7 +32,7 @@ export const CreateScriptButton = memo(function CreateScriptButton() {
     try {
       const created = await createScript.mutateAsync({
         name: "Untitled script",
-        projectId: "default"
+        projectId: creationProjectId()
       });
       openTab({
         type: "script",

--- a/web/src/components/sketch/SketchListPanel.tsx
+++ b/web/src/components/sketch/SketchListPanel.tsx
@@ -5,7 +5,10 @@ import type { DragEvent } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { usePanelStore } from "../../stores/PanelStore";
-import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import {
+  useWorkspaceTabsStore,
+  creationProjectId
+} from "../../stores/WorkspaceTabsStore";
 import { serializeDragData, useDragDropStore } from "../../lib/dragdrop";
 import type { SidebarDocumentItem } from "../../stores/SidebarDocumentActionsStore";
 import {
@@ -174,7 +177,7 @@ export const CreateSketchButton = memo(function CreateSketchButton() {
       const sketch = await createSketch.mutateAsync({
         id: newDocumentId(),
         name: "Untitled sketch",
-        projectId: "default"
+        projectId: creationProjectId()
       });
       if (location.pathname.startsWith("/workspace")) {
         openTab({

--- a/web/src/components/storyboard/StoryboardListPanel.tsx
+++ b/web/src/components/storyboard/StoryboardListPanel.tsx
@@ -8,7 +8,10 @@ import {
   useStoryboards
 } from "../../hooks/storyboard/useStoryboards";
 import { usePanelStore } from "../../stores/PanelStore";
-import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import {
+  useWorkspaceTabsStore,
+  creationProjectId
+} from "../../stores/WorkspaceTabsStore";
 import type { SidebarDocumentItem } from "../../stores/SidebarDocumentActionsStore";
 import { useSidebarDocumentMenu } from "../../hooks/useSidebarDocumentMenu";
 import { trpc } from "../../trpc/client";
@@ -32,7 +35,7 @@ export const CreateStoryboardButton = memo(function CreateStoryboardButton() {
     try {
       const created = await createStoryboard.mutateAsync({
         name: "Untitled storyboard",
-        projectId: "default"
+        projectId: creationProjectId()
       });
       openTab({
         type: "storyboard",

--- a/web/src/components/timeline/TimelineListPanel.tsx
+++ b/web/src/components/timeline/TimelineListPanel.tsx
@@ -6,7 +6,10 @@ import { useLocation, useNavigate } from "react-router-dom";
 
 import { useCreateTimeline, useTimelines } from "../../hooks/useTimelineSequence";
 import { usePanelStore } from "../../stores/PanelStore";
-import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import {
+  useWorkspaceTabsStore,
+  creationProjectId
+} from "../../stores/WorkspaceTabsStore";
 import { serializeDragData, useDragDropStore } from "../../lib/dragdrop";
 import type { SidebarDocumentItem } from "../../stores/SidebarDocumentActionsStore";
 import {
@@ -170,7 +173,7 @@ export const CreateTimelineButton = memo(function CreateTimelineButton() {
       const timeline = await createTimeline.mutateAsync({
         id: newDocumentId(),
         name: "Untitled video",
-        projectId: "default"
+        projectId: creationProjectId()
       });
       if (location.pathname.startsWith("/workspace")) {
         openTab({

--- a/web/src/components/workspace/OpenMenu.tsx
+++ b/web/src/components/workspace/OpenMenu.tsx
@@ -34,7 +34,10 @@ import { useAssetStore } from "../../stores/AssetStore";
 import { useNotificationStore } from "../../stores/NotificationStore";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import useGlobalChatStore from "../../stores/GlobalChatStore";
-import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import {
+  useWorkspaceTabsStore,
+  creationProjectId
+} from "../../stores/WorkspaceTabsStore";
 import { newDocumentId } from "../../lib/newDocumentId";
 
 /** Render a blank white PNG to seed a "New image" canvas asset. */
@@ -237,7 +240,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
       runCreate("video", async () => {
         const sequence = await createTimeline.mutateAsync({
           name: "Untitled video",
-          projectId: "default"
+          projectId: creationProjectId()
         });
         openTab({
           type: "timeline",
@@ -254,7 +257,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
       runCreate("storyboard", async () => {
         const created = await createStoryboard.mutateAsync({
           name: "Untitled storyboard",
-          projectId: "default"
+          projectId: creationProjectId()
         });
         openTab({
           type: "storyboard",
@@ -271,7 +274,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
       runCreate(name, async () => {
         const created = await installExampleStoryboard.mutateAsync({
           slug,
-          projectId: "default"
+          projectId: creationProjectId()
         });
         openTab({
           type: "storyboard",
@@ -289,7 +292,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
         const created = await createApplication.mutateAsync({
           name: "Untitled app",
           description: "",
-          projectId: "default"
+          projectId: creationProjectId()
         });
         openTab({
           type: "application",
@@ -306,7 +309,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
       runCreate("script", async () => {
         const created = await createScript.mutateAsync({
           name: "Untitled script",
-          projectId: "default"
+          projectId: creationProjectId()
         });
         openTab({
           type: "script",
@@ -323,7 +326,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
       runCreate("JS script", async () => {
         const created = await createJsScript.mutateAsync({
           name: "Untitled JS script",
-          projectId: "default"
+          projectId: creationProjectId()
         });
         openTab({
           type: "jsscript",

--- a/web/src/components/workspace/__tests__/OpenMenuStoryboards.test.tsx
+++ b/web/src/components/workspace/__tests__/OpenMenuStoryboards.test.tsx
@@ -42,6 +42,7 @@ jest.mock("../../../hooks/storyboard/useStoryboards", () => ({
 
 const openTab = jest.fn();
 jest.mock("../../../stores/WorkspaceTabsStore", () => ({
+  creationProjectId: () => "default",
   useWorkspaceTabsStore: <T,>(selector: (s: { openTab: jest.Mock }) => T) =>
     selector({ openTab })
 }));

--- a/web/src/hooks/jsScript/useJsScriptServerSync.ts
+++ b/web/src/hooks/jsScript/useJsScriptServerSync.ts
@@ -45,6 +45,7 @@ import {
   registerJsScriptSaver,
   type JsScriptSaveResult
 } from "./jsScriptSaveRegistry";
+import { creationProjectId } from "../../stores/WorkspaceTabsStore";
 
 const AUTOSAVE_DEBOUNCE_MS = 750;
 const RETRY_DELAY_MS = 5_000;
@@ -150,7 +151,7 @@ export const useJsScriptServerSync = (
           >[0] = {
             id: scriptId,
             name: local?.name || DEFAULT_NAME,
-            projectId: "default"
+            projectId: creationProjectId()
           };
           if (local) input.document = local.document;
           const created = await trpcClient.jsScripts.create.mutate(input);

--- a/web/src/hooks/script/useAssembleScriptTimeline.ts
+++ b/web/src/hooks/script/useAssembleScriptTimeline.ts
@@ -14,7 +14,10 @@
 import { useCallback, useState } from "react";
 import { trpcClient } from "../../trpc/client";
 import { useScriptStore } from "../../stores/script/ScriptStore";
-import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import {
+  useWorkspaceTabsStore,
+  creationProjectId
+} from "../../stores/WorkspaceTabsStore";
 import { buildScriptTimelineDocument } from "../../components/script/assembleScriptTimeline";
 import type { TimelineClip } from "@nodetool-ai/timeline";
 import { loadLinkedBoard } from "../../lib/linkedAssembly";
@@ -111,7 +114,7 @@ export const useAssembleScriptTimeline =
           const sequence = await trpcClient.timeline.create.mutate({
             id: newDocumentId(),
             name,
-            projectId: "default"
+            projectId: creationProjectId()
           });
           await trpcClient.timeline.update.mutate({
             id: sequence.id,

--- a/web/src/hooks/storyboard/useAssembleTimeline.ts
+++ b/web/src/hooks/storyboard/useAssembleTimeline.ts
@@ -17,7 +17,10 @@ import { useCallback, useState } from "react";
 import type { TimelineClip, TimelineTrack } from "@nodetool-ai/timeline";
 import { trpcClient } from "../../trpc/client";
 import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
-import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import {
+  useWorkspaceTabsStore,
+  creationProjectId
+} from "../../stores/WorkspaceTabsStore";
 import { buildTimelineDocument } from "../../components/storyboard/assembleTimeline";
 import { linkedScriptId } from "../../lib/scriptStoryboardLink";
 import { loadLinkedScript } from "../../lib/linkedAssembly";
@@ -112,7 +115,7 @@ export const useAssembleTimeline = (): UseAssembleTimelineResult => {
         const sequence = await trpcClient.timeline.create.mutate({
           id: newDocumentId(),
           name,
-          projectId: "default"
+          projectId: creationProjectId()
         });
         await trpcClient.timeline.update.mutate({
           id: sequence.id,

--- a/web/src/hooks/useEditVideoAsset.ts
+++ b/web/src/hooks/useEditVideoAsset.ts
@@ -12,7 +12,10 @@ import { useNavigate } from "react-router-dom";
 import { makeTrack } from "@nodetool-ai/timeline";
 import type { Asset } from "../stores/ApiTypes";
 import { trpcClient } from "../trpc/client";
-import { useWorkspaceTabsStore } from "../stores/WorkspaceTabsStore";
+import {
+  useWorkspaceTabsStore,
+  creationProjectId
+} from "../stores/WorkspaceTabsStore";
 import { useNotificationStore } from "../stores/NotificationStore";
 import { assetToClip } from "../components/timeline/dnd/assetToClipAdapter";
 import { newDocumentId } from "../lib/newDocumentId";
@@ -39,7 +42,7 @@ export const useEditVideoAsset = (): ((asset: Asset) => Promise<void>) => {
         const sequence = await trpcClient.timeline.create.mutate({
           id: newDocumentId(),
           name: asset.name || "Untitled video",
-          projectId: "default"
+          projectId: creationProjectId()
         });
         const track = makeTrack({ type: "video", index: 0, name: "Video" });
         const clip = assetToClip(asset, track.id, 0);

--- a/web/src/stores/WorkspaceTabsStore.ts
+++ b/web/src/stores/WorkspaceTabsStore.ts
@@ -64,6 +64,11 @@ interface OpenTabInput {
 interface WorkspaceTabsState {
   tabs: WorkspaceTab[];
   activeTabId: string | null;
+  /**
+   * The project new documents are created into. Null means none is open, and
+   * a creation then lands in the loose bucket ({@link LOOSE_PROJECT_ID}).
+   */
+  activeProjectId: string | null;
 
   /**
    * Open a document tab. If a tab for the same `(type, ref)` already
@@ -79,7 +84,11 @@ interface WorkspaceTabsState {
   setTitle: (ref: string, type: WorkspaceTabType, title: string) => void;
   moveTab: (id: string, toIndex: number) => void;
   getActiveTab: () => WorkspaceTab | null;
+  setActiveProjectId: (projectId: string | null) => void;
 }
+
+/** The project id documents carry when no project is open. */
+export const LOOSE_PROJECT_ID = "default";
 
 export const tabId = (type: WorkspaceTabType, ref: string): string =>
   `${type}:${ref}`;
@@ -160,6 +169,7 @@ export const useWorkspaceTabsStore = create<WorkspaceTabsState>()(
   persist(
     (set, get) => ({
       ...seedTabsFromLegacy(),
+      activeProjectId: null,
 
       openTab: ({ type, ref, mode, title }) => {
         const id = tabId(type, ref);
@@ -247,15 +257,26 @@ export const useWorkspaceTabsStore = create<WorkspaceTabsState>()(
       getActiveTab: () => {
         const { tabs, activeTabId } = get();
         return tabs.find((t) => t.id === activeTabId) ?? null;
-      }
+      },
+
+      setActiveProjectId: (projectId) => set({ activeProjectId: projectId })
     }),
     {
       name: "workspace-tabs-storage",
       version: 1,
       partialize: (state) => ({
         tabs: state.tabs,
-        activeTabId: state.activeTabId
+        activeTabId: state.activeTabId,
+        activeProjectId: state.activeProjectId
       })
     }
   )
 );
+
+/**
+ * The project a newly created document belongs to. Read outside React — every
+ * creation site is inside a mutation callback, not a render — so a project
+ * opened after the component mounted is still the one that counts.
+ */
+export const creationProjectId = (): string =>
+  useWorkspaceTabsStore.getState().activeProjectId ?? LOOSE_PROJECT_ID;

--- a/web/src/stores/__tests__/WorkspaceTabsStore.test.ts
+++ b/web/src/stores/__tests__/WorkspaceTabsStore.test.ts
@@ -1,8 +1,10 @@
 import {
   useWorkspaceTabsStore,
+  creationProjectId,
   nextActiveAfterClose,
   seedTabsFromLegacy,
   tabId,
+  LOOSE_PROJECT_ID,
   type WorkspaceTab
 } from "../WorkspaceTabsStore";
 
@@ -19,7 +21,7 @@ const tab = (
 });
 
 const reset = (tabs: WorkspaceTab[] = [], activeTabId: string | null = null) => {
-  useWorkspaceTabsStore.setState({ tabs, activeTabId });
+  useWorkspaceTabsStore.setState({ tabs, activeTabId, activeProjectId: null });
 };
 
 beforeEach(() => {
@@ -183,5 +185,19 @@ describe("seedTabsFromLegacy", () => {
   it("ignores malformed openWorkflows", () => {
     localStorage.setItem("openWorkflows", "{not json");
     expect(seedTabsFromLegacy()).toEqual({ tabs: [], activeTabId: null });
+  });
+});
+
+describe("creationProjectId", () => {
+  it("names the loose bucket while no project is open", () => {
+    expect(creationProjectId()).toBe(LOOSE_PROJECT_ID);
+  });
+
+  it("follows the project that was opened after the caller was created", () => {
+    const create = () => creationProjectId();
+    useWorkspaceTabsStore.getState().setActiveProjectId("proj-1");
+    expect(create()).toBe("proj-1");
+    useWorkspaceTabsStore.getState().setActiveProjectId(null);
+    expect(create()).toBe(LOOSE_PROJECT_ID);
   });
 });

--- a/web/src/studio/StudioHome.tsx
+++ b/web/src/studio/StudioHome.tsx
@@ -33,6 +33,7 @@ import type {
   StudioDocumentKind,
   StudioProject
 } from "./groupLinkedProjects";
+import { creationProjectId } from "../stores/WorkspaceTabsStore";
 
 const KIND_LABEL = {
   storyboard: "Storyboard",
@@ -159,7 +160,7 @@ const StudioHome = () => {
     creatingRef.current = true;
     setCreating("storyboard");
     createStoryboard
-      .mutateAsync({ name: "Untitled storyboard", projectId: "default" })
+      .mutateAsync({ name: "Untitled storyboard", projectId: creationProjectId() })
       .then((created) => navigate(`/studio/storyboard/${created.id}`))
       .finally(() => {
         creatingRef.current = false;
@@ -172,7 +173,7 @@ const StudioHome = () => {
     creatingRef.current = true;
     setCreating("script");
     createScript
-      .mutateAsync({ name: "Untitled script", projectId: "default" })
+      .mutateAsync({ name: "Untitled script", projectId: creationProjectId() })
       .then((created) => navigate(`/studio/script/${created.id}`))
       .finally(() => {
         creatingRef.current = false;


### PR DESCRIPTION
## What changed

Phase 1 of `docs/plans/project-view/PLAN.md` — the backend substrate for making the project the unit of the workspace. Every document table already carried `project_id` and every creation site hardcoded `"default"`; this adds the row that column points at. A `projects` table and `Project` model (name plus free-text `kind`), a `projects` tRPC router, and a rollup: `projects.get` reads one query per document table and derives each document's status from its stored payload — a board's shots/stills/clips, a script's lines voiced and stale (`needsVoicing`), a cut's clip count and duration — plus the project's spend split into stills / clips / voice / pipeline. Prediction rows gain nullable `project_id` and `document_id`, plumbed through `GenerationSpend`, `NodeCostSpend` and `RunCostLedgerOptions` so a host that knows a project attributes its spend; existing rows keep a null, because a run outside a project has no project. An unpriced row is counted rather than summed as zero, so a project total is a lower bound the caller can say so about. On the web side the thirteen creation sites read `creationProjectId()` instead of the literal — the store's `activeProjectId` is null until Phase 2 opens a project, so behavior is unchanged today and the switch lands in one place.

Two deliberate limits. `"default"` stays the loose-documents bucket: it gets no row, and nothing is migrated into one. And a cut's *render* state is not reported — nothing on the sequence row records it, so the status line reports size only rather than inventing the fact.

One thing the plan asked for that needed more than it named: P3 wants per-document spend, and `project_id` alone cannot answer that. `document_id` is added alongside it in the same migration.

## Verification

- [x] `npm run test:affected` — packages green; `web` (1202 suites / 13687 tests) and `electron` (63 / 686) run separately and pass. Two failures were investigated and are not this diff:
  - `@nodetool-ai/image-nodes` (52 tests) failed identically on a clean tree — the documented headless-Vulkan gap. `apt-get install -y mesa-vulkan-drivers` (lavapipe, what CI installs) makes it 231/231.
  - `@nodetool-ai/cli` `run-dsl.test.ts > --json flag …` times out at 30 s under the loaded parallel run and passes standalone (57 files / 674 tests, and 10/10 for that file alone).
- [x] `npm run typecheck` — `web` and `electron` clean. `mobile` fails on missing modules (`expo`, `react-native`, …) because `mobile/node_modules` was never installed in this container; no mobile file is touched.
- [x] `npm run lint` (exit 0, warnings only, all pre-existing)
- [x] `npm run nodetool -- harness gate --base origin/main` → `Gate: 4/4 selfchecks passed`

## Agent capabilities

No capability added, and no capability's declared contract changed.

## New checks

The migration test asserts the new table and the two new columns exist after a fresh migrate. Inverted once to prove it bites — renaming the added column to `project_id_DISABLED` in the migration:

```
 × should all apply cleanly to a fresh database 76ms
 × should be idempotent (running twice produces same result) 61ms
 × should handle baselining of legacy database 59ms
      Tests  3 failed | 38 passed (41)
```

Restored: `Tests  41 passed (41)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTooaSjMLE3DwnxPsoc1SF

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTooaSjMLE3DwnxPsoc1SF)_