### PR TITLE
feat(atlascloud): ship 60 more image and video models

### DIFF
--- a/packages/atlascloud-nodes/AGENTS.md
+++ b/packages/atlascloud-nodes/AGENTS.md
@@ -44,6 +44,11 @@ Package specifics from shipped fixes:
   the *set* of layers it returns — is deliberately not shipped. A model that
   returns N interchangeable variants (`n`, `num_images`) is fine; one whose
   outputs are not interchangeable is not.
+- **Suppress an option by name, not by upstream's `disabled` flag.** AtlasCloud
+  marks `enable_base64_output` / `enable_sync_mode` disabled on most models but
+  not on the FLUX.1 open-weight ones, and either switch breaks the
+  poll-then-download flow. `SUPPRESSED_FIELDS` in the sync script is the list;
+  `output_dir` (a server-side path on Tencent's upscaler) is there too.
 - **The manifest is generated, not hand-edited.** `node
   scripts/sync-atlascloud-manifest.mjs` reconciles every entry's fields against
   the `Input` schema AtlasCloud publishes for that model (reachable from the
@@ -51,6 +56,14 @@ Package specifics from shipped fixes:
   without writing. Hand-tuned enums, wrong separators (`1024x1024` vs
   `1024*1024`) and stale option lists are what the script exists to prevent. Add
   a *model* by hand — the script only maintains the fields of models we ship.
+  Two shapes the script cannot fill in for a new entry, so write them yourself:
+  asset fields (it never touches `image`/`video`/`audio`/`list[…]` props), and
+  a schema property typed `anyOf` rather than a scalar — Cosmos 3 Super's
+  `image_size` is one, and hand-declaring it as an `enum` is what keeps the
+  control, since the script preserves an option list the schema no longer
+  carries. After adding entries, `--check` must report the manifest up to date;
+  a drift line against a model you just added means the entry disagrees with
+  the schema it was written from.
 - **Chat is not a node concern.** AtlasCloud's LLMs are OpenAI-compatible at
   `https://api.atlascloud.ai/v1` and are served by `AtlasCloudProvider` in
   `packages/runtime`, which extends `OpenAICompatProvider`. Only the async

--- a/packages/atlascloud-nodes/README.md
+++ b/packages/atlascloud-nodes/README.md
@@ -3,9 +3,10 @@
 AtlasCloud.ai nodes for [NodeTool](https://nodetool.ai).
 
 Run [AtlasCloud](https://www.atlascloud.ai) image and video models inside NodeTool
-workflows — GPT Image, Nano Banana, Seedream, Qwen Image, Reve, Youchuan and Wan
-for images; Seedance, Veo, Kling, Wan, MiniMax, HappyHorse and Grok Imagine for
-video.
+workflows — GPT Image, Nano Banana, Seedream, FLUX, Qwen Image, Ideogram, Reve,
+HiDream, Krea, Youchuan and Wan for images; Seedance, Veo, Kling, Wan, MiniMax,
+Vidu, PixVerse, LTX, HappyHorse and Grok Imagine for video; plus upscalers,
+photo cleanup and lip-sync as prompt-free utility nodes.
 
 Node fields are generated from AtlasCloud's published model schemas. Re-sync them
 with `node scripts/sync-atlascloud-manifest.mjs` (or `--check` to detect drift).
@@ -23,16 +24,37 @@ npm install @nodetool-ai/atlascloud-nodes
 
 | Node | Type |
 | --- | --- |
+| Cosmos 3 Super — Text to Image | `atlascloud.image.Cosmos3SuperTextToImage` |
+| FLUX.1 Dev | `atlascloud.image.FluxDev` |
+| FLUX.1 Kontext Dev | `atlascloud.image.FluxKontextDev` |
+| FLUX.1 Schnell | `atlascloud.image.FluxSchnell` |
+| FLUX.2 Flex — Edit | `atlascloud.image.Flux2FlexEdit` |
+| FLUX.2 Flex — Text to Image | `atlascloud.image.Flux2FlexTextToImage` |
+| FLUX.2 Pro — Edit | `atlascloud.image.Flux2ProEdit` |
+| FLUX.2 Pro — Text to Image | `atlascloud.image.Flux2ProTextToImage` |
+| GPT Image 1 — Edit | `atlascloud.image.GPTImage1Edit` |
+| GPT Image 1 — Text to Image | `atlascloud.image.GPTImage1TextToImage` |
+| GPT Image 1 Mini — Edit | `atlascloud.image.GPTImage1MiniEdit` |
+| GPT Image 1 Mini — Text to Image | `atlascloud.image.GPTImage1MiniTextToImage` |
 | GPT Image 1.5 — Edit | `atlascloud.image.GPTImage15Edit` |
 | GPT Image 1.5 — Text to Image | `atlascloud.image.GPTImage15TextToImage` |
 | GPT Image 2 — Edit | `atlascloud.image.GPTImage2Edit` |
 | GPT Image 2 — Text to Image | `atlascloud.image.GPTImage2TextToImage` |
+| Grok Imagine Image — Edit | `atlascloud.image.GrokImagineImageEdit` |
+| Grok Imagine Image — Text to Image | `atlascloud.image.GrokImagineImageTextToImage` |
 | Grok Imagine Image 2.0 — Edit | `atlascloud.image.GrokImagineImage2Edit` |
 | Grok Imagine Image 2.0 — Text to Image | `atlascloud.image.GrokImagineImage2TextToImage` |
 | Grok Imagine Image Quality — Edit | `atlascloud.image.GrokImagineImageQualityEdit` |
 | Grok Imagine Image Quality — Text to Image | `atlascloud.image.GrokImagineImageQualityTextToImage` |
+| HiDream O1 1.5 — Edit | `atlascloud.image.HiDreamO115Edit` |
+| HiDream O1 1.5 — Text to Image | `atlascloud.image.HiDreamO115TextToImage` |
+| Ideogram v4 Quality — Text to Image | `atlascloud.image.IdeogramV4QualityTextToImage` |
+| Ideogram v4 Turbo — Text to Image | `atlascloud.image.IdeogramV4TurboTextToImage` |
+| Image Upscaler | `atlascloud.image.ImageUpscaler` |
+| Krea 2 Turbo — Text to Image | `atlascloud.image.Krea2TurboTextToImage` |
 | MAI Image 2.5 — Edit | `atlascloud.image.MaiImage25Edit` |
 | MAI Image 2.5 — Text to Image | `atlascloud.image.MaiImage25TextToImage` |
+| MAI Image 2.5 Flash — Edit | `atlascloud.image.MaiImage25FlashEdit` |
 | MAI Image 2.5 Flash — Text to Image | `atlascloud.image.MaiImage25FlashTextToImage` |
 | Nano Banana 2 — Edit | `atlascloud.image.NanoBanana2Edit` |
 | Nano Banana 2 — Text to Image | `atlascloud.image.NanoBanana2TextToImage` |
@@ -42,6 +64,7 @@ npm install @nodetool-ai/atlascloud-nodes
 | Nano Banana Pro — Edit (Ultra) | `atlascloud.image.NanoBananaProEditUltra` |
 | Nano Banana Pro — Text to Image | `atlascloud.image.NanoBananaProTextToImage` |
 | Nano Banana Pro — Text to Image (Ultra) | `atlascloud.image.NanoBananaProTextToImageUltra` |
+| Photo Cleanup | `atlascloud.image.PhotoCleanup` |
 | Qwen Image 2.0 — Edit | `atlascloud.image.QwenImage2Edit` |
 | Qwen Image 2.0 — Text to Image | `atlascloud.image.QwenImage2TextToImage` |
 | Qwen Image 2.0 Pro — Edit | `atlascloud.image.QwenImage2ProEdit` |
@@ -53,10 +76,15 @@ npm install @nodetool-ai/atlascloud-nodes
 | Reve 2.1 — Edit | `atlascloud.image.Reve21Edit` |
 | Reve 2.1 — Remix | `atlascloud.image.Reve21Remix` |
 | Reve 2.1 — Text to Image | `atlascloud.image.Reve21TextToImage` |
+| Seedream v4.5 — Edit | `atlascloud.image.SeedreamV45Edit` |
+| Seedream v4.5 — Text to Image | `atlascloud.image.SeedreamV45TextToImage` |
 | Seedream v5.0 Lite — Edit | `atlascloud.image.SeedreamV5LiteEdit` |
 | Seedream v5.0 Lite — Text to Image | `atlascloud.image.SeedreamV5LiteTextToImage` |
 | Seedream v5.0 Pro — Edit | `atlascloud.image.SeedreamV5ProEdit` |
 | Seedream v5.0 Pro — Text to Image | `atlascloud.image.SeedreamV5ProTextToImage` |
+| Tencent Image Upscaler | `atlascloud.image.TencentImageUpscaler` |
+| Wan 2.6 — Image Edit | `atlascloud.image.Wan26ImageEdit` |
+| Wan 2.6 — Text to Image | `atlascloud.image.Wan26TextToImage` |
 | Wan 2.7 — Image Edit | `atlascloud.image.Wan27ImageEdit` |
 | Wan 2.7 — Text to Image | `atlascloud.image.Wan27TextToImage` |
 | Wan 2.7 Pro — Image Edit | `atlascloud.image.Wan27ProImageEdit` |
@@ -73,14 +101,23 @@ npm install @nodetool-ai/atlascloud-nodes
 | Youchuan v8.2 — Text to Image | `atlascloud.image.YouchuanV82TextToImage` |
 | Z-Image Turbo — Text to Image | `atlascloud.image.ZImageTurboTextToImage` |
 | Avatar Omni Human 1.5 — Audio to Video | `atlascloud.video.AvatarOmniHuman15` |
+| Cosmos 3 Super — Image to Video | `atlascloud.video.Cosmos3SuperImageToVideo` |
 | Gemini Omni Flash — Image to Video | `atlascloud.video.GeminiOmniFlashImageToVideo` |
 | Gemini Omni Flash — Reference to Video | `atlascloud.video.GeminiOmniFlashReferenceToVideo` |
 | Gemini Omni Flash — Text to Video | `atlascloud.video.GeminiOmniFlashTextToVideo` |
 | Gemini Omni Flash — Video Edit | `atlascloud.video.GeminiOmniFlashVideoEdit` |
 | Grok Imagine Video v1.5 — Image to Video | `atlascloud.video.GrokImagineVideo15ImageToVideo` |
+| Grok Imagine Video v1.5 — Reference to Video | `atlascloud.video.GrokImagineVideo15ReferenceToVideo` |
+| Grok Imagine Video v1.5 — Text to Video | `atlascloud.video.GrokImagineVideo15TextToVideo` |
+| Hailuo 2.3 Pro — Image to Video | `atlascloud.video.Hailuo23ProImageToVideo` |
+| Hailuo 2.3 Pro — Text to Video | `atlascloud.video.Hailuo23ProTextToVideo` |
 | HappyHorse 1.1 — Image to Video | `atlascloud.video.HappyHorse11ImageToVideo` |
 | HappyHorse 1.1 — Reference to Video | `atlascloud.video.HappyHorse11ReferenceToVideo` |
 | HappyHorse 1.1 — Text to Video | `atlascloud.video.HappyHorse11TextToVideo` |
+| Kling v2.6 Pro — Image to Video | `atlascloud.video.KlingV26ProImageToVideo` |
+| Kling v2.6 Pro — Text to Video | `atlascloud.video.KlingV26ProTextToVideo` |
+| Kling v3.0 4K — Image to Video | `atlascloud.video.KlingV34kImageToVideo` |
+| Kling v3.0 4K — Text to Video | `atlascloud.video.KlingV34kTextToVideo` |
 | Kling v3.0 Pro — Image to Video | `atlascloud.video.KlingV3ProImageToVideo` |
 | Kling v3.0 Pro — Text to Video | `atlascloud.video.KlingV3ProTextToVideo` |
 | Kling v3.0 Std — Image to Video | `atlascloud.video.KlingV3StdImageToVideo` |
@@ -89,9 +126,19 @@ npm install @nodetool-ai/atlascloud-nodes
 | Kling v3.0 Turbo — Text to Video | `atlascloud.video.KlingV3TurboTextToVideo` |
 | Kling Video O3 4K — Image to Video | `atlascloud.video.KlingVideoO34kImageToVideo` |
 | Kling Video O3 4K — Text to Video | `atlascloud.video.KlingVideoO34kTextToVideo` |
+| Kling Video O3 Pro — Image to Video | `atlascloud.video.KlingVideoO3ProImageToVideo` |
+| Kling Video O3 Pro — Reference to Video | `atlascloud.video.KlingVideoO3ProReferenceToVideo` |
+| Kling Video O3 Pro — Text to Video | `atlascloud.video.KlingVideoO3ProTextToVideo` |
+| Kling Video O3 Std — Image to Video | `atlascloud.video.KlingVideoO3StdImageToVideo` |
+| Kling Video O3 Std — Reference to Video | `atlascloud.video.KlingVideoO3StdReferenceToVideo` |
+| Kling Video O3 Std — Text to Video | `atlascloud.video.KlingVideoO3StdTextToVideo` |
+| LTX 2.3 Quality — Image to Video | `atlascloud.video.Ltx23QualityImageToVideo` |
+| LTX 2.3 Quality — Text to Video | `atlascloud.video.Ltx23QualityTextToVideo` |
 | MiniMax H3 — Image to Video | `atlascloud.video.MinimaxH3ImageToVideo` |
 | MiniMax H3 — Reference to Video | `atlascloud.video.MinimaxH3ReferenceToVideo` |
 | MiniMax H3 — Text to Video | `atlascloud.video.MinimaxH3TextToVideo` |
+| PixVerse v6 — Image to Video | `atlascloud.video.PixverseV6ImageToVideo` |
+| PixVerse v6 — Text to Video | `atlascloud.video.PixverseV6TextToVideo` |
 | Seedance 2.0 — Image to Video | `atlascloud.video.Seedance2ImageToVideo` |
 | Seedance 2.0 — Reference to Video | `atlascloud.video.Seedance2ReferenceToVideo` |
 | Seedance 2.0 — Text to Video | `atlascloud.video.Seedance2TextToVideo` |
@@ -104,14 +151,28 @@ npm install @nodetool-ai/atlascloud-nodes
 | Seedance 2.5 — Image to Video | `atlascloud.video.Seedance25ImageToVideo` |
 | Seedance 2.5 — Reference to Video | `atlascloud.video.Seedance25ReferenceToVideo` |
 | Seedance 2.5 — Text to Video | `atlascloud.video.Seedance25TextToVideo` |
+| Seedance v1.5 Pro — Image to Video | `atlascloud.video.SeedanceV15ProImageToVideo` |
+| Seedance v1.5 Pro — Text to Video | `atlascloud.video.SeedanceV15ProTextToVideo` |
+| Sync Lipsync v3 | `atlascloud.video.SyncLipsyncV3` |
+| VEED Lipsync | `atlascloud.video.VeedLipsync` |
 | Veo 3.1 — Image to Video | `atlascloud.video.Veo31ImageToVideo` |
+| Veo 3.1 — Reference to Video | `atlascloud.video.Veo31ReferenceToVideo` |
 | Veo 3.1 — Text to Video | `atlascloud.video.Veo31TextToVideo` |
 | Veo 3.1 Fast — Image to Video | `atlascloud.video.Veo31FastImageToVideo` |
 | Veo 3.1 Fast — Text to Video | `atlascloud.video.Veo31FastTextToVideo` |
 | Veo 3.1 Lite — Image to Video | `atlascloud.video.Veo31LiteImageToVideo` |
+| Veo 3.1 Lite — Start and End Frame to Video | `atlascloud.video.Veo31LiteStartEndFrameToVideo` |
 | Veo 3.1 Lite — Text to Video | `atlascloud.video.Veo31LiteTextToVideo` |
+| Video Upscaler | `atlascloud.video.VideoUpscaler` |
+| Vidu Q3 — Reference to Video | `atlascloud.video.ViduQ3ReferenceToVideo` |
+| Vidu Q3 Pro — Image to Video | `atlascloud.video.ViduQ3ProImageToVideo` |
+| Vidu Q3 Pro — Text to Video | `atlascloud.video.ViduQ3ProTextToVideo` |
+| Wan 2.6 — Image to Video | `atlascloud.video.Wan26ImageToVideo` |
+| Wan 2.6 — Text to Video | `atlascloud.video.Wan26TextToVideo` |
 | Wan 2.7 — Image to Video | `atlascloud.video.Wan27ImageToVideo` |
+| Wan 2.7 — Reference to Video | `atlascloud.video.Wan27ReferenceToVideo` |
 | Wan 2.7 — Text to Video | `atlascloud.video.Wan27TextToVideo` |
+| Wan 2.7 — Video Edit | `atlascloud.video.Wan27VideoEdit` |
 | Wan 3.0 — Image to Video | `atlascloud.video.Wan30ImageToVideo` |
 | Wan 3.0 — Reference to Video | `atlascloud.video.Wan30ReferenceToVideo` |
 | Wan 3.0 — Text to Video | `atlascloud.video.Wan30TextToVideo` |

--- a/packages/atlascloud-nodes/src/atlascloud-manifest.json
+++ b/packages/atlascloud-nodes/src/atlascloud-manifest.json
@@ -704,6 +704,31 @@
         "default": false,
         "title": "Image Search",
         "description": "Ground generation in real-time image search."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed. Does not guarantee determinism but may improve repeatability. -1 means a random seed will be used."
+      },
+      {
+        "name": "top_p",
+        "type": "float",
+        "default": 0.95,
+        "title": "Top P",
+        "description": "Probability threshold for top-p sampling",
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "temperature",
+        "type": "float",
+        "default": 1,
+        "title": "Temperature",
+        "description": "Creativity allowed in the responses. Best results at default 1.0. Lower values may impact reasoning.",
+        "min": 0,
+        "max": 1
       }
     ]
   },
@@ -811,6 +836,31 @@
         "default": false,
         "title": "Image Search",
         "description": "Ground generation in real-time image search."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed. Does not guarantee determinism but may improve repeatability. -1 means a random seed will be used."
+      },
+      {
+        "name": "top_p",
+        "type": "float",
+        "default": 0.95,
+        "title": "Top P",
+        "description": "Probability threshold for top-p sampling",
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "temperature",
+        "type": "float",
+        "default": 1,
+        "title": "Temperature",
+        "description": "Creativity allowed in the responses. Best results at default 1.0. Lower values may impact reasoning.",
+        "min": 0,
+        "max": 1
       }
     ]
   },
@@ -1139,6 +1189,31 @@
         "type": "bool",
         "default": false,
         "title": "Web Search"
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed. Does not guarantee determinism but may improve repeatability. -1 means a random seed will be used."
+      },
+      {
+        "name": "top_p",
+        "type": "float",
+        "default": 0.95,
+        "title": "Top P",
+        "description": "Probability threshold for top-p sampling",
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "temperature",
+        "type": "float",
+        "default": 1,
+        "title": "Temperature",
+        "description": "Creativity allowed in the responses. Best results at default 1.0. Lower values may impact reasoning.",
+        "min": 0,
+        "max": 1
       }
     ]
   },
@@ -1225,6 +1300,31 @@
         "type": "bool",
         "default": false,
         "title": "Web Search"
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed. Does not guarantee determinism but may improve repeatability. -1 means a random seed will be used."
+      },
+      {
+        "name": "top_p",
+        "type": "float",
+        "default": 0.95,
+        "title": "Top P",
+        "description": "Probability threshold for top-p sampling",
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "temperature",
+        "type": "float",
+        "default": 1,
+        "title": "Temperature",
+        "description": "Creativity allowed in the responses. Best results at default 1.0. Lower values may impact reasoning.",
+        "min": 0,
+        "max": 1
       }
     ]
   },
@@ -1414,6 +1514,17 @@
           "enabled",
           "disabled"
         ]
+      },
+      {
+        "name": "prompt_optimization_mode",
+        "type": "enum",
+        "default": "standard",
+        "title": "Prompt Optimization Mode",
+        "description": "Prompt optimization mode. 'standard' (default) produces higher-quality prompt optimization but takes longer. 'fast' takes significantly less time with slightly lower quality.",
+        "values": [
+          "standard",
+          "fast"
+        ]
       }
     ]
   },
@@ -1487,6 +1598,28 @@
           "enabled",
           "disabled"
         ]
+      },
+      {
+        "name": "background",
+        "type": "enum",
+        "default": "opaque",
+        "title": "Background",
+        "description": "Controls whether the generated image carries an alpha channel.",
+        "values": [
+          "opaque",
+          "transparent"
+        ]
+      },
+      {
+        "name": "prompt_optimization_mode",
+        "type": "enum",
+        "default": "standard",
+        "title": "Prompt Optimization Mode",
+        "description": "Prompt optimization mode. 'standard' (default) produces higher-quality prompt optimization but takes longer. 'fast' takes significantly less time with slightly lower quality.",
+        "values": [
+          "standard",
+          "fast"
+        ]
       }
     ]
   },
@@ -1554,6 +1687,31 @@
           "high",
           "minimal"
         ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed. Does not guarantee determinism but may improve repeatability. -1 means a random seed will be used."
+      },
+      {
+        "name": "top_p",
+        "type": "float",
+        "default": 0.95,
+        "title": "Top P",
+        "description": "Probability threshold for top-p sampling",
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "temperature",
+        "type": "float",
+        "default": 1,
+        "title": "Temperature",
+        "description": "Creativity allowed in the responses. Best results at default 1.0. Lower values may impact reasoning.",
+        "min": 0,
+        "max": 1
       }
     ]
   },
@@ -1629,6 +1787,31 @@
           "high",
           "minimal"
         ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed. Does not guarantee determinism but may improve repeatability. -1 means a random seed will be used."
+      },
+      {
+        "name": "top_p",
+        "type": "float",
+        "default": 0.95,
+        "title": "Top P",
+        "description": "Probability threshold for top-p sampling",
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "temperature",
+        "type": "float",
+        "default": 1,
+        "title": "Temperature",
+        "description": "Creativity allowed in the responses. Best results at default 1.0. Lower values may impact reasoning.",
+        "min": 0,
+        "max": 1
       }
     ]
   },
@@ -2446,12 +2629,13 @@
       {
         "name": "resolution",
         "type": "enum",
-        "default": "1080P",
+        "default": "1080p",
         "title": "Resolution",
         "description": "Output video resolution.",
         "values": [
-          "720P",
-          "1080P"
+          "480p",
+          "720p",
+          "1080p"
         ]
       },
       {
@@ -2521,12 +2705,13 @@
       {
         "name": "resolution",
         "type": "enum",
-        "default": "1080P",
+        "default": "1080p",
         "title": "Resolution",
         "description": "Output video resolution.",
         "values": [
-          "720P",
-          "1080P"
+          "480p",
+          "720p",
+          "1080p"
         ]
       },
       {
@@ -2579,12 +2764,13 @@
       {
         "name": "resolution",
         "type": "enum",
-        "default": "1080P",
+        "default": "1080p",
         "title": "Resolution",
         "description": "Output video resolution.",
         "values": [
-          "720P",
-          "1080P"
+          "480p",
+          "720p",
+          "1080p"
         ]
       },
       {
@@ -3349,9 +3535,7 @@
         "description": "Output video resolution. 720P and 1080P are native Wan 2.7 outputs. Choose 1080P-SR for sharper HD detail, cleaner edges, and better texture retention. For the same duration, 1080P…",
         "values": [
           "720P",
-          "1080P",
-          "1080P-SR",
-          "1440P-SR"
+          "1080P"
         ]
       },
       {
@@ -6905,6 +7089,13 @@
           "3:4",
           "9:16"
         ]
+      },
+      {
+        "name": "prompt_expansion",
+        "type": "bool",
+        "default": false,
+        "title": "Prompt Expansion",
+        "description": "Whether to expand the prompt for better results."
       }
     ]
   },
@@ -6985,6 +7176,13 @@
         "values": [
           "adaptive"
         ]
+      },
+      {
+        "name": "prompt_expansion",
+        "type": "bool",
+        "default": false,
+        "title": "Prompt Expansion",
+        "description": "Whether to expand the prompt for better results."
       }
     ]
   },
@@ -7083,6 +7281,13 @@
           "3:4",
           "9:16"
         ]
+      },
+      {
+        "name": "prompt_expansion",
+        "type": "bool",
+        "default": false,
+        "title": "Prompt Expansion",
+        "description": "Whether to expand the prompt for better results."
       }
     ]
   },
@@ -7732,6 +7937,4329 @@
           "low",
           "high"
         ]
+      }
+    ]
+  },
+  {
+    "className": "Flux2ProTextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "black-forest-labs/flux-2-pro/text-to-image",
+    "outputType": "image",
+    "title": "FLUX.2 Pro — Text to Image",
+    "description": "AtlasCloud / Black Forest Labs FLUX.2 Pro — text to image with high prompt adherence and legible text.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt for image generation.",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "str",
+        "default": "1024*1024",
+        "title": "Size",
+        "description": "Image dimensions in width*height format (e.g., 1024*1024, 1280*720), If not specified, the model will determine the optimal dimension."
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "jpeg",
+        "title": "Output Format",
+        "description": "The format of the output image.",
+        "values": [
+          "jpeg",
+          "png"
+        ]
+      },
+      {
+        "name": "safety_tolerance",
+        "type": "int",
+        "default": 2,
+        "title": "Safety Tolerance",
+        "description": "Tolerance level for input and output moderation. Between 0 and 5, 0 being most strict, 5 being least strict.",
+        "min": 0,
+        "max": 5
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for reproducibility. Use -1 for a random seed."
+      }
+    ]
+  },
+  {
+    "className": "Flux2ProEdit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "black-forest-labs/flux-2-pro/edit",
+    "outputType": "image",
+    "title": "FLUX.2 Pro — Edit",
+    "description": "AtlasCloud / Black Forest Labs FLUX.2 Pro — edits up to 8 input images from a text instruction.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt for image editing.",
+        "required": true
+      },
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "Images to edit. Up to 8. Connect from upstream nodes, drag/drop, or paste public URLs.",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "str",
+        "default": "1024*1024",
+        "title": "Size",
+        "description": "Image dimensions in width*height format (e.g., 1024*1024, 1280*720), If not specified, the model will determine the optimal dimension."
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "jpeg",
+        "title": "Output Format",
+        "description": "The format of the output image.",
+        "values": [
+          "jpeg",
+          "png"
+        ]
+      },
+      {
+        "name": "safety_tolerance",
+        "type": "int",
+        "default": 2,
+        "title": "Safety Tolerance",
+        "description": "Tolerance level for input and output moderation. Between 0 and 5, 0 being most strict, 5 being least strict.",
+        "min": 0,
+        "max": 5
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for reproducibility. Use -1 for a random seed."
+      }
+    ]
+  },
+  {
+    "className": "Flux2FlexTextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "black-forest-labs/flux-2-flex/text-to-image",
+    "outputType": "image",
+    "title": "FLUX.2 Flex — Text to Image",
+    "description": "AtlasCloud / Black Forest Labs FLUX.2 Flex — text to image with exposed guidance and step count.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt for image generation.",
+        "required": true
+      },
+      {
+        "name": "enable_prompt_expansion",
+        "type": "bool",
+        "default": true,
+        "title": "Enable Prompt Expansion",
+        "description": "Whether to use prompt upsampling to enhance the prompt before generation."
+      },
+      {
+        "name": "size",
+        "type": "str",
+        "default": "1024*1024",
+        "title": "Size",
+        "description": "Image dimensions in width*height format (e.g., 1024*1024, 1280*720), If not specified, the model will determine the optimal dimension."
+      },
+      {
+        "name": "guidance_scale",
+        "type": "float",
+        "default": 5,
+        "title": "Guidance Scale",
+        "description": "Guidance scale for image generation. High guidance scales improve prompt adherence at the cost of reduced realism.",
+        "min": 1.5,
+        "max": 10
+      },
+      {
+        "name": "num_inference_steps",
+        "type": "int",
+        "default": 50,
+        "title": "Num Inference Steps",
+        "description": "Number of steps for image generation. Higher steps lead to more detailed and realistic images.",
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "jpeg",
+        "title": "Output Format",
+        "description": "The format of the output image.",
+        "values": [
+          "jpeg",
+          "png"
+        ]
+      },
+      {
+        "name": "safety_tolerance",
+        "type": "int",
+        "default": 2,
+        "title": "Safety Tolerance",
+        "description": "Tolerance level for input and output moderation. Between 0 and 5, 0 being most strict, 5 being least strict.",
+        "min": 0,
+        "max": 5
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for reproducibility. Use -1 for a random seed."
+      }
+    ]
+  },
+  {
+    "className": "Flux2FlexEdit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "black-forest-labs/flux-2-flex/edit",
+    "outputType": "image",
+    "title": "FLUX.2 Flex — Edit",
+    "description": "AtlasCloud / Black Forest Labs FLUX.2 Flex — image editing with exposed guidance and step count.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt for image editing.",
+        "required": true
+      },
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "Images to edit. Connect from upstream nodes, drag/drop, or paste public URLs.",
+        "required": true
+      },
+      {
+        "name": "enable_prompt_expansion",
+        "type": "bool",
+        "default": true,
+        "title": "Enable Prompt Expansion",
+        "description": "Whether to use prompt upsampling to enhance the prompt before generation."
+      },
+      {
+        "name": "size",
+        "type": "str",
+        "default": "1024*1024",
+        "title": "Size",
+        "description": "Image dimensions in width*height format (e.g., 1024*1024, 1280*720), If not specified, the model will determine the optimal dimension."
+      },
+      {
+        "name": "guidance_scale",
+        "type": "float",
+        "default": 5,
+        "title": "Guidance Scale",
+        "description": "Guidance scale for image generation. High guidance scales improve prompt adherence at the cost of reduced realism.",
+        "min": 1.5,
+        "max": 10
+      },
+      {
+        "name": "num_inference_steps",
+        "type": "int",
+        "default": 50,
+        "title": "Num Inference Steps",
+        "description": "Number of steps for image generation. Higher steps lead to more detailed and realistic images.",
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "jpeg",
+        "title": "Output Format",
+        "description": "The format of the output image.",
+        "values": [
+          "jpeg",
+          "png"
+        ]
+      },
+      {
+        "name": "safety_tolerance",
+        "type": "int",
+        "default": 2,
+        "title": "Safety Tolerance",
+        "description": "Tolerance level for input and output moderation. Between 0 and 5, 0 being most strict, 5 being least strict.",
+        "min": 0,
+        "max": 5
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for reproducibility. Use -1 for a random seed."
+      }
+    ]
+  },
+  {
+    "className": "FluxDev",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "black-forest-labs/flux-dev",
+    "outputType": "image",
+    "title": "FLUX.1 Dev",
+    "description": "AtlasCloud / Black Forest Labs FLUX.1 Dev — text to image, or image to image when a source image is connected.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "The same seed and the same prompt given to the same version of the model will output the same image every time."
+      },
+      {
+        "name": "size",
+        "type": "str",
+        "default": "1024*1024",
+        "title": "Size",
+        "description": "The size of the generated image."
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Source Image (optional)",
+        "description": "Optional image to transform. Leave empty for pure text to image."
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The prompt to generate an image from.",
+        "required": true
+      },
+      {
+        "name": "strength",
+        "type": "float",
+        "default": 0.8,
+        "title": "Strength",
+        "description": "Strength indicates extent to transform the reference image",
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "mask_image",
+        "type": "image",
+        "default": null,
+        "title": "Mask (optional)",
+        "description": "Optional inpainting mask. White marks the region to regenerate."
+      },
+      {
+        "name": "num_images",
+        "type": "int",
+        "default": 1,
+        "title": "Num Images",
+        "description": "The number of images to generate.",
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "guidance_scale",
+        "type": "float",
+        "default": 3.5,
+        "title": "Guidance Scale",
+        "description": "Flux embedded guidance strength. Higher values make the image follow the prompt more closely. This is not True CFG and does not require a negative prompt. Default 3.5.",
+        "min": 1,
+        "max": 20
+      },
+      {
+        "name": "num_inference_steps",
+        "type": "int",
+        "default": 28,
+        "title": "Num Inference Steps",
+        "description": "The number of inference steps to perform.",
+        "min": 1,
+        "max": 50
+      }
+    ]
+  },
+  {
+    "className": "FluxSchnell",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "black-forest-labs/flux-schnell",
+    "outputType": "image",
+    "title": "FLUX.1 Schnell",
+    "description": "AtlasCloud / Black Forest Labs FLUX.1 Schnell — the fast distilled FLUX. Text to image, or image to image with a source image.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed (-1 for random)"
+      },
+      {
+        "name": "size",
+        "type": "str",
+        "default": "1024*1024",
+        "title": "Size",
+        "description": "Output image size"
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Source Image (optional)",
+        "description": "Optional image to transform. Leave empty for pure text to image."
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Input prompt for image generation",
+        "required": true
+      },
+      {
+        "name": "strength",
+        "type": "float",
+        "default": 0.8,
+        "title": "Strength",
+        "description": "Strength indicates extent to transform the reference image",
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "mask_image",
+        "type": "image",
+        "default": null,
+        "title": "Mask (optional)",
+        "description": "Optional inpainting mask. White marks the region to regenerate."
+      },
+      {
+        "name": "num_images",
+        "type": "int",
+        "default": 1,
+        "title": "Num Images",
+        "description": "Number of images to generate",
+        "min": 1,
+        "max": 4
+      }
+    ]
+  },
+  {
+    "className": "FluxKontextDev",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "black-forest-labs/flux-kontext-dev",
+    "outputType": "image",
+    "title": "FLUX.1 Kontext Dev",
+    "description": "AtlasCloud / Black Forest Labs FLUX.1 Kontext Dev — instruction-driven image editing that keeps the rest of the frame.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "The same seed and the same prompt given to the same version of the model will output the same image every time."
+      },
+      {
+        "name": "size",
+        "type": "str",
+        "default": null,
+        "title": "Size",
+        "description": "The size of the generated image."
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Image to edit. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The prompt to generate an image from.",
+        "required": true
+      },
+      {
+        "name": "num_images",
+        "type": "int",
+        "default": 1,
+        "title": "Num Images",
+        "description": "The number of images to generate.",
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "guidance_scale",
+        "type": "float",
+        "default": 2.5,
+        "title": "Guidance Scale",
+        "description": "Flux embedded guidance strength. Higher values make the image follow the prompt more closely. This is not True CFG and does not require a negative prompt. Default 2.5.",
+        "min": 1,
+        "max": 20
+      },
+      {
+        "name": "num_inference_steps",
+        "type": "int",
+        "default": 28,
+        "title": "Num Inference Steps",
+        "description": "The number of inference steps to perform.",
+        "min": 1,
+        "max": 50
+      }
+    ]
+  },
+  {
+    "className": "IdeogramV4TurboTextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "ideogram/v4/turbo/text-to-image",
+    "outputType": "image",
+    "title": "Ideogram v4 Turbo — Text to Image",
+    "description": "AtlasCloud / Ideogram v4 Turbo — fast text to image, strong at typography and logos.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text description of the image to generate. Maximum 2,000 characters.",
+        "required": true
+      },
+      {
+        "name": "image_size",
+        "type": "enum",
+        "default": "landscape_16_9",
+        "title": "Image Size",
+        "description": "Output image size preset.",
+        "values": [
+          "square_hd",
+          "square",
+          "portrait_3_4",
+          "portrait_9_16",
+          "landscape_4_3",
+          "landscape_16_9"
+        ]
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "jpeg",
+        "title": "Output Format",
+        "description": "File format of the generated image.",
+        "values": [
+          "jpeg",
+          "png"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "Random seed for reproducibility. Use the same seed and prompt to reproduce results.",
+        "min": 0
+      }
+    ]
+  },
+  {
+    "className": "IdeogramV4QualityTextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "ideogram/v4/quality/text-to-image",
+    "outputType": "image",
+    "title": "Ideogram v4 Quality — Text to Image",
+    "description": "AtlasCloud / Ideogram v4 Quality — the slower, higher-fidelity Ideogram v4 tier.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text description of the image to generate. Maximum 2,000 characters.",
+        "required": true
+      },
+      {
+        "name": "image_size",
+        "type": "enum",
+        "default": "landscape_16_9",
+        "title": "Image Size",
+        "description": "Output image size preset.",
+        "values": [
+          "square_hd",
+          "square",
+          "portrait_3_4",
+          "portrait_9_16",
+          "landscape_4_3",
+          "landscape_16_9"
+        ]
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "jpeg",
+        "title": "Output Format",
+        "description": "File format of the generated image.",
+        "values": [
+          "jpeg",
+          "png"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "Random seed for reproducibility. Use the same seed and prompt to reproduce results.",
+        "min": 0
+      }
+    ]
+  },
+  {
+    "className": "HiDreamO115TextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "hidream-o1-1.5/text-to-image",
+    "outputType": "image",
+    "title": "HiDream O1 1.5 — Text to Image",
+    "description": "AtlasCloud / HiDream O1 1.5 — text to image with optional reference images for style or subject.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text prompt describing the image to generate. Maximum 2,500 characters.",
+        "required": true
+      },
+      {
+        "name": "reference_image_urls",
+        "type": "list[image]",
+        "default": null,
+        "title": "Reference Images (optional)",
+        "description": "Optional images that anchor style or subject."
+      },
+      {
+        "name": "image_size",
+        "type": "enum",
+        "default": "landscape_4_3",
+        "title": "Image Size",
+        "description": "Output image size. Choose a preset or specify custom dimensions.",
+        "values": [
+          "square_hd",
+          "square",
+          "portrait_4_3",
+          "portrait_16_9",
+          "landscape_4_3",
+          "landscape_16_9"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "type": "int",
+        "default": 50,
+        "title": "Num Inference Steps",
+        "description": "Number of denoising steps. Higher values improve quality but increase generation time.",
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "guidance_scale",
+        "type": "float",
+        "default": 5,
+        "title": "Guidance Scale",
+        "description": "Classifier-free guidance scale. Higher values make the output follow the prompt more closely.",
+        "min": 1,
+        "max": 20
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "png",
+        "title": "Output Format",
+        "description": "Output image format.",
+        "values": [
+          "png",
+          "jpeg",
+          "webp"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "HiDreamO115Edit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "hidream-o1-1.5/edit",
+    "outputType": "image",
+    "title": "HiDream O1 1.5 — Edit",
+    "description": "AtlasCloud / HiDream O1 1.5 — edits reference images from a text instruction.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text prompt describing the image to generate. Maximum 2,500 characters.",
+        "required": true
+      },
+      {
+        "name": "reference_image_urls",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "Images to edit. Connect from upstream nodes, drag/drop, or paste public URLs.",
+        "required": true
+      },
+      {
+        "name": "image_size",
+        "type": "enum",
+        "default": "landscape_4_3",
+        "title": "Image Size",
+        "description": "Output image size. Choose a preset or specify custom dimensions.",
+        "values": [
+          "square_hd",
+          "square",
+          "portrait_4_3",
+          "portrait_16_9",
+          "landscape_4_3",
+          "landscape_16_9"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "type": "int",
+        "default": 50,
+        "title": "Num Inference Steps",
+        "description": "Number of denoising steps. Higher values improve quality but increase generation time.",
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "guidance_scale",
+        "type": "float",
+        "default": 5,
+        "title": "Guidance Scale",
+        "description": "Classifier-free guidance scale. Higher values make the output follow the prompt more closely.",
+        "min": 1,
+        "max": 20
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "png",
+        "title": "Output Format",
+        "description": "Output image format.",
+        "values": [
+          "png",
+          "jpeg",
+          "webp"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "Krea2TurboTextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "krea-2-turbo/text-to-image",
+    "outputType": "image",
+    "title": "Krea 2 Turbo — Text to Image",
+    "description": "AtlasCloud / Krea 2 Turbo — fast text to image tuned against the over-processed look.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text prompt describing the image to generate.",
+        "required": true
+      },
+      {
+        "name": "image_size",
+        "type": "enum",
+        "default": "square_hd",
+        "title": "Image Size",
+        "description": "Output image size. Choose a preset or specify custom dimensions.",
+        "values": [
+          "square_hd",
+          "square",
+          "portrait_3_4",
+          "portrait_9_16",
+          "landscape_4_3",
+          "landscape_16_9"
+        ]
+      },
+      {
+        "name": "num_images",
+        "type": "int",
+        "default": 1,
+        "title": "Num Images",
+        "description": "Number of images to generate.",
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "Seed for reproducible generation. Omit for a random seed."
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "png",
+        "title": "Output Format",
+        "description": "Output image format.",
+        "values": [
+          "png",
+          "jpeg"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "Cosmos3SuperTextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "nvidia/cosmos-3-super/text-to-image",
+    "outputType": "image",
+    "title": "Cosmos 3 Super — Text to Image",
+    "description": "AtlasCloud / NVIDIA Cosmos 3 Super — text to image with a negative prompt and exposed sampler settings.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The text prompt describing the image to generate. Maximum 2,500 characters.",
+        "required": true
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "Text describing content to exclude from the generated image."
+      },
+      {
+        "name": "image_size",
+        "type": "enum",
+        "default": "landscape_16_9",
+        "title": "Resolution",
+        "description": "Output resolution preset.",
+        "values": [
+          "square_hd",
+          "square",
+          "portrait_4_3",
+          "portrait_16_9",
+          "landscape_4_3",
+          "landscape_16_9"
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "type": "int",
+        "default": 28,
+        "title": "Num Inference Steps",
+        "description": "Number of denoising steps. Higher values improve quality but increase generation time.",
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "guidance_scale",
+        "type": "float",
+        "default": 4,
+        "title": "Guidance Scale",
+        "description": "Classifier-free guidance scale. Higher values make the output follow the prompt more closely.",
+        "min": 1,
+        "max": 20
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "jpeg",
+        "title": "Output Format",
+        "description": "Output image format.",
+        "values": [
+          "jpeg",
+          "png"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "Random seed for reproducibility. Use the same seed and prompt to reproduce results.",
+        "min": 0
+      },
+      {
+        "name": "enable_safety_checker",
+        "type": "bool",
+        "default": false,
+        "title": "Enable Safety Checker",
+        "description": "Enable or disable the safety checker. Disabling the safety checker may result in NSFW content."
+      }
+    ]
+  },
+  {
+    "className": "Cosmos3SuperImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "nvidia/cosmos-3-super/image-to-video",
+    "outputType": "video",
+    "title": "Cosmos 3 Super — Image to Video",
+    "description": "AtlasCloud / NVIDIA Cosmos 3 Super — animates a still image for 1-7 seconds.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text description of the motion and scene to generate. Maximum 2,500 characters.",
+        "required": true
+      },
+      {
+        "name": "image_url",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Image to animate. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "Text describing content to exclude from the generated video."
+      },
+      {
+        "name": "image_size",
+        "type": "enum",
+        "default": "landscape_16_9",
+        "title": "Resolution",
+        "description": "Output resolution preset.",
+        "values": [
+          "square_hd",
+          "square",
+          "portrait_4_3",
+          "portrait_16_9",
+          "landscape_4_3",
+          "landscape_16_9"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds (1-7).",
+        "values": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7
+        ]
+      },
+      {
+        "name": "num_inference_steps",
+        "type": "int",
+        "default": 28,
+        "title": "Num Inference Steps",
+        "description": "Number of denoising steps. Higher values improve quality but increase generation time.",
+        "min": 1,
+        "max": 50
+      },
+      {
+        "name": "guidance_scale",
+        "type": "float",
+        "default": 6,
+        "title": "Guidance Scale",
+        "description": "Classifier-free guidance scale. Higher values make the output follow the prompt more closely.",
+        "min": 1,
+        "max": 20
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "Random seed for reproducibility. Use the same seed and prompt to reproduce results.",
+        "min": 0
+      },
+      {
+        "name": "enable_safety_checker",
+        "type": "bool",
+        "default": false,
+        "title": "Enable Safety Checker",
+        "description": "Enable or disable the safety checker. Disabling the safety checker may result in NSFW content."
+      }
+    ]
+  },
+  {
+    "className": "SeedreamV45TextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "bytedance/seedream-v4.5",
+    "outputType": "image",
+    "title": "Seedream v4.5 — Text to Image",
+    "description": "AtlasCloud / ByteDance Seedream v4.5 — text to image up to 4K.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "enum",
+        "default": "2048*2048",
+        "title": "Size",
+        "description": "Output image size in 'WIDTH*HEIGHT' pixels. 16 preset resolutions at 2K and 4K tiers.",
+        "values": [
+          "2048*2048",
+          "2304*1728",
+          "1728*2304",
+          "2848*1600",
+          "1600*2848",
+          "2496*1664",
+          "1664*2496",
+          "3136*1344",
+          "4096*4096",
+          "4704*3520",
+          "3520*4704",
+          "5504*3040",
+          "3040*5504",
+          "4992*3328",
+          "3328*4992",
+          "6240*2656"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "SeedreamV45Edit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "bytedance/seedream-v4.5/edit",
+    "outputType": "image",
+    "title": "Seedream v4.5 — Edit",
+    "description": "AtlasCloud / ByteDance Seedream v4.5 — edits input images from a text instruction.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "Images to edit. Connect from upstream nodes, drag/drop, or paste public URLs.",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "size",
+        "type": "enum",
+        "default": "2048*2048",
+        "title": "Size",
+        "description": "Output image size in 'WIDTH*HEIGHT' pixels. 16 preset resolutions at 2K and 4K tiers.",
+        "values": [
+          "2048*2048",
+          "2304*1728",
+          "1728*2304",
+          "2848*1600",
+          "1600*2848",
+          "2496*1664",
+          "1664*2496",
+          "3136*1344",
+          "4096*4096",
+          "4704*3520",
+          "3520*4704",
+          "5504*3040",
+          "3040*5504",
+          "4992*3328",
+          "3328*4992",
+          "6240*2656"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "GPTImage1TextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "openai/gpt-image-1/text-to-image",
+    "outputType": "image",
+    "title": "GPT Image 1 — Text to Image",
+    "description": "AtlasCloud / OpenAI GPT Image 1 — text to image with selectable quality tier.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "quality",
+        "type": "enum",
+        "default": "medium",
+        "title": "Quality",
+        "description": "The quality of the generated image.",
+        "values": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "size",
+        "type": "enum",
+        "default": "1024x1024",
+        "title": "Size",
+        "description": "The size of the generated media in pixels (widthxheight).",
+        "values": [
+          "1024x1024",
+          "1024x1536",
+          "1536x1024"
+        ]
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "png",
+        "title": "Output Format",
+        "description": "Output image format.",
+        "values": [
+          "png",
+          "jpeg"
+        ]
+      },
+      {
+        "name": "output_compression",
+        "type": "int",
+        "default": 100,
+        "title": "Output Compression",
+        "description": "Compression level for output image.",
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "n",
+        "type": "int",
+        "default": 1,
+        "title": "N",
+        "description": "Number of images to generate.",
+        "min": 1,
+        "max": 10
+      }
+    ]
+  },
+  {
+    "className": "GPTImage1Edit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "openai/gpt-image-1/edit",
+    "outputType": "image",
+    "title": "GPT Image 1 — Edit",
+    "description": "AtlasCloud / OpenAI GPT Image 1 — edits input images, optionally masked.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "image",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "Images to edit. Connect from upstream nodes, drag/drop, or paste public URLs.",
+        "required": true
+      },
+      {
+        "name": "mask_image",
+        "type": "image",
+        "default": null,
+        "title": "Mask (optional)",
+        "description": "Optional mask. Transparent pixels mark the region to regenerate."
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "quality",
+        "type": "enum",
+        "default": "medium",
+        "title": "Quality",
+        "description": "The quality of the generated image.",
+        "values": [
+          "high",
+          "medium",
+          "low"
+        ]
+      },
+      {
+        "name": "size",
+        "type": "enum",
+        "default": "1024x1024",
+        "title": "Size",
+        "description": "The size of the generated media in pixels (width*height).",
+        "values": [
+          "1024x1024",
+          "1024x1536",
+          "1536x1024"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "GPTImage1MiniTextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "openai/gpt-image-1-mini/text-to-image",
+    "outputType": "image",
+    "title": "GPT Image 1 Mini — Text to Image",
+    "description": "AtlasCloud / OpenAI GPT Image 1 Mini — the cheaper GPT Image 1 tier for drafts and volume.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "quality",
+        "type": "enum",
+        "default": "medium",
+        "title": "Quality",
+        "description": "The quality of the generated image.",
+        "values": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      {
+        "name": "size",
+        "type": "enum",
+        "default": "1024x1024",
+        "title": "Size",
+        "description": "The size of the generated media in pixels (widthxheight).",
+        "values": [
+          "1024x1024",
+          "1024x1536",
+          "1536x1024"
+        ]
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "png",
+        "title": "Output Format",
+        "description": "Output image format.",
+        "values": [
+          "png",
+          "jpeg"
+        ]
+      },
+      {
+        "name": "output_compression",
+        "type": "int",
+        "default": 100,
+        "title": "Output Compression",
+        "description": "Compression level for output image.",
+        "min": 0,
+        "max": 100
+      },
+      {
+        "name": "n",
+        "type": "int",
+        "default": 1,
+        "title": "N",
+        "description": "Number of images to generate.",
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      }
+    ]
+  },
+  {
+    "className": "GPTImage1MiniEdit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "openai/gpt-image-1-mini/edit",
+    "outputType": "image",
+    "title": "GPT Image 1 Mini — Edit",
+    "description": "AtlasCloud / OpenAI GPT Image 1 Mini — the cheaper edit tier for drafts and volume.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "Images to edit. Connect from upstream nodes, drag/drop, or paste public URLs.",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "quality",
+        "type": "enum",
+        "default": "medium",
+        "title": "Quality",
+        "description": "The quality of the generated image.",
+        "values": [
+          "high",
+          "medium",
+          "low"
+        ]
+      },
+      {
+        "name": "size",
+        "type": "enum",
+        "default": "1024x1024",
+        "title": "Size",
+        "description": "The size of the generated media in pixels (width*height).",
+        "values": [
+          "1024x1024",
+          "1024x1536",
+          "1536x1024"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "GrokImagineImageTextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "xai/grok-imagine-image/text-to-image",
+    "outputType": "image",
+    "title": "Grok Imagine Image — Text to Image",
+    "description": "AtlasCloud / xAI Grok Imagine Image — text to image, 1-4 variants per call.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Natural-language description of the image to generate.",
+        "required": true
+      },
+      {
+        "name": "num_images",
+        "type": "enum",
+        "default": 1,
+        "title": "Num Images",
+        "description": "Number of images to generate. Each image is billed separately.",
+        "values": [
+          1,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "1:1",
+        "title": "Aspect Ratio",
+        "description": "Aspect ratio of the generated image.",
+        "values": [
+          "1:1",
+          "3:4",
+          "4:3",
+          "9:16",
+          "16:9",
+          "2:3",
+          "3:2",
+          "9:19.5",
+          "19.5:9",
+          "9:20",
+          "20:9",
+          "1:2",
+          "2:1"
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1k",
+        "title": "Resolution",
+        "description": "Output resolution. 1k = 1024x1024, 2k = 2048x2048.",
+        "values": [
+          "1k",
+          "2k"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "GrokImagineImageEdit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "xai/grok-imagine-image/edit",
+    "outputType": "image",
+    "title": "Grok Imagine Image — Edit",
+    "description": "AtlasCloud / xAI Grok Imagine Image — edits source images from a text instruction.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Editing instruction. For multi-image references, cite each input as <IMAGE_0>, <IMAGE_1>, ...",
+        "required": true
+      },
+      {
+        "name": "image_urls",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "Source images. Connect from upstream nodes, drag/drop, or paste public URLs.",
+        "required": true
+      },
+      {
+        "name": "num_images",
+        "type": "enum",
+        "default": 1,
+        "title": "Num Images",
+        "description": "Number of edited images to generate. Each output image is billed separately.",
+        "values": [
+          1,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "auto",
+        "title": "Aspect Ratio",
+        "description": "Aspect ratio of the edited image. With a single source image, the output respects the input's aspect ratio regardless of this value. `auto` lets the model pick.",
+        "values": [
+          "auto",
+          "1:1",
+          "3:4",
+          "4:3",
+          "9:16",
+          "16:9",
+          "2:3",
+          "3:2",
+          "9:19.5",
+          "19.5:9",
+          "9:20",
+          "20:9",
+          "1:2",
+          "2:1"
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1k",
+        "title": "Resolution",
+        "description": "Output resolution. 1k = 1024x1024, 2k = 2048x2048.",
+        "values": [
+          "1k",
+          "2k"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "MaiImage25FlashEdit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "microsoft/mai-image-2.5-flash/edit",
+    "outputType": "image",
+    "title": "MAI Image 2.5 Flash — Edit",
+    "description": "AtlasCloud / Microsoft MAI-Image-2.5-Flash — fast single-image editing from a text instruction.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt describing the edit to perform on the image. Maximum context length: 32,000 tokens.",
+        "required": true
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Image to edit. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      }
+    ]
+  },
+  {
+    "className": "Wan26TextToImage",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "alibaba/wan-2.6/text-to-image",
+    "outputType": "image",
+    "title": "Wan 2.6 — Text to Image",
+    "description": "AtlasCloud / Alibaba Wan 2.6 — text to image with a negative prompt and a wide size list.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "enable_prompt_expansion",
+        "type": "bool",
+        "default": false,
+        "title": "Enable Prompt Expansion",
+        "description": "If set to true, the prompt optimizer will be enabled."
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": null,
+        "title": "Negative Prompt",
+        "description": "Negative prompt for the generation."
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The prompt for generating the image.",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
+      },
+      {
+        "name": "size",
+        "type": "enum",
+        "default": "1280*1280",
+        "title": "Size",
+        "description": "The size of the generated image in pixels (width*height).",
+        "values": [
+          "576*1344",
+          "720*1280",
+          "720*1680",
+          "768*1024",
+          "800*1200",
+          "936*2184",
+          "960*1280",
+          "960*1440",
+          "1024*768",
+          "1024*1024",
+          "1080*1920",
+          "1168*1752",
+          "1200*800",
+          "1200*1600",
+          "1224*1632",
+          "1280*720",
+          "1280*960",
+          "1280*1280",
+          "1344*576",
+          "1440*960",
+          "1440*1440",
+          "1600*1200",
+          "1632*1224",
+          "1680*720",
+          "1752*1168",
+          "1920*1080",
+          "2184*936"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "Wan26ImageEdit",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "alibaba/wan-2.6/image-edit",
+    "outputType": "image",
+    "title": "Wan 2.6 — Image Edit",
+    "description": "AtlasCloud / Alibaba Wan 2.6 — edits input images from a text instruction.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "enable_prompt_expansion",
+        "type": "bool",
+        "default": false,
+        "title": "Enable Prompt Expansion",
+        "description": "If set to true, the prompt optimizer will be enabled."
+      },
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Images",
+        "description": "Images to edit. Connect from upstream nodes, drag/drop, or paste public URLs.",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": null,
+        "title": "Negative Prompt",
+        "description": "Negative prompt for the generation."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
+      },
+      {
+        "name": "size",
+        "type": "enum",
+        "default": "1280*1280",
+        "title": "Size",
+        "description": "The size of the generated image in pixels (width*height).",
+        "values": [
+          "576*1344",
+          "720*1280",
+          "720*1680",
+          "768*1024",
+          "800*1200",
+          "816*1904",
+          "936*1664",
+          "960*1280",
+          "960*1440",
+          "1024*768",
+          "1024*1024",
+          "1040*1560",
+          "1104*1472",
+          "1200*800",
+          "1280*720",
+          "1280*960",
+          "1280*1280",
+          "1344*576",
+          "1440*960",
+          "1472*1104",
+          "1560*1040",
+          "1664*936",
+          "1680*720",
+          "1904*816"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "ImageUpscaler",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "atlascloud/image-upscaler",
+    "outputType": "image",
+    "title": "Image Upscaler",
+    "description": "AtlasCloud Image Upscaler — enlarges an image up to 4x without a prompt.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Image to upscale. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "outscale",
+        "type": "float",
+        "default": 1,
+        "title": "Outscale",
+        "description": "Output scale multiplier. Use 2.0 for standard upscaling and 4.0 for the maximum exposed scale.",
+        "min": 1,
+        "max": 4
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "jpeg",
+        "title": "Output Format",
+        "description": "Output image format.",
+        "values": [
+          "jpeg",
+          "png",
+          "webp",
+          "jpg"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "TencentImageUpscaler",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "tencent/image/upscaler",
+    "outputType": "image",
+    "title": "Tencent Image Upscaler",
+    "description": "AtlasCloud / Tencent Image Upscaler — upscales by percentage, target side, or fixed size, in four fidelity tiers.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "image_url",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Image to upscale. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "type",
+        "type": "enum",
+        "default": "ultra",
+        "title": "Type",
+        "description": "Advanced super-resolution type. standard = generic upscale (fastest ~5s); super = AIGC scenes (~15s); ultra = more detail enhancement (~15s); fidelity = ultra high fidelity for e-c…",
+        "values": [
+          "standard",
+          "super",
+          "ultra",
+          "fidelity"
+        ]
+      },
+      {
+        "name": "mode",
+        "type": "enum",
+        "default": "percent",
+        "title": "Mode",
+        "description": "Super-resolution mode. percent = scale by a factor (use percent); aspect = keep aspect ratio, scale to fit given dimensions; fixed = force exact dimensions.",
+        "values": [
+          "percent",
+          "aspect",
+          "fixed"
+        ]
+      },
+      {
+        "name": "percent",
+        "type": "float",
+        "default": 2,
+        "title": "Percent",
+        "description": "Scale factor for mode=percent. 1.0 = keep resolution (enhance only), 2.0 = 2x. Range 1.0~10.0.",
+        "min": 1,
+        "max": 10
+      },
+      {
+        "name": "width",
+        "type": "int",
+        "default": null,
+        "title": "Width",
+        "description": "Target width in pixels (for mode=aspect / fixed).",
+        "min": 1
+      },
+      {
+        "name": "height",
+        "type": "int",
+        "default": null,
+        "title": "Height",
+        "description": "Target height in pixels (for mode=aspect / fixed).",
+        "min": 1
+      },
+      {
+        "name": "long_side",
+        "type": "int",
+        "default": null,
+        "title": "Long Side",
+        "description": "Target long-edge in pixels (for mode=aspect / fixed). Alternative to width/height.",
+        "min": 1
+      },
+      {
+        "name": "short_side",
+        "type": "int",
+        "default": null,
+        "title": "Short Side",
+        "description": "Target short-edge in pixels (for mode=aspect / fixed). Alternative to width/height.",
+        "min": 1
+      },
+      {
+        "name": "encode_format",
+        "type": "enum",
+        "default": "JPEG",
+        "title": "Encode Format",
+        "description": "Output image encode format.",
+        "values": [
+          "JPEG",
+          "PNG",
+          "WEBP",
+          "BMP"
+        ]
+      },
+      {
+        "name": "encode_quality",
+        "type": "int",
+        "default": 80,
+        "title": "Encode Quality",
+        "description": "Output image encode quality (1-100). Applies to lossy formats.",
+        "min": 1,
+        "max": 100
+      }
+    ]
+  },
+  {
+    "className": "PhotoCleanup",
+    "moduleName": "image",
+    "modality": "image",
+    "modelId": "atlascloud/photo-cleanup",
+    "outputType": "image",
+    "title": "Photo Cleanup",
+    "description": "AtlasCloud Photo Cleanup — removes compression artifacts and noise from a photo.",
+    "pollInterval": 3000,
+    "maxAttempts": 300,
+    "fields": [
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Photo to clean up. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "png",
+        "title": "Output Format",
+        "description": "Output image format.",
+        "values": [
+          "png",
+          "jpeg",
+          "webp",
+          "jpg"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "KlingVideoO3ProTextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "kwaivgi/kling-video-o3-pro/text-to-video",
+    "outputType": "video",
+    "title": "Kling Video O3 Pro — Text to Video",
+    "description": "AtlasCloud / Kuaishou Kling Video O3 Pro — text to video up to 15 seconds with native sound.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video.",
+        "values": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds (3-15).",
+        "values": [
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ]
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation."
+      },
+      {
+        "name": "sound",
+        "type": "bool",
+        "default": true,
+        "title": "Sound",
+        "description": "Whether to generate audio for the video."
+      },
+      {
+        "name": "multi_shot",
+        "type": "bool",
+        "default": false,
+        "title": "Multi Shot",
+        "description": "Whether to enable multi-shot generation."
+      },
+      {
+        "name": "shot_type",
+        "type": "enum",
+        "default": null,
+        "title": "Shot Type",
+        "description": "Multi-shot mode. customize = caller provides per-shot prompts; intelligence = model auto-splits the top-level prompt into shots. Required when multi_shot=true.",
+        "values": [
+          "customize",
+          "intelligence"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "KlingVideoO3ProImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "kwaivgi/kling-video-o3-pro/image-to-video",
+    "outputType": "video",
+    "title": "Kling Video O3 Pro — Image to Video",
+    "description": "AtlasCloud / Kuaishou Kling Video O3 Pro — animates a first frame, with an optional last frame.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds (3-15).",
+        "values": [
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ]
+      },
+      {
+        "name": "end_image",
+        "type": "image",
+        "default": null,
+        "title": "Last Frame (optional)",
+        "description": "Optional ending frame."
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "First Frame",
+        "description": "Image used as the first frame. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation."
+      },
+      {
+        "name": "sound",
+        "type": "bool",
+        "default": true,
+        "title": "Sound",
+        "description": "Whether to automatically add audio to the generated video."
+      },
+      {
+        "name": "multi_shot",
+        "type": "bool",
+        "default": false,
+        "title": "Multi Shot",
+        "description": "Whether to enable multi-shot generation."
+      },
+      {
+        "name": "shot_type",
+        "type": "enum",
+        "default": null,
+        "title": "Shot Type",
+        "description": "Multi-shot mode. customize = caller provides per-shot prompts; intelligence = model auto-splits the top-level prompt into shots. Required when multi_shot=true.",
+        "values": [
+          "customize",
+          "intelligence"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "KlingVideoO3ProReferenceToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "kwaivgi/kling-video-o3-pro/reference-to-video",
+    "outputType": "video",
+    "title": "Kling Video O3 Pro — Reference to Video",
+    "description": "AtlasCloud / Kuaishou Kling Video O3 Pro — generates video from reference images or a reference video.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video.",
+        "values": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds (3-15).",
+        "values": [
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ]
+      },
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Reference Images",
+        "description": "Reference images that anchor subject and style."
+      },
+      {
+        "name": "keep_original_sound",
+        "type": "bool",
+        "default": true,
+        "title": "Keep Original Sound",
+        "description": "Whether to keep the original sound from the reference video."
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation."
+      },
+      {
+        "name": "sound",
+        "type": "bool",
+        "default": false,
+        "title": "Sound",
+        "description": "Whether to generate audio for the video."
+      },
+      {
+        "name": "video",
+        "type": "video",
+        "default": null,
+        "title": "Reference Video",
+        "description": "Reference video whose motion or content anchors the generation."
+      },
+      {
+        "name": "multi_shot",
+        "type": "bool",
+        "default": false,
+        "title": "Multi Shot",
+        "description": "Whether to enable multi-shot generation."
+      },
+      {
+        "name": "shot_type",
+        "type": "enum",
+        "default": null,
+        "title": "Shot Type",
+        "description": "Multi-shot mode. customize = caller provides per-shot prompts; intelligence = model auto-splits the top-level prompt into shots. Required when multi_shot=true.",
+        "values": [
+          "customize",
+          "intelligence"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "KlingVideoO3StdTextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "kwaivgi/kling-video-o3-std/text-to-video",
+    "outputType": "video",
+    "title": "Kling Video O3 Std — Text to Video",
+    "description": "AtlasCloud / Kuaishou Kling Video O3 Std — the cheaper Kling O3 tier for text to video.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video.",
+        "values": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds (3-15).",
+        "values": [
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ]
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation."
+      },
+      {
+        "name": "sound",
+        "type": "bool",
+        "default": true,
+        "title": "Sound",
+        "description": "Whether to generate audio for the video."
+      },
+      {
+        "name": "multi_shot",
+        "type": "bool",
+        "default": false,
+        "title": "Multi Shot",
+        "description": "Whether to enable multi-shot generation."
+      },
+      {
+        "name": "shot_type",
+        "type": "enum",
+        "default": null,
+        "title": "Shot Type",
+        "description": "Multi-shot mode. customize = caller provides per-shot prompts; intelligence = model auto-splits the top-level prompt into shots. Required when multi_shot=true.",
+        "values": [
+          "customize",
+          "intelligence"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "KlingVideoO3StdImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "kwaivgi/kling-video-o3-std/image-to-video",
+    "outputType": "video",
+    "title": "Kling Video O3 Std — Image to Video",
+    "description": "AtlasCloud / Kuaishou Kling Video O3 Std — animates a first frame, with an optional last frame.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds (3-15).",
+        "values": [
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ]
+      },
+      {
+        "name": "end_image",
+        "type": "image",
+        "default": null,
+        "title": "Last Frame (optional)",
+        "description": "Optional ending frame."
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "First Frame",
+        "description": "Image used as the first frame. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation."
+      },
+      {
+        "name": "sound",
+        "type": "bool",
+        "default": true,
+        "title": "Sound",
+        "description": "Whether to automatically add audio to the generated video."
+      },
+      {
+        "name": "multi_shot",
+        "type": "bool",
+        "default": false,
+        "title": "Multi Shot",
+        "description": "Whether to enable multi-shot generation."
+      },
+      {
+        "name": "shot_type",
+        "type": "enum",
+        "default": null,
+        "title": "Shot Type",
+        "description": "Multi-shot mode. customize = caller provides per-shot prompts; intelligence = model auto-splits the top-level prompt into shots. Required when multi_shot=true.",
+        "values": [
+          "customize",
+          "intelligence"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "KlingVideoO3StdReferenceToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "kwaivgi/kling-video-o3-std/reference-to-video",
+    "outputType": "video",
+    "title": "Kling Video O3 Std — Reference to Video",
+    "description": "AtlasCloud / Kuaishou Kling Video O3 Std — generates video from reference images or a reference video.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video.",
+        "values": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds (3-15).",
+        "values": [
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ]
+      },
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Reference Images",
+        "description": "Reference images that anchor subject and style."
+      },
+      {
+        "name": "keep_original_sound",
+        "type": "bool",
+        "default": true,
+        "title": "Keep Original Sound",
+        "description": "Whether to keep the original sound from the reference video."
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation."
+      },
+      {
+        "name": "sound",
+        "type": "bool",
+        "default": false,
+        "title": "Sound",
+        "description": "Whether to generate audio for the video."
+      },
+      {
+        "name": "video",
+        "type": "video",
+        "default": null,
+        "title": "Reference Video",
+        "description": "Reference video whose motion or content anchors the generation."
+      },
+      {
+        "name": "multi_shot",
+        "type": "bool",
+        "default": false,
+        "title": "Multi Shot",
+        "description": "Whether to enable multi-shot generation."
+      },
+      {
+        "name": "shot_type",
+        "type": "enum",
+        "default": null,
+        "title": "Shot Type",
+        "description": "Multi-shot mode. customize = caller provides per-shot prompts; intelligence = model auto-splits the top-level prompt into shots. Required when multi_shot=true.",
+        "values": [
+          "customize",
+          "intelligence"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "KlingV34kTextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "kwaivgi/kling-v3.0-4k/text-to-video",
+    "outputType": "video",
+    "title": "Kling v3.0 4K — Text to Video",
+    "description": "AtlasCloud / Kuaishou Kling v3.0 4K — text to video at 4K with native sound.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video.",
+        "values": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "cfg_scale",
+        "type": "float",
+        "default": 0.5,
+        "title": "Cfg Scale",
+        "description": "Flexibility in video generation; The higher the value, the lower the model's degree of flexibility, and the stronger the relevance to the user's prompt.",
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds (3-15).",
+        "values": [
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ]
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": null,
+        "title": "Negative Prompt",
+        "description": "The negative prompt for the generation."
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation."
+      },
+      {
+        "name": "sound",
+        "type": "bool",
+        "default": true,
+        "title": "Sound",
+        "description": "Whether sound is generated simultaneously when generating a video."
+      },
+      {
+        "name": "multi_shot",
+        "type": "bool",
+        "default": false,
+        "title": "Multi Shot",
+        "description": "Whether to enable multi-shot generation."
+      },
+      {
+        "name": "shot_type",
+        "type": "enum",
+        "default": null,
+        "title": "Shot Type",
+        "description": "Multi-shot mode. customize = caller provides per-shot prompts; intelligence = model auto-splits the top-level prompt into shots. Required when multi_shot=true.",
+        "values": [
+          "customize",
+          "intelligence"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "KlingV34kImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "kwaivgi/kling-v3.0-4k/image-to-video",
+    "outputType": "video",
+    "title": "Kling v3.0 4K — Image to Video",
+    "description": "AtlasCloud / Kuaishou Kling v3.0 4K — animates a first frame at 4K, with an optional last frame.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "cfg_scale",
+        "type": "float",
+        "default": 0.5,
+        "title": "Cfg Scale",
+        "description": "Flexibility in video generation; The higher the value, the lower the model's degree of flexibility, and the stronger the relevance to the user's prompt.",
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds (3-15).",
+        "values": [
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ]
+      },
+      {
+        "name": "end_image",
+        "type": "image",
+        "default": null,
+        "title": "Last Frame (optional)",
+        "description": "Optional ending frame."
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "First Frame",
+        "description": "Image used as the first frame. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": null,
+        "title": "Negative Prompt",
+        "description": "The negative prompt for the generation."
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation."
+      },
+      {
+        "name": "sound",
+        "type": "bool",
+        "default": true,
+        "title": "Sound",
+        "description": "Whether sound is generated simultaneously when generating a video."
+      },
+      {
+        "name": "resolution",
+        "type": "str",
+        "default": "1080P",
+        "title": "Resolution",
+        "description": "The resolution of the generated video."
+      },
+      {
+        "name": "multi_shot",
+        "type": "bool",
+        "default": false,
+        "title": "Multi Shot",
+        "description": "Whether to enable multi-shot generation."
+      },
+      {
+        "name": "shot_type",
+        "type": "enum",
+        "default": null,
+        "title": "Shot Type",
+        "description": "Multi-shot mode. customize = caller provides per-shot prompts; intelligence = model auto-splits the top-level prompt into shots. Required when multi_shot=true.",
+        "values": [
+          "customize",
+          "intelligence"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "KlingV26ProTextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "kwaivgi/kling-v2.6-pro/text-to-video",
+    "outputType": "video",
+    "title": "Kling v2.6 Pro — Text to Video",
+    "description": "AtlasCloud / Kuaishou Kling v2.6 Pro — 5 or 10 second text to video with native sound.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "1:1",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated media.",
+        "values": [
+          "1:1",
+          "9:16",
+          "16:9"
+        ]
+      },
+      {
+        "name": "cfg_scale",
+        "type": "float",
+        "default": 0.5,
+        "title": "Cfg Scale",
+        "description": "Flexibility in video generation; The higher the value, the lower the model’s degree of flexibility, and the stronger the relevance to the user’s prompt.",
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds.",
+        "values": [
+          5,
+          10
+        ]
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": null,
+        "title": "Negative Prompt",
+        "description": "The negative prompt for the generation."
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "sound",
+        "type": "bool",
+        "default": true,
+        "title": "Sound",
+        "description": "Whether sound is generated simultaneously when generating a video"
+      }
+    ]
+  },
+  {
+    "className": "KlingV26ProImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "kwaivgi/kling-v2.6-pro/image-to-video",
+    "outputType": "video",
+    "title": "Kling v2.6 Pro — Image to Video",
+    "description": "AtlasCloud / Kuaishou Kling v2.6 Pro — animates a still image for 5 or 10 seconds.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "cfg_scale",
+        "type": "float",
+        "default": 0.5,
+        "title": "Cfg Scale",
+        "description": "Flexibility in video generation; The higher the value, the lower the model’s degree of flexibility, and the stronger the relevance to the user’s prompt.",
+        "min": 0,
+        "max": 1
+      },
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds.",
+        "values": [
+          5,
+          10
+        ]
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Image to animate. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": null,
+        "title": "Negative Prompt",
+        "description": "The negative prompt for the generation."
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation."
+      },
+      {
+        "name": "sound",
+        "type": "bool",
+        "default": true,
+        "title": "Sound",
+        "description": "Whether sound is generated simultaneously when generating a video"
+      }
+    ]
+  },
+  {
+    "className": "SeedanceV15ProTextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "bytedance/seedance-v1.5-pro/text-to-video",
+    "outputType": "video",
+    "title": "Seedance v1.5 Pro — Text to Video",
+    "description": "AtlasCloud / ByteDance Seedance v1.5 Pro — text to video with native audio.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated media.",
+        "values": [
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "camera_fixed",
+        "type": "bool",
+        "default": false,
+        "title": "Camera Fixed",
+        "description": "Whether to fix the camera position."
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds.",
+        "min": 4,
+        "max": 12
+      },
+      {
+        "name": "generate_audio",
+        "type": "bool",
+        "default": true,
+        "title": "Generate Audio",
+        "description": "Whether to generate audio."
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "Video resolution.",
+        "values": [
+          "720p",
+          "480p"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
+      }
+    ]
+  },
+  {
+    "className": "SeedanceV15ProImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "bytedance/seedance-v1.5-pro/image-to-video",
+    "outputType": "video",
+    "title": "Seedance v1.5 Pro — Image to Video",
+    "description": "AtlasCloud / ByteDance Seedance v1.5 Pro — animates a first frame (and optional last frame) with native audio.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": null,
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated media.",
+        "values": [
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "camera_fixed",
+        "type": "bool",
+        "default": false,
+        "title": "Camera Fixed",
+        "description": "Whether to fix the camera position."
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds.",
+        "min": 4,
+        "max": 12
+      },
+      {
+        "name": "generate_audio",
+        "type": "bool",
+        "default": true,
+        "title": "Generate Audio",
+        "description": "Whether to generate audio."
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "First Frame",
+        "description": "Image used as the first frame. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "last_image",
+        "type": "image",
+        "default": null,
+        "title": "Last Frame (optional)",
+        "description": "Optional ending frame."
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation."
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "Video resolution.",
+        "values": [
+          "720p",
+          "480p"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
+      }
+    ]
+  },
+  {
+    "className": "Wan26TextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "alibaba/wan-2.6/text-to-video",
+    "outputType": "video",
+    "title": "Wan 2.6 — Text to Video",
+    "description": "AtlasCloud / Alibaba Wan 2.6 — 5, 10 or 15 second text to video, optionally driven by an audio track.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "audio",
+        "type": "audio",
+        "default": null,
+        "title": "Audio (optional)",
+        "description": "Optional audio track the generation is timed to."
+      },
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds.",
+        "values": [
+          5,
+          10,
+          15
+        ]
+      },
+      {
+        "name": "enable_prompt_expansion",
+        "type": "bool",
+        "default": true,
+        "title": "Enable Prompt Expansion",
+        "description": "If set to true, the prompt optimizer will be enabled."
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": null,
+        "title": "Negative Prompt",
+        "description": "Negative prompt for the generation."
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The prompt for generating the output.",
+        "required": true
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
+      },
+      {
+        "name": "size",
+        "type": "enum",
+        "default": "1280*720",
+        "title": "Size",
+        "description": "The size of the generated media in pixels (width*height).",
+        "values": [
+          "1280*720",
+          "720*1280",
+          "960*960",
+          "1088*832",
+          "832*1088",
+          "1920*1080",
+          "1080*1920",
+          "1440*1440",
+          "1632*1248",
+          "1248*1632"
+        ],
+        "required": true
+      },
+      {
+        "name": "shot_type",
+        "type": "enum",
+        "default": "multi",
+        "title": "Shot Type",
+        "description": "Generate video in multi camera angles, only works when set enable_prompt_expansion to true.",
+        "values": [
+          "multi",
+          "single"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "type": "bool",
+        "default": true,
+        "title": "Generate Audio",
+        "description": "Whether to automatically add audio to the generated video."
+      }
+    ]
+  },
+  {
+    "className": "Wan26ImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "alibaba/wan-2.6/image-to-video",
+    "outputType": "video",
+    "title": "Wan 2.6 — Image to Video",
+    "description": "AtlasCloud / Alibaba Wan 2.6 — animates a still image, optionally driven by an audio track.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "audio",
+        "type": "audio",
+        "default": null,
+        "title": "Audio (optional)",
+        "description": "Optional audio track the generation is timed to."
+      },
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds.",
+        "values": [
+          5,
+          10,
+          15
+        ]
+      },
+      {
+        "name": "enable_prompt_expansion",
+        "type": "bool",
+        "default": true,
+        "title": "Enable Prompt Expansion",
+        "description": "If set to true, the prompt optimizer will be enabled."
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Image to animate. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": null,
+        "title": "Negative Prompt",
+        "description": "Negative prompt for the generation."
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The prompt for generating the output.",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "The resolution of the generated video.",
+        "values": [
+          "720p",
+          "1080p"
+        ],
+        "required": true
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
+      },
+      {
+        "name": "shot_type",
+        "type": "enum",
+        "default": "multi",
+        "title": "Shot Type",
+        "description": "Generate video in multi camera angles, only works when set enable_prompt_expansion to true.",
+        "values": [
+          "multi",
+          "single"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "type": "bool",
+        "default": true,
+        "title": "Generate Audio",
+        "description": "Whether to automatically add audio to the generated video."
+      }
+    ]
+  },
+  {
+    "className": "Wan27ReferenceToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "alibaba/wan-2.7/reference-to-video",
+    "outputType": "video",
+    "title": "Wan 2.7 — Reference to Video",
+    "description": "AtlasCloud / Alibaba Wan 2.7 — generates video from reference images, videos and an optional audio track.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt describing the desired video. Use labels like \"character1\" and \"character2\" to map reference materials to characters. Maximum length is 5000 characters.",
+        "required": true
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": null,
+        "title": "Negative Prompt",
+        "description": "Text describing elements to exclude from the video. Maximum length is 500 characters."
+      },
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Reference Images",
+        "description": "Reference images that anchor subject and style."
+      },
+      {
+        "name": "videos",
+        "type": "list[video]",
+        "default": null,
+        "title": "Reference Videos",
+        "description": "Reference videos that anchor motion or content."
+      },
+      {
+        "name": "audio",
+        "type": "audio",
+        "default": null,
+        "title": "Audio (optional)",
+        "description": "Optional audio track the generation is timed to."
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1080P",
+        "title": "Resolution",
+        "description": "Output video resolution. Higher resolution increases cost.",
+        "values": [
+          "720P",
+          "1080P"
+        ]
+      },
+      {
+        "name": "ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Ratio",
+        "description": "Aspect ratio of the generated video.",
+        "values": [
+          "16:9",
+          "9:16",
+          "1:1",
+          "4:3",
+          "3:4"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration",
+        "description": "Video duration in seconds. Longer duration increases cost.",
+        "min": 2,
+        "max": 10
+      },
+      {
+        "name": "prompt_extend",
+        "type": "bool",
+        "default": false,
+        "title": "Prompt Extend",
+        "description": "Whether to use AI to enhance the prompt for better video quality. Increases generation time."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for video generation. Range: 0 to 2147483647. Use -1 for a random seed.",
+        "min": -1,
+        "max": 2147483647
+      }
+    ]
+  },
+  {
+    "className": "Wan27VideoEdit",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "alibaba/wan-2.7/video-edit",
+    "outputType": "video",
+    "title": "Wan 2.7 — Video Edit",
+    "description": "AtlasCloud / Alibaba Wan 2.7 — edits an existing video from a text instruction, with optional reference images.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text instruction describing the desired edit. Maximum length is 5000 characters."
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": null,
+        "title": "Negative Prompt",
+        "description": "Text describing elements to exclude from the video. Maximum length is 500 characters."
+      },
+      {
+        "name": "video",
+        "type": "video",
+        "default": null,
+        "title": "Video",
+        "description": "Video to edit. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Reference Images (optional)",
+        "description": "Optional images that anchor subject or style."
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1080P",
+        "title": "Resolution",
+        "description": "Output video resolution. Higher resolution increases cost.",
+        "values": [
+          "720P",
+          "1080P"
+        ]
+      },
+      {
+        "name": "ratio",
+        "type": "enum",
+        "default": null,
+        "title": "Ratio",
+        "description": "Aspect ratio of the output video. When omitted, the output follows the input video's aspect ratio.",
+        "values": [
+          "16:9",
+          "9:16",
+          "1:1",
+          "4:3",
+          "3:4"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": null,
+        "title": "Duration",
+        "description": "Output video duration in seconds. Set to 0 or omit to match the input video duration. When set to a positive value, the output is clipped from the start of the input video.",
+        "min": 0,
+        "max": 10
+      },
+      {
+        "name": "prompt_extend",
+        "type": "bool",
+        "default": true,
+        "title": "Prompt Extend",
+        "description": "Whether to use AI to enhance the prompt for better video quality. Increases generation time."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed for video generation. Range: 0 to 2147483647. Use -1 for a random seed.",
+        "min": -1,
+        "max": 2147483647
+      }
+    ]
+  },
+  {
+    "className": "Veo31ReferenceToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "google/veo3.1/reference-to-video",
+    "outputType": "video",
+    "title": "Veo 3.1 — Reference to Video",
+    "description": "AtlasCloud / Google Veo 3.1 — 8 second video from reference images, up to 4K.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "generate_audio",
+        "type": "bool",
+        "default": false,
+        "title": "Generate Audio",
+        "description": "Whether to generate audio."
+      },
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Reference Images",
+        "description": "Reference images that anchor subject and style.",
+        "required": true
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": null,
+        "title": "Negative Prompt",
+        "description": "The negative prompt for the generation."
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": 8,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds.",
+        "values": [
+          8
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "Video resolution.",
+        "values": [
+          "720p",
+          "1080p",
+          "4k"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "The random seed to use for the generation."
+      }
+    ]
+  },
+  {
+    "className": "Veo31LiteStartEndFrameToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "google/veo3.1-lite/start-end-frame-to-video",
+    "outputType": "video",
+    "title": "Veo 3.1 Lite — Start and End Frame to Video",
+    "description": "AtlasCloud / Google Veo 3.1 Lite — interpolates between a first and a last frame.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text description for the video between the first and last frames. Supports audio cues per Veo prompt guidance.",
+        "required": true
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "First Frame",
+        "description": "Image used as the first frame. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "last_image",
+        "type": "image",
+        "default": null,
+        "title": "Last Frame",
+        "description": "Image used as the final frame.",
+        "required": true
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video",
+        "values": [
+          "16:9",
+          "9:16"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": 8,
+        "title": "Duration",
+        "description": "Length of the generated video in seconds (durationSeconds).",
+        "values": [
+          4,
+          6,
+          8
+        ]
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "Output resolution. 1080p only supports 8s duration. Veo 3.1 Lite does not support 4K.",
+        "values": [
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": -1,
+        "title": "Seed",
+        "description": "Random seed. Does not guarantee determinism but may improve repeatability. -1 means a random seed will be used."
+      }
+    ]
+  },
+  {
+    "className": "Hailuo23ProTextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "minimax/hailuo-2.3/t2v-pro",
+    "outputType": "video",
+    "title": "Hailuo 2.3 Pro — Text to Video",
+    "description": "AtlasCloud / MiniMax Hailuo 2.3 Pro — text to video, prompt in and clip out.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "enable_prompt_expansion",
+        "type": "bool",
+        "default": true,
+        "title": "Enable Prompt Expansion",
+        "description": "The model automatically optimizes incoming prompts to enhance output quality."
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      }
+    ]
+  },
+  {
+    "className": "Hailuo23ProImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "minimax/hailuo-2.3/i2v-pro",
+    "outputType": "video",
+    "title": "Hailuo 2.3 Pro — Image to Video",
+    "description": "AtlasCloud / MiniMax Hailuo 2.3 Pro — animates a still image.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "enable_prompt_expansion",
+        "type": "bool",
+        "default": true,
+        "title": "Enable Prompt Expansion",
+        "description": "The model automatically optimizes incoming prompts to enhance output quality."
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Image to animate. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation."
+      }
+    ]
+  },
+  {
+    "className": "ViduQ3ProTextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "vidu/q3-pro/text-to-video",
+    "outputType": "video",
+    "title": "Vidu Q3 Pro — Text to Video",
+    "description": "AtlasCloud / Vidu Q3 Pro — text to video with generated audio and a general or anime style.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "4:3",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated media.",
+        "values": [
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "1:1"
+        ]
+      },
+      {
+        "name": "bgm",
+        "type": "bool",
+        "default": true,
+        "title": "Bgm",
+        "description": "The background music for generating the output."
+      },
+      {
+        "name": "duration",
+        "type": "float",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds.",
+        "min": 1,
+        "max": 16
+      },
+      {
+        "name": "generate_audio",
+        "type": "bool",
+        "default": true,
+        "title": "Generate Audio",
+        "description": "Whether to generate audio."
+      },
+      {
+        "name": "movement_amplitude",
+        "type": "enum",
+        "default": "auto",
+        "title": "Movement Amplitude",
+        "description": "The movement amplitude of objects in the frame. Defaults to auto, accepted value: auto small medium large.",
+        "values": [
+          "auto",
+          "small",
+          "medium",
+          "large"
+        ]
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "The resolution of the generated media. Native 540p, 720p, and 1080p use the original Vidu route when available.",
+        "values": [
+          "540p",
+          "720p",
+          "1080p",
+          "1080p-sr",
+          "1440p-sr"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
+      },
+      {
+        "name": "style",
+        "type": "enum",
+        "default": "general",
+        "title": "Style",
+        "description": "The style of output video.",
+        "values": [
+          "general",
+          "anime"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "ViduQ3ProImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "vidu/q3-pro/image-to-video",
+    "outputType": "video",
+    "title": "Vidu Q3 Pro — Image to Video",
+    "description": "AtlasCloud / Vidu Q3 Pro — animates a still image with generated audio.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "bgm",
+        "type": "bool",
+        "default": true,
+        "title": "Bgm",
+        "description": "The background music for generating the output."
+      },
+      {
+        "name": "duration",
+        "type": "float",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds.",
+        "min": 1,
+        "max": 16
+      },
+      {
+        "name": "generate_audio",
+        "type": "bool",
+        "default": true,
+        "title": "Generate Audio",
+        "description": "Whether to generate audio."
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Image to animate. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "movement_amplitude",
+        "type": "enum",
+        "default": "auto",
+        "title": "Movement Amplitude",
+        "description": "The movement amplitude of objects in the frame. Defaults to auto, accepted value: auto small medium large.",
+        "values": [
+          "auto",
+          "small",
+          "medium",
+          "large"
+        ]
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "The resolution of the generated media. Native 540p, 720p, and 1080p use the original Vidu route when available.",
+        "values": [
+          "540p",
+          "720p",
+          "1080p",
+          "1080p-sr",
+          "1440p-sr"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. -1 means a random seed will be used."
+      }
+    ]
+  },
+  {
+    "className": "ViduQ3ReferenceToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "vidu/q3/reference-to-video",
+    "outputType": "video",
+    "title": "Vidu Q3 — Reference to Video",
+    "description": "AtlasCloud / Vidu Q3 — generates video from reference images that fix the subject across shots.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": null,
+        "title": "Reference Images",
+        "description": "Reference images that anchor subject and style.",
+        "required": true
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "A textual description for video generation.",
+        "required": true
+      },
+      {
+        "name": "duration",
+        "type": "float",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated video in seconds.",
+        "min": 3,
+        "max": 16
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "The resolution of the generated media. Native 540p, 720p, and 1080p use the original Vidu route when available.",
+        "values": [
+          "540p",
+          "720p",
+          "1080p",
+          "1080p-sr",
+          "1440p-sr"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "type": "bool",
+        "default": true,
+        "title": "Generate Audio",
+        "description": "Whether to generate audio for the video."
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the output video.",
+        "values": [
+          "16:9",
+          "9:16",
+          "3:4",
+          "4:3",
+          "1:1"
+        ]
+      },
+      {
+        "name": "movement_amplitude",
+        "type": "enum",
+        "default": "auto",
+        "title": "Movement Amplitude",
+        "description": "The movement amplitude of objects in the frame.",
+        "values": [
+          "auto",
+          "small",
+          "medium",
+          "large"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": 0,
+        "title": "Seed",
+        "description": "The random seed to use for the generation. Set -1 for random."
+      }
+    ]
+  },
+  {
+    "className": "PixverseV6TextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "pixverse/v6/text-to-video",
+    "outputType": "video",
+    "title": "PixVerse v6 — Text to Video",
+    "description": "AtlasCloud / PixVerse v6 — 1 to 15 second text to video with sound.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds (1-15).",
+        "values": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ]
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "sound",
+        "type": "bool",
+        "default": true,
+        "title": "Sound",
+        "description": "Whether sound is generated simultaneously when generating a video."
+      },
+      {
+        "name": "quality",
+        "type": "enum",
+        "default": "720p",
+        "title": "Quality",
+        "description": "The resolution of the generated video.",
+        "values": [
+          "360p",
+          "540p",
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "The aspect ratio of the generated video.",
+        "values": [
+          "16:9",
+          "9:16",
+          "1:1",
+          "4:3",
+          "3:4",
+          "2:3",
+          "3:2",
+          "21:9"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "Random seed for reproducibility."
+      }
+    ]
+  },
+  {
+    "className": "PixverseV6ImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "pixverse/v6/image-to-video",
+    "outputType": "video",
+    "title": "PixVerse v6 — Image to Video",
+    "description": "AtlasCloud / PixVerse v6 — animates a still image with sound.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": 5,
+        "title": "Duration",
+        "description": "The duration of the generated media in seconds (1-15).",
+        "values": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ]
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt for the generation.",
+        "required": true
+      },
+      {
+        "name": "image",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Image to animate. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "sound",
+        "type": "bool",
+        "default": true,
+        "title": "Sound",
+        "description": "Whether to generate audio simultaneously when generating a video."
+      },
+      {
+        "name": "quality",
+        "type": "enum",
+        "default": "720p",
+        "title": "Quality",
+        "description": "The resolution of the generated video.",
+        "values": [
+          "360p",
+          "540p",
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "Random seed for reproducibility."
+      }
+    ]
+  },
+  {
+    "className": "Ltx23QualityTextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "ltx-2.3-quality/text-to-video",
+    "outputType": "video",
+    "title": "LTX 2.3 Quality — Text to Video",
+    "description": "AtlasCloud / Lightricks LTX 2.3 Quality — text to video with a frame-count control and optional audio.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text description of the video to generate. Maximum 2,000 characters.",
+        "required": true
+      },
+      {
+        "name": "num_frames",
+        "type": "int",
+        "default": 121,
+        "title": "Num Frames",
+        "description": "Number of frames to generate. Must be a multiple of 8 plus 1 (e.g. 25, 41, 81, 121, 161, 201, 241, 257).",
+        "min": 25,
+        "max": 257
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "landscape_16_9",
+        "title": "Resolution",
+        "description": "Output video resolution preset.",
+        "values": [
+          "square_hd",
+          "square",
+          "portrait_3_4",
+          "portrait_9_16",
+          "landscape_4_3",
+          "landscape_16_9"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "type": "bool",
+        "default": false,
+        "title": "Generate Audio",
+        "description": "Whether to generate accompanying audio for the video."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "Random seed for reproducibility. Use the same seed and prompt to reproduce results.",
+        "min": 0
+      }
+    ]
+  },
+  {
+    "className": "Ltx23QualityImageToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "ltx-2.3-quality/image-to-video",
+    "outputType": "video",
+    "title": "LTX 2.3 Quality — Image to Video",
+    "description": "AtlasCloud / Lightricks LTX 2.3 Quality — animates a still image with a frame-count control.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text description of the desired video motion and style. Maximum 2,000 characters.",
+        "required": true
+      },
+      {
+        "name": "image_url",
+        "type": "image",
+        "default": null,
+        "title": "Image",
+        "description": "Image to animate. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "num_frames",
+        "type": "int",
+        "default": 121,
+        "title": "Num Frames",
+        "description": "Number of frames to generate. Must be a multiple of 8 plus 1 (e.g. 25, 41, 81, 121, 161, 201, 241, 257).",
+        "min": 25,
+        "max": 257
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "landscape_16_9",
+        "title": "Resolution",
+        "description": "Output video resolution preset.",
+        "values": [
+          "square_hd",
+          "square",
+          "portrait_3_4",
+          "portrait_9_16",
+          "landscape_4_3",
+          "landscape_16_9"
+        ]
+      },
+      {
+        "name": "generate_audio",
+        "type": "bool",
+        "default": false,
+        "title": "Generate Audio",
+        "description": "Whether to generate accompanying audio for the video."
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": null,
+        "title": "Seed",
+        "description": "Random seed for reproducibility. Use the same seed and prompt to reproduce results.",
+        "min": 0
+      }
+    ]
+  },
+  {
+    "className": "GrokImagineVideo15TextToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "xai/grok-imagine-video-v1.5/text-to-video",
+    "outputType": "video",
+    "title": "Grok Imagine Video v1.5 — Text to Video",
+    "description": "AtlasCloud / xAI Grok Imagine Video v1.5 — text to video up to 1080p.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Natural-language description of the video to generate, including subject, motion, camera work, and audio direction. Native synchronized audio is generated in the same pass.",
+        "required": true
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 8,
+        "title": "Duration",
+        "description": "Length of generated video in seconds. Range: 1–15.",
+        "min": 1,
+        "max": 15
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "Output resolution.",
+        "values": [
+          "480p",
+          "720p",
+          "1080p"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "Output aspect ratio.",
+        "values": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "GrokImagineVideo15ReferenceToVideo",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "xai/grok-imagine-video-v1.5/reference-to-video",
+    "outputType": "video",
+    "title": "Grok Imagine Video v1.5 — Reference to Video",
+    "description": "AtlasCloud / xAI Grok Imagine Video v1.5 — generates video from reference images.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Natural-language video description. Reference <IMAGE_N> tags to attach specific reference images to scene elements.",
+        "required": true
+      },
+      {
+        "name": "image_urls",
+        "type": "list[image]",
+        "default": null,
+        "title": "Reference Images",
+        "description": "Reference images that anchor subject and style.",
+        "required": true
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 8,
+        "title": "Duration",
+        "description": "Length of generated video in seconds. Range: 1–15.",
+        "min": 1,
+        "max": 15
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "Output resolution. Reference-to-video is capped at 720p.",
+        "values": [
+          "480p",
+          "720p"
+        ]
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "Output aspect ratio.",
+        "values": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "3:2",
+          "2:3"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "VideoUpscaler",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "atlascloud/video-upscaler",
+    "outputType": "video",
+    "title": "Video Upscaler",
+    "description": "AtlasCloud Video Upscaler — re-renders a clip at 1080p or 2K without a prompt.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "video",
+        "type": "video",
+        "default": null,
+        "title": "Video",
+        "description": "Video to upscale. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "target_resolution",
+        "type": "enum",
+        "default": "1080p",
+        "title": "Target Resolution",
+        "description": "Output resolution for video upscaling. 2k uses the 2560x1440 pixel tier. 4K is not currently exposed.",
+        "values": [
+          "1080p",
+          "2k"
+        ]
+      }
+    ]
+  },
+  {
+    "className": "SyncLipsyncV3",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "sync/lipsync-v3",
+    "outputType": "video",
+    "title": "Sync Lipsync v3",
+    "description": "AtlasCloud / Sync.so Lipsync v3 — re-syncs a speaker's lips in a video to a separate audio track.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "video_url",
+        "type": "video",
+        "default": null,
+        "title": "Video",
+        "description": "Video whose lips are re-synced. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "audio_url",
+        "type": "audio",
+        "default": null,
+        "title": "Audio",
+        "description": "Driving audio the lips are synced to.",
+        "required": true
+      },
+      {
+        "name": "sync_mode",
+        "type": "enum",
+        "default": "cut_off",
+        "title": "Sync Mode",
+        "description": "How to handle duration mismatch between video and audio. cut_off: trim to shorter; loop: repeat video; bounce: ping-pong; silence: pad audio; remap: time-remap.",
+        "values": [
+          "cut_off",
+          "loop",
+          "bounce",
+          "silence",
+          "remap"
+        ],
+        "required": true
+      }
+    ]
+  },
+  {
+    "className": "VeedLipsync",
+    "moduleName": "video",
+    "modality": "video",
+    "modelId": "veed/lipsync",
+    "outputType": "video",
+    "title": "VEED Lipsync",
+    "description": "AtlasCloud / VEED Lipsync — re-syncs a speaker's lips in a video to a separate audio track.",
+    "pollInterval": 3000,
+    "maxAttempts": 600,
+    "fields": [
+      {
+        "name": "video_url",
+        "type": "video",
+        "default": null,
+        "title": "Video",
+        "description": "Video whose lips are re-synced. Connect from an upstream node, drag/drop, or paste a public URL.",
+        "required": true
+      },
+      {
+        "name": "audio_url",
+        "type": "audio",
+        "default": null,
+        "title": "Audio",
+        "description": "Driving audio the lips are synced to.",
+        "required": true
       }
     ]
   }

--- a/scripts/sync-atlascloud-manifest.mjs
+++ b/scripts/sync-atlascloud-manifest.mjs
@@ -38,11 +38,20 @@ const TYPE_MAP = {
 const ASSET_TYPES = new Set(["image", "video", "audio"]);
 
 // Options AtlasCloud declares that we deliberately do not surface:
-//  - enable_base64_output / enable_sync_mode are flagged `disabled` upstream
-//    (API-only transport switches) and would break the poll+download flow.
+//  - enable_base64_output / enable_sync_mode are API-only transport switches
+//    that would break the poll+download flow. Most models flag them `disabled`
+//    upstream, but not all (the FLUX.1 open-weight ones don't), so name them
+//    here rather than relying on that flag.
 //  - return_last_frame makes the job emit a second output the single-output
 //    node can't surface, so the toggle would silently do nothing.
-const SUPPRESSED_FIELDS = new Set(["return_last_frame"]);
+//  - output_dir is a server-side path on Tencent's upscaler — meaningless to a
+//    NodeTool run, which stores the result as an asset.
+const SUPPRESSED_FIELDS = new Set([
+  "return_last_frame",
+  "enable_base64_output",
+  "enable_sync_mode",
+  "output_dir"
+]);
 
 const isAssetField = (field) =>
   ASSET_TYPES.has(field.type) || field.type.startsWith("list[");


### PR DESCRIPTION
## What changed

AtlasCloud's catalog carries 320 image and video models; NodeTool shipped 97 of them. This adds 60 more, chosen as whole families we had no node for — FLUX.2 and FLUX.1, Ideogram v4, HiDream O1 1.5, Krea 2 Turbo, NVIDIA Cosmos 3 Super, Seedream v4.5, GPT Image 1 / 1 Mini, Grok Imagine Image, Wan 2.6, Kling Video O3 Pro/Std, Kling v3.0 4K, Kling v2.6 Pro, Seedance v1.5 Pro, Hailuo 2.3 Pro, Vidu Q3, PixVerse v6, LTX 2.3 Quality — plus the endpoints that complete a family already shipped (Wan 2.7 reference-to-video and video-edit, Veo 3.1 reference-to-video, Veo 3.1 Lite start/end frame, Grok Imagine Video v1.5 text and reference, MAI Image 2.5 Flash edit), and five prompt-free utilities: image and video upscalers, photo cleanup, and two lip-sync models. Every entry's scalar fields were derived from the `Input` schema AtlasCloud publishes for that model rather than hand-typed, so `sync-atlascloud-manifest.mjs --check` reports the manifest up to date; that same run applied 67 pre-existing drifts on already-shipped models, among them HappyHorse 1.1's `resolution`, whose `"1080P"` the API no longer accepts. Two shapes are deliberately excluded on the package's existing "a node surfaces one output" rule — `seedream-v5.0-pro/layer-decomposition` and the `*-sequential` models return a set that is not interchangeable — and the 3D and audio-output models have no modality here at all.

The script change is a correctness fix the new models surfaced: `enable_base64_output` / `enable_sync_mode` are marked `disabled` upstream on most models but **not** on the FLUX.1 open-weight ones, and either switch returns base64 instead of the URL the poll-then-download flow needs, so they are now suppressed by name. `output_dir` (a server-side path on Tencent's upscaler, meaningless to a NodeTool run) is suppressed too.

## Verification

**CI: 19 of 21 checks green** on the current head `cd10258b`, including `test-packages`, `typecheck`, `build`, `bundle`, `docker`, `test-app`, `app-build`, all three CodeQL analyses, and every E2E leg. `test-packages` is the one that matters most here — it runs the `runtime` and `atlascloud-nodes` suites on a runner provisioned with `mesa-vulkan-drivers ffmpeg`, so it covers the suites this sandbox cannot run (below) and it passed.

The two red checks are one failure, and it is not this PR's. `lint` fails on `anti-slop(no-conditional-empty-object-spread)` at `web/src/components/storyboard/ShotInspector.tsx:450`, present verbatim on `main` (it arrived with `fa28ff67`); `quality` is the rollup restating it, its log reading `changes:success static:failure build:success built:success docker:success`, and since `typecheck` passed, `static` is red only from `lint`. A verified patch is in [this comment](https://github.com/nodetool-ai/nodetool/pull/5373#issuecomment-5465605949), with a [correction](https://github.com/nodetool-ai/nodetool/pull/5373#issuecomment-5465671893) for generics that were stripped as HTML tags. An earlier, different base failure at `AssetViewer.tsx:297` ([reported here](https://github.com/nodetool-ai/nodetool/pull/5373#issuecomment-5465343994)) was fixed on `main` and picked up by merging `main` into this branch as `cd10258b`.

Local runs, for the record — this sandbox lacks binaries CI installs, so each gap was ruled out rather than left as a bare failure:

- `npm run test:affected` — the failure was `@nodetool-ai/runtime`, whose `tests/providers/video-frame-fallback.test.ts` dies at `spawn ffmpeg ENOENT`; that file predates this branch (`ed1c89fe`) and this diff touches no file under `packages/runtime`. The rest of the package: 163 of 164 files, 3110 tests passing. The AtlasCloud-relevant part run directly — `atlascloud`, `manifest-models`, `offline-model-index` — is 5 files, 191 tests, all passing, which is the check that exercises this manifest. CI's `test-packages` since confirmed the whole suite green.
- An earlier run stopped on `@nodetool-ai/image-nodes` with `No WebGPU adapter available (Node/Dawn)`. Installed the lavapipe ICD per AGENTS.md § WebGPU on a headless machine and re-ran that package alone: 24 files, 229 tests, all passing.
- Full parallel `test:affected` runs on this box also fail one *random* package per run (`chat` once, `deploy` the next), each of which passes standalone — `chat` 30/30, `deploy` 861/861 — and both pass in CI. That is this sandbox's concurrency limits, not the code.
- `npm run typecheck` — exit 0 locally (the 15 `TS2307` lines are `mobile/`, whose dependency tree is not installed here); green in CI.
- `npm run dev:nodetool -- harness gate --base main` — 0 surfaces touched, 0 selfchecks selected.

Checks specific to this diff:

- `node scripts/sync-atlascloud-manifest.mjs --check` → `atlascloud-manifest.json is up to date.` Before the sync it reported 67 drifts, every one against a **previously shipped** model — no new entry disagreed with the schema it was written from, which is what makes the generated fields trustworthy rather than plausible.
- `npm run test --workspace=packages/atlascloud-nodes` → 2 files, 81 tests passing, including the manifest invariants (`images` is always `list[image]`, `wrapInto` count unchanged at 9, no `return_last_frame`).
- Registry smoke test on the built package: 157 node classes register, 157 unique node types.
- The README node table was regenerated from the manifest; the generator reproduces all 97 existing rows byte-for-byte **and in the same order**, so the diff there is a pure insertion.

## Agent capabilities

No capability added or re-declared.

## New checks

No new check, rule, or audit. The two added `SUPPRESSED_FIELDS` entries extend an existing filter rather than introducing a gate.