### PR TITLE
fix(chat): hide copy-conversation and new-chat buttons on mobile

### DIFF
--- a/web/src/components/chat/containers/ChatView.tsx
+++ b/web/src/components/chat/containers/ChatView.tsx
@@ -283,6 +283,9 @@ const ChatView = ({
   // Right rails use fixed widths. Below `md` they leave the conversation
   // almost no room, so they drop out entirely on phones and narrow panels.
   const railsFit = useMediaQuery(theme.breakpoints.up("md"));
+  // The overlay's copy-conversation and new-chat buttons crowd the header on
+  // phones, where the composer already exposes a new-chat action.
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const hasAgentExecutionMessages = useMemo(
     () => messages.some((message) => message.role === "agent_execution"),
     [messages]
@@ -324,10 +327,10 @@ const ChatView = ({
     <div className="chat-view" css={cssStyles}>
       <div className="chat-main">
         {(canShowMemorySidebar ||
-          messages.length > 0 ||
-          (showNewChatButton && onNewChat)) && (
+          (!isMobile && messages.length > 0) ||
+          (!isMobile && showNewChatButton && onNewChat)) && (
           <FlexRow className="chat-overlay-actions" align="center" gap={2}>
-            {messages.length > 0 && (
+            {!isMobile && messages.length > 0 && (
               <ToolbarIconButton
                 onClick={handleCopyConversation}
                 tooltip="Copy conversation as JSON"
@@ -342,7 +345,7 @@ const ChatView = ({
                 icon={<PsychologyOutlinedIcon fontSize="small" />}
               />
             )}
-            {showNewChatButton && onNewChat && (
+            {!isMobile && showNewChatButton && onNewChat && (
               <ToolbarIconButton
                 onClick={onNewChat}
                 tooltip="New chat"


### PR DESCRIPTION
## What changed

`ChatView`'s top-right overlay strip (copy conversation as JSON, new chat) crowded the header on mobile web. Both buttons are now hidden below the `sm` breakpoint using the same `useMediaQuery(theme.breakpoints.down("sm"))` pattern already used in `ChatComposer`. The memory-panel toggle is untouched — it already only shows when `railsFit` (≥ `md`) holds.

## Verification

- [x] `npm run test:affected` — 180 suites passed (1584 passed, 3 skipped)
- [ ] `npm run typecheck` — pre-existing failures unrelated to this change (missing `@nodetool-ai/node-sdk/dist/*` type declarations from unbuilt packages); reproduced identically on `main` before this change
- [x] `npm run lint` — passes clean (only pre-existing warnings in unrelated files)
- [ ] `npm run dev:nodetool -- harness gate --base main` — fails in this sandbox because backend packages aren't built (`Cannot find module '@nodetool-ai/node-sdk/dist/index.js'`), same root cause as the typecheck gap above

## Agent capabilities

N/A — no capability added or changed.

## New checks

N/A — no new check added.


---
_Generated by [Claude Code](https://claude.ai/code/session_013yEYKEBM83D61tMFPJfG33)_