### PR TITLE
copy(marketing): rewrite project section headline and subheadline

### DIFF
--- a/marketing/src/components/ProjectSection.tsx
+++ b/marketing/src/components/ProjectSection.tsx
@@ -33,8 +33,8 @@ export default function ProjectSection() {
             transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            A chatbot leaves you a transcript. <br />
-            <span className="text-white">This leaves you a project.</span>
+            Go from conversation to <br />
+            <span className="text-white">complete project.</span>
           </motion.h2>
 
           <motion.p
@@ -44,11 +44,8 @@ export default function ProjectSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Say what you want made. The agent plans the documents it takes,
-            builds them where you can watch, and files them under one project —
-            a board, a script, a cut, each opening in the editor that made it.
-            The four frames below are one session with the same teaser, from
-            the first sentence to the shelf it ends up on.
+            Stop copy-pasting from chat windows. Describe what you need, and
+            NodeTool generates the full project in seconds.
           </motion.p>
 
           <motion.a


### PR DESCRIPTION
## What changed

The landing page's project section led with a comparison ("A chatbot leaves you a transcript. This leaves you a project.") and a four-sentence paragraph that described the frames the tabs below already show. Headline is now "Go from conversation to complete project." and the subheadline is two sentences naming the pain and the outcome: "Stop copy-pasting from chat windows. Describe what you need, and NodeTool generates the full project in seconds." Copy only — one file, no markup, layout, or component changes. It also drops the word "chatbot", which BRAND.md § Lexicon forbids for the agent.

## Verification

Copy-only text inside JSX in `marketing/`, which is not a root workspace: `npm run typecheck` and `npm run lint` cover `packages/*/src`, `web/src`, `electron` and `mobile/src`, and none of them read this file. `npm run test:affected --dry-run` reports the file as belonging to no workspace and therefore selects the whole suite, which this diff cannot reach.

- [ ] `npm run test:affected` — not run; the plan is "everything" only because `marketing/` maps to no workspace. CI runs it on the PR.
- [ ] `npm run typecheck` — does not cover `marketing/`. `npx tsc -p marketing/tsconfig.json --noEmit` reports missing-module errors (`framer-motion`, `lodash`, `uuid`) across every file in the tree, unrelated to this diff: marketing's dependencies are not installed in this environment.
- [ ] `npm run lint` — does not cover `marketing/`.
- [ ] `npm run dev:nodetool -- harness gate --base main` — no surface in the harness registry owns `marketing/`.

Grepped for the replaced strings across `marketing/`, `web/` and `docs/`: the only occurrence was the component itself, so no test, snapshot or generated page pinned the old copy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvtNuDU9AMFTLZnJ2BS5mg)_