### PR TITLE
feat(projects): start a project by saying what you want made

### DIFF
--- a/web/src/components/projects/NewProjectSurface.tsx
+++ b/web/src/components/projects/NewProjectSurface.tsx
@@ -1,0 +1,502 @@
+/**
+ * "What do you want to make?" — the surface a project is started from.
+ *
+ * The prompt goes to the project's own agent, which builds the documents; the
+ * shape shortcut says what chain to expect and is stored as the project's
+ * kind. Blank documents keep their place at the foot of the view, opening
+ * loose tabs the way the `+ New` menu always did.
+ */
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { Entity } from "@nodetool-ai/protocol";
+
+import {
+  BORDER_RADIUS,
+  Box,
+  Caption,
+  CloseButton,
+  Divider,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  Label,
+  MenuItemPrimitive,
+  Popover,
+  ResponsiveImage,
+  ScrollArea,
+  SPACING,
+  Text,
+  TextInput,
+  TYPOGRAPHY
+} from "../ui_primitives";
+import type { MessageContent } from "../../stores/ApiTypes";
+import { useFileHandling } from "../chat/hooks/useFileHandling";
+import { useEntities } from "../../serverState/useEntities";
+import { useNotificationStore } from "../../stores/NotificationStore";
+import {
+  PROJECT_NEW_REF,
+  LOOSE_PROJECT_ID,
+  tabId,
+  useWorkspaceTabsStore
+} from "../../stores/WorkspaceTabsStore";
+import {
+  useCreateProject,
+  useOpenProject,
+  useProjectSummaries
+} from "../../hooks/useProjects";
+import { TYPE_COLOR, TYPE_GLYPH } from "../workspace/tabTypeIdentity";
+import {
+  TEXT_FILE_TEMPLATES,
+  useNewDocumentCatalog,
+  type NewDocumentSubmenu
+} from "../workspace/newDocumentCatalog";
+import { useExampleStoryboards } from "../../hooks/storyboard/useStoryboards";
+import { stageProjectFirstTurn } from "./projectAgent";
+import { PROJECT_COLOR } from "./projectIdentity";
+import {
+  DEFAULT_SHAPE_ID,
+  PROJECT_SHAPES,
+  composeFirstTurn,
+  estimateFromHistory,
+  formatEstimate,
+  projectNameFromPrompt,
+  shapeById
+} from "./projectShapes";
+
+/** Width of the centered column, per the new-project mockup. */
+const COLUMN_WIDTH = 860;
+
+interface SubmenuAnchor {
+  kind: NewDocumentSubmenu;
+  element: HTMLElement;
+}
+
+const NewProjectSurface = () => {
+  const [prompt, setPrompt] = useState("");
+  const [shapeId, setShapeId] = useState(DEFAULT_SHAPE_ID);
+  const [entityIds, setEntityIds] = useState<string[]>([]);
+  const [entityAnchor, setEntityAnchor] = useState<HTMLElement | null>(null);
+  const [submenu, setSubmenu] = useState<SubmenuAnchor | null>(null);
+  const [starting, setStarting] = useState(false);
+  const refInputRef = useRef<HTMLInputElement>(null);
+
+  const shape = shapeById(shapeId);
+  const { droppedFiles, addFiles, removeFile, getFileContents } =
+    useFileHandling();
+  const { data: entities } = useEntities();
+  const summaries = useProjectSummaries();
+  const createProject = useCreateProject();
+  const openProject = useOpenProject();
+  const closeTab = useWorkspaceTabsStore((state) => state.closeTab);
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification
+  );
+
+  // Blank documents opened from here are loose, as the strip promises — the
+  // project being described does not exist yet.
+  const {
+    entries,
+    createTextFile,
+    createBlankStoryboard,
+    installStoryboardExample,
+    creating
+  } = useNewDocumentCatalog({ projectId: LOOSE_PROJECT_ID }, () =>
+    setSubmenu(null)
+  );
+  const { data: exampleData, isLoading: examplesLoading } =
+    useExampleStoryboards(submenu?.kind === "storyboards");
+
+  const selectedEntities = useMemo(
+    () => (entities ?? []).filter((entity) => entityIds.includes(entity.id)),
+    [entities, entityIds]
+  );
+
+  const estimate = useMemo(
+    () => estimateFromHistory(summaries.data ?? [], shape.kind),
+    [summaries.data, shape.kind]
+  );
+
+  const toggleEntity = useCallback((entity: Entity) => {
+    setEntityIds((ids) =>
+      ids.includes(entity.id)
+        ? ids.filter((id) => id !== entity.id)
+        : [...ids, entity.id]
+    );
+  }, []);
+
+  const handleRefImages = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(event.target.files ?? []);
+      if (files.length > 0) {
+        addFiles(files);
+      }
+      // Clear the input so picking the same file twice still registers.
+      event.target.value = "";
+    },
+    [addFiles]
+  );
+
+  const handleStart = useCallback(async () => {
+    const text = prompt.trim();
+    if (text.length === 0 || starting) {
+      return;
+    }
+    setStarting(true);
+    try {
+      const project = await createProject.mutateAsync({
+        name: projectNameFromPrompt(text, shape),
+        kind: shape.kind
+      });
+      const content: MessageContent[] = [
+        {
+          type: "text",
+          text: composeFirstTurn({
+            prompt: text,
+            shape,
+            entityNames: selectedEntities.map((entity) => entity.name)
+          })
+        },
+        ...getFileContents()
+      ];
+      stageProjectFirstTurn(project.id, content);
+      await openProject(project);
+      closeTab(tabId("project-new", PROJECT_NEW_REF));
+    } catch (error) {
+      addNotification({
+        type: "error",
+        alert: true,
+        content: `Could not start the project: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      });
+    } finally {
+      setStarting(false);
+    }
+  }, [
+    addNotification,
+    closeTab,
+    createProject,
+    getFileContents,
+    openProject,
+    prompt,
+    selectedEntities,
+    shape,
+    starting
+  ]);
+
+  return (
+    <ScrollArea fullHeight>
+      <FlexColumn align="center" sx={{ minHeight: "100%", px: SPACING.xl }}>
+        <FlexColumn
+          gap={SPACING.xl}
+          sx={{ width: "100%", maxWidth: `${COLUMN_WIDTH}px`, pt: SPACING.xxxl }}
+        >
+          <FlexColumn gap={SPACING.md} align="center">
+            <Text size="big">What do you want to make?</Text>
+            <Caption
+              color="secondary"
+              sx={{ maxWidth: "560px", textAlign: "center" }}
+            >
+              An agent plans the documents — a board, a script, a cut — and
+              builds them while you watch. Everything it makes stays editable.
+            </Caption>
+          </FlexColumn>
+
+          <FlexColumn
+            gap={SPACING.lg}
+            sx={{
+              bgcolor: "background.paper",
+              border: "1px solid",
+              borderColor: "primary.main",
+              borderRadius: BORDER_RADIUS.lg,
+              p: SPACING.xl
+            }}
+          >
+            <TextInput
+              value={prompt}
+              autoFocus
+              multiline
+              rows={3}
+              label="Project prompt"
+              hideLabel
+              placeholder="A 30-second launch spot for our desk lamp — warm, minimal, night-time mood"
+              onChange={(event) => setPrompt(event.target.value)}
+            />
+
+            {droppedFiles.length > 0 && (
+              <FlexRow gap={SPACING.md} wrap>
+                {droppedFiles.map((file) => (
+                  <Box key={file.id} sx={{ position: "relative" }}>
+                    <ResponsiveImage
+                      locator={file.dataUri}
+                      alt={file.name}
+                      fit="cover"
+                      borderRadius={BORDER_RADIUS.sm}
+                      showErrorFallback
+                      sx={{ width: "48px", height: "48px" }}
+                    />
+                    <CloseButton
+                      onClick={() => removeFile(file.id)}
+                      tooltip={`Remove ${file.name}`}
+                      buttonSize="small"
+                      iconVariant="clear"
+                      sx={{ position: "absolute", top: -6, right: -6 }}
+                    />
+                  </Box>
+                ))}
+              </FlexRow>
+            )}
+
+            <FlexRow align="center" gap={SPACING.md} wrap>
+              <EditorButton
+                variant="outlined"
+                density="compact"
+                onClick={() => refInputRef.current?.click()}
+              >
+                {`Ref images · ${droppedFiles.length}`}
+              </EditorButton>
+              <input
+                ref={refInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                aria-label="Reference images"
+                onChange={handleRefImages}
+                style={{ display: "none" }}
+              />
+              <EditorButton
+                variant="outlined"
+                density="compact"
+                onClick={(event) => setEntityAnchor(event.currentTarget)}
+              >
+                {selectedEntities.length === 0
+                  ? "Entities · none"
+                  : `Entities · ${selectedEntities
+                      .map((entity) => entity.name)
+                      .join(", ")}`}
+              </EditorButton>
+              <Box sx={{ flex: 1 }} />
+              {estimate && (
+                <Box component="span" sx={{ ...TYPOGRAPHY.mono.caption }}>
+                  {formatEstimate(estimate)}
+                </Box>
+              )}
+              <EditorButton
+                variant="contained"
+                color="primary"
+                density="normal"
+                disabled={prompt.trim().length === 0 || starting}
+                onClick={() => void handleStart()}
+              >
+                Start
+              </EditorButton>
+            </FlexRow>
+          </FlexColumn>
+
+          <FlexRow justify="center" gap={SPACING.md} wrap>
+            {PROJECT_SHAPES.map((entry) => {
+              const active = entry.id === shapeId;
+              return (
+                <Box
+                  key={entry.id}
+                  component="button"
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => setShapeId(entry.id)}
+                  sx={{
+                    height: "28px",
+                    px: SPACING.lg,
+                    cursor: "pointer",
+                    borderRadius: BORDER_RADIUS.pill,
+                    border: "1px solid",
+                    borderColor: active ? PROJECT_COLOR : "divider",
+                    color: active ? PROJECT_COLOR : "text.secondary",
+                    bgcolor: "transparent",
+                    ...TYPOGRAPHY.sans.body
+                  }}
+                >
+                  {entry.label}
+                </Box>
+              );
+            })}
+          </FlexRow>
+
+          <FlexRow justify="center" align="center" gap={SPACING.md} wrap>
+            <Caption color="muted">
+              {shape.chain.length === 0
+                ? `${shape.label} starts bare — ask the agent for what you need`
+                : `${shape.label} sets up`}
+            </Caption>
+            {shape.chain.map((step, index) => (
+              <FlexRow key={step.type} align="center" gap={SPACING.md}>
+                {index > 0 && <Caption color="muted">→</Caption>}
+                <Box
+                  component="span"
+                  aria-hidden
+                  sx={{ color: TYPE_COLOR[step.type] }}
+                >
+                  {TYPE_GLYPH[step.type]}
+                </Box>
+                <Caption color="secondary">{step.label}</Caption>
+              </FlexRow>
+            ))}
+          </FlexRow>
+        </FlexColumn>
+
+        <Box sx={{ flex: 1, minHeight: SPACING.xxxl }} />
+
+        <FlexColumn
+          gap={SPACING.md}
+          sx={{
+            width: "100%",
+            maxWidth: `${COLUMN_WIDTH}px`,
+            pb: SPACING.xxl
+          }}
+        >
+          <Divider />
+          <FlexRow align="baseline" gap={SPACING.md}>
+            <Caption
+              color="muted"
+              sx={{ textTransform: "uppercase", letterSpacing: "0.08em" }}
+            >
+              Blank document
+            </Caption>
+            <Caption color="muted">
+              — opens as a loose tab, outside any project
+            </Caption>
+          </FlexRow>
+          <Box
+            sx={{
+              display: "grid",
+              gap: SPACING.sm,
+              gridTemplateColumns: {
+                xs: "repeat(2, minmax(0, 1fr))",
+                sm: "repeat(3, minmax(0, 1fr))",
+                md: "repeat(6, minmax(0, 1fr))"
+              }
+            }}
+          >
+            {entries.map((entry) => (
+              <Box
+                key={entry.key}
+                component="button"
+                type="button"
+                disabled={creating !== null}
+                onClick={(event: React.MouseEvent<HTMLButtonElement>) =>
+                  entry.submenu
+                    ? setSubmenu({
+                        kind: entry.submenu,
+                        element: event.currentTarget
+                      })
+                    : void entry.create?.()
+                }
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: (theme) => theme.spacing(SPACING.md),
+                  height: "32px",
+                  px: SPACING.md,
+                  cursor: "pointer",
+                  border: "none",
+                  bgcolor: "transparent",
+                  borderRadius: BORDER_RADIUS.md,
+                  color: "text.primary",
+                  "&:hover": { bgcolor: "action.hover" }
+                }}
+              >
+                <Box
+                  component="span"
+                  aria-hidden
+                  sx={{ color: TYPE_COLOR[entry.type] }}
+                >
+                  {TYPE_GLYPH[entry.type]}
+                </Box>
+                <Label>
+                  {entry.submenu ? `${entry.label} ▸` : entry.label}
+                </Label>
+              </Box>
+            ))}
+          </Box>
+        </FlexColumn>
+      </FlexColumn>
+
+      <Popover
+        open={entityAnchor !== null}
+        anchorEl={entityAnchor}
+        onClose={() => setEntityAnchor(null)}
+        placement="bottom-left"
+        maxWidth={320}
+        maxHeight="50vh"
+      >
+        <FlexColumn sx={{ width: 300, py: 0.5 }}>
+          {(entities ?? []).length === 0 ? (
+            <Caption color="secondary" sx={{ px: 2, py: 1.5 }}>
+              The entity library is empty.
+            </Caption>
+          ) : (
+            (entities ?? []).map((entity) => (
+              <MenuItemPrimitive
+                key={entity.id}
+                label={entity.name}
+                secondary={entity.kind}
+                compact
+                selected={entityIds.includes(entity.id)}
+                onClick={() => toggleEntity(entity)}
+              />
+            ))
+          )}
+        </FlexColumn>
+      </Popover>
+
+      <Popover
+        open={submenu !== null}
+        anchorEl={submenu?.element ?? null}
+        onClose={() => setSubmenu(null)}
+        placement="top-left"
+        maxWidth={340}
+        maxHeight="50vh"
+      >
+        <FlexColumn sx={{ width: 320, py: 0.5 }}>
+          {submenu?.kind === "texts" &&
+            TEXT_FILE_TEMPLATES.map((template) => (
+              <MenuItemPrimitive
+                key={template.filename}
+                label={template.label}
+                compact
+                disabled={creating !== null}
+                onClick={() => void createTextFile(template)}
+              />
+            ))}
+          {submenu?.kind === "storyboards" && (
+            <>
+              <MenuItemPrimitive
+                label="Blank storyboard"
+                compact
+                dividerAfter
+                disabled={creating !== null}
+                onClick={() => void createBlankStoryboard()}
+              />
+              {!examplesLoading &&
+                (exampleData ?? []).map((example) => (
+                  <MenuItemPrimitive
+                    key={example.slug}
+                    label={example.name}
+                    secondary={`${example.shotCount} shot${
+                      example.shotCount === 1 ? "" : "s"
+                    }, already rendered`}
+                    compact
+                    disabled={creating !== null}
+                    onClick={() =>
+                      void installStoryboardExample(example.slug, example.name)
+                    }
+                  />
+                ))}
+            </>
+          )}
+        </FlexColumn>
+      </Popover>
+    </ScrollArea>
+  );
+};
+
+export default NewProjectSurface;

--- a/web/src/components/projects/ProjectAgentPanel.tsx
+++ b/web/src/components/projects/ProjectAgentPanel.tsx
@@ -8,7 +8,7 @@
  * second chat that happens to be next to it.
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 
 import {
@@ -26,6 +26,7 @@ import type { Message, MessageContent } from "../../stores/ApiTypes";
 import { resolveUiContext } from "../../lib/chat/uiContext";
 import { trpc } from "../../trpc/client";
 import ProjectAgentThread from "./ProjectAgentThread";
+import { projectSystemPrompt, takeProjectFirstTurn } from "./projectAgent";
 
 const NO_MESSAGES: Message[] = [];
 
@@ -36,23 +37,14 @@ interface ProjectAgentPanelProps {
   threadId: string | null;
 }
 
-/**
- * Tells the agent which project it is working in. The tab context already
- * lists the open documents; this names the group they belong to, so a request
- * to "add a shot" lands in this project's board rather than the last one
- * touched.
- */
-const projectSystemPrompt = (name: string, id: string): string =>
-  `You are working inside the project "${name}" (project id ${id}). ` +
-  `Documents you create belong to it, and the documents open in this ` +
-  `workspace are its own.`;
-
 const ProjectAgentPanel = ({
   projectId,
   projectName,
   threadId: boundThreadId
 }: ProjectAgentPanelProps) => {
   const [threadId, setThreadId] = useState<string | null>(boundThreadId);
+  /** True once this thread's persisted history is in the message cache. */
+  const [historyLoaded, setHistoryLoaded] = useState(false);
   const ensureThread = trpc.projects.thread.useMutation();
   const ensureThreadAsync = ensureThread.mutateAsync;
 
@@ -95,6 +87,8 @@ const ProjectAgentPanel = ({
       await fetchThread(id);
       if (cancelled) return;
       await loadMessages(id);
+      if (cancelled) return;
+      setHistoryLoaded(true);
     };
     bind().catch((error) => {
       console.error("Failed to open the project thread:", error);
@@ -130,6 +124,23 @@ const ProjectAgentPanel = ({
     },
     [threadId, sendMessage, selectedModel, systemPrompt]
   );
+
+  // A project started from the new-project surface arrives with its opening
+  // turn staged. It is sent from here rather than there, and only once the
+  // history has loaded: a full load replaces the message cache, so a turn sent
+  // before it lands would be wiped by it.
+  const firstTurnSent = useRef(false);
+  useEffect(() => {
+    if (!threadId || !historyLoaded || firstTurnSent.current) {
+      return;
+    }
+    const first = takeProjectFirstTurn(projectId);
+    if (!first) {
+      return;
+    }
+    firstTurnSent.current = true;
+    handleSend(first);
+  }, [threadId, historyLoaded, projectId, handleSend]);
 
   const handleStop = useCallback(() => {
     if (threadId) stopGeneration(threadId);

--- a/web/src/components/projects/ProjectListSurface.tsx
+++ b/web/src/components/projects/ProjectListSurface.tsx
@@ -4,7 +4,6 @@ import {
   BORDER_RADIUS,
   Box,
   Caption,
-  Dialog,
   Divider,
   EditorButton,
   FlexColumn,
@@ -15,7 +14,6 @@ import {
   ScrollArea,
   SearchInput,
   Text,
-  TextInput,
   TYPOGRAPHY
 } from "../ui_primitives";
 import { useNotificationStore } from "../../stores/NotificationStore";
@@ -25,7 +23,7 @@ import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
 import { TYPE_COLOR, TYPE_GLYPH } from "../workspace/tabTypeIdentity";
 import {
   useAssignDocument,
-  useCreateProject,
+  useOpenNewProjectTab,
   useOpenProject,
   useProjectSummaries,
   useUnassignedDocuments
@@ -82,14 +80,12 @@ const parseDragPayload = (payload: string): LooseDocument | null => {
  */
 const ProjectListSurface = () => {
   const [search, setSearch] = useState("");
-  const [newName, setNewName] = useState("");
-  const [dialogOpen, setDialogOpen] = useState(false);
 
   const summaries = useProjectSummaries();
   const unassigned = useUnassignedDocuments();
-  const createProject = useCreateProject();
   const assignDocument = useAssignDocument();
   const openProject = useOpenProject();
+  const openNewProject = useOpenNewProjectTab();
   const openTab = useWorkspaceTabsStore((state) => state.openTab);
   const addNotification = useNotificationStore(
     (state) => state.addNotification
@@ -117,27 +113,6 @@ const ProjectListSurface = () => {
     },
     [openProject]
   );
-
-  const handleCreate = useCallback(async () => {
-    const name = newName.trim();
-    if (name.length === 0) {
-      return;
-    }
-    try {
-      const project = await createProject.mutateAsync({ name, kind: "" });
-      setDialogOpen(false);
-      setNewName("");
-      await openProject(project);
-    } catch (error) {
-      addNotification({
-        type: "error",
-        alert: true,
-        content: `Could not create the project: ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      });
-    }
-  }, [addNotification, createProject, newName, openProject]);
 
   const handleDropDocument = useCallback(
     (projectId: string, payload: string) => {
@@ -189,7 +164,7 @@ const ProjectListSurface = () => {
         <EditorButton
           variant="contained"
           color="primary"
-          onClick={() => setDialogOpen(true)}
+          onClick={openNewProject}
         >
           + New project
         </EditorButton>
@@ -221,7 +196,7 @@ const ProjectListSurface = () => {
             <Box
               component="button"
               type="button"
-              onClick={() => setDialogOpen(true)}
+              onClick={openNewProject}
               sx={{
                 minHeight: "268px",
                 display: "flex",
@@ -241,7 +216,7 @@ const ProjectListSurface = () => {
               </Box>
               <Label>Start a project</Label>
               <Caption color="muted">
-                Name it, then let an agent build its documents
+                Say what you want made, and an agent builds its documents
               </Caption>
             </Box>
           </Box>
@@ -312,24 +287,6 @@ const ProjectListSurface = () => {
           </FlexRow>
         </Box>
       )}
-
-      <Dialog
-        open={dialogOpen}
-        onClose={() => setDialogOpen(false)}
-        title="Start a project"
-        showActions
-        confirmText="Create"
-        confirmDisabled={newName.trim().length === 0}
-        onConfirm={() => void handleCreate()}
-      >
-        <TextInput
-          value={newName}
-          autoFocus
-          label="Project name"
-          placeholder="Aurora launch spot"
-          onChange={(event) => setNewName(event.target.value)}
-        />
-      </Dialog>
     </FlexColumn>
   );
 };

--- a/web/src/components/projects/__tests__/NewProjectSurface.test.tsx
+++ b/web/src/components/projects/__tests__/NewProjectSurface.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Starting a project: what Start creates, what the agent is handed, and that
+ * the blank-document strip still opens loose tabs.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+const createProject = jest.fn(async () => ({
+  id: "p9",
+  name: "A spot for our desk lamp",
+  kind: "spot",
+  threadId: null,
+  createdAt: "",
+  updatedAt: ""
+}));
+const openProject = jest.fn(async () => undefined);
+
+jest.mock("../../../hooks/useProjects", () => ({
+  useCreateProject: () => ({ mutateAsync: createProject }),
+  useOpenProject: () => openProject,
+  useProjectSummaries: () => ({ data: [] })
+}));
+
+jest.mock("../../../serverState/useEntities", () => ({
+  useEntities: () => ({
+    data: [
+      {
+        id: "e1",
+        kind: "prop",
+        name: "Aurora lamp",
+        descriptor: "a warm desk lamp",
+        reference_images: []
+      }
+    ]
+  })
+}));
+
+const createWorkflow = jest.fn(async () => undefined);
+const catalogOptions = jest.fn();
+jest.mock("../../workspace/newDocumentCatalog", () => ({
+  TEXT_FILE_TEMPLATES: [
+    { label: "Markdown (.md)", filename: "Untitled.md", mimeType: "text/markdown", content: "" }
+  ],
+  useNewDocumentCatalog: (options: unknown) => {
+    catalogOptions(options);
+    return {
+      entries: [
+        {
+          key: "workflow",
+          label: "Workflow",
+          menuLabel: "New workflow",
+          type: "workflow",
+          icon: null,
+          create: createWorkflow
+        },
+        {
+          key: "text",
+          label: "Text",
+          menuLabel: "New text file…",
+          type: "text",
+          icon: null,
+          submenu: "texts"
+        }
+      ],
+      createTextFile: jest.fn(),
+      createBlankStoryboard: jest.fn(),
+      installStoryboardExample: jest.fn(),
+      creating: null
+    };
+  }
+}));
+
+jest.mock("../../../hooks/storyboard/useStoryboards", () => ({
+  useExampleStoryboards: () => ({ data: [], isLoading: false })
+}));
+
+const closeTab = jest.fn();
+jest.mock("../../../stores/WorkspaceTabsStore", () => ({
+  ...jest.requireActual("../../../stores/WorkspaceTabsStore"),
+  useWorkspaceTabsStore: <T,>(selector: (s: { closeTab: jest.Mock }) => T) =>
+    selector({ closeTab })
+}));
+
+jest.mock("../../../stores/NotificationStore", () => ({
+  useNotificationStore: <T,>(
+    selector: (s: { addNotification: jest.Mock }) => T
+  ) => selector({ addNotification: jest.fn() })
+}));
+
+import NewProjectSurface from "../NewProjectSurface";
+import { takeProjectFirstTurn } from "../projectAgent";
+
+const renderSurface = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <NewProjectSurface />
+    </ThemeProvider>
+  );
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("NewProjectSurface", () => {
+  it("shows the selected shape's document chain", async () => {
+    renderSurface();
+    expect(screen.getByText("30s spot sets up")).toBeInTheDocument();
+    expect(screen.getByText("Board")).toBeInTheDocument();
+    expect(screen.getByText("Cut")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Music video" }));
+    expect(screen.getByText("Music video sets up")).toBeInTheDocument();
+    expect(screen.queryByText("Script")).not.toBeInTheDocument();
+  });
+
+  it("shows no estimate when no past project of the shape was priced", () => {
+    renderSurface();
+    expect(screen.queryByText(/est\. \$/)).not.toBeInTheDocument();
+  });
+
+  it("cannot start until something is asked for", async () => {
+    renderSurface();
+    expect(screen.getByRole("button", { name: "Start" })).toBeDisabled();
+    await userEvent.type(
+      screen.getByPlaceholderText(/30-second launch spot/),
+      "A spot for our desk lamp"
+    );
+    expect(screen.getByRole("button", { name: "Start" })).toBeEnabled();
+  });
+
+  it("creates the project, stages its first turn, and opens its group", async () => {
+    renderSurface();
+    await userEvent.type(
+      screen.getByPlaceholderText(/30-second launch spot/),
+      "A spot for our desk lamp"
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Entities · none" }));
+    await userEvent.click(screen.getByText("Aurora lamp"));
+    await userEvent.keyboard("{Escape}");
+    await userEvent.click(screen.getByRole("button", { name: "Start" }));
+
+    await waitFor(() =>
+      expect(createProject).toHaveBeenCalledWith({
+        name: "A spot for our desk lamp",
+        kind: "spot"
+      })
+    );
+    await waitFor(() =>
+      expect(openProject).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "p9" })
+      )
+    );
+    expect(closeTab).toHaveBeenCalledWith("project-new:new");
+
+    const staged = takeProjectFirstTurn("p9");
+    expect(staged).not.toBeNull();
+    const text = staged?.[0].type === "text" ? staged[0].text : "";
+    expect(text).toContain("A spot for our desk lamp");
+    expect(text).toContain("30-second spot");
+    expect(text).toContain("Use these entities: Aurora lamp.");
+  });
+
+  it("opens blank documents outside any project", async () => {
+    renderSurface();
+    expect(catalogOptions).toHaveBeenCalledWith({ projectId: "default" });
+    await userEvent.click(screen.getByRole("button", { name: "Workflow" }));
+    expect(createWorkflow).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/projects/__tests__/ProjectAgentPanel.test.tsx
+++ b/web/src/components/projects/__tests__/ProjectAgentPanel.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * The project's agent column: it binds the project's own thread, and sends the
+ * opening turn the new-project surface staged — once, after the history it
+ * would otherwise be overwritten by has loaded.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+const ensureThread = jest.fn(async () => ({ threadId: "t1" }));
+jest.mock("../../../trpc/client", () => ({
+  trpc: { projects: { thread: { useMutation: () => ({ mutateAsync: ensureThread }) } } }
+}));
+
+interface SentMessage {
+  role: string;
+  content: unknown[];
+  system_prompt?: string;
+}
+const sendMessage = jest.fn(
+  async (_message: SentMessage, _threadId: string) => undefined
+);
+const fetchThread = jest.fn(async () => null);
+const loadMessages = jest.fn(async () => []);
+const chatState = {
+  connect: jest.fn(async () => undefined),
+  fetchThread,
+  loadMessages,
+  sendMessage,
+  stopGeneration: jest.fn(),
+  messageCache: {} as Record<string, unknown[]>,
+  selectedModel: { provider: "anthropic", id: "claude-sonnet-5" }
+};
+jest.mock("../../../stores/GlobalChatStore", () => ({
+  __esModule: true,
+  default: <T,>(selector: (s: typeof chatState) => T) => selector(chatState),
+  useThreadRuntime: () => ({ status: "idle", toolMessage: null })
+}));
+
+jest.mock("../ProjectAgentThread", () => ({
+  __esModule: true,
+  default: () => <div data-testid="thread" />
+}));
+
+jest.mock("../../chat/composer/ChatComposer", () => ({
+  __esModule: true,
+  default: () => <div data-testid="composer" />
+}));
+
+import ProjectAgentPanel from "../ProjectAgentPanel";
+import { stageProjectFirstTurn } from "../projectAgent";
+
+const renderPanel = (threadId: string | null = null) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ProjectAgentPanel projectId="p1" projectName="Aurora" threadId={threadId} />
+    </ThemeProvider>
+  );
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("ProjectAgentPanel", () => {
+  it("creates the project's thread on first visit and loads its history", async () => {
+    renderPanel();
+    await waitFor(() => expect(ensureThread).toHaveBeenCalledWith({ id: "p1" }));
+    await waitFor(() => expect(loadMessages).toHaveBeenCalledWith("t1"));
+    expect(await screen.findByTestId("thread")).toBeInTheDocument();
+  });
+
+  it("sends a staged opening turn once, into the project's thread", async () => {
+    stageProjectFirstTurn("p1", [{ type: "text", text: "A spot for our lamp" }]);
+    renderPanel("t1");
+
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(1));
+    const [message, threadId] = sendMessage.mock.calls[0];
+    expect(threadId).toBe("t1");
+    expect(message.role).toBe("user");
+    expect(message.content).toEqual([
+      { type: "text", text: "A spot for our lamp" }
+    ]);
+    expect(message.system_prompt).toContain("Aurora");
+    // The history load lands before the send, or the send would be wiped.
+    expect(loadMessages.mock.invocationCallOrder[0]).toBeLessThan(
+      sendMessage.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("sends nothing when no opening turn was staged", async () => {
+    renderPanel("t1");
+    await waitFor(() => expect(loadMessages).toHaveBeenCalled());
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/projects/__tests__/ProjectListSurface.test.tsx
+++ b/web/src/components/projects/__tests__/ProjectListSurface.test.tsx
@@ -48,20 +48,14 @@ const unassigned = {
 
 const assignDocument = jest.fn();
 const openProject = jest.fn();
-const createProject = jest.fn(async () => ({
-  id: "p2",
-  name: "Meridian",
-  kind: "",
-  createdAt: "",
-  updatedAt: ""
-}));
+const openNewProject = jest.fn();
 
 jest.mock("../../../hooks/useProjects", () => ({
   useProjectSummaries: () => summaries,
   useUnassignedDocuments: () => unassigned,
-  useCreateProject: () => ({ mutateAsync: createProject }),
   useAssignDocument: () => ({ mutate: assignDocument }),
-  useOpenProject: () => openProject
+  useOpenProject: () => openProject,
+  useOpenNewProjectTab: () => openNewProject
 }));
 
 const openTab = jest.fn();
@@ -132,19 +126,12 @@ describe("ProjectListSurface", () => {
     expect(assignDocument).not.toHaveBeenCalled();
   });
 
-  it("creates a project from the dialog and opens it", async () => {
+  it("starts a project on the new-project surface", async () => {
     renderSurface();
     await userEvent.click(screen.getByRole("button", { name: "+ New project" }));
-    await userEvent.type(screen.getByLabelText("Project name"), "Meridian");
-    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+    expect(openNewProject).toHaveBeenCalled();
 
-    await waitFor(() =>
-      expect(createProject).toHaveBeenCalledWith({ name: "Meridian", kind: "" })
-    );
-    await waitFor(() =>
-      expect(openProject).toHaveBeenCalledWith(
-        expect.objectContaining({ id: "p2" })
-      )
-    );
+    await userEvent.click(screen.getByRole("button", { name: /Start a project/ }));
+    expect(openNewProject).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/src/components/projects/__tests__/projectAgent.test.ts
+++ b/web/src/components/projects/__tests__/projectAgent.test.ts
@@ -1,0 +1,31 @@
+/**
+ * The staged opening turn: it reaches the panel that binds the project's
+ * thread, and it is sent once.
+ */
+
+import {
+  projectSystemPrompt,
+  stageProjectFirstTurn,
+  takeProjectFirstTurn
+} from "../projectAgent";
+
+describe("projectSystemPrompt", () => {
+  it("names the project the agent works in", () => {
+    const prompt = projectSystemPrompt("Aurora Launch Spot", "p1");
+    expect(prompt).toContain("Aurora Launch Spot");
+    expect(prompt).toContain("p1");
+  });
+});
+
+describe("staged first turn", () => {
+  it("hands the content over once, then has nothing left", () => {
+    const content = [{ type: "text" as const, text: "A spot for our lamp" }];
+    stageProjectFirstTurn("p1", content);
+    expect(takeProjectFirstTurn("p1")).toEqual(content);
+    expect(takeProjectFirstTurn("p1")).toBeNull();
+  });
+
+  it("has nothing for a project nobody staged a prompt for", () => {
+    expect(takeProjectFirstTurn("p-unknown")).toBeNull();
+  });
+});

--- a/web/src/components/projects/__tests__/projectShapes.test.ts
+++ b/web/src/components/projects/__tests__/projectShapes.test.ts
@@ -1,0 +1,100 @@
+/**
+ * What a project is named, what its agent is first told, and when an estimate
+ * may be shown at all.
+ */
+
+import {
+  composeFirstTurn,
+  estimateFromHistory,
+  formatEstimate,
+  projectNameFromPrompt,
+  shapeById
+} from "../projectShapes";
+import type { ProjectDetail } from "../projectStatus";
+
+const spot = shapeById("spot");
+const empty = shapeById("empty");
+
+const summary = (
+  kind: string,
+  totalUsd: number,
+  unpricedCount = 0
+): ProjectDetail =>
+  ({
+    project: {
+      id: `p-${kind}-${totalUsd}`,
+      name: kind,
+      kind,
+      threadId: null,
+      createdAt: "",
+      updatedAt: ""
+    },
+    documents: [],
+    spend: { totalUsd, unpricedCount, byCategory: [] }
+  }) as ProjectDetail;
+
+describe("projectNameFromPrompt", () => {
+  it("names the project after the prompt's first line", () => {
+    expect(
+      projectNameFromPrompt("Aurora launch spot\nwarm and minimal", spot)
+    ).toBe("Aurora launch spot");
+  });
+
+  it("cuts a long first line at a word boundary", () => {
+    const name = projectNameFromPrompt("word ".repeat(30), spot);
+    expect(name.length).toBeLessThanOrEqual(61);
+    expect(name.endsWith("…")).toBe(true);
+  });
+
+  it("falls back to the shape when the prompt says nothing", () => {
+    expect(projectNameFromPrompt("   ", spot)).toBe("30s spot");
+    expect(projectNameFromPrompt("", empty)).toBe("New project");
+  });
+});
+
+describe("composeFirstTurn", () => {
+  it("carries the prompt, the shape's brief, and the named entities", () => {
+    const turn = composeFirstTurn({
+      prompt: "A spot for our desk lamp",
+      shape: spot,
+      entityNames: ["Aurora lamp", "Night street"]
+    });
+    expect(turn).toContain("A spot for our desk lamp");
+    expect(turn).toContain("30-second spot");
+    expect(turn).toContain("Use these entities: Aurora lamp, Night street.");
+  });
+
+  it("is the prompt alone for a shape that briefs nothing", () => {
+    expect(
+      composeFirstTurn({ prompt: "Whatever I want", shape: empty, entityNames: [] })
+    ).toBe("Whatever I want");
+  });
+});
+
+describe("estimateFromHistory", () => {
+  it("reads a range off past projects of the same kind", () => {
+    const estimate = estimateFromHistory(
+      [summary("spot", 3.1), summary("spot", 5.8), summary("trailer", 40)],
+      "spot"
+    );
+    expect(estimate).toEqual({ minUsd: 3.1, maxUsd: 5.8, samples: 2 });
+    expect(formatEstimate(estimate!)).toBe(
+      "est. $3.10–$5.80 · from 2 past projects · provider rates, no markup"
+    );
+  });
+
+  it("gives no estimate from fewer than two priced projects", () => {
+    expect(estimateFromHistory([summary("spot", 3.1)], "spot")).toBeNull();
+    expect(estimateFromHistory([], "spot")).toBeNull();
+  });
+
+  it("leaves out a project whose total is only a lower bound", () => {
+    expect(
+      estimateFromHistory([summary("spot", 3.1), summary("spot", 5.8, 2)], "spot")
+    ).toBeNull();
+  });
+
+  it("has nothing to read for a shape with no kind", () => {
+    expect(estimateFromHistory([summary("", 3.1), summary("", 5.8)], "")).toBeNull();
+  });
+});

--- a/web/src/components/projects/projectAgent.ts
+++ b/web/src/components/projects/projectAgent.ts
@@ -1,0 +1,47 @@
+/**
+ * What the project's agent is told, and how a prompt written on the
+ * new-project surface reaches the thread the overview owns.
+ *
+ * The two surfaces are separate tabs, and only the overview's panel knows when
+ * the thread is bound and its history loaded — so the prompt is staged here
+ * and sent from there, rather than raced against the panel's own first load.
+ */
+
+import type { MessageContent } from "../../stores/ApiTypes";
+
+/**
+ * Tells the agent which project it is working in. The tab context already
+ * lists the open documents; this names the group they belong to, so a request
+ * to "add a shot" lands in this project's board rather than the last one
+ * touched.
+ */
+export const projectSystemPrompt = (name: string, id: string): string =>
+  `You are working inside the project "${name}" (project id ${id}). ` +
+  `Documents you create belong to it, and the documents open in this ` +
+  `workspace are its own.`;
+
+/** Prompts waiting for their project's agent panel to mount, by project id. */
+const staged = new Map<string, MessageContent[]>();
+
+/** Hand the project's opening turn to whichever panel binds its thread next. */
+export const stageProjectFirstTurn = (
+  projectId: string,
+  content: MessageContent[]
+): void => {
+  staged.set(projectId, content);
+};
+
+/**
+ * Take the staged opening turn, if there is one. Taking clears it: a turn is
+ * sent once, and a panel that remounts must not send it again.
+ */
+export const takeProjectFirstTurn = (
+  projectId: string
+): MessageContent[] | null => {
+  const content = staged.get(projectId);
+  if (!content) {
+    return null;
+  }
+  staged.delete(projectId);
+  return content;
+};

--- a/web/src/components/projects/projectShapes.ts
+++ b/web/src/components/projects/projectShapes.ts
@@ -1,0 +1,180 @@
+/**
+ * What a project can be started as, and the pure pieces the new-project
+ * surface derives from a prompt: the project's name, the first turn its agent
+ * reads, and what a run of this shape has cost before.
+ *
+ * A shape only names documents a project can actually hold (the six types
+ * `projectDocumentType` lists), so the chain a shortcut promises is the chain
+ * the overview will show.
+ */
+
+import type { WorkspaceTabType } from "../../stores/WorkspaceTabsStore";
+import type { ProjectDetail } from "./projectStatus";
+
+export interface ProjectShapeStep {
+  /** The document type — the chain row draws its glyph and color from it. */
+  type: WorkspaceTabType;
+  label: string;
+}
+
+export interface ProjectShape {
+  id: string;
+  label: string;
+  /** Stored on the project row, and the key its cost history is read by. */
+  kind: string;
+  /** The documents the shape sets up. Empty for a project that starts bare. */
+  chain: readonly ProjectShapeStep[];
+  /** Told to the agent as what to build. Empty when the prompt is the whole ask. */
+  brief: string;
+}
+
+const BOARD: ProjectShapeStep = { type: "storyboard", label: "Board" };
+const SCRIPT: ProjectShapeStep = { type: "script", label: "Script" };
+const CUT: ProjectShapeStep = { type: "timeline", label: "Cut" };
+
+export const PROJECT_SHAPES: readonly ProjectShape[] = [
+  {
+    id: "spot",
+    label: "30s spot",
+    kind: "spot",
+    chain: [BOARD, SCRIPT, CUT],
+    brief:
+      "Set this up as a 30-second spot: a storyboard of shots, a voiceover " +
+      "script for them, and a cut assembled from the rendered clips."
+  },
+  {
+    id: "trailer",
+    label: "Trailer",
+    kind: "trailer",
+    chain: [BOARD, SCRIPT, CUT],
+    brief:
+      "Set this up as a trailer: a storyboard of shots, a voiceover script, " +
+      "and a cut assembled from the rendered clips."
+  },
+  {
+    id: "music-video",
+    label: "Music video",
+    kind: "music video",
+    chain: [BOARD, CUT],
+    brief:
+      "Set this up as a music video: a storyboard of shots and a cut " +
+      "assembled from the rendered clips, with no spoken script."
+  },
+  {
+    id: "app",
+    label: "Mini app",
+    kind: "app",
+    chain: [{ type: "application", label: "App" }],
+    brief:
+      "Set this up as a mini app: the workflows it runs, and an app document " +
+      "whose widgets are bound to them."
+  },
+  {
+    id: "empty",
+    label: "Empty project",
+    kind: "",
+    chain: [],
+    brief: ""
+  }
+];
+
+export const DEFAULT_SHAPE_ID = "spot";
+
+export const shapeById = (id: string): ProjectShape =>
+  PROJECT_SHAPES.find((shape) => shape.id === id) ?? PROJECT_SHAPES[0];
+
+/** How long a name derived from the prompt may run before it is cut short. */
+const NAME_LIMIT = 60;
+
+/**
+ * The project's name, taken from the prompt's first line. A name is what the
+ * tab and the card carry, so it is trimmed to a phrase rather than left as a
+ * paragraph; an empty prompt falls back to the shape's own label.
+ */
+export const projectNameFromPrompt = (
+  prompt: string,
+  shape: ProjectShape
+): string => {
+  const firstLine = prompt.trim().split("\n")[0]?.trim() ?? "";
+  if (firstLine.length === 0) {
+    return shape.label === "Empty project" ? "New project" : shape.label;
+  }
+  if (firstLine.length <= NAME_LIMIT) {
+    return firstLine;
+  }
+  const cut = firstLine.slice(0, NAME_LIMIT);
+  const lastSpace = cut.lastIndexOf(" ");
+  return `${(lastSpace > 20 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`;
+};
+
+interface FirstTurnInput {
+  prompt: string;
+  shape: ProjectShape;
+  /** Entity names picked from the library, injected by name downstream. */
+  entityNames: readonly string[];
+}
+
+/**
+ * The first thing the project's agent reads: what the user asked for, what
+ * shape they picked, and which library entities to season the prompts with.
+ * Each part is omitted when it says nothing.
+ */
+export const composeFirstTurn = ({
+  prompt,
+  shape,
+  entityNames
+}: FirstTurnInput): string => {
+  const parts = [prompt.trim()];
+  if (shape.brief.length > 0) {
+    parts.push(shape.brief);
+  }
+  if (entityNames.length > 0) {
+    parts.push(`Use these entities: ${entityNames.join(", ")}.`);
+  }
+  return parts.filter((part) => part.length > 0).join("\n\n");
+};
+
+export interface SpendEstimate {
+  minUsd: number;
+  maxUsd: number;
+  /** Projects the range was read off. */
+  samples: number;
+}
+
+/**
+ * What this shape has cost before, read off the user's own finished projects
+ * of the same kind. A project carrying unpriced calls is left out — its total
+ * is a lower bound, and a range built from lower bounds understates.
+ *
+ * Fewer than two priced projects is no range, and no line: an estimate nothing
+ * was measured for would be a number we made up.
+ */
+export const estimateFromHistory = (
+  summaries: readonly ProjectDetail[],
+  kind: string
+): SpendEstimate | null => {
+  if (kind.length === 0) {
+    return null;
+  }
+  const totals = summaries
+    .filter(
+      (entry) =>
+        entry.project.kind === kind &&
+        entry.spend.unpricedCount === 0 &&
+        entry.spend.totalUsd > 0
+    )
+    .map((entry) => entry.spend.totalUsd);
+  if (totals.length < 2) {
+    return null;
+  }
+  return {
+    minUsd: Math.min(...totals),
+    maxUsd: Math.max(...totals),
+    samples: totals.length
+  };
+};
+
+/** `est. $3.10–$5.80 · provider rates, no markup` */
+export const formatEstimate = (estimate: SpendEstimate): string =>
+  `est. $${estimate.minUsd.toFixed(2)}–$${estimate.maxUsd.toFixed(2)} · ` +
+  `from ${estimate.samples} past projects · provider rates, no markup`;

--- a/web/src/components/workspace/OpenMenu.tsx
+++ b/web/src/components/workspace/OpenMenu.tsx
@@ -1,15 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
 import AddRoundedIcon from "@mui/icons-material/AddRounded";
-import ArticleOutlinedIcon from "@mui/icons-material/ArticleOutlined";
-import ImageOutlinedIcon from "@mui/icons-material/ImageOutlined";
-import MovieOutlinedIcon from "@mui/icons-material/MovieOutlined";
-import DashboardOutlinedIcon from "@mui/icons-material/DashboardOutlined";
-import DashboardCustomizeOutlinedIcon from "@mui/icons-material/DashboardCustomizeOutlined";
-import ViewInArOutlinedIcon from "@mui/icons-material/ViewInArOutlined";
-import ForumOutlinedIcon from "@mui/icons-material/ForumOutlined";
-import DataObjectOutlinedIcon from "@mui/icons-material/DataObjectOutlined";
-import RecordVoiceOverOutlinedIcon from "@mui/icons-material/RecordVoiceOverOutlined";
-import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
 import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
 
 import {
@@ -20,66 +10,14 @@ import {
   Caption,
   LoadingSpinner
 } from "../ui_primitives";
-import { useCreateTimeline } from "../../hooks/useTimelineSequence";
+import { useExampleStoryboards } from "../../hooks/storyboard/useStoryboards";
+import { useOpenNewProjectTab } from "../../hooks/useProjects";
+import { PROJECT_GLYPH } from "../projects/projectIdentity";
 import {
-  useCreateStoryboard,
-  useExampleStoryboards,
-  useInstallExampleStoryboard
-} from "../../hooks/storyboard/useStoryboards";
-import { useCreateApplication } from "../../hooks/useApplications";
-import { useCreateScript } from "../../hooks/script/useScripts";
-import { useCreateJsScript } from "../../hooks/jsScript/useJsScripts";
-import { useCreateSkill } from "../../hooks/skills/useSkills";
-import { useAssetStore } from "../../stores/AssetStore";
-import { useNotificationStore } from "../../stores/NotificationStore";
-import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
-import useGlobalChatStore from "../../stores/GlobalChatStore";
-import {
-  useWorkspaceTabsStore,
-  creationProjectId
-} from "../../stores/WorkspaceTabsStore";
-import { newDocumentId } from "../../lib/newDocumentId";
-
-/** Render a blank white PNG to seed a "New image" canvas asset. */
-const createBlankImageFile = (): Promise<File> =>
-  new Promise((resolve, reject) => {
-    const canvas = document.createElement("canvas");
-    canvas.width = 1024;
-    canvas.height = 1024;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) {
-      reject(new Error("Canvas 2D context unavailable"));
-      return;
-    }
-    ctx.fillStyle = "#ffffff";
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    canvas.toBlob((blob) => {
-      if (!blob) {
-        reject(new Error("Failed to render blank image"));
-        return;
-      }
-      resolve(new File([blob], "Untitled.png", { type: "image/png" }));
-    }, "image/png");
-  });
-
-/**
- * Build a starter `.glb` (a single box, like a default cube) to seed a
- * "New 3D model" tab. Three.js is imported lazily so its weight only loads when
- * the user actually creates a model.
- */
-const createBlankModelFile = async (): Promise<File> => {
-  const [THREE, { createPrimitive }, { exportSceneToGlb }] = await Promise.all([
-    import("three"),
-    import("../model_editor/objectFactory"),
-    import("../model_editor/exportGltf")
-  ]);
-  const scene = new THREE.Scene();
-  const box = createPrimitive("box");
-  box.name = "Box";
-  scene.add(box);
-  const blob = await exportSceneToGlb(scene);
-  return new File([blob], "Untitled.glb", { type: "model/gltf-binary" });
-};
+  TEXT_FILE_TEMPLATES,
+  useNewDocumentCatalog,
+  type NewDocumentSubmenu
+} from "./newDocumentCatalog";
 
 interface OpenMenuProps {
   anchorEl: HTMLElement | null;
@@ -87,310 +25,28 @@ interface OpenMenuProps {
   onClose: () => void;
 }
 
-type MenuView = "root" | "texts" | "storyboards";
-
-interface TextFileTemplate {
-  label: string;
-  filename: string;
-  mimeType: string;
-  content: string;
-}
-
-const TEXT_FILE_TEMPLATES: readonly TextFileTemplate[] = [
-  {
-    label: "Markdown (.md)",
-    filename: "Untitled.md",
-    mimeType: "text/markdown",
-    content: "# Untitled\n"
-  },
-  {
-    label: "JSON (.json)",
-    filename: "Untitled.json",
-    mimeType: "application/json",
-    content: "{}\n"
-  },
-  {
-    label: "YAML (.yaml)",
-    filename: "Untitled.yaml",
-    mimeType: "application/x-yaml",
-    content: "---\n"
-  },
-  {
-    label: "CSV (.csv)",
-    filename: "Untitled.csv",
-    mimeType: "text/csv",
-    content: "Column 1\n"
-  },
-  {
-    label: "TSV (.tsv)",
-    filename: "Untitled.tsv",
-    mimeType: "text/tab-separated-values",
-    content: "Column 1\n"
-  },
-  {
-    label: "Plain text (.txt)",
-    filename: "Untitled.txt",
-    mimeType: "text/plain",
-    content: ""
-  }
-];
+type MenuView = "root" | NewDocumentSubmenu;
 
 /**
- * The `[+]` menu for the workspace tab bar: create a new document as a tab.
+ * The `[+]` menu for the workspace tab bar. A project comes first — it is what
+ * most new work starts as — and the blank documents keep their list below it.
  */
 const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
   const [view, setView] = useState<MenuView>("root");
-  /** Label of the "New X" creator currently in flight, if any. */
-  const [creating, setCreating] = useState<string | null>(null);
-
-  const addNotification = useNotificationStore(
-    (state) => state.addNotification
-  );
-  const openTab = useWorkspaceTabsStore((state) => state.openTab);
-  const createNew = useWorkflowManager((state) => state.createNew);
-  const createNewThread = useGlobalChatStore((state) => state.createNewThread);
-  const createAsset = useAssetStore((state) => state.createAsset);
-  const createTimeline = useCreateTimeline();
-  const createStoryboard = useCreateStoryboard();
-  const installExampleStoryboard = useInstallExampleStoryboard();
-  const createApplication = useCreateApplication();
-  const createScript = useCreateScript();
-  const createJsScript = useCreateJsScript();
-  const createSkill = useCreateSkill();
 
   const close = useCallback(() => {
     setView("root");
     onClose();
   }, [onClose]);
 
-  /**
-   * Run one of the "New X" creators: block re-entry while it is in flight,
-   * close the menu on success, and surface a failure as a toast instead of a
-   * dead click.
-   */
-  const runCreate = useCallback(
-    async (label: string, create: () => Promise<void>) => {
-      setCreating(label);
-      try {
-        await create();
-        close();
-      } catch (error) {
-        addNotification({
-          type: "error",
-          alert: true,
-          content: `Could not create ${label}: ${
-            error instanceof Error ? error.message : "unknown error"
-          }`
-        });
-      } finally {
-        setCreating(null);
-      }
-    },
-    [addNotification, close]
-  );
-
-  const handleNew = useCallback(
-    () =>
-      runCreate("workflow", async () => {
-        const workflow = await createNew();
-        openTab({
-          type: "workflow",
-          ref: workflow.id,
-          mode: "edit",
-          title: workflow.name
-        });
-      }),
-    [runCreate, createNew, openTab]
-  );
-
-  const handleNewImage = useCallback(
-    () =>
-      runCreate("image", async () => {
-        const asset = await createAsset(await createBlankImageFile());
-        openTab({
-          type: "image",
-          ref: asset.id,
-          mode: "edit",
-          title: asset.name || "Untitled image"
-        });
-      }),
-    [runCreate, createAsset, openTab]
-  );
-
-  const handleNewText = useCallback(
-    (template: TextFileTemplate) =>
-      runCreate("text file", async () => {
-        const asset = await createAsset(
-          new File([template.content], template.filename, {
-            type: template.mimeType
-          })
-        );
-        openTab({
-          type: "text",
-          ref: asset.id,
-          mode: "edit",
-          title: asset.name || template.filename
-        });
-      }),
-    [runCreate, createAsset, openTab]
-  );
-
-  const handleNewVideo = useCallback(
-    () =>
-      runCreate("video", async () => {
-        const sequence = await createTimeline.mutateAsync({
-          name: "Untitled video",
-          projectId: creationProjectId()
-        });
-        openTab({
-          type: "timeline",
-          ref: sequence.id,
-          mode: "edit",
-          title: sequence.name || "Untitled video",
-          projectId: sequence.projectId
-        });
-      }),
-    [runCreate, createTimeline, openTab]
-  );
-
-  const handleNewStoryboard = useCallback(
-    () =>
-      runCreate("storyboard", async () => {
-        const created = await createStoryboard.mutateAsync({
-          name: "Untitled storyboard",
-          projectId: creationProjectId()
-        });
-        openTab({
-          type: "storyboard",
-          ref: created.id,
-          mode: "edit",
-          title: created.name,
-          projectId: created.projectId
-        });
-      }),
-    [runCreate, createStoryboard, openTab]
-  );
-
-  const handleStoryboardExample = useCallback(
-    (slug: string, name: string) =>
-      runCreate(name, async () => {
-        const created = await installExampleStoryboard.mutateAsync({
-          slug,
-          projectId: creationProjectId()
-        });
-        openTab({
-          type: "storyboard",
-          ref: created.id,
-          mode: "edit",
-          title: created.name,
-          projectId: created.projectId
-        });
-      }),
-    [runCreate, installExampleStoryboard, openTab]
-  );
-
-  const handleNewApp = useCallback(
-    () =>
-      runCreate("app", async () => {
-        const created = await createApplication.mutateAsync({
-          name: "Untitled app",
-          description: "",
-          projectId: creationProjectId()
-        });
-        openTab({
-          type: "application",
-          ref: created.id,
-          mode: "edit",
-          title: created.name,
-          projectId: created.projectId
-        });
-      }),
-    [runCreate, createApplication, openTab]
-  );
-
-  const handleNewScript = useCallback(
-    () =>
-      runCreate("script", async () => {
-        const created = await createScript.mutateAsync({
-          name: "Untitled script",
-          projectId: creationProjectId()
-        });
-        openTab({
-          type: "script",
-          ref: created.id,
-          mode: "edit",
-          title: created.name,
-          projectId: created.projectId
-        });
-      }),
-    [runCreate, createScript, openTab]
-  );
-
-  const handleNewJsScript = useCallback(
-    () =>
-      runCreate("JS script", async () => {
-        const created = await createJsScript.mutateAsync({
-          name: "Untitled JS script",
-          projectId: creationProjectId()
-        });
-        openTab({
-          type: "jsscript",
-          ref: created.id,
-          mode: "edit",
-          title: created.name,
-          projectId: created.projectId
-        });
-      }),
-    [runCreate, createJsScript, openTab]
-  );
-
-  const handleNewSkill = useCallback(
-    () =>
-      runCreate("skill", async () => {
-        const created = await createSkill.mutateAsync({
-          id: newDocumentId(),
-          name: `skill-${Date.now().toString(36)}`,
-          description: "A reusable skill for the NodeTool agent.",
-          content:
-            "# New skill\n\nDescribe what this skill does and when the agent should use it."
-        });
-        openTab({
-          type: "skill",
-          ref: created.id,
-          mode: "edit",
-          title: created.name || "Untitled skill"
-        });
-      }),
-    [runCreate, createSkill, openTab]
-  );
-
-  const handleNewChat = useCallback(
-    () =>
-      runCreate("chat", async () => {
-        const threadId = await createNewThread();
-        openTab({
-          type: "chat",
-          ref: threadId,
-          mode: "view",
-          title: "New chat"
-        });
-      }),
-    [runCreate, createNewThread, openTab]
-  );
-
-  const handleNewModel = useCallback(
-    () =>
-      runCreate("3D model", async () => {
-        const asset = await createAsset(await createBlankModelFile());
-        openTab({
-          type: "model3d",
-          ref: asset.id,
-          mode: "edit",
-          title: asset.name || "Untitled model"
-        });
-      }),
-    [runCreate, createAsset, openTab]
-  );
+  const openNewProject = useOpenNewProjectTab();
+  const {
+    entries,
+    createTextFile,
+    createBlankStoryboard,
+    installStoryboardExample,
+    creating
+  } = useNewDocumentCatalog({}, close);
 
   const { data: exampleData, isLoading: examplesLoading } =
     useExampleStoryboards(open && view === "storyboards");
@@ -409,73 +65,29 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
         {view === "root" && (
           <>
             <MenuItemPrimitive
-              label="New workflow"
-              icon={<AddRoundedIcon fontSize="small" />}
-              onClick={() => void handleNew()}
-              disabled={creating !== null}
+              label="Start a project…"
+              secondary="An agent plans and builds its documents"
+              icon={<span aria-hidden>{PROJECT_GLYPH}</span>}
+              dividerAfter
+              onClick={() => {
+                close();
+                openNewProject();
+              }}
             />
-            <MenuItemPrimitive
-              label="New chat"
-              icon={<ForumOutlinedIcon fontSize="small" />}
-              onClick={() => void handleNewChat()}
-              disabled={creating !== null}
-            />
-            <MenuItemPrimitive
-              label="New text file…"
-              icon={<ArticleOutlinedIcon fontSize="small" />}
-              hasSubmenu
-              onClick={() => setView("texts")}
-              disabled={creating !== null}
-            />
-            <MenuItemPrimitive
-              label="New image"
-              icon={<ImageOutlinedIcon fontSize="small" />}
-              onClick={() => void handleNewImage()}
-              disabled={creating !== null}
-            />
-            <MenuItemPrimitive
-              label="New video"
-              icon={<MovieOutlinedIcon fontSize="small" />}
-              onClick={() => void handleNewVideo()}
-              disabled={creating !== null}
-            />
-            <MenuItemPrimitive
-              label="New storyboard…"
-              icon={<DashboardOutlinedIcon fontSize="small" />}
-              hasSubmenu
-              onClick={() => setView("storyboards")}
-              disabled={creating !== null}
-            />
-            <MenuItemPrimitive
-              label="New app"
-              icon={<DashboardCustomizeOutlinedIcon fontSize="small" />}
-              onClick={() => void handleNewApp()}
-              disabled={creating !== null}
-            />
-            <MenuItemPrimitive
-              label="New script"
-              icon={<RecordVoiceOverOutlinedIcon fontSize="small" />}
-              onClick={() => void handleNewScript()}
-              disabled={creating !== null}
-            />
-            <MenuItemPrimitive
-              label="New JS script"
-              icon={<DataObjectOutlinedIcon fontSize="small" />}
-              onClick={() => void handleNewJsScript()}
-              disabled={creating !== null}
-            />
-            <MenuItemPrimitive
-              label="New skill"
-              icon={<AutoAwesomeOutlinedIcon fontSize="small" />}
-              onClick={() => void handleNewSkill()}
-              disabled={creating !== null}
-            />
-            <MenuItemPrimitive
-              label="New 3D model"
-              icon={<ViewInArOutlinedIcon fontSize="small" />}
-              onClick={() => void handleNewModel()}
-              disabled={creating !== null}
-            />
+            {entries.map((entry) => (
+              <MenuItemPrimitive
+                key={entry.key}
+                label={entry.menuLabel}
+                icon={entry.icon}
+                hasSubmenu={entry.submenu !== undefined}
+                onClick={() =>
+                  entry.submenu
+                    ? setView(entry.submenu)
+                    : void entry.create?.()
+                }
+                disabled={creating !== null}
+              />
+            ))}
           </>
         )}
 
@@ -491,7 +103,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
               <MenuItemPrimitive
                 key={template.filename}
                 label={template.label}
-                onClick={() => void handleNewText(template)}
+                onClick={() => void createTextFile(template)}
                 disabled={creating !== null}
               />
             ))}
@@ -509,7 +121,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
             <MenuItemPrimitive
               label="Blank storyboard"
               icon={<AddRoundedIcon fontSize="small" />}
-              onClick={() => void handleNewStoryboard()}
+              onClick={() => void createBlankStoryboard()}
               disabled={creating !== null}
               dividerAfter
             />
@@ -531,7 +143,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
                   example.shotCount === 1 ? "" : "s"
                 }, already rendered`}
                 onClick={() =>
-                  void handleStoryboardExample(example.slug, example.name)
+                  void installStoryboardExample(example.slug, example.name)
                 }
                 disabled={creating !== null}
               />

--- a/web/src/components/workspace/TabContent.tsx
+++ b/web/src/components/workspace/TabContent.tsx
@@ -31,6 +31,9 @@ const ProjectListSurface = React.lazy(
 const ProjectOverviewSurface = React.lazy(
   () => import("../projects/ProjectOverviewSurface")
 );
+const NewProjectSurface = React.lazy(
+  () => import("../projects/NewProjectSurface")
+);
 
 interface TabContentProps {
   tab: WorkspaceTab;
@@ -83,6 +86,8 @@ const surfaceFor = (tab: WorkspaceTab, active: boolean) => {
       return <ProjectListSurface />;
     case "project":
       return <ProjectOverviewSurface refId={tab.ref} />;
+    case "project-new":
+      return <NewProjectSurface />;
     default: {
       // Exhaustiveness guard — a new WorkspaceTabType must add a case here.
       const exhaustive: never = tab.type;

--- a/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -57,7 +57,8 @@ const SUPPORTS_BOTH_MODES = {
   application: false,
   page: false,
   "project-list": false,
-  project: false
+  project: false,
+  "project-new": false
 } satisfies Record<WorkspaceTabType, boolean>;
 
 

--- a/web/src/components/workspace/__tests__/OpenMenuProjects.test.tsx
+++ b/web/src/components/workspace/__tests__/OpenMenuProjects.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * The `[+]` menu leads with a project and keeps the blank documents below it.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+const openNewProject = jest.fn();
+jest.mock("../../../hooks/useProjects", () => ({
+  useOpenNewProjectTab: () => openNewProject
+}));
+
+const createDocument = jest.fn(async () => undefined);
+jest.mock("../newDocumentCatalog", () => ({
+  TEXT_FILE_TEMPLATES: [],
+  useNewDocumentCatalog: () => ({
+    entries: [
+      {
+        key: "workflow",
+        label: "Workflow",
+        menuLabel: "New workflow",
+        type: "workflow",
+        icon: null,
+        create: createDocument
+      }
+    ],
+    createTextFile: jest.fn(),
+    createBlankStoryboard: jest.fn(),
+    installStoryboardExample: jest.fn(),
+    creating: null
+  })
+}));
+
+jest.mock("../../../hooks/storyboard/useStoryboards", () => ({
+  useExampleStoryboards: () => ({ data: undefined, isLoading: false })
+}));
+
+import OpenMenu from "../OpenMenu";
+
+const onClose = jest.fn();
+const renderMenu = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <OpenMenu anchorEl={document.body} open onClose={onClose} />
+    </ThemeProvider>
+  );
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("OpenMenu projects", () => {
+  it("opens the new-project surface and closes the menu", async () => {
+    renderMenu();
+    await userEvent.click(screen.getByText("Start a project…"));
+    expect(openNewProject).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("still creates a blank document from the list below", async () => {
+    renderMenu();
+    await userEvent.click(screen.getByText("New workflow"));
+    expect(createDocument).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/workspace/newDocumentCatalog.tsx
+++ b/web/src/components/workspace/newDocumentCatalog.tsx
@@ -1,0 +1,521 @@
+/**
+ * The "new blank document" catalog: one list of creators, two renderings —
+ * the `+ New` popover and the strip at the foot of the new-project surface.
+ *
+ * Each entry either creates its document straight away or names a submenu the
+ * caller renders (text templates, storyboard examples), so both surfaces offer
+ * the same set without either owning the creators.
+ */
+
+import { useCallback, useState, type ReactNode } from "react";
+import AddRoundedIcon from "@mui/icons-material/AddRounded";
+import ArticleOutlinedIcon from "@mui/icons-material/ArticleOutlined";
+import ImageOutlinedIcon from "@mui/icons-material/ImageOutlined";
+import MovieOutlinedIcon from "@mui/icons-material/MovieOutlined";
+import DashboardOutlinedIcon from "@mui/icons-material/DashboardOutlined";
+import DashboardCustomizeOutlinedIcon from "@mui/icons-material/DashboardCustomizeOutlined";
+import ViewInArOutlinedIcon from "@mui/icons-material/ViewInArOutlined";
+import ForumOutlinedIcon from "@mui/icons-material/ForumOutlined";
+import DataObjectOutlinedIcon from "@mui/icons-material/DataObjectOutlined";
+import RecordVoiceOverOutlinedIcon from "@mui/icons-material/RecordVoiceOverOutlined";
+import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
+
+import { useCreateTimeline } from "../../hooks/useTimelineSequence";
+import {
+  useCreateStoryboard,
+  useInstallExampleStoryboard
+} from "../../hooks/storyboard/useStoryboards";
+import { useCreateApplication } from "../../hooks/useApplications";
+import { useCreateScript } from "../../hooks/script/useScripts";
+import { useCreateJsScript } from "../../hooks/jsScript/useJsScripts";
+import { useCreateSkill } from "../../hooks/skills/useSkills";
+import { useAssetStore } from "../../stores/AssetStore";
+import { useNotificationStore } from "../../stores/NotificationStore";
+import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
+import useGlobalChatStore from "../../stores/GlobalChatStore";
+import {
+  creationProjectId,
+  useWorkspaceTabsStore,
+  type WorkspaceTabType
+} from "../../stores/WorkspaceTabsStore";
+import { newDocumentId } from "../../lib/newDocumentId";
+
+/** Render a blank white PNG to seed a "New image" canvas asset. */
+const createBlankImageFile = (): Promise<File> =>
+  new Promise((resolve, reject) => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 1024;
+    canvas.height = 1024;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      reject(new Error("Canvas 2D context unavailable"));
+      return;
+    }
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        reject(new Error("Failed to render blank image"));
+        return;
+      }
+      resolve(new File([blob], "Untitled.png", { type: "image/png" }));
+    }, "image/png");
+  });
+
+/**
+ * Build a starter `.glb` (a single box, like a default cube) to seed a
+ * "New 3D model" tab. Three.js is imported lazily so its weight only loads when
+ * the user actually creates a model.
+ */
+const createBlankModelFile = async (): Promise<File> => {
+  const [THREE, { createPrimitive }, { exportSceneToGlb }] = await Promise.all([
+    import("three"),
+    import("../model_editor/objectFactory"),
+    import("../model_editor/exportGltf")
+  ]);
+  const scene = new THREE.Scene();
+  const box = createPrimitive("box");
+  box.name = "Box";
+  scene.add(box);
+  const blob = await exportSceneToGlb(scene);
+  return new File([blob], "Untitled.glb", { type: "model/gltf-binary" });
+};
+
+export interface TextFileTemplate {
+  label: string;
+  filename: string;
+  mimeType: string;
+  content: string;
+}
+
+export const TEXT_FILE_TEMPLATES: readonly TextFileTemplate[] = [
+  {
+    label: "Markdown (.md)",
+    filename: "Untitled.md",
+    mimeType: "text/markdown",
+    content: "# Untitled\n"
+  },
+  {
+    label: "JSON (.json)",
+    filename: "Untitled.json",
+    mimeType: "application/json",
+    content: "{}\n"
+  },
+  {
+    label: "YAML (.yaml)",
+    filename: "Untitled.yaml",
+    mimeType: "application/x-yaml",
+    content: "---\n"
+  },
+  {
+    label: "CSV (.csv)",
+    filename: "Untitled.csv",
+    mimeType: "text/csv",
+    content: "Column 1\n"
+  },
+  {
+    label: "TSV (.tsv)",
+    filename: "Untitled.tsv",
+    mimeType: "text/tab-separated-values",
+    content: "Column 1\n"
+  },
+  {
+    label: "Plain text (.txt)",
+    filename: "Untitled.txt",
+    mimeType: "text/plain",
+    content: ""
+  }
+];
+
+/** Entries whose second choice the caller renders. */
+export type NewDocumentSubmenu = "texts" | "storyboards";
+
+export interface NewDocumentEntry {
+  key: string;
+  /** The document, named — what the grid shows. */
+  label: string;
+  /** The same as an action — what the menu shows. */
+  menuLabel: string;
+  /** The tab this opens; the grid draws its glyph and color from the type. */
+  type: WorkspaceTabType;
+  icon: ReactNode;
+  /** Set when the entry opens a submenu instead of creating immediately. */
+  submenu?: NewDocumentSubmenu;
+  create?: () => Promise<void>;
+}
+
+interface NewDocumentCatalogOptions {
+  /**
+   * The project created documents belong to. Defaults to whichever project is
+   * open, so the `+ New` menu keeps filing into it; the new-project surface
+   * passes the loose bucket, because its strip promises a loose tab.
+   */
+  projectId?: string;
+}
+
+export interface NewDocumentCatalog {
+  entries: readonly NewDocumentEntry[];
+  createTextFile: (template: TextFileTemplate) => Promise<void>;
+  createBlankStoryboard: () => Promise<void>;
+  installStoryboardExample: (slug: string, name: string) => Promise<void>;
+  /** Label of the creator in flight, if any — callers disable while it runs. */
+  creating: string | null;
+}
+
+/**
+ * The creators behind every "New X", each reporting failure as a toast rather
+ * than a dead click. `onCreated` lets a caller close its own menu when one
+ * succeeds.
+ */
+export const useNewDocumentCatalog = (
+  options: NewDocumentCatalogOptions = {},
+  onCreated?: () => void
+): NewDocumentCatalog => {
+  const [creating, setCreating] = useState<string | null>(null);
+
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification
+  );
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const createNew = useWorkflowManager((state) => state.createNew);
+  const createNewThread = useGlobalChatStore((state) => state.createNewThread);
+  const createAsset = useAssetStore((state) => state.createAsset);
+  const createTimeline = useCreateTimeline();
+  const createStoryboard = useCreateStoryboard();
+  const installExampleStoryboard = useInstallExampleStoryboard();
+  const createApplication = useCreateApplication();
+  const createScript = useCreateScript();
+  const createJsScript = useCreateJsScript();
+  const createSkill = useCreateSkill();
+
+  const { projectId } = options;
+  // Read at click time, not at render: a project opened after this mounted is
+  // still the one a new document belongs to.
+  const targetProject = useCallback(
+    () => projectId ?? creationProjectId(),
+    [projectId]
+  );
+
+  const runCreate = useCallback(
+    async (label: string, create: () => Promise<void>) => {
+      setCreating(label);
+      try {
+        await create();
+        onCreated?.();
+      } catch (error) {
+        addNotification({
+          type: "error",
+          alert: true,
+          content: `Could not create ${label}: ${
+            error instanceof Error ? error.message : "unknown error"
+          }`
+        });
+      } finally {
+        setCreating(null);
+      }
+    },
+    [addNotification, onCreated]
+  );
+
+  const createWorkflow = useCallback(
+    () =>
+      runCreate("workflow", async () => {
+        const workflow = await createNew();
+        openTab({
+          type: "workflow",
+          ref: workflow.id,
+          mode: "edit",
+          title: workflow.name
+        });
+      }),
+    [runCreate, createNew, openTab]
+  );
+
+  const createChat = useCallback(
+    () =>
+      runCreate("chat", async () => {
+        const threadId = await createNewThread();
+        openTab({
+          type: "chat",
+          ref: threadId,
+          mode: "view",
+          title: "New chat"
+        });
+      }),
+    [runCreate, createNewThread, openTab]
+  );
+
+  const createTextFile = useCallback(
+    (template: TextFileTemplate) =>
+      runCreate("text file", async () => {
+        const asset = await createAsset(
+          new File([template.content], template.filename, {
+            type: template.mimeType
+          })
+        );
+        openTab({
+          type: "text",
+          ref: asset.id,
+          mode: "edit",
+          title: asset.name || template.filename
+        });
+      }),
+    [runCreate, createAsset, openTab]
+  );
+
+  const createImage = useCallback(
+    () =>
+      runCreate("image", async () => {
+        const asset = await createAsset(await createBlankImageFile());
+        openTab({
+          type: "image",
+          ref: asset.id,
+          mode: "edit",
+          title: asset.name || "Untitled image"
+        });
+      }),
+    [runCreate, createAsset, openTab]
+  );
+
+  const createVideo = useCallback(
+    () =>
+      runCreate("video", async () => {
+        const sequence = await createTimeline.mutateAsync({
+          name: "Untitled video",
+          projectId: targetProject()
+        });
+        openTab({
+          type: "timeline",
+          ref: sequence.id,
+          mode: "edit",
+          title: sequence.name || "Untitled video",
+          projectId: sequence.projectId
+        });
+      }),
+    [runCreate, createTimeline, openTab, targetProject]
+  );
+
+  const createBlankStoryboard = useCallback(
+    () =>
+      runCreate("storyboard", async () => {
+        const created = await createStoryboard.mutateAsync({
+          name: "Untitled storyboard",
+          projectId: targetProject()
+        });
+        openTab({
+          type: "storyboard",
+          ref: created.id,
+          mode: "edit",
+          title: created.name,
+          projectId: created.projectId
+        });
+      }),
+    [runCreate, createStoryboard, openTab, targetProject]
+  );
+
+  const installStoryboardExample = useCallback(
+    (slug: string, name: string) =>
+      runCreate(name, async () => {
+        const created = await installExampleStoryboard.mutateAsync({
+          slug,
+          projectId: targetProject()
+        });
+        openTab({
+          type: "storyboard",
+          ref: created.id,
+          mode: "edit",
+          title: created.name,
+          projectId: created.projectId
+        });
+      }),
+    [runCreate, installExampleStoryboard, openTab, targetProject]
+  );
+
+  const createApp = useCallback(
+    () =>
+      runCreate("app", async () => {
+        const created = await createApplication.mutateAsync({
+          name: "Untitled app",
+          description: "",
+          projectId: targetProject()
+        });
+        openTab({
+          type: "application",
+          ref: created.id,
+          mode: "edit",
+          title: created.name,
+          projectId: created.projectId
+        });
+      }),
+    [runCreate, createApplication, openTab, targetProject]
+  );
+
+  const createScriptDocument = useCallback(
+    () =>
+      runCreate("script", async () => {
+        const created = await createScript.mutateAsync({
+          name: "Untitled script",
+          projectId: targetProject()
+        });
+        openTab({
+          type: "script",
+          ref: created.id,
+          mode: "edit",
+          title: created.name,
+          projectId: created.projectId
+        });
+      }),
+    [runCreate, createScript, openTab, targetProject]
+  );
+
+  const createJsScriptDocument = useCallback(
+    () =>
+      runCreate("JS script", async () => {
+        const created = await createJsScript.mutateAsync({
+          name: "Untitled JS script",
+          projectId: targetProject()
+        });
+        openTab({
+          type: "jsscript",
+          ref: created.id,
+          mode: "edit",
+          title: created.name,
+          projectId: created.projectId
+        });
+      }),
+    [runCreate, createJsScript, openTab, targetProject]
+  );
+
+  const createSkillDocument = useCallback(
+    () =>
+      runCreate("skill", async () => {
+        const created = await createSkill.mutateAsync({
+          id: newDocumentId(),
+          name: `skill-${Date.now().toString(36)}`,
+          description: "A reusable skill for the NodeTool agent.",
+          content:
+            "# New skill\n\nDescribe what this skill does and when the agent should use it."
+        });
+        openTab({
+          type: "skill",
+          ref: created.id,
+          mode: "edit",
+          title: created.name || "Untitled skill"
+        });
+      }),
+    [runCreate, createSkill, openTab]
+  );
+
+  const createModel = useCallback(
+    () =>
+      runCreate("3D model", async () => {
+        const asset = await createAsset(await createBlankModelFile());
+        openTab({
+          type: "model3d",
+          ref: asset.id,
+          mode: "edit",
+          title: asset.name || "Untitled model"
+        });
+      }),
+    [runCreate, createAsset, openTab]
+  );
+
+  const entries: NewDocumentEntry[] = [
+    {
+      key: "workflow",
+      label: "Workflow",
+      menuLabel: "New workflow",
+      type: "workflow",
+      icon: <AddRoundedIcon fontSize="small" />,
+      create: createWorkflow
+    },
+    {
+      key: "chat",
+      label: "Chat",
+      menuLabel: "New chat",
+      type: "chat",
+      icon: <ForumOutlinedIcon fontSize="small" />,
+      create: createChat
+    },
+    {
+      key: "text",
+      label: "Text",
+      menuLabel: "New text file…",
+      type: "text",
+      icon: <ArticleOutlinedIcon fontSize="small" />,
+      submenu: "texts"
+    },
+    {
+      key: "image",
+      label: "Image",
+      menuLabel: "New image",
+      type: "image",
+      icon: <ImageOutlinedIcon fontSize="small" />,
+      create: createImage
+    },
+    {
+      key: "video",
+      label: "Video",
+      menuLabel: "New video",
+      type: "timeline",
+      icon: <MovieOutlinedIcon fontSize="small" />,
+      create: createVideo
+    },
+    {
+      key: "storyboard",
+      label: "Storyboard",
+      menuLabel: "New storyboard…",
+      type: "storyboard",
+      icon: <DashboardOutlinedIcon fontSize="small" />,
+      submenu: "storyboards"
+    },
+    {
+      key: "app",
+      label: "App",
+      menuLabel: "New app",
+      type: "application",
+      icon: <DashboardCustomizeOutlinedIcon fontSize="small" />,
+      create: createApp
+    },
+    {
+      key: "script",
+      label: "Script",
+      menuLabel: "New script",
+      type: "script",
+      icon: <RecordVoiceOverOutlinedIcon fontSize="small" />,
+      create: createScriptDocument
+    },
+    {
+      key: "jsscript",
+      label: "JS script",
+      menuLabel: "New JS script",
+      type: "jsscript",
+      icon: <DataObjectOutlinedIcon fontSize="small" />,
+      create: createJsScriptDocument
+    },
+    {
+      key: "skill",
+      label: "Skill",
+      menuLabel: "New skill",
+      type: "skill",
+      icon: <AutoAwesomeOutlinedIcon fontSize="small" />,
+      create: createSkillDocument
+    },
+    {
+      key: "model3d",
+      label: "3D model",
+      menuLabel: "New 3D model",
+      type: "model3d",
+      icon: <ViewInArOutlinedIcon fontSize="small" />,
+      create: createModel
+    }
+  ];
+
+  return {
+    entries,
+    createTextFile,
+    createBlankStoryboard,
+    installStoryboardExample,
+    creating
+  };
+};

--- a/web/src/components/workspace/tabTypeIdentity.ts
+++ b/web/src/components/workspace/tabTypeIdentity.ts
@@ -25,7 +25,8 @@ export const TYPE_GLYPH = {
   application: "◧",
   page: "☰",
   "project-list": PROJECT_GLYPH,
-  project: PROJECT_GLYPH
+  project: PROJECT_GLYPH,
+  "project-new": PROJECT_GLYPH
 } satisfies Record<WorkspaceTabType, string>;
 
 /** Pin color per tab type, reusing the app's canonical data-type palette. */
@@ -46,5 +47,6 @@ export const TYPE_COLOR = {
   application: colorForType("any"),
   page: colorForType("any"),
   "project-list": PROJECT_COLOR,
-  project: PROJECT_COLOR
+  project: PROJECT_COLOR,
+  "project-new": PROJECT_COLOR
 } satisfies Record<WorkspaceTabType, string>;

--- a/web/src/hooks/useProjects.ts
+++ b/web/src/hooks/useProjects.ts
@@ -8,9 +8,29 @@ import { useCallback } from "react";
 
 import { trpc, trpcClient } from "../trpc/client";
 import {
+  PROJECT_NEW_REF,
   useWorkspaceTabsStore,
   type ProjectTabDocument
 } from "../stores/WorkspaceTabsStore";
+
+/**
+ * Open the surface a project is started from. One tab, so every entry point —
+ * the `+ New` menu, the list's ghost card, its header button — lands on the
+ * same one rather than stacking copies.
+ */
+export const useOpenNewProjectTab = () => {
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  return useCallback(
+    () =>
+      openTab({
+        type: "project-new",
+        ref: PROJECT_NEW_REF,
+        mode: "view",
+        title: "New project"
+      }),
+    [openTab]
+  );
+};
 
 export const useProjects = () =>
   trpc.projects.list.useQuery({}, { staleTime: 30_000 });

--- a/web/src/stores/WorkspaceTabsStore.ts
+++ b/web/src/stores/WorkspaceTabsStore.ts
@@ -40,7 +40,10 @@ export type WorkspaceTabType =
   // The projects list. One per workspace — `ref` is the constant below.
   | "project-list"
   // A project's overview. `ref` is a project id (trpc.projects.*).
-  | "project";
+  | "project"
+  // The surface a project is started from. One per workspace — `ref` is the
+  // constant below, and the tab closes once the project it described exists.
+  | "project-new";
 
 export type WorkspaceTabMode = "view" | "edit";
 
@@ -130,6 +133,9 @@ export const LOOSE_PROJECT_ID = "default";
 
 /** The projects list is one tab, so its `ref` is a constant. */
 export const PROJECT_LIST_REF = "projects";
+
+/** The new-project surface is one tab, so its `ref` is a constant too. */
+export const PROJECT_NEW_REF = "new";
 
 export const tabId = (type: WorkspaceTabType, ref: string): string =>
   `${type}:${ref}`;


### PR DESCRIPTION
## What changed

Phase 4 of `docs/plans/project-view/PLAN.md`: the surface a project begins on. A new `project-new` tab asks what you want to make, takes a shape shortcut, and on Start creates the project row, opens its group at the overview, and hands the prompt to the project's own agent thread — the new-project tab stages the turn and the overview's panel sends it once its history has loaded, because a full load replaces the message cache and would otherwise wipe a turn sent before it. Ref images ride along as message content and entities picked from the library are named in the turn, which is how `injectEntities` matches them. The estimate line is read off the user's own past projects of the same kind and only from two or more whose spend carries no unpriced calls — fewer than that shows no line rather than a number nobody measured. `+ New` now leads with "Start a project…" and keeps its document list beneath it; that list and the surface's 6-column blank-document strip come from one `newDocumentCatalog` hook, so they cannot drift, and the strip passes the loose bucket as its caption promises. The projects list's name dialog is gone: its button and ghost card open the surface instead.

Two deliberate departures from the mockup. There is no "Research report" shape — its documents would be a workflow and a text file, neither of which carries a `project_id`, so the overview would show an empty project. There is no voice chip — a voice is bound per speaker inside a script, and a project row has nowhere to keep one. The rail still opens the projects list, which carries both entry points into the new surface.

## Verification

- [x] `npm run test:affected` — 222 suites, 1776 passed, 3 skipped
- [x] `npm run typecheck` — web clean. The mobile leg fails on missing `react-native`/`expo` modules: `mobile/node_modules` was never installed in this container, and nothing here touches mobile.
- [x] `npm run lint` — exit 0
- [ ] `npm run dev:nodetool -- harness gate --base main` — not run against a useful base: this container's local `main` is behind `origin/main`, so the gate selected surfaces from unrelated merged commits. The diff is web UI only and maps to no harness selfcheck.

The panel's ordering guarantee is pinned rather than assumed: `ProjectAgentPanel.test.tsx` asserts the history load precedes the send. It failed first — the staged turn went out before `loadMessages` for a project that already named its thread — which is what the `historyLoaded` flag fixes.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8p5YaffRM7vhkrTXctsrV)_