### PR TITLE
fix(pricing): repoint a delisted parity case, tolerate delistings

### DIFF
--- a/packages/model-pricing/tests/genspend-sync.test.ts
+++ b/packages/model-pricing/tests/genspend-sync.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../../../scripts/sync-genspend-pricing.mjs";
 import {
   MIN_PRICED_CASES,
+  NO_CATALOG_ENTRY,
   PARITY_CASES,
   priceCase,
   quoteRequest,
@@ -864,6 +865,64 @@ describe("parity check", () => {
     });
     expect(verdict.ok).toBe(false);
     expect(verdict.failures[0].detail).toContain("1.5");
+  });
+
+  /**
+   * An offering GenSpend stops serving leaves the export, so the sync drops our
+   * row and `/quote` refuses the step. The case then has nothing to assert.
+   * Tolerating that is only safe while it needs both halves, which is what
+   * these three pin.
+   */
+  describe("a delisted offering", () => {
+    const flat = {
+      unit_price: 0.05,
+      billing_unit: "images",
+      unit_class: "per-image",
+      model_slug: "m",
+      match: "provider-id",
+      live: true,
+      source_url: "https://example.test/m"
+    };
+    const one = [{ name: "delistable", key: "p:m", model: "m", provider: "p" }];
+    const compare = (prices: Record<string, unknown>, error: string) =>
+      runComparison({ catalog: { prices }, cases: one, quoteSteps: [{ error }] })
+        .results[0];
+
+    it("is reported as gone rather than as a disagreement", () => {
+      const result = compare({}, 'model is not available at "p"');
+      expect(result.ok).toBe(true);
+      expect(result.delisted).toBe(true);
+      expect(result.priced).toBe(false);
+      expect(priceCase(null, {}).declined).toBe(NO_CATALOG_ENTRY);
+    });
+
+    it("still fails while our catalog prices what the quote refuses", () => {
+      // The direction that matters: shipping a price for a model the provider
+      // no longer serves.
+      const result = compare({ "p:m": flat }, 'model is not available at "p"');
+      expect(result.ok).toBe(false);
+      expect(result.delisted).toBe(false);
+      expect(result.detail).toContain("0.05");
+    });
+
+    it("does not excuse a row lost for any other reason", () => {
+      const result = compare({}, "no priceable offering for that spec");
+      expect(result.ok).toBe(false);
+      expect(result.delisted).toBe(false);
+    });
+
+    it("cannot hollow the run out quietly", () => {
+      // Every case delisted is still a vacuous run, not a green one.
+      const verdict = runComparison({
+        catalog: { prices: {} },
+        quoteSteps: PARITY_CASES.map(() => ({
+          error: 'model is not available at "p"'
+        }))
+      });
+      expect(verdict.ok).toBe(false);
+      expect(verdict.vacuous).toBe(true);
+      expect(verdict.reason).toContain("delisted");
+    });
   });
 
   it("asks the quote endpoint for exactly the cases it checks", () => {

--- a/scripts/genspend/parity-check.mjs
+++ b/scripts/genspend/parity-check.mjs
@@ -33,8 +33,17 @@
  *   `/quote` declines outright, so there is no figure to compare. They are
  *   excluded from the total on both sides, which is what matters.
  *
+ * A case can also go stale on GenSpend's side: an offering they stop serving is
+ * dropped from the export, so the sync drops our row and `/quote` refuses the
+ * step. Both sides then agree, and the case has nothing left to assert — it is
+ * reported as delisted and does not count toward the priced total. That path
+ * needs both halves (see `isDelisted`), because a quote that declines while we
+ * still carry a price is the finding worth failing on: the shipped catalog is
+ * quoting a model the provider no longer serves.
+ *
  * Exit code 0 only when every case matched AND at least `MIN_PRICED_CASES` were
  * really priced: a run that resolved nothing must fail rather than pass empty.
+ * That count is what stops delistings from hollowing the check out quietly.
  */
 
 import { readFileSync } from "node:fs";
@@ -54,9 +63,22 @@ export const EPSILON = 1e-6;
 
 /**
  * A parity run that priced fewer cases than this proves nothing — a catalog
- * that lost every key would otherwise pass with zero comparisons.
+ * that lost every key would otherwise pass with zero comparisons. It is also
+ * the backstop under `DELISTED_QUOTE_ERROR`: delistings stop being tolerated
+ * once enough of them have hollowed the run out.
  */
 export const MIN_PRICED_CASES = 15;
+
+/** The catalog has no row for the case's key at all. */
+export const NO_CATALOG_ENTRY = "no catalog entry";
+
+/**
+ * `/quote` says the offering is gone at that provider. GenSpend has no
+ * structured field for it, so the prose is the signal; a change to the wording
+ * surfaces as a failed case rather than a silent reclassification, which is the
+ * safe direction.
+ */
+export const DELISTED_QUOTE_ERROR = /not available at/i;
 
 /** GenSpend's video ladder, plus the spellings a provider page uses for it. */
 const RESOLUTION_TIERS = {
@@ -91,7 +113,7 @@ const near = (a, b) => Math.abs(a - b) <= EPSILON + Math.abs(b) * 1e-9;
  * publish, because understating is the direction that hurts.
  */
 export function priceCase(entry, params = {}) {
-  if (!entry) return { declined: "no catalog entry" };
+  if (!entry) return { declined: NO_CATALOG_ENTRY };
   if ((entry.data_flags ?? []).some((f) => f.severity === "quote_wrong")) {
     return { declined: "known quote discrepancy" };
   }
@@ -239,15 +261,20 @@ export function priceCase(entry, params = {}) {
 export const PARITY_CASES = [
   {
     name: "flat per-image price",
-    key: "together:black-forest-labs/FLUX.1-schnell",
-    model: "flux-1-schnell",
-    provider: "together"
-  },
-  {
-    name: "flat per-image price, a second provider",
     key: "fal_ai:fal-ai/flux-1/dev",
     model: "flux-1-dev",
     provider: "fal"
+  },
+  {
+    // Keeps a second provider in the set, on the entry-level path: no
+    // `variants`, so the unit price and class come off the entry itself. It
+    // replaced a Together per-image case GenSpend delisted; `/quote` prices no
+    // Together image offering our catalog carries, so the swap is to video.
+    name: "per-second on an entry with no variant grid, a second provider",
+    key: "together:minimax/hailuo-02",
+    model: "hailuo-02",
+    provider: "together",
+    params: { seconds: 6, resolution: "720p" }
   },
   {
     name: "per-second × duration, no ladder to narrow",
@@ -372,6 +399,23 @@ export const PARITY_CASES = [
   }
 ];
 
+/**
+ * Did GenSpend stop serving this offering since the case was pinned?
+ *
+ * Both halves must say so. `/quote` names the delisting, and our own catalog
+ * has dropped the row — which `buildPriceIndex` does only for an offering the
+ * export no longer marks `available`. A case where the quote declines but we
+ * still carry a price is the opposite finding and stays a failure: it means the
+ * shipped catalog quotes a model the provider no longer serves.
+ */
+function isDelisted(local, step) {
+  return (
+    local.declined === NO_CATALOG_ENTRY &&
+    typeof step?.error === "string" &&
+    DELISTED_QUOTE_ERROR.test(step.error)
+  );
+}
+
 /** One case's verdict, for the report and the exit code. */
 function compareCase(testCase, entry, step) {
   const local = priceCase(entry, testCase.params ?? {});
@@ -381,21 +425,25 @@ function compareCase(testCase, entry, step) {
 
   if (local.declined || remote === null) {
     const agree = Boolean(local.declined) && remote === null;
+    const delisted = !declineExpected && agree && isDelisted(local, step);
     return {
       name: testCase.name,
       key: testCase.key,
       priced: false,
       declined: true,
-      ok: agree && declineExpected,
+      delisted,
+      ok: delisted || (agree && declineExpected),
       local: local.declined ?? local.costUsd,
       remote: step?.error ?? remote,
-      detail: agree
-        ? declineExpected
-          ? "both declined"
-          : "both declined, but the case expected a price"
-        : `local ${local.declined ?? local.costUsd} vs quote ${
-            step?.error ?? remote
-          }`
+      detail: delisted
+        ? `delisted: ${step.error}`
+        : agree
+          ? declineExpected
+            ? "both declined"
+            : "both declined, but the case expected a price"
+          : `local ${local.declined ?? local.costUsd} vs quote ${
+              step?.error ?? remote
+            }`
     };
   }
 
@@ -405,6 +453,7 @@ function compareCase(testCase, entry, step) {
     key: testCase.key,
     priced: true,
     declined: false,
+    delisted: false,
     ok,
     local: local.costUsd,
     remote,
@@ -424,16 +473,22 @@ export function runComparison({ catalog, quoteSteps, cases = PARITY_CASES }) {
     compareCase(testCase, catalog?.prices?.[testCase.key] ?? null, quoteSteps[i])
   );
   const priced = results.filter((r) => r.priced && r.ok).length;
+  const delisted = results.filter((r) => r.delisted);
   const failures = results.filter((r) => !r.ok);
   const vacuous = priced < MIN_PRICED_CASES;
   return {
     results,
     priced,
+    delisted,
     failures,
     vacuous,
     ok: failures.length === 0 && !vacuous,
     reason: vacuous
-      ? `only ${priced} case(s) priced — at least ${MIN_PRICED_CASES} must match a real price, or the check passes on nothing`
+      ? `only ${priced} case(s) priced — at least ${MIN_PRICED_CASES} must match a real price, or the check passes on nothing${
+          delisted.length > 0
+            ? `; ${delisted.length} case(s) are pinned to offerings GenSpend has delisted and need repointing`
+            : ""
+        }`
       : failures.length > 0
         ? `${failures.length} case(s) disagree with GenSpend's calculator`
         : null
@@ -510,17 +565,27 @@ async function main() {
     console.log(JSON.stringify(verdict, null, 2));
   } else {
     for (const result of verdict.results) {
-      console.log(
-        `${result.ok ? "ok  " : "FAIL"} ${result.name.padEnd(52)} ${result.detail}`
-      );
+      const label = result.ok ? (result.delisted ? "gone" : "ok  ") : "FAIL";
+      console.log(`${label} ${result.name.padEnd(52)} ${result.detail}`);
     }
     console.log(
       `\n${verdict.priced}/${PARITY_CASES.length} case(s) priced and matched against ${QUOTE_URL}.`
     );
+    if (verdict.delisted.length > 0) {
+      console.log(
+        `${verdict.delisted.length} case(s) are pinned to offerings GenSpend has since delisted. ` +
+          `Repoint them at a live offering:`
+      );
+      for (const result of verdict.delisted) {
+        console.log(`  - ${result.key}`);
+      }
+    }
   }
 
+  // stdout, not stderr: on stderr this line interleaved into the middle of the
+  // report it summarizes, which is how the CI log read.
   if (!verdict.ok) {
-    console.error(`\nParity check failed: ${verdict.reason}`);
+    console.log(`\nParity check failed: ${verdict.reason}`);
     process.exit(1);
   }
 }


### PR DESCRIPTION
## What changed

The nightly parity check failed on `flat per-image price` because GenSpend marked `flux-1-schnell` at `together` as `unavailable`. `buildPriceIndex` drops a non-available offering, so the freshly synced catalog had no row and `/quote` refused the step — both sides agreed, but the case expected a price. That failure sits before the `Detect changes` and `Open PR` steps with no `continue-on-error`, so the sync PR that would have removed the stale row was never opened, and the shipped catalog kept quoting a model the provider no longer serves. Three entries are in that state today: `together:black-forest-labs/FLUX.1-schnell` and `fal_ai:fal-ai/imagen4/preview` (both `unavailable`) and `gemini:imagen-4.0-generate-001` (`deprecated`). This repoints the stale case and teaches the check to tell a delisting apart from a disagreement, so one more delisting reports itself instead of wedging the sync.

The repoint is not the obvious one. `/quote` declines **every** Together image offering the catalog carries — not just the delisted one — so the second-provider slot moves to `together:minimax/hailuo-02` (per-second, entry-level path, no variant grid; $0.056 × 6 = $0.336, confirmed live), and `fal_ai:fal-ai/flux-1/dev` takes over the flat per-image assertion. 17 of 19 cases now price, up from 16.

The delisting rule needs both halves to agree before it excuses anything: our catalog has no row (`NO_CATALOG_ENTRY`, which the sync produces only for a non-available offering) **and** `/quote` answers `not available at`. A quote that declines while the catalog still carries a price stays a failure — that is the direction worth catching, and it is exactly what the shipped catalog looks like right now. A row missing for any other reason stays a failure too, and `MIN_PRICED_CASES` still fails a run that delistings have hollowed out. GenSpend has no structured field for this, so the prose is the signal; a wording change surfaces as a failed case rather than a silent reclassification.

Also moves the `Parity check failed:` line from stderr to stdout — on stderr it interleaved into the middle of the report it summarizes, which is how the CI log read.

## Verification

```
$ node scripts/genspend/parity-check.mjs
ok   flat per-image price                                 $0.025000
ok   per-second on an entry with no variant grid, a second provider $0.336000
...
ok   duration outside the receipted clip envelope         both declined

17/19 case(s) priced and matched against https://genspend.io/api/v1/quote.
```

- [x] `npm run test:affected` — packages 112/112 tasks; web 1212 suites / 13805 tests; electron 63 suites / 686 tests; mobile 76 suites / 1027 tests. Three sandbox gaps had to be cleared first, none related to this diff: `mesa-vulkan-drivers` (image-nodes then 229/229), `ffmpeg` (runtime then 3126/3126), and `npm --prefix mobile install`. CI installs the first two already.
- [x] `npm run typecheck` — web and electron clean. Mobile reports 36 pre-existing errors, all `sync_mode` missing from test fixtures in files this diff does not touch and which import nothing it changes.
- [x] `npm run lint` — exit 0 (warnings only, all pre-existing).
- [x] `npm run dev:nodetool -- harness gate --base main` — 0 selfchecks; the two changed files touch no registered surface.

## New checks

The delisting classification is a new rule, so it was inverted in all three directions that must still fail:

```
both dropped it            → delisted: model is not available at "p"   (ok)
we still price it          → local 0.05 vs quote model is not available at "p"   (FAIL)
row missing, other reason  → both declined, but the case expected a price        (FAIL)
every case delisted        → vacuous, "only 0 case(s) priced ... 1 case(s) are
                             pinned to offerings GenSpend has delisted"          (FAIL)
```

- [x] The check was inverted and observed failing; the four cases above are pinned in `packages/model-pricing/tests/genspend-sync.test.ts` (`describe("a delisted offering")`), and `npm run test --workspace=packages/model-pricing` passes 149/149.
- [x] The tolerated path cannot pass by matching nothing: `MIN_PRICED_CASES` is unchanged, so it fails a run whose cases have all gone quiet, and the vacuity reason now names the delistings that caused it.

---
_Generated by [Claude Code](https://claude.ai/code/session_017XTJXwLkxo3dnu428BXXiU)_