### PR TITLE
fix(web): show Projects entry in mobile side panel

### DIFF
--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -865,6 +865,8 @@ const MobilePanelLeft: React.FC<{
    * (MobileRailLauncher), so this variant renders only the sheet.
    */
   hideLauncher?: boolean;
+  /** Same condition as the desktop rail's showProjects. */
+  showProjects?: boolean;
 }> = ({
   activeView,
   activeNodeCategory,
@@ -876,7 +878,8 @@ const MobilePanelLeft: React.FC<{
   onViewChange,
   handlePanelToggle,
   hiddenViews,
-  hideLauncher = false
+  hideLauncher = false,
+  showProjects = false
 }) => {
   const theme = useTheme();
   // The app pages (Settings, Help, Downloads, …) are a section of this sheet
@@ -971,6 +974,12 @@ const MobilePanelLeft: React.FC<{
             ))}
 
             <FlexRow className="mobile-tab-group" gap={SPACING.xs}>
+              {showProjects && (
+                <ProjectsRailButton
+                  onSelect={onClose}
+                  tooltipPlacement="bottom"
+                />
+              )}
               <Tooltip
                 title="More"
                 placement="bottom"
@@ -1128,6 +1137,7 @@ const PanelLeft: React.FC = () => {
         handlePanelToggle={handlePanelToggle}
         hiddenViews={hiddenViews}
         hideLauncher={isWorkspace}
+        showProjects={isWorkspace}
       />
     );
   }

--- a/web/src/components/panels/__tests__/PanelLeftMobile.test.tsx
+++ b/web/src/components/panels/__tests__/PanelLeftMobile.test.tsx
@@ -155,8 +155,18 @@ it("keeps the visible desktop groups in the mobile tab row", () => {
     ["Sketches", "Scripts", "Storyboards", "Entities", "Timelines"],
     ["JS Scripts", "Skills"],
     ["Workspace", "Assets", "Library"],
-    ["More"]
+    ["Projects", "More"]
   ]);
+});
+
+it("offers Projects in the workspace shell", async () => {
+  const user = userEvent.setup();
+  renderPanel();
+
+  const projects = screen.getByLabelText("Projects");
+  expect(projects).toBeInTheDocument();
+
+  await user.click(projects);
 });
 
 it("reaches the app pages through More, not a second menu button", async () => {

--- a/web/src/components/projects/ProjectsRailButton.tsx
+++ b/web/src/components/projects/ProjectsRailButton.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import DiamondOutlinedIcon from "@mui/icons-material/DiamondOutlined";
 
 import { ToolbarIconButton, Tooltip } from "../ui_primitives";
+import type { TooltipProps } from "../ui_primitives";
 import { TOOLTIP_ENTER_DELAY } from "../../config/constants";
 import {
   PROJECT_LIST_REF,
@@ -13,7 +14,13 @@ import { PROJECT_COLOR } from "./projectIdentity";
  * The rail's Projects entry. Unlike the views below it this opens a tab
  * rather than a drawer — the projects list is a surface, not a sidebar.
  */
-const ProjectsRailButton = () => {
+const ProjectsRailButton = ({
+  onSelect,
+  tooltipPlacement = "right-start"
+}: {
+  onSelect?: () => void;
+  tooltipPlacement?: TooltipProps["placement"];
+}) => {
   const openTab = useWorkspaceTabsStore((state) => state.openTab);
   const onProjectSurface = useWorkspaceTabsStore((state) => {
     const active = state.tabs.find((tab) => tab.id === state.activeTabId);
@@ -27,12 +34,13 @@ const ProjectsRailButton = () => {
       mode: "view",
       title: "Projects"
     });
-  }, [openTab]);
+    onSelect?.();
+  }, [openTab, onSelect]);
 
   return (
     <Tooltip
       title="Projects"
-      placement="right-start"
+      placement={tooltipPlacement}
       delay={TOOLTIP_ENTER_DELAY}
     >
       <ToolbarIconButton


### PR DESCRIPTION
## What changed

The mobile bottom sheet (`MobilePanelLeft` in `web/src/components/panels/PanelLeft.tsx`) never rendered a Projects entry. The desktop rail (`VerticalToolbar`) renders `ProjectsRailButton` directly, but the mobile sheet's tab row was built only from `LEFT_PANEL_GROUPS` (drawer-view categories) plus a "More" button for app pages — `ProjectsRailButton` opens a tab rather than toggling a drawer view, so it was never wired into the mobile component tree. This change adds `ProjectsRailButton` to the mobile tab row (guarded by the same `isWorkspace` condition the desktop rail uses), and closes the sheet on selection since selecting Projects navigates to a tab rather than switching the sheet's active drawer view.

## Verification

- [x] `npm run test:affected` — initially failed on the existing `PanelLeftMobile.test.tsx` snapshot of the tab row (didn't include "Projects"); updated that assertion and added a test that the Projects button is present and clickable. Re-ran `npx jest src/components/panels/__tests__/PanelLeftMobile.test.tsx` — 6/6 passing.
- [x] `npm run typecheck` — no new errors in touched files (pre-existing unrelated failures exist repo-wide from unbuilt backend packages in this sandbox)
- [x] `npm run lint` — clean on touched files
- [ ] `npm run dev:nodetool -- harness gate --base main` — could not run: backend packages aren't built in this sandboxed session (`@nodetool-ai/node-sdk/dist` missing). Diff is scoped entirely to `web/src/components/panels/` and `web/src/components/projects/`, no capability or backend surface touched.

## Agent capabilities

Skipped — no capability added or re-declared.

## New checks

Skipped — no new check, rule, or audit added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AZs823ekRbYY8WTd1ec6Gn)_