### PR TITLE
feat(agents): drop the browser_* capabilities under the cloud profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1736,7 +1736,10 @@ values, a screenshot comes back as base64. The capability module
 the half that needs a `ProcessingContext`, turning those bytes into an asset
 reference and an asset id into bytes. That split is what lets the capabilities
 and the `lib.browser.Screenshot` node share one implementation. One session
-exists per process and every caller shares it. Extension setup, the wire
+exists per process and every caller shares it — which is why the cloud profile
+drops all fourteen (`packages/agents/src/browser-gate.ts`): one shared page
+across tenants is a single-tenant shape, and the node catalog already agreed by
+leaving `lib.browser` out of `CLOUD_NODE_NAMESPACES`. Extension setup, the wire
 protocol and its limits: [docs/chrome-extension.md](docs/chrome-extension.md).
 
 ### Code authoring tools (no workflow, no browser)

--- a/docs/CLOUD_NODE_CURATION.md
+++ b/docs/CLOUD_NODE_CURATION.md
@@ -174,10 +174,10 @@ that egress policy is written down in the ComfyUI row of
 
 The namespace is kept. The product surface is the standard Agent plus
 Classifier, Extractor, Summarizer, CreateThread, and EnhancePrompt.
-Specialist tool-agent nodes were removed. ffmpeg and browser are CodeAct
+Specialist tool-agent nodes were removed. ffmpeg and page fetching are CodeAct
 capabilities (`nodetool.media.ffmpeg`, `nodetool.web.browse`) — the same
 binaries the image installs, reached from chat and from the Code node instead
-of from an agent node. yt-dlp is not: see below.
+of from an agent node. yt-dlp and the live browser are not: see below.
 
 ## yt-dlp
 
@@ -200,6 +200,39 @@ error. The capability itself refuses too, for a host that resolves it by name.
 
 The binary stays in the image: `docker-compose.yml` self-hosting runs the same
 image with `NODETOOL_NODE_PROFILE=full`, and that install keeps both surfaces.
+
+## The live browser
+
+`lib.browser.Screenshot` fell out with its namespace — `lib.browser` is not in
+`CLOUD_NODE_NAMESPACES` — and the fourteen `browser_*` capabilities that drive
+the same page (`browser_view`, `browser_click`, `browser_capture_media`, …)
+are off under the cloud profile too.
+
+They are a single-tenant surface. The browser session is a **process
+singleton**: one page, shared by every caller in the process, so on a managed
+server two tenants' agents drive the same tab and whatever the first signed
+into is what the second one's `browser_view` reads. The extension transport is
+worse — `/ws/extension` is unauthenticated and single-connection, so one user's
+own Chrome would be reachable by anybody's run. Neither is a defect to fix
+behind a flag; both are what the surface is for. It belongs on a machine its
+user owns.
+
+The capabilities are dropped from the belt by `isBrowserEnabled()`
+([`packages/agents/src/browser-gate.ts`](../packages/agents/src/browser-gate.ts)),
+which reads the same two env vars `isCloudProfileActive` reads, so chat, an
+AgentNode and the Code node all see the same absence. Each implementation
+refuses as well, because the belt is discovery and not enforcement: the sandbox
+mount serves every registered capability module, so a guest importing
+`@nodetool-ai/sandbox-nodetool/browser` reaches them with no belt in between.
+
+`/ws/extension` is gated separately and was already closed here — the route is
+not registered when `NODETOOL_ENV=production` unless
+`NODETOOL_ENABLE_EXTENSION_BRIDGE=1`. That switch now opens a bridge nothing on
+a cloud deployment can use; the capabilities are off regardless of it.
+
+Chromium stays in the image (`Dockerfile`), like the yt-dlp binary: the same
+image self-hosts with `NODETOOL_NODE_PROFILE=full`, and that install keeps both
+surfaces.
 
 ## Maintenance
 

--- a/docs/chrome-extension.md
+++ b/docs/chrome-extension.md
@@ -173,6 +173,14 @@ Element indexes are rebuilt on every `browser_view`, so an agent views before it
 
 `extension_connected` is `null`, not `false`, where the process cannot answer — a CLI reaching `/ws/extension` over a URL would have to open a socket to find out, so it reports "unknown" rather than guessing.
 
+**Not available on nodetool.ai.** The cloud profile drops all fourteen: the
+browser session is one page per server process, shared by every caller, which
+is a single-tenant shape — and the extension transport would put one user's own
+Chrome behind an unauthenticated socket on a shared server. They are offered
+where the machine belongs to its user: the desktop app, a local server, or a
+self-hosted install (`NODETOOL_NODE_PROFILE=full`). See
+[Cloud node curation](CLOUD_NODE_CURATION.md).
+
 Permission-wise: reading the page (`browser_status`, `browser_view`, `browser_console_view`) is classified `read`, `browser_restart` and `browser_console_exec` are `execute`, and everything that acts on the page — a click, a keystroke, an upload — is `external`, because it lands on a third-party site inside the user's own logged-in session.
 
 The action loop itself is `@nodetool-ai/browser` (`packages/browser/`), which knows nothing about agents, nodes or assets — a screenshot comes back from it as base64. The capability module imports it directly and owns the half that needs a `ProcessingContext`: persisting those bytes as an asset, and resolving an asset id back to bytes for an upload. That split is why the `lib.browser.Screenshot` node can share the same action loop without depending on the agent layer.

--- a/docs/chrome-extension.md
+++ b/docs/chrome-extension.md
@@ -179,7 +179,7 @@ is a single-tenant shape — and the extension transport would put one user's ow
 Chrome behind an unauthenticated socket on a shared server. They are offered
 where the machine belongs to its user: the desktop app, a local server, or a
 self-hosted install (`NODETOOL_NODE_PROFILE=full`). See
-[Cloud node curation](CLOUD_NODE_CURATION.md).
+[Cloud node curation](https://github.com/nodetool-ai/nodetool/blob/main/docs/CLOUD_NODE_CURATION.md).
 
 Permission-wise: reading the page (`browser_status`, `browser_view`, `browser_console_view`) is classified `read`, `browser_restart` and `browser_console_exec` are `execute`, and everything that acts on the page — a click, a keystroke, an upload — is `external`, because it lands on a third-party site inside the user's own logged-in session.
 

--- a/packages/agents/src/browser-gate.ts
+++ b/packages/agents/src/browser-gate.ts
@@ -1,0 +1,44 @@
+/**
+ * Availability gate for the `browser_*` capabilities.
+ *
+ * Driving a browser is a single-tenant capability wearing a multi-tenant
+ * server's clothes. The session is a process singleton — one page, shared by
+ * every caller in the process — so on a managed server two tenants' agents
+ * drive the same tab, and whatever the first one signed into is what the
+ * second one's `browser_view` reads. The extension transport is worse still:
+ * `/ws/extension` is unauthenticated and single-connection, so one user's
+ * Chrome would be reachable by anybody's run.
+ *
+ * Neither is a defect to fix behind a flag; both are what the surface is for.
+ * It belongs on a machine its user owns — a desktop app, a local server, a
+ * self-hosted install — so under the cloud profile the capabilities are left
+ * off every belt and refuse when reached by name.
+ *
+ * Same switch that prunes the node catalog: `NODETOOL_NODE_PROFILE=cloud`, or
+ * `NODETOOL_ENV=production` with the profile unset. The node catalog already
+ * agrees — `lib.browser` is not in `CLOUD_NODE_NAMESPACES`, so the Screenshot
+ * node is gone from the cloud product too. A self-hosted install of the same
+ * image sets `NODETOOL_NODE_PROFILE=full` and keeps both, as does every local
+ * install.
+ */
+
+import {
+  CLOUD_PROFILE_ENV,
+  NODE_ENV_VAR,
+  isCloudProfileActive
+} from "@nodetool-ai/protocol";
+
+/** Whether the `browser_*` capabilities should be offered on this deployment. */
+export function isBrowserEnabled(): boolean {
+  return !isCloudProfileActive(
+    process.env[CLOUD_PROFILE_ENV],
+    process.env[NODE_ENV_VAR]
+  );
+}
+
+/** What a `browser_*` capability answers where this deployment offers none. */
+export const BROWSER_DISABLED_ERROR =
+  "Browser control is not available on this deployment. It drives one shared " +
+  "browser session per server process, so it is offered only where the " +
+  "machine belongs to its user — the desktop app, a local server, or a " +
+  "self-hosted install.";

--- a/packages/agents/src/capabilities/browser.ts
+++ b/packages/agents/src/capabilities/browser.ts
@@ -14,6 +14,10 @@
  * `browser_status`, which reports the one in force, and `browser_restart`,
  * which changes it.
  *
+ * Not offered under the cloud profile: the session is one page per server
+ * process, shared by every caller, which is a single-tenant shape. See
+ * `../browser-gate.ts`.
+ *
  * What this file owns is the half the action package deliberately does not:
  * the `ProcessingContext`. A screenshot comes back from `@nodetool-ai/browser`
  * as base64 and leaves here as an asset reference; an upload arrives as an
@@ -45,6 +49,7 @@ import {
 } from "@nodetool-ai/browser";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 
+import { BROWSER_DISABLED_ERROR, isBrowserEnabled } from "../browser-gate.js";
 import { persistOutput } from "../tools/asset-persist.js";
 import type {
   CapabilityExport,
@@ -277,6 +282,9 @@ function action(spec: CapabilitySpec): CapabilityExport {
   return {
     spec,
     impl: async (run: CapabilityRun, args: Record<string, unknown>) => {
+      // The cloud profile leaves these off every belt, so a model never sees
+      // them. A guest that imports this module by name still lands here.
+      if (!isBrowserEnabled()) return { error: BROWSER_DISABLED_ERROR };
       const { context } = run;
       try {
         const params =
@@ -308,6 +316,7 @@ function action(spec: CapabilitySpec): CapabilityExport {
 const browserStatusCapability: CapabilityExport = {
   spec: browserStatusSpec,
   impl: async () => {
+    if (!isBrowserEnabled()) return { error: BROWSER_DISABLED_ERROR };
     try {
       return await browserStatus();
     } catch (err) {

--- a/packages/agents/src/tools/builtin-tools.ts
+++ b/packages/agents/src/tools/builtin-tools.ts
@@ -31,6 +31,7 @@ import type { Tool } from "./base-tool.js";
 import { registerTool } from "./tool-registry.js";
 import { toolForCapabilityName } from "../capabilities/lazy-tool.js";
 import { isYtDlpEnabled } from "../yt-dlp-gate.js";
+import { isBrowserEnabled } from "../browser-gate.js";
 
 export const BUILTIN_TOOL_NAMES: readonly string[] = [
   // Filesystem (workspace-relative)
@@ -187,6 +188,8 @@ export const BUILTIN_TOOL_NAMES: readonly string[] = [
   // extension, the tab the user is already signed in to. The action loop is
   // `@nodetool-ai/browser`, which this package depends on directly, so every
   // host assembling this belt can serve them.
+  //
+  // Dropped under the cloud profile — see `availableBuiltinToolNames`.
   "browser_status",
   "browser_view",
   "browser_navigate",
@@ -229,16 +232,29 @@ export function getBuiltinTools(): Tool[] {
   return availableBuiltinToolNames().map((name) => toolForCapabilityName(name));
 }
 
+/** The `browser_*` names, which stand or fall together. */
+const BROWSER_TOOL_NAMES: readonly string[] = BUILTIN_TOOL_NAMES.filter((name) =>
+  name.startsWith("browser_")
+);
+
 /**
  * {@link BUILTIN_TOOL_NAMES} minus the ones this deployment does not offer.
  *
- * Only `yt_dlp` is conditional today: the cloud profile drops it (see
- * {@link isYtDlpEnabled}), so an agent, a Code node and a JS script all see the
- * same belt as the node catalog — one gate rather than a per-host filter.
+ * Both conditions are the cloud profile: it drops `yt_dlp` (see
+ * {@link isYtDlpEnabled}) and the `browser_*` capabilities (see
+ * {@link isBrowserEnabled}), so an agent, a Code node and a JS script all see
+ * the same belt as the node catalog — one gate rather than a per-host filter.
+ *
+ * Dropping a name here is what a model sees; it is not the enforcement. A
+ * guest that imports the owning capability module reaches the implementation
+ * without a belt, so each gated implementation refuses on its own too.
  */
 export function availableBuiltinToolNames(): readonly string[] {
-  if (isYtDlpEnabled()) return BUILTIN_TOOL_NAMES;
-  return BUILTIN_TOOL_NAMES.filter((name) => name !== "yt_dlp");
+  const dropped = new Set<string>();
+  if (!isYtDlpEnabled()) dropped.add("yt_dlp");
+  if (!isBrowserEnabled()) for (const name of BROWSER_TOOL_NAMES) dropped.add(name);
+  if (dropped.size === 0) return BUILTIN_TOOL_NAMES;
+  return BUILTIN_TOOL_NAMES.filter((name) => !dropped.has(name));
 }
 
 /**

--- a/packages/agents/tests/browser-gate.test.ts
+++ b/packages/agents/tests/browser-gate.test.ts
@@ -1,0 +1,157 @@
+/**
+ * The cloud profile drops the `browser_*` capabilities.
+ *
+ * Two doors have to agree. The belt every host assembles
+ * (`availableBuiltinToolNames`) is what a model sees, so dropping a name there
+ * is discovery. It is not enforcement: the sandbox mount serves every
+ * registered capability module, so a guest importing
+ * `@nodetool-ai/sandbox-nodetool/browser` reaches the implementations with no
+ * belt in between — which is why each one refuses on its own too.
+ *
+ * The gate is the switch that prunes the node catalog, and the two already
+ * agree: `lib.browser` is absent from `CLOUD_NODE_NAMESPACES`, so the cloud
+ * product has neither the Screenshot node nor these capabilities.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+
+/** Fail loudly if the gate lets a call through to the action layer. */
+const reached: string[] = [];
+const action = (name: string) => async () => {
+  reached.push(name);
+  return { ran: name };
+};
+
+vi.mock("@nodetool-ai/browser", () => ({
+  browserView: action("browserView"),
+  browserNavigate: action("browserNavigate"),
+  browserRestart: action("browserRestart"),
+  browserClick: action("browserClick"),
+  browserInput: action("browserInput"),
+  browserMoveMouse: action("browserMoveMouse"),
+  browserPressKey: action("browserPressKey"),
+  browserSelectOption: action("browserSelectOption"),
+  browserScroll: action("browserScroll"),
+  browserConsoleExec: action("browserConsoleExec"),
+  browserConsoleView: action("browserConsoleView"),
+  browserCaptureMedia: action("browserCaptureMedia"),
+  browserUploadAsset: action("browserUploadAsset"),
+  browserStatus: action("browserStatus")
+}));
+
+const { BUILTIN_TOOL_NAMES, availableBuiltinToolNames, getBuiltinTools } =
+  await import("../src/tools/builtin-tools.js");
+const { BROWSER_DISABLED_ERROR, isBrowserEnabled } = await import(
+  "../src/browser-gate.js"
+);
+const { module: browserModule } = await import("../src/capabilities/browser.js");
+const { UNGATED, createCapabilityRun } = await import(
+  "../src/capabilities/invoke.js"
+);
+
+const KEYS = ["NODETOOL_NODE_PROFILE", "NODETOOL_ENV"] as const;
+const saved: Record<string, string | undefined> = {};
+
+/** Every `browser_*` name the module declares. */
+const BROWSER_NAMES = browserModule.exports.map((entry) => entry.spec.name);
+
+beforeEach(() => {
+  reached.length = 0;
+  for (const key of KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+describe("isBrowserEnabled", () => {
+  it("is on for a local install", () => {
+    expect(isBrowserEnabled()).toBe(true);
+  });
+
+  it("is off under the cloud profile and in production", () => {
+    process.env["NODETOOL_NODE_PROFILE"] = "cloud";
+    expect(isBrowserEnabled()).toBe(false);
+    delete process.env["NODETOOL_NODE_PROFILE"];
+    process.env["NODETOOL_ENV"] = "production";
+    expect(isBrowserEnabled()).toBe(false);
+  });
+
+  it("is on for a self-hosted production install", () => {
+    process.env["NODETOOL_ENV"] = "production";
+    process.env["NODETOOL_NODE_PROFILE"] = "full";
+    expect(isBrowserEnabled()).toBe(true);
+  });
+});
+
+describe("the belt", () => {
+  it("carries every browser_* name by default", () => {
+    const names = availableBuiltinToolNames();
+    for (const name of BROWSER_NAMES) expect(names).toContain(name);
+    const built = getBuiltinTools().map((tool) => tool.name);
+    for (const name of BROWSER_NAMES) expect(built).toContain(name);
+  });
+
+  it("drops all of them under the cloud profile, and nothing adjacent", () => {
+    process.env["NODETOOL_NODE_PROFILE"] = "cloud";
+    const names = availableBuiltinToolNames();
+    for (const name of BROWSER_NAMES) expect(names).not.toContain(name);
+    const built = getBuiltinTools().map((tool) => tool.name);
+    for (const name of BROWSER_NAMES) expect(built).not.toContain(name);
+
+    // `browser` is the web module's fetch-a-page-as-text capability — a
+    // different thing that shares a prefix, and it stays.
+    expect(names).toContain("browser");
+    expect(names).toContain("take_screenshot");
+
+    // The profile drops yt_dlp too (yt-dlp-gate.test.ts); nothing else goes.
+    const dropped = BUILTIN_TOOL_NAMES.filter((name) => !names.includes(name));
+    expect([...dropped].sort()).toEqual([...BROWSER_NAMES, "yt_dlp"].sort());
+  });
+
+  it("keeps them for a self-hosted production install", () => {
+    process.env["NODETOOL_ENV"] = "production";
+    process.env["NODETOOL_NODE_PROFILE"] = "full";
+    const names = availableBuiltinToolNames();
+    for (const name of BROWSER_NAMES) expect(names).toContain(name);
+  });
+});
+
+describe("the capabilities themselves", () => {
+  const run = createCapabilityRun({
+    context: {} as unknown as ProcessingContext,
+    gate: UNGATED
+  });
+
+  it("every one refuses under the cloud profile, reaching no browser", async () => {
+    process.env["NODETOOL_NODE_PROFILE"] = "cloud";
+
+    for (const entry of browserModule.exports) {
+      await expect(entry.impl(run, {})).resolves.toEqual({
+        error: BROWSER_DISABLED_ERROR
+      });
+    }
+    // The refusal is before the action layer, not a failure inside it.
+    expect(reached).toEqual([]);
+  });
+
+  it("says where the surface does belong", () => {
+    expect(BROWSER_DISABLED_ERROR).toContain("desktop app");
+    expect(BROWSER_DISABLED_ERROR).toContain("self-hosted");
+  });
+
+  it("reaches the action layer when the profile allows it", async () => {
+    await expect(
+      browserModule.exports
+        .find((entry) => entry.spec.name === "browser_status")
+        ?.impl(run, {})
+    ).resolves.toEqual({ ran: "browserStatus" });
+    expect(reached).toEqual(["browserStatus"]);
+  });
+});

--- a/packages/agents/tests/yt-dlp-gate.test.ts
+++ b/packages/agents/tests/yt-dlp-gate.test.ts
@@ -60,13 +60,18 @@ describe("the belt", () => {
     expect(getBuiltinTools().map((tool) => tool.name)).toContain("yt_dlp");
   });
 
-  it("drops only yt_dlp under the cloud profile", () => {
+  it("drops yt_dlp under the cloud profile, keeping the rest of its neighbours", () => {
     process.env["NODETOOL_NODE_PROFILE"] = "cloud";
     const names = availableBuiltinToolNames();
     expect(names).not.toContain("yt_dlp");
     expect(names).toContain("ffmpeg");
-    expect(names).toHaveLength(BUILTIN_TOOL_NAMES.length - 1);
     expect(getBuiltinTools().map((tool) => tool.name)).not.toContain("yt_dlp");
+    // The profile drops the `browser_*` capabilities too (browser-gate.test.ts),
+    // so what leaves the belt is this one plus those — and nothing else.
+    const dropped = BUILTIN_TOOL_NAMES.filter((name) => !names.includes(name));
+    expect(dropped.filter((name) => !name.startsWith("browser_"))).toEqual([
+      "yt_dlp"
+    ]);
   });
 });
 


### PR DESCRIPTION
## What changed

Driving a browser is a single-tenant capability, and the cloud product is not that. The session is a process singleton — one page, shared by every caller in the process — so on a managed server two tenants' agents drive the same tab, and whatever the first one signed into is what the second one's `browser_view` reads. The extension transport is worse still: `/ws/extension` is unauthenticated and single-connection, so one user's own Chrome would be reachable by anybody's run. Neither is a defect to fix behind a flag; both are what the surface is for, and it belongs on a machine its user owns.

`isBrowserEnabled()` mirrors `isYtDlpEnabled()` exactly — same `NODETOOL_NODE_PROFILE=cloud` / `NODETOOL_ENV=production` switch, so a self-hosted install of the same image keeps everything with `NODETOOL_NODE_PROFILE=full`. The node catalog already agreed: `lib.browser` is absent from `CLOUD_NODE_NAMESPACES`, so the Screenshot node was already gone from the cloud product while the fourteen capabilities driving the same page sat on every belt.

It is gated in **two** places, because the belt is discovery and not enforcement. The names leave `availableBuiltinToolNames()`, so no model sees them and the AgentNode picker resolves nothing — but the sandbox mount serves every *registered* capability module, so a guest importing `@nodetool-ai/sandbox-nodetool/browser` would reach the implementations with no belt in between. Each implementation therefore refuses on its own too, naming where the surface does belong rather than only saying no.

The `/ws/extension` bridge is deliberately left alone. It is gated separately and was already closed in production unless `NODETOOL_ENABLE_EXTENSION_BRIDGE=1`; folding it onto this gate would either loosen it for a self-hosted production install or break that documented escape hatch. The two stay independent and `docs/CLOUD_NODE_CURATION.md` records how they interact. Chromium stays in the image, like the yt-dlp binary, for the self-hosted profile that runs the same image — worth revisiting separately if nothing else needs it.

## Verification

- [x] `npm run test:affected` — the touched packages run clean: `agents` 3656, `websocket` 2618, `base-nodes` 2006, `cli` 674, `browser` 14. One unrelated failure: `packages/deploy`'s `exports all public API` times out at vitest's 5s default under 18-way parallel load, because it cold-`await import`s a barrel that transitively pulls in `@nodetool-ai/websocket`. It passes in isolation with the cache forced off both on this branch (866 tests) and on `main`, so it is a pre-existing fragility this diff only exposes by invalidating its turbo cache.
- [x] `npm run typecheck` — web and electron clean. Mobile's errors are its absent `node_modules` in this environment, unrelated.
- [x] `npm run lint` — exit 0.
- [x] `npm run dev:nodetool -- harness gate --base main` — 3/3 selfchecks passed (run as `--base HEAD~1`).

Both gates were inverted once and observed failing. Replacing `isBrowserEnabled()`'s body with `return true`:

```
 × is off under the cloud profile and in production
 × drops all of them under the cloud profile, and nothing adjacent
 × every one refuses under the cloud profile, reaching no browser
 Tests  3 failed | 12 passed (15)
```

The existing `yt-dlp-gate.test.ts` also caught this correctly: it pinned the cloud belt at exactly `BUILTIN_TOOL_NAMES.length - 1`. That assertion is now written to name what leaves the belt rather than count it, so it still fails if anything *other* than `yt_dlp` and the `browser_*` set is dropped.

## Agent capabilities

- [x] `npm run capabilities:check` passes — `capability table is current (248 capabilities)`.
- [x] No capability added or re-declared. Only availability changed, so no `contract` fingerprint moved. The new `tests/browser-gate.test.ts` covers the gate for all fourteen alongside the existing `tests/capabilities-browser.test.ts`.

## New checks

- [x] Inverted once and observed failing — output above.
- [x] The belt assertions enumerate rather than count: `browser-gate.test.ts` compares the dropped set against the module's own export list, so it cannot pass by matching nothing, and it asserts the neighbouring `browser` (the `web` module's fetch-a-page capability, a different thing sharing a prefix) and `take_screenshot` both survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gRAPvqAUexdbntZt9cuJN

---
_Generated by [Claude Code](https://claude.ai/code/session_019gRAPvqAUexdbntZt9cuJN)_