### PR TITLE
ci: skip the quality gate for marketing-only diffs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -33,8 +33,8 @@ see below.
 
 | Workflow | Purpose | Ring | Required today? |
 |---|---|---|---|
-| `test.yml` | Full quality gate (typecheck, lint, tests) via `quality-checks.yml`, scoped to the trees the diff can reach | 0 | Required |
-| `quality-checks.yml` | Reusable gate: deps/lint static legs, one shared build, five `built` legs (typecheck+parity+examples, test-packages, test-app, bundle+ring0, app-build), a standalone `mobile` leg, and a path-gated `docker` leg that builds the image, boots it, and loads the app in a browser | 0 | Required (infra called by `test.yml`) |
+| `test.yml` | Full quality gate (typecheck, lint, tests) via `quality-checks.yml`; skipped for prose-only and marketing-only diffs | 0 | Required |
+| `quality-checks.yml` | Reusable gate: deps/lint static legs, one shared build, five `built` legs (typecheck+parity+examples, test-packages, test-app, bundle+ring0, app-build), and a path-gated `docker` leg that builds the image, boots it, and loads the app in a browser | 0 | Required (infra called by `test.yml`) |
 | `page-load-smoke.yml` | Playwright: every route loads against a seeded backend | 0 | Required |
 | `e2e-runner.yml` | Browser-driven e2e_runner suite against the real backend stack | 1 | Required (also gates PRs today, ahead of the ring split) |
 | `docker.yml` | Build and push the GHCR image (main, `preview/**`, tags) | 1 | Required |
@@ -149,43 +149,57 @@ explicit "prose only", so a `changes` job that never reported runs everything.
 Prose still gets its own checks: `docs-lint.yml` on any `**/*.md`, and
 `docs-ci.yml` (site build plus link check) on `docs/**`.
 
-## Three trees, three scopes
+## marketing/ is scoped out of the gate
 
-The repo is three npm projects, not one, and the gate no longer treats them as
-one. The `changes` job in `test.yml` classifies the diff into two more outputs
-alongside the prose one, and `quality-checks.yml` takes them as the `shared`
-and `mobile` inputs:
+The repo is three npm projects, not one: the root workspace, `mobile/` and
+`marketing/`, the latter two with their own lockfiles and their own installs.
+Only one of the three is actually separable, and the gate now reflects that.
 
-| tree | what it is | what a change to it runs |
-| --- | --- | --- |
-| root workspace (`packages/`, `web/`, `electron/`, `examples/`, `reliability/`, `scripts/`, root config) | the one npm workspace | the whole gate — static legs, the package build, the five `built` legs, `docker`, plus `integration` and `workflow-runner-e2e` |
-| `mobile/` | Expo app, own lockfile, installed with `npm --prefix mobile ci` | the two static legs (they cover mobile's lockfile, its pinned SDK versions and `mobile/src`), the shared package `build`, and the `mobile` job (`typecheck:mobile` + `test:mobile`) — but none of the five `built` legs, `docker`, `integration` or `workflow-runner-e2e` |
-| `marketing/` | Next.js site, own lockfile, deployed to Cloudflare | nothing in `test.yml` — `marketing-ci.yml` is its gate |
+`test.yml`'s `changes` job emits a `shared` output beside the prose one, and
+`quality-checks.yml` takes it as the `shared` input. It is false only for a
+diff confined to `marketing/**` (plus that workflow's own file), and then every
+leg inside the gate skips — the same mechanism, and the same fail-safe reading,
+as `docs-only`. `integration` and `workflow-runner-e2e` skip with it. Before
+this, a one-line marketing copy change built ~55 backend packages, typechecked
+three apps, ran every suite, built the container image and drove two browser
+E2E jobs.
 
-The two real dependency edges are wired in, so "separate" never means "stale":
+The edge back the other way is wired in too, so "separate" never means "stale":
+three of `marketing-ci.yml`'s steps check committed generated files against
+data in `packages/`, so `packages/base-nodes/nodetool/examples|assets/`
+`nodetool-base/**` and `packages/*-nodes/src/*-manifest.json` are in that
+workflow's `paths`. Without them a PR editing an example workflow or a provider
+manifest landed green and left the site's generated files stale.
 
-- **mobile → root workspace.** Two edges, and they pull in different
-  directions. `mobile/tsconfig.json` maps `@nodetool-ai/app-runtime`,
-  `timeline`, `gpu` and two `protocol` subpaths to `../packages/*/src`, so a
-  change to any of those four packages runs the `mobile` job. Everything else
-  mobile imports from the workspace — notably the AppRouter type from
-  `@nodetool-ai/websocket/trpc`, which is not a mobile dependency at all —
-  resolves through the root `node_modules` symlink to a package's `dist`, so
-  the `mobile` job consumes the shared `build` artifact. That is why `build`
-  runs for a mobile-only PR while `built` does not.
-- **marketing → root workspace.** Three of `marketing-ci.yml`'s steps check
-  committed generated files against data in `packages/`:
-  `packages/base-nodes/nodetool/examples|assets/nodetool-base/**` and
-  `packages/*-nodes/src/*-manifest.json` are in that workflow's `paths` for
-  exactly that reason.
+### Why mobile/ is not scoped out
 
-Within the root workspace the backend suite prunes itself: on PRs the
+`mobile/` looks equally separable and is not. Its typecheck imports the
+AppRouter type from `@nodetool-ai/websocket/trpc` — a package that is not a
+mobile dependency at all — and `@nodetool-ai/protocol`; both resolve through
+the root `node_modules` symlinks to those packages' built `dist`. Only the four
+packages `mobile/tsconfig.json` path-maps (`app-runtime`, `timeline`, `gpu`,
+two `protocol` subpaths) are read as source. So `typecheck:mobile` needs the
+full package build, and it stays inside the `built` legs.
+
+An attempt to split it into its own job was reverted: with the shared package
+dist downloaded it still failed on `@nodetool-ai/protocol` exports
+(`Shot`, `ShotStatus`, `TRPC_MAX_BATCH_SIZE`, `processingMessageSchemas`) that
+the `built` legs resolve fine, and the cause was not identified — the split job
+restored a byte-identical `mobile/node_modules` cache and ran the identical
+command. Making mobile genuinely separable means changing how it resolves
+those two packages, not how CI is wired.
+
+Note a latent fragility found along the way, not fixed here: the mobile
+typecheck's green depends on `mobile/node_modules` coming from the CI cache,
+where `npm ci` is skipped. A cold cache installs `@nodetool-ai/protocol` from
+the registry at 0.7.0-rc.11, which shadows the workspace copy and is stale
+enough to fail the typecheck with exactly the errors above. A cache miss on
+`mobile/package-lock.json` would therefore turn the `typecheck` leg red on
+main.
+
+Within the root workspace the backend suite still prunes itself: on PRs the
 `test-packages` leg runs `turbo run test --affected`, so only packages the diff
 changed and their dependents are tested.
-
-Same fail-safe reading as the prose filter: both outputs default to "true", and
-the legs skip only on an explicit "false", so a `changes` job that never
-reported runs the whole gate.
 
 ## Manual Trigger
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -159,15 +159,20 @@ and `mobile` inputs:
 | tree | what it is | what a change to it runs |
 | --- | --- | --- |
 | root workspace (`packages/`, `web/`, `electron/`, `examples/`, `reliability/`, `scripts/`, root config) | the one npm workspace | the whole gate — static legs, the package build, the five `built` legs, `docker`, plus `integration` and `workflow-runner-e2e` |
-| `mobile/` | Expo app, own lockfile, `@nodetool-ai/protocol` from the registry | the two static legs (they cover mobile's lockfile, its pinned SDK versions and `mobile/src`) and the `mobile` job (`typecheck:mobile` + `test:mobile`) |
+| `mobile/` | Expo app, own lockfile, installed with `npm --prefix mobile ci` | the two static legs (they cover mobile's lockfile, its pinned SDK versions and `mobile/src`), the shared package `build`, and the `mobile` job (`typecheck:mobile` + `test:mobile`) — but none of the five `built` legs, `docker`, `integration` or `workflow-runner-e2e` |
 | `marketing/` | Next.js site, own lockfile, deployed to Cloudflare | nothing in `test.yml` — `marketing-ci.yml` is its gate |
 
 The two real dependency edges are wired in, so "separate" never means "stale":
 
-- **mobile → root workspace.** `mobile/tsconfig.json` maps `@nodetool-ai/`
-  `app-runtime`, `timeline`, `gpu` and two `protocol` subpaths to
-  `../packages/*/src`, so a change to any of those four packages runs the
-  `mobile` job as well.
+- **mobile → root workspace.** Two edges, and they pull in different
+  directions. `mobile/tsconfig.json` maps `@nodetool-ai/app-runtime`,
+  `timeline`, `gpu` and two `protocol` subpaths to `../packages/*/src`, so a
+  change to any of those four packages runs the `mobile` job. Everything else
+  mobile imports from the workspace — notably the AppRouter type from
+  `@nodetool-ai/websocket/trpc`, which is not a mobile dependency at all —
+  resolves through the root `node_modules` symlink to a package's `dist`, so
+  the `mobile` job consumes the shared `build` artifact. That is why `build`
+  runs for a mobile-only PR while `built` does not.
 - **marketing → root workspace.** Three of `marketing-ci.yml`'s steps check
   committed generated files against data in `packages/`:
   `packages/base-nodes/nodetool/examples|assets/nodetool-base/**` and

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -33,8 +33,8 @@ see below.
 
 | Workflow | Purpose | Ring | Required today? |
 |---|---|---|---|
-| `test.yml` | Full quality gate (typecheck, lint, tests) via `quality-checks.yml` | 0 | Required |
-| `quality-checks.yml` | Reusable gate: deps/lint static legs, one shared build, five `built` legs (typecheck+parity+examples, test-packages, test-app, bundle+ring0, app-build), and a path-gated `docker` leg that builds the image, boots it, and loads the app in a browser | 0 | Required (infra called by `test.yml`) |
+| `test.yml` | Full quality gate (typecheck, lint, tests) via `quality-checks.yml`, scoped to the trees the diff can reach | 0 | Required |
+| `quality-checks.yml` | Reusable gate: deps/lint static legs, one shared build, five `built` legs (typecheck+parity+examples, test-packages, test-app, bundle+ring0, app-build), a standalone `mobile` leg, and a path-gated `docker` leg that builds the image, boots it, and loads the app in a browser | 0 | Required (infra called by `test.yml`) |
 | `page-load-smoke.yml` | Playwright: every route loads against a seeded backend | 0 | Required |
 | `e2e-runner.yml` | Browser-driven e2e_runner suite against the real backend stack | 1 | Required (also gates PRs today, ahead of the ring split) |
 | `docker.yml` | Build and push the GHCR image (main, `preview/**`, tags) | 1 | Required |
@@ -148,6 +148,39 @@ explicit "prose only", so a `changes` job that never reported runs everything.
 
 Prose still gets its own checks: `docs-lint.yml` on any `**/*.md`, and
 `docs-ci.yml` (site build plus link check) on `docs/**`.
+
+## Three trees, three scopes
+
+The repo is three npm projects, not one, and the gate no longer treats them as
+one. The `changes` job in `test.yml` classifies the diff into two more outputs
+alongside the prose one, and `quality-checks.yml` takes them as the `shared`
+and `mobile` inputs:
+
+| tree | what it is | what a change to it runs |
+| --- | --- | --- |
+| root workspace (`packages/`, `web/`, `electron/`, `examples/`, `reliability/`, `scripts/`, root config) | the one npm workspace | the whole gate — static legs, the package build, the five `built` legs, `docker`, plus `integration` and `workflow-runner-e2e` |
+| `mobile/` | Expo app, own lockfile, `@nodetool-ai/protocol` from the registry | the two static legs (they cover mobile's lockfile, its pinned SDK versions and `mobile/src`) and the `mobile` job (`typecheck:mobile` + `test:mobile`) |
+| `marketing/` | Next.js site, own lockfile, deployed to Cloudflare | nothing in `test.yml` — `marketing-ci.yml` is its gate |
+
+The two real dependency edges are wired in, so "separate" never means "stale":
+
+- **mobile → root workspace.** `mobile/tsconfig.json` maps `@nodetool-ai/`
+  `app-runtime`, `timeline`, `gpu` and two `protocol` subpaths to
+  `../packages/*/src`, so a change to any of those four packages runs the
+  `mobile` job as well.
+- **marketing → root workspace.** Three of `marketing-ci.yml`'s steps check
+  committed generated files against data in `packages/`:
+  `packages/base-nodes/nodetool/examples|assets/nodetool-base/**` and
+  `packages/*-nodes/src/*-manifest.json` are in that workflow's `paths` for
+  exactly that reason.
+
+Within the root workspace the backend suite prunes itself: on PRs the
+`test-packages` leg runs `turbo run test --affected`, so only packages the diff
+changed and their dependents are tested.
+
+Same fail-safe reading as the prose filter: both outputs default to "true", and
+the legs skip only on an explicit "false", so a `changes` job that never
+reported runs the whole gate.
 
 ## Manual Trigger
 

--- a/.github/workflows/marketing-ci.yml
+++ b/.github/workflows/marketing-ci.yml
@@ -16,16 +16,35 @@ name: Marketing CI/CD
 #                            Storage permissions for the account below
 #   CLOUDFLARE_ACCOUNT_ID  — the Cloudflare account that owns the Worker
 
+# The paths below are the site plus the reverse dependency edge. marketing/ is
+# otherwise its own npm project and the root workspace's Quality Gate skips
+# entirely for a marketing-only PR (see the `shared` filter in test.yml), but
+# three of this workflow's steps check generated files against data that lives
+# in packages/:
+#
+#   gen:templates          → packages/base-nodes/nodetool/examples|assets/nodetool-base
+#   seo:provider-catalog   → packages/*-nodes/src/*-manifest.json
+#   seo:check              → packages/base-nodes/nodetool/examples/nodetool-base
+#
+# Without them a PR that edits an example workflow or a provider manifest lands
+# green and leaves the marketing site's committed generated files stale until
+# some unrelated marketing PR trips over it.
 on:
   push:
     branches:
       - main
     paths:
       - "marketing/**"
+      - "packages/base-nodes/nodetool/examples/nodetool-base/**"
+      - "packages/base-nodes/nodetool/assets/nodetool-base/**"
+      - "packages/*-nodes/src/*-manifest.json"
       - ".github/workflows/marketing-ci.yml"
   pull_request:
     paths:
       - "marketing/**"
+      - "packages/base-nodes/nodetool/examples/nodetool-base/**"
+      - "packages/base-nodes/nodetool/assets/nodetool-base/**"
+      - "packages/*-nodes/src/*-manifest.json"
       - ".github/workflows/marketing-ci.yml"
 
 # Least-privilege token: this workflow only reads the repo to build/lint/deploy

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -173,10 +173,14 @@ jobs:
   # as a cache hit rather than rebuilding its `^build` dependencies.
   build:
     name: build
-    # `built` needs this job, so skipping it skips every leg that consumes the
-    # dist artifact too — which is exactly what a mobile-only or marketing-only
-    # PR wants: none of those legs reads a line the diff touched.
-    if: ${{ !inputs.docs-only && inputs.shared }}
+    # Also runs for a mobile-only PR. `mobile/` is a separate npm project, but
+    # its typecheck is not self-contained: `@nodetool-ai/websocket/trpc` (the
+    # AppRouter type) is not a mobile dependency at all and resolves only
+    # through the root workspace symlink, whose `exports` point at
+    # `dist/trpc/router.d.ts`. So the mobile leg needs this artifact, and both
+    # it and `built` are skipped together only when the diff reaches neither
+    # tree — a marketing-only or docs-only PR.
+    if: ${{ !inputs.docs-only && (inputs.shared || inputs.mobile) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -232,6 +236,9 @@ jobs:
   built:
     name: ${{ matrix.check }}
     needs: build
+    # `build` alone no longer implies these legs should run: it also runs for a
+    # mobile-only PR, which has nothing for the root-workspace checks to say.
+    if: ${{ !inputs.docs-only && inputs.shared }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -388,20 +395,23 @@ jobs:
           ${{ matrix.command }}
           echo "::endgroup::"
 
-  # The Expo app. Its own job rather than a leg of `built`, because it needs
-  # nothing that job produces: `mobile/` is a separate npm project (its own
-  # lockfile, `@nodetool-ai/protocol` resolved from the registry) and the four
-  # root packages its tsconfig `paths` point at are read as TypeScript source,
-  # not as built dist. Keeping it off `needs: build` is the whole point — a
-  # mobile-only PR then skips the ~55-package build and every leg behind it,
-  # and finishes in the time the build alone used to take.
+  # The Expo app. Its own job rather than a leg of `built` so it can run when
+  # `built` does not: a mobile-only PR reaches this job and skips the five
+  # root-workspace legs, `docker`, `integration` and `workflow-runner-e2e`.
   #
-  # It still installs the root workspace: `npm run typecheck:mobile` runs
-  # `tsc --build packages/protocol` first, which needs the root TypeScript.
+  # It does share `built`'s dist artifact, though. `mobile/` is a separate npm
+  # project, but its typecheck is not self-contained: it imports the AppRouter
+  # type from `@nodetool-ai/websocket/trpc`, which is not a mobile dependency
+  # at all and resolves only through the root workspace symlink, whose
+  # `exports` point at `dist/trpc/router.d.ts`. The same goes for
+  # `@nodetool-ai/protocol` — the four packages mobile's tsconfig `paths` map
+  # to source are the exception, not the rule.
+  #
   # Lint is not here — the `static` leg's oxlint pass already covers
   # `mobile/src`, and that leg runs whenever this one does.
   mobile:
     name: mobile
+    needs: build
     if: ${{ !inputs.docs-only && inputs.mobile }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -415,6 +425,12 @@ jobs:
         uses: ./.github/actions/setup-build
         with:
           build-packages: "false"
+
+      - name: Download package dist
+        uses: actions/download-artifact@v8
+        with:
+          name: packages-dist
+          path: packages
 
       # mobile is NOT a root workspace (separate dependency tree), so its
       # node_modules is cached on its own lockfile and `npm ci` is skipped on hit.
@@ -564,10 +580,10 @@ jobs:
   #
   # `always()` so the gate reports even when a leg is skipped. A `skipped` job
   # passes: `docker` is skipped by design when the diff cannot reach the image,
-  # `mobile` when it cannot reach the Expo app, and `build`/`built` when it
-  # never leaves mobile/ or marketing/ — a leg skipped that way must not hold
-  # the required check red. Anything else — failure, cancelled, or a leg
-  # skipped because its own upstream failed — fails the gate.
+  # `mobile` when it cannot reach the Expo app, and `built` when it never
+  # leaves mobile/ or marketing/ — a leg skipped that way must not hold the
+  # required check red. Anything else — failure, cancelled, or a leg skipped
+  # because its own upstream failed — fails the gate.
   quality:
     name: quality
     needs: [changes, static, build, built, mobile, docker]

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -30,23 +30,18 @@ on:
         default: false
       shared:
         description: >-
-          Whether this push can reach the root workspace tree (packages/, web/,
-          electron/, examples/, reliability/, scripts/, root config). When
-          false the diff is confined to `mobile/` and/or `marketing/` — both
-          separate npm projects with their own lockfiles — so the package
-          build and everything downstream of it (typecheck, the backend and
-          app test legs, the release gates, the image build) has nothing to
-          say and is skipped. The `quality` gate job still runs and reports.
-        required: false
-        type: boolean
-        default: true
-      mobile:
-        description: >-
-          Whether this push can reach the Expo app in `mobile/` — either
-          `mobile/**` itself or one of the packages its tsconfig `paths`
-          resolve to source. When false the mobile leg is skipped. Independent
-          of `shared`: a mobile-only PR is `shared: false, mobile: true`, a
-          packages-only PR is usually the reverse.
+          Whether this push can reach the root workspace tree — everything but
+          `marketing/`, which is a separate npm project with its own lockfile,
+          built and deployed by marketing-ci.yml. When false, every leg here is
+          skipped for the same reason `docs-only` skips them: none of them
+          reads a line the diff touched. The `quality` gate job still runs and
+          reports, so a required status check is never left Pending.
+
+          `mobile/` is deliberately NOT carved out. It is also a separate npm
+          project, but its typecheck resolves `@nodetool-ai/websocket`'s router
+          types and `@nodetool-ai/protocol` through the root workspace, so it
+          is not separable from this gate without a change to how mobile
+          resolves those packages. See the workflows README.
         required: false
         type: boolean
         default: true
@@ -79,8 +74,8 @@ jobs:
   changes:
     name: changes
     # Nothing to decide when the caller already knows the diff is prose, or
-    # that it never leaves mobile/ and marketing/: the only consumer of this
-    # job is the `docker` leg, which is skipped in both cases too.
+    # that it never leaves marketing/: the only consumer of this job is the
+    # `docker` leg, which is skipped in both cases too.
     if: ${{ !inputs.docs-only && inputs.shared }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -112,15 +107,9 @@ jobs:
   # Static checks that need no built packages. Kept independent of `build` so
   # the fastest signals (lint, dependency guards) are not delayed behind the
   # ~minutes-long package build. Each leg surfaces its own status check.
-  # Runs for a mobile-only PR too, deliberately: `check-lockfile-sync.mjs`
-  # resolves `mobile/package-lock.json`, `check-coupled-deps.mjs` compares
-  # mobile's pinned SDK versions against web's and electron's, and
-  # `check-key-boundaries.mjs` covers `mobile/src` — as does the `lint` leg's
-  # oxlint pass. Both legs run on source with no package build, so they cost a
-  # couple of minutes rather than the gate's full critical path.
   static:
     name: ${{ matrix.check }}
-    if: ${{ !inputs.docs-only && (inputs.shared || inputs.mobile) }}
+    if: ${{ !inputs.docs-only && inputs.shared }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -173,14 +162,9 @@ jobs:
   # as a cache hit rather than rebuilding its `^build` dependencies.
   build:
     name: build
-    # Also runs for a mobile-only PR. `mobile/` is a separate npm project, but
-    # its typecheck is not self-contained: `@nodetool-ai/websocket/trpc` (the
-    # AppRouter type) is not a mobile dependency at all and resolves only
-    # through the root workspace symlink, whose `exports` point at
-    # `dist/trpc/router.d.ts`. So the mobile leg needs this artifact, and both
-    # it and `built` are skipped together only when the diff reaches neither
-    # tree — a marketing-only or docs-only PR.
-    if: ${{ !inputs.docs-only && (inputs.shared || inputs.mobile) }}
+    # `built` needs this job, so skipping it skips every leg that consumes the
+    # dist artifact too.
+    if: ${{ !inputs.docs-only && inputs.shared }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -236,9 +220,6 @@ jobs:
   built:
     name: ${{ matrix.check }}
     needs: build
-    # `build` alone no longer implies these legs should run: it also runs for a
-    # mobile-only PR, which has nothing for the root-workspace checks to say.
-    if: ${{ !inputs.docs-only && inputs.shared }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -282,11 +263,8 @@ jobs:
           #      `next build`s cost minutes each and belong to deploys, not
           #      the PR gate.
           - check: typecheck
-            # `typecheck:web` + `typecheck:electron`, not the root `typecheck`
-            # script: `typecheck:mobile` belongs to the `mobile` job below, so
-            # a packages-only PR does not pay for `npm ci --prefix mobile`, and
-            # a mobile-only PR does not drag this whole leg along with it.
-            command: npm run typecheck:web && npm run typecheck:electron && npm run lint:design --workspace=web && npm test --workspace=@nodetool-ai/base-nodes -- parity example-workflows && npm run validate:examples && npm run codegen:dsl:check && npm run build:sandbox-dsl:check && npm run build:sandbox-flow:check && npm run typecheck:examples
+            command: npm run typecheck && npm run lint:design --workspace=web && npm test --workspace=@nodetool-ai/base-nodes -- parity example-workflows && npm run validate:examples && npm run codegen:dsl:check && npm run build:sandbox-dsl:check && npm run build:sandbox-flow:check && npm run typecheck:examples
+            mobile-deps: "true"
             extra-apt: ""
             is-test: "false"
             fetch-depth: "1"
@@ -303,12 +281,13 @@ jobs:
             # main (no base sha) the full suite runs. Needs fetch-depth: 0 for
             # the SCM diff and TURBO_SCM_BASE (set on the Run step below).
             command: npm run test:packages${{ github.event_name == 'pull_request' && ' -- --affected' || '' }}
+            mobile-deps: "false"
             extra-apt: "mesa-vulkan-drivers ffmpeg"
             is-test: "true"
             fetch-depth: "0"
           - check: test-app
-            # web + electron only; `test:mobile` runs in the `mobile` job.
-            command: npm run test:web && npm run test:electron
+            command: npm run test
+            mobile-deps: "true"
             extra-apt: ""
             is-test: "true"
             fetch-depth: "1"
@@ -333,6 +312,7 @@ jobs:
           # (matching the Ring 0 flake budget of zero).
           - check: bundle
             command: npm run backend:smoke && npm run reliability:ring0
+            mobile-deps: "false"
             extra-apt: ""
             is-test: "false"
             fetch-depth: "1"
@@ -346,6 +326,7 @@ jobs:
           # is not green, the harness broke.
           - check: app-build
             command: npm run dev:nodetool -- eval app-build --cases greeting-card,draft-then-publish -p ollama -m none --no-find-model --min-success 1
+            mobile-deps: "false"
             extra-apt: ""
             is-test: "false"
             fetch-depth: "1"
@@ -381,6 +362,20 @@ jobs:
           name: reliability-harness-dist
           path: reliability/harness/dist
 
+      # mobile is NOT a root workspace (separate dependency tree), so its
+      # node_modules is cached on its own lockfile and `npm ci` is skipped on hit.
+      - name: Cache mobile node_modules
+        if: matrix.mobile-deps == 'true'
+        id: mobile-node-modules
+        uses: actions/cache@v6
+        with:
+          path: mobile/node_modules
+          key: ${{ runner.os }}-mobile-node-modules-${{ hashFiles('mobile/package-lock.json') }}
+
+      - name: Install mobile dependencies
+        if: matrix.mobile-deps == 'true' && steps.mobile-node-modules.outputs.cache-hit != 'true'
+        run: cd mobile && npm ci
+
       - name: Run ${{ matrix.check }}
         # skip-tests drops the package + app test legs without touching the
         # static checks. The leg still spins up but does no work, so it stays
@@ -394,65 +389,6 @@ jobs:
           echo "::group::${{ matrix.check }}"
           ${{ matrix.command }}
           echo "::endgroup::"
-
-  # The Expo app. Its own job rather than a leg of `built` so it can run when
-  # `built` does not: a mobile-only PR reaches this job and skips the five
-  # root-workspace legs, `docker`, `integration` and `workflow-runner-e2e`.
-  #
-  # It does share `built`'s dist artifact, though. `mobile/` is a separate npm
-  # project, but its typecheck is not self-contained: it imports the AppRouter
-  # type from `@nodetool-ai/websocket/trpc`, which is not a mobile dependency
-  # at all and resolves only through the root workspace symlink, whose
-  # `exports` point at `dist/trpc/router.d.ts`. The same goes for
-  # `@nodetool-ai/protocol` — the four packages mobile's tsconfig `paths` map
-  # to source are the exception, not the rule.
-  #
-  # Lint is not here — the `static` leg's oxlint pass already covers
-  # `mobile/src`, and that leg runs whenever this one does.
-  mobile:
-    name: mobile
-    needs: build
-    if: ${{ !inputs.docs-only && inputs.mobile }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 1
-
-      - name: Set up Node, install deps
-        uses: ./.github/actions/setup-build
-        with:
-          build-packages: "false"
-
-      - name: Download package dist
-        uses: actions/download-artifact@v8
-        with:
-          name: packages-dist
-          path: packages
-
-      # mobile is NOT a root workspace (separate dependency tree), so its
-      # node_modules is cached on its own lockfile and `npm ci` is skipped on hit.
-      - name: Cache mobile node_modules
-        id: mobile-node-modules
-        uses: actions/cache@v6
-        with:
-          path: mobile/node_modules
-          key: ${{ runner.os }}-mobile-node-modules-${{ hashFiles('mobile/package-lock.json') }}
-
-      - name: Install mobile dependencies
-        if: steps.mobile-node-modules.outputs.cache-hit != 'true'
-        run: cd mobile && npm ci
-
-      - name: Typecheck mobile
-        run: npm run typecheck:mobile
-
-      # Same reading as the `built` test legs: skip-tests drops the test suite
-      # and leaves the typecheck above as the gate.
-      - name: Test mobile
-        if: ${{ !inputs.skip-tests }}
-        run: npm run test:mobile
 
   # The deploy artifact. docker.yml only builds after a merge to main, so until
   # this leg existed nothing verified the image before it landed: a Dockerfile
@@ -580,13 +516,12 @@ jobs:
   #
   # `always()` so the gate reports even when a leg is skipped. A `skipped` job
   # passes: `docker` is skipped by design when the diff cannot reach the image,
-  # `mobile` when it cannot reach the Expo app, and `built` when it never
-  # leaves mobile/ or marketing/ — a leg skipped that way must not hold the
-  # required check red. Anything else — failure, cancelled, or a leg skipped
-  # because its own upstream failed — fails the gate.
+  # and a leg skipped that way must not hold the required check red. Anything
+  # else — failure, cancelled, or a leg skipped because its own upstream failed
+  # — fails the gate.
   quality:
     name: quality
-    needs: [changes, static, build, built, mobile, docker]
+    needs: [changes, static, build, built, docker]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -603,7 +538,6 @@ jobs:
             "static:${{ needs.static.result }}" \
             "build:${{ needs.build.result }}" \
             "built:${{ needs.built.result }}" \
-            "mobile:${{ needs.mobile.result }}" \
             "docker:${{ needs.docker.result }}"; do
             name="${leg%%:*}"
             result="${leg#*:}"

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -28,6 +28,28 @@ on:
         required: false
         type: boolean
         default: false
+      shared:
+        description: >-
+          Whether this push can reach the root workspace tree (packages/, web/,
+          electron/, examples/, reliability/, scripts/, root config). When
+          false the diff is confined to `mobile/` and/or `marketing/` — both
+          separate npm projects with their own lockfiles — so the package
+          build and everything downstream of it (typecheck, the backend and
+          app test legs, the release gates, the image build) has nothing to
+          say and is skipped. The `quality` gate job still runs and reports.
+        required: false
+        type: boolean
+        default: true
+      mobile:
+        description: >-
+          Whether this push can reach the Expo app in `mobile/` — either
+          `mobile/**` itself or one of the packages its tsconfig `paths`
+          resolve to source. When false the mobile leg is skipped. Independent
+          of `shared`: a mobile-only PR is `shared: false, mobile: true`, a
+          packages-only PR is usually the reverse.
+        required: false
+        type: boolean
+        default: true
     outputs:
       all-passed:
         description: 'Whether every quality check leg passed.'
@@ -56,9 +78,10 @@ jobs:
   # cannot resolve a base builds the image rather than waving it through.
   changes:
     name: changes
-    # Nothing to decide when the caller already knows the diff is prose: the
-    # only consumer of this job is the `docker` leg, which is skipped too.
-    if: ${{ !inputs.docs-only }}
+    # Nothing to decide when the caller already knows the diff is prose, or
+    # that it never leaves mobile/ and marketing/: the only consumer of this
+    # job is the `docker` leg, which is skipped in both cases too.
+    if: ${{ !inputs.docs-only && inputs.shared }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -89,9 +112,15 @@ jobs:
   # Static checks that need no built packages. Kept independent of `build` so
   # the fastest signals (lint, dependency guards) are not delayed behind the
   # ~minutes-long package build. Each leg surfaces its own status check.
+  # Runs for a mobile-only PR too, deliberately: `check-lockfile-sync.mjs`
+  # resolves `mobile/package-lock.json`, `check-coupled-deps.mjs` compares
+  # mobile's pinned SDK versions against web's and electron's, and
+  # `check-key-boundaries.mjs` covers `mobile/src` — as does the `lint` leg's
+  # oxlint pass. Both legs run on source with no package build, so they cost a
+  # couple of minutes rather than the gate's full critical path.
   static:
     name: ${{ matrix.check }}
-    if: ${{ !inputs.docs-only }}
+    if: ${{ !inputs.docs-only && (inputs.shared || inputs.mobile) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -145,8 +174,9 @@ jobs:
   build:
     name: build
     # `built` needs this job, so skipping it skips every leg that consumes the
-    # dist artifact too.
-    if: ${{ !inputs.docs-only }}
+    # dist artifact too — which is exactly what a mobile-only or marketing-only
+    # PR wants: none of those legs reads a line the diff touched.
+    if: ${{ !inputs.docs-only && inputs.shared }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -245,8 +275,11 @@ jobs:
           #      `next build`s cost minutes each and belong to deploys, not
           #      the PR gate.
           - check: typecheck
-            command: npm run typecheck && npm run lint:design --workspace=web && npm test --workspace=@nodetool-ai/base-nodes -- parity example-workflows && npm run validate:examples && npm run codegen:dsl:check && npm run build:sandbox-dsl:check && npm run build:sandbox-flow:check && npm run typecheck:examples
-            mobile-deps: "true"
+            # `typecheck:web` + `typecheck:electron`, not the root `typecheck`
+            # script: `typecheck:mobile` belongs to the `mobile` job below, so
+            # a packages-only PR does not pay for `npm ci --prefix mobile`, and
+            # a mobile-only PR does not drag this whole leg along with it.
+            command: npm run typecheck:web && npm run typecheck:electron && npm run lint:design --workspace=web && npm test --workspace=@nodetool-ai/base-nodes -- parity example-workflows && npm run validate:examples && npm run codegen:dsl:check && npm run build:sandbox-dsl:check && npm run build:sandbox-flow:check && npm run typecheck:examples
             extra-apt: ""
             is-test: "false"
             fetch-depth: "1"
@@ -263,13 +296,12 @@ jobs:
             # main (no base sha) the full suite runs. Needs fetch-depth: 0 for
             # the SCM diff and TURBO_SCM_BASE (set on the Run step below).
             command: npm run test:packages${{ github.event_name == 'pull_request' && ' -- --affected' || '' }}
-            mobile-deps: "false"
             extra-apt: "mesa-vulkan-drivers ffmpeg"
             is-test: "true"
             fetch-depth: "0"
           - check: test-app
-            command: npm run test
-            mobile-deps: "true"
+            # web + electron only; `test:mobile` runs in the `mobile` job.
+            command: npm run test:web && npm run test:electron
             extra-apt: ""
             is-test: "true"
             fetch-depth: "1"
@@ -294,7 +326,6 @@ jobs:
           # (matching the Ring 0 flake budget of zero).
           - check: bundle
             command: npm run backend:smoke && npm run reliability:ring0
-            mobile-deps: "false"
             extra-apt: ""
             is-test: "false"
             fetch-depth: "1"
@@ -308,7 +339,6 @@ jobs:
           # is not green, the harness broke.
           - check: app-build
             command: npm run dev:nodetool -- eval app-build --cases greeting-card,draft-then-publish -p ollama -m none --no-find-model --min-success 1
-            mobile-deps: "false"
             extra-apt: ""
             is-test: "false"
             fetch-depth: "1"
@@ -344,20 +374,6 @@ jobs:
           name: reliability-harness-dist
           path: reliability/harness/dist
 
-      # mobile is NOT a root workspace (separate dependency tree), so its
-      # node_modules is cached on its own lockfile and `npm ci` is skipped on hit.
-      - name: Cache mobile node_modules
-        if: matrix.mobile-deps == 'true'
-        id: mobile-node-modules
-        uses: actions/cache@v6
-        with:
-          path: mobile/node_modules
-          key: ${{ runner.os }}-mobile-node-modules-${{ hashFiles('mobile/package-lock.json') }}
-
-      - name: Install mobile dependencies
-        if: matrix.mobile-deps == 'true' && steps.mobile-node-modules.outputs.cache-hit != 'true'
-        run: cd mobile && npm ci
-
       - name: Run ${{ matrix.check }}
         # skip-tests drops the package + app test legs without touching the
         # static checks. The leg still spins up but does no work, so it stays
@@ -371,6 +387,56 @@ jobs:
           echo "::group::${{ matrix.check }}"
           ${{ matrix.command }}
           echo "::endgroup::"
+
+  # The Expo app. Its own job rather than a leg of `built`, because it needs
+  # nothing that job produces: `mobile/` is a separate npm project (its own
+  # lockfile, `@nodetool-ai/protocol` resolved from the registry) and the four
+  # root packages its tsconfig `paths` point at are read as TypeScript source,
+  # not as built dist. Keeping it off `needs: build` is the whole point — a
+  # mobile-only PR then skips the ~55-package build and every leg behind it,
+  # and finishes in the time the build alone used to take.
+  #
+  # It still installs the root workspace: `npm run typecheck:mobile` runs
+  # `tsc --build packages/protocol` first, which needs the root TypeScript.
+  # Lint is not here — the `static` leg's oxlint pass already covers
+  # `mobile/src`, and that leg runs whenever this one does.
+  mobile:
+    name: mobile
+    if: ${{ !inputs.docs-only && inputs.mobile }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Set up Node, install deps
+        uses: ./.github/actions/setup-build
+        with:
+          build-packages: "false"
+
+      # mobile is NOT a root workspace (separate dependency tree), so its
+      # node_modules is cached on its own lockfile and `npm ci` is skipped on hit.
+      - name: Cache mobile node_modules
+        id: mobile-node-modules
+        uses: actions/cache@v6
+        with:
+          path: mobile/node_modules
+          key: ${{ runner.os }}-mobile-node-modules-${{ hashFiles('mobile/package-lock.json') }}
+
+      - name: Install mobile dependencies
+        if: steps.mobile-node-modules.outputs.cache-hit != 'true'
+        run: cd mobile && npm ci
+
+      - name: Typecheck mobile
+        run: npm run typecheck:mobile
+
+      # Same reading as the `built` test legs: skip-tests drops the test suite
+      # and leaves the typecheck above as the gate.
+      - name: Test mobile
+        if: ${{ !inputs.skip-tests }}
+        run: npm run test:mobile
 
   # The deploy artifact. docker.yml only builds after a merge to main, so until
   # this leg existed nothing verified the image before it landed: a Dockerfile
@@ -388,7 +454,7 @@ jobs:
   docker:
     name: docker
     needs: changes
-    if: ${{ !inputs.docs-only && needs.changes.outputs.docker == 'true' }}
+    if: ${{ !inputs.docs-only && inputs.shared && needs.changes.outputs.docker == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -498,12 +564,13 @@ jobs:
   #
   # `always()` so the gate reports even when a leg is skipped. A `skipped` job
   # passes: `docker` is skipped by design when the diff cannot reach the image,
-  # and a leg skipped that way must not hold the required check red. Anything
-  # else — failure, cancelled, or a leg skipped because its own upstream failed
-  # — fails the gate.
+  # `mobile` when it cannot reach the Expo app, and `build`/`built` when it
+  # never leaves mobile/ or marketing/ — a leg skipped that way must not hold
+  # the required check red. Anything else — failure, cancelled, or a leg
+  # skipped because its own upstream failed — fails the gate.
   quality:
     name: quality
-    needs: [changes, static, build, built, docker]
+    needs: [changes, static, build, built, mobile, docker]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -520,6 +587,7 @@ jobs:
             "static:${{ needs.static.result }}" \
             "build:${{ needs.build.result }}" \
             "built:${{ needs.built.result }}" \
+            "mobile:${{ needs.mobile.result }}" \
             "docker:${{ needs.docker.result }}"; do
             name="${leg%%:*}"
             result="${leg#*:}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,31 +57,20 @@ jobs:
   # "true", so a filter that cannot resolve a base runs everything rather than
   # waving a change through.
   #
-  # It also decides which of the three independent trees this push can reach.
-  # The repo holds three npm projects, not one: the root workspace
-  # (packages/, web/, electron/, examples/, reliability/), `mobile/` (its own
-  # lockfile, installed with `npm --prefix mobile ci`), and `marketing/` (its
-  # own lockfile, built and deployed by marketing-ci.yml). A change confined to
-  # one of them has nothing to say about the others, and every leg it starts
-  # anyway holds a runner the rest of the queue waits behind.
+  # It also decides whether the diff can reach the root workspace at all.
+  # `marketing/` is a separate npm project — its own lockfile, its own install,
+  # built and deployed by marketing-ci.yml — and nothing in this workflow
+  # touches it. A marketing-only PR used to build ~55 backend packages,
+  # typecheck three apps, run every suite, build the container image and drive
+  # two browser E2E jobs; with an account-wide cap of ~20 concurrent jobs, that
+  # is time the rest of the queue spends waiting. `shared` is false for such a
+  # diff and every leg skips, exactly as it does for prose.
   #
-  #   shared → the root workspace tree. Everything except docs, `marketing/**`,
-  #            `mobile/**` and those two trees' own workflows. Drives the
-  #            package build, the backend/app test legs, the image build and
-  #            the integration/E2E jobs below.
-  #   mobile → `mobile/**` plus the four packages its tsconfig `paths` resolve
-  #            to source (protocol, app-runtime, timeline, gpu), and the root
-  #            files the mobile job itself stands on (the workspace lockfile
-  #            and package.json, tsconfig.base.json, .nvmrc). Not a complete
-  #            list of what the mobile typecheck reads — it also resolves
-  #            `@nodetool-ai/websocket`'s router types through the root
-  #            workspace, so the mobile leg consumes the shared package build
-  #            rather than standing alone.
-  #
-  # `marketing/**` gets no output here on purpose: nothing in this workflow
-  # touches it. It is built, linted, tested and deployed by marketing-ci.yml,
-  # which carries the reverse edge (the packages whose data its generated files
-  # are checked against).
+  # `mobile/` is NOT carved out, though it is also a separate npm project. Its
+  # typecheck resolves `@nodetool-ai/websocket`'s router types (not a mobile
+  # dependency at all) and `@nodetool-ai/protocol` through the root workspace,
+  # so it is not separable from this gate without changing how mobile resolves
+  # those packages. See the workflows README.
   changes:
     name: changes
     runs-on: ubuntu-latest
@@ -89,7 +78,6 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code || 'true' }}
       shared: ${{ steps.filter.outputs.shared || 'true' }}
-      mobile: ${{ steps.filter.outputs.mobile || 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -105,19 +93,7 @@ jobs:
             code:
               - '!{docs/**,*.md,**/AGENTS.md,**/CLAUDE.md,.github/**/*.md}'
             shared:
-              - '!{docs/**,*.md,**/AGENTS.md,**/CLAUDE.md,.github/**/*.md,marketing/**,mobile/**,.github/workflows/marketing-ci.yml,.github/workflows/eas-build.yml}'
-            mobile:
-              - 'mobile/**'
-              - 'packages/protocol/**'
-              - 'packages/app-runtime/**'
-              - 'packages/timeline/**'
-              - 'packages/gpu/**'
-              - 'package.json'
-              - 'package-lock.json'
-              - 'tsconfig.base.json'
-              - '.nvmrc'
-              - '.github/workflows/test.yml'
-              - '.github/workflows/quality-checks.yml'
+              - '!{docs/**,*.md,**/AGENTS.md,**/CLAUDE.md,.github/**/*.md,marketing/**,.github/workflows/marketing-ci.yml}'
 
   quality:
     name: Quality Gate (npm run check)
@@ -144,14 +120,10 @@ jobs:
       # A documentation-only push skips every leg inside the gate. The gate job
       # itself still runs and reports, so the required check lands green.
       docs-only: ${{ needs.changes.outputs.code == 'false' }}
-      # Which trees the gate has to check. A marketing-only PR sets both to
-      # false and every leg inside skips (marketing-ci.yml is its gate); a
-      # mobile-only PR runs the cheap guards plus the mobile leg and skips the
-      # 55-package build and everything downstream of it. Same fail-safe
-      # reading as `docs-only`: the outputs default to 'true', so a filter that
-      # could not resolve a base runs the whole gate.
+      # Same fail-safe reading as `docs-only`: the output defaults to 'true',
+      # so a filter that could not resolve a base runs the whole gate. False
+      # only for a diff confined to marketing/, whose gate is marketing-ci.yml.
       shared: ${{ needs.changes.outputs.shared != 'false' }}
-      mobile: ${{ needs.changes.outputs.mobile != 'false' }}
 
   # Heavy jobs run concurrently with the quality gate (both wait only on the
   # seconds-long `changes` job) rather than after it, so
@@ -165,9 +137,9 @@ jobs:
     name: Workflow Integration Tests
     needs: changes
     # Same fail-safe reading as the gate above: skip only on an explicit
-    # "prose", or an explicit "this diff never leaves marketing/ or mobile/" —
-    # it runs shipped-workflow execution out of packages/base-nodes, which
-    # neither of those trees can reach.
+    # "prose", or an explicit "this diff never leaves marketing/" — it runs
+    # shipped-workflow execution out of packages/base-nodes, which marketing
+    # cannot reach.
     if: ${{ always() && needs.changes.outputs.code != 'false' && needs.changes.outputs.shared != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,9 +72,11 @@ jobs:
   #   mobile → `mobile/**` plus the four packages its tsconfig `paths` resolve
   #            to source (protocol, app-runtime, timeline, gpu), and the root
   #            files the mobile job itself stands on (the workspace lockfile
-  #            and package.json, tsconfig.base.json, .nvmrc) — between them,
-  #            every way a root-workspace change can break
-  #            `npm run typecheck:mobile`.
+  #            and package.json, tsconfig.base.json, .nvmrc). Not a complete
+  #            list of what the mobile typecheck reads — it also resolves
+  #            `@nodetool-ai/websocket`'s router types through the root
+  #            workspace, so the mobile leg consumes the shared package build
+  #            rather than standing alone.
   #
   # `marketing/**` gets no output here on purpose: nothing in this workflow
   # touches it. It is built, linted, tested and deployed by marketing-ci.yml,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,12 +56,38 @@ jobs:
   # Fails open: the step is `continue-on-error` and the output falls back to
   # "true", so a filter that cannot resolve a base runs everything rather than
   # waving a change through.
+  #
+  # It also decides which of the three independent trees this push can reach.
+  # The repo holds three npm projects, not one: the root workspace
+  # (packages/, web/, electron/, examples/, reliability/), `mobile/` (its own
+  # lockfile, installed with `npm --prefix mobile ci`), and `marketing/` (its
+  # own lockfile, built and deployed by marketing-ci.yml). A change confined to
+  # one of them has nothing to say about the others, and every leg it starts
+  # anyway holds a runner the rest of the queue waits behind.
+  #
+  #   shared → the root workspace tree. Everything except docs, `marketing/**`,
+  #            `mobile/**` and those two trees' own workflows. Drives the
+  #            package build, the backend/app test legs, the image build and
+  #            the integration/E2E jobs below.
+  #   mobile → `mobile/**` plus the four packages its tsconfig `paths` resolve
+  #            to source (protocol, app-runtime, timeline, gpu), and the root
+  #            files the mobile job itself stands on (the workspace lockfile
+  #            and package.json, tsconfig.base.json, .nvmrc) — between them,
+  #            every way a root-workspace change can break
+  #            `npm run typecheck:mobile`.
+  #
+  # `marketing/**` gets no output here on purpose: nothing in this workflow
+  # touches it. It is built, linted, tested and deployed by marketing-ci.yml,
+  # which carries the reverse edge (the packages whose data its generated files
+  # are checked against).
   changes:
     name: changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       code: ${{ steps.filter.outputs.code || 'true' }}
+      shared: ${{ steps.filter.outputs.shared || 'true' }}
+      mobile: ${{ steps.filter.outputs.mobile || 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -76,6 +102,20 @@ jobs:
           filters: |
             code:
               - '!{docs/**,*.md,**/AGENTS.md,**/CLAUDE.md,.github/**/*.md}'
+            shared:
+              - '!{docs/**,*.md,**/AGENTS.md,**/CLAUDE.md,.github/**/*.md,marketing/**,mobile/**,.github/workflows/marketing-ci.yml,.github/workflows/eas-build.yml}'
+            mobile:
+              - 'mobile/**'
+              - 'packages/protocol/**'
+              - 'packages/app-runtime/**'
+              - 'packages/timeline/**'
+              - 'packages/gpu/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig.base.json'
+              - '.nvmrc'
+              - '.github/workflows/test.yml'
+              - '.github/workflows/quality-checks.yml'
 
   quality:
     name: Quality Gate (npm run check)
@@ -102,6 +142,14 @@ jobs:
       # A documentation-only push skips every leg inside the gate. The gate job
       # itself still runs and reports, so the required check lands green.
       docs-only: ${{ needs.changes.outputs.code == 'false' }}
+      # Which trees the gate has to check. A marketing-only PR sets both to
+      # false and every leg inside skips (marketing-ci.yml is its gate); a
+      # mobile-only PR runs the cheap guards plus the mobile leg and skips the
+      # 55-package build and everything downstream of it. Same fail-safe
+      # reading as `docs-only`: the outputs default to 'true', so a filter that
+      # could not resolve a base runs the whole gate.
+      shared: ${{ needs.changes.outputs.shared != 'false' }}
+      mobile: ${{ needs.changes.outputs.mobile != 'false' }}
 
   # Heavy jobs run concurrently with the quality gate (both wait only on the
   # seconds-long `changes` job) rather than after it, so
@@ -114,8 +162,11 @@ jobs:
   integration:
     name: Workflow Integration Tests
     needs: changes
-    # Same fail-safe reading as the gate above: skip only on an explicit "prose".
-    if: ${{ always() && needs.changes.outputs.code != 'false' }}
+    # Same fail-safe reading as the gate above: skip only on an explicit
+    # "prose", or an explicit "this diff never leaves marketing/ or mobile/" —
+    # it runs shipped-workflow execution out of packages/base-nodes, which
+    # neither of those trees can reach.
+    if: ${{ always() && needs.changes.outputs.code != 'false' && needs.changes.outputs.shared != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -132,7 +183,7 @@ jobs:
   workflow-runner-e2e:
     name: Workflow Runner Browser E2E
     needs: changes
-    if: ${{ always() && needs.changes.outputs.code != 'false' }}
+    if: ${{ always() && needs.changes.outputs.code != 'false' && needs.changes.outputs.shared != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
 


### PR DESCRIPTION
> **Description rewritten after merge.** The original text described a design that was reverted in `bdf0290` before this landed: a standalone `mobile` job and a `mobile` scope input, neither of which shipped. What follows describes what actually merged. The reverted attempt is kept below because the finding behind it is worth having.

## What changed

The repo is three npm projects, not one — the root workspace, `mobile/` and `marketing/`, the latter two with their own lockfiles and installs — but the Quality Gate treated every PR as if it touched all of them. A one-line marketing copy change built ~55 backend packages, typechecked three apps, ran every suite, built the container image and drove two browser E2E jobs; with an account-wide cap of ~20 concurrent jobs, that is time the rest of the queue spends waiting.

`test.yml`'s `changes` job now emits a `shared` output beside the existing prose one, and `quality-checks.yml` takes it as a `shared` input. It is false only for a diff confined to `marketing/**` plus that workflow's own file, and then every leg inside the gate skips — the same mechanism, and the same fail-safe reading, as `docs-only`. `integration` and `workflow-runner-e2e` skip with it. The `quality` aggregate still runs on `always()`, so the required check is never left Pending.

The edge back the other way is wired in too, so "separate" never means "stale": three of `marketing-ci.yml`'s steps check committed generated files against data in `packages/`, so `packages/base-nodes/nodetool/examples|assets/nodetool-base/**` and `packages/*-nodes/src/*-manifest.json` join its `paths`. That closes a pre-existing gap where a PR editing an example workflow or a provider manifest landed green and left the site's generated files stale.

**For any PR that is not marketing-only, the gate is identical to main.** The whole `quality-checks.yml` diff is one new input and four `if` conditions; no leg's commands or steps changed.

## Why mobile/ is not scoped out

`mobile/` looks equally separable and is not. Its typecheck imports the AppRouter type from `@nodetool-ai/websocket/trpc` — a package that is not a mobile dependency at all — and `@nodetool-ai/protocol`; both resolve through the root `node_modules` symlinks to those packages' built `dist`. Only the four packages `mobile/tsconfig.json` path-maps (`app-runtime`, `timeline`, `gpu`, two `protocol` subpaths) are read as source. So `typecheck:mobile` needs the full package build and stays inside the `built` legs.

The split was attempted and reverted. Giving the job the shared dist artifact fixed the `websocket/trpc` failure and its whole tRPC cascade, but it still failed on `@nodetool-ai/protocol` exports (`Shot`, `ShotStatus`, `TRPC_MAX_BATCH_SIZE`, `processingMessageSchemas`) that main's `typecheck` leg resolves fine on the same commit — while restoring a byte-identical `mobile/node_modules` cache (same key, same 158,618,107 B) and running the identical command. The leading `typecheck:web`/`typecheck:electron` in main's chain were ruled out locally: both are `tsc --noEmit`, and the full chain fails identically. Cause not identified, so the split was reverted rather than retried. Making mobile separable means changing how it resolves those two packages, not how CI is wired.

## Latent fragility found on the way (not fixed here)

The mobile typecheck is green on main only because the CI cache lets it skip `npm ci`. A cold cache installs `@nodetool-ai/protocol` from the registry at `0.7.0-rc.11`, which shadows the workspace copy and is missing all four symbols above. A cache miss on `mobile/package-lock.json` would therefore turn the `typecheck` leg — a required check — red on main. Verified in both directions locally. Documented in `.github/workflows/README.md`; left unfixed rather than widening this PR.

## Verification

This diff touches only `.github/workflows/**`, so the template's `npm run typecheck` / `lint` / `test:affected` boxes have nothing in it to report on and were not run. Instead:

- `actionlint` clean (exit 0) over all three changed workflows, which also validates the reusable-workflow call — the new `shared` input resolves against what `test.yml` passes.
- YAML parse of all three files. The anchor/alias form GitHub Actions rejects was replaced with explicit lists in `marketing-ci.yml`.
- Both `dorny/paths-filter` patterns run through `picomatch` with the action's own `{ dot: true }`:

  | change set | `code` | `shared` |
  | --- | --- | --- |
  | marketing only | true | false |
  | `marketing-ci.yml` only | true | false |
  | marketing + packages | true | true |
  | mobile only | true | true |
  | web only | true | true |
  | packages only | true | true |
  | docs only | false | false |
  | `test.yml` only | true | true |

- For the mobile investigation: full workspace install plus `npm run build:packages` (59/59 tasks), then `npm run typecheck:mobile` (exit 0) and `npm run test:mobile` (exit 0, 77 suites / 1030 tests) — and the same commands failing with 36 errors once the stale registry `protocol` is present, which is what established the fragility above.

- [ ] `npm run test:affected` — not applicable, no source changed
- [ ] `npm run typecheck` — not applicable, no source changed
- [ ] `npm run lint` — not applicable, no source changed
- [ ] `npm run dev:nodetool -- harness gate --base main` — not applicable, no source changed

## Agent capabilities

Skipped — no capability added or re-declared.

## New checks

Skipped — no check, rule, or audit added. This narrows when existing checks run; it adds none.