### PR TITLE
feat(agents): OpenAI and Gemini web search as SERP providers

### DIFF
--- a/docs/serpapi-integration.md
+++ b/docs/serpapi-integration.md
@@ -82,9 +82,11 @@ lists everything the engine returned, `omitted` names the keys left out, and
 ## `serpapi_search` or `web_search`?
 
 `web_search` is one query against whichever SERP provider this install
-configured (`SERP_PROVIDER`: SerpAPI, DataForSEO, Brave, or Apify), normalized
-to title/url/snippet. Reach for it for a plain web question — it is provider-
-agnostic and its results are already in the shape an agent wants.
+configured (`SERP_PROVIDER`: SerpAPI, DataForSEO, Brave, Apify, OpenAI, or
+Gemini), normalized to title/url/snippet — the two model-backed providers
+answer in prose and their citations are what gets normalized. Reach for it for
+a plain web question — it is provider-agnostic and its results are already in
+the shape an agent wants.
 
 `serpapi_search` is the layer under that, for the questions a plain web search
 cannot ask: a citation count, a maps listing's hours, a product's price history,

--- a/packages/agents/src/capabilities/web.ts
+++ b/packages/agents/src/capabilities/web.ts
@@ -342,6 +342,25 @@ export function webSearchImpl(provider?: SerpProvider): CapabilityImpl {
     const keepRecords = (records: Array<Record<string, unknown>>) =>
       records.filter((r) => keep((r.link as string | null) ?? null));
 
+    /**
+     * Append a model-backed backend's citations to its prose answer.
+     *
+     * OpenAI and Gemini answer a search with an argument rather than a result
+     * list, and the pages behind it are the only way a reader can check one.
+     * Both are read into the same `{title, url}` shape by their provider, so
+     * one formatter serves them and the domain filters still apply.
+     */
+    const withSources = (text: string, raw: unknown): string => {
+      const sources = (
+        Array.isArray(raw) ? (raw as Array<{ title: string; url: string }>) : []
+      ).filter((s) => keep(s.url));
+      if (sources.length === 0) return text;
+      const lines = sources
+        .map((s, i) => `${i + 1}. ${s.title}\n   ${s.url}`)
+        .join("\n\n");
+      return `${text}\n\nSources:\n\n${lines}`;
+    };
+
     /** A SERP-factory backend: build the client, search, format. */
     const serpFactoryBackend = (
       name: SerpProviderType,
@@ -572,7 +591,7 @@ export function webSearchImpl(provider?: SerpProvider): CapabilityImpl {
           const result = unwrapBackendResult(
             await openAiWebSearch(ctx, { query: effectiveQuery })
           );
-          return String(result.results ?? "");
+          return withSources(String(result.results ?? ""), result.sources);
         }
       },
       {
@@ -593,14 +612,7 @@ export function webSearchImpl(provider?: SerpProvider): CapabilityImpl {
           const text = Array.isArray(result.results)
             ? result.results.join("\n\n")
             : String(result.results ?? "");
-          const sources = (
-            (result.sources ?? []) as Array<{ title: string; url: string }>
-          ).filter((s) => keep(s.url));
-          if (sources.length === 0) return text;
-          const sourceLines = sources
-            .map((s, i) => `${i + 1}. ${s.title}\n   ${s.url}`)
-            .join("\n\n");
-          return `${text}\n\nSources:\n\n${sourceLines}`;
+          return withSources(text, result.sources);
         }
       }
     ];

--- a/packages/agents/src/tools/google-tools.ts
+++ b/packages/agents/src/tools/google-tools.ts
@@ -4,12 +4,15 @@
  * This is not a tool. `capabilities/web.ts` picks the first configured backend
  * and calls the function below; the model never sees a `google_grounded_search`
  * name, because choosing a search provider is the host's job, not the model's.
+ *
+ * The call itself lives in `serp-providers/gemini-provider.ts`, which is also
+ * what `SERP_PROVIDER=gemini` builds. This file is the context-aware half:
+ * resolve the key, return `{error}` rather than throwing.
  */
 
 import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { GeminiSearchProvider } from "./serp-providers/gemini-provider.js";
 import { isFunction, isString } from "../utils/type-guards.js";
-
-const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
 
 async function getGeminiApiKey(context?: ProcessingContext): Promise<string> {
   // Prefer the context's secretResolver (encrypted DB) over env vars so the
@@ -45,7 +48,7 @@ export async function googleGroundedSearch(
 ): Promise<{
   query?: string;
   results?: string[];
-  sources?: Array<{ title: string; url: string }>;
+  sources?: Array<{ title: string; url: string; snippet: string }>;
   status?: string;
   error?: string;
 }> {
@@ -56,79 +59,22 @@ export async function googleGroundedSearch(
 
   try {
     const apiKey = await getGeminiApiKey(context);
-    const url = `${GEMINI_API_BASE}/models/gemini-3.5-flash:generateContent?key=${apiKey}`;
-
-    const body = {
-      contents: [{ role: "user", parts: [{ text: query }] }],
-      tools: [{ googleSearch: {} }],
-      generationConfig: { responseModalities: ["TEXT"] }
-    };
-
-    const response = await fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body)
-    });
-
-    if (!response.ok) {
-      return {
-        error: `Gemini API error: ${response.status} ${response.statusText}`
-      };
-    }
-
-    const data = (await response.json()) as Record<string, unknown>;
-    const candidates = data["candidates"] as
-      | Array<Record<string, unknown>>
-      | undefined;
-
-    if (!candidates?.length) {
-      return { error: "No response received from Gemini API" };
-    }
-
-    const candidate = candidates[0];
-    const content = candidate["content"] as Record<string, unknown> | undefined;
-    const parts = content?.["parts"] as
-      | Array<Record<string, unknown>>
-      | undefined;
-
-    const results: string[] = [];
-    if (parts) {
-      for (const part of parts) {
-        if (isString(part["text"])) {
-          results.push(part["text"]);
-        }
-      }
-    }
-
-    const groundingMetadata = candidate["groundingMetadata"] as
-      | Record<string, unknown>
-      | undefined;
-    const sources: Array<{ title: string; url: string }> = [];
-
-    if (groundingMetadata) {
-      const chunks = groundingMetadata["groundingChunks"] as
-        | Array<Record<string, unknown>>
-        | undefined;
-      if (chunks) {
-        for (const chunk of chunks) {
-          const web = chunk["web"] as Record<string, unknown> | undefined;
-          if (web?.["uri"]) {
-            sources.push({
-              title: String(web["title"] ?? "Unknown Source"),
-              url: String(web["uri"])
-            });
-          }
-        }
-      }
-    }
+    const answer = await new GeminiSearchProvider(apiKey).answer(query);
 
     return {
       query,
-      results,
-      sources,
+      results: answer.texts,
+      sources: answer.citations.map((c) => ({
+        title: c.title,
+        url: c.url,
+        snippet: c.snippet
+      })),
       status: "success"
     };
   } catch (e) {
-    return { error: `Google grounded search failed: ${String(e)}` };
+    // The provider and the key resolver already name what failed; re-prefixing
+    // would turn "No response received from Gemini API" into a sentence with
+    // two verbs and no more information.
+    return { error: e instanceof Error ? e.message : String(e) };
   }
 }

--- a/packages/agents/src/tools/openai-tools.ts
+++ b/packages/agents/src/tools/openai-tools.ts
@@ -4,14 +4,17 @@
  * This is not a tool. `capabilities/web.ts` picks the first configured backend
  * and calls the function below; the model never sees an `openai_web_search`
  * name, because choosing a search provider is the host's job, not the model's.
+ *
+ * The call itself lives in `serp-providers/openai-provider.ts`, which is also
+ * what `SERP_PROVIDER=openai` builds. This file is the context-aware half:
+ * resolve the key, return `{error}` rather than throwing.
  */
 
 import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { OpenAiSearchProvider } from "./serp-providers/openai-provider.js";
 import { isFunction, isString } from "../utils/type-guards.js";
 
-async function getOpenAIClient(context?: ProcessingContext) {
-  // Dynamic import to avoid hard dependency
-  const { OpenAI } = await import("openai");
+async function getOpenAIApiKey(context?: ProcessingContext): Promise<string> {
   // Prefer the context's secretResolver (which checks the encrypted DB
   // before env vars). Fall back to env directly for callers that don't
   // pass a context.
@@ -21,7 +24,7 @@ async function getOpenAIClient(context?: ProcessingContext) {
       : null;
   const apiKey = fromCtx ?? process.env["OPENAI_API_KEY"];
   if (!apiKey) throw new Error("OPENAI_API_KEY is not set");
-  return new OpenAI({ apiKey });
+  return apiKey;
 }
 
 /**
@@ -43,26 +46,35 @@ export async function openAiSearchConfigured(
 export async function openAiWebSearch(
   context: ProcessingContext,
   params: { query?: unknown }
-): Promise<{ query?: string; results?: string; status?: string; error?: string }> {
+): Promise<{
+  query?: string;
+  results?: string;
+  sources?: Array<{ title: string; url: string; snippet: string }>;
+  status?: string;
+  error?: string;
+}> {
   const query = params.query;
   if (!isString(query) || !query) {
     return { error: "Search query is required" };
   }
 
   try {
-    const client = await getOpenAIClient(context);
-    const completion = await client.chat.completions.create({
-      model: "gpt-4o-search-preview",
-      web_search_options: {},
-      messages: [{ role: "user", content: query }]
-    });
+    const apiKey = await getOpenAIApiKey(context);
+    const answer = await new OpenAiSearchProvider(apiKey).answer(query);
 
     return {
       query,
-      results: completion.choices[0]?.message?.content ?? "",
+      results: answer.text,
+      sources: answer.citations.map((c) => ({
+        title: c.title,
+        url: c.url,
+        snippet: c.snippet
+      })),
       status: "success"
     };
   } catch (e) {
-    return { error: `Web search failed: ${String(e)}` };
+    // The provider and the key resolver already name what failed; re-prefixing
+    // would say "Web search failed: OpenAI web search request failed: ...".
+    return { error: e instanceof Error ? e.message : String(e) };
   }
 }

--- a/packages/agents/src/tools/serp-providers/gemini-provider.ts
+++ b/packages/agents/src/tools/serp-providers/gemini-provider.ts
@@ -1,0 +1,192 @@
+/**
+ * Gemini grounded search as a SERP provider.
+ *
+ * Gemini answers in prose and attaches `groundingMetadata`: one
+ * `groundingChunk` per page it read, plus `groundingSupports` tying spans of
+ * the answer back to the chunks that support them. The chunks are the ranked
+ * result list and the supports are the snippets, so the same call serves both
+ * shapes: `search` returns the chunks normalised to `SearchResult`, and
+ * `answer` returns the prose the routed `web_search` capability prints.
+ *
+ * This is the one implementation of the call. `tools/google-tools.ts` resolves
+ * the key from a `ProcessingContext` and delegates here.
+ */
+
+import type { SerpProvider, SearchResult, SearchOptions } from "./index.js";
+
+const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
+
+/** The model the grounded-search call runs on. */
+export const GEMINI_SEARCH_MODEL = "gemini-3.5-flash";
+
+/** What a chunk with no title of its own is called. */
+export const UNKNOWN_SOURCE_TITLE = "Unknown Source";
+
+/** How much supporting text is kept as a snippet. */
+const MAX_SNIPPET_CHARS = 400;
+
+/** One Gemini answer, with the pages it grounded on. */
+export interface GeminiSearchAnswer {
+  /** The text parts of the answer, in order. */
+  texts: string[];
+  /** The grounding chunks as ranked results. */
+  citations: SearchResult[];
+  /** The response as Gemini returned it. */
+  raw: unknown;
+}
+
+interface GroundingSupport {
+  segment?: { text?: unknown };
+  groundingChunkIndices?: unknown;
+}
+
+interface GroundingChunk {
+  web?: { uri?: unknown; title?: unknown };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * The answer spans each chunk supports, joined into one snippet.
+ *
+ * A chunk nothing supports keeps an empty snippet rather than being dropped —
+ * Gemini cites pages it read without always tying a span to them.
+ */
+function snippetsByChunk(
+  supports: readonly GroundingSupport[]
+): Map<number, string> {
+  const byChunk = new Map<number, string[]>();
+  for (const support of supports) {
+    const text = support?.segment?.text;
+    if (typeof text !== "string" || !text.trim()) continue;
+    const indices = support.groundingChunkIndices;
+    if (!Array.isArray(indices)) continue;
+    for (const index of indices) {
+      if (typeof index !== "number" || !Number.isInteger(index)) continue;
+      const existing = byChunk.get(index);
+      if (existing) existing.push(text.trim());
+      else byChunk.set(index, [text.trim()]);
+    }
+  }
+  return new Map(
+    [...byChunk].map(([index, parts]) => [
+      index,
+      parts.join(" ").slice(0, MAX_SNIPPET_CHARS)
+    ])
+  );
+}
+
+/** Read `groundingMetadata` into ranked results. */
+export function citationsFromGrounding(
+  metadata: Record<string, unknown> | undefined
+): SearchResult[] {
+  const chunks = metadata?.groundingChunks;
+  if (!Array.isArray(chunks)) return [];
+  const supports = Array.isArray(metadata?.groundingSupports)
+    ? (metadata.groundingSupports as GroundingSupport[])
+    : [];
+  const snippets = snippetsByChunk(supports);
+
+  const results: SearchResult[] = [];
+  chunks.forEach((chunk: GroundingChunk, index: number) => {
+    const uri = chunk?.web?.uri;
+    if (typeof uri !== "string" || !uri) return;
+    const title = chunk.web?.title;
+    results.push({
+      title: typeof title === "string" && title ? title : UNKNOWN_SOURCE_TITLE,
+      url: uri,
+      snippet: snippets.get(index) ?? "",
+      position: results.length + 1
+    });
+  });
+  return results;
+}
+
+export class GeminiSearchProvider implements SerpProvider {
+  private readonly apiKey: string;
+  private readonly model: string;
+
+  constructor(apiKey: string, model: string = GEMINI_SEARCH_MODEL) {
+    this.apiKey = apiKey;
+    this.model = model;
+  }
+
+  /** Ask Gemini with its search tool on, and read the prose and grounding. */
+  async answer(query: string): Promise<GeminiSearchAnswer> {
+    const url = `${GEMINI_API_BASE}/models/${this.model}:generateContent?key=${this.apiKey}`;
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          contents: [{ role: "user", parts: [{ text: query }] }],
+          tools: [{ googleSearch: {} }],
+          generationConfig: { responseModalities: ["TEXT"] }
+        })
+      });
+    } catch (e) {
+      // A transport failure says only "fetch failed"; name the call so the
+      // message the caller surfaces says which service went down.
+      throw new Error(
+        `Gemini grounded search request failed: ${(e as Error).message}`
+      );
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `Gemini API error: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const data = (await response.json()) as Record<string, unknown>;
+    const candidates = data.candidates;
+    if (!Array.isArray(candidates) || candidates.length === 0) {
+      throw new Error("No response received from Gemini API");
+    }
+
+    const candidate = candidates[0] as Record<string, unknown>;
+    const content = candidate.content;
+    const parts = isRecord(content) ? content.parts : undefined;
+    const texts: string[] = [];
+    if (Array.isArray(parts)) {
+      for (const part of parts) {
+        if (isRecord(part) && typeof part.text === "string") {
+          texts.push(part.text);
+        }
+      }
+    }
+
+    const metadata = candidate.groundingMetadata;
+    return {
+      texts,
+      citations: citationsFromGrounding(
+        isRecord(metadata) ? metadata : undefined
+      ),
+      raw: data
+    };
+  }
+
+  /**
+   * The grounded pages as a ranked result list.
+   *
+   * Gemini's search tool takes no result count, so `numResults` truncates what
+   * came back rather than narrowing the request.
+   */
+  async search(
+    query: string,
+    options?: SearchOptions
+  ): Promise<SearchResult[]> {
+    const { citations } = await this.answer(query);
+    const numResults = options?.numResults;
+    return numResults === undefined
+      ? citations
+      : citations.slice(0, numResults);
+  }
+
+  async searchRaw(query: string): Promise<unknown> {
+    return (await this.answer(query)).raw;
+  }
+}

--- a/packages/agents/src/tools/serp-providers/index.ts
+++ b/packages/agents/src/tools/serp-providers/index.ts
@@ -67,7 +67,9 @@ export type SerpProviderType =
   | "serpapi"
   | "dataforseo"
   | "brave"
-  | "apify";
+  | "apify"
+  | "openai"
+  | "gemini";
 
 interface SecretResolver {
   getSecret?: (key: string) => Promise<string | null>;
@@ -94,7 +96,9 @@ export const SERP_PROVIDER_SECRETS: Readonly<
   serpapi: ["SERPAPI_API_KEY"],
   dataforseo: ["DATA_FOR_SEO_LOGIN", "DATA_FOR_SEO_PASSWORD"],
   brave: ["BRAVE_API_KEY"],
-  apify: ["APIFY_API_TOKEN", "APIFY_API_KEY"]
+  apify: ["APIFY_API_TOKEN", "APIFY_API_KEY"],
+  openai: ["OPENAI_API_KEY"],
+  gemini: ["GEMINI_API_KEY"]
 };
 
 /**
@@ -114,7 +118,12 @@ export const SERP_PROVIDER_SEARCH_TYPES: Readonly<
   serpapi: ["web"],
   dataforseo: ["web"],
   brave: ["web", "images"],
-  apify: ["web"]
+  apify: ["web"],
+  // OpenAI and Gemini answer in prose and cite the pages they read; the
+  // citations are the result list. Neither has an image or news endpoint, so
+  // routing skips them for those types instead of answering with pages.
+  openai: ["web"],
+  gemini: ["web"]
 };
 
 /**
@@ -195,9 +204,35 @@ export async function createSerpProvider(
       return new (await import("./apify-provider.js")).ApifyProvider(key);
     }
 
+    case "openai": {
+      const key = await getSecret("OPENAI_API_KEY", resolver);
+      if (!key) {
+        throw new Error(
+          "OPENAI_API_KEY is required for the OpenAI search provider. Set it as an environment variable or via settings."
+        );
+      }
+      return new (await import("./openai-provider.js")).OpenAiSearchProvider(
+        key
+      );
+    }
+
+    case "gemini": {
+      const key = await getSecret("GEMINI_API_KEY", resolver);
+      if (!key) {
+        throw new Error(
+          "GEMINI_API_KEY is required for the Gemini search provider. Set it as an environment variable or via settings."
+        );
+      }
+      return new (await import("./gemini-provider.js")).GeminiSearchProvider(
+        key
+      );
+    }
+
     default:
       throw new Error(
-        `Unknown SERP provider: ${providerType}. Supported: serpapi, dataforseo, brave, apify`
+        `Unknown SERP provider: ${providerType}. Supported: ${Object.keys(
+          SERP_PROVIDER_SECRETS
+        ).join(", ")}`
       );
   }
 }
@@ -206,3 +241,5 @@ export { SerpApiProvider } from "./serpapi-provider.js";
 export { DataForSeoProvider } from "./dataforseo-provider.js";
 export { BraveProvider } from "./brave-provider.js";
 export { ApifyProvider } from "./apify-provider.js";
+export { OpenAiSearchProvider, OPENAI_SEARCH_MODEL } from "./openai-provider.js";
+export { GeminiSearchProvider, GEMINI_SEARCH_MODEL } from "./gemini-provider.js";

--- a/packages/agents/src/tools/serp-providers/openai-provider.ts
+++ b/packages/agents/src/tools/serp-providers/openai-provider.ts
@@ -1,0 +1,153 @@
+/**
+ * OpenAI web search as a SERP provider.
+ *
+ * OpenAI's search-enabled chat model answers in prose and attaches a
+ * `url_citation` annotation per page it read. The citations are the ranked
+ * result list — a title, a URL, and the span of the answer that page
+ * supported — so the same call serves both shapes: `search` returns the
+ * citations normalised to `SearchResult`, and `answer` returns the prose the
+ * routed `web_search` capability prints.
+ *
+ * This is the one implementation of the call. `tools/openai-tools.ts` resolves
+ * the key from a `ProcessingContext` and delegates here.
+ */
+
+import type { SerpProvider, SearchResult, SearchOptions } from "./index.js";
+
+/** The chat model that carries the web-search tool. */
+export const OPENAI_SEARCH_MODEL = "gpt-4o-search-preview";
+
+/** How much of the cited span is kept as a snippet. */
+const MAX_SNIPPET_CHARS = 400;
+
+/** One OpenAI answer, with the pages it cited. */
+export interface OpenAiSearchAnswer {
+  /** The model's prose answer. */
+  text: string;
+  /** The cited pages, deduplicated by URL, in the order they appear. */
+  citations: SearchResult[];
+  /** The completion as OpenAI returned it. */
+  raw: unknown;
+}
+
+interface UrlCitation {
+  url?: unknown;
+  title?: unknown;
+  start_index?: unknown;
+  end_index?: unknown;
+}
+
+interface Annotation {
+  type?: unknown;
+  url_citation?: UrlCitation;
+}
+
+function readIndex(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0
+    ? value
+    : null;
+}
+
+/**
+ * The slice of the answer a citation covers, as the result's snippet.
+ *
+ * A citation with no usable span is not dropped: the page is still a result,
+ * it just has nothing to quote.
+ */
+function snippetFor(text: string, citation: UrlCitation): string {
+  const start = readIndex(citation.start_index);
+  const end = readIndex(citation.end_index);
+  if (start === null || end === null || end <= start) return "";
+  return text.slice(start, end).trim().slice(0, MAX_SNIPPET_CHARS);
+}
+
+/**
+ * Read the `url_citation` annotations off an assistant message into ranked
+ * results. Duplicates are collapsed on URL — the model cites one page several
+ * times across an answer — keeping the first mention's snippet and position.
+ */
+export function citationsFromAnswer(
+  text: string,
+  annotations: readonly Annotation[]
+): SearchResult[] {
+  const byUrl = new Map<string, SearchResult>();
+  for (const annotation of annotations) {
+    if (annotation?.type !== "url_citation") continue;
+    const citation = annotation.url_citation;
+    const url = citation?.url;
+    if (typeof url !== "string" || !url) continue;
+    if (byUrl.has(url)) continue;
+    byUrl.set(url, {
+      title: typeof citation?.title === "string" ? citation.title : "",
+      url,
+      snippet: snippetFor(text, citation ?? {}),
+      position: byUrl.size + 1
+    });
+  }
+  return [...byUrl.values()];
+}
+
+export class OpenAiSearchProvider implements SerpProvider {
+  private readonly apiKey: string;
+  private readonly model: string;
+
+  constructor(apiKey: string, model: string = OPENAI_SEARCH_MODEL) {
+    this.apiKey = apiKey;
+    this.model = model;
+  }
+
+  /** Ask the search model, and read both the prose and the citations. */
+  async answer(query: string): Promise<OpenAiSearchAnswer> {
+    // Dynamic import so `openai` stays an optional dependency of this path.
+    const { OpenAI } = await import("openai");
+    const client = new OpenAI({ apiKey: this.apiKey });
+    let completion;
+    try {
+      completion = await client.chat.completions.create({
+        model: this.model,
+        web_search_options: {},
+        messages: [{ role: "user", content: query }]
+      });
+    } catch (e) {
+      // Name the call, so a transport or auth failure the SDK reports tersely
+      // still says which service it came from.
+      throw new Error(
+        `OpenAI web search request failed: ${(e as Error).message}`
+      );
+    }
+
+    const message = completion.choices[0]?.message;
+    const text = message?.content ?? "";
+    const annotations = (message as { annotations?: unknown } | undefined)
+      ?.annotations;
+    return {
+      text,
+      citations: citationsFromAnswer(
+        text,
+        Array.isArray(annotations) ? (annotations as Annotation[]) : []
+      ),
+      raw: completion
+    };
+  }
+
+  /**
+   * The cited pages as a ranked result list.
+   *
+   * OpenAI's search tool takes no result count, so `numResults` truncates what
+   * came back rather than narrowing the request.
+   */
+  async search(
+    query: string,
+    options?: SearchOptions
+  ): Promise<SearchResult[]> {
+    const { citations } = await this.answer(query);
+    const numResults = options?.numResults;
+    return numResults === undefined
+      ? citations
+      : citations.slice(0, numResults);
+  }
+
+  async searchRaw(query: string): Promise<unknown> {
+    return (await this.answer(query)).raw;
+  }
+}

--- a/packages/agents/tests/capabilities-web.test.ts
+++ b/packages/agents/tests/capabilities-web.test.ts
@@ -194,6 +194,78 @@ describe("behaviour through toolFromCapability", () => {
     expect(String(bad.error)).toContain("Invalid URL");
   });
 
+  it("appends the pages the gemini backend grounded on, filtered", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        candidates: [
+          {
+            content: { parts: [{ text: "Otters are mustelids." }] },
+            groundingMetadata: {
+              groundingChunks: [
+                { web: { uri: "https://good.example/otters", title: "Otters" } },
+                { web: { uri: "https://bad.example/otters", title: "Spam" } }
+              ]
+            }
+          }
+        ]
+      })
+    } as unknown as Response);
+
+    const context = makeContext({ GEMINI_API_KEY: "key" });
+    const tool = asTool(byName("web_search"));
+    const result = String(
+      await tool.process(context, {
+        query: "otters",
+        backend: "gemini",
+        blocked_domains: ["bad.example"]
+      })
+    );
+
+    expect(result).toContain("Otters are mustelids.");
+    expect(result).toContain("1. Otters\n   https://good.example/otters");
+    expect(result).not.toContain("bad.example");
+  });
+
+  it("appends the pages the openai backend cited", async () => {
+    const create = vi.fn().mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: "Otters are mustelids.",
+            annotations: [
+              {
+                type: "url_citation",
+                url_citation: {
+                  url: "https://good.example/otters",
+                  title: "Otters",
+                  start_index: 0,
+                  end_index: 21
+                }
+              }
+            ]
+          }
+        }
+      ]
+    });
+    vi.doMock("openai", () => ({
+      OpenAI: function () {
+        return { chat: { completions: { create } } };
+      }
+    }));
+
+    const context = makeContext({ OPENAI_API_KEY: "key" });
+    const tool = asTool(byName("web_search"));
+    const result = String(
+      await tool.process(context, { query: "otters", backend: "openai" })
+    );
+
+    expect(result).toContain("Otters are mustelids.");
+    expect(result).toContain("1. Otters\n   https://good.example/otters");
+    vi.doUnmock("openai");
+  });
+
   it("names every unconfigured backend when a news search has none", async () => {
     const context = makeContext();
     const tool = asTool(byName("web_search"));

--- a/packages/agents/tests/serp-providers-model-backed.test.ts
+++ b/packages/agents/tests/serp-providers-model-backed.test.ts
@@ -1,0 +1,330 @@
+/**
+ * The two model-backed SERP providers: OpenAI web search and Gemini grounded
+ * search.
+ *
+ * They answer a query with prose plus the pages the model read, so what makes
+ * them usable as SERP providers is the citation extraction — the prose is not
+ * a result list. These tests pin that reading, in both directions: a citation
+ * the API returned must become a result, and a response that carries no usable
+ * citation must produce none rather than one empty row.
+ *
+ * They also pin that the three places naming the provider set agree — the
+ * factory's secret table, the settings catalog the UI renders, and the classes
+ * themselves — because a provider missing from any one of them is silently
+ * unselectable rather than broken.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { settingCatalog } from "@nodetool-ai/config";
+import {
+  SERP_PROVIDER_SECRETS,
+  SERP_PROVIDER_SEARCH_TYPES,
+  createSerpProvider,
+  serpProviderConfigured,
+  type SerpProviderType
+} from "../src/tools/serp-providers/index.js";
+import { citationsFromAnswer } from "../src/tools/serp-providers/openai-provider.js";
+import {
+  GeminiSearchProvider,
+  citationsFromGrounding
+} from "../src/tools/serp-providers/gemini-provider.js";
+
+const anySecret = { getSecret: async (key: string) => `test-${key}` };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// The provider set, across the three tables that name it
+// ---------------------------------------------------------------------------
+
+describe("the SERP provider set", () => {
+  it("offers openai and gemini in the settings catalog", () => {
+    const entry = settingCatalog().find((s) => s.envVar === "SERP_PROVIDER");
+    expect(entry?.enum).toEqual(Object.keys(SERP_PROVIDER_SECRETS));
+  });
+
+  it("builds a client for every provider the secret table names", async () => {
+    for (const name of Object.keys(
+      SERP_PROVIDER_SECRETS
+    ) as SerpProviderType[]) {
+      const client = await createSerpProvider(name, anySecret);
+      expect(typeof client.search, name).toBe("function");
+    }
+  });
+
+  it.each([
+    ["openai", "OPENAI_API_KEY"],
+    ["gemini", "GEMINI_API_KEY"]
+  ] as const)("reads %s from the key it declares", async (name, key) => {
+    expect(SERP_PROVIDER_SECRETS[name]).toEqual([key]);
+    expect(SERP_PROVIDER_SEARCH_TYPES[name]).toEqual(["web"]);
+    expect(await serpProviderConfigured(name, { getSecret: async () => null }))
+      .toBe(false);
+    expect(
+      await serpProviderConfigured(name, {
+        getSecret: async (k: string) => (k === key ? "set" : null)
+      })
+    ).toBe(true);
+  });
+
+  it("refuses to build one without its key", async () => {
+    const none = { getSecret: async () => null };
+    await expect(createSerpProvider("openai", none)).rejects.toThrow(
+      /OPENAI_API_KEY is required/
+    );
+    await expect(createSerpProvider("gemini", none)).rejects.toThrow(
+      /GEMINI_API_KEY is required/
+    );
+  });
+
+  it("names every supported provider when asked for an unknown one", async () => {
+    await expect(createSerpProvider("bing", anySecret)).rejects.toThrow(
+      /Supported: .*openai, gemini/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenAI: url_citation annotations → results
+// ---------------------------------------------------------------------------
+
+describe("citationsFromAnswer", () => {
+  const text = "Rates held steady this quarter. Housing starts fell.";
+
+  it("reads a citation's span as its snippet", () => {
+    expect(
+      citationsFromAnswer(text, [
+        {
+          type: "url_citation",
+          url_citation: {
+            url: "https://fed.example/statement",
+            title: "Rate statement",
+            start_index: 0,
+            end_index: 31
+          }
+        }
+      ])
+    ).toEqual([
+      {
+        title: "Rate statement",
+        url: "https://fed.example/statement",
+        snippet: "Rates held steady this quarter.",
+        position: 1
+      }
+    ]);
+  });
+
+  it("collapses repeat citations of one page, keeping the first", () => {
+    const results = citationsFromAnswer(text, [
+      {
+        type: "url_citation",
+        url_citation: { url: "https://a.example", start_index: 0, end_index: 5 }
+      },
+      {
+        type: "url_citation",
+        url_citation: { url: "https://b.example", start_index: 6, end_index: 12 }
+      },
+      {
+        type: "url_citation",
+        url_citation: { url: "https://a.example", start_index: 32, end_index: 45 }
+      }
+    ]);
+    expect(results.map((r) => [r.url, r.position, r.snippet])).toEqual([
+      ["https://a.example", 1, "Rates"],
+      ["https://b.example", 2, "held s"]
+    ]);
+  });
+
+  it("keeps a citation whose span is missing or inverted, with no snippet", () => {
+    expect(
+      citationsFromAnswer(text, [
+        { type: "url_citation", url_citation: { url: "https://a.example" } },
+        {
+          type: "url_citation",
+          url_citation: {
+            url: "https://b.example",
+            start_index: 20,
+            end_index: 4
+          }
+        }
+      ]).map((r) => r.snippet)
+    ).toEqual(["", ""]);
+  });
+
+  it("ignores annotations that are not url citations or carry no url", () => {
+    expect(
+      citationsFromAnswer(text, [
+        { type: "file_citation", url_citation: { url: "https://a.example" } },
+        { type: "url_citation", url_citation: { url: "" } },
+        { type: "url_citation" }
+      ])
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gemini: groundingMetadata → results
+// ---------------------------------------------------------------------------
+
+describe("citationsFromGrounding", () => {
+  it("joins the supported spans of each chunk into its snippet", () => {
+    expect(
+      citationsFromGrounding({
+        groundingChunks: [
+          { web: { uri: "https://a.example", title: "A" } },
+          { web: { uri: "https://b.example", title: "B" } }
+        ],
+        groundingSupports: [
+          { segment: { text: "First span." }, groundingChunkIndices: [0] },
+          { segment: { text: "Second span." }, groundingChunkIndices: [0, 1] }
+        ]
+      })
+    ).toEqual([
+      {
+        title: "A",
+        url: "https://a.example",
+        snippet: "First span. Second span.",
+        position: 1
+      },
+      {
+        title: "B",
+        url: "https://b.example",
+        snippet: "Second span.",
+        position: 2
+      }
+    ]);
+  });
+
+  it("names a titleless chunk rather than dropping it", () => {
+    expect(
+      citationsFromGrounding({
+        groundingChunks: [{ web: { uri: "https://a.example" } }]
+      })
+    ).toEqual([
+      {
+        title: "Unknown Source",
+        url: "https://a.example",
+        snippet: "",
+        position: 1
+      }
+    ]);
+  });
+
+  it("skips a chunk with no web uri and keeps positions contiguous", () => {
+    expect(
+      citationsFromGrounding({
+        groundingChunks: [
+          { web: { uri: "https://a.example" } },
+          { retrievedContext: { title: "not the web" } },
+          { web: { uri: "https://c.example" } }
+        ] as unknown[],
+        // The support points at chunk 2, which is the third entry — indices
+        // are into the original array, not into the results.
+        groundingSupports: [
+          { segment: { text: "Third." }, groundingChunkIndices: [2] }
+        ]
+      })
+    ).toEqual([
+      {
+        title: "Unknown Source",
+        url: "https://a.example",
+        snippet: "",
+        position: 1
+      },
+      {
+        title: "Unknown Source",
+        url: "https://c.example",
+        snippet: "Third.",
+        position: 2
+      }
+    ]);
+  });
+
+  it("reports no citations when there is no grounding metadata", () => {
+    expect(citationsFromGrounding(undefined)).toEqual([]);
+    expect(citationsFromGrounding({})).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GeminiSearchProvider end to end over a stubbed fetch
+// ---------------------------------------------------------------------------
+
+describe("GeminiSearchProvider.search", () => {
+  function stubFetch(body: unknown, ok = true, status = 200) {
+    return vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok,
+      status,
+      statusText: ok ? "OK" : "Forbidden",
+      json: async () => body
+    } as Response);
+  }
+
+  it("returns the grounded pages as ranked results", async () => {
+    const fetchSpy = stubFetch({
+      candidates: [
+        {
+          content: { parts: [{ text: "An answer." }] },
+          groundingMetadata: {
+            groundingChunks: [{ web: { uri: "https://a.example", title: "A" } }]
+          }
+        }
+      ]
+    });
+
+    const results = await new GeminiSearchProvider("k").search("rates");
+
+    expect(results).toEqual([
+      {
+        title: "A",
+        url: "https://a.example",
+        snippet: "",
+        position: 1
+      }
+    ]);
+    expect(String(fetchSpy.mock.calls[0][0])).toContain(
+      "/models/gemini-3.5-flash:generateContent"
+    );
+  });
+
+  it("truncates to numResults rather than narrowing the request", async () => {
+    stubFetch({
+      candidates: [
+        {
+          content: { parts: [] },
+          groundingMetadata: {
+            groundingChunks: [
+              { web: { uri: "https://a.example" } },
+              { web: { uri: "https://b.example" } },
+              { web: { uri: "https://c.example" } }
+            ]
+          }
+        }
+      ]
+    });
+
+    const results = await new GeminiSearchProvider("k").search("rates", {
+      numResults: 2
+    });
+    expect(results.map((r) => r.url)).toEqual([
+      "https://a.example",
+      "https://b.example"
+    ]);
+  });
+
+  it("throws on a failed request instead of returning nothing", async () => {
+    stubFetch({}, false, 403);
+    await expect(new GeminiSearchProvider("k").search("rates")).rejects.toThrow(
+      /Gemini API error: 403/
+    );
+  });
+
+  it("names the service when the transport fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("fetch failed"));
+    await expect(new GeminiSearchProvider("k").search("rates")).rejects.toThrow(
+      /Gemini grounded search request failed: fetch failed/
+    );
+  });
+});

--- a/packages/config/src/setting-catalog.ts
+++ b/packages/config/src/setting-catalog.ts
@@ -215,7 +215,7 @@ s(
   "SERP_PROVIDER",
   "Search",
   "Select which search provider to use for web search operations.",
-  ["serpapi", "dataforseo", "brave", "apify"]
+  ["serpapi", "dataforseo", "brave", "apify", "openai", "gemini"]
 );
 s(
   "ZAI_USE_CODING_PLAN",

--- a/packages/runtime/tests/url-egress-inventory.ts
+++ b/packages/runtime/tests/url-egress-inventory.ts
@@ -539,12 +539,6 @@ export const URL_EGRESS_INVENTORY: EgressEntry[] = [
     "api.dataforseo.com."
   ),
   fixedHost(
-    "packages/agents/src/tools/google-tools.ts",
-    "Google Workspace tools",
-    "the user's Google OAuth token",
-    "googleapis.com endpoints built from constants."
-  ),
-  fixedHost(
     "packages/agents/src/tools/serp-providers/apify-provider.ts",
     "Apify search backend",
     "APIFY_API_TOKEN",
@@ -561,6 +555,12 @@ export const URL_EGRESS_INVENTORY: EgressEntry[] = [
     "DataForSEO search backend",
     "DataForSEO basic auth",
     "api.dataforseo.com."
+  ),
+  fixedHost(
+    "packages/agents/src/tools/serp-providers/gemini-provider.ts",
+    "Gemini search backend",
+    "GEMINI_API_KEY",
+    "generativelanguage.googleapis.com, model id from a constant."
   ),
   fixedHost(
     "packages/atlascloud-nodes/src/atlascloud-base.ts",

--- a/web/src/utils/searchProviders.ts
+++ b/web/src/utils/searchProviders.ts
@@ -5,7 +5,13 @@
  * `packages/agents/src/tools/serp-tool-factory.ts`).
  */
 
-export type SerpProviderId = "brave" | "serpapi" | "dataforseo" | "apify";
+export type SerpProviderId =
+  | "brave"
+  | "serpapi"
+  | "dataforseo"
+  | "apify"
+  | "openai"
+  | "gemini";
 
 interface SearchProviderConfig {
   id: SerpProviderId;
@@ -58,6 +64,24 @@ export const SEARCH_PROVIDER_CONFIGS: Record<SerpProviderId, SearchProviderConfi
     credentialFields: ["APIFY_API_TOKEN"],
     getApiKeyUrl: "https://console.apify.com/account/integrations",
     getApiKeyLabel: "Get Apify API Token"
+  },
+  openai: {
+    id: "openai",
+    label: "OpenAI Web Search",
+    description:
+      "Reuses your OpenAI key. Answers in prose and cites the pages it read.",
+    credentialFields: ["OPENAI_API_KEY"],
+    getApiKeyUrl: "https://platform.openai.com/api-keys",
+    getApiKeyLabel: "Get OpenAI API Key"
+  },
+  gemini: {
+    id: "gemini",
+    label: "Gemini Grounded Search",
+    description:
+      "Reuses your Gemini key. Answers in prose and cites the pages it read.",
+    credentialFields: ["GEMINI_API_KEY"],
+    getApiKeyUrl: "https://aistudio.google.com/app/apikey",
+    getApiKeyLabel: "Get Gemini API Key"
   }
 };
 


### PR DESCRIPTION
## What changed

OpenAI web search and Gemini grounded search already backed the routed `web_search` capability, but neither was reachable through `SERP_PROVIDER` — an install holding only an OpenAI or Gemini key had no selectable search provider, and `createSearchTool` could not build one. Both are now `SerpProvider` implementations. They answer a query with prose rather than a result list, so what makes them SERP providers is reading their citations: OpenAI's `url_citation` annotations (the cited span of the answer becomes the snippet, deduplicated by URL) and Gemini's `groundingChunks` joined with the `groundingSupports` that cite each one. Neither service has a news or image endpoint, so `SERP_PROVIDER_SEARCH_TYPES` lists `web` only and routing skips them for the other types instead of answering an image search with pages.

The HTTP call now lives once, in the provider class. `openai-tools.ts` and `google-tools.ts` keep the context-aware half — resolve the key from the secret store, report `{error}` instead of throwing — and delegate to it, so there is one implementation per API rather than two. Their `sources` now carry snippets, and the routed capability appends them to both backends' prose through one formatter; the openai backend was dropping its citations entirely, leaving the reader an argument with no way to check it. `openai` and `gemini` are added to the `SERP_PROVIDER` settings enum and to the web provider configs, and a test pins the catalog enum against the factory's secret table so a provider cannot be added to one and not the other.

## Verification

- [x] `npm run test:affected` — `@nodetool-ai/agents` 230 files passed / 1 skipped, `@nodetool-ai/config` 12 passed, plus `chat`, `websocket`, `cli` green. `@nodetool-ai/image-nodes` fails with `CheckVkSuccessImpl … dawn/native/vulkan/VulkanError.cpp` — the documented headless-Vulkan gap (AGENTS.md § WebGPU on a headless machine), unrelated to this diff, which touches no image node.
- [x] `npm run typecheck` — `typecheck:web` and `typecheck:electron` clean. `typecheck:mobile` fails on `Cannot find module 'react-native'` etc. because `mobile/node_modules` is absent in this container; mobile is not a root workspace and nothing here touches it.
- [x] `npm run lint` (exit 0)
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — `Gate: 3/3 selfchecks passed`, 255/255 graphs validate. (`--base main` has no merge base in a shallow clone.)

## Agent capabilities

No capability is added and no declared contract changes — `web_search`'s spec, schema and category are untouched; the diff is behind the routing table.

- [x] `npm run capabilities:check` passes (`capability table is current (228 capabilities)`)

## New checks

Three new checks, each inverted once and observed failing:

- Catalog ↔ factory drift (`the SERP provider set › offers openai and gemini in the settings catalog`). Removing `"gemini"` from the `SERP_PROVIDER` enum:
  ```
  AssertionError: expected [ 'serpapi', 'dataforseo', …(3) ] to deeply equal [ 'serpapi', 'dataforseo', …(4) ]
  Tests  1 failed | 17 skipped (18)
  ```
- Gemini snippet join (`citationsFromGrounding › joins the supported spans of each chunk`). Replacing `parts.join(" ")` with `parts[0]`:
  ```
  AssertionError: expected [ { title: 'A', …(3) }, …(1) ] to deeply equal [ { title: 'A', …(3) }, …(1) ]
  Tests  1 failed | 17 skipped (18)
  ```
- OpenAI citation dedup (`citationsFromAnswer › collapses repeat citations of one page`). Dropping the `byUrl.has(url)` guard:
  ```
  AssertionError: expected [ …(2) ] to deeply equal [ …(2) ]
  Tests  1 failed | 17 skipped (18)
  ```

The two routed-backend tests in `capabilities-web.test.ts` were also inverted (removing `withSources` from both `run` bodies):
```
× appends the pages the gemini backend grounded on, filtered
× appends the pages the openai backend cited
AssertionError: expected 'Otters are mustelids.' to contain '1. Otters\n   https://good.example/ot…'
Tests  2 failed | 14 passed (16)
```

The existing `serp-providers-images.test.ts` walk — which asserts `SERP_PROVIDER_SEARCH_TYPES` matches what each client class implements, in both directions — now covers the two new providers and passes without change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uvj9vruwqqiUbLugo9pt3s

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvj9vruwqqiUbLugo9pt3s)_