### PR TITLE
fix(marketing): play the hero reel on iOS Safari

### DIFF
--- a/marketing/src/components/HeroDemoPlayer.tsx
+++ b/marketing/src/components/HeroDemoPlayer.tsx
@@ -6,8 +6,16 @@
  *
  * The poster is a plain <img> with a srcSet and high fetch priority, and it
  * stays the LCP element — a <video poster> cannot carry either. The video
- * mounts only once the section is on screen, fades in when it can play, and
- * never autoplays for a reader who asked for reduced motion.
+ * mounts only once the section is on screen, is revealed once it is actually
+ * painting frames, and never autoplays for a reader who asked for reduced
+ * motion.
+ *
+ * iOS Safari drives two of the decisions here. It caps preloading at metadata
+ * and fetches media data only once playback is requested, so `canplay` never
+ * fires on its own — starting playback from that event deadlocks the player on
+ * iPhone. And Low Power Mode refuses muted autoplay outright, so the control
+ * has to appear on metadata rather than on readiness, or there is no way to
+ * start the reel by hand.
  */
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Pause, Play } from "lucide-react";
@@ -20,7 +28,8 @@ export default function HeroDemoPlayer({ alt }: HeroDemoPlayerProps) {
   const frameRef = useRef<HTMLDivElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
   const [mountVideo, setMountVideo] = useState(false);
-  const [ready, setReady] = useState(false);
+  const [hasMetadata, setHasMetadata] = useState(false);
+  const [started, setStarted] = useState(false);
   const [playing, setPlaying] = useState(false);
 
   // Load the reel only when the hero is actually on screen — a multi-MB file
@@ -45,26 +54,25 @@ export default function HeroDemoPlayer({ alt }: HeroDemoPlayerProps) {
     return () => observer.disconnect();
   }, []);
 
-  const onCanPlay = useCallback(() => {
-    setReady(true);
-    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    if (reduced) return;
-    void videoRef.current?.play().then(
-      () => setPlaying(true),
-      () => {
-        // Refused (power saving, background tab). The poster is the fallback.
-      }
-    );
-  }, []);
+  // play() is what starts the download on iOS, so it is called as soon as the
+  // element exists rather than waiting for a readiness event that data would
+  // have to arrive for.
+  useEffect(() => {
+    if (!mountVideo) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    void videoRef.current?.play().catch(() => {
+      // Refused (Low Power Mode, power saving, background tab). The poster
+      // holds and the button below offers it.
+    });
+  }, [mountVideo]);
 
   const toggle = useCallback(() => {
     const video = videoRef.current;
     if (!video) return;
     if (video.paused) {
-      void video.play().then(() => setPlaying(true), () => {});
+      void video.play().catch(() => {});
     } else {
       video.pause();
-      setPlaying(false);
     }
   }, []);
 
@@ -90,18 +98,26 @@ export default function HeroDemoPlayer({ alt }: HeroDemoPlayerProps) {
           loop
           playsInline
           preload="metadata"
-          onCanPlay={onCanPlay}
+          onLoadedMetadata={() => setHasMetadata(true)}
+          onPlaying={() => {
+            setStarted(true);
+            setPlaying(true);
+          }}
+          onPause={() => setPlaying(false)}
           aria-label={alt}
           className={`absolute inset-0 h-full w-full rounded-xl object-cover transition-opacity duration-500 ${
-            ready ? "opacity-100" : "opacity-0"
+            started ? "opacity-100" : "opacity-0"
           }`}
         >
-          <source src="/hero-project.webm" type="video/webm" />
+          {/* The codecs are spelled out so a browser that cannot decode VP9
+              rejects this source outright instead of selecting it on a bare
+              type and stalling. */}
+          <source src="/hero-project.webm" type='video/webm; codecs="vp9"' />
           <source src="/hero-project.mp4" type="video/mp4" />
         </video>
       )}
 
-      {ready && (
+      {hasMetadata && (
         <button
           type="button"
           onClick={toggle}


### PR DESCRIPTION
## What changed

`HeroDemoPlayer` started playback from `canplay` and gated both the fade-in and the play/pause button on that same event. iOS Safari caps preloading at metadata and fetches media data only once playback is requested, so `canplay` never fires on its own — no play, no data, no `canplay`, no play. On iPhone the reel sat at opacity 0 behind the poster with no control to start it by hand. The fix requests playback as soon as the element mounts (muted + `playsInline` autoplay is permitted on iOS, and `play()` is what starts the download there), shows the control on `loadedmetadata` so Low Power Mode — which refuses muted autoplay outright — still leaves a way to start the reel, and reveals the video on `playing` rather than `canplay` so the poster holds until there are real frames behind it. The WebM source now declares `codecs="vp9"`, so a browser that cannot decode VP9 rejects it instead of selecting it on a bare `video/webm` and stalling; Chromium still picks the smaller WebM, so no bandwidth regression.

## Verification

Reproduced the failure in Chromium by suppressing `canplay` on `HTMLMediaElement` — the one condition iOS imposes — against the real page on `next dev`:

```
== OLD ==
no-canplay: {"paused":true,"time":0,"opacity":"0"} button: 0
== NEW ==
no-canplay: {"paused":false,"time":6.23,"opacity":"1"} button: 1
```

Unmodified Chromium, desktop and an iPhone 13 viewport, both still fine after the change:

```
desktop         {"src":"hero-project.webm","readyState":4,"paused":false,"time":6.42,"opacity":"1"} button: 1
iphone-viewport {"src":"hero-project.webm","readyState":4,"paused":false,"time":6.49,"opacity":"1"} button: 1
```

- [x] `npx tsc --noEmit -p marketing/tsconfig.json` — clean
- [x] `npm run lint` in `marketing/` — no new findings (`HeroDemoPlayer.tsx` not flagged; the remaining warnings are pre-existing `no-img-element` / `exhaustive-deps` in other files)
- [ ] `npm run test:affected` — the root plan falls back to the whole repo because `marketing/` is not a workspace, and none of `packages`/`web`/`electron`/`mobile` imports this file. `marketing/`'s own suites are Playwright (Chromium-only, full production build); the Chromium runs above cover the same ground for this diff.
- [ ] `npm run dev:nodetool -- harness gate --base main` — no harness surface maps to `marketing/`

Not verified here: a real iPhone. The deadlock is reproduced and fixed under a simulation of Safari's preload behavior, not on the device itself.

## Agent capabilities

No capability added or changed.

## New checks

No check, rule, or audit added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZNBNghDcRZGgBcsm9vYks)_