### PR TITLE
feat(runtime): read video on vision models that have no video content part

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -253,7 +253,9 @@ jobs:
           # mesa-vulkan-drivers ships lavapipe (CPU Vulkan ICD) so Dawn can
           # acquire a WebGPU adapter on GPU-less runners — without it the
           # shader-backed base-nodes tests fail with "No WebGPU adapter
-          # available (Node/Dawn)".
+          # available (Node/Dawn)". ffmpeg decodes the clip the runtime's
+          # video-frame fallback samples for providers with no video content
+          # part; without it those tests have nothing to decode.
           - check: test-packages
             # On PRs, `--affected` prunes the Turbo graph to packages changed
             # since the base commit plus their dependents, so unaffected backend
@@ -262,7 +264,7 @@ jobs:
             # the SCM diff and TURBO_SCM_BASE (set on the Run step below).
             command: npm run test:packages${{ github.event_name == 'pull_request' && ' -- --affected' || '' }}
             mobile-deps: "false"
-            extra-apt: "mesa-vulkan-drivers"
+            extra-apt: "mesa-vulkan-drivers ffmpeg"
             is-test: "true"
             fetch-depth: "0"
           - check: test-app

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -268,6 +268,33 @@ sandbox: running in-process (<reason>); a CPU-bound guest will block this thread
 NODETOOL_SANDBOX_INPROC=1 nodetool serve
 ```
 
+## Video Input on Vision Models
+
+Most chat APIs are OpenAI-compatible and have no `video` content part. A clip
+sent to one used to be refused outright, even when the model behind the
+endpoint reads images perfectly well. The runtime now samples the clip into
+stills with `ffmpeg` and sends those instead, labelled with their timestamps,
+under a header naming the frame count and the sample rate — so a model that
+needs the audio or the motion between frames can say it is missing rather than
+invent it. A provider that reads video natively (Gemini) still gets the whole
+clip and never goes through this path.
+
+`ffmpeg` and `ffprobe` must be on `PATH`; without them the call fails naming
+the binary. The sample is bounded by four settings:
+
+- `NODETOOL_VIDEO_FRAME_FALLBACK=0` turns the whole thing off and restores the
+  refusal, for a caller that would rather fail than pay for a lossy read.
+- `NODETOOL_VIDEO_FRAME_MAX_FRAMES` — frames per clip. Default `16`.
+- `NODETOOL_VIDEO_FRAME_MAX_FPS` — ceiling on the sample rate. Default `1`.
+  A clip long enough that the frame budget cannot reach this rate is sampled
+  more sparsely so the frames still span the whole thing.
+- `NODETOOL_VIDEO_FRAME_MAX_DIMENSION` — longest edge of each frame, in pixels.
+  Default `768`. Frames are never upscaled.
+
+```bash
+NODETOOL_VIDEO_FRAME_MAX_FRAMES=8 NODETOOL_VIDEO_FRAME_MAX_FPS=0.5 nodetool serve
+```
+
 ## Development-Only Settings
 
 Two settings exist for local development and are off unless set:
@@ -528,6 +555,10 @@ missing binary.
 | `NODETOOL_SUPERVISOR_PROVIDER` / `NODETOOL_SUPERVISOR_MODEL` | Provider and model that supervise a run when nothing nearer names one | no | Only consulted for a run that asked to be supervised; neither turns supervision on. On the server the order is the request, then the connection's configured defaults, then these — they exist for hosts that have no per-connection defaults at all, such as the trigger dispatcher's headless runs. A supervised run that resolves neither logs that and runs unsupervised rather than failing. The CLI reads `NODETOOL_SUPERVISOR_MODEL` alone, as a single `provider/model` string behind `--supervisor-model`, defaulting to `anthropic/claude-sonnet-4-6`. See [CLI › Supervised runs](cli.md#supervised-runs) |
 | `NODETOOL_INSTANCE_ID` | Which server instance this process is, for multi-instance routing | no | Overrides `FLY_MACHINE_ID`, which Fly sets and whose value the proxy's `fly-replay: instance=<id>` header also addresses — so one string both stamps a job row and routes a handshake back to the instance that owns the run. Letters, digits, `_` and `-` only: the value is written into a response header verbatim, so anything else is refused with a one-time warning. Unset or refused means single-machine, and every feature keyed off it is inert. Set it on a non-Fly multi-instance deployment |
 | `NODETOOL_JOB_CANCEL_POLL_MS` | How often an instance re-reads its own running jobs to notice a remote cancel | no | Default `15000`; `0` disables the poll. Anything unparseable or negative keeps the default. It only matters alongside `NODETOOL_INSTANCE_ID` / `FLY_MACHINE_ID` — a cancel arriving at the instance that holds the run is immediate and never waits for this |
+| `NODETOOL_VIDEO_FRAME_FALLBACK` | `0` refuses a video sent to a provider with no video content part instead of sampling frames from it | no | Any other value (or unset) keeps the fallback on. See [Video Input on Vision Models](#video-input-on-vision-models) |
+| `NODETOOL_VIDEO_FRAME_MAX_FRAMES` | Frames sampled from one clip | no | Default `16`. Anything unparseable or non-positive keeps the default |
+| `NODETOOL_VIDEO_FRAME_MAX_FPS` | Ceiling on the frame sample rate | no | Default `1`. A clip too long for the frame budget to reach this rate is sampled more sparsely, so the frames still span it |
+| `NODETOOL_VIDEO_FRAME_MAX_DIMENSION` | Longest edge of a sampled frame, in pixels | no | Default `768`. Frames are never upscaled |
 | `NODETOOL_SHIPPED_PACKS_DIR` | Roots the sandbox packs that ship with NodeTool are read from | no | Comma-, semicolon-, or `PATH`-separator-delimited, same as `NODETOOL_PACK_SEARCH_PATHS`. Candidates that do not exist are dropped, so a bad path yields no packs rather than an error. Unset, the loader looks for `_sandbox/` beside the bundled `server.mjs` (packaged desktop app, Docker image), then walks up to `packages/sandbox-packs` (a checkout). Set it only for a host that stages the packs somewhere else. See [Sandbox package design](sandbox-package-design.md) |
 | `NODETOOL_SANDBOX_INPROC` | Run every QuickJS guest on the calling thread instead of a worker | no | `1` only. A chosen fallback, so it warns about nothing. A CPU-bound guest then blocks the thread — on the server's main thread that freezes the event loop, including the frame that would have cancelled the run. See [JavaScript sandbox threading](#javascript-sandbox-threading) |
 | `NODETOOL_SANDBOX_WORKER` | Require the sandbox worker path | no | `require` only. A run that cannot reach a worker fails with `the sandbox worker path is required (NODETOOL_SANDBOX_WORKER=require) but unavailable: <reason>` rather than falling back in-process. Runs that stream their inputs never reach a worker, so this fails them |

--- a/docs/url-egress-inventory.md
+++ b/docs/url-egress-inventory.md
@@ -103,8 +103,10 @@ Everything here fetches a URL somebody else chose, through the protected fetch.
 | provider result downloads | `packages/runtime/src/providers/{fal,replicate,kie,topaz,meshy,rodin,minimax,evolink,gemini,anthropic}-provider.ts` | provider response |
 | MCP OAuth Client ID Metadata Document fetch | `packages/websocket/src/oauth/cimd.ts` | model/client (an MCP client's self-hosted `client_id` URL) |
 
-The provider row is ten files, each downloading a URL a provider's response
-named:
+The provider row is eleven files, each downloading a URL a provider's response
+named — plus one reading a URL the caller's own message named
+(`video-frame-fallback.ts`, which fetches a video content part so ffmpeg can
+sample stills from it for a model that cannot read video):
 
 - `packages/runtime/src/providers/fal-provider.ts`
 - `packages/runtime/src/providers/replicate-provider.ts`
@@ -116,6 +118,7 @@ named:
 - `packages/runtime/src/providers/evolink-provider.ts`
 - `packages/runtime/src/providers/gemini-provider.ts`
 - `packages/runtime/src/providers/anthropic-provider.ts`
+- `packages/runtime/src/providers/video-frame-fallback.ts`
 
 Screening code itself: `packages/runtime/src/providers/safe-url.ts`,
 `packages/runtime/src/external-media-fetch.ts`,

--- a/packages/agents/src/capabilities/media.specs.ts
+++ b/packages/agents/src/capabilities/media.specs.ts
@@ -336,11 +336,13 @@ export const UNDERSTAND_VIDEO_SCHEMA: JsonSchema = {
 export const understandVideoSpec: CapabilitySpec = {
   name: "understand_video",
   description:
-    "Send a video plus an instruction to a multimodal chat model (Gemini " +
-    "reads video natively) and return the model's answer as text. Use it to " +
-    "describe or summarize a clip, answer questions about what happens in " +
-    "it, or extract on-screen text. Takes the whole video, not sampled " +
-    "frames — for a single still use critique_image instead.",
+    "Send a video plus an instruction to a multimodal chat model and return " +
+    "the model's answer as text. Use it to describe or summarize a clip, " +
+    "answer questions about what happens in it, or extract on-screen text. " +
+    "A provider that reads video natively (Gemini) gets the whole clip with " +
+    "its audio; every other vision model is sent stills sampled from it, " +
+    "which carry no audio and no motion between frames. For a single still " +
+    "use critique_image instead.",
   inputSchema: UNDERSTAND_VIDEO_SCHEMA,
   // Unlisted in `TOOL_PERMISSION_CATEGORIES`, so the gate classes it
   // `external` — the same category the vision judges carry.

--- a/packages/agents/src/capabilities/media.ts
+++ b/packages/agents/src/capabilities/media.ts
@@ -1254,28 +1254,17 @@ const scoreImageAdherence: CapabilityExport = {
 // ---------------------------------------------------------------------------
 
 /**
- * Why a provider cannot read a clip, and what to do instead.
- *
- * The trap this names: a model search surfaces a video-capable model family
- * (Gemini) served by an aggregator over an OpenAI-compatible chat API, which
- * has no video content part. The model reads video; that route does not.
- */
-function videoInputRefusal(provider: string): string {
-  return (
-    `${provider} does not accept video input. A model catalog can list a ` +
-    `video-capable model family behind an OpenAI-compatible endpoint, which ` +
-    `has no video content part — reading the clip needs a provider that takes ` +
-    `video natively (gemini), not just a model that can. Otherwise sample ` +
-    `frames with ffmpeg and read them with critique_image.`
-  );
-}
-
-/**
  * Read a video with a multimodal chat model.
  *
  * The video rides as a `video` content part next to the instruction; the
  * context's media resolver inlines an `asset://` URI and the provider decides
  * whether the bytes go inline or through its files API.
+ *
+ * A provider with no video content part is not refused here any more: the
+ * runtime samples the clip into stills with ffmpeg and sends those. The reply
+ * carries `read_as` so the caller knows which of the two it got — a frame read
+ * has no audio and nothing between the samples, and an answer that depends on
+ * either should be treated as a guess.
  */
 const understandVideo: CapabilityExport = {
   spec: understandVideoSpec,
@@ -1297,16 +1286,19 @@ const understandVideo: CapabilityExport = {
         : DEFAULT_UNDERSTAND_VIDEO_TOKENS;
 
     try {
-      if (!(await run.context.providerSupportsVideoInput(m.provider))) {
-        return { error: videoInputRefusal(m.provider) };
-      }
+      const native = await run.context.providerSupportsVideoInput(m.provider);
       const text = await judgeCall(
         run.context,
         m,
         [textPart(prompt), videoPart(video)],
         maxTokens
       );
-      return { text, provider: m.provider, model: m.model };
+      return {
+        text,
+        provider: m.provider,
+        model: m.model,
+        read_as: native ? "video" : "sampled_frames"
+      };
     } catch (e) {
       return {
         error: `understand_video failed: ${e instanceof Error ? e.message : String(e)}`

--- a/packages/agents/tests/capabilities-media.test.ts
+++ b/packages/agents/tests/capabilities-media.test.ts
@@ -247,7 +247,8 @@ describe("understand_video through the adapter", () => {
     expect(result).toEqual({
       text: "A fox crosses a snowfield.",
       provider: "gemini",
-      model: "gemini-3-pro"
+      model: "gemini-3-pro",
+      read_as: "video"
     });
     expect(partsOf(predict)).toEqual([
       { type: "text", text: "What happens?" },
@@ -325,12 +326,17 @@ describe("understand_video through the adapter", () => {
     );
   });
 
-  // The failure this capability actually hit: a model search offered
+  // The case this capability used to refuse outright: a model search offers
   // `google/gemini-2.5-flash` served by AtlasCloud, whose chat API is
-  // OpenAI-compatible, so the call died inside the provider with a message
-  // naming openai.
-  it("refuses a provider that cannot take video, before spending a call", async () => {
-    const predict = vi.fn();
+  // OpenAI-compatible and has no video content part. The runtime now samples
+  // the clip into frames for it, so the call goes through — and the answer
+  // says which of the two reads produced it, because a frame read has no audio
+  // and nothing between the samples.
+  it("calls a provider that cannot take video, and reports the frame read", async () => {
+    const predict = vi.fn(async () => ({
+      role: "assistant",
+      content: "A fox crosses a snowfield."
+    }));
     const result = (await asTool(understandVideo).process(
       makeContext(predict),
       {
@@ -340,11 +346,13 @@ describe("understand_video through the adapter", () => {
       }
     )) as Record<string, unknown>;
 
-    expect(String(result["error"])).toMatch(
-      /atlascloud does not accept video input/
-    );
-    expect(String(result["error"])).toMatch(/gemini/);
-    expect(predict).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      text: "A fox crosses a snowfield.",
+      provider: "atlascloud",
+      model: "google/gemini-2.5-flash",
+      read_as: "sampled_frames"
+    });
+    expect(predict).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -420,7 +420,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "understand_video",
     module: "media",
     impl: "packages/agents/src/capabilities/media.ts",
-    contract: "d92926897d42",
+    contract: "a5a78285c120",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-media.test.ts",

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -66,6 +66,10 @@ import {
 import { logProviderRequestFailure } from "./provider-request-log.js";
 import { annotateProviderError } from "./provider-error.js";
 import { applyEntityReferences } from "./entity-references.js";
+import {
+  expandVideoContentAsFrames,
+  videoFrameFallbackEnabled
+} from "./video-frame-fallback.js";
 import type { Span } from "@opentelemetry/api";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { createLogger, getDefaultAssetsPath } from "@nodetool-ai/config";
@@ -326,6 +330,7 @@ export abstract class BaseProvider {
   protected constructor(provider: ProviderId) {
     this.provider = provider;
     this.installModalityFailureLogging();
+    this.installVideoFrameFallback();
   }
 
   /**
@@ -388,6 +393,84 @@ export abstract class BaseProvider {
         wrapModalityGenerator(this, original, args)
       );
     }
+  }
+
+  /**
+   * Make a `video` content part readable by a provider whose chat API has no
+   * place to put one: sample the clip into stills and send those instead.
+   *
+   * Wrapping the instance's own methods (the pattern
+   * {@link installModalityFailureLogging} uses) is what makes it transparent.
+   * Not every caller goes through the traced wrappers — `packages/llm-nodes`
+   * and the jtbd optimizer call `generateMessages` straight — and a seam only
+   * some callers pass through is not a fallback, it is a coin flip.
+   *
+   * A provider that reads video natively is left alone, and so is one whose
+   * `generateMessage` delegates to its own `generateMessages`: by then the
+   * video parts are already frames, and the second pass is a no-op.
+   */
+  private installVideoFrameFallback(): void {
+    // An arrow, so the `async function*` below (which binds its own `this`)
+    // still reaches this instance.
+    const sample = (args: {
+      messages: Message[];
+      model: string;
+      signal?: AbortSignal;
+    }): Promise<Message[]> => this.sampleVideoAsFrames(args);
+
+    // `generateMessage` and `generateMessages` are abstract, so a subclass that
+    // implements only one leaves the other undefined at construction — wrap
+    // what is there, the way installModalityFailureLogging does.
+    const message = this.generateMessage;
+    if (isCallable(message)) {
+      const original = message.bind(this);
+      Reflect.set(
+        this,
+        "generateMessage",
+        async (
+          args: Parameters<BaseProvider["generateMessage"]>[0]
+        ): Promise<Message> =>
+          original({ ...args, messages: await sample(args) })
+      );
+    }
+
+    const messages = this.generateMessages;
+    if (isCallable(messages)) {
+      const original = messages.bind(this);
+      Reflect.set(
+        this,
+        "generateMessages",
+        async function* (
+          args: Parameters<BaseProvider["generateMessages"]>[0]
+        ): AsyncGenerator<ProviderStreamItem> {
+          yield* original({
+            ...args,
+            messages: await sample(args)
+          });
+        }
+      );
+    }
+  }
+
+  /**
+   * The messages to actually send: unchanged unless this provider cannot take
+   * video and the conversation carries some.
+   */
+  private async sampleVideoAsFrames(args: {
+    messages: Message[];
+    model: string;
+    signal?: AbortSignal;
+  }): Promise<Message[]> {
+    if (this.supportsVideoInput || !videoFrameFallbackEnabled()) {
+      return args.messages;
+    }
+    // Returns the same array when nothing carries video, which is every call
+    // but the rare one.
+    return await expandVideoContentAsFrames(args.messages, {
+      resolveUri: (uri) => this.resolveUri(uri),
+      signal: args.signal,
+      provider: this.provider
+    });
   }
 
   static requiredSecrets(): string[] {

--- a/packages/runtime/src/providers/cassette-provider.ts
+++ b/packages/runtime/src/providers/cassette-provider.ts
@@ -513,6 +513,14 @@ export class CassetteProvider extends BaseProvider {
     return this.inner.hasToolSupport(model);
   }
 
+  /**
+   * The inner provider's answer, so a cassette over Gemini keeps sending whole
+   * clips instead of being downgraded to sampled frames by the base fallback.
+   */
+  override get supportsVideoInput(): boolean {
+    return this.inner.supportsVideoInput;
+  }
+
   // -------------------------------------------------------------------------
   // Matching
   // -------------------------------------------------------------------------

--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -923,13 +923,19 @@ export class OpenAIProvider extends BaseProvider {
     }
 
     if (content.type === "video") {
-      // Named for the configured provider, not the wire format: every
+      // Reached only with the fallback switched off: BaseProvider otherwise
+      // samples the clip into frames before conversion whenever
+      // `supportsVideoInput` is false, and a missing ffmpeg fails there with
+      // its own message. Named for the configured provider, not the wire
+      // format: every
       // OpenAI-compatible re-host lands here, and reporting "openai" sent a
       // diagnosis after the wrong provider.
       throw new Error(
         `video input is not supported by ${this.provider} — its chat API is ` +
-          `OpenAI-compatible, which has no video content part. Use a provider ` +
-          `whose chat models read video natively (gemini).`
+          `OpenAI-compatible, which has no video content part. Frame sampling ` +
+          `is off (NODETOOL_VIDEO_FRAME_FALLBACK=0); unset it to read the clip ` +
+          `as stills, or use a provider whose chat models read video natively ` +
+          `(gemini).`
       );
     }
 

--- a/packages/runtime/src/providers/video-frame-fallback.ts
+++ b/packages/runtime/src/providers/video-frame-fallback.ts
@@ -1,0 +1,195 @@
+/**
+ * Read a video with a vision model that has no video content part.
+ *
+ * Most chat APIs are OpenAI-compatible and have nowhere to put a clip, so a
+ * `video` part reaching them used to be a hard refusal — even when the model
+ * behind the endpoint reads images perfectly well. This samples the clip into
+ * stills with ffmpeg and puts them on the message as ordinary image parts,
+ * labelled with their timestamps so the model can reason about order and
+ * timing.
+ *
+ * It is a downgrade, and it says so: the header text names the frame count and
+ * the sample rate, so a model that needs continuous motion or the audio track
+ * can report that it is missing rather than inventing it. A provider that
+ * reads video natively (`supportsVideoInput`) never comes through here.
+ */
+
+import type { Message, MessageContent, MessageVideoContent } from "./types.js";
+import { safeFetch } from "./safe-url.js";
+import { sampleVideoFrames, type VideoFrameSample } from "./video-frames.js";
+import { createLogger } from "@nodetool-ai/config";
+
+const log = createLogger("nodetool:video-frame-fallback");
+
+export type VideoFrameFallbackOptions = {
+  /** Resolve a non-`data:` URI the way the provider would (asset files, legacy paths). */
+  resolveUri?: (uri: string) => Promise<string>;
+  signal?: AbortSignal;
+  /** Provider id, for the log line and the error message. */
+  provider?: string;
+};
+
+/**
+ * Whether the fallback is on. `NODETOOL_VIDEO_FRAME_FALLBACK=0` turns it off
+ * and restores the old refusal, for a caller that would rather fail than
+ * silently pay for a lossy read.
+ */
+export function videoFrameFallbackEnabled(): boolean {
+  const raw = globalThis.process?.env?.["NODETOOL_VIDEO_FRAME_FALLBACK"];
+  return raw !== "0" && raw !== "false";
+}
+
+/** Whether any message carries a `video` content part. */
+function messagesContainVideo(messages: readonly Message[]): boolean {
+  return messages.some(
+    (m) =>
+      Array.isArray(m.content) && m.content.some((c) => c.type === "video")
+  );
+}
+
+function decodeBase64(b64: string): Uint8Array {
+  return new Uint8Array(Buffer.from(b64, "base64"));
+}
+
+/** The bytes behind a `data:` URI. */
+function parseDataUri(uri: string): Uint8Array {
+  const comma = uri.indexOf(",");
+  if (comma < 0) throw new Error("Invalid data URI");
+  return decodeBase64(uri.slice(comma + 1));
+}
+
+/**
+ * Source a video part's bytes: inline data first, then its URI. The container
+ * type is not read off the ref — ffmpeg sniffs it from the file itself, which
+ * is right more often than a `mimeType` the caller guessed.
+ */
+async function videoContentBytes(
+  video: MessageVideoContent["video"],
+  options: VideoFrameFallbackOptions
+): Promise<Uint8Array> {
+  if (typeof video.data === "string" && video.data.length > 0) {
+    return video.data.startsWith("data:")
+      ? parseDataUri(video.data)
+      : decodeBase64(video.data);
+  }
+  if (video.data instanceof Uint8Array && video.data.length > 0) {
+    return video.data;
+  }
+  if (!video.uri) return new Uint8Array();
+
+  const resolved = video.uri.startsWith("data:")
+    ? video.uri
+    : ((await options.resolveUri?.(video.uri)) ?? video.uri);
+  if (resolved.startsWith("data:")) return parseDataUri(resolved);
+
+  const resp = await safeFetch(
+    resolved,
+    options.signal ? { signal: options.signal } : undefined
+  );
+  if (!resp.ok) throw new Error(`Failed to fetch video: ${resp.status}`);
+  return new Uint8Array(await resp.arrayBuffer());
+}
+
+function round(value: number, digits = 1): string {
+  return value.toFixed(digits).replace(/\.0+$/, "");
+}
+
+/** The header that tells the model what it is looking at, and what it is not. */
+export function frameHeaderText(sample: VideoFrameSample): string {
+  const count = sample.frames.length;
+  const duration =
+    sample.durationSec !== null ? `${round(sample.durationSec)}s ` : "";
+  const rate =
+    sample.fps >= 1
+      ? `${round(sample.fps, 2)} frames/second`
+      : `one frame every ${round(1 / sample.fps, 1)}s`;
+  const cut = sample.truncated
+    ? ` Sampling stopped at the frame limit, so the end of the clip is not shown.`
+    : "";
+  return (
+    `[The following ${count} still frame${count === 1 ? "" : "s"} were ` +
+    `sampled from a ${duration}video at ${rate}, in order. They are stills: ` +
+    `there is no audio and no motion between them.${cut}]`
+  );
+}
+
+/** One frame as an image part, preceded by its timestamp. */
+function framePartsFor(sample: VideoFrameSample): MessageContent[] {
+  const parts: MessageContent[] = [];
+  for (const [index, frame] of sample.frames.entries()) {
+    parts.push({
+      type: "text",
+      text: `Frame ${index + 1} at ${round(frame.timeSec)}s:`
+    });
+    parts.push({
+      type: "image_url",
+      image: {
+        uri: `data:${frame.mimeType};base64,${Buffer.from(frame.data).toString("base64")}`,
+        mimeType: frame.mimeType
+      }
+    });
+  }
+  return parts;
+}
+
+/**
+ * Replace every `video` content part with sampled frames. Messages with no
+ * video are returned untouched (same object identity), so this is cheap to
+ * call on every request.
+ */
+export async function expandVideoContentAsFrames(
+  messages: Message[],
+  options: VideoFrameFallbackOptions = {}
+): Promise<Message[]> {
+  if (!messagesContainVideo(messages)) return messages;
+
+  const out: Message[] = [];
+  for (const message of messages) {
+    if (
+      !Array.isArray(message.content) ||
+      !message.content.some((c) => c.type === "video")
+    ) {
+      out.push(message);
+      continue;
+    }
+    const parts: MessageContent[] = [];
+    for (const part of message.content) {
+      if (part.type !== "video") {
+        parts.push(part);
+        continue;
+      }
+      const bytes = await videoContentBytes(
+        (part as MessageVideoContent).video,
+        options
+      );
+      if (bytes.length === 0) {
+        parts.push({
+          type: "text",
+          text: "[A video was attached but its bytes could not be read.]"
+        });
+        continue;
+      }
+      const sample = await sampleVideoFrames(bytes, {
+        signal: options.signal
+      });
+      if (sample.frames.length === 0) {
+        throw new Error(
+          `ffmpeg decoded no frames from the attached video, so ` +
+            `${options.provider ?? "this provider"} has nothing to read. The ` +
+            `file may not be a video, or may use a codec this ffmpeg build ` +
+            `does not decode.`
+        );
+      }
+      log.debug("Sampled a video into frames", {
+        provider: options.provider,
+        frames: sample.frames.length,
+        fps: sample.fps,
+        durationSec: sample.durationSec
+      });
+      parts.push({ type: "text", text: frameHeaderText(sample) });
+      parts.push(...framePartsFor(sample));
+    }
+    out.push({ ...message, content: parts });
+  }
+  return out;
+}

--- a/packages/runtime/src/providers/video-frames.ts
+++ b/packages/runtime/src/providers/video-frames.ts
@@ -1,0 +1,275 @@
+/**
+ * Sample a video into still frames with ffmpeg.
+ *
+ * This is what lets a vision model that cannot read a clip still answer
+ * questions about one: the bytes are decoded here, a bounded number of frames
+ * come back as JPEGs, and the caller sends them as ordinary image content.
+ *
+ * The argv is ours, not a model's — the only input path is a temp file this
+ * module wrote — so the containment `packages/agents/src/host-binary-guard.ts`
+ * applies to a model-supplied argv is not needed. `-protocol_whitelist file`
+ * and `-nostdin` still go in: an mp4 can name an external opener, and a child
+ * that inherits the server's stdin outlives the call.
+ */
+
+import { importNodeBuiltin } from "@nodetool-ai/config";
+
+/** A single sampled frame, JPEG-encoded. */
+export type SampledFrame = {
+  data: Uint8Array;
+  mimeType: string;
+  /** Seconds into the clip, derived from the sample rate. */
+  timeSec: number;
+};
+
+export type VideoFrameSample = {
+  frames: SampledFrame[];
+  /** Clip length from ffprobe, or null when the probe did not answer. */
+  durationSec: number | null;
+  /** Frames per second actually requested of ffmpeg. */
+  fps: number;
+  /**
+   * True when the frame cap stopped the sample before the end of the clip.
+   * Only reachable with an unknown duration: once ffprobe answers, the rate is
+   * chosen to fit the budget across the whole clip and the cap never bites.
+   */
+  truncated: boolean;
+};
+
+export type SampleVideoFramesOptions = {
+  /** Hard cap on frames returned. */
+  maxFrames?: number;
+  /** Ceiling on the sample rate; a short clip is sampled no denser than this. */
+  maxFps?: number;
+  /** Longest edge of each frame, in pixels. Frames are never upscaled. */
+  maxDimension?: number;
+  signal?: AbortSignal;
+};
+
+/** ffmpeg or ffprobe is not installed. Names the binary and the way out. */
+export class FrameSamplingUnavailableError extends Error {
+  readonly binary: string;
+  constructor(binary: string) {
+    super(
+      `${binary} is not installed or not on PATH. Reading a video with a ` +
+        `provider that has no video content part samples frames with ffmpeg ` +
+        `first — install ffmpeg (the Package Manager UI can do this), or use ` +
+        `a provider whose chat models read video natively (gemini).`
+    );
+    this.name = "FrameSamplingUnavailableError";
+    this.binary = binary;
+  }
+}
+
+const DEFAULT_MAX_FRAMES = 16;
+const DEFAULT_MAX_FPS = 1;
+const DEFAULT_MAX_DIMENSION = 768;
+/** ffmpeg `-q:v` for the JPEG encoder (2 = best, 31 = worst). */
+const JPEG_QUALITY = 4;
+const FFMPEG_MAX_BUFFER = 8 * 1024 * 1024;
+
+/** Read a positive number from the environment, or fall back. */
+function envNumber(name: string, fallback: number): number {
+  const raw = Number(globalThis.process?.env?.[name]);
+  return Number.isFinite(raw) && raw > 0 ? raw : fallback;
+}
+
+/** Frame-sampling limits, env-overridable. Read per call so a test can vary them. */
+function frameSamplingLimits(): Required<
+  Pick<SampleVideoFramesOptions, "maxFrames" | "maxFps" | "maxDimension">
+> {
+  return {
+    maxFrames: Math.floor(
+      envNumber("NODETOOL_VIDEO_FRAME_MAX_FRAMES", DEFAULT_MAX_FRAMES)
+    ),
+    maxFps: envNumber("NODETOOL_VIDEO_FRAME_MAX_FPS", DEFAULT_MAX_FPS),
+    maxDimension: Math.floor(
+      envNumber("NODETOOL_VIDEO_FRAME_MAX_DIMENSION", DEFAULT_MAX_DIMENSION)
+    )
+  };
+}
+
+type ExecResult = { stdout: string; stderr: string };
+
+async function nodeModules(): Promise<{
+  cp: typeof import("node:child_process");
+  fs: typeof import("node:fs/promises");
+  os: typeof import("node:os");
+  path: typeof import("node:path");
+}> {
+  const [cp, fs, os, path] = await Promise.all([
+    importNodeBuiltin<typeof import("node:child_process")>(
+      "node:child_process"
+    ),
+    importNodeBuiltin<typeof import("node:fs/promises")>("node:fs/promises"),
+    importNodeBuiltin<typeof import("node:os")>("node:os"),
+    importNodeBuiltin<typeof import("node:path")>("node:path")
+  ]);
+  if (!cp || !fs || !os || !path) {
+    throw new Error("Video frame sampling requires Node built-in modules");
+  }
+  return { cp, fs, os, path };
+}
+
+/** Whether a spawn failed because the binary is not on PATH. */
+function isSpawnEnoent(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: unknown }).code === "ENOENT"
+  );
+}
+
+async function run(
+  cp: typeof import("node:child_process"),
+  binary: "ffmpeg" | "ffprobe",
+  args: string[],
+  signal?: AbortSignal
+): Promise<ExecResult> {
+  return await new Promise<ExecResult>((resolve, reject) => {
+    cp.execFile(
+      binary,
+      args,
+      { maxBuffer: FFMPEG_MAX_BUFFER, signal, windowsHide: true },
+      (error, stdout, stderr) => {
+        if (error) {
+          if (isSpawnEnoent(error)) {
+            reject(new FrameSamplingUnavailableError(binary));
+            return;
+          }
+          reject(error);
+          return;
+        }
+        resolve({ stdout: String(stdout), stderr: String(stderr) });
+      }
+    );
+  });
+}
+
+/** Clip length in seconds, or null when ffprobe cannot say. */
+async function probeDuration(
+  cp: typeof import("node:child_process"),
+  file: string,
+  signal?: AbortSignal
+): Promise<number | null> {
+  try {
+    const { stdout } = await run(
+      cp,
+      "ffprobe",
+      [
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "csv=p=0",
+        file
+      ],
+      signal
+    );
+    const seconds = Number(stdout.trim().split("\n")[0]);
+    return Number.isFinite(seconds) && seconds > 0 ? seconds : null;
+  } catch (error) {
+    // A missing binary is actionable and must reach the caller. A probe that
+    // ran and failed (an odd container, no format header) is not: the sample
+    // falls back to the ceiling rate below.
+    if (error instanceof FrameSamplingUnavailableError) throw error;
+    return null;
+  }
+}
+
+/**
+ * The sample rate that spreads `maxFrames` across the whole clip without
+ * exceeding `maxFps`. An unknown duration samples at the ceiling and lets the
+ * frame cap stop it.
+ */
+export function frameRateFor(
+  durationSec: number | null,
+  maxFrames: number,
+  maxFps: number
+): number {
+  if (durationSec === null || durationSec <= 0) return maxFps;
+  // The first frame lands at t=0, so N frames need N-1 intervals to reach the
+  // end of the clip. Sampling at N/duration instead leaves the tail unseen.
+  const spread = maxFrames > 1 ? (maxFrames - 1) / durationSec : 1 / durationSec;
+  return Math.min(maxFps, Math.max(spread, 0.01));
+}
+
+/**
+ * Fit inside a square of `maxDimension` without upscaling. ffmpeg's
+ * `force_original_aspect_ratio=decrease` would enlarge a smaller frame, which
+ * costs tokens and adds no detail.
+ */
+function scaleFilter(maxDimension: number): string {
+  const m = maxDimension;
+  return `scale='if(gt(iw,ih),min(${m},iw),-2)':'if(gt(iw,ih),-2,min(${m},ih))'`;
+}
+
+/**
+ * Decode `bytes` and return up to `maxFrames` JPEG stills spread across the
+ * clip. Throws {@link FrameSamplingUnavailableError} when ffmpeg is absent.
+ */
+export async function sampleVideoFrames(
+  bytes: Uint8Array,
+  options: SampleVideoFramesOptions = {}
+): Promise<VideoFrameSample> {
+  const limits = frameSamplingLimits();
+  const maxFrames = Math.max(1, options.maxFrames ?? limits.maxFrames);
+  const maxFps = options.maxFps ?? limits.maxFps;
+  const maxDimension = options.maxDimension ?? limits.maxDimension;
+
+  const { cp, fs, os, path } = await nodeModules();
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "nodetool-vframes-"));
+  const input = path.join(dir, "input.bin");
+  const outDir = path.join(dir, "frames");
+  try {
+    await fs.writeFile(input, bytes);
+    await fs.mkdir(outDir);
+
+    const durationSec = await probeDuration(cp, input, options.signal);
+    const fps = frameRateFor(durationSec, maxFrames, maxFps);
+
+    await run(
+      cp,
+      "ffmpeg",
+      [
+        "-nostdin",
+        "-y",
+        "-v",
+        "error",
+        "-protocol_whitelist",
+        "file",
+        "-i",
+        input,
+        "-vf",
+        `fps=${fps.toFixed(6)},${scaleFilter(maxDimension)}`,
+        "-frames:v",
+        String(maxFrames),
+        "-q:v",
+        String(JPEG_QUALITY),
+        path.join(outDir, "frame_%04d.jpg")
+      ],
+      options.signal
+    );
+
+    const names = (await fs.readdir(outDir))
+      .filter((n) => n.startsWith("frame_") && n.endsWith(".jpg"))
+      .sort();
+    const frames: SampledFrame[] = [];
+    for (const [index, name] of names.entries()) {
+      frames.push({
+        data: new Uint8Array(await fs.readFile(path.join(outDir, name))),
+        mimeType: "image/jpeg",
+        timeSec: index / fps
+      });
+    }
+    return {
+      frames,
+      durationSec,
+      fps,
+      truncated: durationSec === null && frames.length >= maxFrames
+    };
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}

--- a/packages/runtime/tests/providers/video-frame-fallback.test.ts
+++ b/packages/runtime/tests/providers/video-frame-fallback.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Video understanding for vision models that cannot read video.
+ *
+ * These tests decode a real clip: ffmpeg is the feature, and a stubbed
+ * ffmpeg would only prove the argv is spelled the way the test spells it. CI
+ * installs it on the `test-packages` leg (`.github/workflows/quality-checks.yml`);
+ * locally, `apt-get install -y ffmpeg`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execFile as execFileCb } from "node:child_process";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { BaseProvider } from "../../src/providers/base-provider.js";
+import {
+  frameRateFor,
+  sampleVideoFrames
+} from "../../src/providers/video-frames.js";
+import {
+  expandVideoContentAsFrames,
+  frameHeaderText
+} from "../../src/providers/video-frame-fallback.js";
+import type {
+  Message,
+  MessageContent,
+  MessageImageContent,
+  ProviderStreamItem
+} from "../../src/providers/types.js";
+
+const execFile = promisify(execFileCb);
+
+/** A 4-second 64×64 test pattern — small enough to decode in milliseconds. */
+const CLIP_SECONDS = 4;
+let clip: Uint8Array;
+/** The same pattern as a raw H.264 stream: decodable, but with no duration. */
+let rawStream: Uint8Array;
+let tmpDir: string;
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "nodetool-vframe-test-"));
+  const out = path.join(tmpDir, "clip.mp4");
+  await execFile("ffmpeg", [
+    "-v",
+    "error",
+    "-f",
+    "lavfi",
+    "-i",
+    `testsrc=size=64x64:rate=10:duration=${CLIP_SECONDS}`,
+    "-c:v",
+    "libx264",
+    "-pix_fmt",
+    "yuv420p",
+    "-y",
+    out
+  ]);
+  clip = new Uint8Array(await fs.readFile(out));
+
+  const raw = path.join(tmpDir, "clip.h264");
+  await execFile("ffmpeg", [
+    "-v",
+    "error",
+    "-f",
+    "lavfi",
+    "-i",
+    "testsrc=size=64x64:rate=10:duration=10",
+    "-c:v",
+    "libx264",
+    "-bsf:v",
+    "h264_mp4toannexb",
+    "-f",
+    "h264",
+    "-y",
+    raw
+  ]);
+  rawStream = new Uint8Array(await fs.readFile(raw));
+}, 60_000);
+
+afterAll(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+});
+
+function videoMessage(): Message {
+  return {
+    role: "user",
+    content: [
+      { type: "text", text: "what happens in this clip?" },
+      { type: "video", video: { data: clip, mimeType: "video/mp4" } }
+    ]
+  };
+}
+
+function imageParts(content: MessageContent[]): MessageImageContent[] {
+  return content.filter(
+    (c): c is MessageImageContent => c.type === "image_url"
+  );
+}
+
+describe("frameRateFor", () => {
+  it("spreads the frame budget over the whole clip", () => {
+    // 9 frames across 8 seconds: one every second, the last at t=8s.
+    expect(frameRateFor(8, 9, 10)).toBeCloseTo(1, 6);
+  });
+
+  it("never samples denser than the ceiling", () => {
+    expect(frameRateFor(1, 16, 1)).toBe(1);
+  });
+
+  it("falls back to the ceiling when the duration is unknown", () => {
+    expect(frameRateFor(null, 16, 2)).toBe(2);
+  });
+});
+
+describe("sampleVideoFrames", () => {
+  it("decodes a clip into timestamped JPEG stills", async () => {
+    const sample = await sampleVideoFrames(clip, { maxFrames: 5, maxFps: 4 });
+
+    expect(sample.durationSec).toBeCloseTo(CLIP_SECONDS, 1);
+    expect(sample.frames.length).toBeGreaterThan(1);
+    expect(sample.frames.length).toBeLessThanOrEqual(5);
+    for (const frame of sample.frames) {
+      expect(frame.mimeType).toBe("image/jpeg");
+      // JPEG SOI marker — proves ffmpeg wrote an image, not an empty file.
+      expect([frame.data[0], frame.data[1]]).toEqual([0xff, 0xd8]);
+    }
+    const stamps = sample.frames.map((f) => f.timeSec);
+    expect(stamps[0]).toBe(0);
+    expect([...stamps].sort((a, b) => a - b)).toEqual(stamps);
+    // The last frame lands near the end of the clip rather than bunching at
+    // the start, which is what a naive `fps = maxFrames / duration` produces.
+    expect(stamps[stamps.length - 1]).toBeGreaterThan(CLIP_SECONDS / 2);
+  });
+
+  it("stops at the frame cap when the duration is unknown, and says so", async () => {
+    // A raw H.264 elementary stream carries no container duration, so the rate
+    // cannot be fitted to the clip and the cap is what ends the sample.
+    const sample = await sampleVideoFrames(rawStream, {
+      maxFrames: 3,
+      maxFps: 1
+    });
+    expect(sample.durationSec).toBeNull();
+    expect(sample.frames).toHaveLength(3);
+    expect(sample.truncated).toBe(true);
+    expect(frameHeaderText(sample)).toMatch(/frame limit/);
+  });
+
+  it("fits frames inside the requested box without upscaling", async () => {
+    const sample = await sampleVideoFrames(clip, {
+      maxFrames: 1,
+      maxDimension: 32
+    });
+    const [width, height] = jpegSize(sample.frames[0].data);
+    expect(width).toBeLessThanOrEqual(32);
+    expect(height).toBeLessThanOrEqual(32);
+  });
+});
+
+describe("expandVideoContentAsFrames", () => {
+  it("replaces a video part with a header and labelled frames", async () => {
+    const [message] = await expandVideoContentAsFrames([videoMessage()]);
+    const content = message.content as MessageContent[];
+
+    expect(content.some((c) => c.type === "video")).toBe(false);
+    expect(content[0]).toEqual({
+      type: "text",
+      text: "what happens in this clip?"
+    });
+    const header = content[1] as { type: "text"; text: string };
+    expect(header.text).toMatch(/still frames? were sampled/);
+    expect(header.text).toMatch(/no audio and no motion/);
+
+    const images = imageParts(content);
+    expect(images.length).toBeGreaterThan(1);
+    for (const image of images) {
+      expect(image.image.uri).toMatch(/^data:image\/jpeg;base64,/);
+    }
+    const labels = content
+      .filter((c): c is { type: "text"; text: string } => c.type === "text")
+      .map((c) => c.text);
+    expect(labels.filter((t) => /^Frame \d+ at /.test(t))).toHaveLength(
+      images.length
+    );
+  });
+
+  it("returns messages carrying no video untouched", async () => {
+    const messages: Message[] = [{ role: "user", content: "plain text" }];
+    expect(await expandVideoContentAsFrames(messages)).toBe(messages);
+  });
+
+  it("reads a video from a data URI as well as inline bytes", async () => {
+    const uri = `data:video/mp4;base64,${Buffer.from(clip).toString("base64")}`;
+    const [message] = await expandVideoContentAsFrames([
+      { role: "user", content: [{ type: "video", video: { uri } }] }
+    ]);
+    expect(imageParts(message.content as MessageContent[]).length).toBeGreaterThan(
+      0
+    );
+  });
+});
+
+/** Records the messages a provider was actually asked to send. */
+class RecordingProvider extends BaseProvider {
+  sent: Message[] = [];
+  constructor(private readonly readsVideo: boolean) {
+    super("test");
+  }
+
+  override get supportsVideoInput(): boolean {
+    return this.readsVideo;
+  }
+
+  async generateMessage(args: {
+    messages: Message[];
+    model: string;
+  }): Promise<Message> {
+    this.sent = args.messages;
+    return { role: "assistant", content: "ok" };
+  }
+
+  async *generateMessages(args: {
+    messages: Message[];
+    model: string;
+  }): AsyncGenerator<ProviderStreamItem> {
+    this.sent = args.messages;
+    yield { type: "chunk", content: "ok", done: true };
+  }
+}
+
+async function drain(gen: AsyncGenerator<ProviderStreamItem>): Promise<void> {
+  for await (const _ of gen) {
+    // The provider records what it was sent; the stream itself is not the point.
+  }
+}
+
+describe("BaseProvider video frame fallback", () => {
+  it("hands a provider without video input the sampled frames", async () => {
+    const provider = new RecordingProvider(false);
+    await provider.generateMessage({
+      messages: [videoMessage()],
+      model: "m"
+    });
+
+    const content = provider.sent[0].content as MessageContent[];
+    expect(content.some((c) => c.type === "video")).toBe(false);
+    expect(imageParts(content).length).toBeGreaterThan(1);
+  });
+
+  it("covers the streaming path too", async () => {
+    const provider = new RecordingProvider(false);
+    await drain(provider.generateMessages({ messages: [videoMessage()], model: "m" }));
+
+    const content = provider.sent[0].content as MessageContent[];
+    expect(content.some((c) => c.type === "video")).toBe(false);
+    expect(imageParts(content).length).toBeGreaterThan(1);
+  });
+
+  it("leaves a provider that reads video natively alone", async () => {
+    const provider = new RecordingProvider(true);
+    await provider.generateMessage({
+      messages: [videoMessage()],
+      model: "m"
+    });
+
+    const content = provider.sent[0].content as MessageContent[];
+    expect(content.some((c) => c.type === "video")).toBe(true);
+    expect(imageParts(content)).toHaveLength(0);
+  });
+
+  it("passes the clip through untouched when the fallback is switched off", async () => {
+    // The inverted condition: without it, every assertion above would also
+    // hold on a fallback that never ran, because the video part would simply
+    // still be there.
+    process.env.NODETOOL_VIDEO_FRAME_FALLBACK = "0";
+    try {
+      const provider = new RecordingProvider(false);
+      await provider.generateMessage({
+        messages: [videoMessage()],
+        model: "m"
+      });
+      const content = provider.sent[0].content as MessageContent[];
+      expect(content.some((c) => c.type === "video")).toBe(true);
+      expect(imageParts(content)).toHaveLength(0);
+    } finally {
+      delete process.env.NODETOOL_VIDEO_FRAME_FALLBACK;
+    }
+  });
+});
+
+/** Width and height from a JPEG's first SOFn marker. */
+function jpegSize(bytes: Uint8Array): [number, number] {
+  let offset = 2;
+  while (offset < bytes.length) {
+    if (bytes[offset] !== 0xff) {
+      offset += 1;
+      continue;
+    }
+    const marker = bytes[offset + 1];
+    const size = (bytes[offset + 2] << 8) + bytes[offset + 3];
+    if (marker >= 0xc0 && marker <= 0xc3) {
+      return [
+        (bytes[offset + 7] << 8) + bytes[offset + 8],
+        (bytes[offset + 5] << 8) + bytes[offset + 6]
+      ];
+    }
+    offset += 2 + size;
+  }
+  throw new Error("No JPEG SOFn marker found");
+}

--- a/packages/runtime/tests/url-egress-inventory.ts
+++ b/packages/runtime/tests/url-egress-inventory.ts
@@ -337,6 +337,12 @@ export const URL_EGRESS_INVENTORY: EgressEntry[] = [
     "file_uri values reaching the provider, plus the Files API download."
   ),
   guardedSafeFetch(
+    "packages/runtime/src/providers/video-frame-fallback.ts",
+    "Video frame sampling for providers with no video content part",
+    "workflow",
+    "Reads a video content part's URI so ffmpeg can sample stills from it."
+  ),
+  guardedSafeFetch(
     "packages/runtime/src/providers/anthropic-provider.ts",
     "Anthropic media input",
     "workflow",


### PR DESCRIPTION
## What changed

A `video` content part reaching an OpenAI-compatible chat API used to be a hard refusal, even when the model behind the endpoint reads images perfectly well — the wire format has nowhere to put a clip. The runtime now samples the clip into stills with ffmpeg and sends them as ordinary image parts. The seam is `BaseProvider`, which wraps its own `generateMessage` / `generateMessages` instance methods the way `installModalityFailureLogging` already does: not every caller goes through the traced wrappers (`packages/llm-nodes` and the jtbd optimizer call `generateMessages` straight), so a seam only some callers pass through would leave the refusal in place for the rest. A provider that reads video natively (`supportsVideoInput`) never comes through here, and `CassetteProvider` now delegates that answer to its inner provider so a cassette over Gemini is not downgraded. The read is lossy and says so: frames carry per-frame timestamps under a header naming the count, the clip length and the sample rate, so a model that needs the audio or the motion between frames can report it is missing rather than invent it. Sixteen frames at up to 1 fps and 768 px by default, spread across the whole clip rather than bunched at the start; the four `NODETOOL_VIDEO_FRAME_*` variables tune it and `_FALLBACK=0` restores the refusal. `understand_video` no longer refuses a provider that cannot take video, and returns `read_as: "video" | "sampled_frames"` so the caller knows which read produced the answer.

## Verification

- [x] `npm run test:affected` — `All affected suites passed.`
- [x] `npm run typecheck` — clean for `web` and `electron`. `mobile` fails on
      `Cannot find module 'react-native'` etc. because `mobile/node_modules` is
      absent in this environment (mobile is not a root workspace); the diff
      touches no mobile file.
- [x] `npm run lint` — exit 0
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 6/6 selfchecks passed`
      (run from `dist` as `npm run nodetool -- harness gate --base origin/main`)

Inverted once to prove the new tests can fail — commenting out the single
`this.installVideoFrameFallback()` call in the `BaseProvider` constructor:

```
 Test Files  1 failed (1)
      Tests  2 failed | 11 passed (13)
```

The two failures were the provider-level cases (`hands a provider without video
input the sampled frames`, `covers the streaming path too`). The suite also
carries a standing inverted case — `passes the clip through untouched when the
fallback is switched off` — so the other assertions cannot be satisfied by a
fallback that never ran.

The URL-egress audit caught the new `safeFetch` call site on its own
(`packages/runtime/src/providers/video-frame-fallback.ts` reported as
unclassified) before it was added to the inventory and to
`docs/url-egress-inventory.md`.

Tests decode a real clip rather than stubbing ffmpeg, so `ffmpeg` joins
`mesa-vulkan-drivers` on the `test-packages` leg's `extra-apt` in
`.github/workflows/quality-checks.yml`.

## Agent capabilities

- [x] `npm run capabilities:check` passes — `capability table is current (229 capabilities)`
- [x] `understand_video`'s contract changed (description, and the impl no
      longer refuses a non-native provider). Its coverage row was regenerated
      with `npm run capabilities:sync` and still names
      `packages/agents/tests/capabilities-media.test.ts`, whose two
      `understand_video` cases were updated: the old "refuses a provider that
      cannot take video" case now asserts the call goes through and reports
      `read_as: "sampled_frames"`.

## New checks

- [x] The check was inverted once and observed failing; the failing output is
      in **Verification** above
- [x] Not an audit — the new tests assert on decoded frame bytes (JPEG SOI
      marker, dimensions read from the SOFn header, ascending timestamps), so
      they cannot pass on an empty sample

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYJJYEh6WjJg3zUEDbp3gx)_