### PR TITLE
test(websocket): cover the extracted sanitize, chat-history and model-interface helpers

### DIFF
--- a/packages/websocket/tests/session-chat-history.test.ts
+++ b/packages/websocket/tests/session-chat-history.test.ts
@@ -1,0 +1,318 @@
+/**
+ * session/chat-history — the stored-message → provider-message conversions
+ * and the workflow-result → message-content mapping, exercised as plain
+ * functions with no socket and no database.
+ */
+
+import { describe, expect, it } from "vitest";
+import { Message } from "@nodetool-ai/models";
+import {
+  PLAN_APPROVAL_CONTEXT_KEY,
+  type RequestPlanApproval,
+  type SandboxClock,
+  type TaskPlan
+} from "@nodetool-ai/agents";
+import {
+  ProcessingContext,
+  type MessageContent,
+  type Message as ProviderMessage
+} from "@nodetool-ai/runtime";
+import {
+  appendContextToLastUser,
+  attachPlanApproval,
+  createWorkflowResponseContent,
+  dbMessageToProviderMessage,
+  extractTextContent,
+  invokedSkillsSection,
+  toolResultDisplayText
+} from "../src/session/chat-history.js";
+
+function dbMessage(data: Record<string, unknown>): Message {
+  return new Message({ thread_id: "thread-1", user_id: "user-1", ...data });
+}
+
+describe("dbMessageToProviderMessage", () => {
+  it("drops messages with non-provider roles", () => {
+    expect(
+      dbMessageToProviderMessage(dbMessage({ role: "agent_execution" }), null)
+    ).toBeNull();
+    // A legacy row can carry an empty role; the constructor only defaults an
+    // absent one.
+    expect(dbMessageToProviderMessage(dbMessage({ role: "" }), "user-1")).toBeNull();
+  });
+
+  it("maps a plain user message, defaulting null content to the empty string", () => {
+    const out = dbMessageToProviderMessage(
+      dbMessage({ role: "user", content: null }),
+      "user-1"
+    );
+    expect(out).toEqual({
+      role: "user",
+      content: "",
+      toolCallId: null,
+      toolCalls: null,
+      threadId: "thread-1"
+    });
+  });
+
+  it("keeps string content and a string tool_call_id", () => {
+    const out = dbMessageToProviderMessage(
+      dbMessage({ role: "tool", content: "result", tool_call_id: "call-9" }),
+      null
+    );
+    expect(out?.content).toBe("result");
+    expect(out?.toolCallId).toBe("call-9");
+  });
+
+  it("resolves array content per block, passing text blocks through", () => {
+    const out = dbMessageToProviderMessage(
+      dbMessage({
+        role: "user",
+        content: [{ type: "text", text: "hello" }]
+      }),
+      "conn-user"
+    );
+    expect(out?.content).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  it("falls back to the connection user when the row has no user_id", () => {
+    const out = dbMessageToProviderMessage(
+      new Message({
+        thread_id: "thread-1",
+        role: "user",
+        content: [{ type: "text", text: "hi" }]
+      }),
+      "conn-user"
+    );
+    expect(out?.content).toEqual([{ type: "text", text: "hi" }]);
+  });
+
+  it("resolves array content with no user at all", () => {
+    const out = dbMessageToProviderMessage(
+      new Message({
+        thread_id: "thread-1",
+        role: "user",
+        content: [{ type: "text", text: "anon" }]
+      }),
+      null
+    );
+    expect(out?.content).toEqual([{ type: "text", text: "anon" }]);
+  });
+
+  it("copies tool calls, carrying thought_signature only when it is a string", () => {
+    const out = dbMessageToProviderMessage(
+      dbMessage({
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          { id: "a", name: "one", args: { x: 1 }, thought_signature: "sig" },
+          { id: "b", name: "two", args: {}, thought_signature: 42 }
+        ]
+      }),
+      null
+    );
+    expect(out?.toolCalls).toEqual([
+      { id: "a", name: "one", args: { x: 1 }, thought_signature: "sig" },
+      { id: "b", name: "two", args: {} }
+    ]);
+  });
+});
+
+describe("toolResultDisplayText", () => {
+  it("joins the text items with newlines", () => {
+    const content: MessageContent[] = [
+      { type: "text", text: "line one" },
+      { type: "image_url", image: { uri: "asset://x" } },
+      { type: "text", text: "line two" }
+    ];
+    expect(toolResultDisplayText(content)).toBe("line one\nline two");
+  });
+
+  it("labels an image-only result", () => {
+    const content: MessageContent[] = [
+      { type: "image_url", image: { uri: "asset://x" } }
+    ];
+    expect(toolResultDisplayText(content)).toBe("[image result]");
+    expect(toolResultDisplayText([])).toBe("[image result]");
+  });
+});
+
+describe("appendContextToLastUser", () => {
+  it("returns the messages untouched when no user message exists", () => {
+    const messages: ProviderMessage[] = [
+      { role: "assistant", content: "hi" },
+      { role: "system", content: "sys" }
+    ];
+    expect(appendContextToLastUser(messages, "ctx")).toBe(messages);
+  });
+
+  it("appends to the last user message's string content, not an earlier one", () => {
+    const messages: ProviderMessage[] = [
+      { role: "user", content: "first" },
+      { role: "assistant", content: "reply" },
+      { role: "user", content: "second" },
+      { role: "assistant", content: "tail" }
+    ];
+    const out = appendContextToLastUser(messages, "extra context");
+    expect(out[0].content).toBe("first");
+    expect(out[2].content).toBe("second\n\nextra context");
+    expect(out[3]).toBe(messages[3]);
+    // Input untouched — the function builds a new array.
+    expect(messages[2].content).toBe("second");
+  });
+
+  it("treats null content as empty when appending", () => {
+    const messages: ProviderMessage[] = [{ role: "user", content: null }];
+    const out = appendContextToLastUser(messages, "only the context");
+    expect(out[0].content).toBe("\n\nonly the context");
+  });
+
+  it("appends a text block when the target content is an array", () => {
+    const messages: ProviderMessage[] = [
+      { role: "user", content: [{ type: "text", text: "look" }] }
+    ];
+    const out = appendContextToLastUser(messages, "memo");
+    expect(out[0].content).toEqual([
+      { type: "text", text: "look" },
+      { type: "text", text: "memo" }
+    ]);
+  });
+});
+
+describe("invokedSkillsSection", () => {
+  const skills = [
+    { name: "Deploy", description: "ship it", content: "  run the deploy  " },
+    { name: "review", description: "look", content: "read the diff" }
+  ];
+
+  it("returns the empty string when the text names no skill", () => {
+    expect(invokedSkillsSection(skills, "just chatting about src/deploy")).toBe(
+      ""
+    );
+  });
+
+  it("formats the bodies of the invoked skills, case-insensitively", () => {
+    const out = invokedSkillsSection(skills, "please /deploy this");
+    expect(out).toContain("## Skill instructions");
+    expect(out).toContain("### /Deploy");
+    expect(out).toContain("run the deploy");
+    expect(out).not.toContain("read the diff");
+  });
+});
+
+describe("attachPlanApproval", () => {
+  const plan: TaskPlan = { title: "plan", tasks: [] };
+
+  it("exposes a callback that forwards the thread id and plan", async () => {
+    const ctx = new ProcessingContext({ jobId: "job-1" });
+    const calls: Array<{ threadId: string | null; plan: TaskPlan }> = [];
+    attachPlanApproval(ctx, "thread-7", async (threadId, p) => {
+      calls.push({ threadId, plan: p });
+      return { decision: "approve" };
+    });
+    const request = ctx.get<RequestPlanApproval>(PLAN_APPROVAL_CONTEXT_KEY);
+    expect(typeof request).toBe("function");
+    await expect(request(plan)).resolves.toEqual({ decision: "approve" });
+    expect(calls).toEqual([{ threadId: "thread-7", plan }]);
+  });
+
+  it("suspends the sandbox clock for the wait and resumes even on rejection", async () => {
+    const ctx = new ProcessingContext({ jobId: "job-2" });
+    let suspended = 0;
+    let resumed = 0;
+    const clock: SandboxClock = {
+      suspend() {
+        suspended++;
+        return () => {
+          resumed++;
+        };
+      },
+      suspendedMs: () => 0
+    };
+    attachPlanApproval(
+      ctx,
+      null,
+      async () => {
+        throw new Error("user closed the dialog");
+      },
+      clock
+    );
+    const request = ctx.get<RequestPlanApproval>(PLAN_APPROVAL_CONTEXT_KEY);
+    await expect(request(plan)).rejects.toThrow("user closed the dialog");
+    expect(suspended).toBe(1);
+    expect(resumed).toBe(1);
+  });
+});
+
+describe("createWorkflowResponseContent", () => {
+  it("answers with a completion note when nothing survives the mapping", () => {
+    expect(createWorkflowResponseContent({})).toEqual([
+      { type: "text", text: "Workflow completed successfully." }
+    ]);
+    expect(
+      createWorkflowResponseContent({ a: null, b: undefined })
+    ).toEqual([{ type: "text", text: "Workflow completed successfully." }]);
+  });
+
+  it("maps strings, lists, scalars, and plain dicts to text content", () => {
+    expect(
+      createWorkflowResponseContent({
+        s: "hello",
+        l: [1, "a", true],
+        n: 42,
+        d: { foo: "bar" }
+      })
+    ).toEqual([
+      { type: "text", text: "hello" },
+      { type: "text", text: "1 a true" },
+      { type: "text", text: "42" },
+      { type: "text", text: '{"foo":"bar"}' }
+    ]);
+  });
+
+  it("maps typed media dicts to media content", () => {
+    expect(
+      createWorkflowResponseContent({
+        i: { type: "image", uri: "asset://i", asset_id: "a1" },
+        v: { type: "video", uri: "asset://v", asset_id: "a2" },
+        a: { type: "audio", uri: "asset://a", asset_id: "a3", data: "zzz" }
+      })
+    ).toEqual([
+      {
+        type: "image",
+        image: { uri: "asset://i", asset_id: "a1", data: undefined }
+      },
+      {
+        type: "video",
+        video: { uri: "asset://v", asset_id: "a2", data: undefined }
+      },
+      {
+        type: "audio",
+        audio: { uri: "asset://a", asset_id: "a3", data: "zzz" }
+      }
+    ]);
+  });
+});
+
+describe("extractTextContent", () => {
+  it("returns a string as-is", () => {
+    expect(extractTextContent("plain")).toBe("plain");
+  });
+
+  it("joins the text items of an array with spaces", () => {
+    expect(
+      extractTextContent([
+        { type: "text", text: "a" },
+        { type: "image", image: {} },
+        { type: "text", text: "b" },
+        { type: "text", text: 7 }
+      ])
+    ).toBe("a b");
+  });
+
+  it("falls back when the array holds no text and for other shapes", () => {
+    expect(extractTextContent([{ type: "image" }], "fb")).toBe("fb");
+    expect(extractTextContent(42, "fb")).toBe("fb");
+    expect(extractTextContent(null)).toBe("");
+  });
+});

--- a/packages/websocket/tests/session-model-interfaces.test.ts
+++ b/packages/websocket/tests/session-model-interfaces.test.ts
@@ -1,0 +1,415 @@
+/**
+ * session/model-interfaces — the server's persistence as one object, against
+ * a real in-memory database. Every closure is called both ways: the row it
+ * should find and the row it must refuse (missing, or another user's).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  Asset,
+  ImageDocument,
+  initTestDb,
+  Message,
+  ModelObserver,
+  Script,
+  TimelineSequence
+} from "@nodetool-ai/models";
+import type { ProcessingContextModelInterfaces } from "@nodetool-ai/runtime";
+import {
+  createRuntimeContext,
+  serverModelInterfaces
+} from "../src/session/model-interfaces.js";
+
+const USER = "user-1";
+const OTHER = "user-2";
+
+/**
+ * The port type narrows every answer to `{id}`; tests re-widen to read the
+ * fields they assert, and fail loudly on an unexpected null.
+ */
+function fields(value: { id: string } | null | undefined): Record<string, unknown> {
+  if (value == null) throw new Error("expected a record, got null");
+  return Object.fromEntries(Object.entries(value));
+}
+
+let ifaces: ProcessingContextModelInterfaces;
+
+beforeEach(() => {
+  initTestDb();
+  ifaces = serverModelInterfaces();
+});
+afterEach(() => ModelObserver.clear());
+
+describe("createMessage / getMessages", () => {
+  it("persists a message with every optional field defaulted to null", async () => {
+    const row = fields(
+      await ifaces.createMessage!({
+        userId: USER,
+        req: { thread_id: "t1", role: "user" }
+      })
+    );
+    expect(row.thread_id).toBe("t1");
+    expect(row.role).toBe("user");
+    expect(row.name).toBeNull();
+    expect(row.content).toBeNull();
+    expect(row.tool_calls).toBeNull();
+    expect(row.tool_call_id).toBeNull();
+    expect(row.workflow_id).toBeNull();
+
+    const stored = await Message.find(String(row.id));
+    expect(stored?.user_id).toBe(USER);
+  });
+
+  it("stores content and tool_calls raw, not double-encoded", async () => {
+    const row = fields(
+      await ifaces.createMessage!({
+        userId: USER,
+        req: {
+          thread_id: "t1",
+          role: "assistant",
+          name: "bot",
+          content: [{ type: "text", text: "hi" }],
+          tool_calls: [{ id: "c1", name: "tool", args: { x: 1 } }],
+          tool_call_id: "c0",
+          workflow_id: "wf-1"
+        }
+      })
+    );
+    const stored = await Message.find(String(row.id));
+    expect(stored?.content).toEqual([{ type: "text", text: "hi" }]);
+    expect(stored?.tool_calls).toEqual([{ id: "c1", name: "tool", args: { x: 1 } }]);
+    expect(stored?.workflow_id).toBe("wf-1");
+  });
+
+  it("scopes a thread's messages to the requesting user", async () => {
+    await seedThread();
+    const result = await ifaces.getMessages!({ userId: USER, threadId: "t1" });
+    expect(result.messages.map((m) => m.id)).toEqual(["m1", "m2", "m3"]);
+    expect(result.next).toBeNull();
+  });
+
+  it("pages forward through the thread via the returned cursor", async () => {
+    await seedThread();
+    const first = await ifaces.getMessages!({
+      userId: USER,
+      threadId: "t1",
+      limit: 2
+    });
+    expect(first.messages.map((m) => m.id)).toEqual(["m1", "m2"]);
+    expect(first.next).toBe("m2");
+
+    const second = await ifaces.getMessages!({
+      userId: USER,
+      threadId: "t1",
+      limit: 2,
+      startKey: first.next
+    });
+    // m4 belongs to the other user and is filtered after pagination.
+    expect(second.messages.map((m) => m.id)).toEqual(["m3"]);
+    expect(second.next).toBeNull();
+  });
+
+  it("reads newest-first when reverse is set", async () => {
+    await seedThread();
+    const page = await ifaces.getMessages!({
+      userId: USER,
+      threadId: "t1",
+      limit: 2,
+      reverse: true
+    });
+    // Desc order is m4 (other user, filtered), m3; the cursor is the last
+    // paginated row, not the last owned one.
+    expect(page.messages.map((m) => m.id)).toEqual(["m3"]);
+    expect(page.next).toBe("m3");
+  });
+
+  async function seedThread(): Promise<void> {
+    const at = (n: number) => `2026-01-01T00:00:0${n}.000Z`;
+    await Message.create({ id: "m1", user_id: USER, thread_id: "t1", role: "user", created_at: at(1) });
+    await Message.create({ id: "m2", user_id: USER, thread_id: "t1", role: "assistant", created_at: at(2) });
+    await Message.create({ id: "m3", user_id: USER, thread_id: "t1", role: "user", created_at: at(3) });
+    await Message.create({ id: "m4", user_id: OTHER, thread_id: "t1", role: "user", created_at: at(4) });
+  }
+});
+
+describe("listFolderAssets / getAssetInfo", () => {
+  it("answers null for a missing folder and for a non-folder id", async () => {
+    expect(
+      await ifaces.listFolderAssets!({ userId: USER, folderId: "nope" })
+    ).toBeNull();
+    await Asset.create({ id: "f1", user_id: USER, name: "a.png", content_type: "image/png" });
+    expect(
+      await ifaces.listFolderAssets!({ userId: USER, folderId: "f1" })
+    ).toBeNull();
+  });
+
+  it("lists files recursively, sorted by name, surviving a parent cycle", async () => {
+    // Distinct created_at, newest-first traversal order (zebra before the
+    // subfolder holding apple) — so the sorted output proves the sort ran.
+    const at = (n: number) => `2026-01-01T00:00:0${n}.000Z`;
+    await Asset.create({ id: "dirA", user_id: USER, name: "A", content_type: "folder", parent_id: "dirB", created_at: at(1) });
+    await Asset.create({ id: "dirB", user_id: USER, name: "B", content_type: "folder", parent_id: "dirA", created_at: at(2) });
+    await Asset.create({ id: "z", user_id: USER, name: "zebra.txt", content_type: "text/plain", parent_id: "dirA", created_at: at(3) });
+    await Asset.create({ id: "a", user_id: USER, name: "apple.txt", content_type: "text/plain", parent_id: "dirB", created_at: at(4) });
+
+    const out = await ifaces.listFolderAssets!({ userId: USER, folderId: "dirA" });
+    expect(out).toEqual([
+      { id: "a", content_type: "text/plain", name: "apple.txt" },
+      { id: "z", content_type: "text/plain", name: "zebra.txt" }
+    ]);
+  });
+
+  it("reads one asset's identity, defaulting missing metadata to null", async () => {
+    await Asset.create({ id: "a1", user_id: USER, name: "pic.png", content_type: "image/png" });
+    await Asset.create({
+      id: "a2",
+      user_id: USER,
+      name: "tagged.png",
+      content_type: "image/png",
+      metadata: { alt: "hi" }
+    });
+
+    expect(await ifaces.getAssetInfo!({ userId: USER, assetId: "a1" })).toEqual({
+      id: "a1",
+      content_type: "image/png",
+      name: "pic.png",
+      metadata: null
+    });
+    expect(
+      (await ifaces.getAssetInfo!({ userId: USER, assetId: "a2" }))?.metadata
+    ).toEqual({ alt: "hi" });
+    expect(await ifaces.getAssetInfo!({ userId: USER, assetId: "missing" })).toBeNull();
+    expect(await ifaces.getAssetInfo!({ userId: OTHER, assetId: "a1" })).toBeNull();
+  });
+});
+
+describe("image documents", () => {
+  const doc = { sketch: { version: 3 }, layerBindings: [] };
+
+  it("creates a document, defaulting the project", async () => {
+    const created = fields(
+      await ifaces.createImageDocument!({
+        userId: USER,
+        name: "Sketch",
+        width: 640,
+        height: 480,
+        document: doc
+      })
+    );
+    expect(created.projectId).toBe("default");
+    expect(created.width).toBe(640);
+    expect(created.document).toEqual(doc);
+
+    const explicit = fields(
+      await ifaces.createImageDocument!({
+        userId: USER,
+        name: "Sketch 2",
+        projectId: "p9",
+        width: 10,
+        height: 10,
+        document: doc
+      })
+    );
+    expect(explicit.projectId).toBe("p9");
+  });
+
+  it("reads only the owner's document", async () => {
+    const created = await ifaces.createImageDocument!({
+      userId: USER,
+      name: "Mine",
+      width: 8,
+      height: 8,
+      document: doc
+    });
+    const id = created.id;
+    expect(fields(await ifaces.getImageDocument!({ userId: USER, id })).name).toBe(
+      "Mine"
+    );
+    expect(await ifaces.getImageDocument!({ userId: OTHER, id })).toBeNull();
+    expect(await ifaces.getImageDocument!({ userId: USER, id: "missing" })).toBeNull();
+    expect(await ImageDocument.findById(id)).not.toBeNull();
+  });
+});
+
+describe("timeline sequences", () => {
+  function seq(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      projectId: "p1",
+      name: "Cut",
+      fps: 30,
+      width: 1920,
+      height: 1080,
+      durationMs: 1000,
+      tracks: [],
+      clips: [],
+      markers: [],
+      ...overrides
+    };
+  }
+
+  it("creates and reads back a sequence, owner-scoped", async () => {
+    const created = fields(
+      await ifaces.createTimelineSequence!({ userId: USER, sequence: seq() })
+    );
+    expect(created.name).toBe("Cut");
+    const id = String(created.id);
+    expect(
+      fields(await ifaces.getTimelineSequence!({ userId: USER, id })).fps
+    ).toBe(30);
+    expect(await ifaces.getTimelineSequence!({ userId: OTHER, id })).toBeNull();
+    expect(await ifaces.getTimelineSequence!({ userId: USER, id: "missing" })).toBeNull();
+  });
+
+  it("updates via CAS on the sequence's updatedAt, refusing stale writes", async () => {
+    const created = fields(
+      await ifaces.createTimelineSequence!({ userId: USER, sequence: seq() })
+    );
+    const id = String(created.id);
+
+    const updated = fields(
+      await ifaces.updateTimelineSequence!({
+        userId: USER,
+        id,
+        sequence: seq({ name: "Recut", durationMs: 2000, updatedAt: created.updatedAt })
+      })
+    );
+    expect(updated.name).toBe("Recut");
+    expect(updated.durationMs).toBe(2000);
+
+    const stale = await ifaces.updateTimelineSequence!({
+      userId: USER,
+      id,
+      sequence: seq({ name: "Clobber", updatedAt: created.updatedAt })
+    });
+    expect(stale).toBeNull();
+    expect((await TimelineSequence.findById(id))?.name).toBe("Recut");
+  });
+
+  it("refuses updates on missing sequences and other users' sequences", async () => {
+    expect(
+      await ifaces.updateTimelineSequence!({ userId: USER, id: "missing", sequence: seq() })
+    ).toBeNull();
+    const created = fields(
+      await ifaces.createTimelineSequence!({ userId: USER, sequence: seq() })
+    );
+    expect(
+      await ifaces.updateTimelineSequence!({
+        userId: OTHER,
+        id: String(created.id),
+        sequence: seq({ updatedAt: created.updatedAt })
+      })
+    ).toBeNull();
+  });
+});
+
+describe("scripts", () => {
+  const doc = { cast: [], sections: [] };
+
+  it("creates with defaults for name and project", async () => {
+    const bare = fields(await ifaces.createScript!({ userId: USER, document: doc }));
+    expect(bare.name).toBe("Untitled script");
+    expect(bare.projectId).toBe("default");
+
+    const named = fields(
+      await ifaces.createScript!({
+        userId: USER,
+        name: "Trailer",
+        projectId: "p2",
+        document: doc
+      })
+    );
+    expect(named.name).toBe("Trailer");
+    expect(named.projectId).toBe("p2");
+  });
+
+  it("reads only the owner's script", async () => {
+    const created = await ifaces.createScript!({ userId: USER, document: doc });
+    const id = created.id;
+    expect(fields(await ifaces.getScript!({ userId: USER, id })).id).toBe(id);
+    expect(await ifaces.getScript!({ userId: OTHER, id })).toBeNull();
+    expect(await ifaces.getScript!({ userId: USER, id: "missing" })).toBeNull();
+  });
+
+  it("patches document and timeline link independently", async () => {
+    const created = await ifaces.createScript!({ userId: USER, document: doc });
+    const id = created.id;
+
+    const withDoc = fields(
+      await ifaces.updateScript!({
+        userId: USER,
+        id,
+        document: { cast: [], sections: [{ id: "s1" }] }
+      })
+    );
+    expect(withDoc.document).toEqual({ cast: [], sections: [{ id: "s1" }] });
+
+    const withTimeline = fields(
+      await ifaces.updateScript!({ userId: USER, id, timelineId: "tl-1" })
+    );
+    expect(withTimeline.timelineId).toBe("tl-1");
+    // The document-only patch above must have left the doc alone here.
+    expect(withTimeline.document).toEqual({ cast: [], sections: [{ id: "s1" }] });
+
+    expect((await Script.findById(id))?.timeline_id).toBe("tl-1");
+  });
+
+  it("refuses a stale baseUpdatedAt, a missing id, and another user's script", async () => {
+    const created = await ifaces.createScript!({ userId: USER, document: doc });
+    const id = created.id;
+
+    expect(
+      await ifaces.updateScript!({
+        userId: USER,
+        id,
+        document: doc,
+        baseUpdatedAt: "2000-01-01T00:00:00.000Z"
+      })
+    ).toBeNull();
+    expect(
+      await ifaces.updateScript!({ userId: USER, id: "missing", document: doc })
+    ).toBeNull();
+    expect(
+      await ifaces.updateScript!({ userId: OTHER, id, document: doc })
+    ).toBeNull();
+  });
+});
+
+describe("createRuntimeContext", () => {
+  it("builds a context with the server persistence installed", () => {
+    const ctx = createRuntimeContext({
+      jobId: "job-1",
+      userId: USER,
+      workspace: null
+    });
+    expect(ctx.jobId).toBe("job-1");
+    expect(ctx.userId).toBe(USER);
+    expect(ctx.workflowId).toBeNull();
+    expect(ctx.threadId).toBeNull();
+    expect(ctx.workspace).toBeNull();
+    expect(ctx.workspaceDir).toBeNull();
+    expect(ctx.assetOutputMode).toBe("native");
+    // The interfaces under test, wired via setModelInterfaces.
+    expect(ctx.hasModelInterface("createMessage")).toBe(true);
+    expect(ctx.hasModelInterface("createAsset")).toBe(true);
+    expect(ctx.hasModelInterface("updateScript")).toBe(true);
+    expect(ctx.hasModelInterface("getJob")).toBe(false);
+  });
+
+  it("passes through workflow, thread, auth and output-mode options", () => {
+    const ctx = createRuntimeContext({
+      jobId: "job-2",
+      workflowId: "wf-1",
+      threadId: "t-1",
+      userId: USER,
+      workspace: null,
+      authToken: "tok",
+      assetOutputMode: "data_uri",
+      persistOutputAssets: false
+    });
+    expect(ctx.workflowId).toBe("wf-1");
+    expect(ctx.threadId).toBe("t-1");
+    expect(ctx.authToken).toBe("tok");
+    expect(ctx.assetOutputMode).toBe("data_uri");
+    expect(ctx.persistOutputAssets).toBe(false);
+  });
+});

--- a/packages/websocket/tests/session-sanitize.test.ts
+++ b/packages/websocket/tests/session-sanitize.test.ts
@@ -1,0 +1,139 @@
+/**
+ * session/sanitize — error text that reaches a client frame.
+ *
+ * The module exists to keep secrets and huge blobs out of error text, so the
+ * cases here are adversarial: real data URIs that must be redacted, text at
+ * and past the truncation boundary, thrown values that are not Errors,
+ * cyclic objects, and values JSON.stringify cannot serialize.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  formatSanitizedError,
+  sanitizeLargeText
+} from "../src/session/sanitize.js";
+
+const MAX = 4000; // MAX_ERROR_TEXT_LENGTH in sanitize.ts
+
+describe("sanitizeLargeText", () => {
+  it("redacts a base64 data URI, naming its mime type and length", () => {
+    const uri = `data:image/png;base64,${"iVBORw0KGgoAAAANSUhEUg".repeat(10)}`;
+    const out = sanitizeLargeText(`upload failed for ${uri} today`);
+    expect(out).toBe(
+      `upload failed for [image/png base64 omitted, ${uri.length} chars] today`
+    );
+    expect(out).not.toContain("base64,iVBOR");
+  });
+
+  it("falls back to 'data' when the URI carries no mime type", () => {
+    const uri = "data:;base64,QUJDRA==";
+    expect(sanitizeLargeText(`x ${uri}`)).toBe(
+      `x [data base64 omitted, ${uri.length} chars]`
+    );
+  });
+
+  it("redacts every data URI in the text, not just the first", () => {
+    const a = "data:audio/wav;base64,AAAA";
+    const b = "data:video/mp4;base64,BBBB";
+    const out = sanitizeLargeText(`${a} and ${b}`);
+    expect(out).toBe(
+      `[audio/wav base64 omitted, ${a.length} chars] and ` +
+        `[video/mp4 base64 omitted, ${b.length} chars]`
+    );
+  });
+
+  it("returns text exactly at the limit unchanged", () => {
+    const text = "a".repeat(MAX);
+    expect(sanitizeLargeText(text)).toBe(text);
+  });
+
+  it("truncates one character past the limit and says how much was cut", () => {
+    const text = "a".repeat(MAX + 1);
+    const out = sanitizeLargeText(text);
+    expect(out).toBe(`${"a".repeat(MAX)}... (truncated 1 chars)`);
+  });
+
+  it("honors a caller-supplied max length", () => {
+    expect(sanitizeLargeText("abcdef", 3)).toBe("abc... (truncated 3 chars)");
+  });
+
+  it("redacts before measuring, so a huge data URI does not force truncation", () => {
+    const uri = `data:application/octet-stream;base64,${"A".repeat(10_000)}`;
+    const out = sanitizeLargeText(`payload: ${uri}`);
+    expect(out).toBe(
+      `payload: [application/octet-stream base64 omitted, ${uri.length} chars]`
+    );
+    expect(out.length).toBeLessThan(MAX);
+  });
+});
+
+describe("formatSanitizedError", () => {
+  it("maps a nullish error to the empty string, never the text 'null'", () => {
+    expect(formatSanitizedError(null)).toBe("");
+    expect(formatSanitizedError(undefined)).toBe("");
+  });
+
+  it("sanitizes a plain string error", () => {
+    const uri = "data:text/plain;base64,c2VjcmV0";
+    expect(formatSanitizedError(`boom ${uri}`)).toBe(
+      `boom [text/plain base64 omitted, ${uri.length} chars]`
+    );
+  });
+
+  it("uses an Error's message and truncates it", () => {
+    const err = new Error("x".repeat(MAX + 5));
+    expect(formatSanitizedError(err)).toBe(
+      `${"x".repeat(MAX)}... (truncated 5 chars)`
+    );
+  });
+
+  it("serializes an object error, reducing nested Errors and redacting nested URIs", () => {
+    const uri = "data:image/jpeg;base64,QUFBQQ==";
+    const parsed = JSON.parse(
+      formatSanitizedError({
+        cause: new Error("inner failure"),
+        blob: `see ${uri}`,
+        list: [1, "ok", null, new Error("in list")],
+        count: 3,
+        flag: true,
+        nothing: null
+      })
+    ) as Record<string, unknown>;
+    expect(parsed).toEqual({
+      cause: "inner failure",
+      blob: `see [image/jpeg base64 omitted, ${uri.length} chars]`,
+      list: [1, "ok", null, "in list"],
+      count: 3,
+      flag: true,
+      nothing: null
+    });
+  });
+
+  it("serializes a top-level array error", () => {
+    expect(formatSanitizedError([new Error("e1"), 2])).toBe('["e1",2]');
+  });
+
+  it("replaces a cycle with [circular] instead of throwing", () => {
+    const cyclic: Record<string, unknown> = { name: "loop" };
+    cyclic.self = cyclic;
+    expect(JSON.parse(formatSanitizedError(cyclic))).toEqual({
+      name: "loop",
+      self: "[circular]"
+    });
+  });
+
+  it("stringifies a thrown scalar that is not an Error", () => {
+    expect(formatSanitizedError(42)).toBe("42");
+    expect(formatSanitizedError(false)).toBe("false");
+  });
+
+  it("falls back to String(error) when JSON serialization fails", () => {
+    // JSON.stringify throws on BigInt; the catch path must still answer.
+    expect(formatSanitizedError(10n)).toBe("10");
+    expect(formatSanitizedError({ n: 10n })).toBe("[object Object]");
+  });
+
+  it("survives a symbol, which JSON.stringify erases to undefined", () => {
+    expect(formatSanitizedError(Symbol("weird"))).toBe("Symbol(weird)");
+  });
+});


### PR DESCRIPTION
## What changed

Three new test files for the near-pure modules the `UnifiedWebSocketRunner` split extracted into `packages/websocket/src/session/` — the least-covered files in the package. `session-sanitize.test.ts` feeds the error sanitizer adversarial inputs: real base64 data URIs that must be redacted (with the mime name and length), text exactly at and one past the 4000-char truncation boundary, thrown non-`Error` values, cyclic objects, and values `JSON.stringify` cannot carry (BigInt, Symbol). `session-chat-history.test.ts` takes both sides of every decision in the stored-message → provider-message conversions, `appendContextToLastUser`, the invoked-skills section, the plan-approval attachment (including clock resume on rejection), and the workflow-result → content mapping. `session-model-interfaces.test.ts` runs `serverModelInterfaces()` against a real in-memory database (`initTestDb`, no module mocking): owner scoping on every read, pagination cursors forward and reverse, CAS conflict paths for timelines and scripts, the folder-cycle guard, raw (not double-encoded) message content, and `createRuntimeContext` wiring. No production code changed.

Branch coverage on the targets, from the full-suite run (`--coverage.include='src/session/**' --coverage.include='src/unified-websocket-runner.ts'`):

| File | % Stmts before → after | % Branch before → after |
|---|---|---|
| `src/session/model-interfaces.ts` | 8.45 → 100 | 0 → 100 |
| `src/session/sanitize.ts` | 32.43 → 97.29 | 26.92 → 96.15 |
| `src/session/chat-history.ts` | 74.62 → 100 | 67.24 → 100 |

The one uncovered line in `sanitize.ts` (line 87, `if (isString(sanitized)) return sanitized;` in `formatSanitizedError`) is unreachable: string and `Error` inputs return before `sanitizeErrorValue` is called, and `sanitizeErrorValue` produces a string only for those two input shapes.

**CI note:** `test.yml` is `pull_request: branches: [main]`, so the Quality Gate does not run against this base branch. The local results below are the real evidence.

## Verification

- [x] Full websocket suite with coverage: **241 test files / 2679 tests, 0 failures** (2,621 tests before this change, +58 added)
- [x] `npm run lint --workspace=packages/websocket` (`tsc --noEmit`) — clean
- [x] `oxlint` (package config and `.oxlintrc.anti-slop-enforced.json`) on the three new files — clean; no module mocking, no `any`
- [ ] `npm run typecheck` — the web and electron legs are unaffected; the mobile leg fails in this worktree with pre-existing module-resolution errors (`mobile/node_modules` is not provisioned; per AGENTS.md this failure predates the change and the diff touches only `packages/websocket/tests/`)

**Mutation evidence** — each production file was mutated once per decision family, the named test observed failing, and the file restored (`git status` clean before commit):

| Mutation | Failing test |
|---|---|
| `sanitize.ts`: replacement returns the raw match (redaction dropped) | 6 failures, e.g. `redacts a base64 data URI, naming its mime type and length` |
| `sanitize.ts`: `<=` → `<` at the truncation boundary | `returns text exactly at the limit unchanged` |
| `sanitize.ts`: `== null` → `=== null` | `maps a nullish error to the empty string, never the text 'null'` |
| `sanitize.ts`: `[circular]` marker changed | `replaces a cycle with [circular] instead of throwing` |
| `sanitize.ts`: catch fallback returns `""` | `survives a symbol, which JSON.stringify erases to undefined` (+1) |
| `sanitize.ts`: truncated-chars count miscomputed | 3 failures incl. `honors a caller-supplied max length` |
| `chat-history.ts`: role allowlist widened | `drops messages with non-provider roles` |
| `chat-history.ts`: `thought_signature` string guard loosened | `copies tool calls, carrying thought_signature only when it is a string` |
| `chat-history.ts`: last-user search flipped to first-user | `appends to the last user message's string content, not an earlier one` |
| `chat-history.ts`: null-value skip removed in `createWorkflowResponseContent` | `answers with a completion note when nothing survives the mapping` |
| `chat-history.ts`: `extractTextContent` fallback removed | `falls back when the array holds no text and for other shapes` |
| `chat-history.ts`: invoked-skill filter removed | `formats the bodies of the invoked skills, case-insensitively` |
| `chat-history.ts`: clock resume dropped in `attachPlanApproval` | `suspends the sandbox clock for the wait and resumes even on rejection` |
| `model-interfaces.ts`: `getMessages` user filter removed | 3 failures incl. `scopes a thread's messages to the requesting user` |
| `model-interfaces.ts`: cycle-guard condition inverted | `lists files recursively, sorted by name, surviving a parent cycle` (deleting the guard outright hangs the run — better-sqlite3 is synchronous, so the infinite recursion never yields to the test timeout; the inverted condition is the terminating proof) |
| `model-interfaces.ts`: folder content-type check dropped | `answers null for a missing folder and for a non-folder id` |
| `model-interfaces.ts`: timeline CAS compares `existing.updated_at` instead of the caller's | `updates via CAS on the sequence's updatedAt, refusing stale writes` |
| `model-interfaces.ts`: script ownership check dropped | `reads only the owner's script` |
| `model-interfaces.ts`: script document patch replaced with a constant | `patches document and timeline link independently` |
| `model-interfaces.ts`: script CAS default swapped for epoch | `patches document and timeline link independently` |
| `model-interfaces.ts`: message content double-encoded | 2 failures incl. `stores content and tool_calls raw, not double-encoded` |
| `model-interfaces.ts`: `setModelInterfaces` call removed from `createRuntimeContext` | `builds a context with the server persistence installed` |
| `model-interfaces.ts`: asset metadata forced to null | `reads one asset's identity, defaulting missing metadata to null` |
| `model-interfaces.ts`: folder sort removed | `lists files recursively, sorted by name, surviving a parent cycle` (the fixture stamps distinct `created_at` so traversal order differs from name order — with tied timestamps this was an equivalent mutant) |

Two mutants were equivalent and replaced with observable ones: removing the `invoked.length === 0` early return (the formatter already returns `""` for an empty list) and unconditional `fields.document` assignment (drizzle ignores `undefined` in `set`).

## Agent capabilities

Skipped — no capability added, no capability contract changed.

## New checks

- [x] Every meaningful test was inverted once (via a production-code mutation, restored afterward) and observed failing; the table above names each mutation and its failing test
- [x] Not an audit — no matching-nothing failure mode

## Not covered, and why

- `sanitize.ts` line 87 — unreachable, reasoning above.
- `model-interfaces.ts` reached 100%, but note `createAsset`/`updateAssetBytes` are re-exports from `lib/asset-model-interface.ts` (covered elsewhere); the tests here assert they are wired, not their internals.

## Observation (not asserted, not fixed)

`sanitizeErrorValue` marks a *shared* (non-cyclic) reference as `[circular]`: the `WeakSet` records every visited object, so `{a: shared, b: shared}` renders `b` as `"[circular]"`. Harmless for error text, but the marker overstates what it found; no test pins that behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrkYim9kcnJnvqhC8RWNoc)_