### PR TITLE
feat(web): show cost estimates in the timeline and sketch editors

### DIFF
--- a/web/src/components/costs/CostEstimateLine.tsx
+++ b/web/src/components/costs/CostEstimateLine.tsx
@@ -1,0 +1,78 @@
+/**
+ * CostEstimateLine
+ *
+ * One muted figure for what the action next to it is about to spend — the
+ * compact form of {@link CostEstimateSummary}, for inspectors and toolbars
+ * where a four-column table does not fit. Everything behind the number lives
+ * in the tooltip, so the row stays quiet until someone asks.
+ *
+ * Renders nothing when the caller has no figure: a surface that shows nothing
+ * is better than one showing a number the run will not match.
+ */
+
+import React, { memo } from "react";
+import { Caption, FlexColumn, Text, Tooltip } from "../ui_primitives";
+
+/** A figure to show, plus what produced it. */
+export interface CostLineDetail {
+  /** The figure, already formatted: "$0.42". */
+  label: string;
+  /**
+   * The figure leaves out a cost we know exists, so it reads "≥" rather than
+   * "≈" — an unpriced clip in the total, a catalog surcharge it omits.
+   */
+  isLowerBound?: boolean;
+  /** Breakdown, assumptions and warnings, one line each. */
+  lines?: string[];
+}
+
+export interface CostEstimateLineProps {
+  estimate: CostLineDetail | null;
+  /** Tooltip heading, e.g. "Estimated cost of this generation". */
+  title: string;
+  /** Screen-reader prefix for the figure. Defaults to "Estimated cost". */
+  ariaPrefix?: string;
+}
+
+const CostEstimateLineInternal: React.FC<CostEstimateLineProps> = ({
+  estimate,
+  title,
+  ariaPrefix = "Estimated cost"
+}) => {
+  if (!estimate) {
+    return null;
+  }
+
+  const prefix = estimate.isLowerBound ? "≥" : "≈";
+  const detail = (
+    <FlexColumn gap={0.5}>
+      <Text size="small">{title}</Text>
+      {estimate.lines?.map((line) => (
+        <Caption key={line} color="secondary">
+          {line}
+        </Caption>
+      ))}
+      <Caption color="secondary">
+        List price from the provider catalog. The run is billed by the provider
+        at its own rates.
+      </Caption>
+    </FlexColumn>
+  );
+
+  return (
+    <Tooltip title={detail} placement="top">
+      <Caption
+        component="span"
+        color="muted"
+        className="cost-estimate-line"
+        aria-label={`${ariaPrefix} ${estimate.label}`}
+        sx={{ fontVariantNumeric: "tabular-nums", whiteSpace: "nowrap" }}
+      >
+        {prefix}&nbsp;{estimate.label}
+      </Caption>
+    </Tooltip>
+  );
+};
+
+export const CostEstimateLine = memo(CostEstimateLineInternal);
+export default CostEstimateLine;

--- a/web/src/components/costs/__tests__/CostEstimateLine.test.tsx
+++ b/web/src/components/costs/__tests__/CostEstimateLine.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * The compact cost line: what it shows, and when it shows nothing at all.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import CostEstimateLine from "../CostEstimateLine";
+
+const renderLine = (props: React.ComponentProps<typeof CostEstimateLine>) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <CostEstimateLine {...props} />
+    </ThemeProvider>
+  );
+
+describe("CostEstimateLine", () => {
+  it("renders nothing when no figure could be reached", () => {
+    const { container } = renderLine({
+      estimate: null,
+      title: "Estimated cost"
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("reads as an approximation, labelled for a screen reader", () => {
+    renderLine({ estimate: { label: "$0.50" }, title: "Estimated cost" });
+    const figure = screen.getByLabelText("Estimated cost $0.50");
+    expect(figure).toHaveTextContent("≈");
+    expect(figure).toHaveTextContent("$0.50");
+  });
+
+  it("reads as a floor when the figure leaves a cost out", () => {
+    renderLine({
+      estimate: { label: "$0.50", isLowerBound: true },
+      title: "Estimated cost",
+      ariaPrefix: "Estimated sequence cost"
+    });
+    expect(
+      screen.getByLabelText("Estimated sequence cost $0.50")
+    ).toHaveTextContent("≥");
+  });
+});

--- a/web/src/components/costs/__tests__/costLine.test.ts
+++ b/web/src/components/costs/__tests__/costLine.test.ts
@@ -1,0 +1,95 @@
+/**
+ * The two adapters onto the compact cost line: what each reads, and when each
+ * refuses to show a figure at all.
+ */
+
+import type { WorkflowCostEstimateDetail } from "@nodetool-ai/node-sdk/cost-estimate";
+import { generationCostLine, workflowCostLine } from "../costLine";
+
+describe("generationCostLine", () => {
+  it("passes nothing through when there is no estimate", () => {
+    expect(generationCostLine(null)).toBeNull();
+  });
+
+  it("reads as a floor once the catalog warns of a missing cost", () => {
+    const line = generationCostLine({
+      label: "$0.50",
+      total: 0.5,
+      quantity: 1,
+      breakdown: "5 s × $0.1/s at 720p",
+      warnings: ["audio is billed separately"]
+    });
+    expect(line?.isLowerBound).toBe(true);
+    expect(line?.lines).toEqual([
+      "5 s × $0.1/s at 720p",
+      "audio is billed separately"
+    ]);
+  });
+
+  it("names the fan-out the figure covers", () => {
+    const line = generationCostLine({
+      label: "$0.16",
+      total: 0.16,
+      quantity: 4,
+      breakdown: "$0.04 per image"
+    });
+    expect(line?.isLowerBound).toBe(false);
+    expect(line?.lines?.[0]).toBe("4 outputs × $0.04 per image");
+  });
+});
+
+function detail(
+  overrides: Partial<WorkflowCostEstimateDetail> = {}
+): WorkflowCostEstimateDetail {
+  return {
+    currency: "USD",
+    total: 0.2,
+    unknown_count: 0,
+    items: [
+      {
+        node_id: "n1",
+        node_type: "nodetool.image.TextToImage",
+        provider: "fal_ai",
+        model: "flux",
+        quantity: 1,
+        estimated_cost: 0.2,
+        confidence: "exact",
+        breakdown: "$0.2 per image"
+      }
+    ],
+    ...overrides
+  };
+}
+
+describe("workflowCostLine", () => {
+  it("shows nothing for a graph with no AI-model node", () => {
+    expect(workflowCostLine(detail({ items: [], total: 0 }))).toBeNull();
+  });
+
+  it("shows nothing when no node in the graph could be priced", () => {
+    const unknownOnly = detail({ unknown_count: 1, total: 0 });
+    unknownOnly.items[0] = {
+      ...unknownOnly.items[0],
+      confidence: "unknown",
+      estimated_cost: 0
+    };
+    expect(workflowCostLine(unknownOnly)).toBeNull();
+  });
+
+  it("lists each priced node and totals them", () => {
+    const line = workflowCostLine(detail());
+    expect(line?.label).toBe("$0.2");
+    expect(line?.isLowerBound).toBe(false);
+    expect(line?.lines).toEqual([
+      "nodetool.image.TextToImage: $0.2 — $0.2 per image"
+    ]);
+  });
+
+  it("reads as a floor while any node is unpriced, and says how many", () => {
+    const line = workflowCostLine(detail({ unknown_count: 2 }));
+    expect(line?.isLowerBound).toBe(true);
+    expect(line?.lines?.at(-1)).toBe(
+      "2 nodes without a known price are excluded."
+    );
+  });
+});

--- a/web/src/components/costs/costLine.ts
+++ b/web/src/components/costs/costLine.ts
@@ -1,0 +1,80 @@
+/**
+ * Adapters onto {@link CostLineDetail} — the compact figure
+ * {@link CostEstimateLine} shows.
+ *
+ * Two things get priced in the media editors: one direct generation, from what
+ * the surface states about it, and a bound workflow, from its graph. Both end
+ * up as the same one-line figure, so the two conversions live together here
+ * rather than being re-derived at every call site.
+ */
+
+import { formatUsd } from "@nodetool-ai/model-pricing";
+import type { WorkflowCostEstimateDetail } from "@nodetool-ai/node-sdk/cost-estimate";
+import type { GenerationCostEstimate } from "../../utils/generationCostEstimate";
+import type { CostLineDetail } from "./CostEstimateLine";
+
+/** One direct generation as a cost line. */
+export function generationCostLine(
+  estimate: GenerationCostEstimate | null
+): CostLineDetail | null {
+  if (!estimate) {
+    return null;
+  }
+  const perOutput =
+    estimate.quantity > 1
+      ? `${estimate.quantity} outputs × ${estimate.breakdown ?? "list price"}`
+      : estimate.breakdown;
+  return {
+    label: estimate.label,
+    isLowerBound: (estimate.warnings?.length ?? 0) > 0,
+    lines: [
+      perOutput,
+      ...(estimate.assumptions ?? []),
+      ...(estimate.warnings ?? [])
+    ].filter((line): line is string => !!line)
+  };
+}
+
+/**
+ * A bound workflow's graph as a cost line: the total, one line per node that
+ * priced, and a count of the nodes that did not. An unpriced node is named
+ * rather than dropped — the total is then a floor, not a quote.
+ */
+export function workflowCostLine(
+  estimate: WorkflowCostEstimateDetail | null
+): CostLineDetail | null {
+  if (!estimate || estimate.items.length === 0) {
+    return null;
+  }
+  const priced = estimate.items.filter(
+    (item) => item.confidence !== "unknown"
+  );
+  if (priced.length === 0) {
+    return null;
+  }
+  const lines = priced.map((item) =>
+    [
+      `${item.node_type}: ${formatUsd(item.estimated_cost)}`,
+      item.breakdown,
+      ...(item.warnings ?? [])
+    ]
+      .filter(Boolean)
+      .join(" — ")
+  );
+  if (estimate.unknown_count > 0) {
+    lines.push(
+      `${estimate.unknown_count} node${
+        estimate.unknown_count === 1 ? "" : "s"
+      } without a known price ${
+        estimate.unknown_count === 1 ? "is" : "are"
+      } excluded.`
+    );
+  }
+  return {
+    label: formatUsd(estimate.total),
+    isLowerBound:
+      estimate.unknown_count > 0 ||
+      priced.some((item) => (item.warnings?.length ?? 0) > 0),
+    lines
+  };
+}

--- a/web/src/components/sketch/Inspector/DirectGenLayerPanel.tsx
+++ b/web/src/components/sketch/Inspector/DirectGenLayerPanel.tsx
@@ -45,6 +45,9 @@ import { useMediaOptions } from "../../../hooks/useModelsByProvider";
 import { useSketchSessionStore } from "../../../stores/sketch/SketchSessionStore";
 import { useSketchStore } from "../state/useSketchStore";
 import { useDirectGenJob } from "../../../hooks/sketch/useDirectGenJob";
+import { useLayerCostEstimate } from "../../../hooks/sketch/useLayerCostEstimate";
+import CostEstimateLine from "../../costs/CostEstimateLine";
+import { generationCostLine } from "../../costs/costLine";
 
 // Defaults for image-to-image controls when the binding has no explicit
 // value yet — same as the media chat composer's image_edit defaults.
@@ -123,6 +126,9 @@ const DirectGenLayerPanelInner: React.FC<DirectGenLayerPanelProps> = ({
         .map((l) => ({ value: l.id, label: l.name })),
     [layers, layer.id]
   );
+
+  // What pressing Generate spends, at the model and size picked above.
+  const costEstimate = useLayerCostEstimate(binding);
 
   const canGenerate =
     !!binding.provider &&
@@ -210,6 +216,13 @@ const DirectGenLayerPanelInner: React.FC<DirectGenLayerPanelProps> = ({
               size="small"
             />
           ))}
+
+        <FlexRow justify="flex-end" fullWidth>
+          <CostEstimateLine
+            estimate={generationCostLine(costEstimate)}
+            title="Estimated cost of this generation"
+          />
+        </FlexRow>
 
         {isRunning ? (
           <EditorButton

--- a/web/src/components/sketch/Inspector/GeneratedLayerPanel.tsx
+++ b/web/src/components/sketch/Inspector/GeneratedLayerPanel.tsx
@@ -16,6 +16,7 @@ import {
   AlertBanner,
   EmptyState,
   FlexColumn,
+  FlexRow,
   LoadingSpinner,
   Panel,
   Box
@@ -27,6 +28,9 @@ import type {
 } from "../../appbuilder/workflowInputForm";
 import { getWorkflowInputKind } from "../../appbuilder/inputKinds";
 import { useSketchGenerationStore } from "../../../stores/sketch/SketchGenerationStore";
+import { useGraphCostEstimate } from "../../../hooks/useGraphCostEstimate";
+import CostEstimateLine from "../../costs/CostEstimateLine";
+import { workflowCostLine } from "../../costs/costLine";
 import { GeneratedLayerHeader } from "./GeneratedLayerHeader";
 import { LayerActions } from "./LayerActions";
 import { LayerVersionList } from "./LayerVersionList";
@@ -149,6 +153,10 @@ export const GeneratedLayerPanel: React.FC<GeneratedLayerPanelProps> = memo(
         );
     }, [workflow]);
 
+    // What one run of the bound workflow spends, priced off the graph the
+    // panel already fetched — no open editor needed.
+    const costEstimate = useGraphCostEstimate(workflow?.graph?.nodes);
+
     const handleInputChange = useCallback(
       (name: string, value: unknown) => {
         setParamOverride(layer.id, name, value);
@@ -236,6 +244,12 @@ export const GeneratedLayerPanel: React.FC<GeneratedLayerPanelProps> = memo(
           </Box>
 
           <Box css={actionsSectionStyles(theme)}>
+            <FlexRow justify="flex-end" fullWidth sx={{ px: 0.5, pb: 0.5 }}>
+              <CostEstimateLine
+                estimate={workflowCostLine(costEstimate)}
+                title="Estimated cost of one run of this workflow"
+              />
+            </FlexRow>
             <LayerActions layerId={layer.id} binding={binding} />
           </Box>
 

--- a/web/src/components/sketch/editor-shell/ConnectedGeneratePopover.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedGeneratePopover.tsx
@@ -55,6 +55,9 @@ import { useSketchStore } from "../state/useSketchStore";
 import { useSketchSessionStore } from "../../../stores/sketch/SketchSessionStore";
 import { useDirectGenJob } from "../../../hooks/sketch/useDirectGenJob";
 import { useMediaOptions } from "../../../hooks/useModelsByProvider";
+import { useLayerCostEstimate } from "../../../hooks/sketch/useLayerCostEstimate";
+import CostEstimateLine from "../../costs/CostEstimateLine";
+import { generationCostLine } from "../../costs/costLine";
 import { SKETCH_SPACING } from "../sketchStyles";
 
 /** Most recent direct-gen binding's model, to seed the form's picker. */
@@ -222,6 +225,16 @@ const ConnectedGeneratePopoverInner: React.FC<ConnectedGeneratePopoverProps> = (
     }
   }, [model, prompt, provider, resolution, aspectRatio, start]);
 
+  // The form creates a text-to-image binding with exactly these fields, so it
+  // prices through the same hook the layer inspector uses.
+  const costEstimate = useLayerCostEstimate({
+    kind: "text-to-image",
+    provider,
+    model,
+    resolution,
+    aspectRatio
+  });
+
   const actionDisabled = generating || !prompt.trim() || !model;
 
   // No bound document → no session to act on (the in-node sketch modal).
@@ -330,6 +343,13 @@ const ConnectedGeneratePopoverInner: React.FC<ConnectedGeneratePopoverProps> = (
               value={aspectRatio}
               options={aspectOptions}
               onChange={handleAspectChange}
+            />
+          </FlexRow>
+
+          <FlexRow justify="flex-end" fullWidth>
+            <CostEstimateLine
+              estimate={generationCostLine(costEstimate)}
+              title="Estimated cost of this generation"
             />
           </FlexRow>
 

--- a/web/src/components/sketch/editor-shell/ConnectedStatusBar.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedStatusBar.tsx
@@ -1,8 +1,9 @@
 /**
  * ConnectedStatusBar — full-width status strip at the bottom of the standalone
  * image editor. Shows canvas dimensions, color space / bit depth, zoom, the
- * active foreground color, live cursor position, selection size, and layer
- * count — all from real store state. It replaces the floating info pill in the
+ * active foreground color, live cursor position, selection size, what
+ * regenerating the document's generated layers costs, and layer count — all
+ * from real store state. It replaces the floating info pill in the
  * standalone editor (the in-node modal keeps the pill).
  *
  * Narrow selectors only; the selection bounds are memoised on the selection
@@ -16,6 +17,8 @@ import React, { memo, useMemo } from "react";
 import { useTheme } from "@mui/material/styles";
 
 import { ColorSwatch, FlexRow, Tooltip } from "../../ui_primitives";
+import CostEstimateLine from "../../costs/CostEstimateLine";
+import { useSketchCostEstimate } from "../../../hooks/sketch/useSketchCostEstimate";
 import { useSketchStore } from "../state/useSketchStore";
 import { useSketchSessionStore } from "../../../stores/sketch/SketchSessionStore";
 import { useSketchCanvasRefStore } from "../../../stores/sketch/SketchCanvasRefStore";
@@ -40,6 +43,7 @@ const ConnectedStatusBarInner: React.FC = () => {
   const selection = useSketchStore((s) => s.selection);
   const hasActiveSelection = useSketchStore((s) => s.hasActiveSelection);
   const fitViewToScreen = useSketchCanvasRefStore((s) => s.fitViewToScreen);
+  const costEstimate = useSketchCostEstimate();
 
   const selBounds = useMemo(
     () =>
@@ -116,9 +120,16 @@ const ConnectedStatusBarInner: React.FC = () => {
         </span>
       )}
 
-      <span style={{ marginLeft: "auto" }}>
-        {layerCount} {layerCount === 1 ? "layer" : "layers"}
-      </span>
+      <FlexRow align="center" gap={1.5} sx={{ marginLeft: "auto" }}>
+        <CostEstimateLine
+          estimate={costEstimate}
+          title="Estimated cost of regenerating every generated layer"
+          ariaPrefix="Estimated document cost"
+        />
+        <span>
+          {layerCount} {layerCount === 1 ? "layer" : "layers"}
+        </span>
+      </FlexRow>
     </FlexRow>
   );
 };

--- a/web/src/components/timeline/BottomStatusBar.tsx
+++ b/web/src/components/timeline/BottomStatusBar.tsx
@@ -2,8 +2,8 @@
 /**
  * BottomStatusBar — Timeline Editor bottom status bar.
  *
- * Contains: local/cloud indicator, generating count, failed count, cost
- * estimate, and a zoom slider.
+ * Contains: local/cloud indicator, generating count, failed count, the
+ * sequence's list-price cost estimate, and a zoom slider.
  */
 
 import React, { memo } from "react";
@@ -18,6 +18,9 @@ import {
   BORDER_RADIUS
 } from "../ui_primitives";
 import type { StatusType } from "../ui_primitives";
+import CostEstimateLine, {
+  type CostLineDetail
+} from "../costs/CostEstimateLine";
 import CloudIcon from "@mui/icons-material/Cloud";
 import ComputerIcon from "@mui/icons-material/Computer";
 
@@ -53,6 +56,11 @@ interface BottomStatusBarProps {
   generatingCount?: number;
   /** Number of failed generations */
   failedCount?: number;
+  /**
+   * List price of generating every clip in the sequence. Omitted (or null)
+   * when nothing in the sequence can be priced.
+   */
+  costEstimate?: CostLineDetail | null;
   /** Current zoom level (1 = 100%) */
   zoom?: number;
   /** Callback when zoom changes */
@@ -72,6 +80,7 @@ export const BottomStatusBar: React.FC<BottomStatusBarProps> = memo(
     mode = "local",
     generatingCount = 0,
     failedCount = 0,
+    costEstimate = null,
     zoom = 1,
     onZoomChange,
     actionSlot
@@ -114,6 +123,12 @@ export const BottomStatusBar: React.FC<BottomStatusBarProps> = memo(
               <Caption color="error">{failedCount} failed</Caption>
             </FlexRow>
           )}
+
+          <CostEstimateLine
+            estimate={costEstimate}
+            title="Estimated cost of generating every clip in this sequence"
+            ariaPrefix="Estimated sequence cost"
+          />
         </FlexRow>
 
         {/* Right: zoom */}

--- a/web/src/components/timeline/Inspector/DirectGenClipPanel.tsx
+++ b/web/src/components/timeline/Inspector/DirectGenClipPanel.tsx
@@ -23,6 +23,9 @@ import { findClipById } from "../../../stores/timeline/clipLookup";
 import { useTimelineHistoryBatch } from "../../../stores/timeline/useTimelineHistoryBatch";
 import { useNotificationStore } from "../../../stores/NotificationStore";
 import { useGenerateClip } from "../../../hooks/timeline/useGenerateClip";
+import { useClipCostEstimate } from "../../../hooks/timeline/useClipCostEstimate";
+import CostEstimateLine from "../../costs/CostEstimateLine";
+import { generationCostLine } from "../../costs/costLine";
 import ImageModelSelect from "../../properties/ImageModelSelect";
 import VideoModelSelect from "../../properties/VideoModelSelect";
 import TTSModelSelect from "../../properties/TTSModelSelect";
@@ -141,6 +144,9 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
         ? "audio"
         : "image";
   const isImageToImage = clip?.bindingKind === "image-to-image";
+
+  // What pressing Generate spends, at the model and settings picked above.
+  const costEstimate = useClipCostEstimate(clip);
 
   // Per-model option constraints from the provider manifest — the same source
   // the media chat composer uses, so both surfaces offer identical choices.
@@ -523,6 +529,13 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
                 />
               </FlexRow>
             )}
+
+            <FlexRow justify="flex-end" fullWidth>
+              <CostEstimateLine
+                estimate={generationCostLine(costEstimate)}
+                title="Estimated cost of this generation"
+              />
+            </FlexRow>
 
             <EditorButton
               fullWidth

--- a/web/src/components/timeline/Inspector/GeneratedClipPanel.tsx
+++ b/web/src/components/timeline/Inspector/GeneratedClipPanel.tsx
@@ -25,6 +25,7 @@ import {
   EditorButton,
   EmptyState,
   FlexColumn,
+  FlexRow,
   LoadingSpinner,
   Panel,
   Box
@@ -36,6 +37,9 @@ import type {
 } from "../../appbuilder/workflowInputForm";
 import { getWorkflowInputKind } from "../../appbuilder/inputKinds";
 import { useGenerateClip } from "../../../hooks/timeline/useGenerateClip";
+import { useGraphCostEstimate } from "../../../hooks/useGraphCostEstimate";
+import CostEstimateLine from "../../costs/CostEstimateLine";
+import { workflowCostLine } from "../../costs/costLine";
 import TuneOutlinedIcon from "@mui/icons-material/TuneOutlined";
 import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
 import StopRoundedIcon from "@mui/icons-material/StopRounded";
@@ -119,6 +123,10 @@ export const GeneratedClipPanel: React.FC<GeneratedClipPanelProps> = memo(
       return () => transientNodeStore.getState().cleanup();
     }, [transientNodeStore]);
     const nodeStoreForForm = managerNodeStore ?? transientNodeStore;
+
+    // What one run of the bound workflow spends, priced off the graph the
+    // panel already fetched — no open editor needed.
+    const costEstimate = useGraphCostEstimate(workflow?.graph?.nodes);
 
     const inputDefinitions = useMemo<WorkflowInputDefinition[]>(() => {
       const nodes = workflow?.graph?.nodes ?? [];
@@ -223,6 +231,12 @@ export const GeneratedClipPanel: React.FC<GeneratedClipPanelProps> = memo(
 
           {workflowId && (
             <FlexColumn gap={0.5} sx={{ px: 1, pb: 1 }}>
+              <FlexRow justify="flex-end" fullWidth>
+                <CostEstimateLine
+                  estimate={workflowCostLine(costEstimate)}
+                  title="Estimated cost of one run of this workflow"
+                />
+              </FlexRow>
               <EditorButton
                 fullWidth
                 variant={isActive ? "outlined" : "contained"}

--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -55,6 +55,7 @@ import TuneOutlinedIcon from "@mui/icons-material/TuneOutlined";
 
 import { TopBar } from "./TopBar";
 import { BottomStatusBar } from "./BottomStatusBar";
+import { useTimelineCostEstimate } from "../../hooks/timeline/useTimelineCostEstimate";
 import { ProjectSettingsDialog } from "./ProjectSettingsDialog";
 import SaveToFolderMenu from "../assets/SaveToFolderMenu";
 import {
@@ -438,6 +439,7 @@ const TimelineStatusBar: React.FC<{ actionSlot?: React.ReactNode }> = memo(
 
   const generatingCount = useGeneratingCount();
   const failedCount = useFailedCount();
+  const costEstimate = useTimelineCostEstimate();
 
   return (
     <BottomStatusBar
@@ -446,6 +448,7 @@ const TimelineStatusBar: React.FC<{ actionSlot?: React.ReactNode }> = memo(
       onZoomChange={handleZoomChange}
       generatingCount={generatingCount}
       failedCount={failedCount}
+      costEstimate={costEstimate}
       actionSlot={actionSlot}
     />
   );

--- a/web/src/components/timeline/TopBarPrompt.tsx
+++ b/web/src/components/timeline/TopBarPrompt.tsx
@@ -30,6 +30,9 @@ import { useTimelineUIStore } from "../../stores/timeline/TimelineUIStore";
 import { useTimelinePlaybackStore } from "../../stores/timeline/TimelinePlaybackStore";
 import { useTimelineDirectGenJob } from "../../hooks/timeline/useTimelineDirectGenJob";
 import { useLastDirectGenModel } from "../../hooks/timeline/useLastDirectGenModel";
+import { useClipCostEstimate } from "../../hooks/timeline/useClipCostEstimate";
+import CostEstimateLine from "../costs/CostEstimateLine";
+import { generationCostLine } from "../costs/costLine";
 import {
   EditorButton,
   FlexColumn,
@@ -251,6 +254,24 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
     />
   );
 
+  // The bar creates a text-to-video clip with exactly these fields, so it
+  // prices through the same hook the clip inspector uses.
+  const costEstimate = useClipCostEstimate({
+    bindingKind: "text-to-video",
+    provider: selectedModel?.provider,
+    model: selectedModel?.id,
+    resolution,
+    aspectRatio: aspect,
+    durationMs: duration * 1000
+  });
+
+  const costLine = (
+    <CostEstimateLine
+      estimate={generationCostLine(costEstimate)}
+      title="Estimated cost of this generation"
+    />
+  );
+
   const generateButton = (
     <EditorButton
       variant="contained"
@@ -400,6 +421,7 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
             }}
           >
             {settingChips}
+            {costLine}
           </FlexRow>
         </FlexColumn>
       ) : (
@@ -411,6 +433,7 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
         >
           {promptField}
           {settingChips}
+          {costLine}
           {generateButton}
         </FlexRow>
       )}

--- a/web/src/hooks/sketch/__tests__/layerCostEstimate.test.ts
+++ b/web/src/hooks/sketch/__tests__/layerCostEstimate.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Layer binding → price mapping, and what a document adds up to. Priced
+ * against the shipped catalogs rather than a mock.
+ */
+
+import type { LayerWorkflowBinding } from "@nodetool-ai/image-editor";
+import { layerGenerationSpec } from "../useLayerCostEstimate";
+import { summarizeLayerCosts } from "../useSketchCostEstimate";
+
+/** A fal image endpoint with a 1K / 2K / 4K ladder. */
+const IMAGE = { provider: "fal_ai", model: "fal-ai/nano-banana-2" };
+
+function binding(
+  overrides: Partial<LayerWorkflowBinding> = {}
+): LayerWorkflowBinding {
+  return {
+    layerId: "l1",
+    kind: "text-to-image",
+    ...IMAGE,
+    resolution: "1K",
+    aspectRatio: "1:1",
+    status: "draft",
+    versions: [],
+    ...overrides
+  };
+}
+
+describe("layerGenerationSpec", () => {
+  it("declines a workflow-bound layer — its cost is its graph's", () => {
+    expect(
+      layerGenerationSpec(binding({ kind: "workflow", workflowId: "w1" }))
+    ).toBeNull();
+  });
+
+  it("declines a layer with no model picked", () => {
+    expect(layerGenerationSpec(binding({ model: undefined }))).toBeNull();
+  });
+
+  it("prices an inpaint layer like the image generation it is", () => {
+    expect(layerGenerationSpec(binding({ kind: "inpaint" }))).toMatchObject({
+      kind: "image",
+      resolution: "1K"
+    });
+  });
+});
+
+describe("summarizeLayerCosts", () => {
+  it("returns nothing for a document with no bindings", () => {
+    expect(summarizeLayerCosts([])).toBeNull();
+  });
+
+  it("sums every priced layer", () => {
+    const one = summarizeLayerCosts([binding()]);
+    const two = summarizeLayerCosts([
+      binding(),
+      binding({ layerId: "l2" })
+    ]);
+    expect(one?.total).toBeGreaterThan(0);
+    expect(two?.total).toBeCloseTo((one?.total ?? 0) * 2, 10);
+    expect(two?.pricedCount).toBe(2);
+    expect(two?.isLowerBound).toBe(false);
+  });
+
+  it("counts a layer it cannot price and says the total is a floor", () => {
+    const summary = summarizeLayerCosts([
+      binding(),
+      binding({ layerId: "l2", kind: "workflow", workflowId: "w1" })
+    ]);
+    expect(summary?.pricedCount).toBe(1);
+    expect(summary?.unpricedCount).toBe(1);
+    expect(summary?.isLowerBound).toBe(true);
+    expect(summary?.lines.at(-1)).toContain("1 layer without a known price");
+  });
+});

--- a/web/src/hooks/sketch/useLayerCostEstimate.ts
+++ b/web/src/hooks/sketch/useLayerCostEstimate.ts
@@ -1,0 +1,73 @@
+/**
+ * What generating one sketch layer costs, at list price.
+ *
+ * Reads the layer's own direct-generation binding — the model it picked and the
+ * output size it will ask for. A workflow-bound layer is not priced here: its
+ * cost is its graph's, which the inspector estimates with `useGraphCostEstimate`
+ * off the fetched workflow.
+ *
+ * Null whenever no figure can be reached — see `estimateGenerationCost`.
+ */
+
+import { useMemo } from "react";
+import type { LayerBindingKind } from "@nodetool-ai/image-editor";
+import {
+  estimateGenerationCost,
+  type GenerationCostEstimate,
+  type GenerationSpec
+} from "../../utils/generationCostEstimate";
+
+/**
+ * The binding fields a direct-generation price is derived from. Structural so
+ * a `LayerWorkflowBinding` satisfies it without a cast.
+ */
+export interface LayerCostFields {
+  kind?: LayerBindingKind;
+  provider?: string;
+  model?: string;
+  resolution?: string;
+  aspectRatio?: string;
+  width?: number;
+  height?: number;
+}
+
+/** The generation a direct-gen binding describes, or null for a workflow. */
+export function layerGenerationSpec(
+  binding: LayerCostFields | undefined | null
+): GenerationSpec | null {
+  if (!binding?.model || !binding.kind || binding.kind === "workflow") {
+    return null;
+  }
+  return {
+    kind: "image",
+    provider: binding.provider ?? null,
+    model: binding.model,
+    resolution: binding.resolution ?? null,
+    aspectRatio: binding.aspectRatio ?? null,
+    width: binding.width ?? null,
+    height: binding.height ?? null
+  };
+}
+
+export function useLayerCostEstimate(
+  binding: LayerCostFields | undefined | null
+): GenerationCostEstimate | null {
+  const { kind, provider, model, resolution, aspectRatio, width, height } =
+    binding ?? {};
+  // Depend on the fields the price is derived from, not on the binding object —
+  // every status change and version append replaces that object.
+  return useMemo(() => {
+    const spec = layerGenerationSpec({
+      kind,
+      provider,
+      model,
+      resolution,
+      aspectRatio,
+      width,
+      height
+    });
+    return spec ? estimateGenerationCost(spec) : null;
+  }, [kind, provider, model, resolution, aspectRatio, width, height]);
+}
+
+export default useLayerCostEstimate;

--- a/web/src/hooks/sketch/useSketchCostEstimate.ts
+++ b/web/src/hooks/sketch/useSketchCostEstimate.ts
@@ -1,0 +1,101 @@
+/**
+ * What regenerating every generated layer in this sketch costs, at list price.
+ *
+ * Sums each layer binding's own direct-generation price. A workflow-bound layer
+ * is counted but not priced: its cost lives in a graph this surface has not
+ * fetched, so the total is a floor and the status bar shows it as one.
+ *
+ * Null when the document has no generated layer to price.
+ */
+
+import { useMemo } from "react";
+import { formatUsd } from "@nodetool-ai/model-pricing";
+import type { LayerWorkflowBinding } from "@nodetool-ai/image-editor";
+import { useSketchSessionStore } from "../../stores/sketch/SketchSessionStore";
+import { estimateGenerationCost } from "../../utils/generationCostEstimate";
+import { layerGenerationSpec } from "./useLayerCostEstimate";
+
+/** How many per-layer lines the tooltip carries before it summarizes. */
+const MAX_DETAIL_LINES = 6;
+
+export interface SketchCostEstimate {
+  total: number;
+  /**
+   * The total leaves out layers it could not price, so it reads as a floor.
+   * Satisfies `CostLineDetail`, which is how the status bar renders it.
+   */
+  isLowerBound: boolean;
+  /** The total, formatted: "$0.12". */
+  label: string;
+  pricedCount: number;
+  /** Bindings counted in the document that no catalog figure covers. */
+  unpricedCount: number;
+  /** Per-layer detail for the tooltip, summarized past `MAX_DETAIL_LINES`. */
+  lines: string[];
+}
+
+/** The pure half: what a document's layer bindings add up to. */
+export function summarizeLayerCosts(
+  bindings: readonly LayerWorkflowBinding[]
+): SketchCostEstimate | null {
+  if (bindings.length === 0) {
+    return null;
+  }
+
+  let total = 0;
+  let unpricedCount = 0;
+  const priced: string[] = [];
+  for (const binding of bindings) {
+    const spec = layerGenerationSpec(binding);
+    const estimate = spec ? estimateGenerationCost(spec) : null;
+    if (!estimate) {
+      unpricedCount += 1;
+      continue;
+    }
+    total += estimate.total;
+    priced.push(
+      `${binding.model}: ${estimate.label}${
+        estimate.breakdown ? ` — ${estimate.breakdown}` : ""
+      }`
+    );
+  }
+  if (priced.length === 0) {
+    return null;
+  }
+
+  const lines =
+    priced.length > MAX_DETAIL_LINES
+      ? [
+          ...priced.slice(0, MAX_DETAIL_LINES),
+          `+${priced.length - MAX_DETAIL_LINES} more layers`
+        ]
+      // Copied, not aliased: the note below is pushed onto `lines`, and
+      // `priced.length` is still the count reported.
+      : [...priced];
+  if (unpricedCount > 0) {
+    lines.push(
+      `${unpricedCount} layer${unpricedCount === 1 ? "" : "s"} without a ` +
+        `known price ${unpricedCount === 1 ? "is" : "are"} excluded ` +
+        `(workflow-bound layers are priced in their inspector).`
+    );
+  }
+
+  return {
+    total,
+    isLowerBound: unpricedCount > 0,
+    label: formatUsd(total),
+    pricedCount: priced.length,
+    unpricedCount,
+    lines
+  };
+}
+
+export function useSketchCostEstimate(): SketchCostEstimate | null {
+  const bindings = useSketchSessionStore((s) => s.bindings);
+  return useMemo(
+    () => summarizeLayerCosts(Object.values(bindings)),
+    [bindings]
+  );
+}
+
+export default useSketchCostEstimate;

--- a/web/src/hooks/timeline/__tests__/clipCostEstimate.test.ts
+++ b/web/src/hooks/timeline/__tests__/clipCostEstimate.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Clip → price mapping, and what a sequence adds up to. Priced against the
+ * shipped catalogs rather than a mock.
+ */
+
+import { makeClip } from "@nodetool-ai/timeline";
+import type { TimelineClip } from "@nodetool-ai/timeline";
+import { clipGenerationSpec } from "../useClipCostEstimate";
+import { summarizeClipCosts } from "../useTimelineCostEstimate";
+
+/** A fal video endpoint whose published grid sells 720p and 1080p apart. */
+const VIDEO = { provider: "fal_ai", model: "wan/v2.6/image-to-video" };
+
+function videoClip(overrides: Partial<TimelineClip> = {}): TimelineClip {
+  return {
+    ...makeClip({ trackId: "t1", startMs: 0, durationMs: 5000 }),
+    name: "Shot 1",
+    mediaType: "video",
+    sourceType: "generated",
+    bindingKind: "text-to-video",
+    resolution: "720p",
+    ...VIDEO,
+    ...overrides
+  };
+}
+
+describe("clipGenerationSpec", () => {
+  it("declines a workflow-bound clip — its cost is its graph's", () => {
+    expect(
+      clipGenerationSpec({ bindingKind: "workflow", model: "whatever" })
+    ).toBeNull();
+  });
+
+  it("declines a clip with no model picked", () => {
+    expect(clipGenerationSpec({ bindingKind: "text-to-video" })).toBeNull();
+  });
+
+  it("bills a video clip for the length it occupies on the timeline", () => {
+    expect(
+      clipGenerationSpec({ ...VIDEO, bindingKind: "text-to-video", durationMs: 8000 })
+    ).toMatchObject({ kind: "video", seconds: 8 });
+  });
+
+  it("leaves an image clip's duration out of the price", () => {
+    expect(
+      clipGenerationSpec({ ...VIDEO, bindingKind: "text-to-image", durationMs: 8000 })
+    ).toMatchObject({ kind: "image", seconds: null });
+  });
+
+  it("maps a text-to-audio clip to the audio kind", () => {
+    expect(
+      clipGenerationSpec({ ...VIDEO, bindingKind: "text-to-audio" })
+    ).toMatchObject({ kind: "audio" });
+  });
+});
+
+describe("summarizeClipCosts", () => {
+  it("returns nothing for a sequence of imported clips", () => {
+    expect(
+      summarizeClipCosts([videoClip({ sourceType: "imported" })])
+    ).toBeNull();
+  });
+
+  it("sums every priced clip", () => {
+    const one = summarizeClipCosts([videoClip()]);
+    const two = summarizeClipCosts([videoClip(), videoClip({ id: "c2" })]);
+    expect(one?.total).toBeGreaterThan(0);
+    expect(two?.total).toBeCloseTo((one?.total ?? 0) * 2, 10);
+    expect(two?.pricedCount).toBe(2);
+    expect(two?.isLowerBound).toBe(false);
+  });
+
+  it("counts a clip it cannot price and says the total is a floor", () => {
+    const summary = summarizeClipCosts([
+      videoClip(),
+      videoClip({ id: "c2", bindingKind: "workflow", workflowId: "w1" })
+    ]);
+    expect(summary?.pricedCount).toBe(1);
+    expect(summary?.unpricedCount).toBe(1);
+    expect(summary?.isLowerBound).toBe(true);
+    expect(summary?.lines.at(-1)).toContain("1 clip without a known price");
+  });
+
+  it("summarizes past six clips instead of listing them all", () => {
+    const clips = Array.from({ length: 9 }, (_, i) =>
+      videoClip({ id: `c${i}` })
+    );
+    const summary = summarizeClipCosts(clips);
+    expect(summary?.pricedCount).toBe(9);
+    expect(summary?.lines).toHaveLength(7);
+    expect(summary?.lines.at(-1)).toBe("+3 more clips");
+  });
+});

--- a/web/src/hooks/timeline/useClipCostEstimate.ts
+++ b/web/src/hooks/timeline/useClipCostEstimate.ts
@@ -1,0 +1,106 @@
+/**
+ * What generating one timeline clip costs, at list price.
+ *
+ * Reads the clip's own direct-generation binding — the model it picked, the
+ * rung, and for video the length the clip occupies on the timeline, which is
+ * what the direct-gen job asks the provider for. A workflow-bound clip is not
+ * priced here: its cost is its graph's, which the inspector estimates with
+ * `useGraphCostEstimate` off the fetched workflow.
+ *
+ * Null whenever no figure can be reached — see `estimateGenerationCost`.
+ */
+
+import { useMemo } from "react";
+import type { ClipBindingKind } from "@nodetool-ai/timeline";
+import {
+  estimateGenerationCost,
+  type GenerationCostEstimate,
+  type GenerationSpec
+} from "../../utils/generationCostEstimate";
+
+/**
+ * The clip fields a direct-generation price is derived from. Structural so a
+ * `TimelineClip` satisfies it without a cast, and so a caller can price a clip
+ * it is about to create.
+ */
+export interface ClipCostFields {
+  bindingKind?: ClipBindingKind;
+  provider?: string;
+  model?: string;
+  resolution?: string;
+  aspectRatio?: string;
+  width?: number;
+  height?: number;
+  durationMs?: number;
+}
+
+/** The generation a direct-gen clip describes, or null for a bound workflow. */
+export function clipGenerationSpec(
+  clip: ClipCostFields | undefined | null
+): GenerationSpec | null {
+  if (!clip?.model || !clip.bindingKind || clip.bindingKind === "workflow") {
+    return null;
+  }
+  const kind =
+    clip.bindingKind === "text-to-video"
+      ? "video"
+      : clip.bindingKind === "text-to-audio"
+        ? "audio"
+        : "image";
+  return {
+    kind,
+    provider: clip.provider ?? null,
+    model: clip.model,
+    resolution: clip.resolution ?? null,
+    aspectRatio: clip.aspectRatio ?? null,
+    width: clip.width ?? null,
+    height: clip.height ?? null,
+    // The direct-gen job derives the requested duration from the clip's own
+    // length on the timeline, so a per-second model is priced for that.
+    seconds:
+      kind === "video"
+        ? Math.max(1, Math.round((clip.durationMs ?? 4000) / 1000))
+        : null
+  };
+}
+
+export function useClipCostEstimate(
+  clip: ClipCostFields | undefined | null
+): GenerationCostEstimate | null {
+  const {
+    bindingKind,
+    provider,
+    model,
+    resolution,
+    aspectRatio,
+    width,
+    height,
+    durationMs
+  } = clip ?? {};
+  // Depend on the fields the price is derived from, not on the clip object —
+  // every trim, move and rename replaces that object.
+  return useMemo(() => {
+    const spec = clipGenerationSpec({
+      bindingKind,
+      provider,
+      model,
+      resolution,
+      aspectRatio,
+      width,
+      height,
+      durationMs
+    });
+    return spec ? estimateGenerationCost(spec) : null;
+  }, [
+    bindingKind,
+    provider,
+    model,
+    resolution,
+    aspectRatio,
+    width,
+    height,
+    durationMs
+  ]);
+}
+
+export default useClipCostEstimate;

--- a/web/src/hooks/timeline/useTimelineCostEstimate.ts
+++ b/web/src/hooks/timeline/useTimelineCostEstimate.ts
@@ -1,0 +1,100 @@
+/**
+ * What generating this whole sequence costs, at list price.
+ *
+ * Sums every generated clip's own direct-generation price. A workflow-bound
+ * clip is counted but not priced: its cost lives in a graph this surface has
+ * not fetched, and inventing a figure for it would make the total read as a
+ * quote. So the total is a floor, and the status bar shows it as one.
+ *
+ * Null when the sequence has nothing generated to price.
+ */
+
+import { useMemo } from "react";
+import { formatUsd } from "@nodetool-ai/model-pricing";
+import type { TimelineClip } from "@nodetool-ai/timeline";
+import { useTimelineStore } from "../../stores/timeline/TimelineStore";
+import { estimateGenerationCost } from "../../utils/generationCostEstimate";
+import { clipGenerationSpec } from "./useClipCostEstimate";
+
+/** How many per-clip lines the tooltip carries before it summarizes. */
+const MAX_DETAIL_LINES = 6;
+
+export interface SequenceCostEstimate {
+  total: number;
+  /**
+   * The total leaves out clips it could not price, so it reads as a floor.
+   * Satisfies `CostLineDetail`, which is how the status bar renders it.
+   */
+  isLowerBound: boolean;
+  /** The total, formatted: "$1.24". */
+  label: string;
+  pricedCount: number;
+  /** Clips counted in the sequence that no catalog figure covers. */
+  unpricedCount: number;
+  /** Per-clip detail for the tooltip, summarized past `MAX_DETAIL_LINES`. */
+  lines: string[];
+}
+
+/** The pure half: what a sequence's clips add up to. */
+export function summarizeClipCosts(
+  clips: readonly TimelineClip[]
+): SequenceCostEstimate | null {
+  const generated = clips.filter((clip) => clip.sourceType === "generated");
+  if (generated.length === 0) {
+    return null;
+  }
+
+  let total = 0;
+  let unpricedCount = 0;
+  const priced: string[] = [];
+  for (const clip of generated) {
+    const spec = clipGenerationSpec(clip);
+    const estimate = spec ? estimateGenerationCost(spec) : null;
+    if (!estimate) {
+      unpricedCount += 1;
+      continue;
+    }
+    total += estimate.total;
+    priced.push(
+      `${clip.name || clip.id.slice(0, 8)}: ${estimate.label}${
+        estimate.breakdown ? ` — ${estimate.breakdown}` : ""
+      }`
+    );
+  }
+  if (priced.length === 0) {
+    return null;
+  }
+
+  const lines =
+    priced.length > MAX_DETAIL_LINES
+      ? [
+          ...priced.slice(0, MAX_DETAIL_LINES),
+          `+${priced.length - MAX_DETAIL_LINES} more clips`
+        ]
+      // Copied, not aliased: the note below is pushed onto `lines`, and
+      // `priced.length` is still the count reported.
+      : [...priced];
+  if (unpricedCount > 0) {
+    lines.push(
+      `${unpricedCount} clip${unpricedCount === 1 ? "" : "s"} without a ` +
+        `known price ${unpricedCount === 1 ? "is" : "are"} excluded ` +
+        `(workflow-bound clips are priced in their inspector).`
+    );
+  }
+
+  return {
+    total,
+    isLowerBound: unpricedCount > 0,
+    label: formatUsd(total),
+    pricedCount: priced.length,
+    unpricedCount,
+    lines
+  };
+}
+
+export function useTimelineCostEstimate(): SequenceCostEstimate | null {
+  const clips = useTimelineStore((s) => s.clips);
+  return useMemo(() => summarizeClipCosts(clips), [clips]);
+}
+
+export default useTimelineCostEstimate;

--- a/web/src/hooks/useGraphCostEstimate.ts
+++ b/web/src/hooks/useGraphCostEstimate.ts
@@ -1,0 +1,91 @@
+/**
+ * useGraphCostEstimate — pre-run cost estimate for a plain graph.
+ *
+ * The estimator half of {@link useWorkflowCostEstimate}, taken off the editor's
+ * NodeStore so a surface that merely *fetched* a workflow can price it too: the
+ * timeline's workflow-bound clips and the sketch's workflow-bound layers both
+ * hold a fetched graph and no open editor.
+ *
+ * Keeps only the nodes that use an AI model, then runs the pure
+ * `estimateWorkflowCost`. Returns null when there is no graph to price.
+ */
+
+import { useMemo } from "react";
+import {
+  estimateWorkflowCost,
+  nodeExpectedQuantity,
+  usesAiModel,
+  type WorkflowCostEstimateDetail
+} from "@nodetool-ai/node-sdk/cost-estimate";
+import { extractPricingParams } from "@nodetool-ai/node-sdk/pricing-params";
+import type { NodeMetadata } from "../stores/ApiTypes";
+import useMetadataStore from "../stores/MetadataStore";
+import { getModelUnitPrice } from "../utils/modelUnitPricing";
+
+/** A graph node as either source gives it: the editor's, or the API's. */
+export interface CostEstimateNode {
+  id: string;
+  type?: string | null;
+  data?: unknown;
+}
+
+/**
+ * A node's property values. The editor stores them under `data.properties`
+ * (`../stores/NodeData`); graphs that arrive from the server carry them spread
+ * on `data`. Read both, the way the server preflight does — reading only the
+ * outer object priced every model-picker node as unknown.
+ */
+function propertyValues(data: unknown): Record<string, unknown> | undefined {
+  if (!data || typeof data !== "object") {
+    return undefined;
+  }
+  const outer = data as Record<string, unknown>;
+  const nested = outer.properties;
+  return nested && typeof nested === "object" && !Array.isArray(nested)
+    ? (nested as Record<string, unknown>)
+    : outer;
+}
+
+/** Price a graph. Pure but for the metadata lookup the caller supplies. */
+export function estimateGraphCost(
+  nodes: readonly CostEstimateNode[],
+  getMetadata: (nodeType: string) => NodeMetadata | undefined
+): WorkflowCostEstimateDetail {
+  const aiNodes = nodes.filter((node) =>
+    node.type ? usesAiModel(getMetadata(node.type)) : false
+  );
+  // Each node contributes its configured fan-out (e.g. num_images) so the
+  // estimate reflects a real run.
+  const quantities: Record<string, number> = Object.fromEntries(
+    aiNodes.map((node) => [
+      node.id,
+      nodeExpectedQuantity(propertyValues(node.data))
+    ])
+  );
+  return estimateWorkflowCost({
+    nodes: aiNodes.map((node) => ({
+      id: node.id,
+      type: node.type ?? "",
+      data: propertyValues(node.data)
+    })),
+    getMetadata: (nodeType) => getMetadata(nodeType),
+    getModelPrice: getModelUnitPrice,
+    // What the node states about the job it will run (duration, resolution,
+    // audio), so a per-second model prices the clip and not one second.
+    getParams: (node) => extractPricingParams(node.data),
+    quantities,
+    currency: "USD"
+  });
+}
+
+export function useGraphCostEstimate(
+  nodes: readonly CostEstimateNode[] | undefined | null
+): WorkflowCostEstimateDetail | null {
+  const getMetadata = useMetadataStore((state) => state.getMetadata);
+  return useMemo(
+    () => (nodes ? estimateGraphCost(nodes, getMetadata) : null),
+    [nodes, getMetadata]
+  );
+}
+
+export default useGraphCostEstimate;

--- a/web/src/hooks/useWorkflowCostEstimate.ts
+++ b/web/src/hooks/useWorkflowCostEstimate.ts
@@ -1,45 +1,22 @@
 /**
- * useWorkflowCostEstimate — reactive pre-run cost estimate for a workflow.
+ * useWorkflowCostEstimate — reactive pre-run cost estimate for an open workflow.
  *
- * Reads the open workflow's nodes (from its NodeStore) and the node-type
- * metadata (which carries `fal_unit_pricing` / `kie_unit_pricing`), keeps only
- * the nodes that use an AI model, then runs the pure {@link estimateWorkflowCost}
- * estimator. Generic nodes (e.g. TextToImage) are priced from their selected
- * `model` field via the FAL/kie pricing catalogs. Re-computes when the graph or
- * metadata changes. Returns `null` when the graph isn't available yet.
+ * Subscribes to the open workflow's NodeStore and prices its graph through
+ * {@link estimateGraphCost}, so the editor's panel and the media editors'
+ * workflow-bound inspectors read one estimator. Re-computes when the graph or
+ * the node-type metadata changes. Returns `null` when the graph isn't
+ * available yet.
  */
 
 import { useCallback, useMemo, useSyncExternalStore } from "react";
 import type { Node } from "@xyflow/react";
-import {
-  estimateWorkflowCost,
-  nodeExpectedQuantity,
-  usesAiModel,
-  type WorkflowCostEstimateDetail
-} from "@nodetool-ai/node-sdk/cost-estimate";
-import { extractPricingParams } from "@nodetool-ai/node-sdk/pricing-params";
+import type { WorkflowCostEstimateDetail } from "@nodetool-ai/node-sdk/cost-estimate";
 import { useWorkflowManager } from "../contexts/WorkflowManagerContext";
 import useMetadataStore from "../stores/MetadataStore";
 import type { NodeData } from "../stores/NodeData";
-import { getModelUnitPrice } from "../utils/modelUnitPricing";
+import { estimateGraphCost } from "./useGraphCostEstimate";
 
 const EMPTY_NODES: Node<NodeData>[] = [];
-
-/**
- * A node's property values. The editor stores them under `data.properties`
- * (`../stores/NodeData`); graphs that arrive from the server carry them spread
- * on `data`. Read both, the way the server preflight does — reading only the
- * outer object priced every model-picker node as unknown.
- */
-function propertyValues(
-  data: Record<string, unknown> | undefined
-): Record<string, unknown> | undefined {
-  if (!data) return undefined;
-  const nested = data.properties;
-  return nested && typeof nested === "object" && !Array.isArray(nested)
-    ? (nested as Record<string, unknown>)
-    : data;
-}
 
 export function useWorkflowCostEstimate(
   workflowId: string
@@ -60,38 +37,10 @@ export function useWorkflowCostEstimate(
   );
   const nodes = useSyncExternalStore(subscribe, getSnapshot);
 
-  return useMemo(() => {
-    if (!nodeStore) {
-      return null;
-    }
-    const aiNodes = nodes.filter((node) =>
-      node.type ? usesAiModel(getMetadata(node.type)) : false
-    );
-    // Each node contributes its configured fan-out (e.g. num_images) so the
-    // estimate reflects a real run.
-    const quantities: Record<string, number> = Object.fromEntries(
-      aiNodes.map((node) => [
-        node.id,
-        nodeExpectedQuantity(
-          propertyValues(node.data as Record<string, unknown> | undefined)
-        )
-      ])
-    );
-    return estimateWorkflowCost({
-      nodes: aiNodes.map((node) => ({
-        id: node.id,
-        type: node.type ?? "",
-        data: propertyValues(node.data as Record<string, unknown> | undefined)
-      })),
-      getMetadata: (nodeType) => getMetadata(nodeType),
-      getModelPrice: getModelUnitPrice,
-      // What the node states about the job it will run (duration, resolution,
-      // audio), so a per-second model prices the clip and not one second.
-      getParams: (node) => extractPricingParams(node.data),
-      quantities,
-      currency: "USD"
-    });
-  }, [nodeStore, nodes, getMetadata]);
+  return useMemo(
+    () => (nodeStore ? estimateGraphCost(nodes, getMetadata) : null),
+    [nodeStore, nodes, getMetadata]
+  );
 }
 
 export default useWorkflowCostEstimate;

--- a/web/src/utils/__tests__/generationCostEstimate.test.ts
+++ b/web/src/utils/__tests__/generationCostEstimate.test.ts
@@ -1,0 +1,93 @@
+/**
+ * estimateGenerationCost — priced against the shipped catalogs, not a mock, so
+ * a catalog change that breaks the editors' figures fails here too.
+ */
+
+import { estimateGenerationCost } from "../generationCostEstimate";
+
+/** A fal video endpoint whose published grid sells 720p and 1080p apart. */
+const VIDEO = { provider: "fal_ai", model: "wan/v2.6/image-to-video" };
+/** A fal image endpoint with a 1K / 2K / 4K ladder. */
+const IMAGE = { provider: "fal_ai", model: "fal-ai/nano-banana-2" };
+
+describe("estimateGenerationCost", () => {
+  it("returns nothing while no model is picked", () => {
+    expect(
+      estimateGenerationCost({ kind: "video", provider: "fal_ai", seconds: 5 })
+    ).toBeNull();
+  });
+
+  it("returns nothing for a model no catalog prices", () => {
+    expect(
+      estimateGenerationCost({
+        kind: "image",
+        provider: "fal_ai",
+        model: "totally-not-a-real-model-xyz"
+      })
+    ).toBeNull();
+  });
+
+  it("bills a per-second video model for the clip's whole duration", () => {
+    const five = estimateGenerationCost({
+      ...VIDEO,
+      kind: "video",
+      resolution: "720p",
+      seconds: 5
+    });
+    const ten = estimateGenerationCost({
+      ...VIDEO,
+      kind: "video",
+      resolution: "720p",
+      seconds: 10
+    });
+    expect(five?.total).toBeGreaterThan(0);
+    expect(ten?.total).toBeCloseTo((five?.total ?? 0) * 2, 10);
+    expect(five?.breakdown).toContain("5 s");
+  });
+
+  it("prices a video rung apart from the one below it", () => {
+    const hd = estimateGenerationCost({
+      ...VIDEO,
+      kind: "video",
+      resolution: "720p",
+      seconds: 5
+    });
+    const fullHd = estimateGenerationCost({
+      ...VIDEO,
+      kind: "video",
+      resolution: "1080p",
+      seconds: 5
+    });
+    expect(fullHd?.total).toBeGreaterThan(hd?.total ?? 0);
+  });
+
+  it("multiplies an image price by the fan-out", () => {
+    const one = estimateGenerationCost({ ...IMAGE, kind: "image" });
+    const four = estimateGenerationCost({
+      ...IMAGE,
+      kind: "image",
+      quantity: 4
+    });
+    expect(one?.total).toBeGreaterThan(0);
+    expect(one?.quantity).toBe(1);
+    expect(four?.quantity).toBe(4);
+    expect(four?.total).toBeCloseTo((one?.total ?? 0) * 4, 10);
+  });
+
+  it("reads the megapixels off a stored pixel size", () => {
+    const bySize = estimateGenerationCost({
+      ...IMAGE,
+      kind: "image",
+      width: 2048,
+      height: 2048
+    });
+    const byPreset = estimateGenerationCost({
+      ...IMAGE,
+      kind: "image",
+      resolution: "2K",
+      aspectRatio: "1:1"
+    });
+    expect(bySize?.total).toBeGreaterThan(0);
+    expect(bySize?.total).toBe(byPreset?.total);
+  });
+});

--- a/web/src/utils/generationCostEstimate.ts
+++ b/web/src/utils/generationCostEstimate.ts
@@ -1,0 +1,122 @@
+/**
+ * List price of one direct generation, priced from what the surface states
+ * about the job rather than from a graph.
+ *
+ * The timeline's clips and the sketch's layers both carry the same fields a
+ * media generation is configured with — a provider/model pair, an output size,
+ * a duration — so both price through this one function, and through the same
+ * `getModelUnitPrice` the editor's cost panel and the server's pre-run budget
+ * gate use. A per-second video model therefore prices the clip that is about to
+ * be generated, not one second of it.
+ *
+ * Returns null whenever a figure would be invented: no model picked, no catalog
+ * entry, or a catalog that refuses to extrapolate (a rung the provider does not
+ * publish, a unit with no fixed value per run). Showing nothing beats showing a
+ * number the run will not match.
+ */
+
+import { formatUsd, getModelUnitPrice } from "@nodetool-ai/model-pricing";
+import type { ModelPriceParams } from "@nodetool-ai/node-sdk/cost-estimate";
+import {
+  resolveImageSize,
+  type ImageResolution
+} from "../stores/MediaGenerationStore";
+
+/** What a surface states about the generation it is about to start. */
+export interface GenerationSpec {
+  /** "image" prices a still, "video" a clip, "audio" a spoken take. */
+  kind: "image" | "video" | "audio";
+  provider?: string | null;
+  model?: string | null;
+  /** The rung in the catalog's own spelling: "1K", "720p". */
+  resolution?: string | null;
+  aspectRatio?: string | null;
+  /** Output pixel size, when the surface stores it (images). */
+  width?: number | null;
+  height?: number | null;
+  /** Output length in seconds (video). */
+  seconds?: number | null;
+  /** How many outputs one press buys. Defaults to 1. */
+  quantity?: number;
+}
+
+export interface GenerationCostEstimate {
+  /** The whole run, fan-out included: "$0.42". */
+  label: string;
+  total: number;
+  /** How many outputs the price covers. */
+  quantity: number;
+  /** How the figure was reached: "10 s × $0.14/s at 1080p". */
+  breakdown?: string;
+  /** What the catalog filled in because the surface states nothing about it. */
+  assumptions?: string[];
+  /** Known-missing costs — the figure is then a lower bound. */
+  warnings?: string[];
+}
+
+/** The megapixels the job will produce, from its size or its size preset. */
+function megapixelsFor(spec: GenerationSpec): number | undefined {
+  if (spec.width && spec.height) {
+    return Math.round(((spec.width * spec.height) / 1_000_000) * 100) / 100;
+  }
+  if (!spec.resolution || !spec.aspectRatio) {
+    return undefined;
+  }
+  const { width, height } = resolveImageSize(
+    spec.resolution as ImageResolution,
+    spec.aspectRatio
+  );
+  return Math.round(((width * height) / 1_000_000) * 100) / 100;
+}
+
+/** The price parameters for a spec, in the vocabulary the catalogs bill in. */
+function priceParams(spec: GenerationSpec): ModelPriceParams {
+  if (spec.kind === "audio") {
+    return {};
+  }
+  const params: ModelPriceParams = {};
+  if (spec.resolution) {
+    params.resolution = spec.resolution;
+  }
+  if (spec.kind === "video") {
+    if (spec.seconds != null && spec.seconds > 0) {
+      params.seconds = spec.seconds;
+    }
+    return params;
+  }
+  const megapixels = megapixelsFor(spec);
+  if (megapixels != null) {
+    params.megapixels = megapixels;
+  }
+  return params;
+}
+
+export function estimateGenerationCost(
+  spec: GenerationSpec
+): GenerationCostEstimate | null {
+  if (!spec.model) {
+    return null;
+  }
+  const quantity = spec.quantity ?? 1;
+  const price = getModelUnitPrice(
+    { id: spec.model, provider: spec.provider ?? null },
+    priceParams(spec)
+  );
+  if (!price || price.declined || !Number.isFinite(price.unit_price)) {
+    return null;
+  }
+  const total = price.unit_price * quantity;
+  if (!(total > 0)) {
+    return null;
+  }
+  return {
+    label: formatUsd(total),
+    total,
+    quantity,
+    breakdown: price.breakdown,
+    assumptions: price.assumptions,
+    warnings: price.warnings
+  };
+}
+
+export default estimateGenerationCost;


### PR DESCRIPTION
## What changed

Both editors spend money on a button press and neither said what a press would cost. Every generation surface in them now carries the same muted figure the chat composer shows: the timeline's direct-gen clip inspector, its quick text-to-video bar, and the sketch's direct-gen layer inspector and generate popover price the model and settings picked right above the button; the workflow-bound clip and layer inspectors price the graph they already fetched. Each status bar carries the whole-document total — the timeline's `BottomStatusBar` docstring has claimed a cost estimate since it was written.

Everything prices through `getModelUnitPrice`, the lookup the editor's cost panel and the server's pre-run budget gate share, so a clip billed per second is priced for the length it occupies on the timeline rather than for one second of it. Two new seams keep that single: `estimateGenerationCost` (`web/src/utils/generationCostEstimate.ts`) prices one direct generation from what a surface states about it — both editors' clip and layer bindings carry the same provider/model/rung/size fields — and `estimateGraphCost` (`web/src/hooks/useGraphCostEstimate.ts`) is `useWorkflowCostEstimate`'s estimator taken off the editor's NodeStore, so a surface holding a merely-fetched workflow can price it too. `CostEstimateLine` is the compact form of the existing `CostEstimateSummary` table, for inspectors and toolbars where four columns do not fit.

A figure is shown only when a catalog can reach one: no model picked, no catalog entry, or a rung the provider does not publish renders nothing rather than a number the run will not match. A total that leaves out something it could not price (a workflow-bound clip, whose cost lives in a graph the status bar has not fetched) reads `≥`, not `≈`, and the tooltip says how many were excluded.

## Verification

- [x] `npm run test:affected` — 19 suites, 126 tests, all passed
- [x] `npm run typecheck` — `typecheck:web` and `typecheck:electron` clean. `typecheck:mobile` reports 36 errors; the same 36 are present on a stashed clean tree (`git stash -u && npm run typecheck:mobile`), and this diff touches no file mobile compiles.
- [x] `npm run lint` — exit 0 (warnings only, all pre-existing)
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 8/8 selfchecks passed`

Environment note: `packages/browser` was not linked into `node_modules` in this sandbox, which failed `@nodetool-ai/automation-nodes#build` and blocked the harness gate. `npm install --ignore-scripts` fixed it; `package.json` and `package-lock.json` are unchanged by this branch.

## New checks

Both new test files were inverted once and observed failing, then restored:

- Dropped `params.seconds` in `estimateGenerationCost` → `estimateGenerationCost › bills a per-second video model for the clip's whole duration` fails (a 10 s clip no longer costs twice a 5 s one).
- Mapped `text-to-video` to the image kind in `clipGenerationSpec` → `clipGenerationSpec › bills a video clip for the length it occupies on the timeline` fails.

The first run of the sequence-total test also caught a real bug in the code under test: `lines` aliased the `priced` array, so pushing the "N clips without a known price" note inflated `pricedCount`. Fixed by copying.

---
_Generated by [Claude Code](https://claude.ai/code/session_0168tmQX2zBrmGmf4obhcz4y)_