### PR TITLE
refactor(storyboard): type the duration patch at the call site

### DIFF
--- a/web/src/components/storyboard/ShotInspector.tsx
+++ b/web/src/components/storyboard/ShotInspector.tsx
@@ -445,10 +445,13 @@ const ShotInspectorInner: React.FC<ShotInspectorProps> = ({
     if (!Number.isFinite(seconds) || seconds <= 0) {
       return;
     }
-    updateShot(boardId, shot.id, {
-      duration_seconds: seconds,
-      ...(linksLines ? { duration_source: "manual" as const } : {})
-    });
+    const patch: Parameters<typeof updateShot>[2] = {
+      duration_seconds: seconds
+    };
+    if (linksLines) {
+      patch.duration_source = "manual";
+    }
+    updateShot(boardId, shot.id, patch);
   }, [durationDraft, updateShot, boardId, shot.id, linksLines]);
 
   const handleDurationKeyDown = useCallback(


### PR DESCRIPTION
## What changed

`commitDuration` in `ShotInspector.tsx` assembled the store patch with a conditional spread, so `duration_source` was only ever checked as an inferred object literal rather than against the type `updateShot` actually accepts. The patch object now carries an explicit annotation — the third entry of `updateShot`'s parameter-tuple type, written with the `Parameters` utility type (see the diff for the exact syntax; angle brackets do not survive this description field) — and the conditional field is a plain `if` assignment. The field name and its value are now checked against the store's own patch type, and the branch reads as the branch it is. Behavior is unchanged.

That type resolves to a partial `Shot` (`StoryboardStore.ts:169`). Deriving it from `updateShot` rather than naming the partial directly keeps the file from needing a `Shot` import it does not otherwise have.

## Verification

- [x] `npm run test:affected` — 3 suites, 53 tests passed (`ShotInspector.test.tsx` among them)
- [x] `npm run typecheck` — `web` clean (`tsc --noEmit` exit 0). Locally `mobile` fails on ~40 `TS2307` module-resolution errors (`react-native`, `expo-*`, `@trpc/react-query`) because this container never ran `npm --prefix mobile install`; mobile is not a root workspace and the diff does not touch it. CI's `typecheck` leg passes.
- [x] `npm run lint` — no errors; the pre-existing warning backlog is unchanged and `ShotInspector.tsx` reports nothing
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 7/7 selfchecks passed`

All 19 CI check runs on `cf55494` are green, and the PR is mergeable with no conflict.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.