### PR TITLE
refactor(websocket): extract CommandRouter from the runner

### DIFF
--- a/packages/websocket/src/session/commands.ts
+++ b/packages/websocket/src/session/commands.ts
@@ -1,0 +1,781 @@
+import { createLogger } from "@nodetool-ai/config";
+import { invocationBelongsToApplication } from "@nodetool-ai/models";
+import type { RpcErrorPayload, WebSocketMode } from "@nodetool-ai/protocol";
+import { isSdkV1RetryableError } from "@nodetool-ai/protocol/api-schemas/sdk-v1.js";
+
+import {
+  chatTurnRegistry,
+  type ChatTurnExecutionHooks,
+  type ChatTurnSession
+} from "../chat-turn-registry.js";
+import { isAppSessionCommandAllowed } from "../lib/app-session-scope.js";
+import {
+  isFiniteNumber,
+  isNonEmptyString,
+  isNumber,
+  isObjectLike,
+  isRecord,
+  isString
+} from "../lib/wire-values.js";
+import { createCallerFactory } from "../trpc/index.js";
+import { appRouter } from "../trpc/router.js";
+import type { HttpApiOptions } from "../http-api.js";
+import type { JobRunExecutionHooks } from "../job-run-registry.js";
+import type { ChatTurnHandler } from "./chat-turn.js";
+import type { ClientSession } from "./client-session.js";
+import type { DirectInferenceHandler } from "./inference.js";
+import type { RunJobRequest } from "./job-execution.js";
+
+const log = createLogger("nodetool.websocket.runner");
+
+/** Highest `job_seq` a resubscribing client claims to already hold. */
+function resumeLastSeq(data: Record<string, unknown>): number {
+  const raw = data["last_seq"];
+  return isFiniteNumber(raw) && raw > 0 ? raw : 0;
+}
+
+/** Where a chat-turn session delivers its frames. */
+interface ChatTurnDeliveryTarget {
+  deliver(message: Record<string, unknown>): Promise<void>;
+}
+
+/**
+ * The connection-level operations a command performs that belong to the host,
+ * not to a domain class: the raw socket, the wire mode, the RPC abort set, the
+ * tool bridges, and the chat-turn session bookkeeping the frame router reads.
+ * The host passes an adapter over its own fields; nothing here is state the
+ * router owns.
+ */
+export interface CommandRouterHost {
+  /**
+   * Raw send, bypassing the chat-session routing `ClientSession.send` applies.
+   * `list_chat_turns` and `resume_chat` announce a session's own frames, so
+   * they must not be stamped into it.
+   */
+  sendToSocket(message: Record<string, unknown>): Promise<void>;
+  /** `set_mode` — the host owns the serialization mode. */
+  setMode(mode: WebSocketMode): void;
+  /** `clear_models` — the host's answer, unchanged by the move. */
+  clearModels(): Promise<Record<string, unknown>>;
+  /** Abort every RPC still waiting on a provider (the host's `rpcAborts`). */
+  cancelRpcCalls(): void;
+  /** Cancel the tool and approval waiters scoped to a thread or job id. */
+  cancelToolScope(scope: string): void;
+  /** Hooks a new chat-turn session carries so a later connection can route to this one. */
+  chatTurnHooks(): ChatTurnExecutionHooks;
+  /** This connection's identity as a chat-turn delivery target. */
+  readonly chatDeliveryTarget: ChatTurnDeliveryTarget;
+  /** The chat-turn session THIS connection is executing, if any. */
+  getChatTurnSession(): ChatTurnSession | null;
+  setChatTurnSession(session: ChatTurnSession | null): void;
+  /** Turns executing elsewhere that this connection reattached to, by thread id. */
+  adoptSession(threadId: string, session: ChatTurnSession): void;
+  forgetAdoptedSession(threadId: string): void;
+}
+
+/**
+ * What the command surface needs from the job region. `JobExecutionManager`
+ * implements all of it; the host passes an adapter rather than the manager
+ * itself because four of these are still reached through the runner's own
+ * transitional delegators, which is where the job suites drive them.
+ */
+export interface CommandRouterJobs {
+  runJob(req: RunJobRequest): Promise<void>;
+  reconnectJob(
+    jobId: string,
+    workflowId?: string,
+    lastSeq?: number
+  ): Promise<void>;
+  cancelJob(
+    jobId: string,
+    workflowId?: string
+  ): Promise<Record<string, unknown>>;
+  getStatus(jobId?: string): Record<string, unknown>;
+  resolveJobControl(
+    jobId: string
+  ): { hooks: JobRunExecutionHooks; workflowId: string | null } | null;
+  /** `stop` for one run — here, through its session, or through its row. */
+  stopJob(jobId: string): Promise<void>;
+  /** Ids of the runs in flight on this connection. Logged by `stream_input`. */
+  activeJobIds(): string[];
+}
+
+export interface CommandRouterDeps {
+  session: ClientSession;
+  jobs: CommandRouterJobs;
+  chat: ChatTurnHandler;
+  inference: DirectInferenceHandler;
+  host: CommandRouterHost;
+  /** Provider and model a direct-generation command falls back to. */
+  defaults: { provider: string; model: string };
+  /** Needed to build the tRPC caller; absent means the RPC commands refuse. */
+  apiOptions?: HttpApiOptions;
+  getPythonBridgeReady?: () => boolean;
+}
+
+/** What every handler is given: the envelope, pre-read of its two id fields. */
+interface CommandContext {
+  command: string;
+  data: Record<string, unknown>;
+  jobId?: string;
+  workflowId?: string;
+  requestId?: string;
+}
+
+type CommandHandler = (
+  ctx: CommandContext
+) => Promise<Record<string, unknown> | null>;
+
+/**
+ * The client's command surface: one dispatch table over the wire commands,
+ * plus the two guards a deployed app's visitor is held to. It is the one place
+ * that composes the other domain classes, and it composes them through their
+ * methods — `get_status` and `stop` ask the job region, `set_permission_mode`
+ * and `chat_message` ask the chat handler, `inference` and the direct
+ * generation commands ask the inference handler. None of their state is
+ * reachable from here.
+ */
+export class CommandRouter {
+  constructor(private readonly deps: CommandRouterDeps) {}
+
+  /**
+   * Answer one command. Returns the legacy reply frame the caller sends, or
+   * `null` when the handler already sent its own frame (every RPC command
+   * does, in {@link runRpc}).
+   *
+   * Unknown commands answer `{ error: "Unknown command" }` — a build that does
+   * not implement a command is not a malformed frame.
+   */
+  async handle(
+    command: string,
+    data: Record<string, unknown>,
+    requestId?: string
+  ): Promise<Record<string, unknown> | null> {
+    const session = this.deps.session;
+    const jobId = isString(data.job_id) ? data.job_id : undefined;
+    const workflowId = isString(data.workflow_id)
+      ? data.workflow_id
+      : undefined;
+    log.debug("Command", { command });
+
+    // A deployed app's visitor reaches this runner as the app's owner, so the
+    // dispatch below would answer them the way it answers the owner. It is an
+    // allowlist rather than a denylist so that a command added later is
+    // refused here until someone decides it belongs — the alternative is a
+    // stranger reading somebody's assets because a table entry grew.
+    if (session.appSession && !isAppSessionCommandAllowed(command)) {
+      log.warn("Command refused for an app session", {
+        command,
+        applicationId: session.appSession.applicationId
+      });
+      return { error: "This command is not available for a published app" };
+    }
+
+    // Every allowed command except `run_job` and `get_status` addresses a run
+    // that already exists, by id, and
+    // the runner resolves a run by (user, job id) — where the user is the app's
+    // *owner*. Without this, a job id from the owner's editor would replay
+    // that run's frames, or cancel it, over a visitor's connection. The
+    // ledger is what says which runs belong to this app: an app run reserves
+    // its row before the job exists, so a job with no row here was not started
+    // by this app. `run_job` is excluded because it *creates* the row — it
+    // reserves against the app's budget inside `admitApplicationRun`, and
+    // `confineAppSessionRun` above is what confines it.
+    if (session.appSession && jobId && command !== "run_job") {
+      const owned = await invocationBelongsToApplication(
+        session.appSession.applicationId,
+        jobId
+      ).catch((err) => {
+        // Fail closed: a ledger read that never completed is not evidence the
+        // run belongs to this app.
+        session.logError("app-session job ownership check failed", err);
+        return false;
+      });
+      if (!owned) {
+        log.warn("Job command refused for an app session", {
+          command,
+          jobId,
+          applicationId: session.appSession.applicationId
+        });
+        return { error: "That run does not belong to this app" };
+      }
+    }
+
+    const handler = this.handlers[command];
+    if (!handler) return { error: "Unknown command" };
+    return handler({ command, data, jobId, workflowId, requestId });
+  }
+
+  /**
+   * Invoke a tRPC procedure and send back a single `rpc_response` frame
+   * correlating to the command's `request_id`. Returns `null` so the receive
+   * loop skips the legacy auto-send (the frame has already been sent here).
+   *
+   * Errors thrown by the procedure are mapped to `rpc_response.error` using
+   * the `apiCode` cause attached by `throwApiError` in the tRPC layer.
+   *
+   * Public only because the runner's transitional `runRpc` delegator — driven
+   * by the lifecycle suite — forwards to it; it goes private when those suites
+   * move onto the router.
+   */
+  async runRpc<TResult>(
+    command: string,
+    requestId: string | null | undefined,
+    fn: () => Promise<TResult>
+  ): Promise<Record<string, unknown> | null> {
+    if (!isNonEmptyString(requestId)) {
+      return { error: "request_id is required for RPC commands" };
+    }
+    try {
+      const result = await fn();
+      await this.deps.session.send({
+        type: "rpc_response",
+        request_id: requestId,
+        command,
+        result
+      });
+    } catch (err) {
+      const trpc = err as {
+        code?: string;
+        message?: string;
+        cause?: { apiCode?: string };
+      };
+      const code = trpc.cause?.apiCode ?? trpc.code ?? "INTERNAL_ERROR";
+      const internalMessage = trpc.message ?? String(err);
+      const error: RpcErrorPayload = {
+        code,
+        message: internalMessage,
+        retryable: isSdkV1RetryableError(code, internalMessage),
+        apiCode: trpc.cause?.apiCode ?? null,
+        trpcCode: trpc.code
+      };
+      await this.deps.session.send({
+        type: "rpc_response",
+        request_id: requestId,
+        command,
+        error
+      });
+    }
+    return null;
+  }
+
+  /**
+   * Build a tRPC caller bound to this connection's `userId`. Used to dispatch
+   * the read-only RPC commands (list_workflows, get_workflow, list_assets,
+   * get_asset, list_nodes, get_node) onto the existing tRPC routers — single
+   * source of truth, no logic duplication.
+   */
+  private getTrpcCaller() {
+    const { session, apiOptions } = this.deps;
+    if (!session.nodeRegistry || !apiOptions || !session.pythonBridge) {
+      throw new Error(
+        "RPC commands require nodeRegistry, apiOptions, and pythonBridge"
+      );
+    }
+    const factory = createCallerFactory(appRouter);
+    return factory({
+      userId: session.userId,
+      registry: session.nodeRegistry,
+      apiOptions,
+      pythonBridge: session.pythonBridge,
+      getPythonBridgeReady: this.deps.getPythonBridgeReady ?? (() => true)
+    });
+  }
+
+  private readonly handlers: Record<string, CommandHandler> = {
+    clear_models: () => this.deps.host.clearModels(),
+
+    run_job: async ({ data, workflowId }) => {
+      // SAFETY: the wire command's `data` is the run request. Every read
+      // is `req.workflow_id ?? …`, so the field the interface declares
+      // required is in practice optional — making it so in `@nodetool-ai/
+      // protocol` is the truthful fix and reaches every client.
+      await this.deps.jobs.runJob(data as unknown as RunJobRequest);
+      return { message: "Job started", workflow_id: workflowId ?? null };
+    },
+
+    reconnect_job: async ({ data, jobId, workflowId }) => {
+      if (!jobId) return { error: "job_id is required" };
+      // Await so an error can't escape as an unhandled rejection; reconnectJob
+      // only replays state (it does not run the job), so this stays quick.
+      await this.deps.jobs
+        .reconnectJob(jobId, workflowId, resumeLastSeq(data))
+        .catch((err) => {
+          log.warn("reconnect_job failed", { jobId, error: String(err) });
+        });
+      return {
+        message: `Reconnecting to job ${jobId}`,
+        job_id: jobId,
+        workflow_id: workflowId ?? null
+      };
+    },
+
+    stream_input: async ({ data, jobId, workflowId }) => {
+      if (!jobId) return { error: "job_id is required" };
+      const target = this.deps.jobs.resolveJobControl(jobId);
+      log.info("stream_input command", {
+        jobId,
+        hasActive: !!target,
+        inputName: data.input,
+        handle: data.handle,
+        hasValue: data.value !== undefined,
+        activeJobIds: this.deps.jobs.activeJobIds()
+      });
+      if (!target) return { error: "No active job/context" };
+      const inputName = isString(data.input) ? data.input : "";
+      if (!inputName.trim()) return { error: "Invalid input name" };
+      const value = data.value;
+      const handle = isString(data.handle) ? data.handle : undefined;
+      try {
+        await target.hooks.pushInput(inputName, value, handle);
+        return {
+          message: "Input item streamed",
+          job_id: jobId,
+          workflow_id: workflowId ?? target.workflowId
+        };
+      } catch (err) {
+        log.error("stream_input failed", {
+          error: err instanceof Error ? err.message : String(err)
+        });
+        return {
+          error: err instanceof Error ? err.message : String(err),
+          job_id: jobId,
+          workflow_id: workflowId ?? target.workflowId
+        };
+      }
+    },
+
+    end_input_stream: async ({ data, jobId, workflowId }) => {
+      if (!jobId) return { error: "job_id is required" };
+      const target = this.deps.jobs.resolveJobControl(jobId);
+      if (!target) return { error: "No active job/context" };
+      const inputName = isString(data.input) ? data.input : "";
+      if (!inputName.trim()) return { error: "Invalid input name" };
+      const handle = isString(data.handle) ? data.handle : undefined;
+      try {
+        target.hooks.finishInputStream(inputName, handle);
+        return {
+          message: "Input stream ended",
+          job_id: jobId,
+          workflow_id: workflowId ?? target.workflowId
+        };
+      } catch (err) {
+        return {
+          error: err instanceof Error ? err.message : String(err),
+          job_id: jobId,
+          workflow_id: workflowId ?? target.workflowId
+        };
+      }
+    },
+
+    cancel_job: async ({ jobId, workflowId }) => {
+      if (!jobId) return { error: "job_id is required" };
+      return this.deps.jobs.cancelJob(jobId, workflowId);
+    },
+
+    // Live parameter path: push property changes into a running job's
+    // node executors (e.g. synth knobs while a patch plays). Misses are
+    // not errors — the canvas already holds the value for the next run.
+    update_node_properties: async ({ data, jobId }) => {
+      if (!jobId) return { error: "job_id is required" };
+      const nodeId = data.node_id;
+      const properties = data.properties;
+      if (!isNonEmptyString(nodeId)) {
+        return { error: "node_id is required" };
+      }
+      if (!isObjectLike(properties)) {
+        return { error: "properties must be an object" };
+      }
+      const target = this.deps.jobs.resolveJobControl(jobId);
+      const applied =
+        target?.hooks.updateNodeProperties(
+          nodeId,
+          properties as Record<string, unknown>
+        ) ?? false;
+      return { applied };
+    },
+
+    get_status: async ({ jobId }) => this.deps.jobs.getStatus(jobId),
+
+    set_mode: async ({ data }) => {
+      const mode = data.mode;
+      if (mode !== "binary" && mode !== "text") {
+        return { error: "mode must be binary or text" };
+      }
+      this.deps.host.setMode(mode);
+      return { message: `Mode set to ${mode}` };
+    },
+
+    set_permission_mode: async ({ data }) => {
+      const threadId = data.thread_id;
+      const mode = data.permission_mode;
+      if (!isNonEmptyString(threadId)) {
+        return { error: "thread_id is required for set_permission_mode" };
+      }
+      if (mode !== "plan" && mode !== "default" && mode !== "auto") {
+        return { error: "permission_mode must be plan, default, or auto" };
+      }
+      this.deps.chat.setPermissionMode(threadId, mode);
+      return {
+        message: `Permission mode set to ${mode}`,
+        thread_id: threadId
+      };
+    },
+
+    chat_message: async ({ data }) => {
+      const { session, chat, host } = this.deps;
+      const threadId = data.thread_id;
+      if (!isNonEmptyString(threadId)) {
+        return { error: "thread_id is required for chat_message command" };
+      }
+      const { seq, signal, controller } = chat.beginTurn();
+      // A resilient session decouples the turn from this socket: frames are
+      // seq-stamped and buffered so a client that disconnects mid-turn can
+      // replay what it missed. Opening supersedes (aborts) any prior turn
+      // still running for this thread — including one detached from a dead
+      // connection.
+      const turn = chatTurnRegistry.open(
+        session.userId ?? "1",
+        threadId,
+        controller,
+        host.chatTurnHooks()
+      );
+      turn.attach(host.chatDeliveryTarget, turn.lastSeq);
+      host.forgetAdoptedSession(threadId);
+      host.setChatTurnSession(turn);
+      // Error frames must be sent (and buffered) before the session
+      // finishes, so the catch runs inside the chain the finally closes.
+      void chat
+        .handleChatMessage(data, seq, signal)
+        .catch(async (err) => {
+          session.logError("chat_message processing failed", err);
+          await session.send({
+            type: "error",
+            message: err instanceof Error ? err.message : String(err),
+            thread_id: threadId
+          });
+        })
+        .finally(() => {
+          chat.endTurn(controller);
+          turn.finish();
+          if (host.getChatTurnSession() === turn) {
+            host.setChatTurnSession(null);
+          }
+        });
+      return {
+        message: "Chat message processing started",
+        thread_id: threadId
+      };
+    },
+
+    // Discovery for a client that starts with no local state (a page
+    // reload): report every turn of this user still running so the
+    // client can reattach each thread with `resume_chat`.
+    list_chat_turns: async () => {
+      const { session, host } = this.deps;
+      const sessions = chatTurnRegistry.listRunningForUser(
+        session.userId ?? "1"
+      );
+      for (const s of sessions) {
+        await host.sendToSocket({
+          type: "chat_turn_active",
+          thread_id: s.threadId,
+          status: "running",
+          last_seq: s.lastSeq
+        });
+      }
+      return { message: "Chat turns listed", count: sessions.length };
+    },
+
+    resume_chat: async ({ data }) => {
+      const { session, host } = this.deps;
+      const threadId = isString(data.thread_id) ? data.thread_id : "";
+      if (!threadId) {
+        return { error: "thread_id is required for resume_chat command" };
+      }
+      const lastSeq = isFiniteNumber(data.last_seq) ? data.last_seq : 0;
+      const turn = chatTurnRegistry.get(session.userId ?? "1", threadId);
+      if (!turn) {
+        // Nothing to replay: no turn ran here, or retention elapsed. The
+        // persisted thread history over REST is the client's fallback.
+        await host.sendToSocket({
+          type: "chat_resumed",
+          thread_id: threadId,
+          status: "unknown",
+          last_seq: 0,
+          replay_count: 0,
+          replay_incomplete: false
+        });
+        return { message: "No chat turn to resume", thread_id: threadId };
+      }
+      // last_seq <= 0 is a fresh client (page reload): it has no frame
+      // state, but the persisted head of the turn is reachable over REST.
+      // Replay only what REST cannot provide — frames after the turn's
+      // last `message` frame — and flag the replay incomplete so the
+      // client reconciles history from REST.
+      const fresh = lastSeq <= 0;
+      const { replay, incomplete } = turn.attach(
+        host.chatDeliveryTarget,
+        fresh ? turn.freshAttachSeq() : lastSeq
+      );
+      if (turn.status === "running" && host.getChatTurnSession() !== turn) {
+        host.adoptSession(threadId, turn);
+      }
+      // Header first, then the missed tail; live frames queue behind them
+      // on the session's ordered delivery chain.
+      await turn.deliverReplay(host.chatDeliveryTarget, [
+        {
+          type: "chat_resumed",
+          thread_id: threadId,
+          status: turn.status,
+          last_seq: turn.lastSeq,
+          replay_count: replay.length,
+          replay_incomplete: fresh || incomplete
+        },
+        ...replay
+      ]);
+      return {
+        message: "Chat resumed",
+        thread_id: threadId,
+        replay_count: replay.length
+      };
+    },
+
+    inference: async ({ data }) => {
+      const { session, chat, inference } = this.deps;
+      const { seq, signal, controller } = chat.beginTurn();
+      const task = inference
+        .handleInference(data, seq, signal)
+        .finally(() => chat.endTurn(controller));
+      void task.catch(async (err) => {
+        session.logError("inference processing failed", err);
+        await session.send({
+          type: "error",
+          message: err instanceof Error ? err.message : String(err)
+        });
+      });
+      return { message: "Inference started" };
+    },
+
+    stop: async ({ data, jobId }) => {
+      const { session, chat, jobs, host } = this.deps;
+      const threadId = isString(data.thread_id) ? data.thread_id : undefined;
+      // Always increment seq to cancel any in-progress chat or inference
+      chat.bumpRequestSeq();
+      // …and abort it for real. The seq bump alone only discards output at
+      // yield boundaries; the signal interrupts blocked awaits and stops
+      // providers that own a subprocess.
+      chat.cancel();
+      host.cancelRpcCalls();
+      if (jobId) {
+        await jobs.stopJob(jobId);
+      }
+      const stopScope = threadId ?? jobId;
+      if (stopScope) {
+        host.cancelToolScope(stopScope);
+      }
+      // The thread's turn may be executing on a previous connection's
+      // runner (detached or adopted after a reconnect) — abort it there.
+      if (threadId) {
+        const registered = chatTurnRegistry.get(
+          session.userId ?? "1",
+          threadId
+        );
+        if (registered && registered.status === "running") {
+          registered.abort();
+        }
+      }
+      await session.send({
+        type: "generation_stopped",
+        message: "Generation stopped by user",
+        job_id: jobId ?? null,
+        thread_id: threadId ?? null
+      });
+      return {
+        message: "Stop command processed",
+        job_id: jobId ?? null,
+        thread_id: threadId ?? null
+      };
+    },
+
+    list_workflows: async ({ command, data, requestId }) => {
+      const caller = this.getTrpcCaller();
+      return this.runRpc(command, requestId, () =>
+        caller.workflows.list(
+          data as Parameters<typeof caller.workflows.list>[0]
+        )
+      );
+    },
+
+    get_workflow: async ({ command, data, requestId }) => {
+      const caller = this.getTrpcCaller();
+      return this.runRpc(command, requestId, () =>
+        caller.workflows.get({ id: String(data.id ?? "") })
+      );
+    },
+
+    list_assets: async ({ command, data, requestId }) => {
+      const caller = this.getTrpcCaller();
+      return this.runRpc(command, requestId, () =>
+        caller.assets.list(data as Parameters<typeof caller.assets.list>[0])
+      );
+    },
+
+    get_asset: async ({ command, data, requestId }) => {
+      const caller = this.getTrpcCaller();
+      return this.runRpc(command, requestId, () =>
+        caller.assets.get({ id: String(data.id ?? "") })
+      );
+    },
+
+    list_nodes: async ({ command, data, requestId }) => {
+      const caller = this.getTrpcCaller();
+      return this.runRpc(command, requestId, () =>
+        caller.nodes.list(data as Parameters<typeof caller.nodes.list>[0])
+      );
+    },
+
+    get_node: async ({ command, data, requestId }) => {
+      const caller = this.getTrpcCaller();
+      return this.runRpc(command, requestId, () =>
+        caller.nodes.get({ node_type: String(data.node_type ?? "") })
+      );
+    },
+
+    generate_text: async ({ command, data, requestId }) => {
+      const { defaults, inference } = this.deps;
+      const provider = String(data.provider ?? defaults.provider);
+      const model = String(data.model ?? defaults.model);
+      const rawMessages = Array.isArray(data.messages) ? data.messages : [];
+      const messages: Array<{ role: string; content: string }> =
+        rawMessages.length > 0
+          ? rawMessages.map((m) => {
+              const msg = m as Record<string, unknown>;
+              return {
+                role: isString(msg.role) ? msg.role : "user",
+                content: isString(msg.content) ? msg.content : ""
+              };
+            })
+          : [];
+      if (messages.length === 0) {
+        const system = isString(data.system) ? data.system.trim() : "";
+        const prompt = isString(data.prompt) ? data.prompt : "";
+        if (system) messages.push({ role: "system", content: system });
+        if (prompt.trim()) messages.push({ role: "user", content: prompt });
+      }
+      const schema = isRecord(data.schema)
+        ? (data.schema as Record<string, unknown>)
+        : undefined;
+      return this.runRpc(command, requestId, () =>
+        inference.runDirectTextGeneration({
+          provider,
+          model,
+          messages,
+          maxTokens: isNumber(data.max_tokens)
+            ? (data.max_tokens as number)
+            : undefined,
+          schema,
+          schemaName: isString(data.schema_name)
+            ? (data.schema_name as string)
+            : "result",
+          schemaDescription: isString(data.schema_description)
+            ? (data.schema_description as string)
+            : "Answer with the requested structure."
+        })
+      );
+    },
+
+    generate_media: async ({ command, data, requestId }) => {
+      const { defaults, inference } = this.deps;
+      const rawMode = data.mode;
+      const mode:
+        | "image"
+        | "image_edit"
+        | "inpaint"
+        | "video"
+        | "video_edit"
+        | "audio" =
+        rawMode === "image_edit"
+          ? "image_edit"
+          : rawMode === "inpaint"
+            ? "inpaint"
+            : rawMode === "video"
+              ? "video"
+              : rawMode === "video_edit"
+                ? "video_edit"
+                : rawMode === "audio"
+                  ? "audio"
+                  : "image";
+      const provider = String(data.provider ?? defaults.provider);
+      const model = String(data.model ?? defaults.model);
+      const prompt = String(data.prompt ?? "");
+      const sourceAssetId = isString(data.source_asset_id)
+        ? (data.source_asset_id as string)
+        : undefined;
+      const maskAssetId = isString(data.mask_asset_id)
+        ? (data.mask_asset_id as string)
+        : undefined;
+      const width = isNumber(data.width) ? (data.width as number) : undefined;
+      const height = isNumber(data.height)
+        ? (data.height as number)
+        : undefined;
+      const aspectRatio = isString(data.aspect_ratio)
+        ? (data.aspect_ratio as string)
+        : undefined;
+      const resolution = isString(data.resolution)
+        ? (data.resolution as string)
+        : undefined;
+      const strength = isNumber(data.strength)
+        ? (data.strength as number)
+        : undefined;
+      const numInferenceSteps = isNumber(data.num_inference_steps)
+        ? (data.num_inference_steps as number)
+        : undefined;
+      const durationSeconds = isNumber(data.duration)
+        ? (data.duration as number)
+        : undefined;
+      const variations = isNumber(data.variations)
+        ? (data.variations as number)
+        : undefined;
+      const voice = isString(data.voice) ? (data.voice as string) : undefined;
+      const speed = isNumber(data.speed) ? (data.speed as number) : undefined;
+      const audioFormat = isString(data.audio_format)
+        ? (data.audio_format as string)
+        : undefined;
+      return this.runRpc(command, requestId, () =>
+        inference.runDirectMediaGeneration({
+          mode,
+          provider,
+          model,
+          prompt,
+          sourceAssetId,
+          maskAssetId,
+          width,
+          height,
+          aspectRatio,
+          resolution,
+          strength,
+          numInferenceSteps,
+          durationSeconds,
+          variations,
+          voice,
+          speed,
+          audioFormat
+        })
+      );
+    },
+
+    transcribe_audio: async ({ command, data, requestId }) => {
+      const { defaults, inference } = this.deps;
+      const provider = String(data.provider ?? defaults.provider);
+      const model = String(data.model ?? defaults.model);
+      const assetId = isString(data.asset_id) ? (data.asset_id as string) : "";
+      const language = isString(data.language)
+        ? (data.language as string)
+        : undefined;
+      return this.runRpc(command, requestId, () =>
+        inference.runDirectTranscription({ provider, model, assetId, language })
+      );
+    }
+  };
+}

--- a/packages/websocket/src/session/job-execution.ts
+++ b/packages/websocket/src/session/job-execution.ts
@@ -335,6 +335,11 @@ export class JobExecutionManager {
     };
   }
 
+  /** Ids of the runs in flight on this connection. Read for diagnostics. */
+  activeJobIds(): string[] {
+    return [...this.activeJobs.keys()];
+  }
+
   /**
    * Job ids of runs still executing on a previous connection's runner that
    * THIS connection reattached to via `reconnect_job`. Client commands for
@@ -2347,6 +2352,27 @@ export class JobExecutionManager {
       job_id: jobId,
       workflow_id: cancelledWorkflowId ?? ""
     };
+  }
+
+  /**
+   * `stop` for one run. The run is cancelled here when this connection owns
+   * it; otherwise it is executing on the connection that started it — this
+   * client only reconnected to it — so it is cancelled through its registered
+   * session, or, when nothing local holds it, through its row.
+   */
+  async stopJob(jobId: string): Promise<void> {
+    const active = this.activeJobs.get(jobId);
+    if (active) {
+      active.session.cancel();
+      active.status = "cancelled";
+      return;
+    }
+    const registered = jobRunRegistry.get(this.session.userId ?? "1", jobId);
+    if (registered && registered.status === "running") {
+      registered.cancel();
+      return;
+    }
+    await requestRemoteJobCancel(this.session.userId ?? "1", jobId);
   }
 
   getStatus(jobId?: string) {

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -5,11 +5,8 @@ import { packWebSocketMessage, unpackWebSocketMessage } from "./messagepack.js";
 import { createLogger, getByteLimitEnv } from "@nodetool-ai/config";
 import { getAssetAdapter } from "./lib/storage.js";
 import {
-  isFiniteNumber,
   isNonEmptyString,
-  isNumber,
   isObjectLike,
-  isRecord,
   isString
 } from "./lib/wire-values.js";
 import {
@@ -26,25 +23,18 @@ import {
   type NodeTypeResolver,
   type NodeValidator
 } from "@nodetool-ai/kernel";
-import {
-  chatTurnRegistry,
-  type ChatTurnExecutionHooks,
-  type ChatTurnSession
+import type {
+  ChatTurnExecutionHooks,
+  ChatTurnSession
 } from "./chat-turn-registry.js";
-import {
-  jobRunRegistry,
-  type JobRunExecutionHooks,
-  type JobRunSession
-} from "./job-run-registry.js";
+import type { JobRunSession } from "./job-run-registry.js";
 import {
   Asset,
-  invocationBelongsToApplication,
   ModelChangeEvent,
   ModelChangeMeta,
   ModelObserver,
   type DBModel
 } from "@nodetool-ai/models";
-import { requestRemoteJobCancel } from "./job-control.js";
 import type {
   MessageContent,
   BaseProvider,
@@ -60,12 +50,10 @@ import type {
   HydratedGraphData,
   NodeDescriptor
 } from "@nodetool-ai/protocol";
-import { isSdkV1RetryableError } from "@nodetool-ai/protocol/api-schemas/sdk-v1.js";
 import type {
   UnifiedCommandType,
   WebSocketCommandEnvelope,
-  WebSocketMode,
-  RpcErrorPayload
+  WebSocketMode
 } from "@nodetool-ai/protocol";
 import {
   webSocketCommandEnvelopeSchema,
@@ -79,14 +67,9 @@ import { type SandboxClock } from "@nodetool-ai/agents";
 import { type CapabilityRun } from "@nodetool-ai/agents";
 import type { NodeMetadata, NodeRegistry } from "@nodetool-ai/node-sdk";
 import type { PythonBridge } from "@nodetool-ai/runtime";
-import { appRouter } from "./trpc/router.js";
-import { createCallerFactory } from "./trpc/index.js";
 import type { HttpApiOptions } from "./http-api.js";
 import { retrieveAssetBytes } from "./lib/asset-paths.js";
-import {
-  isAppSessionCommandAllowed,
-  type AppSessionScope
-} from "./lib/app-session-scope.js";
+import type { AppSessionScope } from "./lib/app-session-scope.js";
 import type {
   FrontendRendererRegistry,
   FrontendRendererToolCall,
@@ -114,8 +97,7 @@ import {
   entityRefResolver,
   estimateDirectTextSpend,
   resolveEntityReferenceImages,
-  type DirectMediaGenerationRequest,
-  type DirectTextGenerationRequest
+  type DirectMediaGenerationRequest
 } from "./session/inference.js";
 import {
   attachPlanApproval as attachPlanApprovalTo,
@@ -160,6 +142,7 @@ export type {
 };
 import type { ClientSession } from "./session/client-session.js";
 import { ChatTurnHandler } from "./session/chat-turn.js";
+import { CommandRouter } from "./session/commands.js";
 
 const log = createLogger("nodetool.websocket.runner");
 
@@ -244,12 +227,6 @@ export interface WebSocketConnection {
   close(code?: number, reason?: string): Promise<void>;
   clientState?: "connected" | "disconnected";
   applicationState?: "connected" | "disconnected";
-}
-
-/** Highest `job_seq` a resubscribing client claims to already hold. */
-function resumeLastSeq(data: Record<string, unknown>): number {
-  const raw = data["last_seq"];
-  return isFiniteNumber(raw) && raw > 0 ? raw : 0;
 }
 
 export class ToolBridge {
@@ -453,8 +430,6 @@ export class UnifiedWebSocketRunner implements ClientSession {
   readonly validateNode?: UnifiedWebSocketRunnerOptions["validateNode"];
   readonly nodeRegistry?: NodeRegistry;
   readonly pythonBridge?: PythonBridge;
-  private getPythonBridgeReady?: () => boolean;
-  private apiOptions?: HttpApiOptions;
   private frontendRendererRegistry?: FrontendRendererRegistry;
   private frontendRendererId: string | null = null;
   private configuredProvidersCache = new ConfiguredProviderCache({
@@ -468,7 +443,6 @@ export class UnifiedWebSocketRunner implements ClientSession {
    * reference to them.
    */
   private readonly jobs: JobExecutionManager;
-  private currentTask: Promise<void> | null = null;
   private heartbeatTimer: NodeJS.Timeout | null = null;
   private statsTimer: NodeJS.Timeout | null = null;
   private statsPrimeTimer: NodeJS.Timeout | null = null;
@@ -489,6 +463,8 @@ export class UnifiedWebSocketRunner implements ClientSession {
   private approvalBridge = new ToolBridge();
   /** This connection's chat turns: state, permissions, and the turn loop. */
   private readonly chat: ChatTurnHandler;
+  /** The client's command surface: one dispatch table over the wire commands. */
+  private readonly commands: CommandRouter;
   private observerRegistered = false;
   /**
    * The detachable session for the chat turn THIS connection is executing.
@@ -534,27 +510,9 @@ export class UnifiedWebSocketRunner implements ClientSession {
     return this.chat.currentRequestSeq;
   }
 
-  /**
-   * Open a chat/inference turn: cancel whatever was running and hand back the
-   * seq + signal the new turn runs under. A superseding message cancels the
-   * previous turn exactly as an explicit Stop does.
-   */
-  private beginChatTurn() {
-    return this.chat.beginTurn();
-  }
-
   /** Abort the in-flight turn, if any. Idempotent. */
   private cancelChatTurn(): void {
     this.chat.cancel();
-  }
-
-  /**
-   * Retire a turn that finished on its own. Clears the controller only when it
-   * is still the current one — a superseding turn has already installed its
-   * own, and clearing that would make a later Stop a no-op.
-   */
-  private endChatTurn(controller: AbortController | null): void {
-    this.chat.endTurn(controller);
   }
 
   /**
@@ -663,8 +621,6 @@ export class UnifiedWebSocketRunner implements ClientSession {
     this.validateNode = options.validateNode;
     this.nodeRegistry = options.nodeRegistry;
     this.pythonBridge = options.pythonBridge;
-    this.getPythonBridgeReady = options.getPythonBridgeReady;
-    this.apiOptions = options.apiOptions;
     this.frontendRendererRegistry = options.frontendRendererRegistry;
     this.getSystemStats = options.getSystemStats ?? createSystemStatsSampler();
     this.systemStatsEnabled =
@@ -728,6 +684,58 @@ export class UnifiedWebSocketRunner implements ClientSession {
         this.resolveEntityReferenceImages(userId, refs),
       resolveSourceImageBytes: (data, mediaGeneration, userId) =>
         this.resolveSourceImageBytes(data, mediaGeneration, userId)
+    });
+    this.commands = new CommandRouter({
+      session: this,
+      // The job region as this connection exposes it: the four commands the
+      // job suites drive through the runner keep going through it, so a spy
+      // on `runner.runJob` still intercepts a `run_job` command.
+      jobs: {
+        runJob: (req) => this.runJob(req),
+        reconnectJob: (jobId, workflowId, lastSeq) =>
+          this.reconnectJob(jobId, workflowId, lastSeq),
+        cancelJob: (jobId, workflowId) => this.cancelJob(jobId, workflowId),
+        getStatus: (jobId) => this.getStatus(jobId),
+        resolveJobControl: (jobId) => this.jobs.resolveJobControl(jobId),
+        stopJob: (jobId) => this.jobs.stopJob(jobId),
+        activeJobIds: () => this.jobs.activeJobIds()
+      },
+      chat: this.chat,
+      inference: this.inference,
+      // What a command does to the connection itself: the socket, the wire
+      // mode, the RPC abort set, the tool bridges, and the chat-turn session
+      // bookkeeping the frame router reads. All host state, reached through
+      // this adapter rather than owned by the router.
+      host: {
+        sendToSocket: (message) => this.sendToSocket(message),
+        setMode: (mode) => {
+          this.mode = mode;
+        },
+        clearModels: () => this.clearModels(),
+        cancelRpcCalls: () => this.cancelRpcCalls(),
+        cancelToolScope: (scope) => {
+          this.toolBridge.cancelScope(scope);
+          this.approvalBridge.cancelScope(scope);
+        },
+        chatTurnHooks: () => this.buildChatTurnHooks(),
+        chatDeliveryTarget: this.chatDeliveryTarget,
+        getChatTurnSession: () => this.chatTurnSession,
+        setChatTurnSession: (session) => {
+          this.chatTurnSession = session;
+        },
+        adoptSession: (threadId, session) => {
+          this.adoptedSessions.set(threadId, session);
+        },
+        forgetAdoptedSession: (threadId) => {
+          this.adoptedSessions.delete(threadId);
+        }
+      },
+      defaults: {
+        provider: this.defaultProvider,
+        model: this.defaultModel
+      },
+      apiOptions: options.apiOptions,
+      getPythonBridgeReady: options.getPythonBridgeReady
     });
   }
 
@@ -870,7 +878,6 @@ export class UnifiedWebSocketRunner implements ClientSession {
       session.detach(this.chatDeliveryTarget);
     }
     this.adoptedSessions.clear();
-    this.currentTask = null;
     await this.jobs.cancelAll();
 
     if (this.websocket) {
@@ -1153,13 +1160,6 @@ export class UnifiedWebSocketRunner implements ClientSession {
     return this.jobs.resolveJobSession(jobId);
   }
 
-  /** Transitional: `handleCommand`'s per-job commands — removed in T7/T8. */
-  private resolveJobControl(
-    jobId: string
-  ): { hooks: JobRunExecutionHooks; workflowId: string | null } | null {
-    return this.jobs.resolveJobControl(jobId);
-  }
-
   /** Transitional: chat's workflow runs register here — removed in T7/T8. */
   private get activeJobs(): Map<string, ActiveJob> {
     return this.jobs.activeJobs;
@@ -1418,31 +1418,14 @@ export class UnifiedWebSocketRunner implements ClientSession {
   }
 
   /**
-   * The direct-generation entry points the RPC commands call. Thin delegations
-   * while `handleCommand` still lives here; they go away with the switch.
+   * The direct-generation entry point the cost-row suite drives directly.
+   * Transitional: the implementation lives on {@link DirectInferenceHandler},
+   * and the RPC commands call it there through {@link CommandRouter}.
    */
-  private runDirectTextGeneration(
-    req: DirectTextGenerationRequest
-  ): Promise<{ text: string; data: Record<string, unknown> | null }> {
-    return this.inference.runDirectTextGeneration(req);
-  }
-
-  private runDirectMediaGeneration(
+  runDirectMediaGeneration(
     req: DirectMediaGenerationRequest
   ): Promise<{ asset_ids: string[] }> {
     return this.inference.runDirectMediaGeneration(req);
-  }
-
-  private runDirectTranscription(req: {
-    provider: string;
-    model: string;
-    assetId: string;
-    language?: string;
-  }): Promise<{
-    text: string;
-    words: Array<{ word: string; startMs: number; endMs: number }>;
-  }> {
-    return this.inference.runDirectTranscription(req);
   }
 
   /**
@@ -1464,613 +1447,25 @@ export class UnifiedWebSocketRunner implements ClientSession {
   }
 
   /**
-   * Build a tRPC caller bound to this connection's `userId`. Used to dispatch
-   * the read-only RPC commands (list_workflows, get_workflow, list_assets,
-   * get_asset, list_nodes, get_node) onto the existing tRPC routers — single
-   * source of truth, no logic duplication.
+   * Transitional: the lifecycle suite drives the RPC frame through the runner.
+   * The implementation is {@link CommandRouter.runRpc}; this adapts the wire
+   * envelope to it and goes when the suite moves onto the router.
    */
-  private getTrpcCaller() {
-    if (!this.nodeRegistry || !this.apiOptions || !this.pythonBridge) {
-      throw new Error(
-        "RPC commands require nodeRegistry, apiOptions, and pythonBridge"
-      );
-    }
-    const factory = createCallerFactory(appRouter);
-    return factory({
-      userId: this.userId,
-      registry: this.nodeRegistry,
-      apiOptions: this.apiOptions,
-      pythonBridge: this.pythonBridge,
-      getPythonBridgeReady: this.getPythonBridgeReady ?? (() => true)
-    });
-  }
-
-  /**
-   * Invoke a tRPC procedure and send back a single `rpc_response` frame
-   * correlating to `command.request_id`. Returns `null` so the receive loop
-   * skips the legacy auto-send (the frame has already been sent here).
-   *
-   * Errors thrown by the procedure are mapped to `rpc_response.error` using
-   * the `apiCode` cause attached by `throwApiError` in the tRPC layer.
-   */
-  private async runRpc<TResult>(
+  runRpc<TResult>(
     command: WebSocketCommandEnvelope,
     fn: () => Promise<TResult>
   ): Promise<Record<string, unknown> | null> {
-    const requestId = command.request_id;
-    if (!isNonEmptyString(requestId)) {
-      return { error: "request_id is required for RPC commands" };
-    }
-    try {
-      const result = await fn();
-      await this.sendMessage({
-        type: "rpc_response",
-        request_id: requestId,
-        command: command.command,
-        result
-      });
-    } catch (err) {
-      const trpc = err as {
-        code?: string;
-        message?: string;
-        cause?: { apiCode?: string };
-      };
-      const code = trpc.cause?.apiCode ?? trpc.code ?? "INTERNAL_ERROR";
-      const internalMessage = trpc.message ?? String(err);
-      const error: RpcErrorPayload = {
-        code,
-        message: internalMessage,
-        retryable: isSdkV1RetryableError(code, internalMessage),
-        apiCode: trpc.cause?.apiCode ?? null,
-        trpcCode: trpc.code
-      };
-      await this.sendMessage({
-        type: "rpc_response",
-        request_id: requestId,
-        command: command.command,
-        error
-      });
-    }
-    return null;
+    return this.commands.runRpc(command.command, command.request_id, fn);
   }
 
   async handleCommand(
     command: WebSocketCommandEnvelope
   ): Promise<Record<string, unknown> | null> {
-    const data = command.data ?? {};
-    const jobId = isString(data.job_id) ? data.job_id : undefined;
-    const workflowId = isString(data.workflow_id)
-      ? data.workflow_id
-      : undefined;
-    log.debug("Command", { command: command.command });
-
-    // A deployed app's visitor reaches this runner as the app's owner, so the
-    // dispatch below would answer them the way it answers the owner. It is an
-    // allowlist rather than a denylist so that a command added later is
-    // refused here until someone decides it belongs — the alternative is a
-    // stranger reading somebody's assets because a switch case grew.
-    if (
-      this.appSession &&
-      !isAppSessionCommandAllowed(command.command as string)
-    ) {
-      log.warn("Command refused for an app session", {
-        command: command.command,
-        applicationId: this.appSession.applicationId
-      });
-      return { error: "This command is not available for a published app" };
-    }
-
-    // Every allowed command except `run_job` and `get_status` addresses a run
-    // that already exists, by id, and
-    // the runner resolves a run by (user, job id) — where the user is the app's
-    // *owner*. Without this, a job id from the owner's editor would replay
-    // that run's frames, or cancel it, over a visitor's connection. The
-    // ledger is what says which runs belong to this app: an app run reserves
-    // its row before the job exists, so a job with no row here was not started
-    // by this app. `run_job` is excluded because it *creates* the row — it
-    // reserves against the app's budget inside `admitApplicationRun`, and
-    // `confineAppSessionRun` above is what confines it.
-    if (this.appSession && jobId && command.command !== "run_job") {
-      const owned = await invocationBelongsToApplication(
-        this.appSession.applicationId,
-        jobId
-      ).catch((err) => {
-        // Fail closed: a ledger read that never completed is not evidence the
-        // run belongs to this app.
-        this.logError("app-session job ownership check failed", err);
-        return false;
-      });
-      if (!owned) {
-        log.warn("Job command refused for an app session", {
-          command: command.command,
-          jobId,
-          applicationId: this.appSession.applicationId
-        });
-        return { error: "That run does not belong to this app" };
-      }
-    }
-
-    switch (command.command as UnifiedCommandType) {
-      case "clear_models":
-        return this.clearModels();
-      case "run_job":
-        // SAFETY: the wire command's `data` is the run request. Every read
-        // is `req.workflow_id ?? …`, so the field the interface declares
-        // required is in practice optional — making it so in `@nodetool-ai/
-        // protocol` is the truthful fix and reaches every client.
-        await this.runJob(data as unknown as RunJobRequest);
-        return { message: "Job started", workflow_id: workflowId ?? null };
-      case "reconnect_job":
-        if (!jobId) return { error: "job_id is required" };
-        // Await so an error can't escape as an unhandled rejection; reconnectJob
-        // only replays state (it does not run the job), so this stays quick.
-        await this.reconnectJob(jobId, workflowId, resumeLastSeq(data)).catch(
-          (err) => {
-            log.warn("reconnect_job failed", { jobId, error: String(err) });
-          }
-        );
-        return {
-          message: `Reconnecting to job ${jobId}`,
-          job_id: jobId,
-          workflow_id: workflowId ?? null
-        };
-      case "stream_input":
-        if (!jobId) return { error: "job_id is required" };
-        {
-          const target = this.resolveJobControl(jobId);
-          log.info("stream_input command", {
-            jobId,
-            hasActive: !!target,
-            inputName: data.input,
-            handle: data.handle,
-            hasValue: data.value !== undefined,
-            activeJobIds: [...this.activeJobs.keys()]
-          });
-          if (!target) return { error: "No active job/context" };
-          const inputName = isString(data.input) ? data.input : "";
-          if (!inputName.trim()) return { error: "Invalid input name" };
-          const value = data.value;
-          const handle = isString(data.handle) ? data.handle : undefined;
-          try {
-            await target.hooks.pushInput(inputName, value, handle);
-            return {
-              message: "Input item streamed",
-              job_id: jobId,
-              workflow_id: workflowId ?? target.workflowId
-            };
-          } catch (err) {
-            log.error("stream_input failed", {
-              error: err instanceof Error ? err.message : String(err)
-            });
-            return {
-              error: err instanceof Error ? err.message : String(err),
-              job_id: jobId,
-              workflow_id: workflowId ?? target.workflowId
-            };
-          }
-        }
-      case "end_input_stream":
-        if (!jobId) return { error: "job_id is required" };
-        {
-          const target = this.resolveJobControl(jobId);
-          if (!target) return { error: "No active job/context" };
-          const inputName = isString(data.input) ? data.input : "";
-          if (!inputName.trim()) return { error: "Invalid input name" };
-          const handle = isString(data.handle) ? data.handle : undefined;
-          try {
-            target.hooks.finishInputStream(inputName, handle);
-            return {
-              message: "Input stream ended",
-              job_id: jobId,
-              workflow_id: workflowId ?? target.workflowId
-            };
-          } catch (err) {
-            return {
-              error: err instanceof Error ? err.message : String(err),
-              job_id: jobId,
-              workflow_id: workflowId ?? target.workflowId
-            };
-          }
-        }
-      case "cancel_job":
-        if (!jobId) return { error: "job_id is required" };
-        return this.cancelJob(jobId, workflowId);
-      case "update_node_properties": {
-        // Live parameter path: push property changes into a running job's
-        // node executors (e.g. synth knobs while a patch plays). Misses are
-        // not errors — the canvas already holds the value for the next run.
-        if (!jobId) return { error: "job_id is required" };
-        const nodeId = data.node_id;
-        const properties = data.properties;
-        if (!isNonEmptyString(nodeId)) {
-          return { error: "node_id is required" };
-        }
-        if (!isObjectLike(properties)) {
-          return { error: "properties must be an object" };
-        }
-        const target = this.resolveJobControl(jobId);
-        const applied =
-          target?.hooks.updateNodeProperties(
-            nodeId,
-            properties as Record<string, unknown>
-          ) ?? false;
-        return { applied };
-      }
-      case "get_status":
-        return this.getStatus(jobId);
-      case "set_mode": {
-        const mode = data.mode;
-        if (mode !== "binary" && mode !== "text") {
-          return { error: "mode must be binary or text" };
-        }
-        this.mode = mode;
-        return { message: `Mode set to ${mode}` };
-      }
-      case "set_permission_mode": {
-        const threadId = data.thread_id;
-        const mode = data.permission_mode;
-        if (!isNonEmptyString(threadId)) {
-          return { error: "thread_id is required for set_permission_mode" };
-        }
-        if (mode !== "plan" && mode !== "default" && mode !== "auto") {
-          return { error: "permission_mode must be plan, default, or auto" };
-        }
-        this.chat.setPermissionMode(threadId, mode);
-        return {
-          message: `Permission mode set to ${mode}`,
-          thread_id: threadId
-        };
-      }
-      case "chat_message": {
-        const threadId = data.thread_id;
-        if (!isNonEmptyString(threadId)) {
-          return { error: "thread_id is required for chat_message command" };
-        }
-        const { seq, signal, controller } = this.beginChatTurn();
-        // A resilient session decouples the turn from this socket: frames are
-        // seq-stamped and buffered so a client that disconnects mid-turn can
-        // replay what it missed. Opening supersedes (aborts) any prior turn
-        // still running for this thread — including one detached from a dead
-        // connection.
-        const session = chatTurnRegistry.open(
-          this.userId ?? "1",
-          threadId,
-          controller,
-          this.buildChatTurnHooks()
-        );
-        session.attach(this.chatDeliveryTarget, session.lastSeq);
-        this.adoptedSessions.delete(threadId);
-        this.chatTurnSession = session;
-        // Error frames must be sent (and buffered) before the session
-        // finishes, so the catch runs inside the chain the finally closes.
-        this.currentTask = this.chat
-          .handleChatMessage(data, seq, signal)
-          .catch(async (err) => {
-            this.logError("chat_message processing failed", err);
-            await this.sendMessage({
-              type: "error",
-              message: err instanceof Error ? err.message : String(err),
-              thread_id: threadId
-            });
-          })
-          .finally(() => {
-            this.endChatTurn(controller);
-            session.finish();
-            if (this.chatTurnSession === session) this.chatTurnSession = null;
-          });
-        return {
-          message: "Chat message processing started",
-          thread_id: threadId
-        };
-      }
-      case "list_chat_turns": {
-        // Discovery for a client that starts with no local state (a page
-        // reload): report every turn of this user still running so the
-        // client can reattach each thread with `resume_chat`.
-        const sessions = chatTurnRegistry.listRunningForUser(
-          this.userId ?? "1"
-        );
-        for (const s of sessions) {
-          await this.sendToSocket({
-            type: "chat_turn_active",
-            thread_id: s.threadId,
-            status: "running",
-            last_seq: s.lastSeq
-          });
-        }
-        return { message: "Chat turns listed", count: sessions.length };
-      }
-      case "resume_chat": {
-        const threadId = isString(data.thread_id) ? data.thread_id : "";
-        if (!threadId) {
-          return { error: "thread_id is required for resume_chat command" };
-        }
-        const lastSeq = isFiniteNumber(data.last_seq) ? data.last_seq : 0;
-        const session = chatTurnRegistry.get(this.userId ?? "1", threadId);
-        if (!session) {
-          // Nothing to replay: no turn ran here, or retention elapsed. The
-          // persisted thread history over REST is the client's fallback.
-          await this.sendToSocket({
-            type: "chat_resumed",
-            thread_id: threadId,
-            status: "unknown",
-            last_seq: 0,
-            replay_count: 0,
-            replay_incomplete: false
-          });
-          return { message: "No chat turn to resume", thread_id: threadId };
-        }
-        // last_seq <= 0 is a fresh client (page reload): it has no frame
-        // state, but the persisted head of the turn is reachable over REST.
-        // Replay only what REST cannot provide — frames after the turn's
-        // last `message` frame — and flag the replay incomplete so the
-        // client reconciles history from REST.
-        const fresh = lastSeq <= 0;
-        const { replay, incomplete } = session.attach(
-          this.chatDeliveryTarget,
-          fresh ? session.freshAttachSeq() : lastSeq
-        );
-        if (session.status === "running" && this.chatTurnSession !== session) {
-          this.adoptedSessions.set(threadId, session);
-        }
-        // Header first, then the missed tail; live frames queue behind them
-        // on the session's ordered delivery chain.
-        await session.deliverReplay(this.chatDeliveryTarget, [
-          {
-            type: "chat_resumed",
-            thread_id: threadId,
-            status: session.status,
-            last_seq: session.lastSeq,
-            replay_count: replay.length,
-            replay_incomplete: fresh || incomplete
-          },
-          ...replay
-        ]);
-        return {
-          message: "Chat resumed",
-          thread_id: threadId,
-          replay_count: replay.length
-        };
-      }
-      case "inference": {
-        const { seq, signal, controller } = this.beginChatTurn();
-        this.currentTask = this.inference
-          .handleInference(data, seq, signal)
-          .finally(() => this.endChatTurn(controller));
-        void this.currentTask.catch(async (err) => {
-          this.logError("inference processing failed", err);
-          await this.sendMessage({
-            type: "error",
-            message: err instanceof Error ? err.message : String(err)
-          });
-        });
-        return { message: "Inference started" };
-      }
-      case "stop": {
-        const threadId = isString(data.thread_id) ? data.thread_id : undefined;
-        // Always increment seq to cancel any in-progress chat or inference
-        this.chat.bumpRequestSeq();
-        // …and abort it for real. The seq bump alone only discards output at
-        // yield boundaries; the signal interrupts blocked awaits and stops
-        // providers that own a subprocess.
-        this.cancelChatTurn();
-        this.cancelRpcCalls();
-        this.currentTask = null;
-        if (jobId) {
-          const active = this.activeJobs.get(jobId);
-          if (active) {
-            active.session.cancel();
-            active.status = "cancelled";
-          } else {
-            // The run may be executing on the connection that started it —
-            // this client reconnected to it. Cancel through its hooks, or,
-            // when nothing local holds it, through its row.
-            const registered = jobRunRegistry.get(this.userId ?? "1", jobId);
-            if (registered && registered.status === "running") {
-              registered.cancel();
-            } else {
-              await requestRemoteJobCancel(this.userId ?? "1", jobId);
-            }
-          }
-        }
-        const stopScope = threadId ?? jobId;
-        if (stopScope) {
-          this.toolBridge.cancelScope(stopScope);
-          this.approvalBridge.cancelScope(stopScope);
-        }
-        // The thread's turn may be executing on a previous connection's
-        // runner (detached or adopted after a reconnect) — abort it there.
-        if (threadId) {
-          const registered = chatTurnRegistry.get(this.userId ?? "1", threadId);
-          if (registered && registered.status === "running") {
-            registered.abort();
-          }
-        }
-        await this.sendMessage({
-          type: "generation_stopped",
-          message: "Generation stopped by user",
-          job_id: jobId ?? null,
-          thread_id: threadId ?? null
-        });
-        return {
-          message: "Stop command processed",
-          job_id: jobId ?? null,
-          thread_id: threadId ?? null
-        };
-      }
-      case "list_workflows": {
-        const caller = this.getTrpcCaller();
-        return this.runRpc(command, () =>
-          caller.workflows.list(
-            data as Parameters<typeof caller.workflows.list>[0]
-          )
-        );
-      }
-      case "get_workflow": {
-        const caller = this.getTrpcCaller();
-        return this.runRpc(command, () =>
-          caller.workflows.get({ id: String(data.id ?? "") })
-        );
-      }
-      case "list_assets": {
-        const caller = this.getTrpcCaller();
-        return this.runRpc(command, () =>
-          caller.assets.list(data as Parameters<typeof caller.assets.list>[0])
-        );
-      }
-      case "get_asset": {
-        const caller = this.getTrpcCaller();
-        return this.runRpc(command, () =>
-          caller.assets.get({ id: String(data.id ?? "") })
-        );
-      }
-      case "list_nodes": {
-        const caller = this.getTrpcCaller();
-        return this.runRpc(command, () =>
-          caller.nodes.list(data as Parameters<typeof caller.nodes.list>[0])
-        );
-      }
-      case "get_node": {
-        const caller = this.getTrpcCaller();
-        return this.runRpc(command, () =>
-          caller.nodes.get({ node_type: String(data.node_type ?? "") })
-        );
-      }
-      case "generate_text": {
-        const provider = String(data.provider ?? this.defaultProvider);
-        const model = String(data.model ?? this.defaultModel);
-        const rawMessages = Array.isArray(data.messages) ? data.messages : [];
-        const messages: Array<{ role: string; content: string }> =
-          rawMessages.length > 0
-            ? rawMessages.map((m) => {
-                const msg = m as Record<string, unknown>;
-                return {
-                  role: isString(msg.role) ? msg.role : "user",
-                  content: isString(msg.content) ? msg.content : ""
-                };
-              })
-            : [];
-        if (messages.length === 0) {
-          const system = isString(data.system) ? data.system.trim() : "";
-          const prompt = isString(data.prompt) ? data.prompt : "";
-          if (system) messages.push({ role: "system", content: system });
-          if (prompt.trim()) messages.push({ role: "user", content: prompt });
-        }
-        const schema = isRecord(data.schema)
-          ? (data.schema as Record<string, unknown>)
-          : undefined;
-        return this.runRpc(command, () =>
-          this.runDirectTextGeneration({
-            provider,
-            model,
-            messages,
-            maxTokens: isNumber(data.max_tokens)
-              ? (data.max_tokens as number)
-              : undefined,
-            schema,
-            schemaName: isString(data.schema_name)
-              ? (data.schema_name as string)
-              : "result",
-            schemaDescription: isString(data.schema_description)
-              ? (data.schema_description as string)
-              : "Answer with the requested structure."
-          })
-        );
-      }
-      case "generate_media": {
-        const rawMode = data.mode;
-        const mode:
-          | "image"
-          | "image_edit"
-          | "inpaint"
-          | "video"
-          | "video_edit"
-          | "audio" =
-          rawMode === "image_edit"
-            ? "image_edit"
-            : rawMode === "inpaint"
-              ? "inpaint"
-              : rawMode === "video"
-                ? "video"
-                : rawMode === "video_edit"
-                  ? "video_edit"
-                  : rawMode === "audio"
-                    ? "audio"
-                    : "image";
-        const provider = String(data.provider ?? this.defaultProvider);
-        const model = String(data.model ?? this.defaultModel);
-        const prompt = String(data.prompt ?? "");
-        const sourceAssetId = isString(data.source_asset_id)
-          ? (data.source_asset_id as string)
-          : undefined;
-        const maskAssetId = isString(data.mask_asset_id)
-          ? (data.mask_asset_id as string)
-          : undefined;
-        const width = isNumber(data.width) ? (data.width as number) : undefined;
-        const height = isNumber(data.height)
-          ? (data.height as number)
-          : undefined;
-        const aspectRatio = isString(data.aspect_ratio)
-          ? (data.aspect_ratio as string)
-          : undefined;
-        const resolution = isString(data.resolution)
-          ? (data.resolution as string)
-          : undefined;
-        const strength = isNumber(data.strength)
-          ? (data.strength as number)
-          : undefined;
-        const numInferenceSteps = isNumber(data.num_inference_steps)
-          ? (data.num_inference_steps as number)
-          : undefined;
-        const durationSeconds = isNumber(data.duration)
-          ? (data.duration as number)
-          : undefined;
-        const variations = isNumber(data.variations)
-          ? (data.variations as number)
-          : undefined;
-        const voice = isString(data.voice) ? (data.voice as string) : undefined;
-        const speed = isNumber(data.speed) ? (data.speed as number) : undefined;
-        const audioFormat = isString(data.audio_format)
-          ? (data.audio_format as string)
-          : undefined;
-        return this.runRpc(command, () =>
-          this.runDirectMediaGeneration({
-            mode,
-            provider,
-            model,
-            prompt,
-            sourceAssetId,
-            maskAssetId,
-            width,
-            height,
-            aspectRatio,
-            resolution,
-            strength,
-            numInferenceSteps,
-            durationSeconds,
-            variations,
-            voice,
-            speed,
-            audioFormat
-          })
-        );
-      }
-      case "transcribe_audio": {
-        const provider = String(data.provider ?? this.defaultProvider);
-        const model = String(data.model ?? this.defaultModel);
-        const assetId = isString(data.asset_id)
-          ? (data.asset_id as string)
-          : "";
-        const language = isString(data.language)
-          ? (data.language as string)
-          : undefined;
-        return this.runRpc(command, () =>
-          this.runDirectTranscription({ provider, model, assetId, language })
-        );
-      }
-      default:
-        return { error: "Unknown command" };
-    }
+    return this.commands.handle(
+      command.command,
+      command.data ?? {},
+      command.request_id
+    );
   }
 
   private startHeartbeat(): void {

--- a/packages/websocket/tests/sdk-v1-execution-contract.test.ts
+++ b/packages/websocket/tests/sdk-v1-execution-contract.test.ts
@@ -49,6 +49,10 @@ const runnerSource = readFileSync(
   new URL("../src/unified-websocket-runner.ts", import.meta.url),
   "utf8"
 );
+const commandRouterSource = readFileSync(
+  new URL("../src/session/commands.ts", import.meta.url),
+  "utf8"
+);
 const websocketPluginSource = readFileSync(
   new URL("../src/plugins/websocket.ts", import.meta.url),
   "utf8"
@@ -98,10 +102,11 @@ describe("SDK v1 execution contract", () => {
     ]);
     expect(goldenCommands).toEqual(declaredExecutionCommands);
     for (const command of declaredExecutionCommands) {
-      const occurrences = runnerSource.match(
-        new RegExp(`case ["']${command}["']`, "g")
+      // The command dispatch is CommandRouter's table, one entry per command.
+      const occurrences = commandRouterSource.match(
+        new RegExp(`^ {4}${command}: `, "gm")
       );
-      expect(occurrences, `${command}: live runner case`).toHaveLength(1);
+      expect(occurrences, `${command}: live runner dispatch`).toHaveLength(1);
     }
   });
 


### PR DESCRIPTION
## What changed

T6 of `docs/websocket-runner-refactor-plan.md`, stacked on the T1–T5 integration branch (`claude/websocket-runner-refactor-agents-u1ndgu-int2`). The 540-line `handleCommand` switch was the last large region on the runner, and it reached across every other one — job control, chat turns, direct inference, tRPC, the socket itself. It is now a dispatch table on `CommandRouter` in `packages/websocket/src/session/commands.ts`, which composes the other domain classes through their methods rather than their state. `unified-websocket-runner.ts` goes 2,432 → 1,827 lines; `commands.ts` is 781.

Two commands read job state directly through the job map — `stream_input` logged its keys, `stop` cancelled an entry in it — so `JobExecutionManager` grew `activeJobIds()` and `stopJob()` and the map stays private to it. What a command does to the *connection* (the wire mode, the RPC abort set, the tool bridges, the chat-turn session bookkeeping the frame router reads) stays host state, reached through an adapter the runner passes in. The runner keeps `handleCommand` and `runRpc` as delegators, so the wire entry point and the suites that drive the RPC frame are unchanged.

**All 24 commands the switch handled are handled by the table**, enumerated both sides and diffed rather than sampled: `cancel_job, chat_message, clear_models, end_input_stream, generate_media, generate_text, get_asset, get_node, get_status, get_workflow, inference, list_assets, list_chat_turns, list_nodes, list_workflows, reconnect_job, resume_chat, run_job, set_mode, set_permission_mode, stop, stream_input, transcribe_audio, update_node_properties` — identical lists, plus the same `{ error: "Unknown command" }` default. No case fell through; every one returned, so the table needed no shared-case handling. Per-case `try`/`catch` (`stream_input`, `end_input_stream`) stayed inside its handler, and `handle` has no `try`/`catch` of its own, as `handleCommand` had none.

Three notes on how the diff differs from the plan's T6 bullet:

1. **The plan is stale on three helpers.** It lists `entityRefResolver`, `resolveEntityReferenceImages` and `retrieveSourceAssetBytes` as moving in T6; T5 already put them in `session/inference.ts` as module-level functions. This diff does not move them again and does not import them — `CommandRouter` reaches the direct-generation surfaces through `DirectInferenceHandler` (`runDirectTextGeneration` / `runDirectMediaGeneration` / `runDirectTranscription`), which is the only thing it needs from that file. `docs/websocket-runner-refactor-plan.md` is not edited here — another branch owns it.
2. **No `registerAbort` dependency.** Nothing in the switch registers an abort controller; the direct-generation RPCs register inside `DirectInferenceHandler` (T5). What `stop` needs is the other half, so the router takes `cancelRpcCalls` instead. `rpcAborts` stays on the host, so `stop` and disconnect still reach every in-flight call.
3. **`trpc` is not a dependency; the router constructs the caller.** The plan lists both `trpc: () => TrpcCaller` and `apiOptions?` in the same constructor, and also says tRPC caller construction is private after the move. Those are mutually exclusive — `apiOptions` is only needed *for* construction — so `getTrpcCaller` moved into the router (private, still built per command, still throwing `RPC commands require …` when a dep is missing) and it takes `apiOptions` + `getPythonBridgeReady`. `appRouter` / `createCallerFactory` are no longer imported by the runner.

`handle(command, data, requestId?)` takes the envelope's three fields. The plan's third parameter is named `requestSeq`, but `request_id` is the only per-command field beyond `command`/`data` the envelope carries, and `runRpc` needs it.

Two consequences worth flagging for review:

- **`currentTask` is gone.** Its only *read* was the `void this.currentTask.catch(…)` chain inside the `inference` case, which is a local variable in the handler now. Nothing else ever read the field, so the write in `disconnect` and the clear in `stop` went with it. No behaviour depends on it.
- **One test file changed, and it is not one I wanted to touch.** `tests/sdk-v1-execution-contract.test.ts` greps live source for exactly one `case "<command>"` per declared SDK execution command, reading `src/unified-websocket-runner.ts` — an assertion that pins the switch to that file by construction, so no dispatch table can satisfy it in place. Its pointer moves to `src/session/commands.ts` and the pattern becomes the table's entry (`^ {4}<command>: `). Same six commands, same "exactly one" assertion, same live-source read. I inverted it — renamed `cancel_job` to `cancel_jobX` in the table — and watched it fail (`AssertionError: cancel_job: live runner dispatch: Target cannot be null or undefined`) before restoring. Every other test file is untouched, including all `unified-websocket-runner*.test.ts`.

## Verification

Run from the worktree at the branch head. Baseline on the base commit was 238 files / 2,621 tests.

| Command | Result |
|---|---|
| `npx vitest run --root packages/websocket` | **238 files / 2,621 tests passed** — matches baseline exactly |
| `npm run lint --workspace=packages/websocket` (`tsc --noEmit`) | pass, no output |
| `npx oxlint packages/websocket/src` | exit 0; the same 4 pre-existing `no-useless-assignment` warnings as the base commit, none in a file this diff adds |
| `npm run lint:anti-slop:enforced` | exit 0; zero findings in `session/commands.ts` |
| `npm run lint` | exit 0 |
| `npm run nodetool -- harness gate --base <this base>` | exit 0 — **but it checked nothing**: "4 changed file(s) touch 0 surface(s) … 0 selfcheck(s) to run". The registry maps no surface to these files, so this is not evidence of anything |

The inverted check, before restoring:

```
AssertionError: cancel_job: live runner dispatch: Target cannot be null or undefined.
    109|       expect(occurrences, `${command}: live runner dispatch`).toHaveLe…
 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

- [x] `npm run test:affected` — **not run as such.** Ran the full `packages/websocket` suite directly instead, which is a superset of what the diff selects (all four changed files are in that one workspace, and no package depends on `@nodetool-ai/websocket`).
- [ ] `npm run typecheck` — **not run**: it compiles `mobile/`, which is not installed in this environment. `tsc --noEmit` over `packages/websocket` was run instead and passes.
- [x] `npm run lint`
- [x] `npm run dev:nodetool -- harness gate --base <int2>` — ran, selected nothing (see above)

### CI on this PR is not coverage

The repo's `test.yml` is `pull_request: branches: [main]`, so the Quality Gate does **not** run on a PR targeting `claude/websocket-runner-refactor-agents-u1ndgu-int2`. Whatever checks appear on this PR are not the gate. The table above is the real evidence.

## Agent capabilities

No capability added or re-declared.

## New checks

No new check. The one existing check whose pointer moved was inverted and observed failing — output above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrkYim9kcnJnvqhC8RWNoc)_