### PR TITLE
feat(projects): make a project a tab group, a list, and an overview

### DIFF
--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -224,6 +224,7 @@ export {
   scriptStatus,
   spendCategory,
   storyboardStatus,
+  storyboardThumbnails,
   summarizeProject,
   summarizeSpend,
   timelineStatus
@@ -236,12 +237,14 @@ export type {
   ProjectDocumentType,
   ProjectSpend,
   ProjectSummary,
+  ProjectThumbnail,
   ScriptStatus,
   SpendCategory,
   SpendRow,
   StoryboardStatus,
   TimelineStatus
 } from "./project-summary.js";
+export { moveDocumentToProject } from "./project-membership.js";
 export {
   Script,
   ScriptConflictError,

--- a/packages/models/src/project-membership.ts
+++ b/packages/models/src/project-membership.ts
@@ -1,0 +1,102 @@
+/**
+ * Moving a document between projects.
+ *
+ * Membership is one column on the document's own table, so a move is one
+ * write per document — there is no join table to keep in step. The write
+ * deliberately leaves `updated_at` alone: a project is not content, and
+ * bumping the column would break the compare-and-swap save of an editor that
+ * has the document open.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { getDb } from "./db.js";
+import { applications } from "./schema/applications.js";
+import { imageDocuments } from "./schema/image-documents.js";
+import { jsScripts } from "./schema/js-scripts.js";
+import { scripts } from "./schema/scripts.js";
+import { storyboards } from "./schema/storyboards.js";
+import { timelineSequences } from "./schema/timeline-sequences.js";
+import type { ProjectDocumentType } from "./project-summary.js";
+
+/**
+ * Point one document at `projectId`. Pass {@link LOOSE_PROJECT_ID} to move it
+ * back out of every project. Returns false when the caller owns no such
+ * document, so a wrong id reads as a miss rather than as a silent no-op.
+ */
+export async function moveDocumentToProject(
+  userId: string,
+  type: ProjectDocumentType,
+  documentId: string,
+  projectId: string
+): Promise<boolean> {
+  const db = getDb();
+  const fields = { project_id: projectId };
+  switch (type) {
+    case "storyboard": {
+      const rows = await db
+        .update(storyboards)
+        .set(fields)
+        .where(
+          and(eq(storyboards.id, documentId), eq(storyboards.user_id, userId))
+        )
+        .returning();
+      return rows.length > 0;
+    }
+    case "script": {
+      const rows = await db
+        .update(scripts)
+        .set(fields)
+        .where(and(eq(scripts.id, documentId), eq(scripts.user_id, userId)))
+        .returning();
+      return rows.length > 0;
+    }
+    case "timeline": {
+      const rows = await db
+        .update(timelineSequences)
+        .set(fields)
+        .where(
+          and(
+            eq(timelineSequences.id, documentId),
+            eq(timelineSequences.user_id, userId)
+          )
+        )
+        .returning();
+      return rows.length > 0;
+    }
+    case "sketch": {
+      const rows = await db
+        .update(imageDocuments)
+        .set(fields)
+        .where(
+          and(
+            eq(imageDocuments.id, documentId),
+            eq(imageDocuments.user_id, userId)
+          )
+        )
+        .returning();
+      return rows.length > 0;
+    }
+    case "application": {
+      const rows = await db
+        .update(applications)
+        .set(fields)
+        .where(
+          and(eq(applications.id, documentId), eq(applications.user_id, userId))
+        )
+        .returning();
+      return rows.length > 0;
+    }
+    case "jsscript": {
+      const rows = await db
+        .update(jsScripts)
+        .set(fields)
+        .where(and(eq(jsScripts.id, documentId), eq(jsScripts.user_id, userId)))
+        .returning();
+      return rows.length > 0;
+    }
+    default: {
+      const exhaustive: never = type;
+      return exhaustive;
+    }
+  }
+}

--- a/packages/models/src/project-summary.ts
+++ b/packages/models/src/project-summary.ts
@@ -86,6 +86,15 @@ export type ProjectDocumentStatus =
   | ScriptStatus
   | TimelineStatus;
 
+/**
+ * A media locator a card can render — the stored `*Ref` shape, passed through
+ * untouched. `asset://` is an identifier, not a URL, so the client resolves it.
+ */
+export interface ProjectThumbnail {
+  uri?: string;
+  asset_id?: string | null;
+}
+
 /** A document card: the tab-open ref, what it shows, and what it cost. */
 export interface ProjectDocumentSummary extends ProjectDocumentRef {
   status: ProjectDocumentStatus | null;
@@ -93,6 +102,8 @@ export interface ProjectDocumentSummary extends ProjectDocumentRef {
   spendUsd: number;
   /** Calls attributed to it that no catalog priced. */
   unpricedCount: number;
+  /** Stills the card montages, oldest shot first. Empty when there are none. */
+  thumbnails: ProjectThumbnail[];
 }
 
 /** What a run paid for, in the categories the spend bar is split by. */
@@ -118,6 +129,9 @@ export interface ProjectSummary {
 
 // ── Status ───────────────────────────────────────────────────────────────────
 
+/** How many stills a card's montage shows. The mockup's grid holds three. */
+const MONTAGE_LIMIT = 3;
+
 export function storyboardStatus(doc: StoryboardDocument): StoryboardStatus {
   return {
     kind: "storyboard",
@@ -125,6 +139,24 @@ export function storyboardStatus(doc: StoryboardDocument): StoryboardStatus {
     stills: doc.shots.filter((shot) => shot.keyframe != null).length,
     clips: doc.shots.filter((shot) => shot.clip != null).length
   };
+}
+
+/** The first stills a board has rendered, for the card montage. */
+export function storyboardThumbnails(
+  doc: StoryboardDocument,
+  limit = MONTAGE_LIMIT
+): ProjectThumbnail[] {
+  const stills: ProjectThumbnail[] = [];
+  for (const shot of doc.shots) {
+    if (stills.length >= limit) break;
+    const keyframe = shot.keyframe;
+    if (!keyframe) continue;
+    stills.push({
+      uri: keyframe.uri,
+      asset_id: keyframe.asset_id ?? null
+    });
+  }
+  return stills;
 }
 
 export function scriptStatus(doc: ScriptDocument): ScriptStatus {
@@ -337,21 +369,28 @@ export async function summarizeProject(
 
   const summarize = (
     ref: ProjectDocumentRef,
-    status: ProjectDocumentStatus | null
+    status: ProjectDocumentStatus | null,
+    thumbnails: ProjectThumbnail[] = []
   ): ProjectDocumentSummary => {
     const spend = perDocument.get(ref.ref);
     return {
       ...ref,
       status,
       spendUsd: spend?.usd ?? 0,
-      unpricedCount: spend?.unpriced ?? 0
+      unpricedCount: spend?.unpriced ?? 0,
+      thumbnails
     };
   };
 
   const documents = newestFirst<ProjectDocumentSummary>([
-    ...rows.storyboards.map((row) =>
-      summarize(toRef("storyboard", row), storyboardStatus(row.toDocument()))
-    ),
+    ...rows.storyboards.map((row) => {
+      const doc = row.toDocument();
+      return summarize(
+        toRef("storyboard", row),
+        storyboardStatus(doc),
+        storyboardThumbnails(doc)
+      );
+    }),
     ...rows.scripts.map((row) =>
       summarize(toRef("script", row), scriptStatus(row.toDocument()))
     ),

--- a/packages/models/tests/project.test.ts
+++ b/packages/models/tests/project.test.ts
@@ -15,11 +15,14 @@ import {
   scriptStatus,
   spendCategory,
   storyboardStatus,
+  storyboardThumbnails,
   summarizeProject,
   summarizeSpend,
   timelineStatus,
   type SpendRow
 } from "../src/project-summary.js";
+import { moveDocumentToProject } from "../src/project-membership.js";
+import { LOOSE_PROJECT_ID } from "../src/project.js";
 import { Prediction } from "../src/prediction.js";
 import { Script, type ScriptDocument } from "../src/script.js";
 import { Storyboard, type StoryboardDocument } from "../src/storyboard.js";
@@ -292,5 +295,69 @@ describe("summarizeProject", () => {
       status: { kind: "storyboard", shots: 2, stills: 1, clips: 0 }
     });
     expect(summary.spend.totalUsd).toBeCloseTo(0.75, 6);
+  });
+});
+
+describe("storyboardThumbnails", () => {
+  it("takes the rendered stills in shot order, skipping the shots without one", () => {
+    const thumbs = storyboardThumbnails(
+      storyboardDoc([
+        shot("a"),
+        shot("b", { keyframe: { type: "image", uri: "asset://b" } }),
+        shot("c", { keyframe: { type: "image", asset_id: "c" } })
+      ])
+    );
+    expect(thumbs).toEqual([
+      { uri: "asset://b", asset_id: null },
+      { uri: undefined, asset_id: "c" }
+    ]);
+  });
+
+  it("stops at the montage limit", () => {
+    const shots = ["a", "b", "c", "d"].map((id) =>
+      shot(id, { keyframe: { type: "image", uri: `asset://${id}` } })
+    );
+    expect(storyboardThumbnails(storyboardDoc(shots))).toHaveLength(3);
+  });
+});
+
+describe("moveDocumentToProject", () => {
+  beforeEach(() => initTestDb());
+
+  it("moves a document in and back out without touching updated_at", async () => {
+    const board = await Storyboard.create<Storyboard>({
+      user_id: "u1",
+      name: "Board"
+    });
+    expect(board.project_id).toBe(LOOSE_PROJECT_ID);
+
+    expect(await moveDocumentToProject("u1", "storyboard", board.id, "p1")).toBe(
+      true
+    );
+    const moved = await Storyboard.findById(board.id);
+    expect(moved?.project_id).toBe("p1");
+    // A move is not an edit: an open editor's compare-and-swap save must
+    // still apply afterwards.
+    expect(moved?.updated_at).toBe(board.updated_at);
+
+    expect(
+      await moveDocumentToProject("u1", "storyboard", board.id, LOOSE_PROJECT_ID)
+    ).toBe(true);
+    expect((await Storyboard.findById(board.id))?.project_id).toBe(
+      LOOSE_PROJECT_ID
+    );
+  });
+
+  it("refuses another user's document and an id that does not exist", async () => {
+    const theirs = await Script.create<Script>({ user_id: "u2", name: "Theirs" });
+    expect(await moveDocumentToProject("u1", "script", theirs.id, "p1")).toBe(
+      false
+    );
+    expect((await Script.findById(theirs.id))?.project_id).toBe(
+      LOOSE_PROJECT_ID
+    );
+    expect(await moveDocumentToProject("u1", "script", "no-such-id", "p1")).toBe(
+      false
+    );
   });
 });

--- a/packages/protocol/src/api-schemas/projects.ts
+++ b/packages/protocol/src/api-schemas/projects.ts
@@ -79,10 +79,22 @@ export const projectDocumentStatus = z.discriminatedUnion("kind", [
 ]);
 export type ProjectDocumentStatus = z.infer<typeof projectDocumentStatus>;
 
+/**
+ * A stored media locator a card renders through `ResponsiveImage`. `asset://`
+ * is an identifier, not a URL — the client resolves it.
+ */
+export const projectThumbnail = z.object({
+  uri: z.string().optional(),
+  asset_id: z.string().nullable().optional()
+});
+export type ProjectThumbnail = z.infer<typeof projectThumbnail>;
+
 export const projectDocumentSummary = projectDocumentRef.extend({
   status: projectDocumentStatus.nullable(),
   spendUsd: z.number(),
-  unpricedCount: z.number()
+  unpricedCount: z.number(),
+  /** Stills the card montages. Empty for the kinds that render none. */
+  thumbnails: z.array(projectThumbnail)
 });
 export type ProjectDocumentSummary = z.infer<typeof projectDocumentSummary>;
 
@@ -113,3 +125,14 @@ export const projectDetail = z.object({
   spend: projectSpend
 });
 export type ProjectDetail = z.infer<typeof projectDetail>;
+
+/**
+ * Move one document into a project, or — with {@link LOOSE_PROJECT_ID} — back
+ * out of every project.
+ */
+export const assignDocumentInput = z.object({
+  projectId: z.string(),
+  type: projectDocumentType,
+  ref: z.string()
+});
+export type AssignDocumentInput = z.infer<typeof assignDocumentInput>;

--- a/packages/websocket/src/trpc/routers/projects.ts
+++ b/packages/websocket/src/trpc/routers/projects.ts
@@ -7,17 +7,27 @@
  * status, per-document spend, and the project's spend split by category.
  *
  * Procedures:
- *   list      (query)    — ProjectResponse[]
- *   get       (query)    — ProjectDetail (project + documents + spend)
- *   documents (query)    — ProjectDocumentRef[]
- *   create    (mutation) — ProjectResponse
- *   update    (mutation) — ProjectResponse
- *   delete    (mutation) — { ok: true }
+ *   list           (query)    — ProjectResponse[]
+ *   summaries      (query)    — ProjectDetail[] (every project, for the list)
+ *   get            (query)    — ProjectDetail (project + documents + spend)
+ *   documents      (query)    — ProjectDocumentRef[]
+ *   unassigned     (query)    — ProjectDocumentRef[] in the loose bucket
+ *   create         (mutation) — ProjectResponse
+ *   update         (mutation) — ProjectResponse
+ *   delete         (mutation) — { ok: true }
+ *   assignDocument (mutation) — { ok: true }
  */
 
 import { z } from "zod";
-import { Project, listProjectDocuments, summarizeProject } from "@nodetool-ai/models";
 import {
+  LOOSE_PROJECT_ID,
+  Project,
+  listProjectDocuments,
+  moveDocumentToProject,
+  summarizeProject
+} from "@nodetool-ai/models";
+import {
+  assignDocumentInput,
   createProjectInput,
   patchProjectInput,
   projectDetail,
@@ -49,6 +59,28 @@ export const projectsRouter = router({
       return items.map((item) => item.toResponse());
     }),
 
+  /**
+   * Every project with the rollup its card shows. The projects list needs
+   * status and spend per card, and asking for them one project at a time is
+   * the same work over N round trips.
+   */
+  summaries: protectedProcedure
+    .input(listInput)
+    .output(z.array(projectDetail))
+    .query(async ({ ctx }) => {
+      const projects = await Project.listByUser(ctx.userId);
+      return Promise.all(
+        projects.map(async (project) => {
+          const summary = await summarizeProject(ctx.userId, project.id);
+          return projectDetail.parse({
+            project: project.toResponse(),
+            documents: summary.documents,
+            spend: summary.spend
+          });
+        })
+      );
+    }),
+
   get: protectedProcedure
     .input(idInput)
     .output(projectDetail)
@@ -69,6 +101,16 @@ export const projectsRouter = router({
       await loadOwned(ctx.userId, input.id);
       return listProjectDocuments(ctx.userId, input.id);
     }),
+
+  /**
+   * The loose bucket: documents belonging to no project. It has no row of its
+   * own by design, so it is its own procedure rather than an id `documents`
+   * would have to special-case.
+   */
+  unassigned: protectedProcedure
+    .input(listInput)
+    .output(z.array(projectDocumentRef))
+    .query(({ ctx }) => listProjectDocuments(ctx.userId, LOOSE_PROJECT_ID)),
 
   create: protectedProcedure
     .input(createProjectInput)
@@ -111,6 +153,28 @@ export const projectsRouter = router({
     .mutation(async ({ ctx, input }) => {
       await loadOwned(ctx.userId, input.id);
       await Project.deleteOwned(ctx.userId, input.id);
+      return { ok: true as const };
+    }),
+
+  /**
+   * Move one document into a project — or, with the loose bucket's id, back
+   * out of every project. The document's own `updated_at` is left alone, so a
+   * move does not conflict with an editor that has it open.
+   */
+  assignDocument: protectedProcedure
+    .input(assignDocumentInput)
+    .output(okOutput)
+    .mutation(async ({ ctx, input }) => {
+      if (input.projectId !== LOOSE_PROJECT_ID) {
+        await loadOwned(ctx.userId, input.projectId);
+      }
+      const moved = await moveDocumentToProject(
+        ctx.userId,
+        input.type,
+        input.ref,
+        input.projectId
+      );
+      if (!moved) throwApiError(ApiErrorCode.NOT_FOUND, "Document not found");
       return { ok: true as const };
     })
 });

--- a/packages/websocket/src/trpc/sandbox-coverage.ts
+++ b/packages/websocket/src/trpc/sandbox-coverage.ts
@@ -588,6 +588,12 @@ export const SANDBOX_API_COVERAGE: Readonly<
       "rather than as untrusted text. A run that could grant itself " +
       "trust could escalate a prompt injection into executed code."
   },
+  "projects.assignDocument": {
+    gap:
+      "Same grouping surface as `projects.create`. Moves one document " +
+      "between projects; both the document and the project are the " +
+      "caller's own rows."
+  },
   "projects.create": {
     gap:
       "A project groups documents that already carry its id, and a run " +
@@ -615,6 +621,16 @@ export const SANDBOX_API_COVERAGE: Readonly<
   },
   "projects.list": {
     gap: "Same grouping surface as `projects.create`."
+  },
+  "projects.summaries": {
+    gap:
+      "Same grouping surface as `projects.create`. The whole list of " +
+      "rollups `projects.get` returns one at a time."
+  },
+  "projects.unassigned": {
+    gap:
+      "Lists the documents in no project. Same grouping surface as " +
+      "`projects.documents`, other side of the same column."
   },
   "projects.update": {
     gap: "Same grouping surface as `projects.create`. Renames a project."

--- a/packages/websocket/tests/trpc-projects.test.ts
+++ b/packages/websocket/tests/trpc-projects.test.ts
@@ -8,8 +8,10 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   initTestDb,
+  LOOSE_PROJECT_ID,
   ModelObserver,
   Prediction,
+  Script,
   Storyboard
 } from "@nodetool-ai/models";
 import { appRouter } from "../src/trpc/router.js";
@@ -118,7 +120,8 @@ describe("projects router", () => {
         updatedAt: board.updated_at,
         status: { kind: "storyboard", shots: 2, stills: 1, clips: 0 },
         spendUsd: 0.5,
-        unpricedCount: 0
+        unpricedCount: 0,
+        thumbnails: [{ uri: "asset://1", asset_id: null }]
       }
     ]);
     expect(detail.spend.totalUsd).toBeCloseTo(0.5, 6);
@@ -137,5 +140,85 @@ describe("projects router", () => {
         updatedAt: board.updated_at
       }
     ]);
+  });
+
+  it("returns one rollup per project in summaries", async () => {
+    const aurora = await caller().projects.create({ name: "Aurora", kind: "" });
+    await caller().projects.create({ name: "Meridian", kind: "" });
+    await Storyboard.create<Storyboard>({
+      user_id: "user-1",
+      project_id: aurora.id,
+      name: "Board"
+    });
+    // Another user's project must not appear in this user's list.
+    await caller("user-2").projects.create({ name: "Theirs", kind: "" });
+
+    const summaries = await caller().projects.summaries({});
+    expect(summaries.map((s) => s.project.name).sort()).toEqual([
+      "Aurora",
+      "Meridian"
+    ]);
+    const auroraSummary = summaries.find((s) => s.project.id === aurora.id);
+    expect(auroraSummary?.documents.map((d) => d.name)).toEqual(["Board"]);
+  });
+
+  it("lists the documents in no project, and moves one in and back out", async () => {
+    const project = await caller().projects.create({ name: "Aurora", kind: "" });
+    const loose = await Script.create<Script>({
+      user_id: "user-1",
+      name: "Scratch VO"
+    });
+    await Script.create<Script>({ user_id: "user-2", name: "Theirs" });
+
+    expect((await caller().projects.unassigned({})).map((d) => d.ref)).toEqual([
+      loose.id
+    ]);
+
+    await caller().projects.assignDocument({
+      projectId: project.id,
+      type: "script",
+      ref: loose.id
+    });
+    expect(await caller().projects.unassigned({})).toEqual([]);
+    expect(
+      (await caller().projects.documents({ id: project.id })).map((d) => d.ref)
+    ).toEqual([loose.id]);
+
+    await caller().projects.assignDocument({
+      projectId: LOOSE_PROJECT_ID,
+      type: "script",
+      ref: loose.id
+    });
+    expect((await caller().projects.unassigned({})).map((d) => d.ref)).toEqual([
+      loose.id
+    ]);
+  });
+
+  it("refuses a move into a project the caller does not own, and of a document they do not own", async () => {
+    const theirs = await caller("user-2").projects.create({
+      name: "Theirs",
+      kind: ""
+    });
+    const mine = await Script.create<Script>({ user_id: "user-1", name: "Mine" });
+    await expect(
+      caller().projects.assignDocument({
+        projectId: theirs.id,
+        type: "script",
+        ref: mine.id
+      })
+    ).rejects.toThrow(/not found/i);
+
+    const project = await caller().projects.create({ name: "Aurora", kind: "" });
+    const notMine = await Script.create<Script>({
+      user_id: "user-2",
+      name: "Theirs"
+    });
+    await expect(
+      caller().projects.assignDocument({
+        projectId: project.id,
+        type: "script",
+        ref: notMine.id
+      })
+    ).rejects.toThrow(/not found/i);
   });
 });

--- a/web/src/components/applications/ApplicationListPanel.tsx
+++ b/web/src/components/applications/ApplicationListPanel.tsx
@@ -68,12 +68,13 @@ const useOpenApplication = () => {
   const location = useLocation();
 
   return useCallback(
-    (id: string, name: string) => {
+    (id: string, name: string, projectId?: string) => {
       openTab({
         type: "application",
         ref: id,
         mode: "edit",
-        title: name || UNTITLED
+        title: name || UNTITLED,
+        projectId
       });
       if (!location.pathname.startsWith("/workspace")) {
         navigate("/workspace");
@@ -95,7 +96,7 @@ export const CreateApplicationButton = memo(function CreateApplicationButton() {
         description: "",
         projectId: creationProjectId()
       });
-      openApplication(created.id, created.name);
+      openApplication(created.id, created.name, created.projectId);
     } catch (error) {
       console.error("Failed to create app", error);
     }
@@ -139,7 +140,7 @@ export const CreateApplicationFromWorkflowButton = memo(
             projectId: creationProjectId(),
             fromWorkflowId: workflowId
           });
-          openApplication(created.id, created.name);
+          openApplication(created.id, created.name, created.projectId);
         } catch (error) {
           console.error("Failed to create app from workflow", error);
         }

--- a/web/src/components/jsScript/JsScriptListPanel.tsx
+++ b/web/src/components/jsScript/JsScriptListPanel.tsx
@@ -45,7 +45,8 @@ export const CreateJsScriptButton = memo(function CreateJsScriptButton() {
         type: "jsscript",
         ref: created.id,
         mode: "edit",
-        title: created.name || DEFAULT_NAME
+        title: created.name || DEFAULT_NAME,
+        projectId: created.projectId
       });
       if (!location.pathname.startsWith("/workspace")) {
         navigate("/workspace");

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -57,6 +57,7 @@ import FavoritesTiles from "../node_menu/FavoritesTiles";
 import QuickAccessSidebar from "../node_menu/QuickAccessSidebar";
 import NodeLibrary from "../node_menu/NodeLibrary";
 import RailAppMenu from "./RailAppMenu";
+import ProjectsRailButton from "../projects/ProjectsRailButton";
 import AppPagesList from "./AppPagesList";
 import WorkspaceTree from "../workspaces/WorkspaceTree";
 
@@ -263,12 +264,15 @@ const VerticalToolbar = memo(function VerticalToolbar({
   onViewChange,
   handlePanelToggle,
   showAppMenu = false,
+  showProjects = false,
   hiddenViews
 }: {
   activeView: LeftPanelView;
   onViewChange: (view: LeftPanelView) => void;
   handlePanelToggle: () => void;
   showAppMenu?: boolean;
+  /** Projects open as tabs, so the entry only exists in the workspace shell. */
+  showProjects?: boolean;
   hiddenViews?: readonly LeftPanelView[];
 }) {
   const panelVisible = usePanelStore((state) => state.panel.isVisible);
@@ -294,6 +298,7 @@ const VerticalToolbar = memo(function VerticalToolbar({
   return (
     <div className="vertical-toolbar">
       {showAppMenu && <RailAppMenu />}
+      {showProjects && <ProjectsRailButton />}
       <QuickAccessSidebar
         activeCategory={renderedActive}
         onCategoryClick={onViewChange}
@@ -1141,6 +1146,7 @@ const PanelLeft: React.FC = () => {
           onViewChange={onViewChange}
           handlePanelToggle={handlePanelToggleClick}
           showAppMenu={isWorkspace}
+          showProjects={isWorkspace}
           hiddenViews={hiddenViews}
         />
 

--- a/web/src/components/projects/ProjectCard.tsx
+++ b/web/src/components/projects/ProjectCard.tsx
@@ -1,0 +1,155 @@
+import { memo, useCallback, useState, type DragEvent } from "react";
+
+import {
+  BORDER_RADIUS,
+  Box,
+  Card,
+  Caption,
+  FlexColumn,
+  FlexRow,
+  MOTION,
+  ResponsiveImage,
+  SPACING,
+  StatusPill,
+  Text,
+  TYPOGRAPHY
+} from "../ui_primitives";
+import { relativeTime } from "../../utils/formatDateAndTime";
+import { PROJECT_COLOR, PROJECT_GLYPH } from "./projectIdentity";
+import {
+  formatSpend,
+  projectProgress,
+  projectStatusLine,
+  type ProjectDetail
+} from "./projectStatus";
+import { TYPE_COLOR, TYPE_GLYPH } from "../workspace/tabTypeIdentity";
+
+const MEDIA_HEIGHT = 176;
+
+interface ProjectCardProps {
+  detail: ProjectDetail;
+  onOpen: (project: ProjectDetail["project"]) => void;
+  /** A loose document was dropped on the card — move it into this project. */
+  onDropDocument: (projectId: string, payload: string) => void;
+}
+
+/**
+ * One project in the list: what it has rendered, what it cost, and — for a
+ * board that has stills — what it looks like.
+ */
+const ProjectCard = ({ detail, onOpen, onDropDocument }: ProjectCardProps) => {
+  const [dropActive, setDropActive] = useState(false);
+  const { project, documents, spend } = detail;
+  const stills = documents.flatMap((doc) => doc.thumbnails).slice(0, 3);
+  const progress = projectProgress(documents);
+
+  const handleDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      setDropActive(false);
+      onDropDocument(project.id, event.dataTransfer.getData("text/plain"));
+    },
+    [onDropDocument, project.id]
+  );
+
+  return (
+    <Card
+      variant="outlined"
+      padding="none"
+      clickable
+      onClick={() => onOpen(project)}
+      aria-label={project.name}
+      onDragOver={(event: DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        setDropActive(true);
+      }}
+      onDragLeave={() => setDropActive(false)}
+      onDrop={handleDrop}
+      sx={{
+        overflow: "hidden",
+        borderRadius: BORDER_RADIUS.lg,
+        borderColor: dropActive ? "primary.main" : "divider",
+        transition: MOTION.border
+      }}
+    >
+      <Box
+        sx={{
+          position: "relative",
+          height: `${MEDIA_HEIGHT}px`,
+          bgcolor: "background.paper",
+          display: "grid",
+          gap: "2px",
+          gridTemplateColumns: stills.length > 1 ? "2fr 1fr" : "1fr",
+          gridTemplateRows: stills.length > 2 ? "1fr 1fr" : "1fr"
+        }}
+      >
+        {stills.map((still, index) => (
+          <ResponsiveImage
+            key={still.asset_id ?? still.uri ?? index}
+            locator={still}
+            alt=""
+            fit="cover"
+            sx={{
+              width: "100%",
+              height: "100%",
+              gridRow: index === 0 && stills.length > 2 ? "span 2" : undefined
+            }}
+          />
+        ))}
+        {stills.length === 0 && (
+          <FlexRow align="center" justify="center" fullHeight>
+            <Caption color="muted">No stills yet</Caption>
+          </FlexRow>
+        )}
+        {progress && (
+          <StatusPill
+            tone={progress.done ? "done" : "neutral"}
+            sx={{
+              position: "absolute",
+              left: SPACING.md,
+              bottom: SPACING.md
+            }}
+          >
+            {progress.label}
+          </StatusPill>
+        )}
+      </Box>
+
+      <FlexColumn gap={SPACING.md} sx={{ p: SPACING.xl }}>
+        <FlexRow align="center" gap={SPACING.md}>
+          <Box component="span" aria-hidden sx={{ color: PROJECT_COLOR }}>
+            {PROJECT_GLYPH}
+          </Box>
+          <Text sx={{ flex: 1, ...TYPOGRAPHY.sans.label }}>{project.name}</Text>
+          <Caption color="secondary">
+            {relativeTime(project.updatedAt)}
+          </Caption>
+        </FlexRow>
+        <Caption color="secondary">{projectStatusLine(documents)}</Caption>
+        <FlexRow align="center" gap={SPACING.md}>
+          <FlexRow gap={SPACING.sm} aria-hidden>
+            {documents.map((doc) => (
+              <Box
+                key={`${doc.type}:${doc.ref}`}
+                component="span"
+                sx={{
+                  color: TYPE_COLOR[doc.type],
+                  ...TYPOGRAPHY.sans.caption
+                }}
+              >
+                {TYPE_GLYPH[doc.type]}
+              </Box>
+            ))}
+          </FlexRow>
+          <Box sx={{ flex: 1 }} />
+          <Box component="span" sx={{ ...TYPOGRAPHY.mono.caption }}>
+            {formatSpend(spend)}
+          </Box>
+          <Caption color="muted">provider rates</Caption>
+        </FlexRow>
+      </FlexColumn>
+    </Card>
+  );
+};
+
+export default memo(ProjectCard);

--- a/web/src/components/projects/ProjectCard.tsx
+++ b/web/src/components/projects/ProjectCard.tsx
@@ -78,7 +78,7 @@ const ProjectCard = ({ detail, onOpen, onDropDocument }: ProjectCardProps) => {
           height: `${MEDIA_HEIGHT}px`,
           bgcolor: "background.paper",
           display: "grid",
-          gap: "2px",
+          gap: SPACING.micro,
           gridTemplateColumns: stills.length > 1 ? "2fr 1fr" : "1fr",
           gridTemplateRows: stills.length > 2 ? "1fr 1fr" : "1fr"
         }}

--- a/web/src/components/projects/ProjectListSurface.tsx
+++ b/web/src/components/projects/ProjectListSurface.tsx
@@ -1,0 +1,337 @@
+import { useCallback, useMemo, useState, type DragEvent } from "react";
+
+import {
+  BORDER_RADIUS,
+  Box,
+  Caption,
+  Dialog,
+  Divider,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  Label,
+  LoadingSpinner,
+  SPACING,
+  ScrollArea,
+  SearchInput,
+  Text,
+  TextInput,
+  TYPOGRAPHY
+} from "../ui_primitives";
+import { useNotificationStore } from "../../stores/NotificationStore";
+import { isRecord, isString } from "../../utils/typePredicates";
+import type { RouterOutputs } from "../../trpc/client";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import { TYPE_COLOR, TYPE_GLYPH } from "../workspace/tabTypeIdentity";
+import {
+  useAssignDocument,
+  useCreateProject,
+  useOpenProject,
+  useProjectSummaries,
+  useUnassignedDocuments
+} from "../../hooks/useProjects";
+import ProjectCard from "./ProjectCard";
+import { PROJECT_COLOR } from "./projectIdentity";
+import type { ProjectDetail } from "./projectStatus";
+
+/**
+ * How many loose documents the strip lists. Every document a user has ever
+ * made is loose until they file it, so the strip shows the newest and says it
+ * is showing only those.
+ */
+const LOOSE_STRIP_LIMIT = 12;
+
+/** A loose document travels as its `(type, ref, name)` on the drag payload. */
+type LooseDocument = RouterOutputs["projects"]["unassigned"][number];
+
+const PROJECT_DOCUMENT_TYPES: readonly LooseDocument["type"][] = [
+  "storyboard",
+  "script",
+  "timeline",
+  "sketch",
+  "application",
+  "jsscript"
+];
+
+const isLooseDocument = (value: unknown): value is LooseDocument => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const { type, ref, name } = value;
+  return (
+    isString(type) &&
+    (PROJECT_DOCUMENT_TYPES as readonly string[]).includes(type) &&
+    isString(ref) &&
+    isString(name)
+  );
+};
+
+/** The strip's own drag payload, or nothing when the drag came from elsewhere. */
+const parseDragPayload = (payload: string): LooseDocument | null => {
+  try {
+    const parsed: unknown = JSON.parse(payload);
+    return isLooseDocument(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * The projects list: every project as a card, and beneath them the documents
+ * that belong to none. Dragging one of those onto a card moves it in.
+ */
+const ProjectListSurface = () => {
+  const [search, setSearch] = useState("");
+  const [newName, setNewName] = useState("");
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const summaries = useProjectSummaries();
+  const unassigned = useUnassignedDocuments();
+  const createProject = useCreateProject();
+  const assignDocument = useAssignDocument();
+  const openProject = useOpenProject();
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification
+  );
+
+  const matches = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    const all = summaries.data ?? [];
+    return needle
+      ? all.filter((entry) =>
+          entry.project.name.toLowerCase().includes(needle)
+        )
+      : all;
+  }, [search, summaries.data]);
+
+  const looseTotal = unassigned.data?.length ?? 0;
+  const loose = useMemo(
+    () => (unassigned.data ?? []).slice(0, LOOSE_STRIP_LIMIT),
+    [unassigned.data]
+  );
+
+  const handleOpen = useCallback(
+    (project: ProjectDetail["project"]) => {
+      void openProject(project);
+    },
+    [openProject]
+  );
+
+  const handleCreate = useCallback(async () => {
+    const name = newName.trim();
+    if (name.length === 0) {
+      return;
+    }
+    try {
+      const project = await createProject.mutateAsync({ name, kind: "" });
+      setDialogOpen(false);
+      setNewName("");
+      await openProject(project);
+    } catch (error) {
+      addNotification({
+        type: "error",
+        alert: true,
+        content: `Could not create the project: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      });
+    }
+  }, [addNotification, createProject, newName, openProject]);
+
+  const handleDropDocument = useCallback(
+    (projectId: string, payload: string) => {
+      const document = parseDragPayload(payload);
+      if (!document) {
+        return;
+      }
+      assignDocument.mutate(
+        { projectId, type: document.type, ref: document.ref },
+        {
+          onError: (error) =>
+            addNotification({
+              type: "error",
+              alert: true,
+              content: `Could not move ${document.name}: ${error.message}`
+            })
+        }
+      );
+    },
+    [addNotification, assignDocument]
+  );
+
+  const handleDragStart = useCallback(
+    (event: DragEvent<HTMLDivElement>, document: LooseDocument) => {
+      event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.setData("text/plain", JSON.stringify(document));
+    },
+    []
+  );
+
+  return (
+    <FlexColumn fullHeight sx={{ overflow: "hidden" }}>
+      <FlexRow
+        align="center"
+        gap={SPACING.xl}
+        sx={{ px: SPACING.xxl, pt: SPACING.xxl, pb: SPACING.md }}
+      >
+        <Text size="big">Projects</Text>
+        <Caption color="secondary">
+          One piece of work — the documents an agent built for it, what it
+          cost, where it stands.
+        </Caption>
+        <Box sx={{ flex: 1 }} />
+        <SearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder="Search projects"
+        />
+        <EditorButton
+          variant="contained"
+          color="primary"
+          onClick={() => setDialogOpen(true)}
+        >
+          + New project
+        </EditorButton>
+      </FlexRow>
+
+      <ScrollArea fullHeight sx={{ px: SPACING.xxl, py: SPACING.xl }}>
+        {summaries.isPending ? (
+          <LoadingSpinner />
+        ) : (
+          <Box
+            sx={{
+              display: "grid",
+              gap: SPACING.xl,
+              gridTemplateColumns: {
+                xs: "1fr",
+                sm: "repeat(2, minmax(0, 1fr))",
+                lg: "repeat(3, minmax(0, 1fr))"
+              }
+            }}
+          >
+            {matches.map((detail) => (
+              <ProjectCard
+                key={detail.project.id}
+                detail={detail}
+                onOpen={handleOpen}
+                onDropDocument={handleDropDocument}
+              />
+            ))}
+            <Box
+              component="button"
+              type="button"
+              onClick={() => setDialogOpen(true)}
+              sx={{
+                minHeight: "268px",
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: SPACING.lg,
+                border: (theme) => `1px dashed ${theme.vars.palette.divider}`,
+                borderRadius: BORDER_RADIUS.lg,
+                background: "transparent",
+                color: "text.secondary",
+                cursor: "pointer"
+              }}
+            >
+              <Box sx={{ color: PROJECT_COLOR, fontSize: "var(--fontSizeBig)" }}>
+                +
+              </Box>
+              <Label>Start a project</Label>
+              <Caption color="muted">
+                Name it, then let an agent build its documents
+              </Caption>
+            </Box>
+          </Box>
+        )}
+      </ScrollArea>
+
+      {loose.length > 0 && (
+        <Box sx={{ px: SPACING.xxl, pb: SPACING.xl }}>
+          <Divider />
+          <FlexRow
+            align="center"
+            gap={SPACING.lg}
+            sx={{ pt: SPACING.lg, pb: SPACING.md }}
+          >
+            <Caption
+              color="muted"
+              sx={{ textTransform: "uppercase", letterSpacing: "0.08em" }}
+            >
+              Not in a project
+            </Caption>
+            {looseTotal > loose.length && (
+              <Caption color="muted">
+                {`${loose.length} most recent of ${looseTotal}`}
+              </Caption>
+            )}
+            <Box sx={{ flex: 1 }} />
+            <Caption color="muted">Drag onto a project card to move it in</Caption>
+          </FlexRow>
+          <FlexRow gap={SPACING.lg} wrap>
+            {loose.map((document) => (
+              <FlexRow
+                key={`${document.type}:${document.ref}`}
+                align="center"
+                gap={SPACING.md}
+                draggable
+                onDragStart={(event: DragEvent<HTMLDivElement>) =>
+                  handleDragStart(event, document)
+                }
+                onClick={() =>
+                  openTab({
+                    type: document.type,
+                    ref: document.ref,
+                    title: document.name
+                  })
+                }
+                sx={{
+                  px: SPACING.lg,
+                  height: "30px",
+                  cursor: "grab",
+                  bgcolor: "background.paper",
+                  border: (theme) => `1px solid ${theme.vars.palette.divider}`,
+                  borderRadius: BORDER_RADIUS.md
+                }}
+              >
+                <Box
+                  component="span"
+                  aria-hidden
+                  sx={{
+                    color: TYPE_COLOR[document.type],
+                    ...TYPOGRAPHY.sans.caption
+                  }}
+                >
+                  {TYPE_GLYPH[document.type]}
+                </Box>
+                <Label color="secondary">{document.name}</Label>
+              </FlexRow>
+            ))}
+          </FlexRow>
+        </Box>
+      )}
+
+      <Dialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        title="Start a project"
+        showActions
+        confirmText="Create"
+        confirmDisabled={newName.trim().length === 0}
+        onConfirm={() => void handleCreate()}
+      >
+        <TextInput
+          value={newName}
+          autoFocus
+          label="Project name"
+          placeholder="Aurora launch spot"
+          onChange={(event) => setNewName(event.target.value)}
+        />
+      </Dialog>
+    </FlexColumn>
+  );
+};
+
+export default ProjectListSurface;

--- a/web/src/components/projects/ProjectOverviewSurface.tsx
+++ b/web/src/components/projects/ProjectOverviewSurface.tsx
@@ -1,0 +1,150 @@
+import { useCallback } from "react";
+
+import {
+  BORDER_RADIUS,
+  Box,
+  Caption,
+  Card,
+  FlexColumn,
+  FlexRow,
+  Label,
+  LoadingSpinner,
+  SPACING,
+  ScrollArea,
+  Text,
+  TYPOGRAPHY
+} from "../ui_primitives";
+import { trpc } from "../../trpc/client";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import { TYPE_COLOR, TYPE_GLYPH } from "../workspace/tabTypeIdentity";
+import { PROJECT_COLOR, PROJECT_GLYPH } from "./projectIdentity";
+import {
+  formatSpend,
+  projectStatusLine,
+  type ProjectDocument
+} from "./projectStatus";
+
+interface ProjectOverviewSurfaceProps {
+  /** The project id — the tab's `ref`. */
+  refId: string;
+}
+
+const documentMeta = (document: ProjectDocument): string => {
+  const spend = `$${document.spendUsd.toFixed(2)}`;
+  return document.unpricedCount > 0
+    ? `${spend} · ${document.unpricedCount} unpriced`
+    : spend;
+};
+
+/**
+ * A project's overview tab: what it is made of, and what it has cost.
+ *
+ * Phase 2 of the project view. The agent thread, the per-type thumbnails and
+ * the spend bar are Phase 3 (`docs/plans/project-view/PLAN.md`, C1–C4); what
+ * is here is the header and the document list they will be arranged around.
+ */
+const ProjectOverviewSurface = ({ refId }: ProjectOverviewSurfaceProps) => {
+  const { data, isPending, error } = trpc.projects.get.useQuery(
+    { id: refId },
+    { staleTime: 15_000 }
+  );
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+
+  const openDocument = useCallback(
+    (document: ProjectDocument) => {
+      openTab({
+        type: document.type,
+        ref: document.ref,
+        title: document.name,
+        projectId: refId
+      });
+    },
+    [openTab, refId]
+  );
+
+  if (isPending) {
+    return <LoadingSpinner />;
+  }
+  if (error) {
+    return (
+      <FlexColumn fullHeight align="center" justify="center">
+        <Caption color="error">{error.message}</Caption>
+      </FlexColumn>
+    );
+  }
+
+  return (
+    <ScrollArea fullHeight sx={{ px: SPACING.xxl, py: SPACING.xxl }}>
+      <FlexColumn gap={SPACING.xxl}>
+        <FlexColumn gap={SPACING.md}>
+          <FlexRow align="center" gap={SPACING.md}>
+            <Box component="span" aria-hidden sx={{ color: PROJECT_COLOR }}>
+              {PROJECT_GLYPH}
+            </Box>
+            <Text size="big">{data.project.name}</Text>
+          </FlexRow>
+          <Caption color="secondary">
+            {projectStatusLine(data.documents)}
+          </Caption>
+          <FlexRow align="baseline" gap={SPACING.md}>
+            <Box component="span" sx={{ ...TYPOGRAPHY.mono.strong }}>
+              {formatSpend(data.spend)}
+            </Box>
+            <Caption color="muted">so far · provider rates, no markup</Caption>
+          </FlexRow>
+        </FlexColumn>
+
+        {data.documents.length === 0 ? (
+          <Caption color="muted">
+            Nothing in this project yet. Anything you create while it is open
+            lands here.
+          </Caption>
+        ) : (
+          <Box
+            sx={{
+              display: "grid",
+              gap: SPACING.xl,
+              gridTemplateColumns: {
+                xs: "1fr",
+                md: "repeat(2, minmax(0, 1fr))"
+              }
+            }}
+          >
+            {data.documents.map((document) => (
+              <Card
+                key={`${document.type}:${document.ref}`}
+                variant="outlined"
+                padding="normal"
+                clickable
+                onClick={() => openDocument(document)}
+                aria-label={document.name}
+                sx={{ borderRadius: BORDER_RADIUS.md }}
+              >
+                <FlexColumn gap={SPACING.sm}>
+                  <FlexRow align="center" gap={SPACING.md}>
+                    <Box
+                      component="span"
+                      aria-hidden
+                      sx={{ color: TYPE_COLOR[document.type] }}
+                    >
+                      {TYPE_GLYPH[document.type]}
+                    </Box>
+                    <Label sx={{ flex: 1 }}>{document.name}</Label>
+                  </FlexRow>
+                  <Caption color="secondary">
+                    {projectStatusLine([document])}
+                  </Caption>
+                  <Caption color="muted" sx={{ ...TYPOGRAPHY.mono.caption }}>
+                    {documentMeta(document)}
+                  </Caption>
+                </FlexColumn>
+              </Card>
+            ))}
+          </Box>
+        )}
+      </FlexColumn>
+    </ScrollArea>
+  );
+};
+
+export default ProjectOverviewSurface;

--- a/web/src/components/projects/ProjectScopeChip.tsx
+++ b/web/src/components/projects/ProjectScopeChip.tsx
@@ -1,0 +1,99 @@
+import { useCallback, useRef, useState } from "react";
+
+import { ContextMenu, MenuItemPrimitive } from "../ui_primitives";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import { useOpenProject, useProjects } from "../../hooks/useProjects";
+import { PROJECT_GLYPH } from "./projectIdentity";
+
+interface ProjectScopeChipProps {
+  projectId: string;
+  /** The group's own tabs supply the name until the project list arrives. */
+  fallbackName: string;
+}
+
+/**
+ * The tab bar's project scope: the name the grouped tabs belong to, and the
+ * menu that switches project, opens the overview, or closes the group.
+ */
+const ProjectScopeChip = ({ projectId, fallbackName }: ProjectScopeChipProps) => {
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
+  const { data: projects } = useProjects();
+  const openProject = useOpenProject();
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const closeProject = useWorkspaceTabsStore((state) => state.closeProject);
+
+  const project = projects?.find((entry) => entry.id === projectId);
+  const name = project?.name ?? fallbackName;
+  const close = useCallback(() => setOpen(false), []);
+
+  const handleOpenOverview = useCallback(() => {
+    close();
+    openTab({
+      type: "project",
+      ref: projectId,
+      mode: "view",
+      title: name,
+      projectId
+    });
+  }, [close, name, openTab, projectId]);
+
+  return (
+    <>
+      <button
+        ref={anchorRef}
+        type="button"
+        className="project-scope"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={`Project ${name}`}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span className="glyph" aria-hidden>
+          {PROJECT_GLYPH}
+        </span>
+        <span className="project-scope-name">{name}</span>
+        <span className="project-scope-caret" aria-hidden>
+          ▾
+        </span>
+      </button>
+      <ContextMenu
+        open={open}
+        anchorEl={anchorRef.current}
+        onClose={close}
+        compact
+      >
+        <MenuItemPrimitive
+          label="Open overview"
+          compact
+          onClick={handleOpenOverview}
+        />
+        <MenuItemPrimitive
+          label="Close group"
+          compact
+          dividerAfter={(projects?.length ?? 0) > 1}
+          onClick={() => {
+            close();
+            closeProject(projectId);
+          }}
+        />
+        {projects
+          ?.filter((entry) => entry.id !== projectId)
+          .map((entry) => (
+            <MenuItemPrimitive
+              key={entry.id}
+              label={entry.name}
+              secondary="Switch to"
+              compact
+              onClick={() => {
+                close();
+                void openProject(entry);
+              }}
+            />
+          ))}
+      </ContextMenu>
+    </>
+  );
+};
+
+export default ProjectScopeChip;

--- a/web/src/components/projects/ProjectsRailButton.tsx
+++ b/web/src/components/projects/ProjectsRailButton.tsx
@@ -1,0 +1,53 @@
+import { useCallback } from "react";
+import DiamondOutlinedIcon from "@mui/icons-material/DiamondOutlined";
+
+import { ToolbarIconButton, Tooltip } from "../ui_primitives";
+import { TOOLTIP_ENTER_DELAY } from "../../config/constants";
+import {
+  PROJECT_LIST_REF,
+  useWorkspaceTabsStore
+} from "../../stores/WorkspaceTabsStore";
+import { PROJECT_COLOR } from "./projectIdentity";
+
+/**
+ * The rail's Projects entry. Unlike the views below it this opens a tab
+ * rather than a drawer — the projects list is a surface, not a sidebar.
+ */
+const ProjectsRailButton = () => {
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const onProjectSurface = useWorkspaceTabsStore((state) => {
+    const active = state.tabs.find((tab) => tab.id === state.activeTabId);
+    return active?.type === "project" || active?.type === "project-list";
+  });
+
+  const handleClick = useCallback(() => {
+    openTab({
+      type: "project-list",
+      ref: PROJECT_LIST_REF,
+      mode: "view",
+      title: "Projects"
+    });
+  }, [openTab]);
+
+  return (
+    <Tooltip
+      title="Projects"
+      placement="right-start"
+      delay={TOOLTIP_ENTER_DELAY}
+    >
+      <ToolbarIconButton
+        tabIndex={-1}
+        ariaLabel="Projects"
+        className={onProjectSurface ? "active" : ""}
+        onClick={handleClick}
+        icon={
+          <DiamondOutlinedIcon
+            sx={onProjectSurface ? { color: PROJECT_COLOR } : undefined}
+          />
+        }
+      />
+    </Tooltip>
+  );
+};
+
+export default ProjectsRailButton;

--- a/web/src/components/projects/__tests__/ProjectListSurface.test.tsx
+++ b/web/src/components/projects/__tests__/ProjectListSurface.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * The projects list: what a card says, and that a loose document dropped on
+ * one is moved into that project.
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+const summaries = {
+  data: [
+    {
+      project: {
+        id: "p1",
+        name: "Aurora Launch Spot",
+        kind: "spot",
+        createdAt: "2026-08-01T00:00:00.000Z",
+        updatedAt: "2026-08-29T00:00:00.000Z"
+      },
+      documents: [
+        {
+          type: "storyboard",
+          ref: "b1",
+          name: "Board",
+          updatedAt: "2026-08-29T00:00:00.000Z",
+          status: { kind: "storyboard", shots: 8, stills: 8, clips: 6 },
+          spendUsd: 4.12,
+          unpricedCount: 0,
+          thumbnails: []
+        }
+      ],
+      spend: { totalUsd: 4.12, unpricedCount: 0, byCategory: [] }
+    }
+  ],
+  isPending: false
+};
+
+const unassigned = {
+  data: [
+    {
+      type: "script",
+      ref: "s1",
+      name: "Scratch VO",
+      updatedAt: "2026-08-28T00:00:00.000Z"
+    }
+  ]
+};
+
+const assignDocument = jest.fn();
+const openProject = jest.fn();
+const createProject = jest.fn(async () => ({
+  id: "p2",
+  name: "Meridian",
+  kind: "",
+  createdAt: "",
+  updatedAt: ""
+}));
+
+jest.mock("../../../hooks/useProjects", () => ({
+  useProjectSummaries: () => summaries,
+  useUnassignedDocuments: () => unassigned,
+  useCreateProject: () => ({ mutateAsync: createProject }),
+  useAssignDocument: () => ({ mutate: assignDocument }),
+  useOpenProject: () => openProject
+}));
+
+const openTab = jest.fn();
+jest.mock("../../../stores/WorkspaceTabsStore", () => ({
+  useWorkspaceTabsStore: <T,>(selector: (s: { openTab: jest.Mock }) => T) =>
+    selector({ openTab })
+}));
+
+jest.mock("../../../stores/NotificationStore", () => ({
+  useNotificationStore: <T,>(
+    selector: (s: { addNotification: jest.Mock }) => T
+  ) => selector({ addNotification: jest.fn() })
+}));
+
+import ProjectListSurface from "../ProjectListSurface";
+
+const renderSurface = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ProjectListSurface />
+    </ThemeProvider>
+  );
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("ProjectListSurface", () => {
+  it("shows each project's derived status and spend", () => {
+    renderSurface();
+    expect(screen.getByText("Aurora Launch Spot")).toBeInTheDocument();
+    expect(screen.getByText("8 shots · stills 8/8")).toBeInTheDocument();
+    expect(screen.getByText("clips 6/8")).toBeInTheDocument();
+    expect(screen.getByText("$4.12")).toBeInTheDocument();
+  });
+
+  it("opens the project as a tab group when its card is clicked", async () => {
+    renderSurface();
+    await userEvent.click(screen.getByLabelText("Aurora Launch Spot"));
+    expect(openProject).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "p1", name: "Aurora Launch Spot" })
+    );
+  });
+
+  it("filters the cards by the search box", async () => {
+    renderSurface();
+    await userEvent.type(screen.getByPlaceholderText("Search projects"), "zzz");
+    await waitFor(() =>
+      expect(screen.queryByText("Aurora Launch Spot")).not.toBeInTheDocument()
+    );
+  });
+
+  it("moves a loose document into the project it is dropped on", () => {
+    renderSurface();
+    const payload = JSON.stringify(unassigned.data[0]);
+    fireEvent.drop(screen.getByLabelText("Aurora Launch Spot"), {
+      dataTransfer: { getData: () => payload }
+    });
+    expect(assignDocument).toHaveBeenCalledWith(
+      { projectId: "p1", type: "script", ref: "s1" },
+      expect.anything()
+    );
+  });
+
+  it("ignores a drop carrying something that is not one of its documents", () => {
+    renderSurface();
+    fireEvent.drop(screen.getByLabelText("Aurora Launch Spot"), {
+      dataTransfer: { getData: () => "workflow:some-id" }
+    });
+    expect(assignDocument).not.toHaveBeenCalled();
+  });
+
+  it("creates a project from the dialog and opens it", async () => {
+    renderSurface();
+    await userEvent.click(screen.getByRole("button", { name: "+ New project" }));
+    await userEvent.type(screen.getByLabelText("Project name"), "Meridian");
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(createProject).toHaveBeenCalledWith({ name: "Meridian", kind: "" })
+    );
+    await waitFor(() =>
+      expect(openProject).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "p2" })
+      )
+    );
+  });
+});

--- a/web/src/components/projects/__tests__/ProjectOverviewSurface.test.tsx
+++ b/web/src/components/projects/__tests__/ProjectOverviewSurface.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * The project overview tab: what the project is made of and what it cost, and
+ * that opening one of its documents keeps it inside the project's tab group.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+const detail = {
+  project: {
+    id: "p1",
+    name: "Aurora",
+    kind: "spot",
+    createdAt: "",
+    updatedAt: ""
+  },
+  documents: [
+    {
+      type: "storyboard",
+      ref: "b1",
+      name: "Board",
+      updatedAt: "2026-08-29T00:00:00.000Z",
+      status: { kind: "storyboard", shots: 8, stills: 8, clips: 6 },
+      spendUsd: 4.12,
+      unpricedCount: 1,
+      thumbnails: []
+    }
+  ],
+  spend: { totalUsd: 4.12, unpricedCount: 1, byCategory: [] }
+};
+
+jest.mock("../../../trpc/client", () => ({
+  trpc: {
+    projects: {
+      get: { useQuery: () => ({ data: detail, isPending: false, error: null }) }
+    }
+  }
+}));
+
+const openTab = jest.fn();
+jest.mock("../../../stores/WorkspaceTabsStore", () => ({
+  useWorkspaceTabsStore: <T,>(selector: (s: { openTab: jest.Mock }) => T) =>
+    selector({ openTab })
+}));
+
+import ProjectOverviewSurface from "../ProjectOverviewSurface";
+
+const renderSurface = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ProjectOverviewSurface refId="p1" />
+    </ThemeProvider>
+  );
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("ProjectOverviewSurface", () => {
+  it("reports the derived status and a spend that names what was unpriced", () => {
+    renderSurface();
+    expect(screen.getByText("Aurora")).toBeInTheDocument();
+    // Once in the header, once on the board's own card.
+    expect(screen.getAllByText("8 shots · stills 8/8")).toHaveLength(2);
+    // The project total and the one document's share are the same figure here.
+    expect(screen.getAllByText("$4.12 · 1 unpriced")).toHaveLength(2);
+  });
+
+  it("opens a document into the project's group", async () => {
+    renderSurface();
+    await userEvent.click(screen.getByLabelText("Board"));
+    expect(openTab).toHaveBeenCalledWith({
+      type: "storyboard",
+      ref: "b1",
+      title: "Board",
+      projectId: "p1"
+    });
+  });
+});

--- a/web/src/components/projects/__tests__/ProjectScopeChip.test.tsx
+++ b/web/src/components/projects/__tests__/ProjectScopeChip.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * The tab bar's project scope chip: it names the group, and its menu is the
+ * one place to leave the group or switch to another project.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+const projects = [
+  { id: "p1", name: "Aurora", kind: "", createdAt: "", updatedAt: "" },
+  { id: "p2", name: "Meridian", kind: "", createdAt: "", updatedAt: "" }
+];
+
+const openProject = jest.fn();
+jest.mock("../../../hooks/useProjects", () => ({
+  useProjects: () => ({ data: projects }),
+  useOpenProject: () => openProject
+}));
+
+const openTab = jest.fn();
+const closeProject = jest.fn();
+jest.mock("../../../stores/WorkspaceTabsStore", () => ({
+  useWorkspaceTabsStore: <T,>(
+    selector: (s: { openTab: jest.Mock; closeProject: jest.Mock }) => T
+  ) => selector({ openTab, closeProject })
+}));
+
+import ProjectScopeChip from "../ProjectScopeChip";
+
+const renderChip = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ProjectScopeChip projectId="p1" fallbackName="Project" />
+    </ThemeProvider>
+  );
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("ProjectScopeChip", () => {
+  it("names the project the group belongs to", () => {
+    renderChip();
+    expect(screen.getByRole("button", { name: "Project Aurora" })).toBeInTheDocument();
+  });
+
+  it("opens the overview into the same group", async () => {
+    renderChip();
+    await userEvent.click(screen.getByRole("button", { name: "Project Aurora" }));
+    await userEvent.click(screen.getByText("Open overview"));
+    expect(openTab).toHaveBeenCalledWith({
+      type: "project",
+      ref: "p1",
+      mode: "view",
+      title: "Aurora",
+      projectId: "p1"
+    });
+  });
+
+  it("closes the group", async () => {
+    renderChip();
+    await userEvent.click(screen.getByRole("button", { name: "Project Aurora" }));
+    await userEvent.click(screen.getByText("Close group"));
+    expect(closeProject).toHaveBeenCalledWith("p1");
+  });
+
+  it("switches to another project, and does not offer the open one", async () => {
+    renderChip();
+    await userEvent.click(screen.getByRole("button", { name: "Project Aurora" }));
+    expect(
+      screen.getByRole("menu").textContent?.includes("Aurora")
+    ).toBe(false);
+    await userEvent.click(screen.getByText("Meridian"));
+    await waitFor(() =>
+      expect(openProject).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "p2" })
+      )
+    );
+  });
+});

--- a/web/src/components/projects/__tests__/projectStatus.test.ts
+++ b/web/src/components/projects/__tests__/projectStatus.test.ts
@@ -1,0 +1,116 @@
+/**
+ * What a project card says, derived from its documents. The rule under test is
+ * that only recorded facts are stated: a cut reports its size, never that it
+ * has been delivered, and unpriced calls are named rather than summed as zero.
+ */
+
+import {
+  formatDuration,
+  formatSpend,
+  projectProgress,
+  projectStatusLine,
+  type ProjectDetail,
+  type ProjectDocument
+} from "../projectStatus";
+
+const document = (over: Partial<ProjectDocument>): ProjectDocument => ({
+  type: "storyboard",
+  ref: "d1",
+  name: "Board",
+  updatedAt: "2026-08-29T00:00:00.000Z",
+  status: null,
+  spendUsd: 0,
+  unpricedCount: 0,
+  thumbnails: [],
+  ...over
+});
+
+const spend = (over: Partial<ProjectDetail["spend"]>): ProjectDetail["spend"] => ({
+  totalUsd: 0,
+  unpricedCount: 0,
+  byCategory: [],
+  ...over
+});
+
+describe("formatDuration", () => {
+  it("reads milliseconds as m:ss", () => {
+    expect(formatDuration(0)).toBe("0:00");
+    expect(formatDuration(102_000)).toBe("1:42");
+    expect(formatDuration(9_000)).toBe("0:09");
+  });
+});
+
+describe("projectStatusLine", () => {
+  it("says so when there is nothing in the project", () => {
+    expect(projectStatusLine([])).toBe("No documents yet");
+  });
+
+  it("reads a board, a script and a cut into one line", () => {
+    expect(
+      projectStatusLine([
+        document({
+          status: { kind: "storyboard", shots: 8, stills: 8, clips: 6 }
+        }),
+        document({
+          type: "script",
+          ref: "s1",
+          status: { kind: "script", lines: 12, voiced: 10, stale: 2 }
+        }),
+        document({
+          type: "timeline",
+          ref: "t1",
+          status: { kind: "timeline", clips: 6, durationMs: 102_000 }
+        })
+      ])
+    ).toBe("8 shots · stills 8/8 · voiced 10/12 · 2 stale · cut 6 clips · 1:42");
+  });
+
+  it("counts documents that derive no status", () => {
+    expect(
+      projectStatusLine([
+        document({ type: "sketch", ref: "k1" }),
+        document({ type: "application", ref: "a1" })
+      ])
+    ).toBe("2 documents");
+  });
+});
+
+describe("projectProgress", () => {
+  it("reports the board's clips, and calls it done only when every shot has one", () => {
+    expect(
+      projectProgress([
+        document({ status: { kind: "storyboard", shots: 8, stills: 8, clips: 6 } })
+      ])
+    ).toEqual({ label: "clips 6/8", done: false });
+    expect(
+      projectProgress([
+        document({ status: { kind: "storyboard", shots: 8, stills: 8, clips: 8 } })
+      ])
+    ).toEqual({ label: "clips 8/8", done: true });
+  });
+
+  it("falls back to the cut's length, and never claims it was rendered", () => {
+    expect(
+      projectProgress([
+        document({
+          type: "timeline",
+          ref: "t1",
+          status: { kind: "timeline", clips: 6, durationMs: 102_000 }
+        })
+      ])
+    ).toEqual({ label: "cut · 1:42", done: false });
+  });
+
+  it("has nothing to say about a project with neither", () => {
+    expect(projectProgress([document({ type: "sketch", ref: "k1" })])).toBeNull();
+  });
+});
+
+describe("formatSpend", () => {
+  it("names what no catalog priced instead of dropping it", () => {
+    expect(formatSpend(spend({ totalUsd: 4.115 }))).toBe("$4.12");
+    expect(formatSpend(spend({ totalUsd: 4.12, unpricedCount: 2 }))).toBe(
+      "$4.12 · 2 unpriced"
+    );
+  });
+});

--- a/web/src/components/projects/projectIdentity.ts
+++ b/web/src/components/projects/projectIdentity.ts
@@ -1,0 +1,11 @@
+/**
+ * One color and one glyph for the project layer, wherever it shows: the rail
+ * entry, the tab-bar scope chip, the grouped tabs' underline, and the cards in
+ * the projects list.
+ *
+ * `info.light` is the theme's cyan (#67E8F9 in dark), read as a CSS variable so
+ * both themes answer for themselves.
+ */
+export const PROJECT_COLOR = "var(--palette-info-light)";
+
+export const PROJECT_GLYPH = "◆";

--- a/web/src/components/projects/projectStatus.ts
+++ b/web/src/components/projects/projectStatus.ts
@@ -1,0 +1,108 @@
+/**
+ * What a project card says about itself, derived from the documents the
+ * server returned. Pure: the same summary always reads the same way, and the
+ * wording is testable without rendering a card.
+ *
+ * Only facts the summary carries are stated. A cut's render state is not one
+ * of them — nothing records it — so no card claims a project is delivered.
+ */
+
+import type { RouterOutputs } from "../../trpc/client";
+
+export type ProjectDetail = RouterOutputs["projects"]["summaries"][number];
+export type ProjectDocument = ProjectDetail["documents"][number];
+export type ProjectDocumentStatus = NonNullable<ProjectDocument["status"]>;
+
+const statusOfKind = <K extends ProjectDocumentStatus["kind"]>(
+  documents: readonly ProjectDocument[],
+  kind: K
+): Extract<ProjectDocumentStatus, { kind: K }> | undefined => {
+  for (const doc of documents) {
+    if (doc.status?.kind === kind) {
+      return doc.status as Extract<ProjectDocumentStatus, { kind: K }>;
+    }
+  }
+  return undefined;
+};
+
+/** `123456` → `2:03`. */
+export const formatDuration = (durationMs: number): string => {
+  const total = Math.max(0, Math.round(durationMs / 1000));
+  const minutes = Math.floor(total / 60);
+  return `${minutes}:${String(total % 60).padStart(2, "0")}`;
+};
+
+/**
+ * The card's one-line status. Documents of the same kind collapse onto the
+ * newest of them — a card is a glance, and the overview tab has the rest.
+ */
+export const projectStatusLine = (
+  documents: readonly ProjectDocument[]
+): string => {
+  if (documents.length === 0) {
+    return "No documents yet";
+  }
+  const parts: string[] = [];
+
+  const board = statusOfKind(documents, "storyboard");
+  if (board) {
+    parts.push(`${board.shots} shots`);
+    if (board.shots > 0) {
+      parts.push(`stills ${board.stills}/${board.shots}`);
+    }
+  }
+
+  const script = statusOfKind(documents, "script");
+  if (script) {
+    parts.push(`voiced ${script.voiced}/${script.lines}`);
+    if (script.stale > 0) {
+      parts.push(`${script.stale} stale`);
+    }
+  }
+
+  const cut = statusOfKind(documents, "timeline");
+  if (cut) {
+    parts.push(`cut ${cut.clips} clips · ${formatDuration(cut.durationMs)}`);
+  }
+
+  if (parts.length === 0) {
+    const label = documents.length === 1 ? "document" : "documents";
+    return `${documents.length} ${label}`;
+  }
+  return parts.join(" · ");
+};
+
+export interface ProjectProgress {
+  label: string;
+  /** Everything the board set out to render exists. */
+  done: boolean;
+}
+
+/**
+ * The pill over the card's montage: how far the clips have got. A project
+ * with no board and no cut gets none rather than an invented one.
+ */
+export const projectProgress = (
+  documents: readonly ProjectDocument[]
+): ProjectProgress | null => {
+  const board = statusOfKind(documents, "storyboard");
+  if (board && board.shots > 0) {
+    return {
+      label: `clips ${board.clips}/${board.shots}`,
+      done: board.clips === board.shots
+    };
+  }
+  const cut = statusOfKind(documents, "timeline");
+  if (cut) {
+    return { label: `cut · ${formatDuration(cut.durationMs)}`, done: false };
+  }
+  return null;
+};
+
+/** `$4.12`, and what the ledger could not price rather than a silent zero. */
+export const formatSpend = (spend: ProjectDetail["spend"]): string => {
+  const amount = `$${spend.totalUsd.toFixed(2)}`;
+  return spend.unpricedCount > 0
+    ? `${amount} · ${spend.unpricedCount} unpriced`
+    : amount;
+};

--- a/web/src/components/script/ScriptListPanel.tsx
+++ b/web/src/components/script/ScriptListPanel.tsx
@@ -38,7 +38,8 @@ export const CreateScriptButton = memo(function CreateScriptButton() {
         type: "script",
         ref: created.id,
         mode: "edit",
-        title: created.name || "Untitled script"
+        title: created.name || "Untitled script",
+        projectId: created.projectId
       });
       if (!location.pathname.startsWith("/workspace")) {
         navigate("/workspace");

--- a/web/src/components/sketch/SketchListPanel.tsx
+++ b/web/src/components/sketch/SketchListPanel.tsx
@@ -184,7 +184,8 @@ export const CreateSketchButton = memo(function CreateSketchButton() {
           type: "sketch",
           ref: sketch.id,
           mode: "edit",
-          title: sketch.name || "Untitled sketch"
+          title: sketch.name || "Untitled sketch",
+          projectId: sketch.projectId
         });
       } else {
         navigate(`/sketch/${sketch.id}`);

--- a/web/src/components/storyboard/ShotStatusPill.tsx
+++ b/web/src/components/storyboard/ShotStatusPill.tsx
@@ -1,38 +1,24 @@
 /**
  * ShotStatusPill
  *
- * The one status vocabulary the shot grid speaks, rendered as a mono pill in
- * the thumbnail's bottom-right corner. Four tones: a rendered clip (success
- * green), a render in flight (video violet, matching the card's border and
- * the progress bar under the thumbnail), a shot waiting on its next step
- * (neutral), and a failed render (error).
+ * What the shot grid says about a shot, in the app's shared pill vocabulary
+ * (`StatusPill`): a rendered clip and its length, a render in flight (video
+ * violet, matching the card's border and the progress bar under the
+ * thumbnail), a shot waiting on its next step, or a failed render.
  */
 
 import { memo } from "react";
 import type { SxProps, Theme } from "@mui/material/styles";
-import { useTheme } from "@mui/material/styles";
 import type { Shot } from "@nodetool-ai/protocol";
 
-import {
-  Box,
-  BORDER_RADIUS,
-  CONTROL,
-  SPACING,
-  TYPOGRAPHY
-} from "../ui_primitives";
+import { StatusPill, type StatusPillTone } from "../ui_primitives";
 import { colorForType } from "../../config/data_types";
-import { hexToRgba } from "../../utils/ColorUtils";
-import { brighten, toHex } from "../../utils/colorMath";
 
 /** Video violet — the app's colour for anything clip-shaped. */
 export const CLIP_COLOR = colorForType("video");
-/** The same violet, lifted off the tinted background it sits on. */
-const CLIP_TEXT = toHex(brighten(CLIP_COLOR, 1.4));
-
-export type ShotPillTone = "done" | "rendering" | "neutral" | "failed";
 
 export interface ShotPill {
-  tone: ShotPillTone;
+  tone: StatusPillTone;
   label: string;
 }
 
@@ -69,43 +55,6 @@ export const shotPill = (
   return { tone: "neutral", label: "planned" };
 };
 
-/** Border and background for a tone, shared with the card's own border. */
-export const toneColors = (
-  tone: ShotPillTone,
-  theme: Theme
-): { color: string; border: string; background: string } => {
-  switch (tone) {
-    case "done": {
-      const green = theme.palette.success.main;
-      return {
-        color: green,
-        border: hexToRgba(green, 0.5),
-        background: hexToRgba(green, 0.12)
-      };
-    }
-    case "rendering":
-      return {
-        color: CLIP_TEXT,
-        border: CLIP_COLOR,
-        background: hexToRgba(CLIP_COLOR, 0.16)
-      };
-    case "failed": {
-      const red = theme.palette.error.main;
-      return {
-        color: red,
-        border: hexToRgba(red, 0.5),
-        background: hexToRgba(red, 0.12)
-      };
-    }
-    default:
-      return {
-        color: theme.palette.text.secondary,
-        border: theme.palette.divider,
-        background: hexToRgba(theme.palette.common.white, 0.06)
-      };
-  }
-};
-
 interface ShotStatusPillProps {
   shot: Shot;
   /** The shot's effective length, shown once it has a clip. */
@@ -118,31 +67,16 @@ const ShotStatusPillInner = ({
   durationSeconds,
   sx
 }: ShotStatusPillProps) => {
-  const theme = useTheme();
   const pill = shotPill(shot, durationSeconds);
-  const colors = toneColors(pill.tone, theme);
-
   return (
-    <Box
+    <StatusPill
+      tone={pill.tone}
+      accent={CLIP_COLOR}
       data-testid="shot-status-pill"
-      data-tone={pill.tone}
-      sx={{
-        display: "inline-flex",
-        alignItems: "center",
-        height: `${CONTROL.height.xs}px`,
-        px: SPACING.sm,
-        borderRadius: BORDER_RADIUS.pill,
-        border: "1px solid",
-        borderColor: colors.border,
-        backgroundColor: colors.background,
-        color: colors.color,
-        whiteSpace: "nowrap",
-        ...TYPOGRAPHY.mono.caption,
-        ...sx
-      }}
+      sx={sx}
     >
       {pill.label}
-    </Box>
+    </StatusPill>
   );
 };
 

--- a/web/src/components/storyboard/StoryboardListPanel.tsx
+++ b/web/src/components/storyboard/StoryboardListPanel.tsx
@@ -41,7 +41,8 @@ export const CreateStoryboardButton = memo(function CreateStoryboardButton() {
         type: "storyboard",
         ref: created.id,
         mode: "edit",
-        title: created.name || "Untitled storyboard"
+        title: created.name || "Untitled storyboard",
+        projectId: created.projectId
       });
       if (!location.pathname.startsWith("/workspace")) {
         navigate("/workspace");

--- a/web/src/components/timeline/TimelineListPanel.tsx
+++ b/web/src/components/timeline/TimelineListPanel.tsx
@@ -180,7 +180,8 @@ export const CreateTimelineButton = memo(function CreateTimelineButton() {
           type: "timeline",
           ref: timeline.id,
           mode: "edit",
-          title: timeline.name || "Untitled video"
+          title: timeline.name || "Untitled video",
+          projectId: timeline.projectId
         });
       } else {
         navigate(`/timeline/${timeline.id}`);

--- a/web/src/components/ui_primitives/STRATEGY.md
+++ b/web/src/components/ui_primitives/STRATEGY.md
@@ -71,7 +71,7 @@ These primitives exist but are barely adopted:
 `CopyButton` | `CloseButton` | `DeleteButton` | `DownloadButton` | `UploadButton` | `EditButton` | `SettingsButton` | `FavoriteButton` | `HelpButton` | `DocsHelpLink` | `UndoRedoButtons`
 
 ### Feedback & Status (replace raw CircularProgress/Alert)
-`LoadingSpinner` | `ProgressBar` | `Skeleton` | `StatusIndicator` | `EmptyState` | `AlertBanner` | `WarningBanner` | `Toast` | `NotificationBadge` | `ConflictBanner`
+`LoadingSpinner` | `ProgressBar` | `Skeleton` | `StatusIndicator` | `StatusPill` | `EmptyState` | `AlertBanner` | `WarningBanner` | `Toast` | `NotificationBadge` | `ConflictBanner`
 
 ### Document merge (external-change offers)
 `ConflictBanner` — the one document-level notice listing the external values a dirty draft refused, with per-value Accept/Discard and an optional viewer. A string `detail` shows the external value; with `draftDetail` too, the viewer is a two-pane Your-edit / External view (JS script `code`). Mounted by every document editor shell; fed by `useDocumentConflicts`.
@@ -169,7 +169,8 @@ Need feedback?
 ├── Nothing to show → EmptyState
 ├── Warning/error → AlertBanner / WarningBanner
 ├── Temporary message → Toast
-└── Status dot/badge → StatusIndicator / NotificationBadge
+├── Status dot/badge → StatusIndicator / NotificationBadge
+└── Render state on a thumbnail or card → StatusPill
 
 Need a menu/nav?
 ├── Context menu → ContextMenu / EditorMenu

--- a/web/src/components/ui_primitives/StatusPill.tsx
+++ b/web/src/components/ui_primitives/StatusPill.tsx
@@ -1,0 +1,117 @@
+/**
+ * StatusPill
+ *
+ * The one status vocabulary the app's media surfaces speak: a mono pill in the
+ * corner of a thumbnail or beside a name. Four tones — a finished render
+ * (success green), a render in flight (`accent`, the caller's own colour), a
+ * step still waiting (neutral), and a failure (error).
+ *
+ * @example
+ * <StatusPill tone="done">clip · 38s</StatusPill>
+ * <StatusPill tone="rendering" accent={CLIP_COLOR}>rendering clip</StatusPill>
+ */
+
+import { memo, type ReactNode } from "react";
+import type { SxProps, Theme } from "@mui/material/styles";
+import { useTheme } from "@mui/material/styles";
+
+import { Box } from "./Box";
+import { BORDER_RADIUS, CONTROL, TYPOGRAPHY } from "./tokens";
+import { SPACING } from "./spacing";
+import { hexToRgba } from "../../utils/ColorUtils";
+import { brighten, toHex } from "../../utils/colorMath";
+
+export type StatusPillTone = "done" | "rendering" | "neutral" | "failed";
+
+export interface StatusPillProps {
+  tone: StatusPillTone;
+  /**
+   * The colour the `rendering` tone is drawn in — the surface's own, so a clip
+   * render reads as the same violet as the card border around it. Ignored by
+   * every other tone.
+   */
+  accent?: string;
+  children: ReactNode;
+  className?: string;
+  "data-testid"?: string;
+  sx?: SxProps<Theme>;
+}
+
+/** Border and background for a tone, shared with the borders around it. */
+export const statusPillColors = (
+  tone: StatusPillTone,
+  theme: Theme,
+  accent?: string
+): { color: string; border: string; background: string } => {
+  switch (tone) {
+    case "done": {
+      const green = theme.palette.success.main;
+      return {
+        color: green,
+        border: hexToRgba(green, 0.5),
+        background: hexToRgba(green, 0.12)
+      };
+    }
+    case "rendering": {
+      const base = accent ?? theme.palette.primary.main;
+      return {
+        // Lifted off the tint it sits on, so the label stays readable.
+        color: toHex(brighten(base, 1.4)),
+        border: base,
+        background: hexToRgba(base, 0.16)
+      };
+    }
+    case "failed": {
+      const red = theme.palette.error.main;
+      return {
+        color: red,
+        border: hexToRgba(red, 0.5),
+        background: hexToRgba(red, 0.12)
+      };
+    }
+    default:
+      return {
+        color: theme.palette.text.secondary,
+        border: theme.palette.divider,
+        background: hexToRgba(theme.palette.common.white, 0.06)
+      };
+  }
+};
+
+const StatusPillInner = ({
+  tone,
+  accent,
+  children,
+  className,
+  "data-testid": testId,
+  sx
+}: StatusPillProps) => {
+  const theme = useTheme();
+  const colors = statusPillColors(tone, theme, accent);
+  return (
+    <Box
+      className={className}
+      data-testid={testId}
+      data-tone={tone}
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        height: `${CONTROL.height.xs}px`,
+        px: SPACING.sm,
+        borderRadius: BORDER_RADIUS.pill,
+        border: "1px solid",
+        borderColor: colors.border,
+        backgroundColor: colors.background,
+        color: colors.color,
+        whiteSpace: "nowrap",
+        ...TYPOGRAPHY.mono.caption,
+        ...sx
+      }}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export const StatusPill = memo(StatusPillInner);
+StatusPill.displayName = "StatusPill";

--- a/web/src/components/ui_primitives/index.ts
+++ b/web/src/components/ui_primitives/index.ts
@@ -98,6 +98,9 @@ export type { ProgressBarProps } from "./ProgressBar";
 export { ExternalLink } from "./ExternalLink";
 export type { ExternalLinkProps } from "./ExternalLink";
 
+export { StatusPill, statusPillColors } from "./StatusPill";
+export type { StatusPillProps, StatusPillTone } from "./StatusPill";
+
 export { StatusIndicator } from "./StatusIndicator";
 export type { StatusIndicatorProps, StatusType } from "./StatusIndicator";
 

--- a/web/src/components/workspace/OpenMenu.tsx
+++ b/web/src/components/workspace/OpenMenu.tsx
@@ -246,7 +246,8 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
           type: "timeline",
           ref: sequence.id,
           mode: "edit",
-          title: sequence.name || "Untitled video"
+          title: sequence.name || "Untitled video",
+          projectId: sequence.projectId
         });
       }),
     [runCreate, createTimeline, openTab]
@@ -263,7 +264,8 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
           type: "storyboard",
           ref: created.id,
           mode: "edit",
-          title: created.name
+          title: created.name,
+          projectId: created.projectId
         });
       }),
     [runCreate, createStoryboard, openTab]
@@ -280,7 +282,8 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
           type: "storyboard",
           ref: created.id,
           mode: "edit",
-          title: created.name
+          title: created.name,
+          projectId: created.projectId
         });
       }),
     [runCreate, installExampleStoryboard, openTab]
@@ -298,7 +301,8 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
           type: "application",
           ref: created.id,
           mode: "edit",
-          title: created.name
+          title: created.name,
+          projectId: created.projectId
         });
       }),
     [runCreate, createApplication, openTab]
@@ -315,7 +319,8 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
           type: "script",
           ref: created.id,
           mode: "edit",
-          title: created.name
+          title: created.name,
+          projectId: created.projectId
         });
       }),
     [runCreate, createScript, openTab]
@@ -332,7 +337,8 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
           type: "jsscript",
           ref: created.id,
           mode: "edit",
-          title: created.name
+          title: created.name,
+          projectId: created.projectId
         });
       }),
     [runCreate, createJsScript, openTab]

--- a/web/src/components/workspace/TabContent.tsx
+++ b/web/src/components/workspace/TabContent.tsx
@@ -25,6 +25,12 @@ const PageSurface = React.lazy(() => import("./PageSurface"));
 const WorkspaceFileSurface = React.lazy(
   () => import("./WorkspaceFileSurface")
 );
+const ProjectListSurface = React.lazy(
+  () => import("../projects/ProjectListSurface")
+);
+const ProjectOverviewSurface = React.lazy(
+  () => import("../projects/ProjectOverviewSurface")
+);
 
 interface TabContentProps {
   tab: WorkspaceTab;
@@ -73,6 +79,10 @@ const surfaceFor = (tab: WorkspaceTab, active: boolean) => {
       return <ChatSurface refId={tab.ref} active={active} />;
     case "page":
       return isPageTabKey(tab.ref) ? <PageSurface pageKey={tab.ref} /> : null;
+    case "project-list":
+      return <ProjectListSurface />;
+    case "project":
+      return <ProjectOverviewSurface refId={tab.ref} />;
     default: {
       // Exhaustiveness guard — a new WorkspaceTabType must add a case here.
       const exhaustive: never = tab.type;

--- a/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 import React, {
+  Fragment,
   useCallback,
   useMemo,
   useRef,
@@ -12,6 +13,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
 import {
+  orderTabsForRender,
   useWorkspaceTabsStore,
   type WorkspaceTab,
   type WorkspaceTabType
@@ -26,7 +28,6 @@ import { renameSketchDocument } from "../../stores/sketch/SketchSessionStore";
 import { readSketchDocumentId } from "../../hooks/sketch/ensureSketchDocumentForAsset";
 import { tabCanRename } from "./tabRename";
 import { useUpdateApplication } from "../../hooks/useApplications";
-import { colorForType } from "../../config/data_types";
 import { TOOLBAR_WIDTH } from "../../config/constants";
 import { MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
 import NotificationButton from "../panels/NotificationButton";
@@ -34,6 +35,9 @@ import OpenMenu from "./OpenMenu";
 import WorkspaceTabItem from "./WorkspaceTabItem";
 import MobileDocumentSelector from "./MobileDocumentSelector";
 import MobileRailLauncher from "../panels/MobileRailLauncher";
+import ProjectScopeChip from "../projects/ProjectScopeChip";
+import { PROJECT_COLOR } from "../projects/projectIdentity";
+import { TYPE_COLOR, TYPE_GLYPH } from "./tabTypeIdentity";
 
 /** Whether a document type supports both View and Edit (vs view-only). */
 const SUPPORTS_BOTH_MODES = {
@@ -51,45 +55,11 @@ const SUPPORTS_BOTH_MODES = {
   "workspace-file": true,
   chat: false,
   application: false,
-  page: false
+  page: false,
+  "project-list": false,
+  project: false
 } satisfies Record<WorkspaceTabType, boolean>;
 
-const TYPE_GLYPH = {
-  workflow: "⬡",
-  image: "▦",
-  sketch: "✎",
-  timeline: "▤",
-  storyboard: "▥",
-  script: "🎙",
-  jsscript: "{ }",
-  skill: "✦",
-  model3d: "◈",
-  audio: "♪",
-  text: "¶",
-  "workspace-file": "🗎",
-  chat: "❝",
-  application: "◧",
-  page: "☰"
-} satisfies Record<WorkspaceTabType, string>;
-
-/** Pin color per tab type, reusing the app's canonical data-type palette. */
-const TYPE_COLOR = {
-  workflow: colorForType("any"),
-  image: colorForType("image"),
-  sketch: colorForType("image"),
-  timeline: colorForType("video"),
-  storyboard: colorForType("video"),
-  script: colorForType("audio"),
-  jsscript: colorForType("str"),
-  skill: colorForType("str"),
-  model3d: colorForType("model_3d"),
-  audio: colorForType("audio"),
-  text: colorForType("text"),
-  "workspace-file": colorForType("file"),
-  chat: colorForType("str"),
-  application: colorForType("any"),
-  page: colorForType("any")
-} satisfies Record<WorkspaceTabType, string>;
 
 const styles = (theme: Theme) =>
   css({
@@ -138,12 +108,46 @@ const styles = (theme: Theme) =>
         color: theme.vars.palette.text.primary,
         backgroundColor: "var(--c_editor_bg_color)"
       },
+      // A tab in the open project's group. The cyan underline is the group's
+      // extent; the chip to its left names it.
+      "&.in-project": {
+        boxShadow: `inset 0 -2px 0 color-mix(in srgb, ${PROJECT_COLOR} 35%, transparent)`
+      },
       "&.drop-target-left": {
         boxShadow: `inset 2px 0 0 ${theme.vars.palette.primary.main}`
       },
       "&.drop-target-right": {
         boxShadow: `inset -2px 0 0 ${theme.vars.palette.primary.main}`
       }
+    },
+
+    "& .project-scope": {
+      WebkitAppRegion: "no-drag",
+      display: "flex",
+      alignItems: "center",
+      gap: getSpacingPx(SPACING.md),
+      flex: "0 0 auto",
+      maxWidth: "220px",
+      padding: `0 ${getSpacingPx(SPACING.lg)}`,
+      border: "none",
+      borderRight: `1px solid ${theme.vars.palette.divider}`,
+      backgroundColor: `color-mix(in srgb, ${PROJECT_COLOR} 6%, transparent)`,
+      boxShadow: `inset 0 -2px 0 ${PROJECT_COLOR}`,
+      color: theme.vars.palette.text.primary,
+      cursor: "pointer",
+      fontSize: "var(--fontSizeSmall)",
+      "& .glyph": { color: PROJECT_COLOR },
+      "& .project-scope-name": {
+        fontWeight: 500,
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap"
+      },
+      "& .project-scope-caret": {
+        fontSize: "var(--fontSizeSmaller)",
+        opacity: 0.6
+      },
+      "&:hover": { backgroundColor: theme.vars.palette.c_overlay_subtle }
     },
 
     "& .tab-input": {
@@ -310,10 +314,28 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
   const updateWorkflow = useWorkflowManager((state) => state.updateWorkflow);
   const saveWorkflow = useWorkflowManager((state) => state.saveWorkflow);
 
+  const activeProjectId = useWorkspaceTabsStore(
+    (state) => state.activeProjectId
+  );
+
   const activeTab = useMemo(
     () => tabs.find((tab) => tab.id === activeTabId) ?? null,
     [tabs, activeTabId]
   );
+
+  // The open project's tabs render as one run behind the scope chip; every
+  // other tab keeps its place.
+  const renderedTabs = useMemo(
+    () => orderTabsForRender(tabs, activeProjectId),
+    [tabs, activeProjectId]
+  );
+  const firstGroupedTabId = renderedTabs.find(
+    (tab) => tab.projectId === activeProjectId
+  )?.id;
+  const groupName =
+    renderedTabs.find(
+      (tab) => tab.type === "project" && tab.ref === activeProjectId
+    )?.title ?? "Project";
 
   const newTabButtonRef = useRef<HTMLButtonElement>(null);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -509,6 +531,14 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
               name: trimmed
             });
             break;
+          case "project":
+            await trpcClient.projects.update.mutate({
+              id: tab.ref,
+              name: trimmed
+            });
+            void trpcUtils.projects.list.invalidate();
+            void trpcUtils.projects.summaries.invalidate();
+            break;
           default:
             break;
         }
@@ -523,7 +553,9 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
       setTitle,
       updateApplication,
       trpcUtils.skills.get,
-      trpcUtils.skills.list
+      trpcUtils.skills.list,
+      trpcUtils.projects.list,
+      trpcUtils.projects.summaries
     ]
   );
 
@@ -608,30 +640,38 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
         />
       ) : (
         <div className="tabs">
-          {tabs.map((tab) => (
-            <WorkspaceTabItem
-              key={tab.id}
-              tab={tab}
-              isActive={tab.id === activeTabId}
-              isEditing={editingTabId === tab.id}
-              canRename={tabCanRename(tab.type)}
-              dropPosition={
-                dropTarget?.id === tab.id ? dropTarget.position : null
-              }
-              typeColor={TYPE_COLOR[tab.type]}
-              typeGlyph={TYPE_GLYPH[tab.type]}
-              onActivate={setActiveTab}
-              onBeginRename={handleBeginRename}
-              onClose={handleClose}
-              onCloseOthers={handleCloseOthers}
-              onCloseAll={handleCloseAll}
-              onDragStart={handleDragStart}
-              onDragOver={handleDragOver}
-              onDragLeave={handleDragLeave}
-              onDrop={handleDrop}
-              onCommitRename={commitRename}
-              onCancelRename={handleCancelRename}
-            />
+          {renderedTabs.map((tab) => (
+            <Fragment key={tab.id}>
+              {tab.id === firstGroupedTabId && activeProjectId && (
+                <ProjectScopeChip
+                  projectId={activeProjectId}
+                  fallbackName={groupName}
+                />
+              )}
+              <WorkspaceTabItem
+                tab={tab}
+                inProject={tab.projectId === activeProjectId}
+                isActive={tab.id === activeTabId}
+                isEditing={editingTabId === tab.id}
+                canRename={tabCanRename(tab.type)}
+                dropPosition={
+                  dropTarget?.id === tab.id ? dropTarget.position : null
+                }
+                typeColor={TYPE_COLOR[tab.type]}
+                typeGlyph={TYPE_GLYPH[tab.type]}
+                onActivate={setActiveTab}
+                onBeginRename={handleBeginRename}
+                onClose={handleClose}
+                onCloseOthers={handleCloseOthers}
+                onCloseAll={handleCloseAll}
+                onDragStart={handleDragStart}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                onCommitRename={commitRename}
+                onCancelRename={handleCancelRename}
+              />
+            </Fragment>
           ))}
         </div>
       )}

--- a/web/src/components/workspace/WorkspaceTabItem.tsx
+++ b/web/src/components/workspace/WorkspaceTabItem.tsx
@@ -22,6 +22,8 @@ import {
 interface WorkspaceTabItemProps {
   tab: WorkspaceTab;
   isActive: boolean;
+  /** Part of the open project's tab group — carries the group's underline. */
+  inProject?: boolean;
   isEditing: boolean;
   canRename: boolean;
   dropPosition: "left" | "right" | null;
@@ -43,6 +45,7 @@ interface WorkspaceTabItemProps {
 const WorkspaceTabItem = ({
   tab,
   isActive,
+  inProject = false,
   isEditing,
   canRename,
   dropPosition,
@@ -133,7 +136,9 @@ const WorkspaceTabItem = ({
   return (
     <>
       <div
-        className={`tab${isActive ? " active" : ""}${dropClass}`}
+        className={`tab${isActive ? " active" : ""}${
+          inProject ? " in-project" : ""
+        }${dropClass}`}
         role="tab"
         aria-selected={isActive}
         tabIndex={0}

--- a/web/src/components/workspace/tabRename.ts
+++ b/web/src/components/workspace/tabRename.ts
@@ -3,7 +3,8 @@ import type { WorkspaceTabType } from "../../stores/WorkspaceTabsStore";
 /**
  * Tab types whose title can be renamed in place. Image tabs host the
  * sketch editor in edit mode, so they share the same rename path.
- * Text tabs cover markdown and other text assets.
+ * Text tabs cover markdown and other text assets. A project's overview tab
+ * carries the project's own name, so renaming it renames the project.
  */
 const RENAMEABLE_TYPES = new Set<WorkspaceTabType>([
   "workflow",
@@ -17,7 +18,8 @@ const RENAMEABLE_TYPES = new Set<WorkspaceTabType>([
   "model3d",
   "chat",
   "application",
-  "text"
+  "text",
+  "project"
 ]);
 
 export const tabCanRename = (type: WorkspaceTabType): boolean =>

--- a/web/src/components/workspace/tabTypeIdentity.ts
+++ b/web/src/components/workspace/tabTypeIdentity.ts
@@ -1,0 +1,50 @@
+/**
+ * The glyph and color a tab type is drawn with — in the tab bar, in mobile's
+ * document selector, and on the cards of the projects list. One table, so the
+ * same document reads the same wherever it is listed.
+ */
+
+import { colorForType } from "../../config/data_types";
+import { PROJECT_COLOR, PROJECT_GLYPH } from "../projects/projectIdentity";
+import type { WorkspaceTabType } from "../../stores/WorkspaceTabsStore";
+
+export const TYPE_GLYPH = {
+  workflow: "⬡",
+  image: "▦",
+  sketch: "✎",
+  timeline: "▤",
+  storyboard: "▥",
+  script: "🎙",
+  jsscript: "{ }",
+  skill: "✦",
+  model3d: "◈",
+  audio: "♪",
+  text: "¶",
+  "workspace-file": "🗎",
+  chat: "❝",
+  application: "◧",
+  page: "☰",
+  "project-list": PROJECT_GLYPH,
+  project: PROJECT_GLYPH
+} satisfies Record<WorkspaceTabType, string>;
+
+/** Pin color per tab type, reusing the app's canonical data-type palette. */
+export const TYPE_COLOR = {
+  workflow: colorForType("any"),
+  image: colorForType("image"),
+  sketch: colorForType("image"),
+  timeline: colorForType("video"),
+  storyboard: colorForType("video"),
+  script: colorForType("audio"),
+  jsscript: colorForType("str"),
+  skill: colorForType("str"),
+  model3d: colorForType("model_3d"),
+  audio: colorForType("audio"),
+  text: colorForType("text"),
+  "workspace-file": colorForType("file"),
+  chat: colorForType("str"),
+  application: colorForType("any"),
+  page: colorForType("any"),
+  "project-list": PROJECT_COLOR,
+  project: PROJECT_COLOR
+} satisfies Record<WorkspaceTabType, string>;

--- a/web/src/hooks/useProjects.ts
+++ b/web/src/hooks/useProjects.ts
@@ -1,0 +1,76 @@
+/**
+ * tRPC hooks for projects, plus the one action that spans the store and the
+ * server: opening a project restores its documents as tabs, and only the
+ * server knows which documents those are.
+ */
+
+import { useCallback } from "react";
+
+import { trpc, trpcClient } from "../trpc/client";
+import {
+  useWorkspaceTabsStore,
+  type ProjectTabDocument
+} from "../stores/WorkspaceTabsStore";
+
+export const useProjects = () =>
+  trpc.projects.list.useQuery({}, { staleTime: 30_000 });
+
+/** Every project with the status and spend its card shows. */
+export const useProjectSummaries = () =>
+  trpc.projects.summaries.useQuery({}, { staleTime: 15_000 });
+
+/** Documents in no project — the list's "Not in a project" strip. */
+export const useUnassignedDocuments = () =>
+  trpc.projects.unassigned.useQuery({}, { staleTime: 15_000 });
+
+const useInvalidateProjects = () => {
+  const utils = trpc.useUtils();
+  return useCallback(() => {
+    void utils.projects.list.invalidate();
+    void utils.projects.summaries.invalidate();
+    void utils.projects.unassigned.invalidate();
+  }, [utils]);
+};
+
+export const useCreateProject = () => {
+  const invalidate = useInvalidateProjects();
+  return trpc.projects.create.useMutation({ onSuccess: invalidate });
+};
+
+export const useRenameProject = () => {
+  const invalidate = useInvalidateProjects();
+  return trpc.projects.update.useMutation({ onSuccess: invalidate });
+};
+
+export const useAssignDocument = () => {
+  const invalidate = useInvalidateProjects();
+  return trpc.projects.assignDocument.useMutation({ onSuccess: invalidate });
+};
+
+/**
+ * Open a project as a tab group: its overview plus one tab per document it
+ * holds. The documents are fetched rather than read from a query cache so a
+ * project opened from anywhere restores the same set.
+ */
+export const useOpenProject = () => {
+  const openProject = useWorkspaceTabsStore((state) => state.openProject);
+  return useCallback(
+    async (project: { id: string; name: string }) => {
+      const documents = await trpcClient.projects.documents.query({
+        id: project.id
+      });
+      openProject({
+        id: project.id,
+        name: project.name,
+        documents: documents.map(
+          (doc): ProjectTabDocument => ({
+            type: doc.type,
+            ref: doc.ref,
+            title: doc.name
+          })
+        )
+      });
+    },
+    [openProject]
+  );
+};

--- a/web/src/stores/WorkspaceTabsStore.ts
+++ b/web/src/stores/WorkspaceTabsStore.ts
@@ -276,9 +276,11 @@ export const useWorkspaceTabsStore = create<WorkspaceTabsState>()(
           type,
           ref,
           mode: mode ?? "edit",
-          title: title ?? "Untitled",
-          ...(project ? { projectId: project } : {})
+          title: title ?? "Untitled"
         };
+        if (project) {
+          tab.projectId = project;
+        }
         set((state) => ({
           tabs: [...state.tabs, tab],
           activeTabId: id

--- a/web/src/stores/WorkspaceTabsStore.ts
+++ b/web/src/stores/WorkspaceTabsStore.ts
@@ -36,7 +36,11 @@ export type WorkspaceTabType =
   | "workspace-file"
   // App pages (Settings, Costs, Model Manager, …) opened from the logo menu.
   // `ref` is a PageTabKey; these have no edit mode.
-  | "page";
+  | "page"
+  // The projects list. One per workspace — `ref` is the constant below.
+  | "project-list"
+  // A project's overview. `ref` is a project id (trpc.projects.*).
+  | "project";
 
 export type WorkspaceTabMode = "view" | "edit";
 
@@ -48,6 +52,13 @@ export interface WorkspaceTab {
   ref: string;
   mode: WorkspaceTabMode;
   title: string;
+  /**
+   * The project this tab belongs to, when it belongs to one. Tabs sharing the
+   * active project render as one group in the tab bar. Absent means loose —
+   * the {@link LOOSE_PROJECT_ID} bucket is spelled as absence here, so a tab
+   * never claims membership in a project that does not exist.
+   */
+  projectId?: string;
 }
 
 interface OpenTabInput {
@@ -59,6 +70,25 @@ interface OpenTabInput {
    */
   mode?: WorkspaceTabMode;
   title?: string;
+  /**
+   * The project the document belongs to. `LOOSE_PROJECT_ID` reads as no
+   * project, so a creation site can pass {@link creationProjectId} straight
+   * through. Omitted leaves an existing tab's project alone.
+   */
+  projectId?: string;
+}
+
+/** A document to restore as a tab when its project opens. */
+export interface ProjectTabDocument {
+  type: WorkspaceTabType;
+  ref: string;
+  title: string;
+}
+
+export interface OpenProjectInput {
+  id: string;
+  name: string;
+  documents?: readonly ProjectTabDocument[];
 }
 
 interface WorkspaceTabsState {
@@ -85,13 +115,63 @@ interface WorkspaceTabsState {
   moveTab: (id: string, toIndex: number) => void;
   getActiveTab: () => WorkspaceTab | null;
   setActiveProjectId: (projectId: string | null) => void;
+  /**
+   * Make `input.id` the active project: open its overview tab, adopt or open a
+   * tab per document, and gather the group into one contiguous run. Documents
+   * come from the caller because the store holds no server state.
+   */
+  openProject: (input: OpenProjectInput) => void;
+  /** Close every tab belonging to a project, and leave it if it was active. */
+  closeProject: (projectId: string) => void;
 }
 
 /** The project id documents carry when no project is open. */
 export const LOOSE_PROJECT_ID = "default";
 
+/** The projects list is one tab, so its `ref` is a constant. */
+export const PROJECT_LIST_REF = "projects";
+
 export const tabId = (type: WorkspaceTabType, ref: string): string =>
   `${type}:${ref}`;
+
+/** A tab's project, with the loose bucket read as no project. */
+const projectOf = (projectId: string | undefined): string | undefined =>
+  projectId && projectId !== LOOSE_PROJECT_ID ? projectId : undefined;
+
+/**
+ * The active project, unless closing tabs left none of it open. A project
+ * nothing on screen belongs to must not keep catching new documents.
+ */
+const stillOpen = (
+  tabs: WorkspaceTab[],
+  activeProjectId: string | null
+): string | null =>
+  activeProjectId && tabs.some((t) => t.projectId === activeProjectId)
+    ? activeProjectId
+    : null;
+
+/**
+ * The tab order the bar renders: the active project's tabs gathered into one
+ * contiguous run, at the position of the first of them. Every other tab keeps
+ * its place. Pure, so the bar renders a group the store never has to maintain.
+ */
+export const orderTabsForRender = (
+  tabs: WorkspaceTab[],
+  activeProjectId: string | null
+): WorkspaceTab[] => {
+  if (!activeProjectId) {
+    return tabs;
+  }
+  const grouped = tabs.filter((t) => t.projectId === activeProjectId);
+  if (grouped.length < 2) {
+    return tabs;
+  }
+  const rest = tabs.filter((t) => t.projectId !== activeProjectId);
+  // Everything before the first group member is loose, so its index is also
+  // how many loose tabs precede the group.
+  const head = tabs.findIndex((t) => t.projectId === activeProjectId);
+  return [...rest.slice(0, head), ...grouped, ...rest.slice(head)];
+};
 
 /**
  * Pick the tab that should become active after `closingId` is removed:
@@ -171,15 +251,21 @@ export const useWorkspaceTabsStore = create<WorkspaceTabsState>()(
       ...seedTabsFromLegacy(),
       activeProjectId: null,
 
-      openTab: ({ type, ref, mode, title }) => {
+      openTab: ({ type, ref, mode, title, projectId }) => {
         const id = tabId(type, ref);
+        const project = projectOf(projectId);
         const existing = get().tabs.find((t) => t.id === id);
         if (existing) {
           set((state) => ({
             activeTabId: id,
             tabs: state.tabs.map((t) =>
               t.id === id
-                ? { ...t, mode: mode ?? t.mode, title: title ?? t.title }
+                ? {
+                    ...t,
+                    mode: mode ?? t.mode,
+                    title: title ?? t.title,
+                    projectId: projectId === undefined ? t.projectId : project
+                  }
                 : t
             )
           }));
@@ -190,7 +276,8 @@ export const useWorkspaceTabsStore = create<WorkspaceTabsState>()(
           type,
           ref,
           mode: mode ?? "edit",
-          title: title ?? "Untitled"
+          title: title ?? "Untitled",
+          ...(project ? { projectId: project } : {})
         };
         set((state) => ({
           tabs: [...state.tabs, tab],
@@ -200,21 +287,36 @@ export const useWorkspaceTabsStore = create<WorkspaceTabsState>()(
       },
 
       closeTab: (id) =>
-        set((state) => ({
-          activeTabId: nextActiveAfterClose(state.tabs, state.activeTabId, id),
-          tabs: state.tabs.filter((t) => t.id !== id)
-        })),
+        set((state) => {
+          const tabs = state.tabs.filter((t) => t.id !== id);
+          return {
+            tabs,
+            activeTabId: nextActiveAfterClose(state.tabs, state.activeTabId, id),
+            activeProjectId: stillOpen(tabs, state.activeProjectId)
+          };
+        }),
 
       closeOthers: (id) =>
         set((state) => {
           const kept = state.tabs.filter((t) => t.id === id);
           return {
             tabs: kept,
-            activeTabId: kept.length > 0 ? id : null
+            activeTabId: kept.length > 0 ? id : null,
+            activeProjectId: stillOpen(kept, state.activeProjectId)
           };
         }),
 
-      setActiveTab: (id) => set({ activeTabId: id }),
+      // Activating a tab that belongs to a project switches the scope to it;
+      // a loose tab leaves the open project alone, so reading a scratch note
+      // does not close the group the user is working in.
+      setActiveTab: (id) =>
+        set((state) => {
+          const project = state.tabs.find((t) => t.id === id)?.projectId;
+          return {
+            activeTabId: id,
+            activeProjectId: project ?? state.activeProjectId
+          };
+        }),
 
       setMode: (id, mode) =>
         set((state) => ({
@@ -259,7 +361,60 @@ export const useWorkspaceTabsStore = create<WorkspaceTabsState>()(
         return tabs.find((t) => t.id === activeTabId) ?? null;
       },
 
-      setActiveProjectId: (projectId) => set({ activeProjectId: projectId })
+      setActiveProjectId: (projectId) => set({ activeProjectId: projectId }),
+
+      openProject: ({ id, name, documents = [] }) =>
+        set((state) => {
+          const overview: WorkspaceTab = {
+            id: tabId("project", id),
+            type: "project",
+            ref: id,
+            mode: "view",
+            title: name,
+            projectId: id
+          };
+          const wanted: WorkspaceTab[] = [
+            overview,
+            ...documents.map((doc) => {
+              const existing = state.tabs.find(
+                (t) => t.id === tabId(doc.type, doc.ref)
+              );
+              return {
+                id: tabId(doc.type, doc.ref),
+                type: doc.type,
+                ref: doc.ref,
+                mode: existing?.mode ?? "edit",
+                title: doc.title,
+                projectId: id
+              } satisfies WorkspaceTab;
+            })
+          ];
+          const wantedIds = new Set(wanted.map((t) => t.id));
+          const others = state.tabs.filter((t) => !wantedIds.has(t.id));
+          // The group lands where its first member already sat, so opening a
+          // project the user has tabs from does not reshuffle the bar.
+          const at = state.tabs.findIndex((t) => wantedIds.has(t.id));
+          const head = at === -1 ? others.length : Math.min(at, others.length);
+          return {
+            tabs: [...others.slice(0, head), ...wanted, ...others.slice(head)],
+            activeTabId: overview.id,
+            activeProjectId: id
+          };
+        }),
+
+      closeProject: (projectId) =>
+        set((state) => {
+          const tabs = state.tabs.filter((t) => t.projectId !== projectId);
+          const activeStillOpen = tabs.some((t) => t.id === state.activeTabId);
+          return {
+            tabs,
+            activeTabId: activeStillOpen
+              ? state.activeTabId
+              : (tabs[tabs.length - 1]?.id ?? null),
+            activeProjectId:
+              state.activeProjectId === projectId ? null : state.activeProjectId
+          };
+        })
     }),
     {
       name: "workspace-tabs-storage",

--- a/web/src/stores/__tests__/WorkspaceTabsStore.test.ts
+++ b/web/src/stores/__tests__/WorkspaceTabsStore.test.ts
@@ -2,6 +2,7 @@ import {
   useWorkspaceTabsStore,
   creationProjectId,
   nextActiveAfterClose,
+  orderTabsForRender,
   seedTabsFromLegacy,
   tabId,
   LOOSE_PROJECT_ID,
@@ -122,6 +123,31 @@ describe("closeTab", () => {
   });
 });
 
+describe("closing the last tab of a project", () => {
+  it("leaves the project, so a new document does not land in it unseen", () => {
+    useWorkspaceTabsStore.getState().openProject({ id: "p1", name: "Aurora" });
+    useWorkspaceTabsStore.getState().closeTab("project:p1");
+    expect(useWorkspaceTabsStore.getState().activeProjectId).toBeNull();
+  });
+
+  it("keeps the project while another of its tabs is still open", () => {
+    useWorkspaceTabsStore.getState().openProject({
+      id: "p1",
+      name: "Aurora",
+      documents: [{ type: "storyboard", ref: "b1", title: "Board" }]
+    });
+    useWorkspaceTabsStore.getState().closeTab("project:p1");
+    expect(useWorkspaceTabsStore.getState().activeProjectId).toBe("p1");
+  });
+
+  it("leaves the project when Close Others keeps a loose tab", () => {
+    useWorkspaceTabsStore.getState().openTab({ type: "workflow", ref: "a" });
+    useWorkspaceTabsStore.getState().openProject({ id: "p1", name: "Aurora" });
+    useWorkspaceTabsStore.getState().closeOthers("workflow:a");
+    expect(useWorkspaceTabsStore.getState().activeProjectId).toBeNull();
+  });
+});
+
 describe("closeOthers", () => {
   it("keeps only the given tab", () => {
     reset(
@@ -199,5 +225,168 @@ describe("creationProjectId", () => {
     expect(create()).toBe("proj-1");
     useWorkspaceTabsStore.getState().setActiveProjectId(null);
     expect(create()).toBe(LOOSE_PROJECT_ID);
+  });
+});
+
+describe("openProject", () => {
+  it("opens the overview first and a tab per document, all in the group", () => {
+    useWorkspaceTabsStore.getState().openProject({
+      id: "p1",
+      name: "Aurora",
+      documents: [
+        { type: "storyboard", ref: "b1", title: "Board" },
+        { type: "timeline", ref: "t1", title: "Cut" }
+      ]
+    });
+
+    const state = useWorkspaceTabsStore.getState();
+    expect(state.tabs.map((t) => t.id)).toEqual([
+      "project:p1",
+      "storyboard:b1",
+      "timeline:t1"
+    ]);
+    expect(state.tabs.every((t) => t.projectId === "p1")).toBe(true);
+    expect(state.activeTabId).toBe("project:p1");
+    expect(state.activeProjectId).toBe("p1");
+  });
+
+  it("adopts a document already open instead of duplicating it, keeping its mode", () => {
+    reset([{ ...tab("timeline", "t1", "view"), title: "Cut" }], "timeline:t1");
+
+    useWorkspaceTabsStore.getState().openProject({
+      id: "p1",
+      name: "Aurora",
+      documents: [{ type: "timeline", ref: "t1", title: "Cut v2" }]
+    });
+
+    const state = useWorkspaceTabsStore.getState();
+    expect(state.tabs.map((t) => t.id)).toEqual(["project:p1", "timeline:t1"]);
+    expect(state.tabs[1]).toMatchObject({
+      mode: "view",
+      title: "Cut v2",
+      projectId: "p1"
+    });
+  });
+
+  it("places the group where its first member already sat", () => {
+    reset([tab("workflow", "a"), tab("storyboard", "b1"), tab("text", "c")]);
+
+    useWorkspaceTabsStore.getState().openProject({
+      id: "p1",
+      name: "Aurora",
+      documents: [{ type: "storyboard", ref: "b1", title: "Board" }]
+    });
+
+    expect(useWorkspaceTabsStore.getState().tabs.map((t) => t.id)).toEqual([
+      "workflow:a",
+      "project:p1",
+      "storyboard:b1",
+      "text:c"
+    ]);
+  });
+});
+
+describe("closeProject", () => {
+  it("closes the group, leaves loose tabs, and clears the active project", () => {
+    useWorkspaceTabsStore.getState().openTab({ type: "workflow", ref: "a" });
+    useWorkspaceTabsStore.getState().openProject({
+      id: "p1",
+      name: "Aurora",
+      documents: [{ type: "storyboard", ref: "b1", title: "Board" }]
+    });
+
+    useWorkspaceTabsStore.getState().closeProject("p1");
+
+    const state = useWorkspaceTabsStore.getState();
+    expect(state.tabs.map((t) => t.id)).toEqual(["workflow:a"]);
+    expect(state.activeTabId).toBe("workflow:a");
+    expect(state.activeProjectId).toBeNull();
+  });
+
+  it("keeps another project open", () => {
+    useWorkspaceTabsStore.getState().openProject({ id: "p1", name: "One" });
+    useWorkspaceTabsStore.getState().openProject({ id: "p2", name: "Two" });
+
+    useWorkspaceTabsStore.getState().closeProject("p1");
+
+    const state = useWorkspaceTabsStore.getState();
+    expect(state.tabs.map((t) => t.id)).toEqual(["project:p2"]);
+    expect(state.activeProjectId).toBe("p2");
+  });
+});
+
+describe("openTab with a project", () => {
+  it("reads the loose bucket as no project", () => {
+    useWorkspaceTabsStore.getState().openTab({
+      type: "storyboard",
+      ref: "b1",
+      projectId: LOOSE_PROJECT_ID
+    });
+    expect(useWorkspaceTabsStore.getState().tabs[0].projectId).toBeUndefined();
+  });
+
+  it("leaves an existing tab's project alone when none is given", () => {
+    useWorkspaceTabsStore
+      .getState()
+      .openTab({ type: "storyboard", ref: "b1", projectId: "p1" });
+    useWorkspaceTabsStore.getState().openTab({ type: "storyboard", ref: "b1" });
+    expect(useWorkspaceTabsStore.getState().tabs[0].projectId).toBe("p1");
+  });
+});
+
+describe("setActiveTab", () => {
+  it("switches the scope to the activated tab's project", () => {
+    reset(
+      [
+        { ...tab("storyboard", "b1"), projectId: "p1" },
+        { ...tab("timeline", "t2"), projectId: "p2" },
+        tab("workflow", "loose")
+      ],
+      "storyboard:b1"
+    );
+    useWorkspaceTabsStore.setState({ activeProjectId: "p1" });
+
+    useWorkspaceTabsStore.getState().setActiveTab("timeline:t2");
+    expect(useWorkspaceTabsStore.getState().activeProjectId).toBe("p2");
+
+    // A loose tab is not a project of its own: the scope stays.
+    useWorkspaceTabsStore.getState().setActiveTab("workflow:loose");
+    expect(useWorkspaceTabsStore.getState().activeProjectId).toBe("p2");
+  });
+});
+
+describe("orderTabsForRender", () => {
+  const grouped = (ref: string): WorkspaceTab => ({
+    ...tab("storyboard", ref),
+    projectId: "p1"
+  });
+
+  it("leaves the order alone when no project is active", () => {
+    const tabs = [grouped("b1"), tab("workflow", "a"), grouped("b2")];
+    expect(orderTabsForRender(tabs, null)).toBe(tabs);
+  });
+
+  it("gathers the group where its first member sits", () => {
+    const tabs = [
+      tab("workflow", "a"),
+      grouped("b1"),
+      tab("text", "c"),
+      grouped("b2")
+    ];
+    expect(orderTabsForRender(tabs, "p1").map((t) => t.ref)).toEqual([
+      "a",
+      "b1",
+      "b2",
+      "c"
+    ]);
+  });
+
+  it("keeps a group that is already contiguous exactly where it is", () => {
+    const tabs = [tab("workflow", "a"), grouped("b1"), grouped("b2")];
+    expect(orderTabsForRender(tabs, "p1").map((t) => t.ref)).toEqual([
+      "a",
+      "b1",
+      "b2"
+    ]);
   });
 });


### PR DESCRIPTION
## What changed

Phase 2 of `docs/plans/project-view/PLAN.md`. Phase 1 gave documents a project and the store a field nothing set; this spends both. A project now opens as a contiguous run of tabs behind a scope chip (`◆ name ▾`, cyan `info.light`), the rail's diamond opens a projects list where each card carries the montage of that project's rendered stills, the status its documents derive, and its spend, and the documents in no project sit beneath as a strip you can drag onto a card to file them. `WorkspaceTab` gains an optional `projectId` — `LOOSE_PROJECT_ID` reads as absence, so a tab never claims membership in a project that does not exist and a creation site can pass `creationProjectId()` straight through — plus `openProject` / `closeProject` and a pure `orderTabsForRender` the bar uses to gather the group, so the store never has to maintain that order. Opening a project adopts tabs its documents already have rather than duplicating them, the group lands where its first member already sat, and closing its last tab leaves the project so nothing keeps catching new documents unseen. Server side this needed three procedures — `projects.summaries` (every rollup in one call, instead of N round trips for the list), `projects.unassigned` (the loose bucket has no row to look up, so it is its own query rather than an id `documents` would special-case) and `projects.assignDocument`, which writes one column and deliberately leaves `updated_at` alone so a move cannot conflict with an editor that has the document open. Storyboard summaries carry up to three stills as locators, resolved client-side. The shot grid's four-tone pill became a `StatusPill` primitive the project cards share; `ShotStatusPill` keeps its wording and its violet and delegates the chrome.

Two departures from the plan, both deliberate. **`project-new` is not registered**: its surface is Phase 4 (D1), and a type nothing can open would be a case in `TabContent`'s exhaustive switch with nothing behind it — until then "+ New project" and the ghost card take a name and open the group. And **a document opened from a sidebar list stays loose**: those six panels pass only `(id, name)` through a shared list primitive, so grouping an existing document happens when its project is opened, not when the document is. Creation sites do pass the created document's server-assigned project, so a document made inside a project joins its group immediately. The `project` overview tab is deliberately plain — header, derived status, spend, document cards — because Phase 3 (C1–C4) arranges the agent thread, the per-type thumbnails and the spend bar around exactly that.

## Verification

- [x] `npm run test:affected` — green apart from three failures that are not this diff:
  - `@nodetool-ai/image-nodes` needs a Vulkan ICD this container lacks (`vkCreateInstance: Found no drivers!`); with lavapipe (`VK_DRIVER_FILES`, per AGENTS.md § WebGPU on a headless machine) it is `24 files / 229 tests passed`.
  - `@nodetool-ai/chat > exports all public API` timed out at 60s under a parallel run; alone it is `4 files / 30 tests passed`.
  - `web > DashboardDocuments > filters by name` timed out at 10s in a file that took 267s under contention; alone the file is `7 tests passed`.
  Full runs otherwise: web `1205/1206 suites, 13720 passed`, electron `63 suites, 686 tests`, backend packages green.
- [x] `npm run typecheck` — web and electron clean. `mobile` fails on `Cannot find module 'react-native'` etc. because `mobile/node_modules` is not installed in this container (it is deliberately not a root workspace); no file under `mobile/` is touched by this diff.
- [x] `npm run lint` — exit 0, no warnings in any added or changed file.
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — **4/4 selfchecks passed** (`main` has no local merge base in this clone, hence `origin/main`). It selects `workflow-execution`, `web-editor`, `script`, `storyboard`. The first run was 2/4: `validate:examples` and `reliability:ring0` both died on `Cannot find module '/home/user/nodetool/packages/cli/dist/…'` — they run from `dist`, and this container had none. After `npm run build:packages` (exit 0) the same command is 4/4.

New tests: `WorkspaceTabsStore` grouping, adoption, placement and scope-clearing (13 cases); `projectStatus` wording, including that a cut reports its size and never that it was delivered, and that unpriced calls are named rather than summed as zero; RTL for the list surface (card contents, search, drag-to-file, a drop carrying something else, create), the scope chip (all three menu actions), and the overview. Server: `summaries` scoping, `unassigned` plus a round trip in and back out of a project, refusals for another user's project and another user's document, `moveDocumentToProject` leaving `updated_at` untouched, and `storyboardThumbnails` order and cap.

## Agent capabilities

No capability is added and no declared contract changes. The six new/changed tRPC procedures are classified in `packages/websocket/src/trpc/sandbox-coverage.ts`; `tests/sandbox-api-coverage.test.ts` passes.

## New checks

No check, rule, or audit is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtbfvTXziG8iPGNo7ER1p5