### PR TITLE
docs(cookbook): focus on creative workflows worth automating

### DIFF
--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -108,8 +108,8 @@
         <ul class="nav-section-list">
           <li><a href="{{ '/use-cases' | relative_url }}" class="sidebar-link" data-nav-path="/use-cases">Use Cases</a></li>
           <li><a href="{{ '/cookbook' | relative_url }}" class="sidebar-link" data-nav-path="/cookbook">Cookbook</a></li>
-          <li><a href="{{ '/cookbook/core-concepts' | relative_url }}" class="sidebar-link" data-nav-path="/cookbook/core-concepts">Core Patterns</a></li>
-          <li><a href="{{ '/cookbook/patterns' | relative_url }}" class="sidebar-link" data-nav-path="/cookbook/patterns">Pipeline Patterns</a></li>
+          <li><a href="{{ '/cookbook/core-concepts' | relative_url }}" class="sidebar-link" data-nav-path="/cookbook/core-concepts">Core Concepts</a></li>
+          <li><a href="{{ '/cookbook/patterns' | relative_url }}" class="sidebar-link" data-nav-path="/cookbook/patterns">Creative Patterns</a></li>
           <li><a href="{{ '/workflows/' | relative_url }}" class="sidebar-link" data-nav-path="/workflows">Workflow Examples</a></li>
         </ul>
       </details>

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -60,7 +60,7 @@ Collections shine in RAG pipelines:
 2. Connect the collection to its `collection` input — the node menu will suggest the selector.
 3. Run the workflow. Index nodes write into the collection; query nodes read from it.
 
-See the full pattern in the [Cookbook → RAG]({{ '/cookbook/patterns#pattern-4-rag-retrieval-augmented-generation' | relative_url }}).
+See the [Chat with Docs example]({{ '/workflows/chat-with-docs' | relative_url }}) for the full query → format → answer wiring.
 
 ---
 
@@ -88,5 +88,4 @@ For multi-user deployments, Supabase-backed collections are an option — see [S
 
 - [Indexing]({{ '/indexing' | relative_url }}) — advanced chunking, hybrid search, maintenance
 - [Asset Management]({{ '/asset-management' | relative_url }}) — add documents to the underlying asset library
-- [Cookbook → RAG]({{ '/cookbook/patterns#pattern-4-rag-retrieval-augmented-generation' | relative_url }}) — wire a collection into a workflow
 - [Chat with Docs example]({{ '/workflows/chat-with-docs' | relative_url }}) — end-to-end RAG workflow

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1,54 +1,65 @@
 ---
 layout: page
-title: "NodeTool Workflow Cookbook"
-description: "Reusable workflow patterns for the NodeTool canvas — core concepts, pipeline patterns, and worked end-to-end examples."
+title: "NodeTool Creative Cookbook"
+description: "Creative workflow patterns worth automating: storyboards, timelines, scripts, sketches, and the graphs that repeat them."
 ---
 
-Reusable patterns for building on the NodeTool canvas. Start with a pattern that
-matches what you want to build, then adapt one of the worked examples.
+The storyboard, timeline, sketch, and script editors are where you make one
+thing and judge it. A workflow graph is where you make the same thing again —
+for the next brief, the next SKU, the next language, the next aspect ratio.
 
-## Cookbook Sections
+This cookbook covers the second half: creative work that repeats often enough
+to be worth wiring up.
 
-1. [**Core Concepts & Architecture**]({{ '/cookbook/core-concepts' | relative_url }}) — how graphs, typed edges, streaming, and node types work.
-2. [**Workflow Patterns**]({{ '/cookbook/patterns' | relative_url }}) — 13 patterns with diagrams and the nodes each one uses.
-3. [**Workflow Gallery**]({{ '/workflows/' | relative_url }}) — step-by-step example workflows you can open and run.
+## Surface or graph
 
-New to the canvas? Read [Core Concepts]({{ '/cookbook/core-concepts' | relative_url }})
-first, then follow a beginner example like
-[Creative Story Ideas]({{ '/workflows/creative-story-ideas' | relative_url }}).
+| What you are doing | Where it belongs |
+|---|---|
+| One film, judged shot by shot | [Storyboard]({{ '/creative-agent' | relative_url }}) |
+| The same film for forty briefs | [Pattern 1]({{ '/cookbook/patterns' | relative_url }}#pattern-1-brief-to-cut) |
+| Trimming, mixing, captioning one cut | [Timeline editor]({{ '/video-editor' | relative_url }}) |
+| Every delivery format of that cut | [Pattern 7]({{ '/cookbook/patterns' | relative_url }}#pattern-7-derivatives) |
+| Painting a mask, composing a frame | [Sketch editor]({{ '/sketch-editor' | relative_url }}) |
+| That composition in twelve styles | [Pattern 5]({{ '/cookbook/patterns' | relative_url }}#pattern-5-sketch-as-control) |
+| Writing and hearing back a line | Script editor |
+| Re-voicing a script after every copy edit | [Pattern 4]({{ '/cookbook/patterns' | relative_url }}#pattern-4-script-to-voiced-cut) |
+| One hero image | Chat, or a single image node |
+| Thirty on-brand assets with one cast | [Pattern 3]({{ '/cookbook/patterns' | relative_url }}#pattern-3-entities) |
 
-## Choose Your Pattern
+## Sections
+
+1. [**Core Concepts**]({{ '/cookbook/core-concepts' | relative_url }}) — typed edges, documents as values, fan-out versus chain, and how to check a graph before it spends.
+2. [**Creative Patterns**]({{ '/cookbook/patterns' | relative_url }}) — eight patterns, each with its graph, its nodes, and the shipped template closest to it.
+3. [**Templates Gallery**]({{ '/templates-gallery' | relative_url }}) — every shipped workflow, runnable from the Examples page.
+
+## Choose a pattern
 
 | I want to… | Pattern | Key nodes |
-|------------|---------|-----------|
-| Transform one input step by step | [1 · Simple Pipeline]({{ '/cookbook/patterns' | relative_url }}#pattern-1-simple-pipeline) | `ImageInput`, `UnsharpMask`, `AutoContrast` |
-| Generate content with an LLM | [2 · Agent-Driven Generation]({{ '/cookbook/patterns' | relative_url }}#pattern-2-agent-driven-generation) | `Agent`, `ListGenerator`, `TextToSpeech` |
-| Show progress during a long run | [3 · Streaming with Previews]({{ '/cookbook/patterns' | relative_url }}#pattern-3-streaming-with-multiple-previews) | `Agent`, `ListGenerator`, `Preview` |
-| Answer questions about documents | [4 · RAG]({{ '/cookbook/patterns' | relative_url }}#pattern-4-rag-retrieval-augmented-generation) | `HybridSearch`, `FormatText`, `Agent` |
-| Get rows you can compute on | [5 · Structured Records]({{ '/cookbook/patterns' | relative_url }}#pattern-5-database-persistence) | `DataGenerator`, `Code` |
-| Process emails or web content | [6 · Email & Web Integration]({{ '/cookbook/patterns' | relative_url }}#pattern-6-email--web-integration) | `GmailSearch`, `Template`, `Summarizer` |
-| Convert between media types | [7 · Multi-Modal Workflows]({{ '/cookbook/patterns' | relative_url }}#pattern-7-multi-modal-workflows) | `Whisper`, `StableDiffusion`, `TextToSpeech` |
-| Transform images with AI | [8 · Advanced Image Processing]({{ '/cookbook/patterns' | relative_url }}#pattern-8-advanced-image-processing) | `StableDiffusionV3MediumImageToImage`, `ImageToText`, `Canny` |
-| Generate video from text | [9 · Text-to-Video]({{ '/cookbook/patterns' | relative_url }}#pattern-9-text-to-video) | `KlingVideoV16ProTextToVideo`, `Sora2TextToVideo` |
-| Animate an image into video | [10 · Image-to-Video]({{ '/cookbook/patterns' | relative_url }}#pattern-10-image-to-video) | `KlingVideoV16StandardImageToVideo`, `SeeDanceV15ProImageToVideo` |
-| Create a lip-synced avatar | [11 · Talking Avatar]({{ '/cookbook/patterns' | relative_url }}#pattern-11-talking-avatar) | `KlingVideoAiAvatarV2Pro`, `Infinitalk` |
-| Upscale and clean up images | [12 · Image Enhancement]({{ '/cookbook/patterns' | relative_url }}#pattern-12-video-enhancement) | `TopazUpscaleImage` |
-| Turn keyframes into a video | [13 · Storyboard to Video]({{ '/cookbook/patterns' | relative_url }}#pattern-13-storyboard-to-video) | `Sora2ImageToVideoPro` |
+|---|---|---|
+| Turn a brief into a rendered film, unattended | [1 · Brief to cut]({{ '/cookbook/patterns' | relative_url }}#pattern-1-brief-to-cut) | `Director`, `ShotBatch`, `ShotChain`, `RenderTimeline` |
+| Gate each shot on a cheap still first | [2 · Shot fan-out]({{ '/cookbook/patterns' | relative_url }}#pattern-2-shot-fan-out) | `ScreenplayShots`, `TextToImage`, `ImageToVideo` |
+| Hold one cast and look across a batch | [3 · Entities]({{ '/cookbook/patterns' | relative_url }}#pattern-3-entities) | `ApplyEntities`, `ListGenerator`, `TextToImage` |
+| Voice a script and caption the cut | [4 · Script to voiced cut]({{ '/cookbook/patterns' | relative_url }}#pattern-4-script-to-voiced-cut) | `VoiceScript`, `ScriptToTimeline`, `ScriptToSubtitles` |
+| Drive generation from a drawn composition | [5 · Sketch as control]({{ '/cookbook/patterns' | relative_url }}#pattern-5-sketch-as-control) | `RenderSketch`, `SketchLayers`, `ImageToImage` |
+| Get a gallery of variants from one brief | [6 · Variant fan-out]({{ '/cookbook/patterns' | relative_url }}#pattern-6-variant-fan-out) | `Agent`, `ListGenerator`, `TextToImage`, `Collect` |
+| Ship one cut in every required shape | [7 · Derivatives]({{ '/cookbook/patterns' | relative_url }}#pattern-7-derivatives) | `Transcript`, `RenderTimeline`, `Resize`, `AddSubtitles` |
+| Handle naming, packaging, subtitle math | [8 · Code node]({{ '/cookbook/patterns' | relative_url }}#pattern-8-code-glue) | `Code` |
 
-## Worked Examples
+## Start from a template
 
-Full walkthroughs with diagrams live in the
-[Workflow Gallery]({{ '/workflows/' | relative_url }}). A few to start with:
+Every pattern names shipped workflows that already implement it. Open the
+**Examples** page in the app menu, load one, and edit it — templates are never
+modified in place.
 
-- [Creative Story Ideas]({{ '/workflows/creative-story-ideas' | relative_url }}) — beginner tutorial for agent generation.
-- [Image Enhance]({{ '/workflows/image-enhance' | relative_url }}) — a simple sharpen-and-contrast pipeline.
-- [Movie Posters]({{ '/workflows/movie-posters' | relative_url }}) — multi-stage generation with strategy and previews.
-- [Image to Audio Story]({{ '/workflows/image-to-audio-story' | relative_url }}) — picture in, narrated story out.
-- [Chat with Docs]({{ '/workflows/chat-with-docs' | relative_url }}) — RAG document Q&A.
+- **Direct a Short Film** — brief in, cut film out, no surface interaction.
+- **Directed Film to Timeline** — the same trip with a still per shot.
+- **Concept Art Iteration Board** — one brief, a gallery of directions.
+- **Podcast Repurposing Studio** — one recording, a whole content pack.
 
-## Build Any Example
+## Building a graph
 
-- Press **Space** to open the node menu and add a node.
-- Drag from an output handle to an input handle to connect nodes.
-- Press **Ctrl/⌘ + Enter** to run.
-- Add **Preview** nodes to inspect intermediate results.
+- Press **Space** to open the node menu.
+- Drag from an output handle to an input handle to connect.
+- Press **Ctrl/⌘ + Enter** to run, and add `Preview` nodes to watch values.
+- Run `nodetool validate` before an expensive run; `nodetool debug` after a
+  failed one.

--- a/docs/cookbook/core-concepts.md
+++ b/docs/cookbook/core-concepts.md
@@ -1,143 +1,111 @@
 ---
 layout: page
-title: Core Concepts & Architecture
+title: Core Concepts
 parent: NodeTool Workflow Cookbook
 nav_order: 1
 ---
-## Core Concepts
 
-### What is a NodeTool Workflow?
+## What a workflow is
 
-A NodeTool workflow is a **Graph** where:
-
-- **Nodes** represent operations (processing, generation, transformation)
-- **Edges** represent data flow between nodes
-- **Execution** follows dependency order automatically
+A workflow is a graph. Nodes are operations, edges carry typed values, and a
+node runs as soon as its inputs are ready — you never order the steps yourself.
 
 ```
-Input → Process → Transform → Output
+Brief → Direct → Still → Clip → Cut
 ```
 
-### Key Principles
+Four rules follow from that:
 
-1. **Data flows through typed edges** — connections enforce type compatibility (image → image, text → text). You cannot connect an image output to a text input.
-2. **Dependency-driven execution** — nodes execute automatically when all their inputs are ready. You never need to specify execution order manually.
-3. **Streaming by default** — many nodes produce output incrementally (token by token, frame by frame), enabling real-time feedback.
-4. **Parallel when possible** — independent branches of a workflow execute concurrently. NodeTool analyzes the graph to maximize parallelism.
-
-### Node Types
-
-| Type                 | Purpose           | Examples                                  |
-| -------------------- | ----------------- | ----------------------------------------- |
-| **Input Nodes**      | Accept parameters | `StringInput`, `ImageInput`, `AudioInput` |
-| **Processing Nodes** | Transform data    | `Resize`, `FilterString`, `ExtractText`   |
-| **Agent Nodes**      | LLM-powered logic | `Agent`, `Summarizer`, `ListGenerator`    |
-| **Output Nodes**     | Return results    | `Output`, `Preview`                       |
-| **Control Nodes**    | Flow control      | `Collect`, `FormatText`                   |
+1. **Edges are typed.** An image output does not connect to a text input. The
+   editor refuses the connection instead of failing at run time.
+2. **Execution follows the data.** Independent branches run at the same time;
+   a `Collect` node is how you wait for a stream to finish.
+3. **Streaming is normal.** `ListGenerator` emits prompts one at a time, and a
+   downstream image node starts on the first one while the last is still being
+   written.
+4. **Failures are local.** A red node stops its own branch. Other branches
+   finish.
 
 ---
 
-## Data Types
+## Documents are values
 
-NodeTool enforces type safety on all connections. Here are the common data types:
+The creative surfaces are documents, and a document travels through a
+graph as one typed value. This is what connects the surface you work in to the
+graph that repeats the work.
 
-| Type | Description | Example Nodes |
-|------|------------|---------------|
-| **String** | Text data | `StringInput`, `Template`, `Agent` |
-| **Image** | Image data (PNG, JPEG, etc.) | `TextToImage`, `Resize`, `ImageInput` |
-| **Audio** | Audio data (WAV, MP3, etc.) | `AudioInput` |
-| **Video** | Video data | `Sora2TextToVideo`, `KlingVideoV16StandardImageToVideo` |
-| **List[T]** | A list of items of type T | `ListGenerator`, `Split`, `Collect` |
-| **Dict** | Key-value pairs | `ParseJSON`, `ExtractJSON` |
-| **Number** | Integer or float | `IntegerInput`, `FloatInput` |
-| **Boolean** | True/false | `BooleanInput` |
+| Document | Into a graph | What reads it | What writes it |
+|---|---|---|---|
+| **Sketch** | `nodetool.constant.Sketch` | `RenderSketch` (image + mask), `SketchLayers` | `CreateSketch` |
+| **Script** | `nodetool.constant.Script` | `LoadScript`, `ScriptToSubtitles` | `VoiceScript`, `ScriptToTimeline` |
+| **Timeline** | `nodetool.constant.Timeline` | `Transcript`, `RenderTimeline` | `AddClips` |
 
-When connecting nodes, NodeTool validates types automatically. Some conversions happen implicitly (e.g., Image formats), while others require explicit conversion nodes.
-
----
-
-## Streaming Architecture
-
-### Why Streaming?
-
-NodeTool workflows support **streaming execution** for:
-
-- **Real-time feedback** — see results as they're generated
-- **Lower latency** — start processing before all data arrives
-- **Better UX** — progress indicators and incremental results
-- **Efficient memory** — process large data in chunks
-
-### Streaming Nodes
-
-Nodes that support streaming output:
-
-| Node | What It Streams |
-|------|----------------|
-| **`Agent`** | LLM responses token by token |
-| **`ListGenerator`** | List items as they're generated |
-| **`RealtimeAgent`** (`openai.agents.RealtimeAgent`) | Audio + text responses simultaneously |
-| **`RealtimeTranscription`** (`openai.agents.RealtimeTranscription`) | Transcription as audio arrives |
-| **`RealtimeAudioInput`** | Audio from an input source |
-
-### Data Flow Patterns
-
-#### Pattern 1: Sequential Pipeline
-
-{% mermaid %}
-graph LR
-    A[Input] --> B[Process] --> C[Transform] --> D[Output]
-{% endmermaid %}
-
-Each node waits for the previous node to complete before starting.
-
-#### Pattern 2: Parallel Branches
-
-{% mermaid %}
-graph LR
-    A[Input] --> B[Process A]
-    A --> C[Process B]
-    B --> D[Output A]
-    C --> E[Output B]
-{% endmermaid %}
-
-Independent branches execute in parallel, improving throughput.
-
-#### Pattern 3: Streaming Pipeline
-
-{% mermaid %}
-graph LR
-    A[Input] --> B[Streaming Agent]
-    B -->|yields chunks| C[Collect]
-    C --> D[Output]
-{% endmermaid %}
-
-Data flows in chunks, enabling real-time updates. The `Collect` node gathers all chunks into a single output.
-
-#### Pattern 4: Fan-In Pattern
-
-{% mermaid %}
-graph LR
-    A[Source A] --> C[Combine]
-    B[Source B] --> C
-    C --> D[Process] --> E[Output]
-{% endmermaid %}
-
-Multiple inputs combine before processing. The Combine node waits for all sources.
+A storyboard is the exception: it has no node of its own, because what a graph
+consumes from it is the screenplay and the timeline it produces.
+`nodetool.creative.Director` writes that same screenplay shape headlessly, so a
+graph can start where the board would have.
 
 ---
 
-## Error Handling
+## Data types
 
-When a node fails during execution:
+| Type | Carries | Typical nodes |
+|---|---|---|
+| `str` | Text | `StringInput`, `Prompt`, `Agent` |
+| `image` | One image | `TextToImage`, `ImageToImage`, `RenderSketch` |
+| `video` | One clip | `TextToVideo`, `ImageToVideo`, `RenderTimeline` |
+| `audio` | One track | `TextToSpeech`, `TextToMusic` |
+| `list[T]` | Many of T | `ListGenerator`, `Collect`, `SketchLayers` |
+| `dict` | A record | `Director` (screenplay), `ScreenplayShots` (shot) |
+| `sketch` `script` `timeline` | A document | the constants above |
+| `image_model` `video_model` `tts_model` | A model choice | `ImageModelInput`, `VideoModelInput` |
 
-1. **The node turns red** — indicating an error occurred
-2. **Downstream nodes are skipped** — they won't receive data from the failed node
-3. **Other branches continue** — independent parts of the workflow still execute
-4. **Error details are available** — click the failed node to see the full error message
+Models are values too. Wire a `VideoModelInput` into several nodes and one
+selection changes the whole graph — which is how a cheap draft run and an
+expensive final run stay the same graph.
 
-**Common strategies for handling errors in workflows:**
+---
 
-- **Add Preview nodes** before and after suspect nodes to inspect data
-- **Use default values** on inputs to handle missing data gracefully
-- **Check model availability** before running — ensure required models are installed
-- **Test incrementally** — build and test workflows one node at a time
+## Fan-out and collection
+
+Most creative graphs are one of these two shapes.
+
+**Stream, then gather.** A generator emits N items, each one runs the same
+pipeline, `Collect` turns the results back into a list.
+
+{% mermaid %}
+graph LR
+  brief["Brief"] --> gen["ListGenerator"] --> img["TextToImage"] --> collect["Collect"] --> out["Output"]
+{% endmermaid %}
+
+**Sequence with carry-over.** Each step depends on the last — a shot seeded by
+the previous shot's final frame. `ShotChain` does this internally; `ForEach`
+plus a `Code` node does it when the rule is your own.
+
+{% mermaid %}
+graph LR
+  shots["ShotBatch"] --> chain["ShotChain (frame → next shot)"] --> cut["AddClips"]
+{% endmermaid %}
+
+The difference matters for cost. Fan-out spends N times in parallel and fails
+independently; a chain spends in order and a failure halfway leaves the tail
+unrendered.
+
+---
+
+## Check before you spend
+
+A video run costs real money, so check the graph statically first:
+
+```bash
+npm run dev:nodetool -- validate workflow.json
+```
+
+It reports unknown node types, missing properties, unselected models, models
+naming a provider you have no key for, and `Code` bodies that will not run —
+in under a second, before any node executes. The workflow editor's estimate
+panel prices the graph from per-node unit pricing in the same spirit.
+
+When a run does fail, `nodetool debug <id>` runs it and hands back every
+message, log, output, and error in one bundle. Details in
+[Workflow Debugging]({{ '/workflow-debugging' | relative_url }}).

--- a/docs/cookbook/patterns.md
+++ b/docs/cookbook/patterns.md
@@ -1,571 +1,330 @@
 ---
 layout: page
-title: Workflow Patterns
+title: Creative Workflow Patterns
 parent: NodeTool Workflow Cookbook
 nav_order: 2
 ---
 
-To build any example:
-– press Space to add nodes
-– drag connections
-– press Ctrl/⌘+Enter to run
-– add Preview nodes to inspect intermediate results
+Eight patterns for creative work worth running more than once. Each one names
+the graph, the nodes, and the shipped template closest to it.
 
-<span id="pattern-1-simple-pipeline"></span>
+To build any of them: press Space to add a node, drag an output handle to an
+input handle, press Ctrl/⌘+Enter to run, and drop `Preview` nodes wherever you
+want to see an intermediate value.
 
-### Pattern 1: Simple Pipeline
+<span id="pattern-1-brief-to-cut"></span>
 
-**Use Case**: Transform input → process → output
+### Pattern 1 · Brief to cut, unattended
 
-**Example**: Image Enhancement
-
-<video controls preload="metadata" poster="{{ '/assets/cookbook/image-enhancement.jpg' | relative_url }}">
-  <source src="{{ '/assets/cookbook/image-enhancement.mp4' | relative_url }}" type="video/mp4">
-</video>
+A line of brief becomes a rendered film: the Director writes the screenplay,
+`ShotChain` films the shots in order, and the clips land on a timeline that gets
+rendered.
 
 {% mermaid %}
-graph TD
-  output["Output"]
-  image_input["ImageInput"]
-  sharpen["UnsharpMask"]
-  auto_contrast["AutoContrast"]
-  image_input --> sharpen
-  sharpen --> auto_contrast
-  auto_contrast --> output
+graph LR
+  brief["StringInput (Brief)"]
+  dir["Director"]
+  batch["ShotBatch"]
+  chain["ShotChain"]
+  cut["AddClips"]
+  render["RenderTimeline"]
+  out["Output (Film)"]
+  brief --> dir --> batch --> chain --> cut --> render --> out
 {% endmermaid %}
 
-**When to Use**:
+`ShotChain` seeds each shot from the previous clip's last frame, which is what
+holds continuity across a cut nobody is watching. Shot 1 has nothing to seed
+from, so it runs text-to-video while the rest run image-to-video — on providers
+that publish those as separate model ids, fill in **Continuation Model** too.
 
-- Simple data transformations
-- Single input, single output
-- No conditional logic needed
+**Nodes**: `nodetool.creative.Director`, `nodetool.creative.ShotBatch`,
+`nodetool.creative.ShotChain`, `nodetool.timeline.AddClips`,
+`nodetool.timeline.RenderTimeline`
+
+**Automate it when** you have many briefs, or one brief that gets re-cut on a
+schedule. **Use the storyboard surface instead** when you want to approve each
+still before paying for its clip.
+
+**Template**: *Direct a Short Film*
 
 ______________________________________________________________________
 
-<span id="pattern-2-agent-driven-generation"></span>
+<span id="pattern-2-shot-fan-out"></span>
 
-### Pattern 2: Agent-Driven Generation
+### Pattern 2 · Shot fan-out through stills
 
-**Use Case**: LLM generates content based on input
-
-**Example**: Image to Story
-
-<video controls preload="metadata" poster="{{ '/assets/cookbook/image-to-story.jpg' | relative_url }}">
-  <source src="{{ '/assets/cookbook/image-to-story.mp4' | relative_url }}" type="video/mp4">
-</video>
-
-{% mermaid %}
-graph TD
-  image_input["Image"]
-  agent_story["Agent (Story Generator)"]
-  preview_audio["Preview (Audio)"]
-  text_to_speech["TextToSpeech"]
-  image_input --> agent_story
-  agent_story --> text_to_speech
-  text_to_speech --> preview_audio
-{% endmermaid %}
-
-**When to Use**:
-
-- Creative generation tasks
-- Multimodal transformations (image→text→audio)
-- Need semantic understanding
-
-**Key Nodes**:
-
-- `Agent`: General-purpose LLM agent with streaming
-- `Summarizer`: Specialized for text summarization
-- `ListGenerator`: Streams list of items
-
-______________________________________________________________________
-
-<span id="pattern-3-streaming-with-multiple-previews"></span>
-
-### Pattern 3: Streaming with Multiple Previews
-
-**Use Case**: Show intermediate results during generation
-
-**Example**: Movie Poster Generator
-
-<video controls preload="metadata" poster="{{ '/assets/cookbook/movie-poster.jpg' | relative_url }}">
-  <source src="{{ '/assets/cookbook/movie-poster.mp4' | relative_url }}" type="video/mp4">
-</video>
-
-{% mermaid %}
-graph TD
-  strategy_llm["Agent (Strategy)"]
-  strategy_template_prompt["String (Strategy Template)"]
-  strategy_preview["Preview (Strategy)"]
-  strategy_prompt_formatter["FormatText (Strategy)"]
-  movie_title_input["StringInput (Title)"]
-  genre_input["StringInput (Genre)"]
-  audience_input["StringInput (Audience)"]
-  image_preview["Preview (Image)"]
-  prompt_list_generator["ListGenerator"]
-  designer_instructions_prompt["String (Designer Instructions)"]
-  preview_prompts["Preview (Prompts)"]
-  text_to_image["TextToImage"]
-  strategy_llm --> strategy_preview
-  strategy_template_prompt --> strategy_prompt_formatter
-  strategy_prompt_formatter --> strategy_llm
-  strategy_llm --> prompt_list_generator
-  designer_instructions_prompt --> prompt_list_generator
-  audience_input --> strategy_prompt_formatter
-  movie_title_input --> strategy_prompt_formatter
-  genre_input --> strategy_prompt_formatter
-  prompt_list_generator --> preview_prompts
-  prompt_list_generator --> text_to_image
-  text_to_image --> image_preview
-{% endmermaid %}
-
-**When to Use**:
-
-- Complex multi-stage generation
-- User needs to see progress
-- Agent planning + execution workflow
-
-**Key Concepts**:
-
-- **Strategy Phase**: Agent plans approach
-- **Preview Nodes**: Show intermediate results
-- **ListGenerator**: Streams generated prompts
-- **Image Generation**: Final output
-
-______________________________________________________________________
-
-<span id="pattern-4-rag-retrieval-augmented-generation"></span>
-
-### Pattern 4: RAG (Retrieval-Augmented Generation)
-
-**Use Case**: Answer questions using documents as context
-
-**Example**: Chat with Docs
-
-<video controls preload="metadata" poster="{{ '/assets/cookbook/chat-with-docs.jpg' | relative_url }}">
-  <source src="{{ '/assets/cookbook/chat-with-docs.mp4' | relative_url }}" type="video/mp4">
-</video>
-
-{% mermaid %}
-graph TD
-  chat_input["StringInput"]
-  output["Output (Answer)"]
-  format_text["FormatText"]
-  hybrid_search["HybridSearch"]
-  agent["Agent"]
-  chat_input --> format_text
-  chat_input --> hybrid_search
-  hybrid_search --> format_text
-  format_text --> agent
-  agent --> output
-{% endmermaid %}
-
-**When to Use**:
-
-- Question-answering over documents
-- Need factual accuracy from specific sources
-- Reduce LLM hallucinations
-
-**Key Components**:
-
-1. **Search**: Query vector database for relevant documents
-1. **Format**: Inject retrieved context into prompt
-1. **Generate**: Stream LLM response with context
-
-______________________________________________________________________
-
-<span id="pattern-5-database-persistence"></span>
-
-### Pattern 5: Structured Records
-
-**Use Case**: Have a model produce rows you can compute on, not prose you have to re-parse
-
-**Example**: AI Flashcard Generator
-
-<video controls preload="metadata" poster="{{ '/assets/cookbook/flashcards-sqlite.jpg' | relative_url }}">
-  <source src="{{ '/assets/cookbook/flashcards-sqlite.mp4' | relative_url }}" type="video/mp4">
-</video>
-
-{% mermaid %}
-graph TD
-  topic_input["StringInput (Topic)"]
-  format_prompt["FormatText"]
-  generate_flashcards["DataGenerator"]
-  plan_study["Code (dedupe & order)"]
-  display_result["Preview"]
-  topic_input --> format_prompt
-  format_prompt --> generate_flashcards
-  generate_flashcards --> plan_study
-  plan_study --> display_result
-{% endmermaid %}
-
-**When to Use**:
-
-- The model's answer is a list of things, each with the same fields
-- Something downstream has to sort, filter, group, or count them
-- You would otherwise be parsing a markdown list back into data
-
-**Key Nodes**:
-
-- `DataGenerator`: ask for named columns and get rows, not a blob
-- `Code` (`nodetool.code.Code`): one script that computes on those rows — here
-  it drops repeated questions and deals one card from each category in turn
-
-**Structured Flow**:
-
-1. Name the columns you want
-1. Generate rows against them
-1. Compute on the rows in one script
-
-______________________________________________________________________
-
-<span id="pattern-6-email--web-integration"></span>
-
-### Pattern 6: Email & Web Integration
-
-**Use Case**: Process emails or web content
-
-**Example**: Summarize Newsletters
-
-<video controls preload="metadata" poster="{{ '/assets/cookbook/summarize-newsletters.jpg' | relative_url }}">
-  <source src="{{ '/assets/cookbook/summarize-newsletters.mp4' | relative_url }}" type="video/mp4">
-</video>
-
-{% mermaid %}
-graph TD
-  gmail_search["GmailSearch"]
-  email_fields["Template"]
-  summarizer_streaming["Summarizer"]
-  preview_summary["Preview (Summary)"]
-  preview_body["Preview (Body)"]
-  gmail_search --> email_fields
-  email_fields --> summarizer_streaming
-  summarizer_streaming --> preview_summary
-  email_fields --> preview_body
-{% endmermaid %}
-
-**When to Use**:
-
-- Automate email processing
-- Monitor RSS feeds
-- Extract web content
-
-**Key Nodes**:
-
-- `Code` (`nodetool.code.Code`): Search Gmail and apply labels with `gmail_search` / `gmail_modify_labels` from `@nodetool-ai/sandbox-nodetool/google` — the `Gmail Search`, `Gmail Add Label` and `Gmail Archive` snippets prefill each one
-- `Template`: Format email fields into text
-- `Code` (`nodetool.code.Code`): Fetch web content with `fetch` and turn it into markdown with `@nodetool-ai/sandbox-html`, or parse an RSS feed with `@nodetool-ai/sandbox-xml` — there is no RSS node
-
-______________________________________________________________________
-
-<span id="pattern-7-multi-modal-workflows"></span>
-
-### Pattern 7: Multi-Modal Workflows
-
-**Use Case**: Convert between different media types
-
-**Example**: Audio to Image
-
-<video controls preload="metadata" poster="{{ '/assets/cookbook/audio-to-image.jpg' | relative_url }}">
-  <source src="{{ '/assets/cookbook/audio-to-image.mp4' | relative_url }}" type="video/mp4">
-</video>
-
-{% mermaid %}
-graph TD
-  stable_diffusion["StableDiffusion"]
-  whisper["Whisper"]
-  audio_input["AudioInput"]
-  output["Output"]
-  whisper --> stable_diffusion
-  audio_input --> whisper
-  stable_diffusion --> output
-{% endmermaid %}
-
-**When to Use**:
-
-- Converting between media types
-- Creating rich multimedia experiences
-- Accessibility applications
-
-**Common Chains**:
-
-- Audio → Text → Image
-- Image → Text → Audio
-- Video → Audio → Text → Summary
-
-______________________________________________________________________
-
-<span id="pattern-8-advanced-image-processing"></span>
-
-### Pattern 8: Advanced Image Processing
-
-**Use Case**: AI-powered image transformations
-
-**Example**: Style Transfer
-
-<video controls preload="metadata" poster="{{ '/assets/cookbook/style-transfer.jpg' | relative_url }}">
-  <source src="{{ '/assets/cookbook/style-transfer.mp4' | relative_url }}" type="video/mp4">
-</video>
-
-{% mermaid %}
-graph TD
-  sd_img2img["StableDiffusionV3MediumImageToImage"]
-  image_input_1["ImageInput"]
-  image_input_2["ImageInput"]
-  output["Output"]
-  image_to_text["ImageToText"]
-  fit_1["Fit"]
-  fit_2["Fit"]
-  sd_img2img --> output
-  image_to_text --> sd_img2img
-  image_input_2 --> fit_1
-  image_input_1 --> fit_2
-  fit_2 --> image_to_text
-  image_input_2 --> sd_img2img
-  fit_2 --> sd_img2img
-{% endmermaid %}
-
-**When to Use**:
-
-- Style transfer between images
-- Controlled image generation
-- Preserving structure while changing style
-
-**Key Techniques**:
-
-- **Img2Img**: Transform while maintaining composition (`StableDiffusionV3MediumImageToImage`, or `StableDiffusion` / `StableDiffusionXL` for text-to-image)
-- **Image-to-Text**: Generate descriptions (`ImageToText`)
-- **Canny**: Edge detection preprocessing
-
-______________________________________________________________________
-
-<span id="pattern-9-text-to-video"></span>
-
-### Pattern 9: Text-to-Video Generation
-
-**Use Case**: Generate videos from text descriptions
-
-**Example**: Cinematic Video from Prompt
-
-<video controls preload="metadata" poster="{{ '/assets/cookbook/text-to-video.jpg' | relative_url }}">
-  <source src="{{ '/assets/cookbook/text-to-video.mp4' | relative_url }}" type="video/mp4">
-</video>
-
-{% mermaid %}
-graph TD
-  string_input["StringInput (Prompt)"]
-  output["Output"]
-  kling_text_to_video["KlingVideoV16ProTextToVideo"]
-  string_input --> kling_text_to_video
-  kling_text_to_video --> output
-{% endmermaid %}
-
-**When to Use**:
-
-- Create videos from text descriptions
-- Generate concept videos and storyboards
-- Produce cinematic content from prompts
-- Rapid video prototyping
-
-**Key Nodes**:
-
-- `KlingVideoV16ProTextToVideo`: High-quality text-to-video (Kling 1.6 Pro)
-- `MinimaxHailuo23ProTextToVideo`: Professional quality (Hailuo 2.3)
-- `Sora2TextToVideo`: OpenAI Sora 2 model
-- `WanProTextToVideo`: Alibaba Wan
-
-**Configuration Tips**:
-
-- Duration: 5-10 seconds for most models
-- Resolution: 768P for faster generation, 1080P for quality
-- Aspect ratios: 16:9 (landscape), 9:16 (portrait), 1:1 (square)
-
-______________________________________________________________________
-
-<span id="pattern-10-image-to-video"></span>
-
-### Pattern 10: Image-to-Video Generation
-
-**Use Case**: Animate images into videos
-
-**Example**: Bring Images to Life
-
-<video controls preload="metadata" poster="{{ '/assets/cookbook/image-to-video.jpg' | relative_url }}">
-  <source src="{{ '/assets/cookbook/image-to-video.mp4' | relative_url }}" type="video/mp4">
-</video>
-
-{% mermaid %}
-graph TD
-  image_input["ImageInput"]
-  string_input["StringInput (Motion Guide)"]
-  output["Output"]
-  kling_image_to_video["KlingVideoV16StandardImageToVideo"]
-  image_input --> kling_image_to_video
-  string_input --> kling_image_to_video
-  kling_image_to_video --> output
-{% endmermaid %}
-
-**When to Use**:
-
-- Animate static images
-- Create motion from photographs
-- Multi-image video generation
-- Product showcases from images
-
-**Key Nodes**:
-
-- `KlingVideoV16StandardImageToVideo`: Kling 1.6 Standard image-to-video
-- `MinimaxHailuo02ProImageToVideo`: High-quality animation (Hailuo 02 Pro)
-- `SeeDanceV15ProImageToVideo`: ByteDance SeeDance 1.5 Pro
-- `WanV225bImageToVideo`: Alibaba Wan 2.2
-
-**Advanced Pattern**: Multi-Image Animation
-
-{% mermaid %}
-graph TD
-  image1["ImageInput (Frame 1)"]
-  image2["ImageInput (Frame 2)"]
-  image3["ImageInput (Frame 3)"]
-  motion_prompt["StringInput (Motion)"]
-  output["Output"]
-  kling_i2v["KlingVideoV16StandardImageToVideo"]
-  kling_i2v --> output
-  image1 --> kling_i2v
-  image2 --> kling_i2v
-  image3 --> kling_i2v
-  motion_prompt --> kling_i2v
-{% endmermaid %}
-
-______________________________________________________________________
-
-<span id="pattern-11-talking-avatar"></span>
-
-### Pattern 11: Talking Avatar Generation
-
-**Use Case**: Create lip-synced avatar videos
-
-**Example**: Virtual Presenter
-
-<video controls preload="metadata" poster="{{ '/assets/cookbook/talking-avatar.jpg' | relative_url }}">
-  <source src="{{ '/assets/cookbook/talking-avatar.mp4' | relative_url }}" type="video/mp4">
-</video>
-
-{% mermaid %}
-graph TD
-  image_input["ImageInput (Face Photo)"]
-  audio_input["AudioInput (Speech)"]
-  output["Output"]
-  kling_avatar["KlingVideoAiAvatarV2Pro"]
-  image_input --> kling_avatar
-  audio_input --> kling_avatar
-  kling_avatar --> output
-{% endmermaid %}
-
-**When to Use**:
-
-- Create virtual presenters
-- Generate lip-synced avatar videos
-- Educational content with AI speakers
-- Virtual influencers and spokespersons
-
-**Key Nodes**:
-
-- `KlingVideoAiAvatarV2Pro`: Pro-quality avatar generation
-- `KlingVideoAiAvatarV2Standard`: Standard mode for faster generation
-- `Infinitalk`: Audio-driven video generation
-
-**Workflow**: Audio + Image → Talking Avatar
-
-1. **Photo Input**: Front-facing portrait image
-2. **Audio Track**: Speech recording or TTS output
-3. **Optional Prompt**: Guide emotions and expressions
-4. **Mode Selection**: Standard (faster) or Pro (higher quality)
-
-______________________________________________________________________
-
-<span id="pattern-12-video-enhancement"></span>
-
-### Pattern 12: Image Enhancement & Upscaling
-
-**Use Case**: Improve image quality and resolution
-
-**Example**: HD Image Upscaling
-
-<video controls preload="metadata" poster="{{ '/assets/cookbook/image-upscaling.jpg' | relative_url }}">
-  <source src="{{ '/assets/cookbook/image-upscaling.mp4' | relative_url }}" type="video/mp4">
-</video>
-
-{% mermaid %}
-graph TD
-  image_input["ImageInput (Low Res)"]
-  output["Output (High Res)"]
-  topaz_upscale["TopazUpscaleImage"]
-  image_input --> topaz_upscale
-  topaz_upscale --> output
-{% endmermaid %}
-
-**When to Use**:
-
-- Upscale low-resolution images
-- Remove noise and artifacts
-- Enhance image quality
-- Prepare images for high-resolution displays
-
-**Key Nodes**:
-
-- `TopazUpscaleImage`: AI-powered upscaling to higher resolutions
-- Denoise option: Reduces artifacts during upscaling
-
-**Configuration**:
-
-- Higher target resolutions for crisp output
-- Denoise: Enable for noisy input images
-- Best for: Enhancing old photos, smartphone images, web graphics
-
-______________________________________________________________________
-
-<span id="pattern-13-storyboard-to-video"></span>
-
-### Pattern 13: Storyboard to Video
-
-**Use Case**: Convert image sequences to coherent videos
-
-**Example**: Visual Story Generation
+The same trip from brief to cut, but with a keyframe in the middle:
+`ScreenplayShots` streams one prompt per shot, each prompt becomes a still, and
+each still is animated.
 
 <video controls preload="metadata" poster="{{ '/assets/cookbook/storyboard-to-video.jpg' | relative_url }}">
   <source src="{{ '/assets/cookbook/storyboard-to-video.mp4' | relative_url }}" type="video/mp4">
 </video>
 
 {% mermaid %}
-graph TD
-  story_prompt["StringInput (Story)"]
-  image1["ImageInput (Scene 1)"]
-  image2["ImageInput (Scene 2)"]
-  image3["ImageInput (Scene 3)"]
-  output["Output"]
-  sora_storyboard["Sora2ImageToVideoPro"]
-  sora_storyboard --> output
-  story_prompt --> sora_storyboard
-  image1 --> sora_storyboard
-  image2 --> sora_storyboard
-  image3 --> sora_storyboard
+graph LR
+  brief["StringInput (Brief)"]
+  dir["Director"]
+  shots["ScreenplayShots (streams)"]
+  still["TextToImage"]
+  clip["ImageToVideo"]
+  collect["Collect"]
+  cut["AddClips"]
+  render["RenderTimeline"]
+  brief --> dir --> shots --> still --> clip --> collect --> cut --> render
 {% endmermaid %}
 
-**When to Use**:
+A still costs cents and a clip costs dollars, so the keyframe is both a control
+point and a cheap thing to inspect after an unattended run. Anchoring every
+keyframe to one style frame — generate it first, then run the shot stills
+through `ImageToImage` against it — is what keeps thirty shots looking like one
+film.
 
-- Create narrative videos from storyboards
-- Combine multiple scenes into one video
-- Professional video pre-visualization
-- Animated story creation
+**Nodes**: `nodetool.creative.ScreenplayShots`, `nodetool.image.TextToImage`,
+`nodetool.image.ImageToImage`, `nodetool.video.ImageToVideo`,
+`nodetool.control.Collect`
 
-**Key Nodes**:
+**Automate it when** the shot count is large enough that clicking through the
+board is the slow part.
 
-- `Sora2ImageToVideoPro`: OpenAI Sora 2 Pro keyframe-driven generation
-- Supports: 1-3 keyframe images
-- Output: Smooth transitions between scenes
+**Templates**: *Directed Film to Timeline*, *Script to Screen*,
+*Movie Trailer Generator*
 
-**Workflow**:
+______________________________________________________________________
 
-1. **Story Prompt**: Describe the narrative arc
-2. **Keyframes**: Provide 1-3 scene images
-3. **Generation**: Sora creates smooth transitions
-4. **Duration**: 1-60 frames configurable
+<span id="pattern-3-entities"></span>
+
+### Pattern 3 · One cast across many assets
+
+Entities are named characters, locations, styles, and props whose canonical
+descriptor is pasted verbatim into every prompt that uses them. That verbatim
+text is what holds a face or a palette steady across a batch.
+
+{% mermaid %}
+graph LR
+  brief["StringInput (Brief)"]
+  prompts["ListGenerator (one prompt per asset)"]
+  apply["ApplyEntities"]
+  image["TextToImage"]
+  collect["Collect"]
+  out["Output"]
+  brief --> prompts --> apply
+  apply -->|prompt| image
+  apply -->|reference_images| image
+  image --> collect --> out
+{% endmermaid %}
+
+`TextToImage`, `ImageToImage`, and `ImageToVideo` take an **entities** property
+directly — reach for `nodetool.creative.ApplyEntities` when something else needs
+the seasoned text, since it returns the composed prompt and the reference images
+as separate outputs.
+
+**Nodes**: `nodetool.creative.ApplyEntities`, `nodetool.generators.ListGenerator`,
+`nodetool.image.TextToImage`
+
+**Automate it when** a campaign needs the same cast in thirty frames.
+**Do it by hand** for a single hero image — the picker in the Prompt node is one
+`@` away.
+
+______________________________________________________________________
+
+<span id="pattern-4-script-to-voiced-cut"></span>
+
+### Pattern 4 · Script to voiced cut and captions
+
+A script is a document with cast voices attached to its lines. `VoiceScript`
+synthesizes every line that is draft or stale, using each line's own voice, and
+saves the takes back onto the script.
+
+{% mermaid %}
+graph LR
+  script["Script (constant)"]
+  voice["VoiceScript"]
+  tl["ScriptToTimeline"]
+  render["RenderTimeline"]
+  subs["ScriptToSubtitles"]
+  out["Output (Cut)"]
+  srt["Output (SRT)"]
+  script --> voice --> tl --> render --> out
+  voice --> subs --> srt
+{% endmermaid %}
+
+Lines already up to date are skipped, so a re-run after a copy edit pays for the
+changed lines only. That is what makes the whole chain worth wiring: the script
+is the source of truth, and the cut plus the subtitle file are both derived from
+it.
+
+**Nodes**: `nodetool.constant.Script`, `nodetool.script.VoiceScript`,
+`nodetool.script.ScriptToTimeline`, `nodetool.script.ScriptToSubtitles`,
+`nodetool.timeline.RenderTimeline`
+
+**Automate it when** copy changes often, or when the same script ships in
+several languages — put an `Agent` translation step in front of the voicing and
+you have a localised master per language.
+
+**Templates**: *Narrate a Script*, *Localise a Script and Revoice It*
+
+______________________________________________________________________
+
+<span id="pattern-5-sketch-as-control"></span>
+
+### Pattern 5 · Sketch as the control input
+
+A sketch document carries layers and a mask. `RenderSketch` flattens it to an
+image plus that mask, which is exactly the pair an image-to-image model wants.
+
+<video controls preload="metadata" poster="{{ '/assets/cookbook/style-transfer.jpg' | relative_url }}">
+  <source src="{{ '/assets/cookbook/style-transfer.mp4' | relative_url }}" type="video/mp4">
+</video>
+
+{% mermaid %}
+graph LR
+  sketch["Sketch (constant)"]
+  render["RenderSketch"]
+  styles["StringListInput (Styles)"]
+  each["ForEach"]
+  img["ImageToImage"]
+  collect["Collect"]
+  out["Output (Variants)"]
+  sketch --> render --> img
+  styles --> each --> img --> collect --> out
+{% endmermaid %}
+
+`SketchLayers` is the other half: it hands you each visible layer as its own
+image with its name, so foreground and background can go through different
+pipelines and be composited back together.
+
+**Nodes**: `nodetool.constant.Sketch`, `nodetool.sketch.RenderSketch`,
+`nodetool.sketch.SketchLayers`, `nodetool.image.ImageToImage`,
+`nodetool.image.Compositor`
+
+**Automate it when** the composition is settled and you want it in twelve
+styles or six aspect ratios. **Paint in the sketch editor** while the
+composition itself is still the question.
+
+______________________________________________________________________
+
+<span id="pattern-6-variant-fan-out"></span>
+
+### Pattern 6 · Variant fan-out from one brief
+
+An agent turns a brief into a direction, a list generator writes N distinct
+prompts against it, and each prompt renders. The fan-out is the point: one input,
+a gallery out.
+
+<video controls preload="metadata" poster="{{ '/assets/cookbook/movie-poster.jpg' | relative_url }}">
+  <source src="{{ '/assets/cookbook/movie-poster.mp4' | relative_url }}" type="video/mp4">
+</video>
+
+{% mermaid %}
+graph LR
+  brief["StringInput (Brief)"]
+  count["IntegerInput (Count)"]
+  direction["Agent (Art Director)"]
+  prompts["ListGenerator"]
+  image["TextToImage"]
+  preview["Preview"]
+  collect["Collect"]
+  out["Output"]
+  brief --> direction --> prompts --> image --> collect --> out
+  count --> prompts
+  prompts --> preview
+{% endmermaid %}
+
+`ListGenerator` streams, so the first prompts render while the last are still
+being written, and a `Preview` on the prompt stream shows you what is coming
+before the images arrive.
+
+**Nodes**: `nodetool.agents.Agent`, `nodetool.generators.ListGenerator`,
+`nodetool.image.TextToImage`, `nodetool.control.Collect`
+
+**Automate it when** you want variety to pick from — concepts, thumbnails,
+poster directions, a social kit.
+
+**Templates**: *Concept Art Iteration Board*, *Hook & Thumbnail Factory*,
+*Movie Posters*, *Brand Asset Generator*
+
+______________________________________________________________________
+
+<span id="pattern-7-derivatives"></span>
+
+### Pattern 7 · Derivatives from a finished cut
+
+One master, many deliverables. `Transcript` reads the timeline's own text, so
+titles, show notes, and social copy come from the cut rather than from a second
+transcription pass.
+
+{% mermaid %}
+graph LR
+  tl["Timeline (constant)"]
+  transcript["Transcript"]
+  agent["Agent (titles, notes, posts)"]
+  render["RenderTimeline"]
+  vertical["Resize (9:16)"]
+  subs["AddSubtitles"]
+  copy["Output (Copy)"]
+  post["Output (Vertical cut)"]
+  tl --> transcript --> agent --> copy
+  tl --> render --> vertical --> subs --> post
+{% endmermaid %}
+
+**Nodes**: `nodetool.constant.Timeline`, `nodetool.timeline.Transcript`,
+`nodetool.timeline.RenderTimeline`, `nodetool.video.Resize`,
+`nodetool.video.AddSubtitles`, `nodetool.agents.Agent`
+
+**Automate it when** every cut ships in more than one shape. Re-running the
+graph after an edit rebuilds every derivative from the same master.
+
+**Templates**: *Cut a Landscape Clip for Vertical*,
+*Podcast Repurposing Studio*, *Subtitle Text from a Recording*
+
+______________________________________________________________________
+
+<span id="pattern-8-code-glue"></span>
+
+### Pattern 8 · Code node for the parts a model should not do
+
+Naming, ordering, deduping, packaging: deterministic work that a model does
+expensively and inconsistently. One `Code` node does it in JavaScript.
+
+{% mermaid %}
+graph LR
+  clip["VideoInput"]
+  audio["ExtractAudio"]
+  asr["AutomaticSpeechRecognition"]
+  code["Code (slugify)"]
+  out["Output (Filename)"]
+  clip --> audio --> asr --> code --> out
+{% endmermaid %}
+
+The body runs in the QuickJS sandbox and imports what it declares. Sandbox packs
+cover the file formats a delivery step usually needs —
+`@nodetool-ai/sandbox-subtitle` for SRT and VTT, `-csv`, `-zip`, `-yaml`,
+`-xlsx`. Validate a body before running the graph with
+`nodetool validate <file>`, or author it against `validate_code` / `run_code` /
+`test_code`.
+
+**Nodes**: `nodetool.code.Code`
+
+**Automate it when** the step has one right answer: a slug, a manifest, a
+per-shot cost table, a subtitle file assembled from timings.
+
+**Template**: *Name a File from Its Narration*
+
+______________________________________________________________________
+
+### Leave it on the surface
+
+A graph earns its place by repeating. These do not repeat, and the surface is
+faster:
+
+| Job | Where it belongs |
+|---|---|
+| Judging a film shot by shot, re-rolling the weak ones | Storyboard |
+| Trimming, mixing, and captioning one cut | Timeline editor |
+| Painting a mask or composing a frame | Sketch editor |
+| Rewriting a line and hearing it back | Script editor |
+| One hero image, one question about a document | Chat |
+
+Each surface is also drivable by the chat agent through its `ui_*` tools, and
+from outside over MCP — so "do it on the surface" does not mean "do it by hand".

--- a/docs/cookbook/patterns.md
+++ b/docs/cookbook/patterns.md
@@ -171,7 +171,8 @@ ______________________________________________________________________
 ### Pattern 5 · Sketch as the control input
 
 A sketch document carries layers and a mask. `RenderSketch` flattens it to an
-image plus that mask, which is exactly the pair an image-to-image model wants.
+image and returns that mask alongside — the composition and the region to
+change, in one node.
 
 <video controls preload="metadata" poster="{{ '/assets/cookbook/style-transfer.jpg' | relative_url }}">
   <source src="{{ '/assets/cookbook/style-transfer.mp4' | relative_url }}" type="video/mp4">
@@ -186,17 +187,22 @@ graph LR
   img["ImageToImage"]
   collect["Collect"]
   out["Output (Variants)"]
-  sketch --> render --> img
+  sketch --> render -->|image| img
   styles --> each --> img --> collect --> out
 {% endmermaid %}
 
+That is the whole-frame version. For a masked edit, send the same node's
+`mask` output alongside its `image` to `openai.image.EditImage`, which repaints
+the white areas and leaves the rest alone — the mask is painted once and every
+variant reuses it.
+
 `SketchLayers` is the other half: it hands you each visible layer as its own
 image with its name, so foreground and background can go through different
-pipelines and be composited back together.
+pipelines and be composited back together with `Compositor`.
 
 **Nodes**: `nodetool.constant.Sketch`, `nodetool.sketch.RenderSketch`,
 `nodetool.sketch.SketchLayers`, `nodetool.image.ImageToImage`,
-`nodetool.image.Compositor`
+`openai.image.EditImage`, `nodetool.image.Compositor`
 
 **Automate it when** the composition is settled and you want it in twelve
 styles or six aspect ratios. **Paint in the sketch editor** while the
@@ -261,15 +267,24 @@ graph LR
   agent["Agent (titles, notes, posts)"]
   render["RenderTimeline"]
   vertical["Resize (9:16)"]
+  audio["ExtractAudio"]
+  asr["Transcribe (segments)"]
   subs["AddSubtitles"]
   copy["Output (Copy)"]
   post["Output (Vertical cut)"]
   tl --> transcript --> agent --> copy
   tl --> render --> vertical --> subs --> post
+  render --> audio --> asr --> subs
 {% endmermaid %}
+
+Burned-in captions need timings, not prose: `AddSubtitles` takes
+`list[audio_chunk]`, which `openai.audio.Transcribe` returns as `segments` or
+`words`. `Transcript` is the text path — it feeds the copy, not the caption
+burn.
 
 **Nodes**: `nodetool.constant.Timeline`, `nodetool.timeline.Transcript`,
 `nodetool.timeline.RenderTimeline`, `nodetool.video.Resize`,
+`nodetool.video.ExtractAudio`, `openai.audio.Transcribe`,
 `nodetool.video.AddSubtitles`, `nodetool.agents.Agent`
 
 **Automate it when** every cut ships in more than one shape. Re-running the

--- a/docs/index.md
+++ b/docs/index.md
@@ -150,7 +150,7 @@ Same code, same workflows. Both AGPL-3.0.
   </article>
 </div>
 
-More patterns — pipelines, data, RAG, email — in the [Cookbook]({{ '/cookbook' | relative_url }}).
+More creative patterns — directed films, entity-consistent batches, script-driven cuts — in the [Cookbook]({{ '/cookbook' | relative_url }}).
 
 ## Get started
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -62,9 +62,9 @@ NodeTool is an open-source, local-first visual environment for building AI workf
 
 ## Examples
 
-- [Cookbook]({{ site.url }}/cookbook): End-to-end patterns and recipes.
-- [Core Patterns]({{ site.url }}/cookbook/core-concepts): Foundational workflow patterns.
-- [Pipeline Patterns]({{ site.url }}/cookbook/patterns): Composition patterns.
+- [Cookbook]({{ site.url }}/cookbook): Creative workflow patterns worth automating.
+- [Core Concepts]({{ site.url }}/cookbook/core-concepts): Typed edges, documents as values, fan-out versus chain.
+- [Creative Patterns]({{ site.url }}/cookbook/patterns): Eight patterns from brief to delivered cut.
 - [Workflow Examples]({{ site.url }}/workflows/): Ready-to-run sample workflows.
 
 ## Configuration


### PR DESCRIPTION
## What changed

The cookbook still described the pre-surface product: thirteen patterns covering RAG Q&A, newsletter summarization, flashcards, single-node upscaling, talking avatars, and keyframe-to-video wiring the storyboard now owns — with node names (`StableDiffusion`, `Whisper`, `KlingVideoV16ProTextToVideo`, `TopazUpscaleImage`, `HybridSearch`, `GmailSearch`) that no longer match the registry. It is replaced with eight creative patterns built on today's surfaces, each keyed to whether automating it actually pays: brief-to-cut with `ShotChain`, shot fan-out through cheap stills, entity-consistent batches, script to voiced cut plus captions, sketch as the control input, variant fan-out, derivatives from a finished cut, and the `Code` node for deterministic glue. A "surface or graph" table opens the index and a "leave it on the surface" section closes the patterns page, so the cookbook is explicit about what not to wire into a graph. Core concepts loses the stale node table and gains documents-as-values (`constant.Sketch` / `Script` / `Timeline`) plus a validate-before-you-spend note. Inbound references were updated: the two RAG anchors in `collections.md` now point at the Chat with Docs example, and the index blurb, `llms.txt` entries, and sidebar labels match the new contents.

Every node type named across the three files was checked against `docs/nodes/catalog.json` (462 nodes) and every cited template against the shipped examples in `packages/base-nodes/nodetool/examples/nodetool-base/`. Two wiring claims failed that check and were corrected in the second commit: `ImageToImage` has no mask input, so masked sketch edits name `openai.image.EditImage`; `AddSubtitles` takes `list[audio_chunk]`, so the caption path goes through `openai.audio.Transcribe` rather than the timeline's prose `Transcript`.

## Verification

Docs-only diff (7 Markdown/HTML files, no workspace owns them), so `test:affected` selects nothing and the harness gate selects no surface:

```
$ npm run test:affected -- --dry-run
Affected test plan (7 changed file(s) in the working tree):
  nothing — no workspace owns the changed files.

$ npm run typecheck   # exit 0
$ npm run lint        # exit 0

$ npm run dev:nodetool -- harness gate --base origin/main
7 changed file(s) touch 0 surface(s):
7 file(s) outside any surface: ...
0 selfcheck(s) to run
```

Two checks written for this change, both run against the final files:

- every backticked node name resolves in `docs/nodes/catalog.json` — `unresolved: none`. It found the two real errors above before they shipped, so it is not passing by matching nothing.
- every internal `relative_url` link and every `#pattern-*` anchor resolves to an existing file or anchor span — `missing: []`. CI's own `Markdown link check (relative links)` agrees.

- [x] `npm run test:affected` (the full `npm run test` + `npm run test:packages` pass is CI's job, not yours)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run dev:nodetool -- harness gate --base main` (run against `origin/main`; local `main` was stale)

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit is added to the repo — the two verification scripts above are one-off and not committed.

## Note for the reviewer

Five video/poster asset pairs under `docs/assets/cookbook/` are now unreferenced (`audio-to-image`, `text-to-video`, `image-to-video`, `talking-avatar`, `image-upscaling`) — they only served the removed patterns. Left in place rather than deleted, in case the workflow gallery wants them.