### PR TITLE
Enable lib.pdf nodes in the production cloud profile

### DIFF
--- a/docs/CLOUD_NODE_CURATION.md
+++ b/docs/CLOUD_NODE_CURATION.md
@@ -150,6 +150,7 @@ that egress policy is written down in the ComfyUI row of
 | `lib.svg`   | SVG / vector graphics                                  |
 | `lib.grid`  | Image grid slicing                                     |
 | `lib.audio` | Audio DSP/effects (reverb, delay, EQ, …)               |
+| `lib.pdf`   | Text/table/markdown extraction, OCR, page rasterization |
 
 ### Provider node namespaces
 
@@ -157,7 +158,7 @@ that egress policy is written down in the ComfyUI row of
 
 ## Namespaces dropped (the "nerdy" set)
 
-- **Data/docs:** `nodetool.data` (dataframes), `nodetool.document`, `lib.pdf`,
+- **Data/docs:** `nodetool.data` (dataframes), `nodetool.document`,
   `lib.markdown`, `lib.html`, `lib.charts`
 - **System/automation:** `lib.os`, `nodetool.workspace`,
   `nodetool.triggers`, `lib.browser`, `lib.video.download`

--- a/packages/protocol/src/cloud-profile.ts
+++ b/packages/protocol/src/cloud-profile.ts
@@ -94,6 +94,7 @@ export const CLOUD_NODE_NAMESPACES: readonly string[] = [
   "lib.svg",
   "lib.grid",
   "lib.audio", // DSP / effects (reverb, delay, EQ, …)
+  "lib.pdf", // text/table/markdown extraction, OCR, page rasterization
 
   // — Provider node namespaces: the big LLM/multimodal labs + Fal + Kie —
   "openai", // openai.text / .image / .audio / .agents

--- a/packages/protocol/tests/cloud-profile.test.ts
+++ b/packages/protocol/tests/cloud-profile.test.ts
@@ -51,6 +51,7 @@ describe("isCloudNodeType", () => {
       "lib.image.warp.Offset",
       "lib.audio.Reverb",
       "lib.svg.Document",
+      "lib.pdf.ExtractText",
       "openai.image.CreateImage",
       "gemini.video.TextToVideo",
       "mistral.text.ChatComplete",
@@ -65,7 +66,6 @@ describe("isCloudNodeType", () => {
   it("rejects the nerdy / out-of-scope namespaces", () => {
     for (const nodeType of [
       "lib.sqlite.GetDatabasePath",
-      "lib.pdf.Screenshot",
       "lib.charts.ChartRenderer",
       "nodetool.data.Filter",
       "nodetool.document.LoadDocumentFile",


### PR DESCRIPTION
## What changed

`lib.pdf` (text/table/markdown extraction, OCR, page rasterization) was pruned from the production cloud profile by omission — it wasn't in `CLOUD_NODE_NAMESPACES`, so `applyCloudNodePolicy` unregistered it at server bootstrap whenever `NODETOOL_ENV=production` or `NODETOOL_NODE_PROFILE=cloud`. It has no host-filesystem dependency (unlike `nodetool.workspace`/`lib.os`) and fits the creative media toolkit alongside `lib.image`/`lib.audio`, so this adds it to the allowlisted namespaces in `packages/protocol/src/cloud-profile.ts` and updates `docs/CLOUD_NODE_CURATION.md` to move it out of the "dropped" list.

## Verification

- [x] `npx vitest run packages/protocol/tests/cloud-profile.test.ts` — 22 passed
- [x] `npm run test --workspace=packages/kernel` — 983 passed (ruled out an unrelated build-race flake seen under a parallel `test:affected` run by re-running standalone, before and after this diff)
- [x] `npm run lint --workspace=packages/protocol`
- [ ] `npm run typecheck` — pre-existing failures unrelated to this diff (unbuilt-package module resolution errors in `web`/`websocket`, e.g. `Cannot find module '@nodetool-ai/base-nodes'`); confirmed present without this change
- [ ] `npm run dev:nodetool -- harness gate --base main` — not run

## Agent capabilities

Skipped — this diff adds no capability and changes no capability's declared contract.

## New checks

Skipped — this diff adds no new check, rule, or audit; it edits an existing curated list plus its existing test.


---
_Generated by [Claude Code](https://claude.ai/code/session_01L2n9F1Jv9wNGT9qJMzTkas)_