### PR TITLE
feat(web): show render and voicing cost estimates before the click

### DIFF
--- a/packages/model-pricing/README.md
+++ b/packages/model-pricing/README.md
@@ -19,8 +19,9 @@ Looked up in order, first hit wins:
 1. **GenSpend, when its entry is parameter-priceable** —
    `src/generated/genspend-pricing.json`, keyed `<provider_id>:<model_id>`. An
    entry qualifies when it publishes a grid (a resolution ladder, a duration
-   rung, an audio axis, an input surcharge) or bills per second. Those rows say
-   what a *rung* costs, so they price the run rather than one unit of it.
+   rung, an audio axis, an input surcharge), or bills per second, per character,
+   or per token. Those rows say what a *rung* costs, so they price the run
+   rather than one unit of it.
 2. **FAL** — `@nodetool-ai/fal-nodes/unit-pricing-catalog`, keyed by `endpoint_id`.
 3. **kie** — `@nodetool-ai/kie-nodes/unit-pricing-catalog`, keyed by `model_id`,
    using the USD conversion (a raw credit figure has no fixed USD value).
@@ -30,9 +31,9 @@ FAL and kie come from the providers themselves, but each carries a single scalar
 per endpoint, and for the 260 FAL rows billed per second that scalar is a rate:
 reported as the price of a run it understated a 4-second clip by 40×. So a
 published GenSpend grid wins, and a FAL/kie scalar is converted here — multiplied
-by the duration or output size the node states, and declined outright for a unit
-with no fixed value per run (credits) or a rate the node states nothing about
-(compute seconds, training steps).
+by the duration, output size, or text length the node states, and declined
+outright for a unit with no fixed value per run (credits) or a rate the node
+states nothing about (compute seconds, training steps).
 
 GenSpend covers every other provider it tracks and NodeTool can run — today
 that is Replicate, AtlasCloud, Together, Gemini, OpenAI, MiniMax, and
@@ -43,6 +44,16 @@ match against that slug. Topaz, Reve, Aki, Meshy, and Rodin are enumerated by
 the sync's model inventory (`scripts/genspend/inventory.mjs`) but are not yet
 in `PROVIDER_IDS_BY_GENSPEND_SLUG`, so none of the five has priced entries
 either.
+
+## Speech models: characters, not runs
+
+The 22 text-to-speech rows are billed `1m_chars` — ElevenLabs' $100 per million.
+That is a rate, and as a per-run figure it read as $100 to voice one line, so
+these rows are multiplied by the `characters` a caller states and decline when
+none was given. The six rows billed `1m_tokens` decline outright: a speech
+model's tokens are the audio it produced, and no text length converts into them.
+Passing off the block price as a run's cost is the failure mode both rules
+exist to prevent.
 
 All three are imported as modules, not read off disk, so the estimate works
 identically in the browser bundle and inside the packaged Electron backend (no

--- a/packages/model-pricing/src/genspend-calc.ts
+++ b/packages/model-pricing/src/genspend-calc.ts
@@ -39,6 +39,9 @@ export { formatUsd };
 /** The same shape with its `readonly` modifiers dropped, for step-by-step construction. */
 type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
+/** A price under construction: the fields are filled in as the rules decide them. */
+type PriceFields = Mutable<ModelParamPrice>;
+
 /**
  * A price computed from stated parameters, with the reasoning that produced it.
  * `unit_price` is the whole per-run figure — a per-second class comes back
@@ -58,6 +61,8 @@ export interface ModelParamPrice extends ModelUnitPricingLike {
   seconds?: number;
   /** The rung the figure was billed at, in the catalog's own spelling. */
   resolution?: string;
+  /** The text length the figure was billed for, when one applied. */
+  characters?: number;
   /** The figure came off a published grid row, not a flat rate. */
   fromGrid?: boolean;
 }
@@ -113,6 +118,24 @@ export function normalizeResolution(value: string | undefined): string | null {
 
 const PER_SECOND_CLASSES = new Set(["per-video-second", "per-audio-second"]);
 
+/** Speech classes billing a block of characters, and the block's size. */
+const CHARACTER_CLASSES = new Map<string, number>([
+  ["per-1k-chars", 1_000],
+  ["per-1m-chars", 1_000_000]
+]);
+
+/**
+ * Classes billing the model's own tokens. A speech model's token count is the
+ * audio it produced, not the text it was given, so nothing a caller states
+ * converts it.
+ */
+const TOKEN_CLASSES = new Set(["per-1k-tokens", "per-1m-tokens"]);
+
+/** How a block of `size` characters is named in a breakdown. */
+function characterBlockLabel(size: number): string {
+  return size >= 1_000_000 ? `${size / 1_000_000}M chars` : `${size / 1_000}K chars`;
+}
+
 /**
  * The megapixel rungs image grids are published at. `1K` is GenSpend's name for
  * a one-megapixel deliverable, which `normalizeResolution` folds to `1MP`.
@@ -165,6 +188,11 @@ export function isParameterPriceable(entry: GenspendPrice): boolean {
     return true;
   }
   if (PER_SECOND_CLASSES.has(entry.unit_class)) return true;
+  // A character or token class is a rate, not a run price. Routing it here is
+  // what multiplies it by the text length — or declines it — instead of
+  // letting the flat-scalar path report ElevenLabs' $100/M as $100 a line.
+  if (CHARACTER_CLASSES.has(entry.unit_class)) return true;
+  if (TOKEN_CLASSES.has(entry.unit_class)) return true;
   return (entry.surcharges ?? []).length > 0;
 }
 
@@ -350,6 +378,42 @@ export function priceGenspendEntry(
   let breakdown: string;
   let seconds = statedSeconds;
 
+  const charBlock = CHARACTER_CLASSES.get(unitClass);
+  if (charBlock !== undefined) {
+    const stated = params.characters;
+    const characters =
+      stated !== undefined && Number.isFinite(stated) && stated > 0
+        ? stated
+        : null;
+    if (characters === null) {
+      return declined(
+        `this model is priced per ${characterBlockLabel(
+          charBlock
+        )}, and no text length was given`
+      );
+    }
+    const result: PriceFields = {
+      unit_price: (unitPrice * characters) / charBlock,
+      billing_unit: entry.billing_unit,
+      currency: GENSPEND_CURRENCY,
+      source: "bundle",
+      breakdown: `${characters} chars × ${money(unitPrice)}/${characterBlockLabel(
+        charBlock
+      )}`,
+      characters,
+      fromGrid: row !== null
+    };
+    if (assumptions.length > 0) result.assumptions = assumptions;
+    if (warnings.length > 0) result.warnings = warnings;
+    return result;
+  }
+
+  if (TOKEN_CLASSES.has(unitClass)) {
+    return declined(
+      "this model is priced per token of generated audio, which nothing stated converts"
+    );
+  }
+
   if (PER_SECOND_CLASSES.has(unitClass)) {
     if (seconds === null) {
       if (clip === null)
@@ -433,7 +497,6 @@ export function priceGenspendEntry(
     );
   }
 
-  type PriceFields = Mutable<ModelParamPrice>;
   const price: PriceFields = {
     unit_price: cost,
     billing_unit: entry.billing_unit,

--- a/packages/model-pricing/tests/model-pricing.test.ts
+++ b/packages/model-pricing/tests/model-pricing.test.ts
@@ -260,6 +260,65 @@ describe("getModelUnitPrice", () => {
     expect(getModelUnitPrice(model)?.assumptions?.length).toBe(1);
   });
 
+  it("prices a speech model by the characters it will synthesize", () => {
+    // ElevenLabs publishes $100 per million characters. Read as a per-run
+    // figure that made one line of dialogue cost $100.
+    const model = { id: "eleven_multilingual_v2", provider: "elevenlabs" };
+    const entry = genspendPricingCatalog.prices["elevenlabs:eleven_multilingual_v2"];
+    expect(entry?.unit_class).toBe("per-1m-chars");
+
+    const price = getModelUnitPrice(model, { characters: 200 });
+    expect(price?.declined).toBeUndefined();
+    expect(price?.unit_price).toBeCloseTo((entry.unit_price * 200) / 1_000_000, 12);
+    expect(price?.breakdown).toContain("200 chars");
+    expect(price?.characters).toBe(200);
+  });
+
+  it("declines a character-billed model when no text length is given", () => {
+    const price = getModelUnitPrice({
+      id: "eleven_multilingual_v2",
+      provider: "elevenlabs"
+    });
+    expect(price?.declined).toContain("no text length");
+    // The block price must never reach a caller as the price of a run.
+    expect(price?.unit_price).toBe(0);
+  });
+
+  it("prices a character-billed model that also publishes a variant grid", () => {
+    // This row is parameter-priceable (it carries a tier variant), so it takes
+    // the GenSpend calculator's path rather than the flat-scalar one.
+    const id = "fal-ai/elevenlabs/tts/turbo-v2.5";
+    const entry = genspendPricingCatalog.prices[`fal_ai:${id}`];
+    expect(isParameterPriceable(entry)).toBe(true);
+    const price = getModelUnitPrice({ id, provider: "fal_ai" }, { characters: 1000 });
+    expect(price?.unit_price).toBeCloseTo((entry.unit_price * 1000) / 1_000_000, 12);
+  });
+
+  it("declines a speech model billed per token of generated audio", () => {
+    // A script's text says nothing about how many audio tokens come out, so
+    // there is no honest conversion — $12 per million must not read as $12.
+    const price = getModelUnitPrice(
+      { id: "gpt-4o-mini-tts", provider: "openai" },
+      { characters: 200 }
+    );
+    expect(price?.declined).toContain("token");
+    expect(price?.unit_price).toBe(0);
+  });
+
+  it("leaves image and video pricing untouched", () => {
+    expect(
+      getModelUnitPrice(
+        { id: "fal-ai/flux/schnell", provider: "fal_ai" },
+        { resolution: "1K", megapixels: 1 }
+      )?.unit_price
+    ).toBeGreaterThan(0);
+    const clip = getModelUnitPrice(
+      { id: "fal-ai/kling-video/v2.5-turbo/pro/image-to-video", provider: "fal_ai" },
+      { resolution: "1080p", seconds: 5 }
+    );
+    expect(clip?.breakdown).toContain("5 s ×");
+  });
+
   it("warns that a collapsed kie row is the cheapest of its tiers", () => {
     const entry = Object.entries(kieUnitPricingCatalog.prices ?? {}).find(
       ([id, row]) =>

--- a/packages/node-sdk/src/cost-estimate.ts
+++ b/packages/node-sdk/src/cost-estimate.ts
@@ -87,6 +87,8 @@ export interface ModelPriceParams {
   /** Duration of a video fed in, which some providers bill instead of output. */
   referenceVideoSeconds?: number;
   megapixels?: number;
+  /** Characters of text a speech job will synthesize. */
+  characters?: number;
 }
 
 /**
@@ -107,6 +109,8 @@ export interface ModelParamPricingLike extends ModelUnitPricingLike {
   seconds?: number;
   /** The rung the figure was billed at, in the catalog's own spelling. */
   resolution?: string;
+  /** The text length the figure was billed for, when one applied. */
+  characters?: number;
   /**
    * The figure came off a published grid row, so it moves with the resolution,
    * duration and audio state the node states. A flat rate leaves it unset.
@@ -159,8 +163,38 @@ const UNSTATED_RATE_UNITS = new Set([
   "steps",
   "train unit",
   "train units",
-  "1m tokens"
+  "1m tokens",
+  // GenSpend's own spelling. A speech model billed per token bills the audio
+  // tokens it produced, which no caller states — pricing it off the text would
+  // be a guess dressed as a quote.
+  "1m_tokens",
+  "1k_tokens"
 ]);
+
+/**
+ * Units billing a block of synthesized characters, and how many characters one
+ * unit price covers. Speech models publish this as `1m_chars` (GenSpend) or as
+ * a block spelling the {@link BLOCK_UNIT} branch reads (`"1000 characters"`).
+ * Left unconverted, ElevenLabs' $100-per-million read as $100 a line.
+ */
+const CHARACTER_BLOCK_UNITS = new Map<string, number>([
+  ["character", 1],
+  ["characters", 1],
+  ["char", 1],
+  ["chars", 1],
+  ["1k_chars", 1_000],
+  ["1m_chars", 1_000_000]
+]);
+
+/** Nouns the block branch prices as characters: `"1000 characters"`. */
+const CHARACTER_NOUNS = new Set(["character", "characters", "char", "chars"]);
+
+/** How a block of `size` characters is named in a breakdown. */
+function characterBlockLabel(size: number): string {
+  if (size >= 1_000_000) return `${size / 1_000_000}M chars`;
+  if (size >= 1_000) return `${size / 1_000}K chars`;
+  return size === 1 ? "char" : `${size} chars`;
+}
 
 /** `"5 seconds"`, `"30 seconds"`, `"16 frames"` — a block of N somethings. */
 const BLOCK_UNIT = /^(\d+(?:\.\d+)?) (.+)$/;
@@ -184,6 +218,34 @@ export const formatUsd = (usd: number): string => {
 export interface ScalarPriceOptions {
   /** >1 means the figure is the cheapest of several published tiers. */
   tierCount?: number;
+}
+
+/**
+ * A character-billed scalar times the text the job will synthesize.
+ *
+ * Declines when no text length was stated: a per-character rate says nothing
+ * about a run on its own, and reporting the block price as the run's cost
+ * overstates one line of dialogue by four or five orders of magnitude.
+ */
+function priceCharacters(
+  price: ModelUnitPricingLike,
+  blockSize: number,
+  characters: number | null,
+  decline: (reason: string) => ModelParamPricingLike,
+  attach: (result: ModelParamPricingLike) => ModelParamPricingLike
+): ModelParamPricingLike {
+  const label = characterBlockLabel(blockSize);
+  if (characters === null) {
+    return decline(
+      `the catalog prices this model per ${label}, and no text length was given`
+    );
+  }
+  return attach({
+    ...price,
+    unit_price: (price.unit_price * characters) / blockSize,
+    breakdown: `${characters} chars × ${formatUsd(price.unit_price)}/${label}`,
+    characters
+  });
 }
 
 /**
@@ -310,10 +372,25 @@ export function priceScalarUnit(
     });
   }
 
+  const characters =
+    params?.characters !== undefined &&
+    Number.isFinite(params.characters) &&
+    params.characters > 0
+      ? params.characters
+      : null;
+
+  const charBlock = CHARACTER_BLOCK_UNITS.get(unit);
+  if (charBlock !== undefined) {
+    return priceCharacters(price, charBlock, characters, decline, attach);
+  }
+
   const block = BLOCK_UNIT.exec(unit);
   if (block) {
     const size = Number(block[1]);
     const noun = block[2];
+    if (CHARACTER_NOUNS.has(noun) && size > 0) {
+      return priceCharacters(price, size, characters, decline, attach);
+    }
     if (PER_SECOND_UNITS.has(noun) && size > 0) {
       if (seconds === null) {
         assumptions.push(

--- a/packages/runtime/tests/providers/manifest-models-hardening.test.ts
+++ b/packages/runtime/tests/providers/manifest-models-hardening.test.ts
@@ -298,10 +298,17 @@ describe("loadManifest IO (via loadImageModels)", () => {
   it("keys the cache by package+path (no cross-package bleed)", () => {
     // A real package yields a non-empty catalog; a different key must not
     // return that cached catalog.
+    //
+    // The manifest is this package's own. `@nodetool-ai/fal-nodes` is the
+    // larger catalog, but it *depends on* runtime, so no dependency edge can
+    // order its build before this test — turbo's `test` dependsOn `^build`
+    // builds a package's dependencies, never its dependents. On a `--affected`
+    // CI run that reached runtime, `fal-manifest.json` was simply not on disk
+    // yet and the catalog came back empty.
     const real = loadImageModels(
-      "@nodetool-ai/fal-nodes",
-      "fal-manifest.json",
-      "fal"
+      "@nodetool-ai/runtime",
+      "providers/aki-manifest.json",
+      "aki"
     );
     expect(real.length).toBeGreaterThan(0);
     expect(loadImageModels(uniq(), "x.json", "p")).toEqual([]);

--- a/web/src/components/script/ScriptDocumentPane.tsx
+++ b/web/src/components/script/ScriptDocumentPane.tsx
@@ -21,7 +21,9 @@ import {
   UndoRedoButtons,
   EmptyState,
   AlertBanner,
+  Caption,
   LoadingSpinner,
+  Tooltip,
   SPACING,
   BORDER_RADIUS,
   TYPOGRAPHY,
@@ -40,6 +42,11 @@ import {
   type ScriptSpeaker
 } from "../../stores/script/ScriptStore";
 import { voiceAll } from "../../stores/script/scriptVoicing";
+import { formatUsd } from "@nodetool-ai/model-pricing";
+import {
+  useVoiceCostEstimate,
+  type VoiceCostEstimate
+} from "../../hooks/script/useVoiceCostEstimate";
 import { exportScriptSubtitles } from "../../stores/script/scriptSubtitles";
 import { useScriptPlaythrough } from "../../hooks/script/useScriptPlaythrough";
 import { useAssembleScriptTimeline } from "../../hooks/script/useAssembleScriptTimeline";
@@ -419,6 +426,80 @@ const SectionBlockInner = ({
  *  re-renders the section being edited. */
 const SectionBlock = memo(SectionBlockInner);
 
+/**
+ * *Voice all* with what the click costs on it.
+ *
+ * The price sits in the label rather than beside it, so it reads as this
+ * button's price and not as some figure the toolbar happens to carry. A script
+ * whose speech models publish only per-token rates shows the plain label and
+ * says why in the tooltip — a synthesized "$0" would be a lie about a billed
+ * call.
+ */
+const VoiceAllButton = ({
+  estimate,
+  onClick
+}: {
+  estimate: VoiceCostEstimate;
+  onClick: () => void;
+}) => {
+  const { lineCount, characters, cost, pricedLineCount, breakdowns, reasons, notes } =
+    estimate;
+  const priced = pricedLineCount > 0 && cost > 0;
+  const partial = priced && pricedLineCount < lineCount;
+
+  return (
+    <Tooltip
+      placement="bottom"
+      title={
+        <FlexColumn gap={SPACING.micro}>
+          <Text size="small">
+            {lineCount === 0
+              ? "Every line is already voiced."
+              : `${lineCount} line${lineCount === 1 ? "" : "s"} · ${characters} characters${
+                  priced ? ` · about ${formatUsd(cost)}` : ""
+                }${
+                  partial
+                    ? ` (${pricedLineCount} of ${lineCount} lines priced)`
+                    : ""
+                }`}
+          </Text>
+          {breakdowns.map((breakdown) => (
+            <Caption key={breakdown} color="secondary">
+              {breakdown}
+            </Caption>
+          ))}
+          {reasons.map((reason) => (
+            <Caption key={reason} color="secondary">
+              {reason}
+            </Caption>
+          ))}
+          {priced &&
+            notes.map((note) => (
+              <Caption key={note} color="secondary">
+                {note}
+              </Caption>
+            ))}
+          {priced && (
+            <Caption color="secondary">
+              List price from the provider catalog. Voicing is billed by the
+              provider at its own rates.
+            </Caption>
+          )}
+        </FlexColumn>
+      }
+    >
+      <EditorButton
+        size="small"
+        variant="contained"
+        startIcon={<GraphicEqIcon fontSize="small" />}
+        onClick={onClick}
+      >
+        {priced ? `Voice all · ~${formatUsd(cost)}` : "Voice all"}
+      </EditorButton>
+    </Tooltip>
+  );
+};
+
 const ScriptDocumentPane = ({
   scriptId,
   readOnly
@@ -558,6 +639,9 @@ const ScriptDocumentPane = ({
     }
   }, [scriptId]);
 
+  // What the click above is about to spend, over the same lines it will voice.
+  const voiceCost = useVoiceCostEstimate(scriptId);
+
   const onSendToTimeline = useCallback(() => {
     void assemble(scriptId).catch(() => {
       // Errors surface via the hook's `error`; swallow to keep the click quiet.
@@ -638,14 +722,10 @@ const ScriptDocumentPane = ({
               <Text size="smaller">Voicing…</Text>
             </FlexRow>
           ) : (
-            <EditorButton
-              size="small"
-              variant="contained"
-              startIcon={<GraphicEqIcon fontSize="small" />}
+            <VoiceAllButton
+              estimate={voiceCost}
               onClick={() => void onVoiceAll()}
-            >
-              Voice all
-            </EditorButton>
+            />
           ))}
         {playing ? (
           <EditorButton

--- a/web/src/components/script/__tests__/ScriptDocumentPane.voiceCost.test.tsx
+++ b/web/src/components/script/__tests__/ScriptDocumentPane.voiceCost.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * The *Voice all* button carries what the click will spend. Speech is billed
+ * by the characters synthesized, so the figure has to come off the script's own
+ * unvoiced lines — and a script with nothing left to voice, or a voice the
+ * catalog cannot price, must show the plain label rather than "$0".
+ */
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import {
+  useScriptStore,
+  type ScriptTake,
+  type VoiceBinding
+} from "../../../stores/script/ScriptStore";
+
+jest.mock("../../../trpc/client", () => ({
+  trpc: {
+    storyboards: { get: { useQuery: jest.fn(() => ({ data: undefined })) } }
+  },
+  trpcClient: {}
+}));
+
+jest.mock("../StoryboardLinkControl", () => ({
+  __esModule: true,
+  default: () => null
+}));
+
+const mockPrice = jest.fn();
+jest.mock("../../../utils/modelUnitPricing", () => ({
+  getModelUnitPrice: (...args: unknown[]) => mockPrice(...args)
+}));
+
+import ScriptDocumentPane from "../ScriptDocumentPane";
+
+const SCRIPT_ID = "script-voice-cost";
+const VOICE: VoiceBinding = {
+  provider: "elevenlabs",
+  model: "eleven_v3",
+  voice: "alloy"
+};
+
+const matchingTake = (): ScriptTake => ({
+  id: "take-a",
+  assetId: "voice-a",
+  durationMs: 2000,
+  words: [],
+  textSnapshot: "Hello there.",
+  voiceSnapshot: VOICE,
+  createdAt: "2026-01-01T00:00:00.000Z"
+});
+
+const seed = (takes: ScriptTake[]): void => {
+  useScriptStore.setState({ scripts: {}, history: {}, saveStatus: {} });
+  useScriptStore.getState().loadScript(SCRIPT_ID, {
+    title: "My script",
+    cast: [{ id: "sp-1", name: "Mara", voice: VOICE }],
+    sections: [
+      {
+        id: "s1",
+        lines: [
+          {
+            id: "line-a",
+            speakerId: "sp-1",
+            // 12 characters.
+            text: "Hello there.",
+            takes,
+            currentTakeId: takes[0]?.id ?? null
+          }
+        ]
+      }
+    ],
+    timelineId: null,
+    storyboardId: null
+  });
+};
+
+const renderPane = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ScriptDocumentPane scriptId={SCRIPT_ID} readOnly={false} />
+    </ThemeProvider>
+  );
+
+describe("ScriptDocumentPane voice cost", () => {
+  beforeEach(() => {
+    mockPrice.mockReset();
+  });
+
+  it("puts the click's price on Voice all", () => {
+    mockPrice.mockReturnValue({
+      unit_price: 0.0012,
+      billing_unit: "1m_chars",
+      currency: "USD",
+      source: "bundle",
+      breakdown: "12 chars × $100/1M chars"
+    });
+    seed([]);
+    renderPane();
+
+    expect(mockPrice).toHaveBeenCalledWith(
+      { id: "eleven_v3", provider: "elevenlabs" },
+      { characters: 12 }
+    );
+    expect(
+      screen.getByRole("button", { name: /Voice all · ~\$0\.0012/ })
+    ).toBeInTheDocument();
+  });
+
+  it("shows the plain label when every line is already voiced", () => {
+    seed([matchingTake()]);
+    renderPane();
+
+    expect(mockPrice).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Voice all" })
+    ).toBeInTheDocument();
+  });
+
+  it("shows the plain label rather than $0 when the model declines", () => {
+    mockPrice.mockReturnValue({
+      unit_price: 0,
+      billing_unit: "1m_tokens",
+      currency: "USD",
+      source: "bundle",
+      declined: "priced per token of generated audio"
+    });
+    seed([]);
+    renderPane();
+
+    expect(
+      screen.getByRole("button", { name: "Voice all" })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -34,11 +34,13 @@ import {
   Skeleton,
   Text,
   TextInput,
+  Tooltip,
   UndoRedoButtons,
   BORDER_RADIUS,
   CONTROL,
   SPACING
 } from "../ui_primitives";
+import { formatUsd } from "@nodetool-ai/model-pricing";
 import {
   useBoard,
   useStoryboardStore,
@@ -58,6 +60,10 @@ import VideoModelSelect from "../properties/VideoModelSelect";
 import { useNotificationStore } from "../../stores/NotificationStore";
 import { useEntities } from "../../serverState/useEntities";
 import { exportStoryboardZip } from "../../utils/storyboardZip";
+import {
+  useRenderBatchCostEstimate,
+  type RenderBatchCostEstimate
+} from "../../hooks/storyboard/useRenderBatchCostEstimate";
 import ScriptLinkControl from "./ScriptLinkControl";
 import ShotCard from "./ShotCard";
 import ShotInspector from "./ShotInspector";
@@ -133,6 +139,71 @@ const shotGridSx = {
     gridTemplateColumns: "minmax(0, 1fr)"
   }
 } as const;
+
+/**
+ * A batch render button with what the click costs on it.
+ *
+ * The price sits in the label rather than beside it: a toolbar of buttons and
+ * a floating figure leaves the reader to guess which button the figure belongs
+ * to, and these two spend very different amounts. A batch nothing prices shows
+ * the label alone and says why in the tooltip — a bare "—" next to a render
+ * button reads as broken.
+ */
+const RenderBatchButton: React.FC<{
+  label: string;
+  estimate: RenderBatchCostEstimate;
+  disabled: boolean;
+  onClick: () => void;
+}> = ({ label, estimate, disabled, onClick }) => {
+  const { shotCount, cost, pricedCount, reasons, notes } = estimate;
+  const priced = pricedCount > 0 && cost > 0;
+  const partial = priced && pricedCount < shotCount;
+
+  return (
+    <Tooltip
+      placement="top"
+      title={
+        <FlexColumn gap={SPACING.micro}>
+          <Text size="small">
+            {priced
+              ? `${shotCount} shot${shotCount === 1 ? "" : "s"} · about ${formatUsd(cost)}${
+                  partial
+                    ? ` (${pricedCount} of ${shotCount} priced — the rest are not in any catalog)`
+                    : ""
+                }`
+              : `${shotCount} shot${shotCount === 1 ? "" : "s"}, none of them priced.`}
+          </Text>
+          {reasons.map((reason) => (
+            <Caption key={reason} color="secondary">
+              {reason}
+            </Caption>
+          ))}
+          {priced &&
+            notes.map((note) => (
+              <Caption key={note} color="secondary">
+                {note}
+              </Caption>
+            ))}
+          {priced && (
+            <Caption color="secondary">
+              List price from the provider catalog. The render is billed by the
+              provider at its own rates.
+            </Caption>
+          )}
+        </FlexColumn>
+      }
+    >
+      {/* A disabled button swallows pointer events, so the tooltip needs a host. */}
+      <Box component="span" sx={{ display: "inline-flex" }}>
+        <EditorButton variant="outlined" onClick={onClick} disabled={disabled}>
+          {`${label}${shotCount > 0 ? ` (${shotCount})` : ""}${
+            priced ? ` · ~${formatUsd(cost)}` : ""
+          }`}
+        </EditorButton>
+      </Box>
+    </Tooltip>
+  );
+};
 
 const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   boardId,
@@ -299,6 +370,10 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
     }
   }, [pendingClips, generateClip, boardId]);
 
+  // What each batch button is about to spend, over exactly the shots it loops.
+  const stillsCost = useRenderBatchCostEstimate(boardId, pendingStills, "still");
+  const clipsCost = useRenderBatchCostEstimate(boardId, pendingClips, "clip");
+
   // The archive is packed server-side from the saved board, so a download
   // shows what the server holds — the local edits an in-flight save has not
   // reached it with yet are not in the zip.
@@ -367,20 +442,18 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
               >
                 Board settings
               </EditorButton>
-              <EditorButton
-                variant="outlined"
+              <RenderBatchButton
+                label="Render stills"
+                estimate={stillsCost}
+                disabled={pendingStills.length === 0 || !!directing}
                 onClick={handleGenerateAllStills}
-                disabled={pendingStills.length === 0 || directing}
-              >
-                {`Render stills${pendingStills.length > 0 ? ` (${pendingStills.length})` : ""}`}
-              </EditorButton>
-              <EditorButton
-                variant="outlined"
+              />
+              <RenderBatchButton
+                label="Render clips"
+                estimate={clipsCost}
+                disabled={pendingClips.length === 0 || !!directing}
                 onClick={handleGenerateAllClips}
-                disabled={pendingClips.length === 0 || directing}
-              >
-                {`Render clips${pendingClips.length > 0 ? ` (${pendingClips.length})` : ""}`}
-              </EditorButton>
+              />
               <EditorButton
                 variant="contained"
                 color="primary"

--- a/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
+++ b/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
@@ -7,6 +7,20 @@ import mockTheme from "../../../__mocks__/themeMock";
 let mockShots: Shot[] = [];
 /** The board's selected shot id, driving the inspector's presence. */
 let activeShot: string | null = null;
+/** The board's render models. Null on both leaves the toolbar unpriced. */
+let boardModels: { imageModel: unknown; videoModel: unknown } = {
+  imageModel: null,
+  videoModel: null
+};
+
+type PriceParams = { resolution?: string; seconds?: number };
+const mockPrice = jest.fn(
+  (_model: unknown, _params: PriceParams): unknown => null
+);
+jest.mock("../../../utils/modelUnitPricing", () => ({
+  getModelUnitPrice: (model: unknown, params: PriceParams) =>
+    mockPrice(model, params)
+}));
 jest.mock("../../../stores/storyboard/StoryboardStore", () => ({
   useBoard: () => ({
     title: "My film",
@@ -15,13 +29,16 @@ jest.mock("../../../stores/storyboard/StoryboardStore", () => ({
     entityIds: [],
     aspectRatio: "16:9",
     directorModel: { id: "model-1" },
-    imageModel: null,
-    videoModel: null,
+    imageModel: boardModels.imageModel,
+    videoModel: boardModels.videoModel,
     shots: mockShots,
     activeShotId: activeShot
   }),
   useStoryboardStore: <T,>(
     selector: (s: {
+      // The toolbar's render estimates read the board's two models straight
+      // off the store, so the mocked state carries the slice they select.
+      boards: Record<string, unknown>;
       setTitle: jest.Mock;
       setBrief: jest.Mock;
       setStyle: jest.Mock;
@@ -35,6 +52,7 @@ jest.mock("../../../stores/storyboard/StoryboardStore", () => ({
     }) => T
   ) =>
     selector({
+      boards: { "board-1": boardModels },
       setTitle: jest.fn(),
       setBrief: jest.fn(),
       setStyle: jest.fn(),
@@ -48,6 +66,18 @@ jest.mock("../../../stores/storyboard/StoryboardStore", () => ({
     }),
   useStoryboardCanUndo: () => false,
   useStoryboardCanRedo: () => false
+}));
+
+// A clip's price moves with its shot's effective duration, which comes from
+// the linked script's takes — so the toolbar's estimate reads the script the
+// board links to. This suite mounts no query client.
+jest.mock("../../../trpc/client", () => ({
+  trpc: {
+    scripts: {
+      get: { useQuery: () => ({ data: undefined }) }
+    }
+  },
+  trpcClient: {}
 }));
 
 // The script-link control reads the real store and a trpc query; it has its
@@ -261,6 +291,45 @@ describe("StoryboardBoard toolbar", () => {
     expect(
       screen.getByRole("button", { name: "Assemble timeline" })
     ).toBeDisabled();
+  });
+
+  it("puts each batch's price on its own button", () => {
+    // Two shots await a still; only the one already holding a keyframe can be
+    // animated, so the two buttons quote different batches.
+    mockShots = [
+      makeShot("s1"),
+      makeShot("s2"),
+      {
+        ...makeShot("s3"),
+        status: "keyframe_ready",
+        keyframe: { type: "image", asset_id: "asset-1" },
+        duration_seconds: 4
+      }
+    ];
+    boardModels = {
+      imageModel: { id: "fal-ai/flux/schnell", provider: "fal_ai" },
+      videoModel: { id: "pixverse/720p", provider: "fal_ai" }
+    };
+    mockPrice.mockImplementation((_model, params) => ({
+      unit_price: params.resolution === "1K" ? 0.01 : 0.5,
+      billing_unit: "images",
+      currency: "USD",
+      source: "bundle"
+    }));
+
+    renderBoard(jest.fn());
+
+    // The figure is the batch, not one shot — and each button quotes its own.
+    expect(
+      screen.getByRole("button", { name: "Render stills (2) · ~$0.02" })
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "Render clips (1) · ~$0.5" })
+    ).toBeEnabled();
+
+    boardModels = { imageModel: null, videoModel: null };
+    mockPrice.mockReset();
+    mockPrice.mockReturnValue(null);
   });
 });
 

--- a/web/src/hooks/script/__tests__/useVoiceCostEstimate.test.tsx
+++ b/web/src/hooks/script/__tests__/useVoiceCostEstimate.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * @jest-environment jsdom
+ *
+ * What *Voice all* quotes before the click. Speech is billed by the characters
+ * it synthesizes, so the figure must come from the script's own text, over
+ * exactly the lines `voiceAll` would voice — and a voice the catalog cannot
+ * price has to say so rather than count as free.
+ */
+import { renderHook, act } from "@testing-library/react";
+
+const mockPrice = jest.fn();
+jest.mock("../../../utils/modelUnitPricing", () => ({
+  getModelUnitPrice: (...args: unknown[]) => mockPrice(...args)
+}));
+
+jest.mock("../../../stores/script/timelineSync", () => ({
+  syncLineClipToTimeline: jest.fn(async () => undefined)
+}));
+
+import { useVoiceCostEstimate } from "../useVoiceCostEstimate";
+import { useScriptStore } from "../../../stores/script/ScriptStore";
+import type { ScriptDraft, ScriptLine } from "../../../stores/script/ScriptStore";
+
+const SCRIPT = "sc-cost";
+
+const MARA = { provider: "elevenlabs", model: "eleven_v3", voice: "alloy" };
+const RUIZ = { provider: "elevenlabs", model: "eleven_flash_v2_5", voice: "echo" };
+
+const line = (id: string, speakerId: string, text: string, takes: ScriptLine["takes"] = []): ScriptLine => ({
+  id,
+  speakerId,
+  text,
+  takes,
+  currentTakeId: takes[0]?.id ?? null
+});
+
+const loadScript = (lines: ScriptLine[]): void => {
+  const script: ScriptDraft = {
+    id: SCRIPT,
+    title: "Film",
+    cast: [
+      { id: "sp-1", name: "Mara", voice: MARA },
+      { id: "sp-2", name: "Ruiz", voice: RUIZ }
+    ],
+    sections: [{ id: "sec-1", lines }],
+    timelineId: null
+  } as ScriptDraft;
+  act(() => {
+    useScriptStore.setState({ scripts: { [SCRIPT]: script } } as never);
+  });
+};
+
+describe("useVoiceCostEstimate", () => {
+  beforeEach(() => {
+    mockPrice.mockReset();
+    mockPrice.mockImplementation(
+      (_model: unknown, params: { characters?: number }) => ({
+        // $100 per million characters, the ElevenLabs shape.
+        unit_price: ((params.characters ?? 0) * 100) / 1_000_000,
+        billing_unit: "1m_chars",
+        currency: "USD",
+        source: "bundle",
+        breakdown: `${params.characters} chars × $100/1M chars`
+      })
+    );
+  });
+
+  it("prices the script by the characters the click will synthesize", () => {
+    loadScript([line("ln-1", "sp-1", "We are closed.")]);
+
+    const { result } = renderHook(() => useVoiceCostEstimate(SCRIPT));
+
+    expect(mockPrice).toHaveBeenCalledWith(
+      { id: "eleven_v3", provider: "elevenlabs" },
+      { characters: 14 }
+    );
+    expect(result.current).toMatchObject({
+      lineCount: 1,
+      characters: 14,
+      pricedLineCount: 1
+    });
+    expect(result.current.cost).toBeCloseTo(0.0014, 12);
+  });
+
+  it("charges two models separately when the cast reads on two", () => {
+    loadScript([
+      line("ln-1", "sp-1", "We are closed."),
+      line("ln-2", "sp-2", "Not to me.")
+    ]);
+
+    const { result } = renderHook(() => useVoiceCostEstimate(SCRIPT));
+
+    // One call per billing model, not one per line.
+    expect(mockPrice).toHaveBeenCalledTimes(2);
+    expect(mockPrice).toHaveBeenCalledWith(
+      { id: "eleven_flash_v2_5", provider: "elevenlabs" },
+      { characters: 10 }
+    );
+    expect(result.current.lineCount).toBe(2);
+    expect(result.current.breakdowns).toHaveLength(2);
+  });
+
+  it("skips lines that are already voiced — the click will not re-voice them", () => {
+    const voiced = line("ln-1", "sp-1", "We are closed.", [
+      {
+        id: "tk-1",
+        assetId: "asset-1",
+        durationMs: 900,
+        words: [],
+        textSnapshot: "We are closed.",
+        voiceSnapshot: MARA,
+        createdAt: "2026-01-01T00:00:00Z"
+      }
+    ]);
+    loadScript([voiced, line("ln-2", "sp-1", "Not to me.")]);
+
+    const { result } = renderHook(() => useVoiceCostEstimate(SCRIPT));
+
+    expect(result.current.lineCount).toBe(1);
+    expect(result.current.characters).toBe(10);
+  });
+
+  it("re-prices a line whose text drifted from its take", () => {
+    const stale = line("ln-1", "sp-1", "We are shut.", [
+      {
+        id: "tk-1",
+        assetId: "asset-1",
+        durationMs: 900,
+        words: [],
+        textSnapshot: "We are closed.",
+        voiceSnapshot: MARA,
+        createdAt: "2026-01-01T00:00:00Z"
+      }
+    ]);
+    loadScript([stale]);
+
+    const { result } = renderHook(() => useVoiceCostEstimate(SCRIPT));
+
+    expect(result.current.lineCount).toBe(1);
+    expect(result.current.characters).toBe(12);
+  });
+
+  it("skips a line with no voice — nothing will voice it", () => {
+    loadScript([line("ln-1", "sp-missing", "Who am I?")]);
+
+    const { result } = renderHook(() => useVoiceCostEstimate(SCRIPT));
+
+    expect(result.current.lineCount).toBe(0);
+    expect(mockPrice).not.toHaveBeenCalled();
+  });
+
+  it("reports a declined model instead of counting its lines as free", () => {
+    mockPrice.mockReturnValue({
+      unit_price: 0,
+      billing_unit: "1m_tokens",
+      currency: "USD",
+      source: "bundle",
+      declined: "priced per token of generated audio"
+    });
+    loadScript([line("ln-1", "sp-1", "We are closed.")]);
+
+    const { result } = renderHook(() => useVoiceCostEstimate(SCRIPT));
+
+    expect(result.current).toMatchObject({
+      lineCount: 1,
+      cost: 0,
+      pricedLineCount: 0
+    });
+    expect(result.current.reasons[0]).toContain("token");
+  });
+});

--- a/web/src/hooks/script/useVoiceCostEstimate.ts
+++ b/web/src/hooks/script/useVoiceCostEstimate.ts
@@ -1,0 +1,127 @@
+/**
+ * useVoiceCostEstimate
+ *
+ * What *Voice all* is about to spend on this script. Speech models are billed
+ * by the characters they synthesize, so the figure is the script's own text:
+ * every line the click would voice, grouped by the voice it would use, each
+ * group's characters priced through `getModelUnitPrice` — the same catalog the
+ * storyboard's render estimates and the server's pre-run budget gate read.
+ *
+ * The lines come from `voiceTargets`, the predicate `voiceAll` itself loops, so
+ * the quote and the click cannot disagree about what gets voiced. Grouping is
+ * by voice rather than by line because a script with two speakers on two models
+ * pays two rates, and one blended number would hide which of them a cast change
+ * moved.
+ *
+ * A voice nothing prices contributes no figure and reports why: several speech
+ * models publish only a per-token rate, and a token of generated audio is not
+ * something a script's text converts into. Counting those lines as free would
+ * understate the click.
+ */
+
+import { useMemo } from "react";
+import { getModelUnitPrice } from "../../utils/modelUnitPricing";
+import { useScriptStore } from "../../stores/script/ScriptStore";
+import { voiceTargets } from "../../stores/script/scriptVoicing";
+
+export interface VoiceCostEstimate {
+  /** Lines the click would voice. */
+  lineCount: number;
+  /** Characters those lines would synthesize. */
+  characters: number;
+  /** Summed USD over the voices that priced. */
+  cost: number;
+  /** How many of those lines carry a figure. */
+  pricedLineCount: number;
+  /** How the figure was reached, one entry per voice: "Narrator · 412 chars × $100/1M chars". */
+  breakdowns: string[];
+  /** Why the rest have no figure, deduplicated. */
+  reasons: string[];
+  /** What the catalog assumed, and what it warns the figure omits. */
+  notes: string[];
+}
+
+const EMPTY: VoiceCostEstimate = {
+  lineCount: 0,
+  characters: 0,
+  cost: 0,
+  pricedLineCount: 0,
+  breakdowns: [],
+  reasons: [],
+  notes: []
+};
+
+/** One model's share of the script: which lines, and how much text. */
+interface VoiceGroup {
+  provider: string;
+  model: string;
+  characters: number;
+  lineCount: number;
+}
+
+export function useVoiceCostEstimate(scriptId: string): VoiceCostEstimate {
+  const script = useScriptStore((state) => state.scripts[scriptId]);
+
+  return useMemo(() => {
+    if (!script) {
+      return EMPTY;
+    }
+    const targets = voiceTargets(script);
+    if (targets.length === 0) {
+      return EMPTY;
+    }
+
+    // Two speakers on one model are one charge, so group by the model that
+    // bills rather than by the voice that reads.
+    const groups = new Map<string, VoiceGroup>();
+    for (const { line, voice } of targets) {
+      const key = `${voice.provider}:${voice.model}`;
+      const group = groups.get(key) ?? {
+        provider: voice.provider,
+        model: voice.model,
+        characters: 0,
+        lineCount: 0
+      };
+      group.characters += line.text.trim().length;
+      group.lineCount += 1;
+      groups.set(key, group);
+    }
+
+    const breakdowns: string[] = [];
+    const reasons: string[] = [];
+    const notes: string[] = [];
+    let cost = 0;
+    let characters = 0;
+    let pricedLineCount = 0;
+
+    for (const group of groups.values()) {
+      characters += group.characters;
+      const price = getModelUnitPrice(
+        { id: group.model, provider: group.provider },
+        { characters: group.characters }
+      );
+      if (!price || price.declined || !Number.isFinite(price.unit_price)) {
+        reasons.push(
+          `${group.model}: ${price?.declined ?? "no published price in the catalog"}`
+        );
+        continue;
+      }
+      cost += price.unit_price;
+      pricedLineCount += group.lineCount;
+      breakdowns.push(`${group.model} · ${price.breakdown ?? ""}`.trim());
+      notes.push(...(price.assumptions ?? []), ...(price.warnings ?? []));
+    }
+
+    return {
+      lineCount: targets.length,
+      characters,
+      cost,
+      pricedLineCount,
+      breakdowns,
+      reasons: Array.from(new Set(reasons)),
+      notes: Array.from(new Set(notes))
+    };
+  }, [script]);
+}
+
+export default useVoiceCostEstimate;

--- a/web/src/hooks/storyboard/__tests__/useRenderBatchCostEstimate.test.tsx
+++ b/web/src/hooks/storyboard/__tests__/useRenderBatchCostEstimate.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * @jest-environment jsdom
+ *
+ * What the toolbar's two batch render buttons quote before the click. The
+ * number has to be the sum over exactly the shots the button loops, and a
+ * batch it cannot price has to say so rather than read as free.
+ */
+import { renderHook, act } from "@testing-library/react";
+
+jest.mock("../../../trpc/client", () => ({
+  trpc: {
+    scripts: {
+      get: { useQuery: () => ({ data: undefined }) }
+    }
+  },
+  trpcClient: {}
+}));
+
+const mockPrice = jest.fn();
+jest.mock("../../../utils/modelUnitPricing", () => ({
+  getModelUnitPrice: (...args: unknown[]) => mockPrice(...args)
+}));
+
+import { useRenderBatchCostEstimate } from "../useRenderBatchCostEstimate";
+import { CLIP_RESOLUTION, STILL_RESOLUTION } from "../renderSpec";
+import { useStoryboardStore } from "../../../stores/storyboard/StoryboardStore";
+import type { Shot } from "@nodetool-ai/protocol";
+
+const BOARD = "board-batch";
+
+const makeShot = (id: string, seconds: number): Shot => ({
+  type: "shot",
+  id,
+  index: 0,
+  action: `shot ${id}`,
+  status: "planned",
+  duration_seconds: seconds
+});
+
+const shots = [makeShot("a", 4), makeShot("b", 6), makeShot("c", 8)];
+
+const selectStillModel = () =>
+  act(() => {
+    useStoryboardStore.getState().setImageModel(BOARD, {
+      type: "image_model",
+      id: "fal-ai/flux/schnell",
+      provider: "fal_ai" as never,
+      name: "Flux Schnell",
+      path: ""
+    });
+  });
+
+const selectClipModel = () =>
+  act(() => {
+    useStoryboardStore.getState().setVideoModel(BOARD, {
+      type: "video_model",
+      id: "pixverse/720p",
+      provider: "fal_ai" as never,
+      name: "Pixverse"
+    });
+  });
+
+describe("useRenderBatchCostEstimate", () => {
+  beforeEach(() => {
+    mockPrice.mockReset();
+    act(() => {
+      useStoryboardStore.getState().removeBoard(BOARD);
+      useStoryboardStore.getState().ensureBoard(BOARD);
+    });
+  });
+
+  it("sums the still price over every shot the button would render", () => {
+    mockPrice.mockReturnValue({
+      unit_price: 0.003,
+      billing_unit: "images",
+      currency: "USD",
+      source: "bundle"
+    });
+    selectStillModel();
+
+    const { result } = renderHook(() =>
+      useRenderBatchCostEstimate(BOARD, shots, "still")
+    );
+
+    // A still carries no duration — its price is the same for every shot.
+    expect(mockPrice).toHaveBeenCalledWith(
+      { id: "fal-ai/flux/schnell", provider: "fal_ai" },
+      { resolution: STILL_RESOLUTION, seconds: undefined }
+    );
+    expect(result.current).toMatchObject({
+      shotCount: 3,
+      pricedCount: 3,
+      reasons: []
+    });
+    expect(result.current.cost).toBeCloseTo(0.009, 9);
+  });
+
+  it("prices each clip at its own shot's duration", () => {
+    // A per-second model: the batch total must move with the shots' lengths,
+    // not be one shot's price times three.
+    mockPrice.mockImplementation(
+      (_model: unknown, params: { seconds?: number }) => ({
+        unit_price: 0.1 * (params.seconds ?? 0),
+        billing_unit: "video",
+        currency: "USD",
+        source: "bundle"
+      })
+    );
+    selectClipModel();
+
+    const { result } = renderHook(() =>
+      useRenderBatchCostEstimate(BOARD, shots, "clip")
+    );
+
+    expect(mockPrice).toHaveBeenCalledWith(
+      { id: "pixverse/720p", provider: "fal_ai" },
+      { resolution: CLIP_RESOLUTION, seconds: 6 }
+    );
+    // 4 s + 6 s + 8 s at $0.1/s.
+    expect(result.current.cost).toBeCloseTo(1.8, 9);
+    expect(result.current.pricedCount).toBe(3);
+  });
+
+  it("says why a batch has no figure instead of quoting zero", () => {
+    const { result } = renderHook(() =>
+      useRenderBatchCostEstimate(BOARD, shots, "clip")
+    );
+
+    expect(mockPrice).not.toHaveBeenCalled();
+    expect(result.current).toMatchObject({
+      shotCount: 3,
+      cost: 0,
+      pricedCount: 0
+    });
+    // One reason, not one per shot: they all fail the same way.
+    expect(result.current.reasons).toEqual([
+      "No clip model picked for this board."
+    ]);
+  });
+
+  it("counts only the shots that priced when the catalog answers for some", () => {
+    mockPrice.mockImplementation((_model: unknown, params: { seconds?: number }) =>
+      params.seconds === 6
+        ? null
+        : {
+            unit_price: 0.5,
+            billing_unit: "video",
+            currency: "USD",
+            source: "bundle"
+          }
+    );
+    selectClipModel();
+
+    const { result } = renderHook(() =>
+      useRenderBatchCostEstimate(BOARD, shots, "clip")
+    );
+
+    expect(result.current.pricedCount).toBe(2);
+    expect(result.current.cost).toBeCloseTo(1.0, 9);
+    expect(result.current.reasons[0]).toContain("No published price");
+  });
+
+  it("is empty for a batch with no shots", () => {
+    const { result } = renderHook(() =>
+      useRenderBatchCostEstimate(BOARD, [], "still")
+    );
+    expect(result.current).toMatchObject({ shotCount: 0, cost: 0 });
+    expect(mockPrice).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/storyboard/shotCostPricing.ts
+++ b/web/src/hooks/storyboard/shotCostPricing.ts
@@ -1,0 +1,90 @@
+/**
+ * Pricing one storyboard render step, apart from React.
+ *
+ * The still and the clip are priced by different models at different rungs,
+ * and only the clip's figure moves with a shot's length. Both the per-shot
+ * inspector line and the toolbar's batch estimate ask the same question of the
+ * same catalog, so the question lives here rather than inside either hook.
+ */
+
+import { getModelUnitPrice } from "../../utils/modelUnitPricing";
+
+/** One render step a shot pays for. */
+export interface ShotCostStep {
+  /** "Still" or "Clip". */
+  label: string;
+  /** The step's cost in USD, or null when nothing prices it. */
+  cost: number | null;
+  /** How the figure was reached: "4 s × $0.1/s at 1080p". */
+  breakdown?: string;
+  /** Why there is no figure, when there is none. */
+  reason?: string;
+}
+
+/** A model selection as the pricing catalog takes it. */
+export interface BoardModel {
+  id: string;
+  provider: string | null;
+  name?: string;
+}
+
+/** A price billed in "units" or "credits" has no fixed currency value. */
+const isVagueBillingUnit = (unit: string | undefined): boolean =>
+  !!unit && /\bunits?\b|\bcredits?\b/i.test(unit.trim());
+
+/** A price that can be shown as money, or null. */
+function usable(
+  price: ReturnType<typeof getModelUnitPrice>
+): NonNullable<ReturnType<typeof getModelUnitPrice>> | null {
+  if (
+    !price ||
+    price.declined ||
+    !Number.isFinite(price.unit_price) ||
+    isVagueBillingUnit(price.billing_unit)
+  ) {
+    return null;
+  }
+  return price;
+}
+
+/**
+ * One step's price, or the reason there is none.
+ *
+ * The rung the render sends is asked for first. A model that publishes no such
+ * rung declines it, and the answer then is the model's base spec plus a note —
+ * dropping the step would hide the clip's cost on every model whose ladder
+ * stops below 1080p.
+ */
+export function priceRenderStep(
+  label: string,
+  model: BoardModel | null,
+  pickerLabel: string,
+  resolution: string,
+  seconds: number | undefined,
+  notes: string[]
+): ShotCostStep {
+  if (!model?.id) {
+    return {
+      label,
+      cost: null,
+      reason: `No ${pickerLabel} picked for this board.`
+    };
+  }
+  const selected = { id: model.id, provider: model.provider };
+  const atRung = usable(getModelUnitPrice(selected, { resolution, seconds }));
+  const price = atRung ?? usable(getModelUnitPrice(selected, { seconds }));
+  if (!price) {
+    return {
+      label,
+      cost: null,
+      reason: `No published price for ${model.name || model.id}.`
+    };
+  }
+  if (!atRung) {
+    notes.push(
+      `${label.toLowerCase()}: this model publishes no ${resolution} price — shown at its base spec`
+    );
+  }
+  notes.push(...(price.assumptions ?? []), ...(price.warnings ?? []));
+  return { label, cost: price.unit_price, breakdown: price.breakdown };
+}

--- a/web/src/hooks/storyboard/useRenderBatchCostEstimate.ts
+++ b/web/src/hooks/storyboard/useRenderBatchCostEstimate.ts
@@ -1,0 +1,118 @@
+/**
+ * useRenderBatchCostEstimate
+ *
+ * What the toolbar's *Render stills* and *Render clips* buttons are about to
+ * spend, across every shot they would fire at. The per-shot inspector answers
+ * the same question one shot at a time; a batch button spends N times that in
+ * one click, which is the number worth seeing before the click.
+ *
+ * Priced through the same `priceRenderStep` the inspector uses, so a shot
+ * cannot be quoted one figure in the inspector and another in the toolbar.
+ * Stills are identical across shots — one model, one rung — while a clip's
+ * price moves with each shot's effective duration, so clips are priced shot by
+ * shot and summed.
+ *
+ * The shots come from the caller, and they are exactly the ones the button
+ * loops over: the estimate is what that click costs, not what an ideal render
+ * of the board would.
+ */
+
+import { useMemo } from "react";
+import type { Shot } from "@nodetool-ai/protocol";
+import { effectiveShotDuration } from "@nodetool-ai/timeline";
+
+import { CLIP_RESOLUTION, STILL_RESOLUTION } from "./renderSpec";
+import { priceRenderStep } from "./shotCostPricing";
+import { useBoardScriptLines } from "./useShotDuration";
+import {
+  useBoardImageModel,
+  useBoardVideoModel
+} from "./useShotCostEstimate";
+
+/** Which of the two render passes a batch is. */
+export type RenderStep = "still" | "clip";
+
+export interface RenderBatchCostEstimate {
+  /** Shots the button would render. */
+  shotCount: number;
+  /** Summed USD over the shots that priced. */
+  cost: number;
+  /** How many of those shots carry a figure. */
+  pricedCount: number;
+  /** Why the rest do not, deduplicated. */
+  reasons: string[];
+  /** What the catalog assumed, and what it warns the figure omits. */
+  notes: string[];
+}
+
+const EMPTY: RenderBatchCostEstimate = {
+  shotCount: 0,
+  cost: 0,
+  pricedCount: 0,
+  reasons: [],
+  notes: []
+};
+
+export function useRenderBatchCostEstimate(
+  boardId: string,
+  shots: Shot[],
+  step: RenderStep
+): RenderBatchCostEstimate {
+  const imageModel = useBoardImageModel(boardId);
+  const videoModel = useBoardVideoModel(boardId);
+  // Clip lengths come from the linked script's takes when there is one; the
+  // lines are fetched once for the whole batch rather than per shot.
+  const linesById = useBoardScriptLines(boardId);
+
+  return useMemo(() => {
+    if (shots.length === 0) {
+      return EMPTY;
+    }
+    const notes: string[] = [];
+    const reasons: string[] = [];
+    let cost = 0;
+    let pricedCount = 0;
+
+    // What the step is, decided once: only the duration varies per shot.
+    const isStill = step === "still";
+    const label = isStill ? "Still" : "Clip";
+    const model = isStill ? imageModel : videoModel;
+    const pickerLabel = isStill ? "still model" : "clip model";
+    const resolution = isStill ? STILL_RESOLUTION : CLIP_RESOLUTION;
+
+    for (const shot of shots) {
+      // A still carries no duration; a clip is priced at the length the render
+      // will ask for, which the linked script's takes may decide.
+      const seconds = isStill
+        ? undefined
+        : (effectiveShotDuration(shot, linesById).seconds ??
+          shot.duration_seconds);
+      const priced = priceRenderStep(
+        label,
+        model,
+        pickerLabel,
+        resolution,
+        seconds,
+        notes
+      );
+      if (priced.cost === null) {
+        if (priced.reason) {
+          reasons.push(priced.reason);
+        }
+        continue;
+      }
+      cost += priced.cost;
+      pricedCount += 1;
+    }
+
+    return {
+      shotCount: shots.length,
+      cost,
+      pricedCount,
+      reasons: Array.from(new Set(reasons)),
+      notes: Array.from(new Set(notes))
+    };
+  }, [shots, step, imageModel, videoModel, linesById]);
+}
+
+export default useRenderBatchCostEstimate;

--- a/web/src/hooks/storyboard/useShotCostEstimate.ts
+++ b/web/src/hooks/storyboard/useShotCostEstimate.ts
@@ -24,22 +24,12 @@
 import { useMemo } from "react";
 import type { Shot } from "@nodetool-ai/protocol";
 import { shotRenderMode } from "@nodetool-ai/protocol";
-import { getModelUnitPrice } from "../../utils/modelUnitPricing";
 import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
 import { useShotDuration } from "./useShotDuration";
 import { CLIP_RESOLUTION, STILL_RESOLUTION } from "./renderSpec";
+import { priceRenderStep, type ShotCostStep } from "./shotCostPricing";
 
-/** One render step the shot pays for. */
-export interface ShotCostStep {
-  /** "Still" or "Clip". */
-  label: string;
-  /** The step's cost in USD, or null when nothing prices it. */
-  cost: number | null;
-  /** How the figure was reached: "4 s × $0.1/s at 1080p". */
-  breakdown?: string;
-  /** Why there is no figure, when there is none. */
-  reason?: string;
-}
+export type { ShotCostStep };
 
 export interface ShotCostEstimate {
   /** The whole-shot cost in USD: every priced step below, summed. */
@@ -52,83 +42,15 @@ export interface ShotCostEstimate {
   notes: string[];
 }
 
-/** A model selection as the pricing catalog takes it. */
-interface BoardModel {
-  id: string;
-  provider: string | null;
-  name?: string;
-}
-
 /**
  * The board's two render models, subscribed one at a time: selecting the whole
  * board would re-run this on every shot edit the board makes.
  */
-const useBoardImageModel = (boardId: string) =>
+export const useBoardImageModel = (boardId: string) =>
   useStoryboardStore((state) => state.boards[boardId]?.imageModel ?? null);
 
-const useBoardVideoModel = (boardId: string) =>
+export const useBoardVideoModel = (boardId: string) =>
   useStoryboardStore((state) => state.boards[boardId]?.videoModel ?? null);
-
-/** A price billed in "units" or "credits" has no fixed currency value. */
-const isVagueBillingUnit = (unit: string | undefined): boolean =>
-  !!unit && /\bunits?\b|\bcredits?\b/i.test(unit.trim());
-
-/** A price that can be shown as money, or null. */
-function usable(
-  price: ReturnType<typeof getModelUnitPrice>
-): NonNullable<ReturnType<typeof getModelUnitPrice>> | null {
-  if (
-    !price ||
-    price.declined ||
-    !Number.isFinite(price.unit_price) ||
-    isVagueBillingUnit(price.billing_unit)
-  ) {
-    return null;
-  }
-  return price;
-}
-
-/**
- * One step's price, or the reason there is none.
- *
- * The rung the render sends is asked for first. A model that publishes no such
- * rung declines it, and the answer then is the model's base spec plus a note —
- * dropping the step would hide the clip's cost on every model whose ladder
- * stops below 1080p.
- */
-function priceStep(
-  label: string,
-  model: BoardModel | null,
-  pickerLabel: string,
-  resolution: string,
-  seconds: number | undefined,
-  notes: string[]
-): ShotCostStep {
-  if (!model?.id) {
-    return {
-      label,
-      cost: null,
-      reason: `No ${pickerLabel} picked for this board.`
-    };
-  }
-  const selected = { id: model.id, provider: model.provider };
-  const atRung = usable(getModelUnitPrice(selected, { resolution, seconds }));
-  const price = atRung ?? usable(getModelUnitPrice(selected, { seconds }));
-  if (!price) {
-    return {
-      label,
-      cost: null,
-      reason: `No published price for ${model.name || model.id}.`
-    };
-  }
-  if (!atRung) {
-    notes.push(
-      `${label.toLowerCase()}: this model publishes no ${resolution} price — shown at its base spec`
-    );
-  }
-  notes.push(...(price.assumptions ?? []), ...(price.warnings ?? []));
-  return { label, cost: price.unit_price, breakdown: price.breakdown };
-}
 
 export function useShotCostEstimate(
   boardId: string,
@@ -144,7 +66,7 @@ export function useShotCostEstimate(
     const notes: string[] = [];
     const steps = [
       rendersStill
-        ? priceStep(
+        ? priceRenderStep(
             "Still",
             imageModel,
             "still model",
@@ -153,7 +75,7 @@ export function useShotCostEstimate(
             notes
           )
         : null,
-      priceStep(
+      priceRenderStep(
         "Clip",
         videoModel,
         "clip model",

--- a/web/src/stores/script/scriptVoicing.ts
+++ b/web/src/stores/script/scriptVoicing.ts
@@ -17,7 +17,10 @@ import { getAssetUrl } from "../../utils/assetHelpers";
 import {
   useScriptStore,
   effectiveVoice,
+  lineStatus,
+  type ScriptDraft,
   type ScriptCaptionWord,
+  type ScriptLine,
   type ScriptTake,
   type VoiceBinding
 } from "./ScriptStore";
@@ -170,6 +173,31 @@ export async function voiceLine(
   }
 }
 
+/** A line `voiceAll` would voice, with the voice it would use. */
+export interface VoiceTarget {
+  line: ScriptLine;
+  voice: VoiceBinding;
+}
+
+/**
+ * The lines a *Voice all* would synthesize: every draft or stale line that has
+ * text and a voice to say it in. Shared with the cost estimate, so what the
+ * toolbar quotes is what the click will voice.
+ */
+export function voiceTargets(script: ScriptDraft): VoiceTarget[] {
+  const targets: VoiceTarget[] = [];
+  for (const section of script.sections) {
+    for (const line of section.lines) {
+      if (!line.text.trim()) continue;
+      const voice = effectiveVoice(line, script.cast);
+      // Re-voice drafts and stale lines; skip up-to-date ones.
+      if (!voice || lineStatus(line, voice) === "voiced") continue;
+      targets.push({ line, voice });
+    }
+  }
+  return targets;
+}
+
 /**
  * Voice every draft/stale line in the script, bounded concurrency, respecting
  * each line's effective voice. Lines already voiced (current take matches) and
@@ -184,21 +212,7 @@ export async function voiceAll(
   const script = store.getState().scripts[scriptId];
   if (!script) return 0;
 
-  const targets = script.sections
-    .flatMap((s) => s.lines)
-    .filter((line) => {
-      if (!line.text.trim()) return false;
-      if (!effectiveVoice(line, script.cast)) return false;
-      const take = line.takes.find((t) => t.id === line.currentTakeId);
-      // Re-voice drafts and stale lines; skip up-to-date ones.
-      return (
-        !take ||
-        take.textSnapshot !== line.text ||
-        JSON.stringify(take.voiceSnapshot) !==
-          JSON.stringify(effectiveVoice(line, script.cast))
-      );
-    })
-    .map((line) => line.id);
+  const targets = voiceTargets(script).map((target) => target.line.id);
 
   let voiced = 0;
   let cursor = 0;


### PR DESCRIPTION
## What changed

The storyboard's *Render stills* / *Render clips* buttons and the Script editor's *Voice all* each fire N generations at once, and none of them said what that would cost — the per-shot inspector answered the question one shot at a time while the batch buttons spend many times that in one click. Each button now carries its own figure in its label, priced over exactly the items it loops (clips shot by shot at their effective duration, stills at one rung times the batch, voicing by the characters of the lines that are actually unvoiced), with the breakdown and any catalog caveats in its tooltip. A batch nothing prices keeps its plain label and says why in the tooltip, because a "$0" beside a billed call is worse than no number.

Speech pricing had to be fixed first. The 22 text-to-speech rows in the GenSpend catalog are billed `1m_chars` — ElevenLabs' $100 per million — and 6 more `1m_tokens`, and neither unit was ever converted: read as a per-run figure, voicing one line quoted $100. Character units are now multiplied by the text length the caller states and decline when none was given; token units decline outright, since a speech model's tokens are the audio it produced and no text length converts into them. That also corrects the chat composer's audio mode, which was showing the same inflated figure.

Two helpers were extracted so a quote cannot drift from the click it describes: `priceRenderStep` out of `useShotCostEstimate`, so the inspector and the toolbar cannot price one shot two ways, and `voiceTargets` out of `voiceAll`, so the estimate and the action agree on which lines get voiced.

## Verification

- [x] `npm run test:affected` — one fully green pass (96/96 turbo tasks; web 1221 suites / 13868 tests; electron 63 suites / 686 tests). Two later runs each hit one `exports all public API` import timeout, in a *different* package each time (`@nodetool-ai/chat` 60s, `@nodetool-ai/deploy` 5s) under parallel load; both pass standalone (chat 30/30, deploy 866/866). `packages/image-nodes` needs the `mesa-vulkan-drivers` ICD this container lacks by default (AGENTS.md § WebGPU on a headless machine); with `VK_DRIVER_FILES` pointed at lavapipe it is 229/229.
- [x] `npm run typecheck` — web and electron clean. Mobile reports missing `react-native`/`expo` modules, which is this container having no `mobile/` install, not the diff.
- [x] `npm run lint` — exit 0, no errors.
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 8/8 selfchecks passed`.

New tests: 5 pricing cases in `packages/model-pricing/tests/model-pricing.test.ts`, plus `useRenderBatchCostEstimate` (5), `useVoiceCostEstimate` (6), `ScriptDocumentPane.voiceCost` (3), and a priced-toolbar case in `StoryboardBoard.test.tsx`.

## New checks

The character/token pricing rules were inverted once and observed failing — the routing in `isParameterPriceable` was disabled and `1m_chars` removed from the scalar table:

```
 × prices a speech model by the characters it will synthesize
 × declines a character-billed model when no text length is given
 Tests  2 failed | 152 passed (154)
```

Restored, the suite is 154/154. The tests assert a real catalog row (`elevenlabs:eleven_multilingual_v2`, `unit_class: "per-1m-chars"`) rather than a fixture, so they cannot pass by matching nothing.

## Agent capabilities

No capability added, and no capability's declared contract changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135cCcEMiX3FFEoLNmaCHYK

---
_Generated by [Claude Code](https://claude.ai/code/session_0135cCcEMiX3FFEoLNmaCHYK)_