### PR TITLE
fix(agents): refuse video input on a provider that cannot read it

### DIFF
--- a/packages/agents/src/capabilities/media.ts
+++ b/packages/agents/src/capabilities/media.ts
@@ -1254,6 +1254,23 @@ const scoreImageAdherence: CapabilityExport = {
 // ---------------------------------------------------------------------------
 
 /**
+ * Why a provider cannot read a clip, and what to do instead.
+ *
+ * The trap this names: a model search surfaces a video-capable model family
+ * (Gemini) served by an aggregator over an OpenAI-compatible chat API, which
+ * has no video content part. The model reads video; that route does not.
+ */
+function videoInputRefusal(provider: string): string {
+  return (
+    `${provider} does not accept video input. A model catalog can list a ` +
+    `video-capable model family behind an OpenAI-compatible endpoint, which ` +
+    `has no video content part — reading the clip needs a provider that takes ` +
+    `video natively (gemini), not just a model that can. Otherwise sample ` +
+    `frames with ffmpeg and read them with critique_image.`
+  );
+}
+
+/**
  * Read a video with a multimodal chat model.
  *
  * The video rides as a `video` content part next to the instruction; the
@@ -1280,6 +1297,9 @@ const understandVideo: CapabilityExport = {
         : DEFAULT_UNDERSTAND_VIDEO_TOKENS;
 
     try {
+      if (!(await run.context.providerSupportsVideoInput(m.provider))) {
+        return { error: videoInputRefusal(m.provider) };
+      }
       const text = await judgeCall(
         run.context,
         m,

--- a/packages/agents/tests/capabilities-media.test.ts
+++ b/packages/agents/tests/capabilities-media.test.ts
@@ -48,7 +48,10 @@ function makeContext(
 ): ProcessingContext {
   return {
     userId: "user-1",
-    runProviderPrediction
+    runProviderPrediction,
+    // What the real providers answer: Gemini reads a clip, an
+    // OpenAI-compatible endpoint has nowhere to put one.
+    providerSupportsVideoInput: async (id: string) => id === "gemini"
   } as unknown as ProcessingContext;
 }
 
@@ -320,6 +323,28 @@ describe("understand_video through the adapter", () => {
     expect(String(result["error"])).toBe(
       "understand_video failed: no video support"
     );
+  });
+
+  // The failure this capability actually hit: a model search offered
+  // `google/gemini-2.5-flash` served by AtlasCloud, whose chat API is
+  // OpenAI-compatible, so the call died inside the provider with a message
+  // naming openai.
+  it("refuses a provider that cannot take video, before spending a call", async () => {
+    const predict = vi.fn();
+    const result = (await asTool(understandVideo).process(
+      makeContext(predict),
+      {
+        provider: "atlascloud",
+        model: "google/gemini-2.5-flash",
+        video: "asset://clip-1.mp4"
+      }
+    )) as Record<string, unknown>;
+
+    expect(String(result["error"])).toMatch(
+      /atlascloud does not accept video input/
+    );
+    expect(String(result["error"])).toMatch(/gemini/);
+    expect(predict).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -3464,6 +3464,17 @@ export class ProcessingContext {
   }
 
   /**
+   * Whether a provider's chat API accepts a `video` content part. Lets a
+   * caller refuse before paying for a prediction that the provider would
+   * reject while resolving the message, which is where the video bytes have
+   * already been fetched and inlined.
+   */
+  async providerSupportsVideoInput(providerId: string): Promise<boolean> {
+    const provider = await this.getProvider(providerId);
+    return provider.supportsVideoInput;
+  }
+
+  /**
    * Generate speech as an encoded audio file (mp3/wav/…). Returns null when the
    * provider doesn't implement the encoded path. Used for providers (FAL, KIE,
    * ElevenLabs) that return audio files instead of streaming PCM.

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -291,6 +291,17 @@ export abstract class BaseProvider {
     return false;
   }
 
+  /**
+   * Whether this provider's chat API accepts a `video` content part. Only
+   * providers that read a whole clip natively answer `true` — an
+   * OpenAI-compatible endpoint re-hosting a video-capable model (AtlasCloud
+   * serving `google/gemini-2.5-flash`, say) does not, because the wire format
+   * has nowhere to put the bytes. Default `false`.
+   */
+  get supportsVideoInput(): boolean {
+    return false;
+  }
+
   setMessageEmitter(fn: (msg: unknown) => void): void {
     this._emitMessage = fn;
   }

--- a/packages/runtime/src/providers/gemini-provider.ts
+++ b/packages/runtime/src/providers/gemini-provider.ts
@@ -696,6 +696,11 @@ export class GeminiProvider extends BaseProvider {
     return true;
   }
 
+  /** Gemini reads a whole clip: see {@link videoContentToGeminiPart}. */
+  override get supportsVideoInput(): boolean {
+    return true;
+  }
+
   // ---------------------------------------------------------------------------
   // Model listing
   // ---------------------------------------------------------------------------

--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -923,7 +923,14 @@ export class OpenAIProvider extends BaseProvider {
     }
 
     if (content.type === "video") {
-      throw new Error("video input is not supported by openai");
+      // Named for the configured provider, not the wire format: every
+      // OpenAI-compatible re-host lands here, and reporting "openai" sent a
+      // diagnosis after the wrong provider.
+      throw new Error(
+        `video input is not supported by ${this.provider} — its chat API is ` +
+          `OpenAI-compatible, which has no video content part. Use a provider ` +
+          `whose chat models read video natively (gemini).`
+      );
     }
 
     const c = content as MessageImageContent;

--- a/packages/runtime/tests/providers/gemini-video-content.test.ts
+++ b/packages/runtime/tests/providers/gemini-video-content.test.ts
@@ -3,6 +3,7 @@ import {
   GeminiProvider,
   GEMINI_INLINE_VIDEO_MAX_BYTES
 } from "../../src/providers/gemini-provider.js";
+import { AtlasCloudProvider } from "../../src/providers/atlascloud-provider.js";
 
 function jsonResponse(
   body: unknown,
@@ -170,5 +171,22 @@ describe("GeminiProvider video content", () => {
     expect(result.contents[0].parts[0]).toEqual({
       text: "[unsupported content type]"
     });
+  });
+});
+
+describe("which providers declare they read video", () => {
+  it("Gemini says yes; an OpenAI-compatible re-host says no and names itself", async () => {
+    expect(new GeminiProvider({ GEMINI_API_KEY: "k" }).supportsVideoInput).toBe(
+      true
+    );
+
+    const atlas = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
+    expect(atlas.supportsVideoInput).toBe(false);
+    await expect(
+      atlas.convertMessage({
+        role: "user",
+        content: [{ type: "video", video: { uri: "x.mp4" } }]
+      })
+    ).rejects.toThrow(/video input is not supported by atlascloud/);
   });
 });


### PR DESCRIPTION
## What changed

`understand_video` handed the clip to whatever provider/model a model search returned. A catalog can list a video-capable model family behind an OpenAI-compatible chat API — AtlasCloud serving `google/gemini-2.5-flash` — and that wire format has no video content part, so the call died deep inside the provider *after* the bytes had been fetched and inlined, with an error naming `openai` rather than the provider actually configured. The model reads video; that route does not, and nothing in the path said so. Providers now declare it: `BaseProvider.supportsVideoInput` (false by default), overridden true by Gemini, which is the one chat provider here that reads a whole clip (`videoContentToGeminiPart`). `ProcessingContext.providerSupportsVideoInput` asks, and `understand_video` refuses up front, naming what to do instead — a provider that takes video natively, or ffmpeg frames through `critique_image`. The OpenAI-compatible branch's error now names `this.provider`, so a re-host's failure points at the re-host.

## Verification

- [x] `npm run lint` — exit 0 (warnings only, all pre-existing: unused imports in `media.ts` and elsewhere)
- [x] `npx vitest run --root packages/runtime` — 163 files, 3110 tests passed
- [x] `npx vitest run --root packages/agents` — 227 passed, 2 failed
- [ ] `npm run typecheck` — fails, pre-existing
- [ ] `npm run test:affected` — not run in full, see below
- [ ] `npm run dev:nodetool -- harness gate --base main` — not runnable, see below

**Pre-existing breakage in this checkout, not from this diff.** `packages/model3d` is declared in the root `package.json` workspaces but has **zero tracked files** (`git ls-files packages/model3d` → 0), so `@nodetool-ai/model3d` resolves to nothing. That makes `npm run build:packages` fail on `@nodetool-ai/agents` (42/43 packages build), which in turn blocks anything reading `packages/cli/dist` — `capabilities:check` and `harness gate` both exit with `ERR_MODULE_NOT_FOUND` on `packages/cli/dist/harness/capability-coverage.js`. `npm run typecheck` reports 14 `TS2307` errors, all missing modules (`@nodetool-ai/model3d`, `@nodetool-ai/base-nodes`, `@nodetool-ai/code-nodes`, `@nodetool-ai/automation-nodes`), none in a file this diff touches. The 2 failing agents suites are `capabilities-flow` and `capabilities-model3d`, for the same reason.

Confirmed pre-existing rather than assumed: `git stash -u` and re-run gives the identical 9 `model3d` type errors and the identical 7 test failures. Because `build:packages` cannot complete, the full `npm run test:affected` plan (47 packages + web + electron, since `runtime` is a base package) is not viable here; the two suites that actually cover this change were run in full instead.

**Both new checks were inverted and observed failing.**

`GeminiProvider.supportsVideoInput` flipped to `false`:

```
AssertionError: expected false to be true // Object.is equality
      Tests  1 failed | 5 passed (6)
```

The `understand_video` pre-check deleted:

```
× refuses a provider that cannot take video, before spending a call 7ms
 FAIL  tests/capabilities-media.test.ts > understand_video through the adapter >
       refuses a provider that cannot take video, before spending a call
      Tests  1 failed | 45 passed (46)
```

Both pass restored.

## Agent capabilities

No capability is added and no declared contract changes — `understandVideoSpec` (name, description, input schema, category, `needsToolCallId`) is untouched. Only the implementation's failure path changed. `capabilities:check` could not be run for the dist reason above.

## New checks

- [x] Each was inverted once and observed failing; the failing output is in **Verification**
- [x] Not an audit — two assertions over live provider instances and one over the capability's return, so neither can pass by matching nothing

---
_Generated by [Claude Code](https://claude.ai/code/session_011GAxF69VD1BvPHcLZ92xkg)_