### PR TITLE
marketing: bring studio and cloud heroes onto the new hero copy and demo reel

### DIFF
--- a/marketing/src/app/cloud/page.tsx
+++ b/marketing/src/app/cloud/page.tsx
@@ -14,7 +14,7 @@ import {
   ArrowRight,
 } from "lucide-react";
 import SiteHeader from "../../components/SiteHeader";
-import CanvasScreenshot from "../../components/CanvasScreenshot";
+import HeroDemoPlayer from "../../components/HeroDemoPlayer";
 import SiteFooter from "../../components/SiteFooter";
 import CloudWaitlist from "../../components/CloudWaitlist";
 
@@ -177,22 +177,28 @@ export default function CloudPage() {
                     Alpha — not generally available
                   </span>
                 </div>
+                {/* Sized a step below the landing hero's 3.25rem cap: this
+                    headline carries an extra clause, and at that cap it wrapped
+                    to five lines in the 5/12 column and pushed the demo out of
+                    line with the copy. text-balance is off for the same reason
+                    — it broke the short first line to equalise against the
+                    much longer second one. */}
                 <h1
                   id="cloud-hero-title"
-                  className="mt-6 text-4xl md:text-6xl font-bold tracking-tight text-white leading-[1.05]"
+                  className="mt-6 text-[clamp(2rem,7vw,2.75rem)] font-bold leading-[1.1] tracking-tight text-white lg:text-[clamp(2rem,3.1vw,2.75rem)]"
                 >
-                  The agent-first studio
+                  You are the director.
                   <br />
-                  <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-300 to-cyan-300">
-                    in your browser.
+                  <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-300 to-cyan-300 pb-[0.12em]">
+                    The agent is your crew — in your browser.
                   </span>
                 </h1>
                 <p className="mt-6 text-lg text-slate-300 leading-relaxed max-w-xl">
-                  NodeTool Cloud is the hosted version of the same open-source
-                  studio. Nothing to install, no hardware to set up: sign in,
-                  pitch your idea, and the agent builds the film on a canvas
-                  you can still edit. Bring your own API keys for whichever
-                  providers you want to use.
+                  Describe your idea. The agent writes the script, storyboards
+                  every scene, generates the footage, and cuts the timeline —
+                  all of it in the hosted version of the same open-source
+                  studio. Nothing to install, no hardware to set up, and your
+                  own API keys for whichever providers you want to use.
                 </p>
                 <div className="mt-6 rounded-lg border border-amber-500/30 bg-amber-500/[0.06] p-4 text-sm text-amber-100/90 max-w-xl">
                   <strong className="text-amber-200">Heads up:</strong> Cloud is
@@ -247,7 +253,7 @@ export default function CloudPage() {
                   }}
                 />
                 <div className="rounded-2xl border border-slate-700/60 bg-slate-900/80 p-1.5 shadow-2xl shadow-black/60 ring-1 ring-white/5 backdrop-blur">
-                  <CanvasScreenshot alt="NodeTool Cloud workflow editor" />
+                  <HeroDemoPlayer alt="NodeTool Cloud: one sentence becomes a storyboard, rendered stills and clips, a cut on the timeline, and a finished film — all in the browser" />
                 </div>
               </div>
             </div>

--- a/marketing/src/app/studio/page.tsx
+++ b/marketing/src/app/studio/page.tsx
@@ -17,7 +17,7 @@ import {
 } from "lucide-react";
 import { SmartDownloadButton } from "../SmartDownloadButton";
 import SiteHeader from "../../components/SiteHeader";
-import CanvasScreenshot from "../../components/CanvasScreenshot";
+import HeroDemoPlayer from "../../components/HeroDemoPlayer";
 import SiteFooter from "../../components/SiteFooter";
 
 // The three-step story is the same one the landing page tells, so it is the
@@ -175,22 +175,28 @@ export default function StudioPage() {
                   <Cpu className="h-3.5 w-3.5" />
                   Studio · Desktop · Open source
                 </span>
+                {/* Sized a step below the landing hero's 3.25rem cap: this
+                    headline carries an extra clause, and at that cap it wrapped
+                    to five lines in the 5/12 column and pushed the demo out of
+                    line with the copy. text-balance is off for the same reason
+                    — it broke the short first line to equalise against the
+                    much longer second one. */}
                 <h1
                   id="studio-hero-title"
-                  className="mt-6 text-balance text-[clamp(2rem,7.5vw,3.25rem)] font-bold leading-[1.1] tracking-tight text-white lg:text-[clamp(2.25rem,3.6vw,3.25rem)]"
+                  className="mt-6 text-[clamp(2rem,7vw,2.75rem)] font-bold leading-[1.1] tracking-tight text-white lg:text-[clamp(2rem,3.1vw,2.75rem)]"
                 >
-                  You direct the vision.
+                  You are the director.
                   <br />
                   <span className="text-transparent bg-clip-text bg-gradient-to-r from-amber-300 to-orange-300 pb-[0.12em]">
-                    The agent builds the film on your hardware.
+                    The agent is your crew — on your hardware.
                   </span>
                 </h1>
                 <p className="mt-6 text-lg text-slate-300 leading-relaxed max-w-xl">
-                  Describe your idea. The agent writes the script, boards every
-                  scene, generates the footage, and cuts the timeline — all of
-                  it on your own machine, on open weights through Ollama and
-                  MLX, or on your own API keys when a cloud model is the right
-                  call.
+                  Describe your idea. The agent writes the script, storyboards
+                  every scene, generates the footage, and cuts the timeline —
+                  all of it on your own machine, on open weights through Ollama
+                  and MLX, or on your own API keys when a cloud model is the
+                  right call.
                 </p>
                 <div className="mt-8 flex flex-col gap-3">
                   <SmartDownloadButton
@@ -252,7 +258,7 @@ export default function StudioPage() {
                   }}
                 />
                 <div className="rounded-2xl border border-slate-700/60 bg-slate-900/80 p-1.5 shadow-2xl shadow-black/60 ring-1 ring-white/5 backdrop-blur">
-                  <CanvasScreenshot alt="NodeTool Studio workflow editor" />
+                  <HeroDemoPlayer alt="NodeTool Studio: one sentence becomes a storyboard, rendered stills and clips, a cut on the timeline, and a finished film — all on your own machine" />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## What changed

Follow-up to #5407, which landed the director/crew hero on the landing page. `/studio` and `/cloud` now open on the same framing, each keeping the differentiator that page exists for — "The agent is your crew — on your hardware." and "— in your browser." Their subheadlines lead with the same four production steps ("writes the script, storyboards every scene, generates the footage, and cuts the timeline") and then land on what that page is for: local weights through Ollama and MLX for Studio, the hosted studio with nothing to install for Cloud. Cloud's previous h1 ("The agent-first studio in your browser") is replaced outright; Studio's kept its structure.

Both heroes swap `CanvasScreenshot` for `HeroDemoPlayer` — the looping demo reel the landing hero already runs — so all three entry points show the product working rather than sitting still.

One layout change came out of actually looking at the result: at the landing hero's 3.25rem cap the longer second line overflowed the 5/12 copy column, wrapping the headline to five lines and pushing the demo down out of alignment with the copy. `text-balance` made it worse by breaking the short first line to equalise against the long second one. Both pages now cap at 2.75rem with `text-balance` off, which puts them at the same three-line shape as the landing hero. The rationale is in a comment above each `<h1>`.

Two things I did not do, both worth a separate call:

- **`CanvasScreenshot` is now dead code.** Studio and Cloud were its last two consumers; nothing else imports it. Left in place rather than deleting it and its three `screen_canvas*.webp` variants, since that is a removal decision rather than part of this change.
- **`/studio` and `/cloud` now pull the demo reel** (3.6 MB webm / 4.7 MB mp4) where they previously pulled a ~96 KB screenshot. `HeroDemoPlayer` only mounts the video once the frame intersects and the poster `<img>` stays the LCP element, so LCP should hold, but per-visit bandwidth on these two pages goes up materially. Worth a look at the Lighthouse job's numbers before this ships if that matters.

## Verification

The root `typecheck` / `lint` / `test:affected` scripts don't cover `marketing/` — it isn't in the root workspaces list and has its own lockfile and CI (`.github/workflows/marketing-ci.yml`). Ran that workflow's build-job checks in `marketing/`:

- [x] `npx tsc --noEmit` — no output, clean
- [x] `npm run lint` on both changed files — `✔ No ESLint warnings or errors`
- [x] `npx next build` — `✓ Compiled successfully`
- [x] Served the production build and drove Chromium over `/`, `/studio`, `/cloud` at 1440×900: each page has exactly one `<h1>` (the invariant `tests/e2e/smoke.spec.ts` asserts), each h1 reads the intended new copy, each hero has a `<video>` present, and no `screen_canvas` image remains on either page
- [x] Screenshotted all three at 1440×900 and both changed pages at 390×844 — headlines sit at three lines, gradient descenders are not clipped, the demo aligns with the copy, and `scrollWidth - clientWidth` is 0 on mobile (no horizontal overflow)

The five-line wrap described above was caught by this screenshot pass and fixed before the commit.

Not run: the Playwright smoke suite and the Lighthouse job, which CI runs on this PR. No e2e spec asserts on hero media or headline text.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMEG1CZiqPpAM1oQ5YzkTf)_