### PR TITLE
feat(projects): give a phone the project chat, documents on demand

### DIFF
--- a/web/src/components/projects/ProjectOverviewSurface.tsx
+++ b/web/src/components/projects/ProjectOverviewSurface.tsx
@@ -1,14 +1,21 @@
 /**
- * A project's overview tab: the conversation that builds it on the left, what
- * it is made of on the right, and what it has cost across the bottom.
+ * A project's overview tab: the conversation that builds it, what it is made
+ * of, and what it has cost.
  *
  * Everything here is derived from the documents the project holds — there is
  * no project content of its own to show. The header's next step names what the
  * documents are waiting on and opens the one that performs it; the render's own
  * controls live there, not here.
+ *
+ * The two halves swap priority with the viewport. On a desktop width both are
+ * on screen at once, the agent in a resizable left dock. On a phone there is
+ * room for one, and the conversation is the one that has to be there: the
+ * documents move into a sheet the header's Documents button opens.
  */
 
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import { useTheme } from "@mui/material/styles";
 
 import {
   Box,
@@ -18,6 +25,7 @@ import {
   FlexColumn,
   FlexRow,
   LoadingSpinner,
+  MobileBottomSheet,
   SPACING,
   ScrollArea,
   StatusPill,
@@ -55,9 +63,18 @@ const ProjectOverviewSurface = ({ refId }: ProjectOverviewSurfaceProps) => {
     { staleTime: 15_000 }
   );
   const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const theme = useTheme();
+  // Below `md` the two columns do not both fit: the agent dock's own minimum
+  // is 320px, which leaves a phone nothing for the cards beside it.
+  const narrow = useMediaQuery(theme.breakpoints.down("md"));
+  const [documentsOpen, setDocumentsOpen] = useState(false);
+  const closeDocuments = useCallback(() => setDocumentsOpen(false), []);
 
   const openDocument = useCallback(
     (document: ProjectDocument) => {
+      // The tab it opens covers this one, so the sheet must not be left open
+      // behind it — coming back would land on the documents, not the chat.
+      setDocumentsOpen(false);
       openTab({
         type: document.type,
         ref: document.ref,
@@ -83,14 +100,50 @@ const ProjectOverviewSurface = ({ refId }: ProjectOverviewSurfaceProps) => {
   const progress = projectProgress(documents);
   const nextStep = projectNextStep(documents);
 
+  const documentCards =
+    documents.length === 0 ? (
+      <Caption color="muted">
+        Nothing in this project yet. Anything you create while it is open lands
+        here.
+      </Caption>
+    ) : (
+      <Box
+        sx={{
+          display: "grid",
+          gap: SPACING.lg,
+          gridTemplateColumns: {
+            xs: "1fr",
+            lg: "repeat(2, minmax(0, 1fr))"
+          }
+        }}
+      >
+        {documents.map((document) => (
+          <ProjectDocumentCard
+            key={`${document.type}:${document.ref}`}
+            document={document}
+            onOpen={openDocument}
+          />
+        ))}
+      </Box>
+    );
+
+  const agent = (
+    <ProjectAgentPanel
+      projectId={project.id}
+      projectName={project.name}
+      threadId={project.threadId}
+    />
+  );
+
   return (
     <FlexColumn fullHeight sx={{ minHeight: 0 }}>
       <FlexRow
         align="center"
-        gap={SPACING.xl}
+        gap={narrow ? SPACING.md : SPACING.xl}
+        wrap={narrow}
         sx={{
-          px: SPACING.xxl,
-          py: SPACING.xl,
+          px: narrow ? SPACING.lg : SPACING.xxl,
+          py: narrow ? SPACING.md : SPACING.xl,
           borderBottom: "1px solid",
           borderColor: "divider"
         }}
@@ -109,20 +162,34 @@ const ProjectOverviewSurface = ({ refId }: ProjectOverviewSurfaceProps) => {
           </FlexRow>
           <Caption color="secondary">{projectStatusLine(documents)}</Caption>
         </FlexColumn>
-        <FlexColumn
-          align="flex-end"
-          gap={SPACING.xs}
-          sx={{
-            pr: SPACING.xl,
-            borderRight: "1px solid",
-            borderColor: "divider"
-          }}
-        >
-          <Box component="span" sx={{ ...TYPOGRAPHY.mono.strong }}>
-            {formatSpend(spend)}
-          </Box>
-          <Caption color="muted">so far · provider rates, no markup</Caption>
-        </FlexColumn>
+        {/* The narrow header keeps the two buttons; the spend reads off the
+            bar in the sheet, where the figures it splits into also are. */}
+        {!narrow && (
+          <FlexColumn
+            align="flex-end"
+            gap={SPACING.xs}
+            sx={{
+              pr: SPACING.xl,
+              borderRight: "1px solid",
+              borderColor: "divider"
+            }}
+          >
+            <Box component="span" sx={{ ...TYPOGRAPHY.mono.strong }}>
+              {formatSpend(spend)}
+            </Box>
+            <Caption color="muted">so far · provider rates, no markup</Caption>
+          </FlexColumn>
+        )}
+        {narrow && (
+          <EditorButton
+            variant="outlined"
+            density="normal"
+            onClick={() => setDocumentsOpen(true)}
+            aria-expanded={documentsOpen}
+          >
+            {`Documents · ${documents.length}`}
+          </EditorButton>
+        )}
         {nextStep && (
           <EditorButton
             variant="contained"
@@ -136,76 +203,68 @@ const ProjectOverviewSurface = ({ refId }: ProjectOverviewSurfaceProps) => {
       </FlexRow>
 
       <FlexRow sx={{ flex: 1, minHeight: 0 }}>
-        <Box
-          sx={{
-            flexShrink: 0,
-            minHeight: 0,
-            display: { xs: "none", md: "flex" }
-          }}
-        >
-          <ResizableSideDock
-            storageKey="projectAgent"
-            side="left"
-            defaultWidth={AGENT_COLUMN_WIDTH}
-            minWidth={320}
-            maxWidth={760}
-            ariaLabel="Resize the project agent"
-          >
-            <ProjectAgentPanel
-              projectId={project.id}
-              projectName={project.name}
-              threadId={project.threadId}
-            />
-          </ResizableSideDock>
-        </Box>
-
-        <FlexColumn sx={{ flex: 1, minWidth: 0, minHeight: 0 }}>
-          <ScrollArea sx={{ flex: 1, minHeight: 0, px: SPACING.xxl }}>
-            <FlexRow
-              align="baseline"
-              gap={SPACING.md}
-              sx={{ pt: SPACING.lg, pb: SPACING.md }}
-            >
-              <Caption color="muted" sx={{ textTransform: "uppercase" }}>
-                Documents
-              </Caption>
-              <Box sx={{ flex: 1 }} />
-              <Caption color="muted">
-                everything below opens as a tab in this group
-              </Caption>
-            </FlexRow>
-            {documents.length === 0 ? (
-              <Caption color="muted">
-                Nothing in this project yet. Anything you create while it is
-                open lands here.
-              </Caption>
-            ) : (
-              <Box
-                sx={{
-                  display: "grid",
-                  gap: SPACING.lg,
-                  gridTemplateColumns: {
-                    xs: "1fr",
-                    lg: "repeat(2, minmax(0, 1fr))"
-                  }
-                }}
-              >
-                {documents.map((document) => (
-                  <ProjectDocumentCard
-                    key={`${document.type}:${document.ref}`}
-                    document={document}
-                    onOpen={openDocument}
-                  />
-                ))}
-              </Box>
-            )}
-          </ScrollArea>
-          <Divider />
-          <Box sx={{ px: SPACING.xxl, py: SPACING.lg }}>
-            <ProjectSpendBar spend={spend} />
+        {narrow ? (
+          <Box sx={{ flex: 1, minWidth: 0, minHeight: 0, display: "flex" }}>
+            {agent}
           </Box>
-        </FlexColumn>
+        ) : (
+          <>
+            <Box sx={{ flexShrink: 0, minHeight: 0, display: "flex" }}>
+              <ResizableSideDock
+                storageKey="projectAgent"
+                side="left"
+                defaultWidth={AGENT_COLUMN_WIDTH}
+                minWidth={320}
+                maxWidth={760}
+                ariaLabel="Resize the project agent"
+              >
+                {agent}
+              </ResizableSideDock>
+            </Box>
+
+            <FlexColumn sx={{ flex: 1, minWidth: 0, minHeight: 0 }}>
+              <ScrollArea sx={{ flex: 1, minHeight: 0, px: SPACING.xxl }}>
+                <FlexRow
+                  align="baseline"
+                  gap={SPACING.md}
+                  sx={{ pt: SPACING.lg, pb: SPACING.md }}
+                >
+                  <Caption color="muted" sx={{ textTransform: "uppercase" }}>
+                    Documents
+                  </Caption>
+                  <Box sx={{ flex: 1 }} />
+                  <Caption color="muted">
+                    everything below opens as a tab in this group
+                  </Caption>
+                </FlexRow>
+                {documentCards}
+              </ScrollArea>
+              <Divider />
+              <Box sx={{ px: SPACING.xxl, py: SPACING.lg }}>
+                <ProjectSpendBar spend={spend} />
+              </Box>
+            </FlexColumn>
+          </>
+        )}
       </FlexRow>
+
+      {narrow && (
+        <MobileBottomSheet
+          open={documentsOpen}
+          onClose={closeDocuments}
+          title="Documents"
+          ariaLabel="Project documents"
+        >
+          <FlexColumn gap={SPACING.lg} sx={{ px: SPACING.lg, py: SPACING.lg }}>
+            <Caption color="muted">
+              everything below opens as a tab in this group
+            </Caption>
+            {documentCards}
+            <Divider />
+            <ProjectSpendBar spend={spend} />
+          </FlexColumn>
+        </MobileBottomSheet>
+      )}
     </FlexColumn>
   );
 };

--- a/web/src/components/projects/__tests__/ProjectOverviewSurface.test.tsx
+++ b/web/src/components/projects/__tests__/ProjectOverviewSurface.test.tsx
@@ -1,12 +1,13 @@
 /**
  * The project overview tab: the header's derived status and next step, the
- * document cards, the spend bar, and that opening a document keeps it inside
- * the project's tab group.
+ * document cards, the spend bar, that opening a document keeps it inside the
+ * project's tab group, and that a phone-width viewport gives the screen to the
+ * conversation and the documents to a sheet.
  *
  * The agent column is stubbed — it is a live chat surface with its own thread
  * hydration, covered by its own tests.
  */
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";
@@ -70,6 +71,14 @@ jest.mock("../../../trpc/client", () => ({
   }
 }));
 
+// The viewport the surface reads. jsdom has no matchMedia for `useMediaQuery`
+// to ask, so it would report a desktop width for every case otherwise.
+let narrowViewport = false;
+jest.mock("@mui/material/useMediaQuery", () => ({
+  __esModule: true,
+  default: () => narrowViewport
+}));
+
 jest.mock("../ProjectAgentPanel", () => ({
   __esModule: true,
   default: () => <div data-testid="agent-panel" />
@@ -90,7 +99,10 @@ const renderSurface = () =>
     </ThemeProvider>
   );
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+  narrowViewport = false;
+});
 
 describe("ProjectOverviewSurface", () => {
   it("reports the derived status and a spend that names what was unpriced", () => {
@@ -138,5 +150,36 @@ describe("ProjectOverviewSurface", () => {
     renderSurface();
     expect(screen.getByText("Late is when ideas show up.")).toBeInTheDocument();
     expect(screen.getByText("stale")).toBeInTheDocument();
+  });
+
+  it("gives a phone the conversation, and the documents on demand", async () => {
+    narrowViewport = true;
+    renderSurface();
+
+    expect(screen.getByTestId("agent-panel")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Script")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Documents · 2" }));
+    expect(screen.getByLabelText("Script")).toBeInTheDocument();
+    // The spend the narrow header drops is on the bar inside the sheet.
+    expect(screen.getByText("clips $2.60")).toBeInTheDocument();
+  });
+
+  it("closes the sheet when a document opens, so the chat is what returns", async () => {
+    narrowViewport = true;
+    renderSurface();
+
+    await userEvent.click(screen.getByRole("button", { name: "Documents · 2" }));
+    await userEvent.click(screen.getByLabelText("Script"));
+
+    expect(openTab).toHaveBeenCalledWith({
+      type: "script",
+      ref: "s1",
+      title: "Script",
+      projectId: "p1"
+    });
+    await waitFor(() =>
+      expect(screen.queryByLabelText("Script")).not.toBeInTheDocument()
+    );
   });
 });


### PR DESCRIPTION
## What changed

The project overview split its width between the agent dock and the document cards, and below the `md` breakpoint it dropped the agent column entirely — so a phone got the cards and no way to talk to the project. Narrow viewports now run the conversation full width and move the documents into a bottom sheet (`MobileBottomSheet`) that a `Documents · N` button in the header opens. Opening a document closes the sheet first, so returning to the tab lands on the chat rather than behind a sheet. The narrow header drops the spend block, which the sheet's `ProjectSpendBar` already reports, and wraps so the two buttons have somewhere to go. Desktop widths are unchanged: same resizable dock, same document column, same spend bar.

## Verification

- [x] `npm run test:affected` — `ProjectOverviewSurface.test.tsx`, 7 passed.
- [ ] `npm run typecheck` — 13 `TS2307` module-not-found errors, all pre-existing in this environment: `npm run build:packages` fails at `@nodetool-ai/automation-nodes` (`Cannot find module '@nodetool-ai/browser'`), so the `dist/` several web imports resolve against is missing. No error is in a file this diff touches; filtering out `TS2307` leaves zero errors under `web/src`.
- [x] `npm run lint` — clean for the changed files (only pre-existing `no-unused-vars` warnings elsewhere); the design-token gates all pass.
- [ ] `npm run dev:nodetool -- harness gate --base main` — cannot run, same unbuilt-package gap: `ERR_MODULE_NOT_FOUND: @nodetool-ai/node-sdk/dist/index.js`.

The two new tests were inverted once (`const narrow = false` in place of the `useMediaQuery` read) and observed failing while the five existing ones stayed green:

```
✓ reports the derived status and a spend that names what was unpriced
✓ names the next step and opens the document that performs it
✓ splits the spend bar by category and shows the unpriced calls
✓ opens a document into the project's group
✓ draws a script card from its stored lines
✕ gives a phone the conversation, and the documents on demand
✕ closes the sheet when a document opens, so the chat is what returns
Tests: 2 failed, 5 passed, 7 total
```

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added — the two new cases are unit tests of the surface, and the inverted run above is in **Verification**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwgQtYxGLVjhQsV2j2CkJn)_