### PR TITLE
feat(projects): give a project an overview to work from

### DIFF
--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -1230,6 +1230,7 @@ function getCreateSchemaSql(): string {
       "user_id" text NOT NULL,
       "name" text NOT NULL,
       "kind" text NOT NULL DEFAULT '',
+      "thread_id" text,
       "created_at" text NOT NULL,
       "updated_at" text NOT NULL
     );

--- a/packages/models/src/migrations/versions.ts
+++ b/packages/models/src/migrations/versions.ts
@@ -3063,6 +3063,27 @@ export const migrations: MigrationDef[] = [
       // SQLite before 3.35 cannot drop a column, and the data in these two is
       // attribution nothing else reads. Leaving them is the safe direction.
     }
+  },
+
+  // ── Bind a project to its agent thread ───────────────────────────────
+  // The overview's left column is the conversation that built the project.
+  // Nullable: a project made by hand has never been talked to, and a null
+  // says so where a fabricated empty thread row would not.
+  {
+    version: "20260829_000002",
+    name: "add_project_thread",
+    createsTables: [],
+    modifiesTables: ["projects"],
+    async up(db) {
+      if (!(await db.columnExists("projects", "thread_id"))) {
+        await db.execute("ALTER TABLE projects ADD COLUMN thread_id TEXT");
+      }
+    },
+    async down(db) {
+      // SQLite before 3.35 cannot drop a column; the value is one id nothing
+      // else reads, so leaving it is the safe direction.
+      void db;
+    }
   }
 ];
 

--- a/packages/models/src/project-summary.ts
+++ b/packages/models/src/project-summary.ts
@@ -95,6 +95,44 @@ export interface ProjectThumbnail {
   asset_id?: string | null;
 }
 
+/** One line of a script card's opening excerpt. */
+export interface ScriptPreviewLine {
+  speaker: string;
+  text: string;
+  /** `voiced` matches its take; `stale` drifted from it; `draft` has none. */
+  state: "voiced" | "stale" | "draft";
+}
+
+export interface ScriptPreview {
+  kind: "script";
+  lines: ScriptPreviewLine[];
+}
+
+export interface TimelinePreviewClip {
+  startMs: number;
+  durationMs: number;
+}
+
+export interface TimelinePreviewTrack {
+  type: "video" | "audio" | "overlay" | "subtitle";
+  name: string;
+  clips: TimelinePreviewClip[];
+}
+
+export interface TimelinePreview {
+  kind: "timeline";
+  /** Total span the bars are laid out against. */
+  durationMs: number;
+  tracks: TimelinePreviewTrack[];
+}
+
+/**
+ * What a document card draws when it has no stills: a script's opening lines,
+ * a cut's tracks as bars. Sliced down to what a 120px card shows, so a card
+ * renders from the summary without fetching the document.
+ */
+export type ProjectDocumentPreview = ScriptPreview | TimelinePreview;
+
 /** A document card: the tab-open ref, what it shows, and what it cost. */
 export interface ProjectDocumentSummary extends ProjectDocumentRef {
   status: ProjectDocumentStatus | null;
@@ -104,6 +142,8 @@ export interface ProjectDocumentSummary extends ProjectDocumentRef {
   unpricedCount: number;
   /** Stills the card montages, oldest shot first. Empty when there are none. */
   thumbnails: ProjectThumbnail[];
+  /** What the card draws in place of stills. Null when there is nothing. */
+  preview: ProjectDocumentPreview | null;
 }
 
 /** What a run paid for, in the categories the spend bar is split by. */
@@ -129,8 +169,15 @@ export interface ProjectSummary {
 
 // ── Status ───────────────────────────────────────────────────────────────────
 
-/** How many stills a card's montage shows. The mockup's grid holds three. */
-const MONTAGE_LIMIT = 3;
+/** How many stills a card's montage shows — the overview's four-still strip. */
+const MONTAGE_LIMIT = 4;
+
+/** Opening lines a script card excerpts. */
+const SCRIPT_PREVIEW_LINES = 4;
+
+/** Tracks a cut's miniature draws, and clips per track. */
+const TIMELINE_PREVIEW_TRACKS = 3;
+const TIMELINE_PREVIEW_CLIPS = 16;
 
 export function storyboardStatus(doc: StoryboardDocument): StoryboardStatus {
   return {
@@ -172,6 +219,67 @@ export function scriptStatus(doc: ScriptDocument): ScriptStatus {
     }
   }
   return { kind: "script", lines: lines.length, voiced, stale };
+}
+
+/**
+ * The script card's excerpt: its opening lines, each with the voicing state
+ * the card's dot reads. Uses the same `needsVoicing` rule the status counts
+ * do, so a line cannot be green in one place and amber in the other.
+ */
+export function scriptPreview(doc: ScriptDocument): ScriptPreview {
+  const cast = doc.cast as ProtocolSpeaker[];
+  const nameOf = new Map(cast.map((speaker) => [speaker.id, speaker.name]));
+  const lines = (
+    scriptLines(doc.sections as ProtocolScriptSection[]) as ProtocolScriptLine[]
+  ).slice(0, SCRIPT_PREVIEW_LINES);
+  return {
+    kind: "script",
+    lines: lines.map((line) => ({
+      speaker: (line.speakerId && nameOf.get(line.speakerId)) || "",
+      text: line.text,
+      state: !needsVoicing(line, effectiveVoice(line, cast))
+        ? "voiced"
+        : currentTake(line)
+          ? "stale"
+          : "draft"
+    }))
+  };
+}
+
+/**
+ * The cut's miniature: its first tracks with each clip reduced to where it
+ * starts and how long it runs. Everything else a clip carries — media,
+ * effects, bindings — is not what a 120px card draws.
+ */
+export function timelinePreview(
+  tracks: readonly {
+    id: string;
+    name: string;
+    type: "video" | "audio" | "overlay" | "subtitle";
+    index: number;
+  }[],
+  clips: readonly { trackId: string; startMs: number; durationMs: number }[],
+  durationMs: number
+): TimelinePreview {
+  const ordered = [...tracks]
+    .sort((a, b) => a.index - b.index)
+    .slice(0, TIMELINE_PREVIEW_TRACKS);
+  return {
+    kind: "timeline",
+    durationMs,
+    tracks: ordered.map((track) => ({
+      type: track.type,
+      name: track.name,
+      clips: clips
+        .filter((clip) => clip.trackId === track.id)
+        .sort((a, b) => a.startMs - b.startMs)
+        .slice(0, TIMELINE_PREVIEW_CLIPS)
+        .map((clip) => ({
+          startMs: clip.startMs,
+          durationMs: clip.durationMs
+        }))
+    }))
+  };
 }
 
 export function timelineStatus(
@@ -370,7 +478,8 @@ export async function summarizeProject(
   const summarize = (
     ref: ProjectDocumentRef,
     status: ProjectDocumentStatus | null,
-    thumbnails: ProjectThumbnail[] = []
+    thumbnails: ProjectThumbnail[] = [],
+    preview: ProjectDocumentPreview | null = null
   ): ProjectDocumentSummary => {
     const spend = perDocument.get(ref.ref);
     return {
@@ -378,7 +487,8 @@ export async function summarizeProject(
       status,
       spendUsd: spend?.usd ?? 0,
       unpricedCount: spend?.unpriced ?? 0,
-      thumbnails
+      thumbnails,
+      preview
     };
   };
 
@@ -391,16 +501,32 @@ export async function summarizeProject(
         storyboardThumbnails(doc)
       );
     }),
-    ...rows.scripts.map((row) =>
-      summarize(toRef("script", row), scriptStatus(row.toDocument()))
-    ),
-    ...rows.timelines.map((row) =>
-      summarize(
+    ...rows.scripts.map((row) => {
+      const doc = row.toDocument();
+      return summarize(
+        toRef("script", row),
+        scriptStatus(doc),
+        [],
+        scriptPreview(doc)
+      );
+    }),
+    ...rows.timelines.map((row) => {
+      const doc = row.toDocument();
+      return summarize(
         toRef("timeline", row),
-        timelineStatus(row.toDocument().clips.length, row.duration_ms)
+        timelineStatus(doc.clips.length, row.duration_ms),
+        [],
+        timelinePreview(doc.tracks, doc.clips, row.duration_ms)
+      );
+    }),
+    // A sketch keeps a rendered thumbnail on its row; nothing else does.
+    ...rows.sketches.map((row) =>
+      summarize(
+        toRef("sketch", row),
+        null,
+        row.thumbnail_asset_id ? [{ asset_id: row.thumbnail_asset_id }] : []
       )
     ),
-    ...rows.sketches.map((row) => summarize(toRef("sketch", row), null)),
     ...rows.applications.map((row) => summarize(toRef("application", row), null)),
     ...rows.jsScripts.map((row) => summarize(toRef("jsscript", row), null))
   ]);

--- a/packages/models/src/project.ts
+++ b/packages/models/src/project.ts
@@ -10,10 +10,11 @@
  * nothing migrates into one.
  */
 
-import { eq, desc, and } from "drizzle-orm";
+import { and, desc, eq, isNull } from "drizzle-orm";
 import { DBModel, createTimeOrderedUuid } from "./base-model.js";
 import { getDb } from "./db.js";
 import { projects } from "./schema/projects.js";
+import { Thread } from "./thread.js";
 
 /** The bucket documents land in when no project is active. */
 export const LOOSE_PROJECT_ID = "default";
@@ -23,6 +24,8 @@ export interface ProjectResponse {
   name: string;
   /** Free text — "spot", "trailer", "report". Not an enum on purpose. */
   kind: string;
+  /** The conversation that builds it, or null while nobody has asked for one. */
+  threadId: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -34,6 +37,7 @@ export class Project extends DBModel {
   declare user_id: string;
   declare name: string;
   declare kind: string;
+  declare thread_id: string | null;
   declare created_at: string;
   declare updated_at: string;
 
@@ -43,6 +47,7 @@ export class Project extends DBModel {
     this.id ??= createTimeOrderedUuid();
     this.name ??= "Untitled project";
     this.kind ??= "";
+    this.thread_id ??= null;
     this.created_at ??= now;
     this.updated_at ??= now;
   }
@@ -56,6 +61,7 @@ export class Project extends DBModel {
       id: this.id,
       name: this.name,
       kind: this.kind,
+      threadId: this.thread_id,
       createdAt: this.created_at,
       updatedAt: this.updated_at
     };
@@ -94,10 +100,52 @@ export class Project extends DBModel {
     return true;
   }
 
+  /**
+   * The project's agent thread, created on first ask.
+   *
+   * The row is created here rather than left to the chat path, because the
+   * project has to be able to name it before anyone has said anything. The
+   * write claims the column only while it is still null, so two callers
+   * racing settle on one thread and the loser's row is dropped rather than
+   * left as a conversation nothing points at.
+   */
+  static async ensureThread(
+    userId: string,
+    id: string
+  ): Promise<string | null> {
+    const project = await Project.findOwned(userId, id);
+    if (!project) return null;
+    if (project.thread_id) return project.thread_id;
+
+    const thread = await Thread.create<Thread>({
+      user_id: userId,
+      title: project.name
+    });
+    const db = getDb();
+    const rows = await db
+      .update(projects)
+      // `updated_at` is left alone: naming the thread is bookkeeping, not
+      // work on the project, and the list orders by when it was last worked on.
+      .set({ thread_id: thread.id })
+      .where(
+        and(
+          eq(projects.id, id),
+          eq(projects.user_id, userId),
+          isNull(projects.thread_id)
+        )
+      )
+      .returning();
+    if (rows.length > 0) return thread.id;
+
+    await thread.delete();
+    const winner = await Project.findOwned(userId, id);
+    return winner?.thread_id ?? null;
+  }
+
   static async updateOwned(
     userId: string,
     id: string,
-    fields: Partial<{ name: string; kind: string }>
+    fields: Partial<{ name: string; kind: string; thread_id: string }>
   ): Promise<Project | null> {
     const db = getDb();
     const rows = await db

--- a/packages/models/src/schema-pg/projects.ts
+++ b/packages/models/src/schema-pg/projects.ts
@@ -8,6 +8,12 @@ export const projects = pgTable(
     name: text("name").notNull(),
     /** Free text — "spot", "trailer", "report", whatever the user calls it. */
     kind: text("kind").notNull().default(""),
+    /**
+     * The conversation that builds this project. Null until someone talks to
+     * the project agent — a project made by hand never has one, and an empty
+     * thread row would be indistinguishable from a conversation nobody read.
+     */
+    thread_id: text("thread_id"),
     created_at: text("created_at").notNull(),
     updated_at: text("updated_at").notNull()
   },

--- a/packages/models/src/schema/projects.ts
+++ b/packages/models/src/schema/projects.ts
@@ -8,6 +8,12 @@ export const projects = sqliteTable(
     name: text("name").notNull(),
     /** Free text — "spot", "trailer", "report", whatever the user calls it. */
     kind: text("kind").notNull().default(""),
+    /**
+     * The conversation that builds this project. Null until someone talks to
+     * the project agent — a project made by hand never has one, and an empty
+     * thread row would be indistinguishable from a conversation nobody read.
+     */
+    thread_id: text("thread_id"),
     created_at: text("created_at").notNull(),
     updated_at: text("updated_at").notNull()
   },

--- a/packages/models/tests/migrations.test.ts
+++ b/packages/models/tests/migrations.test.ts
@@ -423,7 +423,7 @@ describe("MigrationRunner", () => {
 // ── Built-in migrations smoke test ───────────────────────────────────
 
 describe("Built-in migrations", () => {
-  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 71;
+  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 72;
 
   it("should have correct count of migrations", () => {
     expect(migrations.length).toBe(EXPECTED_BUILT_IN_MIGRATION_COUNT);

--- a/packages/models/tests/project.test.ts
+++ b/packages/models/tests/project.test.ts
@@ -12,18 +12,21 @@ import { initTestDb } from "../src/db.js";
 import { Project } from "../src/project.js";
 import {
   listProjectDocuments,
+  scriptPreview,
   scriptStatus,
   spendCategory,
   storyboardStatus,
   storyboardThumbnails,
   summarizeProject,
   summarizeSpend,
+  timelinePreview,
   timelineStatus,
   type SpendRow
 } from "../src/project-summary.js";
 import { moveDocumentToProject } from "../src/project-membership.js";
 import { LOOSE_PROJECT_ID } from "../src/project.js";
 import { Prediction } from "../src/prediction.js";
+import { Thread } from "../src/thread.js";
 import { Script, type ScriptDocument } from "../src/script.js";
 import { Storyboard, type StoryboardDocument } from "../src/storyboard.js";
 import { TimelineSequence } from "../src/timeline-sequence.js";
@@ -96,6 +99,35 @@ describe("Project model", () => {
     expect(await Project.deleteOwned("u1", project.id)).toBe(true);
     expect(await Project.findById(project.id)).toBeNull();
     expect((await Storyboard.findById(board.id))?.project_id).toBe(project.id);
+  });
+});
+
+describe("Project.ensureThread", () => {
+  beforeEach(() => initTestDb());
+
+  it("creates the thread once and answers with the same id after", async () => {
+    const project = await Project.create<Project>({
+      user_id: "u1",
+      name: "Aurora"
+    });
+    const first = await Project.ensureThread("u1", project.id);
+    expect(first).toBeTruthy();
+
+    const second = await Project.ensureThread("u1", project.id);
+    expect(second).toBe(first);
+
+    const thread = await Thread.find("u1", first!);
+    expect(thread?.title).toBe("Aurora");
+    const [threads] = await Thread.paginate("u1", { limit: 10 });
+    expect(threads).toHaveLength(1);
+  });
+
+  it("answers nothing for a project the caller does not own", async () => {
+    const project = await Project.create<Project>({
+      user_id: "u2",
+      name: "Someone else's"
+    });
+    expect(await Project.ensureThread("u1", project.id)).toBeNull();
   });
 });
 
@@ -314,10 +346,93 @@ describe("storyboardThumbnails", () => {
   });
 
   it("stops at the montage limit", () => {
-    const shots = ["a", "b", "c", "d"].map((id) =>
+    const shots = ["a", "b", "c", "d", "e"].map((id) =>
       shot(id, { keyframe: { type: "image", uri: `asset://${id}` } })
     );
-    expect(storyboardThumbnails(storyboardDoc(shots))).toHaveLength(3);
+    expect(storyboardThumbnails(storyboardDoc(shots))).toHaveLength(4);
+  });
+});
+
+describe("document previews", () => {
+  const voice = { provider: "p", model: "m", voice: "v" };
+  const take = (id: string, textSnapshot: string) => ({
+    id,
+    assetId: `a-${id}`,
+    durationMs: 1000,
+    words: [],
+    textSnapshot,
+    voiceSnapshot: voice,
+    createdAt: "2026-01-01T00:00:00.000Z"
+  });
+
+  it("excerpts a script's opening lines with the state its dots read", () => {
+    const doc: ScriptDocument = {
+      cast: [{ id: "s1", name: "Narrator", voice }],
+      sections: [
+        {
+          id: "sec",
+          lines: [
+            {
+              id: "l1",
+              speakerId: "s1",
+              text: "hello",
+              currentTakeId: "t1",
+              takes: [take("t1", "hello")]
+            },
+            {
+              id: "l2",
+              speakerId: "s1",
+              text: "rewritten",
+              currentTakeId: "t2",
+              takes: [take("t2", "the old words")]
+            },
+            { id: "l3", speakerId: "s1", text: "unvoiced", takes: [] }
+          ]
+        }
+      ]
+    };
+    expect(scriptPreview(doc).lines).toEqual([
+      { speaker: "Narrator", text: "hello", state: "voiced" },
+      { speaker: "Narrator", text: "rewritten", state: "stale" },
+      { speaker: "Narrator", text: "unvoiced", state: "draft" }
+    ]);
+  });
+
+  it("keeps a preview line's state in step with the status counts", () => {
+    const doc: ScriptDocument = {
+      cast: [],
+      sections: [{ id: "sec", lines: [{ id: "l1", text: "no voice", takes: [] }] }]
+    };
+    expect(scriptPreview(doc).lines[0].state).toBe("draft");
+    expect(scriptPreview(doc).lines[0].speaker).toBe("");
+    expect(scriptStatus(doc).voiced).toBe(0);
+  });
+
+  it("lays a cut's clips out per track, in start order", () => {
+    const tracks = [
+      { id: "t2", name: "A1", type: "audio" as const, index: 1 },
+      { id: "t1", name: "V1", type: "video" as const, index: 0 }
+    ];
+    const clips = [
+      { trackId: "t1", startMs: 5_000, durationMs: 3_000 },
+      { trackId: "t1", startMs: 0, durationMs: 5_000 },
+      { trackId: "t2", startMs: 0, durationMs: 8_000 }
+    ];
+    expect(timelinePreview(tracks, clips, 8_000)).toEqual({
+      kind: "timeline",
+      durationMs: 8_000,
+      tracks: [
+        {
+          type: "video",
+          name: "V1",
+          clips: [
+            { startMs: 0, durationMs: 5_000 },
+            { startMs: 5_000, durationMs: 3_000 }
+          ]
+        },
+        { type: "audio", name: "A1", clips: [{ startMs: 0, durationMs: 8_000 }] }
+      ]
+    });
   });
 });
 

--- a/packages/protocol/src/api-schemas/projects.ts
+++ b/packages/protocol/src/api-schemas/projects.ts
@@ -9,6 +9,8 @@ export const projectResponse = z.object({
   id: z.string(),
   name: z.string(),
   kind: z.string(),
+  /** The conversation that builds it, or null while nobody has asked for one. */
+  threadId: z.string().nullable(),
   createdAt: z.string(),
   updatedAt: z.string()
 });
@@ -89,12 +91,49 @@ export const projectThumbnail = z.object({
 });
 export type ProjectThumbnail = z.infer<typeof projectThumbnail>;
 
+/**
+ * What a document card draws above its name, for the kinds whose glance is not
+ * a picture: a script's opening lines with their voicing state, and a cut's
+ * tracks reduced to bars. Both are already-stored facts sliced down to what a
+ * 120px card can show, so the card renders without fetching the document.
+ */
+export const projectDocumentPreview = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("script"),
+    lines: z.array(
+      z.object({
+        speaker: z.string(),
+        text: z.string(),
+        /** `voiced` matches its take; `stale` drifted from it; `draft` has none. */
+        state: z.enum(["voiced", "stale", "draft"])
+      })
+    )
+  }),
+  z.object({
+    kind: z.literal("timeline"),
+    /** Total span the bars are laid out against, in milliseconds. */
+    durationMs: z.number(),
+    tracks: z.array(
+      z.object({
+        type: z.enum(["video", "audio", "overlay", "subtitle"]),
+        name: z.string(),
+        clips: z.array(
+          z.object({ startMs: z.number(), durationMs: z.number() })
+        )
+      })
+    )
+  })
+]);
+export type ProjectDocumentPreview = z.infer<typeof projectDocumentPreview>;
+
 export const projectDocumentSummary = projectDocumentRef.extend({
   status: projectDocumentStatus.nullable(),
   spendUsd: z.number(),
   unpricedCount: z.number(),
   /** Stills the card montages. Empty for the kinds that render none. */
-  thumbnails: z.array(projectThumbnail)
+  thumbnails: z.array(projectThumbnail),
+  /** What the card draws when it has no stills. Null when there is nothing. */
+  preview: projectDocumentPreview.nullable()
 });
 export type ProjectDocumentSummary = z.infer<typeof projectDocumentSummary>;
 

--- a/packages/websocket/src/trpc/routers/projects.ts
+++ b/packages/websocket/src/trpc/routers/projects.ts
@@ -12,6 +12,7 @@
  *   get            (query)    — ProjectDetail (project + documents + spend)
  *   documents      (query)    — ProjectDocumentRef[]
  *   unassigned     (query)    — ProjectDocumentRef[] in the loose bucket
+ *   thread         (mutation) — { threadId } (the project's agent thread)
  *   create         (mutation) — ProjectResponse
  *   update         (mutation) — ProjectResponse
  *   delete         (mutation) — { ok: true }
@@ -111,6 +112,21 @@ export const projectsRouter = router({
     .input(listInput)
     .output(z.array(projectDocumentRef))
     .query(({ ctx }) => listProjectDocuments(ctx.userId, LOOSE_PROJECT_ID)),
+
+  /**
+   * The project's agent thread, created on first ask. A mutation rather than a
+   * query because the first call writes: the overview needs an id to render a
+   * composer against before anyone has said anything.
+   */
+  thread: protectedProcedure
+    .input(idInput)
+    .output(z.object({ threadId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await loadOwned(ctx.userId, input.id);
+      const threadId = await Project.ensureThread(ctx.userId, input.id);
+      if (!threadId) throwApiError(ApiErrorCode.NOT_FOUND, "Project not found");
+      return { threadId };
+    }),
 
   create: protectedProcedure
     .input(createProjectInput)

--- a/packages/websocket/src/trpc/sandbox-coverage.ts
+++ b/packages/websocket/src/trpc/sandbox-coverage.ts
@@ -627,6 +627,13 @@ export const SANDBOX_API_COVERAGE: Readonly<
       "Same grouping surface as `projects.create`. The whole list of " +
       "rollups `projects.get` returns one at a time."
   },
+  "projects.thread": {
+    gap:
+      "Names — creating on first ask — the conversation that builds a " +
+      "project, so its overview can render the thread the user already " +
+      "has. It returns an id, never a message; reading the conversation " +
+      "still goes through the threads and messages surfaces."
+  },
   "projects.unassigned": {
     gap:
       "Lists the documents in no project. Same grouping surface as " +

--- a/packages/websocket/tests/trpc-projects.test.ts
+++ b/packages/websocket/tests/trpc-projects.test.ts
@@ -36,6 +36,25 @@ describe("projects router", () => {
   beforeEach(() => initTestDb());
   afterEach(() => ModelObserver.clear());
 
+  it("names one agent thread per project, and refuses another user's", async () => {
+    const project = await caller().projects.create({ name: "Aurora" });
+
+    const { threadId } = await caller().projects.thread({ id: project.id });
+    expect(threadId).toBeTruthy();
+    expect((await caller().projects.thread({ id: project.id })).threadId).toBe(
+      threadId
+    );
+    // The project carries it, so the overview can open the thread without
+    // asking for it again.
+    expect((await caller().projects.get({ id: project.id })).project.threadId).toBe(
+      threadId
+    );
+
+    await expect(
+      caller("user-2").projects.thread({ id: project.id })
+    ).rejects.toThrow();
+  });
+
   it("creates, lists, updates and deletes", async () => {
     const created = await caller().projects.create({
       name: "Aurora Launch Spot",
@@ -121,7 +140,8 @@ describe("projects router", () => {
         status: { kind: "storyboard", shots: 2, stills: 1, clips: 0 },
         spendUsd: 0.5,
         unpricedCount: 0,
-        thumbnails: [{ uri: "asset://1", asset_id: null }]
+        thumbnails: [{ uri: "asset://1", asset_id: null }],
+        preview: null
       }
     ]);
     expect(detail.spend.totalUsd).toBeCloseTo(0.5, 6);

--- a/web/src/components/chat/composer/ChatComposer.tsx
+++ b/web/src/components/chat/composer/ChatComposer.tsx
@@ -31,6 +31,8 @@ interface ChatComposerProps {
   onNewChat?: () => void;
   disabled?: boolean;
   toolbarNode?: React.ReactNode;
+  /** Override the textarea placeholder. */
+  placeholder?: string;
 }
 
 const ChatComposer: React.FC<ChatComposerProps> = memo(({
@@ -40,7 +42,8 @@ const ChatComposer: React.FC<ChatComposerProps> = memo(({
   onStop,
   onNewChat,
   disabled = false,
-  toolbarNode
+  toolbarNode,
+  placeholder
 }) => {
   const theme = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
@@ -240,9 +243,10 @@ const ChatComposer: React.FC<ChatComposerProps> = memo(({
             onChange={handleOnChange}
             onKeyDown={handleKeyDown}
             placeholder={
-              isMobile
+              placeholder ??
+              (isMobile
                 ? "Type a message..."
-                : "Type a message... (Shift+Enter for new line)"
+                : "Type a message... (Shift+Enter for new line)")
             }
           />
           <div className="composer-footer">

--- a/web/src/components/chat/containers/ChatInputSection.tsx
+++ b/web/src/components/chat/containers/ChatInputSection.tsx
@@ -104,6 +104,7 @@ const ChatInputSection = ({
             onStop={onStop}
             onNewChat={onNewChat}
             toolbarNode={composerToolbar}
+            placeholder={placeholder}
           />
         ) : (
           <MediaChatComposer

--- a/web/src/components/projects/ProjectAgentPanel.tsx
+++ b/web/src/components/projects/ProjectAgentPanel.tsx
@@ -1,0 +1,173 @@
+/**
+ * The overview's left column: the conversation that builds the project.
+ *
+ * The thread is the project's own — `projects.thread` names it, creating one
+ * on first ask — so the same conversation is here whether it was started from
+ * the overview or from the new-project surface. Sends go straight to that
+ * thread, which is what makes the column the project's agent rather than a
+ * second chat that happens to be next to it.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
+
+import {
+  Caption,
+  FlexColumn,
+  LoadingSpinner,
+  SPACING,
+  ScrollArea
+} from "../ui_primitives";
+import ChatComposer from "../chat/composer/ChatComposer";
+import useGlobalChatStore, {
+  useThreadRuntime
+} from "../../stores/GlobalChatStore";
+import type { Message, MessageContent } from "../../stores/ApiTypes";
+import { resolveUiContext } from "../../lib/chat/uiContext";
+import { trpc } from "../../trpc/client";
+import ProjectAgentThread from "./ProjectAgentThread";
+
+const NO_MESSAGES: Message[] = [];
+
+interface ProjectAgentPanelProps {
+  projectId: string;
+  projectName: string;
+  /** The thread the project already names, when it has one. */
+  threadId: string | null;
+}
+
+/**
+ * Tells the agent which project it is working in. The tab context already
+ * lists the open documents; this names the group they belong to, so a request
+ * to "add a shot" lands in this project's board rather than the last one
+ * touched.
+ */
+const projectSystemPrompt = (name: string, id: string): string =>
+  `You are working inside the project "${name}" (project id ${id}). ` +
+  `Documents you create belong to it, and the documents open in this ` +
+  `workspace are its own.`;
+
+const ProjectAgentPanel = ({
+  projectId,
+  projectName,
+  threadId: boundThreadId
+}: ProjectAgentPanelProps) => {
+  const [threadId, setThreadId] = useState<string | null>(boundThreadId);
+  const ensureThread = trpc.projects.thread.useMutation();
+  const ensureThreadAsync = ensureThread.mutateAsync;
+
+  const { connect, fetchThread, loadMessages, sendMessage, stopGeneration } =
+    useGlobalChatStore(
+      useShallow((state) => ({
+        connect: state.connect,
+        fetchThread: state.fetchThread,
+        loadMessages: state.loadMessages,
+        sendMessage: state.sendMessage,
+        stopGeneration: state.stopGeneration
+      }))
+    );
+  const messages = useGlobalChatStore((state) =>
+    threadId ? (state.messageCache[threadId] ?? NO_MESSAGES) : NO_MESSAGES
+  );
+  const runtime = useThreadRuntime(threadId);
+  const selectedModel = useGlobalChatStore((state) => state.selectedModel);
+
+  // The shared chat socket is a singleton; other mounted surfaces depend on
+  // it, so this never disconnects on unmount.
+  useEffect(() => {
+    connect().catch((error) => {
+      console.error("Failed to connect chat:", error);
+    });
+  }, [connect]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const bind = async () => {
+      // A project that already names its thread needs no write; only the
+      // first visit creates one.
+      const id =
+        boundThreadId ??
+        (await ensureThreadAsync({ id: projectId })).threadId;
+      if (cancelled) return;
+      setThreadId(id);
+      // The row exists on the server, so a fetch registers it with the store
+      // rather than guessing at a local one.
+      await fetchThread(id);
+      if (cancelled) return;
+      await loadMessages(id);
+    };
+    bind().catch((error) => {
+      console.error("Failed to open the project thread:", error);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, boundThreadId, ensureThreadAsync, fetchThread, loadMessages]);
+
+  const systemPrompt = useMemo(
+    () => projectSystemPrompt(projectName, projectId),
+    [projectName, projectId]
+  );
+
+  const handleSend = useCallback(
+    (content: MessageContent[]) => {
+      if (!threadId) return;
+      sendMessage(
+        {
+          type: "message",
+          name: "",
+          role: "user",
+          provider: selectedModel?.provider,
+          model: selectedModel?.id,
+          content,
+          system_prompt: systemPrompt,
+          ui_context: resolveUiContext(undefined, "workspace_chat")
+        },
+        threadId
+      ).catch((error) => {
+        console.error("Failed to send to the project agent:", error);
+      });
+    },
+    [threadId, sendMessage, selectedModel, systemPrompt]
+  );
+
+  const handleStop = useCallback(() => {
+    if (threadId) stopGeneration(threadId);
+  }, [threadId, stopGeneration]);
+
+  const isStreaming = runtime.status === "streaming";
+  const isLoading = runtime.status === "loading";
+
+  return (
+    <FlexColumn fullHeight sx={{ minHeight: 0 }}>
+      <Caption
+        color="muted"
+        sx={{ px: SPACING.xl, pt: SPACING.lg, textTransform: "uppercase" }}
+      >
+        Project agent
+      </Caption>
+      <ScrollArea sx={{ flex: 1, minHeight: 0, px: SPACING.xl }}>
+        {threadId ? (
+          <ProjectAgentThread
+            messages={messages}
+            runningToolMessage={runtime.toolMessage}
+          />
+        ) : (
+          <LoadingSpinner />
+        )}
+      </ScrollArea>
+      <FlexColumn sx={{ p: SPACING.lg }}>
+        <ChatComposer
+          isLoading={isLoading}
+          isStreaming={isStreaming}
+          onSendMessage={handleSend}
+          onStop={handleStop}
+          disabled={!threadId}
+          placeholder="Ask for a change to this project…"
+        />
+      </FlexColumn>
+    </FlexColumn>
+  );
+};
+
+export default ProjectAgentPanel;

--- a/web/src/components/projects/ProjectAgentThread.tsx
+++ b/web/src/components/projects/ProjectAgentThread.tsx
@@ -1,0 +1,134 @@
+/**
+ * The project's conversation, rendered for a 460px column.
+ *
+ * A user turn is a bubble; an agent turn is its text plus a mono chip per tool
+ * it called, and — while a call is in flight — the pill saying what is
+ * running. Roles the compact column cannot render (an agent-execution trace,
+ * a tool result) are left to the full chat surface rather than flattened into
+ * something misleading.
+ */
+
+import { memo } from "react";
+
+import {
+  BORDER_RADIUS,
+  Box,
+  Caption,
+  FlexColumn,
+  FlexRow,
+  SPACING,
+  StatusPill,
+  TYPOGRAPHY
+} from "../ui_primitives";
+import ChatMarkdown from "../chat/message/ChatMarkdown";
+import type { Message, ToolCall } from "../../stores/ApiTypes";
+import { isString } from "../../utils/typePredicates";
+
+/** The turn's text, whatever shape the content arrived in. */
+const messageText = (message: Message): string => {
+  const content = message.content;
+  if (isString(content)) return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) =>
+      part && typeof part === "object" && "type" in part && part.type === "text"
+        ? ((part as { text?: unknown }).text ?? "")
+        : ""
+    )
+    .filter(isString)
+    .join("\n")
+    .trim();
+};
+
+const ToolChips = ({ calls }: { calls: readonly ToolCall[] }) => (
+  <FlexRow gap={SPACING.sm} sx={{ flexWrap: "wrap" }}>
+    {calls.map((call) => (
+      <Box
+        key={call.id}
+        component="span"
+        sx={{
+          px: SPACING.sm,
+          py: SPACING.micro,
+          borderRadius: BORDER_RADIUS.xs,
+          bgcolor: "background.paper",
+          border: "1px solid",
+          borderColor: "divider",
+          color: "text.secondary",
+          ...TYPOGRAPHY.mono.caption
+        }}
+      >
+        {call.name}
+      </Box>
+    ))}
+  </FlexRow>
+);
+
+const UserTurn = ({ text }: { text: string }) => (
+  <Box
+    sx={{
+      alignSelf: "flex-end",
+      maxWidth: "85%",
+      px: SPACING.lg,
+      py: SPACING.md,
+      bgcolor: "background.paper",
+      borderRadius: BORDER_RADIUS.lg,
+      ...TYPOGRAPHY.sans.body
+    }}
+  >
+    {text}
+  </Box>
+);
+
+const AgentTurn = ({ message }: { message: Message }) => {
+  const text = messageText(message);
+  const calls = message.tool_calls ?? [];
+  if (!text && calls.length === 0) return null;
+  return (
+    <FlexColumn gap={SPACING.md} sx={{ alignSelf: "flex-start", width: "100%" }}>
+      {text && <ChatMarkdown content={text} />}
+      {calls.length > 0 && <ToolChips calls={calls} />}
+    </FlexColumn>
+  );
+};
+
+interface ProjectAgentThreadProps {
+  messages: readonly Message[];
+  /** What the agent is doing right now, when it is doing something. */
+  runningToolMessage?: string | null;
+}
+
+const ProjectAgentThread = ({
+  messages,
+  runningToolMessage
+}: ProjectAgentThreadProps) => {
+  if (messages.length === 0 && !runningToolMessage) {
+    return (
+      <Caption color="muted">
+        Nothing here yet. Ask for a change and the agent builds it into this
+        project.
+      </Caption>
+    );
+  }
+  return (
+    <FlexColumn gap={SPACING.lg}>
+      {messages.map((message, index) => {
+        const key = message.id ?? `turn-${index}`;
+        if (message.role === "user") {
+          const text = messageText(message);
+          return text ? <UserTurn key={key} text={text} /> : null;
+        }
+        if (message.role === "assistant") {
+          return <AgentTurn key={key} message={message} />;
+        }
+        return null;
+      })}
+      {runningToolMessage && (
+        <StatusPill tone="rendering" sx={{ alignSelf: "flex-start" }}>
+          {runningToolMessage}
+        </StatusPill>
+      )}
+    </FlexColumn>
+  );
+};
+
+export default memo(ProjectAgentThread);

--- a/web/src/components/projects/ProjectDocumentCard.tsx
+++ b/web/src/components/projects/ProjectDocumentCard.tsx
@@ -1,0 +1,82 @@
+/**
+ * One document in a project's overview: what it looks like, how far it has
+ * got, and what it has cost. Clicking it opens the document as a tab inside
+ * the project's group.
+ */
+
+import { memo, useCallback } from "react";
+
+import {
+  BORDER_RADIUS,
+  Box,
+  Caption,
+  Card,
+  FlexColumn,
+  FlexRow,
+  Label,
+  SPACING,
+  StatusPill,
+  TYPOGRAPHY
+} from "../ui_primitives";
+import { TYPE_COLOR, TYPE_GLYPH } from "../workspace/tabTypeIdentity";
+import ProjectDocumentPreview from "./ProjectDocumentPreview";
+import {
+  documentProgress,
+  documentStatusLine,
+  formatDocumentSpend,
+  type ProjectDocument
+} from "./projectStatus";
+
+interface ProjectDocumentCardProps {
+  document: ProjectDocument;
+  onOpen: (document: ProjectDocument) => void;
+}
+
+const ProjectDocumentCard = ({
+  document,
+  onOpen
+}: ProjectDocumentCardProps) => {
+  const handleOpen = useCallback(() => onOpen(document), [onOpen, document]);
+  const progress = documentProgress(document);
+
+  return (
+    <Card
+      variant="outlined"
+      padding="none"
+      clickable
+      onClick={handleOpen}
+      aria-label={document.name}
+      sx={{ overflow: "hidden", borderRadius: BORDER_RADIUS.md }}
+    >
+      <ProjectDocumentPreview document={document} />
+      <FlexColumn gap={SPACING.sm} sx={{ p: SPACING.lg }}>
+        <FlexRow align="center" gap={SPACING.md}>
+          <Box
+            component="span"
+            aria-hidden
+            sx={{ color: TYPE_COLOR[document.type] }}
+          >
+            {TYPE_GLYPH[document.type]}
+          </Box>
+          <Label sx={{ flex: 1, minWidth: 0 }}>{document.name}</Label>
+          {progress && (
+            <StatusPill tone={progress.tone}>{progress.label}</StatusPill>
+          )}
+        </FlexRow>
+        <FlexRow align="baseline" gap={SPACING.md}>
+          <Caption color="secondary" sx={{ flex: 1, minWidth: 0 }}>
+            {documentStatusLine(document)}
+          </Caption>
+          <Box
+            component="span"
+            sx={{ ...TYPOGRAPHY.mono.caption, color: "text.secondary" }}
+          >
+            {formatDocumentSpend(document)}
+          </Box>
+        </FlexRow>
+      </FlexColumn>
+    </Card>
+  );
+};
+
+export default memo(ProjectDocumentCard);

--- a/web/src/components/projects/ProjectDocumentPreview.tsx
+++ b/web/src/components/projects/ProjectDocumentPreview.tsx
@@ -1,0 +1,226 @@
+/**
+ * The picture on a project document card.
+ *
+ * Four ways a document shows what it is, in the order the summary can answer:
+ * the stills a board or a sketch has rendered, a script's opening lines with
+ * their voicing state, a cut's tracks as bars, and — for the kinds that carry
+ * no glance of their own — the type's glyph.
+ */
+
+import { memo, type ReactNode } from "react";
+
+import {
+  BORDER_RADIUS,
+  Box,
+  Caption,
+  FlexColumn,
+  FlexRow,
+  ResponsiveImage,
+  SPACING,
+  TYPOGRAPHY
+} from "../ui_primitives";
+import { colorForType } from "../../config/data_types";
+import { TYPE_COLOR, TYPE_GLYPH } from "../workspace/tabTypeIdentity";
+import type { ProjectDocument } from "./projectStatus";
+
+/** Height of the media area, per the overview mockup's card geometry. */
+const PREVIEW_HEIGHT = 120;
+
+type Preview = NonNullable<ProjectDocument["preview"]>;
+type ScriptPreview = Extract<Preview, { kind: "script" }>;
+type TimelinePreview = Extract<Preview, { kind: "timeline" }>;
+
+/** A line's dot: voiced reads as done, stale as needing another pass. */
+const LINE_STATE_COLOR: Record<ScriptPreview["lines"][number]["state"], string> =
+  {
+    voiced: "var(--palette-success-main)",
+    stale: "var(--palette-warning-main)",
+    draft: "var(--palette-text-disabled)"
+  };
+
+const TRACK_COLOR: Record<TimelinePreview["tracks"][number]["type"], string> = {
+  video: colorForType("video"),
+  audio: colorForType("audio"),
+  overlay: colorForType("image"),
+  subtitle: colorForType("str")
+};
+
+const Frame = ({ children }: { children: ReactNode }) => (
+  <Box
+    sx={{
+      height: `${PREVIEW_HEIGHT}px`,
+      bgcolor: "background.default",
+      overflow: "hidden"
+    }}
+  >
+    {children}
+  </Box>
+);
+
+const StillStrip = ({ document }: { document: ProjectDocument }) => (
+  <Frame>
+    <Box
+      sx={{
+        height: "100%",
+        display: "grid",
+        gap: SPACING.micro,
+        gridTemplateColumns: `repeat(${document.thumbnails.length}, minmax(0, 1fr))`
+      }}
+    >
+      {document.thumbnails.map((still, index) => (
+        <ResponsiveImage
+          key={still.asset_id ?? still.uri ?? index}
+          locator={still}
+          alt=""
+          fit="cover"
+          sx={{ width: "100%", height: "100%" }}
+        />
+      ))}
+    </Box>
+  </Frame>
+);
+
+const ScriptLines = ({ preview }: { preview: ScriptPreview }) => (
+  <Frame>
+    <FlexColumn gap={SPACING.md} sx={{ p: SPACING.lg, bgcolor: "background.paper" }}>
+      {preview.lines.map((line, index) => (
+        <FlexRow key={index} align="center" gap={SPACING.md} sx={{ minWidth: 0 }}>
+          <Box
+            aria-hidden
+            sx={{
+              width: "6px",
+              height: "6px",
+              flexShrink: 0,
+              borderRadius: BORDER_RADIUS.circle,
+              bgcolor: LINE_STATE_COLOR[line.state]
+            }}
+          />
+          {line.speaker && (
+            <Box
+              component="span"
+              sx={{ ...TYPOGRAPHY.mono.caption, color: "text.secondary" }}
+            >
+              {line.speaker}
+            </Box>
+          )}
+          <Caption
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap"
+            }}
+          >
+            {line.text}
+          </Caption>
+          {line.state === "stale" && (
+            <Box
+              component="span"
+              sx={{
+                ...TYPOGRAPHY.mono.caption,
+                color: "warning.main"
+              }}
+            >
+              stale
+            </Box>
+          )}
+        </FlexRow>
+      ))}
+    </FlexColumn>
+  </Frame>
+);
+
+const TrackBars = ({ preview }: { preview: TimelinePreview }) => {
+  // A cut with no duration recorded still has clips; lay them out against the
+  // span they cover rather than dividing by zero.
+  const span =
+    preview.durationMs > 0
+      ? preview.durationMs
+      : preview.tracks.reduce(
+          (max, track) =>
+            track.clips.reduce(
+              (end, clip) => Math.max(end, clip.startMs + clip.durationMs),
+              max
+            ),
+          0
+        );
+  return (
+    <Frame>
+      <FlexColumn
+        gap={SPACING.sm}
+        justify="center"
+        fullHeight
+        sx={{ p: SPACING.lg }}
+      >
+        {preview.tracks.map((track) => (
+          <FlexRow key={track.name} align="center" gap={SPACING.sm}>
+            <Box
+              component="span"
+              sx={{
+                width: "30px",
+                flexShrink: 0,
+                ...TYPOGRAPHY.mono.caption,
+                color: "text.disabled"
+              }}
+            >
+              {track.name}
+            </Box>
+            <Box sx={{ position: "relative", flex: 1, height: "18px" }}>
+              {span > 0 &&
+                track.clips.map((clip, index) => (
+                  <Box
+                    key={index}
+                    sx={{
+                      position: "absolute",
+                      top: 0,
+                      bottom: 0,
+                      left: `${(clip.startMs / span) * 100}%`,
+                      width: `${Math.max((clip.durationMs / span) * 100, 1)}%`,
+                      borderRadius: BORDER_RADIUS.xs,
+                      border: "1px solid",
+                      borderColor: TRACK_COLOR[track.type],
+                      opacity: 0.7
+                    }}
+                  />
+                ))}
+            </Box>
+          </FlexRow>
+        ))}
+      </FlexColumn>
+    </Frame>
+  );
+};
+
+const GlyphPlaceholder = ({ document }: { document: ProjectDocument }) => (
+  <Frame>
+    <FlexRow align="center" justify="center" fullHeight>
+      <Box
+        component="span"
+        aria-hidden
+        sx={{ color: TYPE_COLOR[document.type], ...TYPOGRAPHY.sans.title }}
+      >
+        {TYPE_GLYPH[document.type]}
+      </Box>
+    </FlexRow>
+  </Frame>
+);
+
+const ProjectDocumentPreview = ({
+  document
+}: {
+  document: ProjectDocument;
+}) => {
+  if (document.thumbnails.length > 0) {
+    return <StillStrip document={document} />;
+  }
+  if (document.preview?.kind === "script") {
+    return <ScriptLines preview={document.preview} />;
+  }
+  if (document.preview?.kind === "timeline") {
+    return <TrackBars preview={document.preview} />;
+  }
+  return <GlyphPlaceholder document={document} />;
+};
+
+export default memo(ProjectDocumentPreview);

--- a/web/src/components/projects/ProjectOverviewSurface.tsx
+++ b/web/src/components/projects/ProjectOverviewSurface.tsx
@@ -1,25 +1,39 @@
+/**
+ * A project's overview tab: the conversation that builds it on the left, what
+ * it is made of on the right, and what it has cost across the bottom.
+ *
+ * Everything here is derived from the documents the project holds — there is
+ * no project content of its own to show. The header's next step names what the
+ * documents are waiting on and opens the one that performs it; the render's own
+ * controls live there, not here.
+ */
+
 import { useCallback } from "react";
 
 import {
-  BORDER_RADIUS,
   Box,
   Caption,
-  Card,
+  Divider,
+  EditorButton,
   FlexColumn,
   FlexRow,
-  Label,
   LoadingSpinner,
   SPACING,
   ScrollArea,
+  StatusPill,
   Text,
   TYPOGRAPHY
 } from "../ui_primitives";
 import { trpc } from "../../trpc/client";
 import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
-import { TYPE_COLOR, TYPE_GLYPH } from "../workspace/tabTypeIdentity";
 import { PROJECT_COLOR, PROJECT_GLYPH } from "./projectIdentity";
+import ProjectAgentPanel from "./ProjectAgentPanel";
+import ProjectDocumentCard from "./ProjectDocumentCard";
+import ProjectSpendBar from "./ProjectSpendBar";
 import {
   formatSpend,
+  projectNextStep,
+  projectProgress,
   projectStatusLine,
   type ProjectDocument
 } from "./projectStatus";
@@ -29,20 +43,9 @@ interface ProjectOverviewSurfaceProps {
   refId: string;
 }
 
-const documentMeta = (document: ProjectDocument): string => {
-  const spend = `$${document.spendUsd.toFixed(2)}`;
-  return document.unpricedCount > 0
-    ? `${spend} · ${document.unpricedCount} unpriced`
-    : spend;
-};
+/** Width of the agent column, per the overview mockup. */
+const AGENT_COLUMN_WIDTH = 460;
 
-/**
- * A project's overview tab: what it is made of, and what it has cost.
- *
- * Phase 2 of the project view. The agent thread, the per-type thumbnails and
- * the spend bar are Phase 3 (`docs/plans/project-view/PLAN.md`, C1–C4); what
- * is here is the header and the document list they will be arranged around.
- */
 const ProjectOverviewSurface = ({ refId }: ProjectOverviewSurfaceProps) => {
   const { data, isPending, error } = trpc.projects.get.useQuery(
     { id: refId },
@@ -73,77 +76,128 @@ const ProjectOverviewSurface = ({ refId }: ProjectOverviewSurfaceProps) => {
     );
   }
 
+  const { project, documents, spend } = data;
+  const progress = projectProgress(documents);
+  const nextStep = projectNextStep(documents);
+
   return (
-    <ScrollArea fullHeight sx={{ px: SPACING.xxl, py: SPACING.xxl }}>
-      <FlexColumn gap={SPACING.xxl}>
-        <FlexColumn gap={SPACING.md}>
+    <FlexColumn fullHeight sx={{ minHeight: 0 }}>
+      <FlexRow
+        align="center"
+        gap={SPACING.xl}
+        sx={{
+          px: SPACING.xxl,
+          py: SPACING.xl,
+          borderBottom: "1px solid",
+          borderColor: "divider"
+        }}
+      >
+        <FlexColumn gap={SPACING.sm} sx={{ flex: 1, minWidth: 0 }}>
           <FlexRow align="center" gap={SPACING.md}>
             <Box component="span" aria-hidden sx={{ color: PROJECT_COLOR }}>
               {PROJECT_GLYPH}
             </Box>
-            <Text size="big">{data.project.name}</Text>
+            <Text size="big">{project.name}</Text>
+            {progress && (
+              <StatusPill tone={progress.done ? "done" : "neutral"}>
+                {progress.label}
+              </StatusPill>
+            )}
           </FlexRow>
-          <Caption color="secondary">
-            {projectStatusLine(data.documents)}
-          </Caption>
-          <FlexRow align="baseline" gap={SPACING.md}>
-            <Box component="span" sx={{ ...TYPOGRAPHY.mono.strong }}>
-              {formatSpend(data.spend)}
-            </Box>
-            <Caption color="muted">so far · provider rates, no markup</Caption>
-          </FlexRow>
+          <Caption color="secondary">{projectStatusLine(documents)}</Caption>
         </FlexColumn>
-
-        {data.documents.length === 0 ? (
-          <Caption color="muted">
-            Nothing in this project yet. Anything you create while it is open
-            lands here.
-          </Caption>
-        ) : (
-          <Box
-            sx={{
-              display: "grid",
-              gap: SPACING.xl,
-              gridTemplateColumns: {
-                xs: "1fr",
-                md: "repeat(2, minmax(0, 1fr))"
-              }
-            }}
-          >
-            {data.documents.map((document) => (
-              <Card
-                key={`${document.type}:${document.ref}`}
-                variant="outlined"
-                padding="normal"
-                clickable
-                onClick={() => openDocument(document)}
-                aria-label={document.name}
-                sx={{ borderRadius: BORDER_RADIUS.md }}
-              >
-                <FlexColumn gap={SPACING.sm}>
-                  <FlexRow align="center" gap={SPACING.md}>
-                    <Box
-                      component="span"
-                      aria-hidden
-                      sx={{ color: TYPE_COLOR[document.type] }}
-                    >
-                      {TYPE_GLYPH[document.type]}
-                    </Box>
-                    <Label sx={{ flex: 1 }}>{document.name}</Label>
-                  </FlexRow>
-                  <Caption color="secondary">
-                    {projectStatusLine([document])}
-                  </Caption>
-                  <Caption color="muted" sx={{ ...TYPOGRAPHY.mono.caption }}>
-                    {documentMeta(document)}
-                  </Caption>
-                </FlexColumn>
-              </Card>
-            ))}
+        <FlexColumn
+          align="flex-end"
+          gap={SPACING.xs}
+          sx={{
+            pr: SPACING.xl,
+            borderRight: "1px solid",
+            borderColor: "divider"
+          }}
+        >
+          <Box component="span" sx={{ ...TYPOGRAPHY.mono.strong }}>
+            {formatSpend(spend)}
           </Box>
+          <Caption color="muted">so far · provider rates, no markup</Caption>
+        </FlexColumn>
+        {nextStep && (
+          <EditorButton
+            variant="contained"
+            density="normal"
+            onClick={() => openDocument(nextStep.document)}
+            title={`Opens ${nextStep.document.name}`}
+          >
+            {nextStep.label}
+          </EditorButton>
         )}
-      </FlexColumn>
-    </ScrollArea>
+      </FlexRow>
+
+      <FlexRow sx={{ flex: 1, minHeight: 0 }}>
+        <Box
+          sx={{
+            width: `${AGENT_COLUMN_WIDTH}px`,
+            flexShrink: 0,
+            minHeight: 0,
+            display: { xs: "none", md: "block" },
+            borderRight: "1px solid",
+            borderColor: "divider"
+          }}
+        >
+          <ProjectAgentPanel
+            projectId={project.id}
+            projectName={project.name}
+            threadId={project.threadId}
+          />
+        </Box>
+
+        <FlexColumn sx={{ flex: 1, minWidth: 0, minHeight: 0 }}>
+          <ScrollArea sx={{ flex: 1, minHeight: 0, px: SPACING.xxl }}>
+            <FlexRow
+              align="baseline"
+              gap={SPACING.md}
+              sx={{ pt: SPACING.lg, pb: SPACING.md }}
+            >
+              <Caption color="muted" sx={{ textTransform: "uppercase" }}>
+                Documents
+              </Caption>
+              <Box sx={{ flex: 1 }} />
+              <Caption color="muted">
+                everything below opens as a tab in this group
+              </Caption>
+            </FlexRow>
+            {documents.length === 0 ? (
+              <Caption color="muted">
+                Nothing in this project yet. Anything you create while it is
+                open lands here.
+              </Caption>
+            ) : (
+              <Box
+                sx={{
+                  display: "grid",
+                  gap: SPACING.lg,
+                  gridTemplateColumns: {
+                    xs: "1fr",
+                    lg: "repeat(2, minmax(0, 1fr))"
+                  }
+                }}
+              >
+                {documents.map((document) => (
+                  <ProjectDocumentCard
+                    key={`${document.type}:${document.ref}`}
+                    document={document}
+                    onOpen={openDocument}
+                  />
+                ))}
+              </Box>
+            )}
+          </ScrollArea>
+          <Divider />
+          <Box sx={{ px: SPACING.xxl, py: SPACING.lg }}>
+            <ProjectSpendBar spend={spend} />
+          </Box>
+        </FlexColumn>
+      </FlexRow>
+    </FlexColumn>
   );
 };
 

--- a/web/src/components/projects/ProjectSpendBar.tsx
+++ b/web/src/components/projects/ProjectSpendBar.tsx
@@ -1,0 +1,151 @@
+/**
+ * What a project cost, split by what it bought.
+ *
+ * One stacked bar over the four ledger categories, and a legend that names
+ * each figure. Calls no catalog priced are shown as their own `unpriced`
+ * segment rather than dropped or summed as zero: a total that silently omits
+ * them reads as cheaper than the project was.
+ */
+
+import { memo, useMemo } from "react";
+
+import {
+  BORDER_RADIUS,
+  Box,
+  Caption,
+  FlexRow,
+  SPACING,
+  TYPOGRAPHY
+} from "../ui_primitives";
+import { colorForType } from "../../config/data_types";
+import type { ProjectDetail } from "./projectStatus";
+
+type ProjectSpend = ProjectDetail["spend"];
+type SpendCategory = ProjectSpend["byCategory"][number]["category"];
+
+/**
+ * A category is drawn in the colour of the medium it bought, from the same
+ * palette the node graph types use — stills fuchsia, clips violet, voice sky.
+ * Pipeline is the LLM work around them, so it takes the app's own primary.
+ */
+const CATEGORY_COLOR: Record<SpendCategory, string> = {
+  stills: colorForType("image"),
+  clips: colorForType("video"),
+  voice: colorForType("audio"),
+  pipeline: "var(--palette-primary-main)"
+};
+
+/** The colour of what nothing could price. */
+const UNPRICED_COLOR = "var(--palette-text-disabled)";
+
+interface Segment {
+  key: string;
+  color: string;
+  /** Share of the bar, 0–1. */
+  share: number;
+  label: string;
+}
+
+const BAR_HEIGHT = 6;
+
+interface ProjectSpendBarProps {
+  spend: ProjectSpend;
+}
+
+const ProjectSpendBar = ({ spend }: ProjectSpendBarProps) => {
+  const segments = useMemo<Segment[]>(() => {
+    const priced = spend.byCategory.filter((entry) => entry.usd > 0);
+    // Unpriced calls have no dollar width of their own, so they take a fixed
+    // slice: the point is that they exist, not how much they were.
+    const unpricedShare = spend.unpricedCount > 0 ? 0.08 : 0;
+    const total = priced.reduce((sum, entry) => sum + entry.usd, 0);
+    const bars: Segment[] = total
+      ? priced.map((entry) => ({
+          key: entry.category,
+          color: CATEGORY_COLOR[entry.category],
+          share: (entry.usd / total) * (1 - unpricedShare),
+          label: `${entry.category} $${entry.usd.toFixed(2)}`
+        }))
+      : [];
+    if (unpricedShare > 0) {
+      const calls = spend.unpricedCount === 1 ? "call" : "calls";
+      bars.push({
+        key: "unpriced",
+        color: UNPRICED_COLOR,
+        share: bars.length > 0 ? unpricedShare : 1,
+        label: `unpriced ${spend.unpricedCount} ${calls}`
+      });
+    }
+    return bars;
+  }, [spend]);
+
+  return (
+    <FlexRow
+      align="center"
+      gap={SPACING.lg}
+      sx={{
+        p: SPACING.lg,
+        bgcolor: "background.paper",
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: BORDER_RADIUS.md
+      }}
+    >
+      <Caption color="muted" sx={{ textTransform: "uppercase" }}>
+        Spend
+      </Caption>
+      <Box
+        role="img"
+        aria-label={
+          segments.length > 0
+            ? segments.map((segment) => segment.label).join(", ")
+            : "nothing spent yet"
+        }
+        sx={{
+          flex: 1,
+          minWidth: 0,
+          display: "flex",
+          height: `${BAR_HEIGHT}px`,
+          borderRadius: BORDER_RADIUS.xs,
+          overflow: "hidden",
+          bgcolor: "background.default"
+        }}
+      >
+        {segments.map((segment) => (
+          <Box
+            key={segment.key}
+            sx={{
+              width: `${segment.share * 100}%`,
+              bgcolor: segment.color
+            }}
+          />
+        ))}
+      </Box>
+      <FlexRow
+        align="center"
+        gap={SPACING.lg}
+        sx={{ flexWrap: "wrap", ...TYPOGRAPHY.mono.caption }}
+      >
+        {segments.map((segment) => (
+          <FlexRow key={segment.key} align="center" gap={SPACING.sm}>
+            <Box
+              aria-hidden
+              sx={{
+                width: `${BAR_HEIGHT}px`,
+                height: `${BAR_HEIGHT}px`,
+                borderRadius: BORDER_RADIUS.circle,
+                bgcolor: segment.color
+              }}
+            />
+            <Box component="span" sx={{ color: "text.secondary" }}>
+              {segment.label}
+            </Box>
+          </FlexRow>
+        ))}
+        <Box component="span">${spend.totalUsd.toFixed(2)}</Box>
+      </FlexRow>
+    </FlexRow>
+  );
+};
+
+export default memo(ProjectSpendBar);

--- a/web/src/components/projects/__tests__/ProjectAgentThread.test.tsx
+++ b/web/src/components/projects/__tests__/ProjectAgentThread.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * The project conversation, rendered for a narrow column: user turns as
+ * bubbles, agent turns as text plus a chip per tool it called, and what is
+ * running right now. Roles the column cannot render are dropped rather than
+ * flattened into something that reads wrong.
+ */
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import type { Message } from "../../../stores/ApiTypes";
+
+jest.mock("../../chat/message/ChatMarkdown", () => ({
+  __esModule: true,
+  default: ({ content }: { content: string }) => <div>{content}</div>
+}));
+
+import ProjectAgentThread from "../ProjectAgentThread";
+
+const renderThread = (
+  messages: Message[],
+  runningToolMessage?: string | null
+) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ProjectAgentThread
+        messages={messages}
+        runningToolMessage={runningToolMessage}
+      />
+    </ThemeProvider>
+  );
+
+describe("ProjectAgentThread", () => {
+  it("says the project has no conversation rather than rendering an empty column", () => {
+    renderThread([]);
+    expect(screen.getByText(/Nothing here yet/)).toBeInTheDocument();
+  });
+
+  it("renders both turn shapes and names each tool the agent called", () => {
+    renderThread([
+      {
+        id: "m1",
+        role: "user",
+        content: [{ type: "text", text: "Make a 30-second launch spot." }]
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: "Broke the spot into 8 shots.",
+        tool_calls: [
+          { id: "t1", name: "create_storyboard", args: {} },
+          { id: "t2", name: "voice_script_lines", args: {} }
+        ]
+      }
+    ]);
+    expect(
+      screen.getByText("Make a 30-second launch spot.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Broke the spot into 8 shots.")).toBeInTheDocument();
+    expect(screen.getByText("create_storyboard")).toBeInTheDocument();
+    expect(screen.getByText("voice_script_lines")).toBeInTheDocument();
+  });
+
+  it("drops a role it cannot render compactly instead of guessing at it", () => {
+    renderThread([
+      { id: "m3", role: "agent_execution", content: "step 1 of 4" }
+    ]);
+    expect(screen.queryByText("step 1 of 4")).not.toBeInTheDocument();
+  });
+
+  it("shows what the agent is doing while it is doing it", () => {
+    renderThread([], "rendering shot 7");
+    expect(screen.getByText("rendering shot 7")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/projects/__tests__/ProjectDocumentPreview.test.tsx
+++ b/web/src/components/projects/__tests__/ProjectDocumentPreview.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * The picture on a document card. Each kind draws from what the summary
+ * already carries, and a kind with nothing to draw falls back to its glyph
+ * rather than an empty box.
+ */
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import type { ProjectDocument } from "../projectStatus";
+
+jest.mock("../../ui_primitives", () => {
+  const actual = jest.requireActual("../../ui_primitives");
+  return {
+    ...actual,
+    ResponsiveImage: ({ locator }: { locator: { asset_id?: string | null } }) => (
+      <div data-testid="still">{locator.asset_id}</div>
+    )
+  };
+});
+
+import ProjectDocumentPreview from "../ProjectDocumentPreview";
+
+const document = (over: Partial<ProjectDocument>): ProjectDocument => ({
+  type: "storyboard",
+  ref: "d1",
+  name: "Board",
+  updatedAt: "",
+  status: null,
+  spendUsd: 0,
+  unpricedCount: 0,
+  thumbnails: [],
+  preview: null,
+  ...over
+});
+
+const renderPreview = (doc: ProjectDocument) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ProjectDocumentPreview document={doc} />
+    </ThemeProvider>
+  );
+
+describe("ProjectDocumentPreview", () => {
+  it("montages the stills a board has rendered", () => {
+    renderPreview(
+      document({ thumbnails: [{ asset_id: "a1" }, { asset_id: "a2" }] })
+    );
+    expect(screen.getAllByTestId("still")).toHaveLength(2);
+  });
+
+  it("draws a cut's tracks against the span it covers", () => {
+    renderPreview(
+      document({
+        type: "timeline",
+        preview: {
+          kind: "timeline",
+          durationMs: 30_000,
+          tracks: [
+            {
+              type: "video",
+              name: "V1",
+              clips: [{ startMs: 0, durationMs: 15_000 }]
+            },
+            { type: "audio", name: "A1", clips: [] }
+          ]
+        }
+      })
+    );
+    expect(screen.getByText("V1")).toBeInTheDocument();
+    expect(screen.getByText("A1")).toBeInTheDocument();
+  });
+
+  it("falls back to the type's glyph when there is nothing to draw", () => {
+    const { container } = renderPreview(document({ type: "application" }));
+    expect(container.textContent).toBe("◧");
+  });
+});

--- a/web/src/components/projects/__tests__/ProjectOverviewSurface.test.tsx
+++ b/web/src/components/projects/__tests__/ProjectOverviewSurface.test.tsx
@@ -1,6 +1,10 @@
 /**
- * The project overview tab: what the project is made of and what it cost, and
- * that opening one of its documents keeps it inside the project's tab group.
+ * The project overview tab: the header's derived status and next step, the
+ * document cards, the spend bar, and that opening a document keeps it inside
+ * the project's tab group.
+ *
+ * The agent column is stubbed — it is a live chat surface with its own thread
+ * hydration, covered by its own tests.
  */
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -12,6 +16,7 @@ const detail = {
     id: "p1",
     name: "Aurora",
     kind: "spot",
+    threadId: null,
     createdAt: "",
     updatedAt: ""
   },
@@ -22,12 +27,39 @@ const detail = {
       name: "Board",
       updatedAt: "2026-08-29T00:00:00.000Z",
       status: { kind: "storyboard", shots: 8, stills: 8, clips: 6 },
-      spendUsd: 4.12,
+      spendUsd: 3.88,
       unpricedCount: 1,
-      thumbnails: []
+      thumbnails: [],
+      preview: null
+    },
+    {
+      type: "script",
+      ref: "s1",
+      name: "Script",
+      updatedAt: "2026-08-28T00:00:00.000Z",
+      status: { kind: "script", lines: 6, voiced: 5, stale: 1 },
+      spendUsd: 0.19,
+      unpricedCount: 0,
+      thumbnails: [],
+      preview: {
+        kind: "script",
+        lines: [
+          { speaker: "VO", text: "Late is when ideas show up.", state: "voiced" },
+          { speaker: "VO", text: "One touch.", state: "stale" }
+        ]
+      }
     }
   ],
-  spend: { totalUsd: 4.12, unpricedCount: 1, byCategory: [] }
+  spend: {
+    totalUsd: 4.07,
+    unpricedCount: 1,
+    byCategory: [
+      { category: "stills", usd: 1.28, unpricedCount: 0 },
+      { category: "clips", usd: 2.6, unpricedCount: 1 },
+      { category: "voice", usd: 0.19, unpricedCount: 0 },
+      { category: "pipeline", usd: 0, unpricedCount: 0 }
+    ]
+  }
 };
 
 jest.mock("../../../trpc/client", () => ({
@@ -36,6 +68,11 @@ jest.mock("../../../trpc/client", () => ({
       get: { useQuery: () => ({ data: detail, isPending: false, error: null }) }
     }
   }
+}));
+
+jest.mock("../ProjectAgentPanel", () => ({
+  __esModule: true,
+  default: () => <div data-testid="agent-panel" />
 }));
 
 const openTab = jest.fn();
@@ -59,20 +96,47 @@ describe("ProjectOverviewSurface", () => {
   it("reports the derived status and a spend that names what was unpriced", () => {
     renderSurface();
     expect(screen.getByText("Aurora")).toBeInTheDocument();
-    // Once in the header, once on the board's own card.
-    expect(screen.getAllByText("8 shots · stills 8/8")).toHaveLength(2);
-    // The project total and the one document's share are the same figure here.
-    expect(screen.getAllByText("$4.12 · 1 unpriced")).toHaveLength(2);
+    expect(
+      screen.getByText("8 shots · stills 8/8 · voiced 5/6 · 1 stale")
+    ).toBeInTheDocument();
+    expect(screen.getByText("$4.07 · 1 unpriced")).toBeInTheDocument();
   });
 
-  it("opens a document into the project's group", async () => {
+  it("names the next step and opens the document that performs it", async () => {
     renderSurface();
-    await userEvent.click(screen.getByLabelText("Board"));
+    // Stills are complete, clips are not — the board is what is waiting.
+    await userEvent.click(screen.getByRole("button", { name: "Render clips" }));
     expect(openTab).toHaveBeenCalledWith({
       type: "storyboard",
       ref: "b1",
       title: "Board",
       projectId: "p1"
     });
+  });
+
+  it("splits the spend bar by category and shows the unpriced calls", () => {
+    renderSurface();
+    expect(screen.getByText("stills $1.28")).toBeInTheDocument();
+    expect(screen.getByText("clips $2.60")).toBeInTheDocument();
+    expect(screen.getByText("unpriced 1 call")).toBeInTheDocument();
+    // A category that spent nothing gets no segment rather than a zero one.
+    expect(screen.queryByText("pipeline $0.00")).not.toBeInTheDocument();
+  });
+
+  it("opens a document into the project's group", async () => {
+    renderSurface();
+    await userEvent.click(screen.getByLabelText("Script"));
+    expect(openTab).toHaveBeenCalledWith({
+      type: "script",
+      ref: "s1",
+      title: "Script",
+      projectId: "p1"
+    });
+  });
+
+  it("draws a script card from its stored lines", () => {
+    renderSurface();
+    expect(screen.getByText("Late is when ideas show up.")).toBeInTheDocument();
+    expect(screen.getByText("stale")).toBeInTheDocument();
   });
 });

--- a/web/src/components/projects/__tests__/projectStatus.test.ts
+++ b/web/src/components/projects/__tests__/projectStatus.test.ts
@@ -5,8 +5,12 @@
  */
 
 import {
+  documentProgress,
+  documentStatusLine,
+  formatDocumentSpend,
   formatDuration,
   formatSpend,
+  projectNextStep,
   projectProgress,
   projectStatusLine,
   type ProjectDetail,
@@ -22,6 +26,7 @@ const document = (over: Partial<ProjectDocument>): ProjectDocument => ({
   spendUsd: 0,
   unpricedCount: 0,
   thumbnails: [],
+  preview: null,
   ...over
 });
 
@@ -112,5 +117,102 @@ describe("formatSpend", () => {
     expect(formatSpend(spend({ totalUsd: 4.12, unpricedCount: 2 }))).toBe(
       "$4.12 · 2 unpriced"
     );
+  });
+});
+
+const board = (stills: number, clips: number, shots = 8): ProjectDocument =>
+  document({ status: { kind: "storyboard", shots, stills, clips } });
+
+const script = (voiced: number, stale: number, lines = 6): ProjectDocument =>
+  document({
+    type: "script",
+    ref: "s1",
+    name: "Script",
+    status: { kind: "script", lines, voiced, stale }
+  });
+
+const cut = (durationMs: number, clips = 9): ProjectDocument =>
+  document({
+    type: "timeline",
+    ref: "t1",
+    name: "Cut",
+    status: { kind: "timeline", clips, durationMs }
+  });
+
+describe("documentStatusLine", () => {
+  it("speaks for one document rather than collapsing a kind", () => {
+    expect(documentStatusLine(board(8, 6))).toBe("8 shots · stills 8/8");
+    expect(documentStatusLine(script(5, 1))).toBe("6 lines · 5 voiced");
+    expect(documentStatusLine(cut(30_000))).toBe("9 clips · 0:30");
+  });
+
+  it("says nothing for a kind whose status is not derived", () => {
+    expect(documentStatusLine(document({ type: "sketch", ref: "k1" }))).toBe("");
+  });
+});
+
+describe("documentProgress", () => {
+  it("calls a board done only when every shot has a clip", () => {
+    expect(documentProgress(board(8, 6))).toEqual({
+      label: "clips 6/8",
+      tone: "neutral"
+    });
+    expect(documentProgress(board(8, 8))).toEqual({
+      label: "clips 8/8",
+      tone: "done"
+    });
+  });
+
+  it("leads with a script's drift, and calls it voiced only with none", () => {
+    expect(documentProgress(script(5, 1))).toEqual({
+      label: "1 line stale",
+      tone: "neutral"
+    });
+    expect(documentProgress(script(6, 0))).toEqual({
+      label: "voiced",
+      tone: "done"
+    });
+  });
+
+  it("reports a cut's length, never that it was rendered", () => {
+    expect(documentProgress(cut(102_000))).toEqual({
+      label: "1:42",
+      tone: "neutral"
+    });
+  });
+});
+
+describe("formatDocumentSpend", () => {
+  it("names a document's unpriced calls rather than summing them as zero", () => {
+    expect(formatDocumentSpend(document({ spendUsd: 3.884 }))).toBe("$3.88");
+    expect(
+      formatDocumentSpend(document({ spendUsd: 3.88, unpricedCount: 1 }))
+    ).toBe("$3.88 · 1 unpriced");
+  });
+});
+
+describe("projectNextStep", () => {
+  it("walks the order a spot is made", () => {
+    expect(projectNextStep([board(4, 0)])?.label).toBe("Render stills");
+    expect(projectNextStep([board(8, 6)])?.label).toBe("Render clips");
+    expect(projectNextStep([board(8, 8)])?.label).toBe("Assemble timeline");
+    expect(projectNextStep([board(8, 8), cut(30_000)])?.label).toBe(
+      "Render master"
+    );
+  });
+
+  it("puts a drifted script ahead of the cut it would be laid into", () => {
+    const step = projectNextStep([board(8, 8), script(5, 1), cut(30_000)]);
+    expect(step?.label).toBe("Re-voice 1 line");
+    expect(step?.document.ref).toBe("s1");
+  });
+
+  it("names the document that performs the step", () => {
+    expect(projectNextStep([board(8, 6)])?.document.ref).toBe("d1");
+  });
+
+  it("has no step for an empty project or an empty board", () => {
+    expect(projectNextStep([])).toBeNull();
+    expect(projectNextStep([board(0, 0, 0)])).toBeNull();
   });
 });

--- a/web/src/components/projects/projectStatus.ts
+++ b/web/src/components/projects/projectStatus.ts
@@ -99,6 +99,133 @@ export const projectProgress = (
   return null;
 };
 
+/**
+ * A document's own status line — the meta row under its card's name. The
+ * project line collapses documents of a kind onto one; this one speaks for
+ * exactly the document it is given, and says nothing for the kinds whose
+ * status the summary does not derive.
+ */
+export const documentStatusLine = (document: ProjectDocument): string => {
+  const status = document.status;
+  if (!status) return "";
+  switch (status.kind) {
+    case "storyboard":
+      return `${status.shots} shots · stills ${status.stills}/${status.shots}`;
+    case "script": {
+      const lines = status.lines === 1 ? "line" : "lines";
+      return `${status.lines} ${lines} · ${status.voiced} voiced`;
+    }
+    case "timeline": {
+      const clips = status.clips === 1 ? "clip" : "clips";
+      return `${status.clips} ${clips} · ${formatDuration(status.durationMs)}`;
+    }
+    default: {
+      const exhaustive: never = status;
+      return exhaustive;
+    }
+  }
+};
+
+export interface DocumentProgress {
+  label: string;
+  tone: "done" | "neutral" | "rendering";
+}
+
+/**
+ * The pill beside a document's name: how far its own work has got. A board
+ * counts its clips, a script its drift, a cut its length — and a kind with
+ * nothing derived gets no pill rather than an invented one.
+ */
+export const documentProgress = (
+  document: ProjectDocument
+): DocumentProgress | null => {
+  const status = document.status;
+  if (!status) return null;
+  switch (status.kind) {
+    case "storyboard":
+      if (status.shots === 0) return null;
+      return {
+        label: `clips ${status.clips}/${status.shots}`,
+        tone: status.clips === status.shots ? "done" : "neutral"
+      };
+    case "script":
+      if (status.stale > 0) {
+        const lines = status.stale === 1 ? "line" : "lines";
+        return { label: `${status.stale} ${lines} stale`, tone: "neutral" };
+      }
+      if (status.lines > 0 && status.voiced === status.lines) {
+        return { label: "voiced", tone: "done" };
+      }
+      return null;
+    case "timeline":
+      // Whether a cut has been rendered is not recorded, so the pill reports
+      // its length — the one thing the sequence row does know.
+      return { label: formatDuration(status.durationMs), tone: "neutral" };
+    default: {
+      const exhaustive: never = status;
+      return exhaustive;
+    }
+  }
+};
+
+/** A document's share of the ledger, naming what nothing priced. */
+export const formatDocumentSpend = (document: ProjectDocument): string => {
+  const amount = `$${document.spendUsd.toFixed(2)}`;
+  return document.unpricedCount > 0
+    ? `${amount} · ${document.unpricedCount} unpriced`
+    : amount;
+};
+
+/** The step a project is waiting on, and the document that performs it. */
+export interface ProjectNextStep {
+  label: string;
+  document: ProjectDocument;
+}
+
+/**
+ * What to do next, read off the documents in the order a spot is made: render
+ * the stills, render the clips, voice what drifted, then cut.
+ *
+ * The action opens the document the step happens in rather than firing the
+ * render itself — the render's own controls (model, shot selection, cost) live
+ * on that surface, and a button here that spent money without showing them
+ * would be spending on the user's behalf.
+ */
+export const projectNextStep = (
+  documents: readonly ProjectDocument[]
+): ProjectNextStep | null => {
+  const board = documents.find((doc) => doc.status?.kind === "storyboard");
+  const boardStatus =
+    board?.status?.kind === "storyboard" ? board.status : null;
+  if (board && boardStatus && boardStatus.shots > 0) {
+    if (boardStatus.stills < boardStatus.shots) {
+      return { label: "Render stills", document: board };
+    }
+    if (boardStatus.clips < boardStatus.shots) {
+      return { label: "Render clips", document: board };
+    }
+  }
+
+  const script = documents.find((doc) => doc.status?.kind === "script");
+  const scriptStatus =
+    script?.status?.kind === "script" ? script.status : null;
+  if (script && scriptStatus && scriptStatus.stale > 0) {
+    const lines = scriptStatus.stale === 1 ? "line" : "lines";
+    return { label: `Re-voice ${scriptStatus.stale} ${lines}`, document: script };
+  }
+
+  const cut = documents.find((doc) => doc.status?.kind === "timeline");
+  if (cut) {
+    return { label: "Render master", document: cut };
+  }
+  // Reached only when the board rendered everything it set out to: the first
+  // block returns while stills or clips are still short.
+  if (board && boardStatus && boardStatus.shots > 0) {
+    return { label: "Assemble timeline", document: board };
+  }
+  return null;
+};
+
 /** `$4.12`, and what the ledger could not price rather than a silent zero. */
 export const formatSpend = (spend: ProjectDetail["spend"]): string => {
   const amount = `$${spend.totalUsd.toFixed(2)}`;


### PR DESCRIPTION
## What changed

Phase 3 of `docs/plans/project-view/PLAN.md`. Phase 2 gave the project tab a header and a list of names; this makes it the surface you work the project from. A project now names its agent thread (`projects.thread_id`, nullable; `projects.thread` returns it, creating one on first ask, with the claim conditional on the column still being null so a race settles on one thread), and the overview renders that conversation for a 460px column — user turns as bubbles, agent turns as text plus a mono chip per tool called, and the pill saying what is running. On the right, one card per document drawing from what the summary already carries: a board's stills, a sketch's stored thumbnail, a script's opening lines with the state each dot reads, a cut's tracks as bars — a new `preview` field sliced to what a 120px card shows, so a card renders without fetching the document. The header derives the next step in the order a spot is made (render the stills, render the clips, re-voice what drifted, then cut) and opens the document that performs it rather than firing the render, because the model, the shot selection and the cost live on that surface. The spend bar splits the total by category in the colour of the medium each bought, with calls no catalog priced taking their own segment rather than being dropped.

Two deliberate departures from the plan. C3's workflow card has no data behind it: workflows carry no `project_id`, so they cannot be in a project, and adding the column is Phase 1's document-set work rather than a card's. And the header pill reports the clips a board has rendered, not "rendering shot 7" — no job state reaches this surface, and a live label it cannot back would be invented.

`ChatComposer` gained the `placeholder` prop `MediaChatComposer` already had, so the simple variant can say what the box is for.

## Verification

- [x] `npm run test:affected` — green. One caveat worth naming: `@nodetool-ai/image-nodes` fails on a box with no Vulkan ICD (`No WebGPU adapter available (Node/Dawn)`), the environment gap `AGENTS.md` documents. Extracting `mesa-vulkan-drivers` and pointing `VK_DRIVER_FILES` at lavapipe makes it pass (`24 files, 229 tests`), which is what CI's `mesa-vulkan-drivers` install does.
- [x] `npm run typecheck` — web and electron clean. The mobile leg cannot run in this container (`mobile/node_modules` is absent, so every import resolves to `TS2307`); nothing in this diff is under `mobile/`.
- [x] `npm run lint` — exit 0.
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 3/3 selfchecks passed`, including all 5 Ring 0 reliability journeys.

New behavior that could fail silently was inverted once to prove its test bites. Dropping the `isNull(projects.thread_id)` guard from `Project.ensureThread`'s claim:

```
FAIL  tests/project.test.ts > Project.ensureThread > creates the thread once and answers with the same id after
AssertionError: expected '3cd1c51469174dc9a80ac23be8e007fd' to be '153aa847df7d466aacc1ae226ef188b5'
      Tests  1 failed | 19 passed (20)
```

## Agent capabilities

`projects.thread` is a new tRPC procedure, so it carries a sandbox-coverage note; the capability table itself is unchanged.

- [x] `npm run capabilities:check` — `capability table is current (229 capabilities)`

## New checks

No new check, rule, or audit — the migration count in `packages/models/tests/migrations.test.ts` moved 71 → 72 for the added migration.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VPQnxzBwWFtR8gxBBWYDoS)_