### PR TITLE
feat(projects): jump between a shot, its line, and its clip

### DIFF
--- a/web/src/components/script/ScriptDocumentPane.tsx
+++ b/web/src/components/script/ScriptDocumentPane.tsx
@@ -45,6 +45,7 @@ import { useScriptPlaythrough } from "../../hooks/script/useScriptPlaythrough";
 import { useAssembleScriptTimeline } from "../../hooks/script/useAssembleScriptTimeline";
 import ScriptLineRow, { TEXT_INSET, type LineKeyNav } from "./ScriptLineRow";
 import { useScriptLineShotLink } from "../../hooks/script/useScriptShotLinks";
+import { useScriptLineFocus } from "../../hooks/script/useScriptLineFocus";
 import StoryboardLinkControl from "./StoryboardLinkControl";
 import ScriptSaveIndicator from "./ScriptSaveIndicator";
 
@@ -258,7 +259,7 @@ const SectionLine = memo(function SectionLine({
 const SectionBlockInner = ({
   scriptId,
   section,
-  currentLineId,
+  highlightedLineId,
   readOnly,
   mobile,
   dnd,
@@ -266,7 +267,8 @@ const SectionBlockInner = ({
 }: {
   scriptId: string;
   section: ScriptSection;
-  currentLineId: string | null;
+  /** The line drawn as highlighted: the one playing, or one jumped to. */
+  highlightedLineId: string | null;
   readOnly: boolean;
   mobile: boolean;
   dnd: LineDnd;
@@ -373,7 +375,7 @@ const SectionBlockInner = ({
           index={index}
           nextLineId={section.lines[index + 1]?.id ?? null}
           cast={cast}
-          highlighted={line.id === currentLineId}
+          highlighted={line.id === highlightedLineId}
           readOnly={readOnly}
           mobile={mobile}
           inset={inset}
@@ -441,6 +443,10 @@ const ScriptDocumentPane = ({
   const onRedo = useCallback(() => redo(scriptId), [redo, scriptId]);
   const { playing, currentLineId, play, stop } =
     useScriptPlaythrough(scriptId);
+  // A shot's "Appears in" chip opens the script at one line; playback's own
+  // highlight wins while it runs.
+  const focusedLineId = useScriptLineFocus(scriptId, sections.length > 0);
+  const highlightedLineId = currentLineId ?? focusedLineId;
   const [voicingAll, setVoicingAll] = useState(false);
   const { assemble, assembling, error: assembleError } =
     useAssembleScriptTimeline();
@@ -742,7 +748,7 @@ const ScriptDocumentPane = ({
             key={section.id}
             scriptId={scriptId}
             section={section}
-            currentLineId={currentLineId}
+            highlightedLineId={highlightedLineId}
             readOnly={readOnly}
             mobile={isMobile}
             dnd={dnd}

--- a/web/src/components/script/ScriptLineRow.tsx
+++ b/web/src/components/script/ScriptLineRow.tsx
@@ -481,6 +481,7 @@ const ScriptLineRow = ({
       <FlexColumn
         gap={SPACING.xs}
         fullWidth
+        data-line-id={line.id}
         sx={{
           position: "relative",
           padding: SPACING.sm,
@@ -506,6 +507,7 @@ const ScriptLineRow = ({
       align="flex-start"
       gap={SPACING.md}
       fullWidth
+      data-line-id={line.id}
       onDragOver={onDragOver}
       onDrop={onDrop}
       sx={{

--- a/web/src/components/script/__tests__/ScriptDocumentPane.lineFocus.test.tsx
+++ b/web/src/components/script/__tests__/ScriptDocumentPane.lineFocus.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import {
+  useScriptStore,
+  type ScriptTake
+} from "../../../stores/script/ScriptStore";
+import { useDocumentFocusStore } from "../../../stores/DocumentFocusStore";
+
+// The gutter's storyboard link reads the board through trpc when it is not
+// open; this suite renders no query client and only reads the line rows.
+jest.mock("../../../trpc/client", () => ({
+  trpc: {
+    storyboards: { get: { useQuery: jest.fn(() => ({ data: undefined })) } }
+  },
+  trpcClient: {}
+}));
+
+// The link control owns its own suite and its own trpc query.
+jest.mock("../StoryboardLinkControl", () => ({
+  __esModule: true,
+  default: () => null
+}));
+
+import ScriptDocumentPane from "../ScriptDocumentPane";
+
+const SCRIPT_ID = "script-1";
+
+const take = (): ScriptTake => ({
+  id: "take-a",
+  assetId: "voice-a",
+  durationMs: 2000,
+  words: [],
+  textSnapshot: "Hello",
+  voiceSnapshot: null,
+  createdAt: "2026-01-01T00:00:00.000Z"
+});
+
+const seed = () => {
+  useScriptStore.setState({ scripts: {}, history: {}, saveStatus: {} });
+  useScriptStore.getState().loadScript(SCRIPT_ID, {
+    title: "My script",
+    cast: [],
+    sections: [
+      {
+        id: "s1",
+        lines: [
+          { id: "line-a", text: "Hello", takes: [take()], currentTakeId: "take-a" },
+          { id: "line-b", text: "Goodbye", takes: [], currentTakeId: null }
+        ]
+      }
+    ],
+    timelineId: null,
+    storyboardId: "board-1"
+  });
+};
+
+const renderPane = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ScriptDocumentPane scriptId={SCRIPT_ID} readOnly={false} />
+    </ThemeProvider>
+  );
+
+/** The row element carrying `lineId`, as the deep link's scroll finds it. */
+const row = (lineId: string): HTMLElement => {
+  const el = document.querySelector<HTMLElement>(`[data-line-id="${lineId}"]`);
+  if (!el) {
+    throw new Error(`no row for line ${lineId}`);
+  }
+  return el;
+};
+
+// jsdom implements no layout, so scrolling is observed rather than performed.
+const scrollIntoView = jest.fn();
+
+describe("ScriptDocumentPane line focus", () => {
+  beforeEach(() => {
+    scrollIntoView.mockClear();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    useDocumentFocusStore.setState({ pending: null });
+    seed();
+  });
+
+  it("scrolls to the line a cross-document link asked for", () => {
+    useDocumentFocusStore.getState().requestDocumentFocus({
+      type: "script",
+      ref: SCRIPT_ID,
+      lineId: "line-b"
+    });
+    renderPane();
+
+    expect(screen.getByDisplayValue("Goodbye")).toBeInTheDocument();
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(scrollIntoView.mock.instances[0]).toBe(row("line-b"));
+    // One-shot: a later render must not re-apply it.
+    expect(useDocumentFocusStore.getState().pending).toBeNull();
+  });
+
+  it("leaves a request for another script alone", () => {
+    const request = {
+      type: "script" as const,
+      ref: "script-other",
+      lineId: "line-b"
+    };
+    useDocumentFocusStore.getState().requestDocumentFocus(request);
+    renderPane();
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(useDocumentFocusStore.getState().pending).toBe(request);
+  });
+});

--- a/web/src/components/storyboard/ShotInspector.tsx
+++ b/web/src/components/storyboard/ShotInspector.tsx
@@ -55,6 +55,8 @@ import {
 import { useEntities } from "../../serverState/useEntities";
 import { getEntityChipSx, getEntityKindDotSx } from "../entities/entityKind";
 import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import { requestDocumentFocus } from "../../stores/DocumentFocusStore";
+import { useShotTimelineLink } from "../../hooks/storyboard/useShotTimelineLink";
 import { isShotGenerating } from "./ShotStatusPill";
 import { colorForType } from "../../config/data_types";
 import { hexToRgba } from "../../utils/ColorUtils";
@@ -92,6 +94,9 @@ const STATUS_META: Record<
 /** Sky — the app's colour for anything script- or voice-shaped. */
 const SCRIPT_COLOR = colorForType("audio");
 
+/** Violet — the app's colour for anything picture-shaped. */
+const TIMELINE_COLOR = colorForType("video");
+
 /**
  * Secondary actions read as text rather than as a row of equal accent links;
  * only the step the shot has not taken yet keeps the accent.
@@ -109,12 +114,16 @@ const quietChipSx = {
 } as const;
 
 /** A cross-document link chip, tinted by the document type it points at. */
-const linkChipSx = {
-  height: `${CONTROL.height.xs}px`,
-  borderRadius: BORDER_RADIUS.md,
-  borderColor: hexToRgba(SCRIPT_COLOR, 0.35),
-  color: SCRIPT_COLOR
-} as const;
+const linkChipSx = (color: string) =>
+  ({
+    height: `${CONTROL.height.xs}px`,
+    borderRadius: BORDER_RADIUS.md,
+    borderColor: hexToRgba(color, 0.35),
+    color
+  }) as const;
+
+const scriptChipSx = linkChipSx(SCRIPT_COLOR);
+const timelineChipSx = linkChipSx(TIMELINE_COLOR);
 
 const cameraLine = (shot: Shot): string =>
   [
@@ -226,27 +235,41 @@ const ShotInspectorInner: React.FC<ShotInspectorProps> = ({
     .filter((p): p is string => p !== null)
     .join(" · ");
 
-  // Where this shot lands in the project's other documents. Only the script
-  // link exists today; the timeline chip arrives with the timeline mapping.
+  // Where this shot lands in the project's other documents: the script line it
+  // covers, and the clip it owns in the assembled cut.
   const scriptLines = useBoardScriptLines(boardId);
-  const scriptLinkLabel = useMemo(() => {
+  const scriptLink = useMemo(() => {
     const ids = shot.script_line_ids ?? [];
     if (!scriptId || ids.length === 0) {
       return null;
     }
     const order = [...scriptLines.keys()];
-    const position = ids
-      .map((id) => order.indexOf(id))
-      .filter((i) => i >= 0)
-      .sort((a, b) => a - b)[0];
-    return position == null ? "Script" : `Script · line ${position + 1}`;
+    const first = ids
+      .map((id) => ({ id, position: order.indexOf(id) }))
+      .filter((entry) => entry.position >= 0)
+      .sort((a, b) => a.position - b.position)[0];
+    return {
+      lineId: first?.id ?? null,
+      label: first ? `Script · line ${first.position + 1}` : "Script"
+    };
   }, [scriptId, scriptLines, shot.script_line_ids]);
+  const timelineLink = useShotTimelineLink(boardId, shot.id);
 
   const handleOpenScript = useCallback(() => {
-    if (scriptId) {
-      openTab({ type: "script", ref: scriptId, mode: "edit", title: "Script" });
+    if (!scriptId) {
+      return;
     }
-  }, [openTab, scriptId]);
+    // Park the line before the tab opens: the script pane reads the request as
+    // it renders, and scrolls to the line rather than to the top.
+    if (scriptLink?.lineId) {
+      requestDocumentFocus({
+        type: "script",
+        ref: scriptId,
+        lineId: scriptLink.lineId
+      });
+    }
+    openTab({ type: "script", ref: scriptId, mode: "edit", title: "Script" });
+  }, [openTab, scriptId, scriptLink]);
 
   const handleToggleDurationSource = useCallback(() => {
     updateShot(boardId, shot.id, {
@@ -315,16 +338,27 @@ const ShotInspectorInner: React.FC<ShotInspectorProps> = ({
         </Box>
         <Divider orientation="vertical" flexItem />
         <Caption color="secondary">Appears in</Caption>
-        {scriptLinkLabel ? (
+        {timelineLink && (
           <Chip
             compact
             variant="outlined"
-            label={scriptLinkLabel}
-            sx={linkChipSx}
+            label={timelineLink.label}
+            sx={timelineChipSx}
+            onClick={timelineLink.open}
+            title="Open the cut with this shot's clip selected"
+          />
+        )}
+        {scriptLink && (
+          <Chip
+            compact
+            variant="outlined"
+            label={scriptLink.label}
+            sx={scriptChipSx}
             onClick={handleOpenScript}
             title="Open the script this shot's lines come from"
           />
-        ) : (
+        )}
+        {!timelineLink && !scriptLink && (
           <Caption color="muted">nothing yet</Caption>
         )}
         <Box sx={{ flex: 1 }} />

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -46,6 +46,7 @@ import {
   useStoryboardCanRedo
 } from "../../stores/storyboard/StoryboardStore";
 import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
+import { useStoryboardShotFocus } from "../../hooks/storyboard/useStoryboardShotFocus";
 import {
   useImageModelsByProvider,
   type ImageModelTask
@@ -155,6 +156,9 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
     shots,
     activeShotId
   } = useBoard(boardId);
+
+  // Land on the shot a script line or a cut clip linked to, once it has loaded.
+  useStoryboardShotFocus(boardId);
 
   const inStudio = useInStudio();
   const setTitle = useStoryboardStore((state) => state.setTitle);

--- a/web/src/components/storyboard/__tests__/ShotInspector.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotInspector.test.tsx
@@ -23,6 +23,8 @@ const removeKeyframeVersionMock = jest.fn();
 const removeClipVersionMock = jest.fn();
 /** Script the board links, if any — set per test before rendering. */
 let linkedScriptId: string | null = null;
+/** Assembled cut the board links, if any — set per test before rendering. */
+let linkedTimelineId: string | null = null;
 jest.mock("../../../stores/storyboard/StoryboardStore", () => {
   const actual = jest.requireActual(
     "../../../stores/storyboard/StoryboardStore"
@@ -42,6 +44,7 @@ jest.mock("../../../stores/storyboard/StoryboardStore", () => {
         boards: {
           "board-1": {
             entityIds: [],
+            timelineId: linkedTimelineId,
             screenplay: linkedScriptId ? { script_id: linkedScriptId } : null
           }
         }
@@ -92,6 +95,45 @@ jest.mock("../../../trpc/client", () => ({
               }
             : { data: undefined }
       }
+    },
+    timeline: {
+      get: {
+        useQuery: (_input: { id: string }, options?: { enabled?: boolean }) =>
+          options?.enabled
+            ? {
+                data: {
+                  id: "timeline-1",
+                  name: "Aurora cut",
+                  clips: [
+                    {
+                      id: "clip-shot-1",
+                      mediaType: "video",
+                      startMs: 12_000,
+                      storyboardBoardId: "board-1",
+                      storyboardShotId: "shot-1"
+                    },
+                    // The shot's audio twin and the voiceover clip covering it
+                    // carry the same shot keys; neither is the shot's clip.
+                    {
+                      id: "clip-shot-1-audio",
+                      mediaType: "audio",
+                      startMs: 12_000,
+                      storyboardBoardId: "board-1",
+                      storyboardShotId: "shot-1"
+                    },
+                    {
+                      id: "clip-vo-1",
+                      mediaType: "video",
+                      startMs: 12_500,
+                      storyboardBoardId: "board-1",
+                      storyboardShotId: "shot-1",
+                      scriptLineId: "line-1"
+                    }
+                  ]
+                }
+              }
+            : { data: undefined }
+      }
     }
   },
   trpcClient: {}
@@ -114,6 +156,7 @@ jest.mock("../ShotScriptPanel", () => stub("script-panel"));
 
 import ShotInspector from "../ShotInspector";
 import { useWorkspaceTabsStore } from "../../../stores/WorkspaceTabsStore";
+import { useDocumentFocusStore } from "../../../stores/DocumentFocusStore";
 
 const makeShot = (overrides: Partial<Shot> = {}): Shot => ({
   type: "shot",
@@ -325,8 +368,10 @@ describe("ShotInspector", () => {
 describe("ShotInspector cross-document links", () => {
   beforeEach(() => {
     linkedScriptId = null;
+    linkedTimelineId = null;
     lineIsVoiced = true;
     useWorkspaceTabsStore.setState({ tabs: [], activeTabId: null });
+    useDocumentFocusStore.setState({ pending: null });
   });
 
   it("says nothing appears elsewhere for an unlinked shot", () => {
@@ -334,7 +379,7 @@ describe("ShotInspector cross-document links", () => {
     expect(screen.getByText("nothing yet")).toBeInTheDocument();
   });
 
-  it("links to the script line the shot covers", async () => {
+  it("links to the script line the shot covers, and opens it there", async () => {
     linkedScriptId = "script-1";
     renderInspector(makeShot({ script_line_ids: ["line-1"] }));
 
@@ -345,6 +390,37 @@ describe("ShotInspector cross-document links", () => {
     expect(tabs.some((t) => t.type === "script" && t.ref === "script-1")).toBe(
       true
     );
+    expect(useDocumentFocusStore.getState().pending).toEqual({
+      type: "script",
+      ref: "script-1",
+      lineId: "line-1"
+    });
+  });
+
+  it("links to the clip the shot owns in the cut, at its timecode", async () => {
+    linkedTimelineId = "timeline-1";
+    renderInspector(makeShot());
+
+    await userEvent.click(screen.getByText("Aurora cut at 00:12"));
+
+    const tabs = useWorkspaceTabsStore.getState().tabs;
+    expect(
+      tabs.some((t) => t.type === "timeline" && t.ref === "timeline-1")
+    ).toBe(true);
+    // The shot's own clip — not its audio twin, not a voiceover clip covering
+    // it — is the one the cut is opened on.
+    expect(useDocumentFocusStore.getState().pending).toEqual({
+      type: "timeline",
+      ref: "timeline-1",
+      clipId: "clip-shot-1"
+    });
+  });
+
+  it("omits the cut chip while the board carries no shot clip there", () => {
+    linkedTimelineId = "timeline-1";
+    renderInspector(makeShot({ id: "shot-2" }));
+    expect(screen.queryByText(/Aurora cut at/)).not.toBeInTheDocument();
+    expect(screen.getByText("nothing yet")).toBeInTheDocument();
   });
 });
 

--- a/web/src/components/timeline/Inspector/ClipStoryboardLink.tsx
+++ b/web/src/components/timeline/Inspector/ClipStoryboardLink.tsx
@@ -1,0 +1,61 @@
+/**
+ * ClipStoryboardLink
+ *
+ * The cut's half of the board ↔ cut link: a chip on a clip that came from a
+ * storyboard shot, naming the shot and jumping back to it on the board. The
+ * board's own selection footer draws the same link in the other direction.
+ *
+ * Renders nothing for a clip carrying no shot provenance, or while the board
+ * it names cannot be read.
+ */
+
+import { memo } from "react";
+import type { TimelineClip } from "@nodetool-ai/timeline";
+
+import { Chip, FlexRow, BORDER_RADIUS, CONTROL, SPACING } from "../../ui_primitives";
+import { colorForType } from "../../../config/data_types";
+import { hexToRgba } from "../../../utils/ColorUtils";
+import { useClipStoryboardLink } from "../../../hooks/timeline/useClipStoryboardLink";
+
+/** Violet — the app's colour for anything picture-shaped. */
+const BOARD_COLOR = colorForType("video");
+
+const chipSx = {
+  height: `${CONTROL.height.xs}px`,
+  borderRadius: BORDER_RADIUS.md,
+  borderColor: hexToRgba(BOARD_COLOR, 0.4),
+  color: BOARD_COLOR
+} as const;
+
+interface ClipStoryboardLinkProps {
+  clip: TimelineClip;
+}
+
+const ClipStoryboardLinkInner = ({ clip }: ClipStoryboardLinkProps) => {
+  const link = useClipStoryboardLink(
+    clip.storyboardBoardId,
+    clip.storyboardShotId
+  );
+
+  if (!link) {
+    return null;
+  }
+
+  return (
+    <FlexRow align="center" sx={{ px: SPACING.xs, pb: SPACING.xs }}>
+      <Chip
+        compact
+        variant="outlined"
+        label={link.label}
+        sx={chipSx}
+        onClick={link.open}
+        title={`Open ${link.shot.slug ?? "this shot"} on the storyboard`}
+      />
+    </FlexRow>
+  );
+};
+
+export const ClipStoryboardLink = memo(ClipStoryboardLinkInner);
+ClipStoryboardLink.displayName = "ClipStoryboardLink";
+
+export default ClipStoryboardLink;

--- a/web/src/components/timeline/Inspector/TimelineInspector.tsx
+++ b/web/src/components/timeline/Inspector/TimelineInspector.tsx
@@ -38,6 +38,7 @@ import {
   parseTimecode
 } from "./InspectorPrimitives.helpers";
 import { ClipAdjustments } from "./ClipAdjustments";
+import { ClipStoryboardLink } from "./ClipStoryboardLink";
 import { ClipAnimations } from "./ClipAnimations";
 import { GeneratedClipPanel } from "./GeneratedClipPanel";
 import { DirectGenClipPanel } from "./DirectGenClipPanel";
@@ -249,6 +250,10 @@ export const TimelineInspector: React.FC = memo(() => {
         metadata={identityMeta}
         accentColor={accentColor}
       />
+
+      {/* Shot clips are assembled as imported media, so this branch is the
+          only one a board link can reach. */}
+      <ClipStoryboardLink clip={clip} />
 
       {textStyle && (
         <>

--- a/web/src/components/timeline/Inspector/__tests__/ClipStoryboardLink.test.tsx
+++ b/web/src/components/timeline/Inspector/__tests__/ClipStoryboardLink.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * The cut's half of the board ↔ cut link: a clip that came from a shot names
+ * it and jumps back with that shot selected.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import type { TimelineClip } from "@nodetool-ai/timeline";
+import mockTheme from "../../../../__mocks__/themeMock";
+
+/** Board served over trpc, i.e. one that is not open in a tab. */
+jest.mock("../../../../trpc/client", () => ({
+  trpc: {
+    storyboards: {
+      get: {
+        useQuery: (_input: { id: string }, options?: { enabled?: boolean }) =>
+          options?.enabled
+            ? {
+                data: {
+                  id: "board-1",
+                  name: "Aurora board",
+                  document: {
+                    shots: [
+                      {
+                        type: "shot",
+                        id: "shot-1",
+                        index: 2,
+                        slug: "Doorway",
+                        action: "A closed door",
+                        status: "rendered"
+                      }
+                    ]
+                  }
+                }
+              }
+            : { data: undefined }
+      }
+    }
+  },
+  trpcClient: {}
+}));
+
+import ClipStoryboardLink from "../ClipStoryboardLink";
+import { useStoryboardStore } from "../../../../stores/storyboard/StoryboardStore";
+import { useWorkspaceTabsStore } from "../../../../stores/WorkspaceTabsStore";
+import { useDocumentFocusStore } from "../../../../stores/DocumentFocusStore";
+
+const clip = (overrides: Partial<TimelineClip> = {}): TimelineClip =>
+  ({
+    id: "clip-1",
+    trackId: "track-1",
+    name: "Doorway",
+    startMs: 12_000,
+    durationMs: 4000,
+    mediaType: "video",
+    sourceType: "imported",
+    status: "generated",
+    locked: false,
+    versions: [],
+    ...overrides
+  }) as TimelineClip;
+
+const renderLink = (c: TimelineClip) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ClipStoryboardLink clip={c} />
+    </ThemeProvider>
+  );
+
+describe("ClipStoryboardLink", () => {
+  beforeEach(() => {
+    useWorkspaceTabsStore.setState({ tabs: [], activeTabId: null });
+    useStoryboardStore.setState({ boards: {} });
+    useDocumentFocusStore.setState({ pending: null });
+  });
+
+  it("shows nothing for a clip that came from no shot", () => {
+    const { container } = renderLink(clip());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("names the shot and opens the board on it", async () => {
+    renderLink(
+      clip({ storyboardBoardId: "board-1", storyboardShotId: "shot-1" })
+    );
+
+    await userEvent.click(screen.getByText("from Board · SH 03"));
+
+    const tabs = useWorkspaceTabsStore.getState().tabs;
+    expect(
+      tabs.some((t) => t.type === "storyboard" && t.ref === "board-1")
+    ).toBe(true);
+    // The board is not open yet, so the shot rides along as a focus request
+    // the board applies once it has loaded.
+    expect(useDocumentFocusStore.getState().pending).toEqual({
+      type: "storyboard",
+      ref: "board-1",
+      shotId: "shot-1"
+    });
+  });
+
+  it("shows nothing while the board carries no such shot", () => {
+    const { container } = renderLink(
+      clip({ storyboardBoardId: "board-1", storyboardShotId: "shot-gone" })
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -79,6 +79,7 @@ import {
   useGeneratingCount,
   useFailedCount
 } from "../../stores/timeline/TimelineGenerationStore";
+import { useTimelineClipFocus } from "../../hooks/timeline/useTimelineClipFocus";
 import { useWorkflowFreshnessCheck } from "../../hooks/timeline/useWorkflowFreshnessCheck";
 import { useTimelineGenerationSubscriptions } from "../../hooks/timeline/useGenerateClip";
 import { useLoadTimelineIntoStore } from "../../hooks/timeline/useLoadTimelineIntoStore";
@@ -505,6 +506,9 @@ const TimelineEditorBody: React.FC<
 
   // Imperative save for the Save button (forces an immediate PATCH).
   const { save: handleSave, isSaving } = useTimelineSave();
+
+  // Land on the clip a cross-document link asked for, once it has loaded.
+  useTimelineClipFocus(sequenceId);
 
   // Reconcile clips against current workflow state on mount.
   useWorkflowFreshnessCheck(sequenceId ?? null);

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -368,6 +368,24 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
       }
     }, []);
 
+    // A deep link into the cut (a storyboard shot's clip) selects a clip that
+    // may sit off-screen. `revealRequest` carries the position it wants seen;
+    // bring it a quarter-viewport in, and leave the view alone when it is
+    // already comfortably inside. Zoom is read imperatively so a later zoom
+    // does not re-run this against a stale request.
+    const revealRequest = useTimelineUIStore((s) => s.revealRequest);
+    useEffect(() => {
+      const el = scrollableRef.current;
+      if (!el || !revealRequest) return;
+      const targetPx = revealRequest.timeMs / uiStoreApi.getState().msPerPx;
+      const margin = el.clientWidth * 0.25;
+      const tooFarLeft = targetPx < el.scrollLeft + margin;
+      const tooFarRight = targetPx > el.scrollLeft + el.clientWidth - margin;
+      if (tooFarLeft || tooFarRight) {
+        el.scrollLeft = Math.max(0, targetPx - margin);
+      }
+    }, [revealRequest, uiStoreApi]);
+
     const handleScroll = useCallback(
       (e: React.UIEvent<HTMLDivElement>) => {
         setScrollLeftPx(e.currentTarget.scrollLeft);

--- a/web/src/hooks/script/useScriptLineFocus.ts
+++ b/web/src/hooks/script/useScriptLineFocus.ts
@@ -1,0 +1,47 @@
+/**
+ * useScriptLineFocus
+ *
+ * The receiving half of a deep link into a script. A storyboard shot's
+ * "Appears in" chip parks a line id before opening the script tab; this runs
+ * inside the pane and, once the document has lines, highlights that line and
+ * scrolls it into view.
+ *
+ * The request is one-shot — dropped as soon as it is applied — but the
+ * highlight is not: it stays until playback or another link moves it, the way
+ * a jumped-to line should stay findable.
+ */
+
+import { useEffect, useState } from "react";
+
+import {
+  useDocumentFocusRequest,
+  useDocumentFocusStore
+} from "../../stores/DocumentFocusStore";
+
+export const useScriptLineFocus = (
+  scriptId: string | null | undefined,
+  ready: boolean
+): string | null => {
+  const request = useDocumentFocusRequest("script", scriptId);
+  const clearDocumentFocus = useDocumentFocusStore(
+    (state) => state.clearDocumentFocus
+  );
+  const [focusedLineId, setFocusedLineId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!request || !ready) {
+      return;
+    }
+    setFocusedLineId(request.lineId);
+    clearDocumentFocus(request);
+    // `scrollIntoView` is absent under jsdom, so the call is guarded rather
+    // than the test environment stubbed.
+    document
+      .querySelector<HTMLElement>(`[data-line-id="${request.lineId}"]`)
+      ?.scrollIntoView?.({ block: "center" });
+  }, [request, ready, clearDocumentFocus]);
+
+  return focusedLineId;
+};
+
+export default useScriptLineFocus;

--- a/web/src/hooks/script/useScriptShotLinks.ts
+++ b/web/src/hooks/script/useScriptShotLinks.ts
@@ -16,6 +16,7 @@ import { trpc } from "../../trpc/client";
 import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
 import { useScriptStoryboardLink } from "../../stores/script/ScriptStore";
 import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import { requestDocumentFocus } from "../../stores/DocumentFocusStore";
 
 /** The shot covering one line, and how to go look at it. */
 export interface ScriptLineShotLink {
@@ -75,10 +76,16 @@ export const useScriptLineShotLink = (
     if (!boardId || !shot) {
       return;
     }
+    // Park the shot before the tab opens: a board that is not already open has
+    // no store entry to select in yet, so selecting here would land on nothing.
+    requestDocumentFocus({
+      type: "storyboard",
+      ref: boardId,
+      shotId: shot.id
+    });
     useWorkspaceTabsStore
       .getState()
       .openTab({ type: "storyboard", ref: boardId, mode: "edit" });
-    useStoryboardStore.getState().selectShot(boardId, shot.id);
   }, [boardId, shots, lineId]);
 
   return useMemo(() => {

--- a/web/src/hooks/storyboard/__tests__/useStoryboardShotFocus.test.tsx
+++ b/web/src/hooks/storyboard/__tests__/useStoryboardShotFocus.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment jsdom
+ *
+ * A shot parked by a sibling document is applied once the board carries it —
+ * which is the point: the click happens before the board has loaded.
+ */
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import { act, renderHook } from "@testing-library/react";
+import type { Shot } from "@nodetool-ai/protocol";
+
+import { useStoryboardStore } from "../../../stores/storyboard/StoryboardStore";
+import { useDocumentFocusStore } from "../../../stores/DocumentFocusStore";
+import { useStoryboardShotFocus } from "../useStoryboardShotFocus";
+
+const shot = (id: string, index: number): Shot => ({
+  type: "shot",
+  id,
+  index,
+  slug: `Shot ${index + 1}`,
+  action: "A closed door",
+  status: "planned"
+});
+
+const loadBoard = (shots: Shot[]): void => {
+  act(() =>
+    useStoryboardStore.getState().loadBoard("board-1", {
+      title: "Aurora board",
+      brief: "",
+      style: "",
+      entityIds: [],
+      aspectRatio: "16:9",
+      directorModel: null,
+      imageModel: null,
+      videoModel: null,
+      screenplay: null,
+      activeShotId: null,
+      timelineId: null,
+      shots
+    })
+  );
+};
+
+beforeEach(() => {
+  useStoryboardStore.setState({ boards: {}, history: {} });
+  useDocumentFocusStore.setState({ pending: null });
+});
+
+describe("useStoryboardShotFocus", () => {
+  it("selects the shot once the board has loaded it", () => {
+    useDocumentFocusStore.getState().requestDocumentFocus({
+      type: "storyboard",
+      ref: "board-1",
+      shotId: "shot-2"
+    });
+
+    renderHook(() => useStoryboardShotFocus("board-1"));
+    // Nothing to select yet — the board is still loading.
+    expect(useDocumentFocusStore.getState().pending).not.toBeNull();
+
+    loadBoard([shot("shot-1", 0), shot("shot-2", 1)]);
+
+    expect(useStoryboardStore.getState().boards["board-1"].activeShotId).toBe(
+      "shot-2"
+    );
+    expect(useDocumentFocusStore.getState().pending).toBeNull();
+  });
+
+  it("leaves a request for another board alone", () => {
+    const request = {
+      type: "storyboard" as const,
+      ref: "board-other",
+      shotId: "shot-1"
+    };
+    useDocumentFocusStore.getState().requestDocumentFocus(request);
+    loadBoard([shot("shot-1", 0)]);
+
+    renderHook(() => useStoryboardShotFocus("board-1"));
+
+    expect(
+      useStoryboardStore.getState().boards["board-1"].activeShotId
+    ).toBeNull();
+    expect(useDocumentFocusStore.getState().pending).toBe(request);
+  });
+});

--- a/web/src/hooks/storyboard/useShotTimelineLink.ts
+++ b/web/src/hooks/storyboard/useShotTimelineLink.ts
@@ -1,0 +1,113 @@
+/**
+ * useShotTimelineLink
+ *
+ * Where a shot lands in the cut. `buildStoryboardTimeline` stamps every clip
+ * it lays down with `storyboardBoardId`/`storyboardShotId`, so the mapping is
+ * read back off the assembled sequence rather than recomputed — a cut the user
+ * has since trimmed or re-ordered reports where the clip *is*, not where an
+ * assemble would put it again.
+ *
+ * The board names its sequence (`board.timelineId`), and the persisted
+ * document is what gets read: a timeline's live stores belong to its own
+ * editor instance and only exist while its tab is open.
+ */
+
+import { useCallback, useMemo } from "react";
+import type { TimelineClip } from "@nodetool-ai/timeline";
+
+import { trpc } from "../../trpc/client";
+import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import { requestDocumentFocus } from "../../stores/DocumentFocusStore";
+
+/** The clip a shot owns in the assembled cut, and how to go look at it. */
+export interface ShotTimelineLink {
+  timelineId: string;
+  clipId: string;
+  startMs: number;
+  /** "Cut v2 at 00:12" — the sequence and where the shot sits in it. */
+  label: string;
+  /** Open the timeline's tab with the clip selected. */
+  open: () => void;
+}
+
+/** 12_000 → "00:12". */
+const timecode = (ms: number): string => {
+  const total = Math.max(0, Math.round(ms / 1000));
+  const mins = Math.floor(total / 60);
+  const secs = total % 60;
+  return `${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+};
+
+/**
+ * The shot's own clip: the video one. A jointly assembled cut stamps the shot
+ * keys onto the voiceover clips covering it too, and those belong to the
+ * script's lines — the audio twin carries no line either, so both keys matter.
+ */
+const shotClipOf = (
+  clips: TimelineClip[],
+  boardId: string,
+  shotId: string
+): TimelineClip | undefined =>
+  clips.find(
+    (clip) =>
+      clip.storyboardShotId === shotId &&
+      clip.storyboardBoardId === boardId &&
+      clip.mediaType === "video" &&
+      !clip.scriptLineId
+  );
+
+export const useShotTimelineLink = (
+  boardId: string,
+  shotId: string
+): ShotTimelineLink | null => {
+  const timelineId = useStoryboardStore(
+    (state) => state.boards[boardId]?.timelineId ?? null
+  );
+  const { data } = trpc.timeline.get.useQuery(
+    { id: timelineId ?? "" },
+    { enabled: !!timelineId, staleTime: 30_000, retry: false }
+  );
+
+  const clip = useMemo(() => {
+    if (!data) {
+      return undefined;
+    }
+    // SAFETY: `timeline.get` types the document as the passthrough zod mirror
+    // of the store's `TimelineClip` — the same payload, structurally described.
+    return shotClipOf(data.clips as TimelineClip[], boardId, shotId);
+  }, [data, boardId, shotId]);
+
+  const open = useCallback(() => {
+    if (!timelineId || !clip) {
+      return;
+    }
+    requestDocumentFocus({
+      type: "timeline",
+      ref: timelineId,
+      clipId: clip.id
+    });
+    useWorkspaceTabsStore.getState().openTab({
+      type: "timeline",
+      ref: timelineId,
+      mode: "edit",
+      title: data?.name
+    });
+  }, [timelineId, clip, data?.name]);
+
+  return useMemo(() => {
+    if (!timelineId || !clip) {
+      return null;
+    }
+    const name = data?.name?.trim() || "Timeline";
+    return {
+      timelineId,
+      clipId: clip.id,
+      startMs: clip.startMs,
+      label: `${name} at ${timecode(clip.startMs)}`,
+      open
+    };
+  }, [timelineId, clip, data?.name, open]);
+};
+
+export default useShotTimelineLink;

--- a/web/src/hooks/storyboard/useStoryboardShotFocus.ts
+++ b/web/src/hooks/storyboard/useStoryboardShotFocus.ts
@@ -1,0 +1,44 @@
+/**
+ * useStoryboardShotFocus
+ *
+ * The board's receiving end of a cross-document link. A script line's gutter
+ * chip or a cut clip's inspector parks a shot id before opening the board's
+ * tab; this applies it once the board has loaded that shot.
+ *
+ * Selecting straight from the click site does not work: a board that is not
+ * already open has no entry in the store yet, and `selectShot` on a board the
+ * store does not carry is a no-op — the tab would open on nothing.
+ */
+
+import { useEffect } from "react";
+
+import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
+import {
+  useDocumentFocusRequest,
+  useDocumentFocusStore
+} from "../../stores/DocumentFocusStore";
+
+export const useStoryboardShotFocus = (
+  boardId: string | null | undefined
+): void => {
+  const request = useDocumentFocusRequest("storyboard", boardId);
+  const hasShot = useStoryboardStore((state) =>
+    request
+      ? !!state.boards[request.ref]?.shots.some((s) => s.id === request.shotId)
+      : false
+  );
+  const selectShot = useStoryboardStore((state) => state.selectShot);
+  const clearDocumentFocus = useDocumentFocusStore(
+    (state) => state.clearDocumentFocus
+  );
+
+  useEffect(() => {
+    if (!request || !hasShot) {
+      return;
+    }
+    selectShot(request.ref, request.shotId);
+    clearDocumentFocus(request);
+  }, [request, hasShot, selectShot, clearDocumentFocus]);
+};
+
+export default useStoryboardShotFocus;

--- a/web/src/hooks/timeline/__tests__/useTimelineClipFocus.test.tsx
+++ b/web/src/hooks/timeline/__tests__/useTimelineClipFocus.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ *
+ * The receiving half of a deep link into the cut: a parked clip id lands as a
+ * selection, a playhead position, and a scroll request — once, and only for
+ * the sequence it names.
+ */
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import { act, renderHook } from "@testing-library/react";
+
+import {
+  createTimelineInstance,
+  TimelineProvider,
+  type TimelineInstance
+} from "../../../stores/timeline/TimelineInstance";
+import { useDocumentFocusStore } from "../../../stores/DocumentFocusStore";
+import { useTimelineClipFocus } from "../useTimelineClipFocus";
+import { makeClip } from "@nodetool-ai/timeline";
+
+let instance: TimelineInstance;
+
+/** One imported clip on a fresh video track. Returns its id. */
+const addClip = (name: string, startMs: number): string => {
+  const doc = instance.doc;
+  act(() => doc.getState().addTrack("video", "V"));
+  const trackId = doc.getState().tracks[0].id;
+  const clip = makeClip({
+    trackId,
+    name,
+    startMs,
+    durationMs: 4000,
+    mediaType: "video",
+    sourceType: "imported",
+    status: "generated",
+    versions: []
+  });
+  act(() => doc.getState().addClip(clip));
+  return clip.id;
+};
+
+const render = (sequenceId: string) =>
+  renderHook(() => useTimelineClipFocus(sequenceId), {
+    wrapper: ({ children }) => (
+      <TimelineProvider instance={instance}>{children}</TimelineProvider>
+    )
+  });
+
+beforeEach(() => {
+  instance = createTimelineInstance();
+  useDocumentFocusStore.setState({ pending: null });
+});
+
+describe("useTimelineClipFocus", () => {
+  it("selects the requested clip, parks the playhead, and asks for a scroll", () => {
+    const clipId = addClip("clip-1", 12_000);
+    useDocumentFocusStore
+      .getState()
+      .requestDocumentFocus({ type: "timeline", ref: "seq-1", clipId });
+
+    render("seq-1");
+
+    expect([...instance.ui.getState().selectedClipIds]).toEqual([clipId]);
+    expect(instance.playback.getState().currentTimeMs).toBe(12_000);
+    expect(instance.ui.getState().revealRequest).toEqual({ timeMs: 12_000 });
+    // One-shot: applying it drops the request.
+    expect(useDocumentFocusStore.getState().pending).toBeNull();
+  });
+
+  it("leaves a request for another sequence alone", () => {
+    const clipId = addClip("clip-1", 12_000);
+    const request = {
+      type: "timeline" as const,
+      ref: "seq-other",
+      clipId
+    };
+    useDocumentFocusStore.getState().requestDocumentFocus(request);
+
+    render("seq-1");
+
+    expect(instance.ui.getState().selectedClipIds.size).toBe(0);
+    expect(useDocumentFocusStore.getState().pending).toBe(request);
+  });
+
+  it("keeps a request naming a clip this sequence does not carry", () => {
+    const request = {
+      type: "timeline" as const,
+      ref: "seq-1",
+      clipId: "clip-gone"
+    };
+    useDocumentFocusStore.getState().requestDocumentFocus(request);
+
+    render("seq-1");
+
+    expect(instance.ui.getState().selectedClipIds.size).toBe(0);
+    expect(useDocumentFocusStore.getState().pending).toBe(request);
+  });
+
+  it("applies a request that arrives after the document loaded", () => {
+    const clipId = addClip("clip-1", 8_000);
+    render("seq-1");
+    expect(instance.ui.getState().selectedClipIds.size).toBe(0);
+
+    act(() =>
+      useDocumentFocusStore
+        .getState()
+        .requestDocumentFocus({ type: "timeline", ref: "seq-1", clipId })
+    );
+
+    expect([...instance.ui.getState().selectedClipIds]).toEqual([clipId]);
+  });
+});

--- a/web/src/hooks/timeline/useClipStoryboardLink.ts
+++ b/web/src/hooks/timeline/useClipStoryboardLink.ts
@@ -1,0 +1,86 @@
+/**
+ * useClipStoryboardLink
+ *
+ * The way back from the cut to the board. A clip assembled from a storyboard
+ * carries `storyboardBoardId`/`storyboardShotId`; this resolves those into the
+ * shot itself so the inspector can name it and jump there with it selected.
+ *
+ * The open board's live shots win; a board that is not open is read from the
+ * server, so the chip names the shot either way.
+ */
+
+import { useCallback, useMemo } from "react";
+import type { Shot } from "@nodetool-ai/protocol";
+
+import { trpc } from "../../trpc/client";
+import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import { requestDocumentFocus } from "../../stores/DocumentFocusStore";
+
+/** The shot a clip came from, and how to go look at it. */
+export interface ClipStoryboardLink {
+  boardId: string;
+  shot: Shot;
+  /** "from Board · SH 03". */
+  label: string;
+  /** Open the board's tab with the shot selected. */
+  open: () => void;
+}
+
+export const useClipStoryboardLink = (
+  boardId: string | null | undefined,
+  shotId: string | null | undefined
+): ClipStoryboardLink | null => {
+  const openShots = useStoryboardStore((state) =>
+    boardId ? state.boards[boardId]?.shots : undefined
+  );
+  const boardTitle = useStoryboardStore((state) =>
+    boardId ? state.boards[boardId]?.title : undefined
+  );
+  const { data } = trpc.storyboards.get.useQuery(
+    { id: boardId ?? "" },
+    { enabled: !!boardId && !openShots, staleTime: 30_000, retry: false }
+  );
+  // SAFETY: the wire document's `shots` is the passthrough zod mirror of
+  // `Shot` — the same payload described structurally and nominally.
+  const shots = openShots ?? (data?.document.shots as Shot[] | undefined);
+  const title = boardTitle ?? data?.name;
+
+  const shot = useMemo(
+    () => (shotId ? shots?.find((s) => s.id === shotId) : undefined),
+    [shots, shotId]
+  );
+
+  const open = useCallback(() => {
+    if (!boardId || !shot) {
+      return;
+    }
+    // Park the shot before the tab opens: a board that is not already open has
+    // no store entry to select in yet.
+    requestDocumentFocus({
+      type: "storyboard",
+      ref: boardId,
+      shotId: shot.id
+    });
+    useWorkspaceTabsStore.getState().openTab({
+      type: "storyboard",
+      ref: boardId,
+      mode: "edit",
+      title
+    });
+  }, [boardId, shot, title]);
+
+  return useMemo(() => {
+    if (!boardId || !shot) {
+      return null;
+    }
+    return {
+      boardId,
+      shot,
+      label: `from Board · SH ${String(shot.index + 1).padStart(2, "0")}`,
+      open
+    };
+  }, [boardId, shot, open]);
+};
+
+export default useClipStoryboardLink;

--- a/web/src/hooks/timeline/useTimelineClipFocus.ts
+++ b/web/src/hooks/timeline/useTimelineClipFocus.ts
@@ -1,0 +1,49 @@
+/**
+ * useTimelineClipFocus
+ *
+ * The receiving half of a deep link into the cut. A cross-document link parks
+ * a clip id in `DocumentFocusStore` before opening the timeline tab; this runs
+ * inside the editor and applies it once the document has loaded — selects the
+ * clip, parks the playhead at its start, and asks the lanes to scroll it into
+ * view. The request is dropped as soon as it is applied, so a later edit does
+ * not re-select the clip.
+ *
+ * A request naming a clip the sequence does not carry (deleted since the link
+ * was drawn) stays pending and applies to nothing; the tab still opens.
+ */
+
+import { useEffect } from "react";
+
+import { useTimelineStore } from "../../stores/timeline/TimelineStore";
+import { useTimelineUIStoreApi } from "../../stores/timeline/TimelineUIStore";
+import { useTimelinePlaybackStoreApi } from "../../stores/timeline/TimelinePlaybackStore";
+import {
+  useDocumentFocusRequest,
+  useDocumentFocusStore
+} from "../../stores/DocumentFocusStore";
+
+export const useTimelineClipFocus = (
+  sequenceId: string | null | undefined
+): void => {
+  const request = useDocumentFocusRequest("timeline", sequenceId);
+  const clip = useTimelineStore((state) =>
+    request ? (state.clips.find((c) => c.id === request.clipId) ?? null) : null
+  );
+  const uiStore = useTimelineUIStoreApi();
+  const playbackStore = useTimelinePlaybackStoreApi();
+  const clearDocumentFocus = useDocumentFocusStore(
+    (state) => state.clearDocumentFocus
+  );
+
+  useEffect(() => {
+    if (!request || !clip) {
+      return;
+    }
+    uiStore.getState().selectClip(clip.id);
+    uiStore.getState().revealAt(clip.startMs);
+    playbackStore.getState().seek(clip.startMs);
+    clearDocumentFocus(request);
+  }, [request, clip, uiStore, playbackStore, clearDocumentFocus]);
+};
+
+export default useTimelineClipFocus;

--- a/web/src/stores/DocumentFocusStore.ts
+++ b/web/src/stores/DocumentFocusStore.ts
@@ -1,0 +1,62 @@
+// DocumentFocusStore.ts
+// -----------------------------------------------------------------
+// "Open that document, at this place."
+//
+// A cross-document link (a storyboard shot's timeline clip, a shot's
+// script line) opens a tab and then has to say *where* in the opened
+// document to land. The tab store carries navigation only, and the
+// target's own state is out of reach at click time — a timeline's
+// stores are per-instance and do not exist until its tab mounts.
+//
+// So the click parks a one-shot request here and the target editor
+// consumes it once its document is loaded. A request that nothing
+// consumes is harmless: it sits until the next one replaces it.
+// -----------------------------------------------------------------
+
+import { create } from "zustand";
+
+export type DocumentFocusRequest =
+  | { type: "timeline"; ref: string; clipId: string }
+  | { type: "script"; ref: string; lineId: string }
+  | { type: "storyboard"; ref: string; shotId: string };
+
+/** The request for one `(type, ref)`, narrowed to that type's shape. */
+export type DocumentFocusFor<T extends DocumentFocusRequest["type"]> = Extract<
+  DocumentFocusRequest,
+  { type: T }
+>;
+
+interface DocumentFocusState {
+  pending: DocumentFocusRequest | null;
+  /** Park a request for the document about to be opened. */
+  requestDocumentFocus: (request: DocumentFocusRequest) => void;
+  /**
+   * Drop `request` once it has been applied. Identity-checked, so a consumer
+   * that applies late cannot clear a newer request that arrived meanwhile.
+   */
+  clearDocumentFocus: (request: DocumentFocusRequest) => void;
+}
+
+export const useDocumentFocusStore = create<DocumentFocusState>((set) => ({
+  pending: null,
+  requestDocumentFocus: (request) => set({ pending: request }),
+  clearDocumentFocus: (request) =>
+    set((state) => (state.pending === request ? { pending: null } : state))
+}));
+
+/** Park a focus request from outside React. */
+export const requestDocumentFocus = (request: DocumentFocusRequest): void =>
+  useDocumentFocusStore.getState().requestDocumentFocus(request);
+
+/** The pending request for this document, or null when it is for another. */
+export const useDocumentFocusRequest = <T extends DocumentFocusRequest["type"]>(
+  type: T,
+  ref: string | null | undefined
+): DocumentFocusFor<T> | null =>
+  useDocumentFocusStore((state) => {
+    const pending = state.pending;
+    if (!ref || pending === null || pending.type !== type || pending.ref !== ref) {
+      return null;
+    }
+    return pending as DocumentFocusFor<T>;
+  });

--- a/web/src/stores/timeline/TimelineUIStore.ts
+++ b/web/src/stores/timeline/TimelineUIStore.ts
@@ -97,6 +97,15 @@ export interface TimelineUIState {
 
   setZoom: (msPerPx: number) => void;
   setScrollLeftPx: (px: number) => void;
+  /**
+   * A timeline position the lanes should bring into view. The lanes scroll
+   * themselves — `scrollLeftPx` is written *from* their scroll handler, so it
+   * is a readout, not a control. Each request is a fresh object so asking for
+   * the same position twice still moves the view.
+   */
+  revealRequest: { timeMs: number } | null;
+  /** Ask the lanes to scroll `timeMs` into view. */
+  revealAt: (timeMs: number) => void;
 
   // ── Fullscreen ───────────────────────────────────────────────────────────
 
@@ -142,6 +151,7 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
   activeTool: "select",
   msPerPx: 10,
   scrollLeftPx: 0,
+  revealRequest: null,
   fullscreen: false,
   expandedFxTrackId: null,
   draggingTrackId: null,
@@ -193,6 +203,8 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
     set({ msPerPx: Math.min(MAX_MS_PER_PX, Math.max(MIN_MS_PER_PX, msPerPx)) }),
 
   setScrollLeftPx: (px) => set({ scrollLeftPx: Math.max(0, px) }),
+
+  revealAt: (timeMs) => set({ revealRequest: { timeMs: Math.max(0, timeMs) } }),
 
   setFullscreen: (full) => set({ fullscreen: full }),
 


### PR DESCRIPTION
## What changed

Phase 5 of `docs/plans/project-view/PLAN.md` — cross-document context. The board's selection footer said "Appears in" and could only name the script; a clip in the cut said nothing about where it came from. Both links now exist, and both land on the thing they name rather than on the top of a document. `useShotTimelineLink` reads the shot's clip out of the board's assembled sequence (`board.timelineId`) instead of re-running the assembly, so a cut that has since been trimmed reports where the clip *is*; it matches the video clip carrying no `scriptLineId`, so neither the shot's audio twin nor a voiceover clip covering it is mistaken for the shot's own. `ClipStoryboardLink` is the other direction, on the imported-clip inspector: "from Board · SH 03", back to the board with that shot selected. Selecting on open needed a handoff, because a timeline's stores belong to its editor instance and do not exist until its tab mounts, and `selectShot` on a board the store does not carry is a no-op — which is why the script gutter's existing jump silently lost its selection whenever the board was not already open. `DocumentFocusStore` parks one request and the target applies it once its document has loaded; that fixes the gutter's jump too. The timeline consumer also parks the playhead at the clip and asks the lanes to scroll it into view — the lanes own their scroll (`scrollLeftPx` is written *from* their scroll handler), so `revealRequest` asks rather than sets, and the view is left alone when the clip is already comfortably inside it. The script consumer highlights the line and scrolls to it, with playback's own highlight still winning while it runs.

The chips carry the mockup's colours (violet for picture, sky for words) but not its ▤/🎙 glyphs: the already-shipped script chip has none, and the type colour is the vocabulary the rest of the app uses.

## Verification

- [x] `npm run test:affected` — 229 suites, 1987 passed, 3 skipped
- [x] `npm run typecheck` — web and electron clean; mobile fails only on its own uninstalled dependency tree (`react-native`, `expo`, `uuid`), untouched by this diff
- [x] `npm run lint` — clean, design-token rules included
- [x] `npm run dev:nodetool -- harness gate` — 2/2 selfchecks passed, 255/255 graphs validate. Run as `--base HEAD~1`: this container's clone is shallow, so `main...HEAD` has no merge base

New tests: `useTimelineClipFocus` (selects, seeks, reveals, one-shot; leaves another sequence's request alone; keeps a request naming a clip the sequence lacks), `useStoryboardShotFocus` (applies once the board loads the shot — the case the old direct `selectShot` dropped), `ClipStoryboardLink` (names the shot, opens the board, silent with no provenance), `ScriptDocumentPane.lineFocus` (scrolls to the requested line), and two cases added to `ShotInspector` for the cut chip.

## Agent capabilities

No capability added or re-declared — web UI only.

## New checks

No check, rule, or audit added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AKT3t8NZ5RzbjKquwF55wj)_