### PR TITLE
⚡ Bolt: Speed up storyboard shot creation by batching inserts

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,37 @@
+const { performance } = require('perf_hooks');
+
+async function benchmark() {
+  const start = performance.now();
+
+  // mock addShot.execute
+  const addShot = {
+    execute: async ({action}) => {
+      // Simulate DB delay
+      await new Promise(r => setTimeout(r, 10));
+      return { shot: { id: 'shot_' + Math.random().toString(36).substring(7) } };
+    }
+  };
+
+  const derived = {
+    shots: Array.from({length: 50}, (_, i) => ({ text: 'action ' + i, scriptLineIds: ['line_' + i] }))
+  };
+
+  const scriptLineIdsByShotId = new Map();
+  const placed = [];
+
+  for (const scaffold of derived.shots) {
+    const action = scaffold.text;
+    const result = await addShot.execute({ action });
+    scriptLineIdsByShotId.set(result.shot.id, scaffold.scriptLineIds);
+    placed.push({
+      id: result.shot.id,
+      scriptLineIds: scaffold.scriptLineIds,
+      action
+    });
+  }
+
+  const end = performance.now();
+  console.log(`Sequential baseline: ${end - start} ms`);
+}
+
+benchmark();

--- a/benchmark_batch.js
+++ b/benchmark_batch.js
@@ -1,0 +1,43 @@
+const { performance } = require('perf_hooks');
+
+async function benchmark() {
+  const start = performance.now();
+
+  // mock addShot.execute
+  const addShot = {
+    execute: async ({action}) => {
+      // Simulate DB delay
+      await new Promise(r => setTimeout(r, 10));
+      return { shot: { id: 'shot_' + Math.random().toString(36).substring(7) } };
+    }
+  };
+
+  const derived = {
+    shots: Array.from({length: 50}, (_, i) => ({ text: 'action ' + i, scriptLineIds: ['line_' + i] }))
+  };
+
+  const scriptLineIdsByShotId = new Map();
+  const placed = [];
+
+  const promises = derived.shots.map(async (scaffold) => {
+    const action = scaffold.text;
+    const result = await addShot.execute({ action });
+    return { result, scaffold, action };
+  });
+
+  const results = await Promise.all(promises);
+
+  for (const { result, scaffold, action } of results) {
+    scriptLineIdsByShotId.set(result.shot.id, scaffold.scriptLineIds);
+    placed.push({
+      id: result.shot.id,
+      scriptLineIds: scaffold.scriptLineIds,
+      action
+    });
+  }
+
+  const end = performance.now();
+  console.log(`Batched version: ${end - start} ms`);
+}
+
+benchmark();

--- a/packages/agents/src/evals/surfaces/creative-pipeline.ts
+++ b/packages/agents/src/evals/surfaces/creative-pipeline.ts
@@ -274,7 +274,10 @@ interface GeneratedArtifact {
  * rather than as the thing being measured.
  */
 export interface MediaBackend {
-  image(prompt: string, label: string): Promise<{ path: string; bytes: Uint8Array }>;
+  image(
+    prompt: string,
+    label: string
+  ): Promise<{ path: string; bytes: Uint8Array }>;
   video(
     from: Uint8Array,
     prompt: string,
@@ -465,9 +468,7 @@ export function createCreativePipelineBridge(
   const cutDurationSeconds = () => {
     const { clips } = timeline.finalState();
     if (clips.length === 0) return 0;
-    return (
-      Math.max(...clips.map((c) => c.startMs + c.durationMs), 0) / 1000
-    );
+    return Math.max(...clips.map((c) => c.startMs + c.durationMs), 0) / 1000;
   };
 
   const briefTools: HeadlessTool[] = [
@@ -605,14 +606,21 @@ export function createCreativePipelineBridge(
       shots: { scriptLineIds: string[]; text: string }[];
     };
     const addShot = byName(storyboard, "ui_storyboard_add_shot");
-    const placed: { id: string; scriptLineIds: string[]; action: string }[] = [];
-    for (const scaffold of derived.shots) {
+    const placed: { id: string; scriptLineIds: string[]; action: string }[] =
+      [];
+    const shotPromises = derived.shots.map(async (scaffold) => {
       // The design's headless fallback: with no director pass the shot's
       // action is the line text it covers, status planned.
       const action = scaffold.text;
       const result = (await addShot.execute({ action })) as {
         shot: { id: string };
       };
+      return { result, scaffold, action };
+    });
+
+    const results = await Promise.all(shotPromises);
+
+    for (const { result, scaffold, action } of results) {
       scriptLineIdsByShotId.set(result.shot.id, scaffold.scriptLineIds);
       placed.push({
         id: result.shot.id,
@@ -715,7 +723,13 @@ export function createCreativePipelineBridge(
     ) => {
       try {
         const out = await run();
-        artifacts.push({ kind, path: out.path, prompt, shotId, bytes: out.bytes.length });
+        artifacts.push({
+          kind,
+          path: out.path,
+          prompt,
+          shotId,
+          bytes: out.bytes.length
+        });
         if (kind === "keyframe" && shotId) keyframeBytes.set(shotId, out.bytes);
       } catch (err) {
         artifacts.push({ kind, prompt, shotId, error: (err as Error).message });
@@ -724,7 +738,10 @@ export function createCreativePipelineBridge(
 
     if (name === "ui_sketch_generate") {
       const prompt = String(args.prompt ?? "");
-      if (prompt) await record("style", prompt, undefined, () => media.image(prompt, "style-frame"));
+      if (prompt)
+        await record("style", prompt, undefined, () =>
+          media.image(prompt, "style-frame")
+        );
       return;
     }
     const shotId = (result as { shot?: { id?: string } })?.shot?.id;
@@ -732,7 +749,9 @@ export function createCreativePipelineBridge(
 
     if (name === "ui_storyboard_generate_keyframe") {
       const prompt = shotAction(shotId);
-      await record("keyframe", prompt, shotId, () => media.image(prompt, `keyframe-${shotId}`));
+      await record("keyframe", prompt, shotId, () =>
+        media.image(prompt, `keyframe-${shotId}`)
+      );
       return;
     }
     if (name === "ui_storyboard_generate_clip") {
@@ -776,8 +795,7 @@ export function createCreativePipelineBridge(
         t.name === "ui_storyboard_update_shot"
       ) {
         const shot = (result as { shot?: { id?: string } })?.shot;
-        const seconds = args
-          ?.durationSeconds;
+        const seconds = args?.durationSeconds;
         if (shot?.id && isNumber(seconds)) {
           shotSeconds.set(shot.id, seconds);
         }
@@ -1007,7 +1025,8 @@ export const CREATIVE_PIPELINE_TOOL_LOOP_CASES: readonly ToolLoopEvalCase<Creati
           },
           {
             name: "forbiddenAvoided",
-            detail: "a forbidden element appears in a shot action or layer name",
+            detail:
+              "a forbidden element appears in a shot action or layer name",
             test: forbiddenAvoided
           }
         ]
@@ -1174,7 +1193,8 @@ The storyboard phase is already done for this job: add the shots that were plann
           },
           {
             name: "boardDerivedFromScript",
-            detail: "the board was built by hand instead of derived, so the two documents are not linked",
+            detail:
+              "the board was built by hand instead of derived, so the two documents are not linked",
             test: (s) => s.scriptLinked
           },
           {
@@ -1201,7 +1221,8 @@ The storyboard phase is already done for this job: add the shots that were plann
           },
           {
             name: "voiceoverClipPerLine",
-            detail: "the cut holds fewer voiceover clips than the script has lines",
+            detail:
+              "the cut holds fewer voiceover clips than the script has lines",
             test: (s) =>
               s.timeline.documentClips.filter((c) => c.scriptLineId).length >=
               s.script.lines.length
@@ -1218,7 +1239,9 @@ The storyboard phase is already done for this job: add the shots that were plann
                 voice.length > 0 &&
                 voice.every(
                   (c) =>
-                    !!c.scriptId && !!c.storyboardBoardId && !!c.storyboardShotId
+                    !!c.scriptId &&
+                    !!c.storyboardBoardId &&
+                    !!c.storyboardShotId
                 )
               );
             }


### PR DESCRIPTION
## What
Updated the `creative-pipeline.ts` storyboard insertion loop to use `Promise.all` instead of sequential asynchronous calls.

## Why
When loading a script into the storyboard, the application previously executed a loop calling `addShot.execute` for each scaffold item, waiting for the database insertion sequentially. This creates an N+1 latency problem. Batching the inserts drastically reduces the time spent waiting on I/O.

## Impact
A synthetic benchmark mimicking the insertion process with 50 shots and 10ms of network/DB delay per call showed:
- Sequential baseline: ~534ms
- Batched version: ~12ms

## Verification
- Code formatted with `prettier`
- Evaluated performance locally via benchmark simulation
- Verified that types and tests continue to pass (`npm run typecheck`, `npm run test`, `tests/creative-pipeline-tool-loop.test.ts`)
- No broken integrations

---
*PR created automatically by Jules for task [6644884282913783558](https://jules.google.com/task/6644884282913783558) started by @georgi*