### PR TITLE
test(websocket): cover ChatTurnHandler supersede, media, error, and job branches

### DIFF
--- a/packages/websocket/tests/chat-turn-handler-errors.test.ts
+++ b/packages/websocket/tests/chat-turn-handler-errors.test.ts
@@ -1,0 +1,341 @@
+/**
+ * The plain-chat turn's failure and routing branches: provider errors
+ * classified into connection / HTTP-status / generic frames, the tool router
+ * (`executeTool`) a provider drives, the superseded drain cap, and the
+ * volatile memory block the turn pastes into its last user message.
+ *
+ * Each test runs a full `handleChatMessage` turn against a provider double
+ * whose `generateLoop` the test scripts.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { initTestDb, Memory, Message } from "@nodetool-ai/models";
+import { SUPERSEDED_TOOL_RESULT } from "../src/chat-tool-call-repair.js";
+import { unroutableToolMessage } from "../src/session/chat-prompt.js";
+import {
+  makeChatTurnHarness,
+  fakeProvider,
+  type ChatTurnHarness,
+  type GenerateLoopArgs
+} from "./chat-turn-test-harness.js";
+
+function chatTurn(threadId: string, content = "hi"): Record<string, unknown> {
+  return { thread_id: threadId, content, provider: "mock", model: "m" };
+}
+
+function throwingProvider(error: unknown): ChatTurnHarness {
+  return makeChatTurnHarness({
+    session: {
+      resolveProvider: async () =>
+        fakeProvider({
+          // eslint-disable-next-line require-yield
+          generateLoop: async function* () {
+            throw error;
+          }
+        })
+    }
+  });
+}
+
+function errorFrame(harness: ChatTurnHarness): Record<string, unknown> {
+  const frames = harness.session.messagesOfType("error");
+  expect(frames).toHaveLength(1);
+  return frames[0];
+}
+
+async function assistantErrorRow(threadId: string): Promise<string> {
+  const [rows] = await Message.paginate(threadId, { limit: 10 });
+  const assistant = rows.find((m) => m.role === "assistant");
+  expect(assistant).toBeDefined();
+  return String(assistant?.content ?? "");
+}
+
+describe("provider error classification", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("classifies ECONNREFUSED as a connection error", async () => {
+    const harness = throwingProvider(
+      new Error("connect ECONNREFUSED 127.0.0.1:11434")
+    );
+    await harness.handler.handleChatMessage(chatTurn("t-err-conn"));
+    const frame = errorFrame(harness);
+    expect(frame.error_type).toBe("connection_error");
+    expect(String(frame.message)).toMatch(/^Connection error: /);
+    // Done chunk still arrives, and the failure is persisted as a turn.
+    expect(
+      harness.session.messagesOfType("chunk").some((c) => c.done === true)
+    ).toBe(true);
+    expect(await assistantErrorRow("t-err-conn")).toContain(
+      "connection error"
+    );
+  });
+
+  it("explains an unresolvable hostname", async () => {
+    const harness = throwingProvider(
+      new Error("getaddrinfo ENOTFOUND api.example.com")
+    );
+    await harness.handler.handleChatMessage(chatTurn("t-err-dns"));
+    const frame = errorFrame(harness);
+    expect(frame.error_type).toBe("connection_error");
+    expect(String(frame.message)).toContain("Unable to resolve hostname");
+  });
+
+  it.each([
+    [400, /^Bad request: /],
+    [401, /^Authentication failed/],
+    [403, /^Access forbidden/],
+    [404, /^Not found/],
+    [429, /^Rate limited/],
+    [503, /^Server error \(503\)/],
+    [418, /^HTTP error \(418\)/]
+  ])("formats HTTP %d", async (status, pattern) => {
+    const harness = throwingProvider(
+      Object.assign(new Error(`upstream ${status}`), { status })
+    );
+    await harness.handler.handleChatMessage(chatTurn(`t-err-${status}`));
+    const frame = errorFrame(harness);
+    expect(frame.error_type).toBe("http_status_error");
+    expect(frame.status_code).toBe(status);
+    expect(String(frame.message)).toMatch(pattern);
+    expect(await assistantErrorRow(`t-err-${status}`)).toContain(
+      `API error (HTTP ${status})`
+    );
+  });
+
+  it("prefers the message the response body carried", async () => {
+    const harness = throwingProvider(
+      Object.assign(new Error("500 from upstream"), {
+        status: 500,
+        body: { error: { message: "billing hard cap reached" } }
+      })
+    );
+    await harness.handler.handleChatMessage(chatTurn("t-err-body"));
+    const frame = errorFrame(harness);
+    expect(frame.message).toBe("billing hard cap reached");
+    expect(frame.status_code).toBe(500);
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const harness = throwingProvider("the provider said no");
+    await harness.handler.handleChatMessage(chatTurn("t-err-string"));
+    const frame = errorFrame(harness);
+    expect(frame.error_type).toBe("error");
+    expect(frame.message).toBe("the provider said no");
+    expect(await assistantErrorRow("t-err-string")).toContain(
+      "I encountered an error: the provider said no"
+    );
+  });
+});
+
+describe("tool routing through executeTool", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("round-trips a client tool through the bridge and prefers the renderer for document tools", async () => {
+    const routed: unknown[] = [];
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            generateLoop: async function* (args: GenerateLoopArgs) {
+              routed.push(
+                await args.executeTool?.({
+                  id: "call_client",
+                  name: "my_client_tool",
+                  args: { a: 1 }
+                })
+              );
+              routed.push(
+                await args.executeTool?.({
+                  id: "call_doc",
+                  name: "ui_get_graph",
+                  args: {}
+                })
+              );
+              yield { type: "chunk", content: "ok", done: true };
+            }
+          })
+      },
+      deps: {
+        clientTools: () => ({
+          my_client_tool: {
+            description: "a client tool",
+            parameters: { type: "object", properties: {} }
+          },
+          // ui_get_graph is also a server tool; the renderer must win.
+          ui_get_graph: {
+            description: "live graph",
+            inputSchema: { type: "object", properties: {} }
+          }
+        })
+      }
+    });
+
+    const turnDone = harness.handler.handleChatMessage(chatTurn("t-tools"));
+
+    await vi.waitFor(() => {
+      expect(
+        harness.session
+          .messagesOfType("tool_call")
+          .some((f) => f.tool_call_id === "call_client")
+      ).toBe(true);
+    });
+    harness.handler.resolveToolResult("call_client", {
+      result: { ok: true }
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        harness.session
+          .messagesOfType("tool_call")
+          .some((f) => f.tool_call_id === "call_doc")
+      ).toBe(true);
+    });
+    harness.handler.resolveToolResult("call_doc", { content: "graph-here" });
+
+    await turnDone;
+    expect(routed[0]).toBe(JSON.stringify({ ok: true }));
+    expect(routed[1]).toBe("graph-here");
+  });
+
+  it("answers an unroutable tool call instead of throwing", async () => {
+    let observed: unknown;
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            generateLoop: async function* (args: GenerateLoopArgs) {
+              // The `tools.` prefix a CodeAct-primed model sometimes emits
+              // must be stripped before routing.
+              observed = await args.executeTool?.({
+                id: "call_bogus",
+                name: "tools.bogus_tool",
+                args: {}
+              });
+              yield { type: "chunk", content: "ok", done: true };
+            }
+          })
+      }
+    });
+    await harness.handler.handleChatMessage(chatTurn("t-tools-bogus"));
+    expect(observed).toBe(
+      JSON.stringify({ error: unroutableToolMessage("bogus_tool") })
+    );
+  });
+});
+
+describe("superseded turn drain cap", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("stops reading a provider that keeps producing and stands in for the open call", async () => {
+    let yielded = 0;
+    let releaseFlood!: () => void;
+    const floodGate = new Promise<void>((r) => {
+      releaseFlood = r;
+    });
+    let announceCall!: () => void;
+    const callAnnounced = new Promise<void>((r) => {
+      announceCall = r;
+    });
+
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            generateLoop: async function* () {
+              yield {
+                type: "message",
+                message: {
+                  role: "assistant",
+                  content: null,
+                  toolCalls: [
+                    { id: "call_open", name: "some_tool", args: {} }
+                  ]
+                }
+              };
+              announceCall();
+              await floodGate;
+              // A provider that ignores the abort: it floods chunks and never
+              // answers the tool call.
+              for (let i = 0; i < 1000; i++) {
+                yielded++;
+                yield { type: "chunk", content: `c${i}`, done: false };
+              }
+            }
+          })
+      }
+    });
+
+    const threadId = "t-drain";
+    const turnDone = harness.handler.handleChatMessage(
+      chatTurn(threadId),
+      harness.handler.currentRequestSeq
+    );
+    await callAnnounced;
+    // A newer message supersedes the turn.
+    harness.handler.bumpRequestSeq();
+    releaseFlood();
+    await turnDone;
+
+    // The drain cap (200) stopped the read well short of the flood.
+    expect(yielded).toBeLessThan(300);
+    // No completion chunk for a turn the user abandoned.
+    expect(
+      harness.session.messagesOfType("chunk").filter((c) => c.done === true)
+    ).toHaveLength(0);
+    // The open call got its stand-in row so the thread stays well-formed.
+    const [rows] = await Message.paginate(threadId, { limit: 20 });
+    const standIn = rows.find(
+      (m) => m.role === "tool" && m.tool_call_id === "call_open"
+    );
+    expect(standIn?.content).toBe(SUPERSEDED_TOOL_RESULT);
+  });
+});
+
+describe("the turn's volatile memory block", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("pastes this thread's memories into the last user message", async () => {
+    const threadId = "t-mem";
+    await Memory.create({
+      user_id: "1",
+      thread_id: threadId,
+      kind: "note",
+      title: "palette locked",
+      content: "the campaign grade is teal-orange"
+    });
+    await Memory.create({
+      user_id: "1",
+      thread_id: "some-other-thread",
+      kind: "note",
+      title: "elsewhere",
+      content: "unrelated"
+    });
+
+    let seen: GenerateLoopArgs["messages"] = [];
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            generateLoop: async function* (args: GenerateLoopArgs) {
+              seen = args.messages;
+              yield { type: "chunk", content: "ok", done: true };
+            }
+          })
+      }
+    });
+    await harness.handler.handleChatMessage(chatTurn(threadId));
+
+    const wire = JSON.stringify(seen);
+    // This thread's memory rides in full; the other thread's only as a count,
+    // never by content.
+    expect(wire).toContain("the campaign grade is teal-orange");
+    expect(wire).not.toContain("unrelated");
+  });
+});

--- a/packages/websocket/tests/chat-turn-handler-lifecycle.test.ts
+++ b/packages/websocket/tests/chat-turn-handler-lifecycle.test.ts
@@ -1,0 +1,281 @@
+/**
+ * ChatTurnHandler turn lifecycle: the seq/abort pair `beginTurn` hands out,
+ * supersede-by-new-turn, `cancel`/`endTurn` controller bookkeeping, the
+ * permission-mode switch, plan approval round-trips, and provider-call cost
+ * logging. All through the public surface, against {@link FakeClientSession}.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { initTestDb, Prediction } from "@nodetool-ai/models";
+import type { TaskPlan } from "@nodetool-ai/agents";
+import { makeChatTurnHarness, fakeProvider } from "./chat-turn-test-harness.js";
+
+/** Let the handler's awaited send land before reading recorded frames. */
+const tick = (): Promise<void> => new Promise((r) => setImmediate(r));
+
+describe("turn lifecycle", () => {
+  it("beginTurn aborts the previous turn and bumps the seq", () => {
+    const { handler } = makeChatTurnHarness();
+    const t1 = handler.beginTurn();
+    expect(t1.signal.aborted).toBe(false);
+    const t2 = handler.beginTurn();
+    expect(t1.signal.aborted).toBe(true);
+    expect(t2.signal.aborted).toBe(false);
+    expect(t2.seq).toBe(t1.seq + 1);
+    expect(handler.currentRequestSeq).toBe(t2.seq);
+  });
+
+  it("bumpRequestSeq advances the seq without aborting the live turn", () => {
+    const { handler } = makeChatTurnHarness();
+    const t1 = handler.beginTurn();
+    handler.bumpRequestSeq();
+    expect(handler.currentRequestSeq).toBe(t1.seq + 1);
+    expect(t1.signal.aborted).toBe(false);
+  });
+
+  it("cancel aborts the in-flight turn and is idempotent", () => {
+    const { handler } = makeChatTurnHarness();
+    const t1 = handler.beginTurn();
+    handler.cancel();
+    expect(t1.signal.aborted).toBe(true);
+    // Second cancel with no live controller must not throw.
+    handler.cancel();
+  });
+
+  it("endTurn retires only the current controller", () => {
+    const { handler } = makeChatTurnHarness();
+    const t1 = handler.beginTurn();
+    const t2 = handler.beginTurn();
+    // Retiring the superseded turn's controller must not clear the live one:
+    // a later Stop still has to abort turn 2.
+    handler.endTurn(t1.controller);
+    handler.cancel();
+    expect(t2.signal.aborted).toBe(true);
+  });
+
+  it("endTurn on the current controller makes a later cancel a no-op", () => {
+    const { handler } = makeChatTurnHarness();
+    const t1 = handler.beginTurn();
+    handler.endTurn(t1.controller);
+    handler.cancel();
+    // The turn finished on its own; nothing was left to abort.
+    expect(t1.signal.aborted).toBe(false);
+  });
+});
+
+describe("permission mode and tool results", () => {
+  it("switching a thread to auto releases every approval waiting on it", async () => {
+    const { handler, approvalBridge } = makeChatTurnHarness();
+    const waiting = approvalBridge.createWaiter("appr_1", 0, "thread-a");
+    const otherThread = approvalBridge.createWaiter("appr_2", 0, "thread-b");
+
+    handler.setPermissionMode("thread-a", "auto");
+
+    await expect(waiting).resolves.toEqual({ decision: "allow" });
+    // The other thread's approval is untouched.
+    let settled = false;
+    void otherThread.then(() => {
+      settled = true;
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(settled).toBe(false);
+    approvalBridge.resolveResult("appr_2", { decision: "deny" });
+    await otherThread;
+  });
+
+  it("switching to default releases nothing", async () => {
+    const { handler, approvalBridge } = makeChatTurnHarness();
+    const waiting = approvalBridge.createWaiter("appr_1", 0, "thread-a");
+    handler.setPermissionMode("thread-a", "default");
+    let settled = false;
+    void waiting.then(() => {
+      settled = true;
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(settled).toBe(false);
+    approvalBridge.resolveResult("appr_1", { decision: "deny" });
+    await waiting;
+  });
+
+  it("resolveToolResult resolves the matching tool bridge waiter", async () => {
+    const { handler, toolBridge } = makeChatTurnHarness();
+    const waiting = toolBridge.createWaiter("call_9", 0);
+    handler.resolveToolResult("call_9", { result: 42 });
+    await expect(waiting).resolves.toEqual({ result: 42 });
+  });
+});
+
+describe("requestPlanApproval", () => {
+  const plan: TaskPlan = {
+    title: "Build the thing",
+    tasks: [
+      {
+        id: "t1",
+        title: "First",
+        // dependsOn deliberately absent: the frame must default it to [].
+        steps: [
+          {
+            id: "s1",
+            instructions: "do it",
+            completed: false,
+            dependsOn: [],
+            logs: []
+          }
+        ]
+      }
+    ]
+  };
+
+  it("emits the serialized plan and resolves approve", async () => {
+    const { handler, session, approvalBridge } = makeChatTurnHarness();
+    const pending = handler.requestPlanApproval("thread-p", plan);
+    await tick();
+    const [frame] = session.messagesOfType("plan_approval_request");
+    expect(frame).toBeDefined();
+    expect(frame.thread_id).toBe("thread-p");
+    expect(frame.plan).toEqual({
+      title: "Build the thing",
+      tasks: [
+        {
+          id: "t1",
+          title: "First",
+          depends_on: [],
+          steps: [{ id: "s1", instructions: "do it" }]
+        }
+      ]
+    });
+    approvalBridge.resolveResult(String(frame.approval_id), {
+      decision: "approve"
+    });
+    await expect(pending).resolves.toEqual({ decision: "approve" });
+  });
+
+  it("returns reject with trimmed feedback", async () => {
+    const { handler, session, approvalBridge } = makeChatTurnHarness();
+    const pending = handler.requestPlanApproval("thread-p", plan);
+    await tick();
+    const [frame] = session.messagesOfType("plan_approval_request");
+    approvalBridge.resolveResult(String(frame.approval_id), {
+      decision: "reject",
+      feedback: "  too broad  "
+    });
+    await expect(pending).resolves.toEqual({
+      decision: "reject",
+      feedback: "too broad"
+    });
+  });
+
+  it("returns reject without feedback when feedback is blank", async () => {
+    const { handler, session, approvalBridge } = makeChatTurnHarness();
+    const pending = handler.requestPlanApproval("thread-p", plan);
+    await tick();
+    const [frame] = session.messagesOfType("plan_approval_request");
+    approvalBridge.resolveResult(String(frame.approval_id), {
+      decision: "reject",
+      feedback: "   "
+    });
+    await expect(pending).resolves.toEqual({ decision: "reject" });
+  });
+
+  it("treats a cancelled wait as a rejection", async () => {
+    const { handler, approvalBridge } = makeChatTurnHarness();
+    const pending = handler.requestPlanApproval("thread-p", plan);
+    await tick();
+    approvalBridge.cancelScope("thread-p");
+    await expect(pending).resolves.toEqual({ decision: "reject" });
+  });
+
+  it("carries a null thread id through the frame", async () => {
+    const { handler, session, approvalBridge } = makeChatTurnHarness();
+    const pending = handler.requestPlanApproval(null, plan);
+    await tick();
+    const [frame] = session.messagesOfType("plan_approval_request");
+    expect(frame.thread_id).toBeNull();
+    approvalBridge.resolveResult(String(frame.approval_id), {
+      decision: "approve"
+    });
+    await expect(pending).resolves.toEqual({ decision: "approve" });
+  });
+});
+
+describe("_logProviderCall", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("writes a priced row for a completed call", async () => {
+    const { handler } = makeChatTurnHarness();
+    await handler._logProviderCall(
+      "1",
+      fakeProvider({ cost: 0.42 }),
+      "mock",
+      "m1",
+      "wf-1",
+      "proj-1"
+    );
+    const [rows] = await Prediction.paginate("1", { provider: "mock" });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].cost).toBeCloseTo(0.42);
+    expect(rows[0].model).toBe("m1");
+    expect(rows[0].workflow_id).toBe("wf-1");
+    expect(rows[0].project_id).toBe("proj-1");
+  });
+
+  it("records an unpriced call as a null cost, never zero", async () => {
+    const { handler } = makeChatTurnHarness();
+    await handler._logProviderCall(
+      "1",
+      fakeProvider({ cost: 0, unpricedReason: "no catalog entry" }),
+      "mock",
+      "m1",
+      null,
+      null
+    );
+    const [rows] = await Prediction.paginate("1", { provider: "mock" });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].cost).toBeNull();
+    expect(rows[0].metadata).toEqual({ unpriced_reason: "no catalog entry" });
+  });
+
+  it("writes nothing when provider or model is missing", async () => {
+    const { handler } = makeChatTurnHarness();
+    await handler._logProviderCall(
+      "1",
+      fakeProvider({ cost: 1 }),
+      "",
+      "m1",
+      null,
+      null
+    );
+    await handler._logProviderCall(
+      "1",
+      fakeProvider({ cost: 1 }),
+      "mock",
+      "",
+      null,
+      null
+    );
+    const [rows] = await Prediction.paginate("1", {});
+    expect(rows).toHaveLength(0);
+  });
+
+  it("swallows a provider whose cost accessor throws", async () => {
+    const { handler } = makeChatTurnHarness();
+    const explosive = fakeProvider({});
+    Object.defineProperty(explosive, "cost", {
+      get() {
+        throw new TypeError("no cost here");
+      }
+    });
+    // Best-effort contract: never throws.
+    await handler._logProviderCall("1", explosive, "mock", "m1", null, null);
+    const generic = fakeProvider({});
+    Object.defineProperty(generic, "cost", {
+      get() {
+        throw new Error("ledger offline");
+      }
+    });
+    await handler._logProviderCall("1", generic, "mock", "m1", null, null);
+    const [rows] = await Prediction.paginate("1", {});
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/websocket/tests/chat-turn-handler-media.test.ts
+++ b/packages/websocket/tests/chat-turn-handler-media.test.ts
@@ -1,0 +1,490 @@
+/**
+ * handleMediaGenerationMessage: the image / video / audio / image_edit /
+ * image_to_video routes a `chat_message` with a `media_generation` payload
+ * takes, their refusal branches, cancellation, and the provider-failure catch.
+ *
+ * Assets are written through the real file storage adapter into a temp
+ * directory (ASSET_FOLDER), so no module is mocked.
+ */
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initTestDb, Message } from "@nodetool-ai/models";
+import { noMediaModelSelectedMessage } from "@nodetool-ai/protocol";
+import {
+  makeChatTurnHarness,
+  fakeProvider,
+  type ChatTurnHarness
+} from "./chat-turn-test-harness.js";
+
+beforeAll(() => {
+  // The lazily-created asset adapter must land in a scratch dir, not the
+  // user's data dir. Set before anything touches storage in this worker.
+  process.env.ASSET_FOLDER = mkdtempSync(join(tmpdir(), "chat-turn-media-"));
+});
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function mediaTurn(
+  threadId: string,
+  mediaGeneration: Record<string, unknown>,
+  content = "a red fox in snow"
+): Record<string, unknown> {
+  return {
+    thread_id: threadId,
+    content,
+    media_generation: mediaGeneration
+  };
+}
+
+function assistantFrames(
+  harness: ChatTurnHarness
+): Array<Record<string, unknown>> {
+  return harness.session
+    .messagesOfType("message")
+    .filter((m) => m.role === "assistant");
+}
+
+describe("media generation refusals", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("refuses a media turn with no model selected", async () => {
+    const harness = makeChatTurnHarness({
+      session: { resolveProvider: async () => fakeProvider({}) }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-nomodel", { mode: "image" })
+    );
+    const [err] = harness.session.messagesOfType("error");
+    expect(err.message).toBe(noMediaModelSelectedMessage("image"));
+    expect(assistantFrames(harness)).toHaveLength(0);
+  });
+
+  it("refuses an empty prompt", async () => {
+    const harness = makeChatTurnHarness({
+      session: { resolveProvider: async () => fakeProvider({}) }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn(
+        "t-media-noprompt",
+        { mode: "image", provider: "mock", model: "img-1" },
+        ""
+      )
+    );
+    const [err] = harness.session.messagesOfType("error");
+    expect(err.message).toBe("Please enter a prompt");
+  });
+
+  it("names an unsupported mode instead of running it", async () => {
+    const harness = makeChatTurnHarness({
+      session: { resolveProvider: async () => fakeProvider({}) }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-unknown", {
+        mode: "hologram",
+        provider: "mock",
+        model: "img-1"
+      })
+    );
+    const [err] = harness.session.messagesOfType("error");
+    expect(String(err.message)).toContain('"hologram" is not yet supported');
+  });
+
+  it("reports a provider failure as a generation error", async () => {
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            textToImages: async () => {
+              throw new Error("model melted");
+            }
+          })
+      }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-fail", {
+        mode: "image",
+        provider: "mock",
+        model: "img-1"
+      })
+    );
+    const [err] = harness.session.messagesOfType("error");
+    expect(err.message).toBe("Generation failed: model melted");
+    expect(assistantFrames(harness)).toHaveLength(0);
+  });
+});
+
+describe("image generation", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("stores each variation as an asset and answers with asset references", async () => {
+    let requestedVariations = 0;
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            textToImages: async (_params, variations) => {
+              requestedVariations = Number(variations);
+              return [PNG, PNG];
+            }
+          })
+      }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-img", {
+        mode: "image",
+        provider: "mock",
+        model: "img-1",
+        variations: 99,
+        width: 512,
+        height: 512
+      })
+    );
+
+    // The variation count is clamped to 8.
+    expect(requestedVariations).toBe(8);
+    const [assistant] = assistantFrames(harness);
+    const content = assistant.content as Array<Record<string, unknown>>;
+    expect(content).toHaveLength(2);
+    for (const block of content) {
+      expect(block.type).toBe("image_url");
+      const image = block.image as Record<string, unknown>;
+      expect(typeof image.asset_id).toBe("string");
+      // Raw bytes never ride the frame.
+      expect(image.data).toBeUndefined();
+    }
+    // Progress chunk before, done chunk after.
+    const chunks = harness.session.messagesOfType("chunk");
+    expect(chunks[0].done).toBe(false);
+    expect(
+      (chunks[0].content_metadata as Record<string, unknown>).media_generation
+    ).toBeDefined();
+    expect(chunks[chunks.length - 1].done).toBe(true);
+    // Persisted for the next turn.
+    const [rows] = await Message.paginate("t-media-img", { limit: 10 });
+    expect(rows.some((m) => m.role === "assistant")).toBe(true);
+  });
+
+  it("routes through imageToImages when an entity carries reference images", async () => {
+    let calledWith: Uint8Array[] | null = null;
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            imageToImages: async (images) => {
+              calledWith = images as Uint8Array[];
+              return [PNG];
+            }
+          })
+      },
+      deps: {
+        resolveEntityReferenceImages: async () => [PNG]
+      }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-entity", {
+        mode: "image",
+        provider: "mock",
+        model: "img-1"
+      })
+    );
+    expect(calledWith).toHaveLength(1);
+    expect(assistantFrames(harness)).toHaveLength(1);
+  });
+
+  it("stops persisting when the turn is cancelled mid-generation", async () => {
+    const controller = new AbortController();
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            textToImages: async () => {
+              // Stop lands while the provider is still working.
+              controller.abort();
+              return [PNG];
+            }
+          })
+      }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-cancel", {
+        mode: "image",
+        provider: "mock",
+        model: "img-1"
+      }),
+      undefined,
+      controller.signal
+    );
+    // No done chunk, no assistant message, nothing persisted beyond the user row.
+    expect(
+      harness.session.messagesOfType("chunk").filter((c) => c.done === true)
+    ).toHaveLength(0);
+    expect(assistantFrames(harness)).toHaveLength(0);
+    const [rows] = await Message.paginate("t-media-cancel", { limit: 10 });
+    expect(rows.filter((m) => m.role === "assistant")).toHaveLength(0);
+  });
+});
+
+describe("video generation", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("uses text-to-video when no source image is attached", async () => {
+    let textToVideoCalled = false;
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            textToVideo: async () => {
+              textToVideoCalled = true;
+              return PNG;
+            }
+          })
+      }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-vid", {
+        mode: "video",
+        provider: "mock",
+        model: "vid-1",
+        aspect_ratio: "16:9",
+        resolution: "720p",
+        duration: 5
+      })
+    );
+    expect(textToVideoCalled).toBe(true);
+    const [assistant] = assistantFrames(harness);
+    const [block] = assistant.content as Array<Record<string, unknown>>;
+    expect(block.type).toBe("video");
+    const video = block.video as Record<string, unknown>;
+    expect(video.format).toBe("mp4");
+    expect(video.duration).toBe(5);
+    expect(typeof video.asset_id).toBe("string");
+  });
+
+  it("routes to image-to-video when the message carries a source image", async () => {
+    let i2vCalled = false;
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            imageToVideo: async () => {
+              i2vCalled = true;
+              return PNG;
+            },
+            textToVideo: async () => {
+              throw new Error("must not fall back to text-to-video");
+            }
+          })
+      },
+      deps: {
+        resolveSourceImageBytes: async () => PNG
+      }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-i2v", {
+        mode: "video",
+        provider: "mock",
+        model: "vid-1"
+      })
+    );
+    expect(i2vCalled).toBe(true);
+    expect(assistantFrames(harness)).toHaveLength(1);
+  });
+});
+
+describe("image_edit and image_to_video", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("refuses image_edit without a source image", async () => {
+    const harness = makeChatTurnHarness({
+      session: { resolveProvider: async () => fakeProvider({}) }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-edit-nosrc", {
+        mode: "image_edit",
+        provider: "mock",
+        model: "img-1"
+      })
+    );
+    const [err] = harness.session.messagesOfType("error");
+    expect(String(err.message)).toContain("A source image is required");
+  });
+
+  it("refuses a zero-length source image the same way", async () => {
+    const harness = makeChatTurnHarness({
+      session: { resolveProvider: async () => fakeProvider({}) },
+      deps: { resolveSourceImageBytes: async () => new Uint8Array(0) }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-edit-empty", {
+        mode: "image_edit",
+        provider: "mock",
+        model: "img-1"
+      })
+    );
+    const [err] = harness.session.messagesOfType("error");
+    expect(String(err.message)).toContain("A source image is required");
+  });
+
+  it("edits against the source image plus entity references", async () => {
+    let sources: Uint8Array[] | null = null;
+    const entityBytes = new Uint8Array([1, 2, 3]);
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            imageToImages: async (images) => {
+              sources = images as Uint8Array[];
+              return [PNG];
+            }
+          })
+      },
+      deps: {
+        resolveSourceImageBytes: async () => PNG,
+        resolveEntityReferenceImages: async () => [entityBytes]
+      }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-edit", {
+        mode: "image_edit",
+        provider: "mock",
+        model: "img-1",
+        strength: 0.6,
+        num_inference_steps: 12
+      })
+    );
+    expect(sources).toEqual([PNG, entityBytes]);
+    const [assistant] = assistantFrames(harness);
+    const content = assistant.content as Array<Record<string, unknown>>;
+    expect(content[0].type).toBe("image_url");
+  });
+
+  it("animates a source image with image_to_video", async () => {
+    let i2vCalled = false;
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            imageToVideo: async () => {
+              i2vCalled = true;
+              return PNG;
+            }
+          })
+      },
+      deps: { resolveSourceImageBytes: async () => PNG }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-i2v2", {
+        mode: "image_to_video",
+        provider: "mock",
+        model: "vid-1",
+        duration: 3
+      })
+    );
+    expect(i2vCalled).toBe(true);
+    const [assistant] = assistantFrames(harness);
+    const [block] = assistant.content as Array<Record<string, unknown>>;
+    expect(block.type).toBe("video");
+    expect((block.video as Record<string, unknown>).duration).toBe(3);
+  });
+});
+
+describe("audio generation", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("prefers the provider's encoded audio and keeps its mime type", async () => {
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            textToSpeechEncoded: async () => ({
+              data: new Uint8Array([1, 2, 3]),
+              mimeType: "audio/mpeg"
+            })
+          })
+      }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-audio-enc", {
+        mode: "audio",
+        provider: "mock",
+        model: "tts-1",
+        voice: "alloy",
+        // Requesting wav while the provider returns mp3 exercises the
+        // native-format fallback warning path.
+        audio_format: "wav"
+      })
+    );
+    const [assistant] = assistantFrames(harness);
+    const [block] = assistant.content as Array<Record<string, unknown>>;
+    expect(block.type).toBe("audio");
+    expect((block.audio as Record<string, unknown>).mimeType).toBe(
+      "audio/mpeg"
+    );
+  });
+
+  it("wraps streamed PCM into a WAV container when nothing encoded exists", async () => {
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            textToSpeechEncoded: async () => null,
+            textToSpeech: async function* () {
+              yield { samples: new Int16Array([0, 1000, -1000]), sampleRate: 16000 };
+              yield { samples: new Int16Array([500, -500]) };
+            }
+          })
+      }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-audio-pcm", {
+        mode: "audio",
+        provider: "mock",
+        model: "tts-1"
+      })
+    );
+    const [assistant] = assistantFrames(harness);
+    const [block] = assistant.content as Array<Record<string, unknown>>;
+    expect((block.audio as Record<string, unknown>).mimeType).toBe(
+      "audio/wav"
+    );
+  });
+
+  it("returns raw PCM when the client asked for pcm", async () => {
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            textToSpeechEncoded: async () => null,
+            textToSpeech: async function* () {
+              yield { samples: new Int16Array([1, 2, 3]), sampleRate: 24000 };
+            }
+          })
+      }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-audio-raw", {
+        mode: "audio",
+        provider: "mock",
+        model: "tts-1",
+        audio_format: "pcm"
+      })
+    );
+    const [assistant] = assistantFrames(harness);
+    const [block] = assistant.content as Array<Record<string, unknown>>;
+    expect((block.audio as Record<string, unknown>).mimeType).toBe(
+      "audio/pcm"
+    );
+  });
+});

--- a/packages/websocket/tests/chat-turn-handler-run-node.test.ts
+++ b/packages/websocket/tests/chat-turn-handler-run-node.test.ts
@@ -1,0 +1,357 @@
+/**
+ * The `run_node` chat tool (a one-node kernel run inside a chat turn), the
+ * provider-session resume fast path with its `loadFullHistory` fallback, and
+ * the persistence branches for array-content assistant messages.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { initTestDb, Message, Thread } from "@nodetool-ai/models";
+import {
+  makeChatTurnHarness,
+  fakeProvider,
+  type ChatTurnHarness,
+  type GenerateLoopArgs
+} from "./chat-turn-test-harness.js";
+
+function chatTurn(threadId: string, content = "hi"): Record<string, unknown> {
+  return { thread_id: threadId, content, provider: "mock", model: "m" };
+}
+
+/**
+ * Answer every tool approval the turn raises with "allow", the way a user
+ * clicking through would. Returns a stop function.
+ */
+function autoApprove(harness: ChatTurnHarness): () => void {
+  const timer = setInterval(() => {
+    for (const frame of harness.session.messagesOfType(
+      "tool_approval_request"
+    )) {
+      harness.approvalBridge.resolveResult(String(frame.approval_id), {
+        decision: "allow"
+      });
+    }
+  }, 5);
+  return () => clearInterval(timer);
+}
+
+const echoExecutor = (node: {
+  id: string;
+  type: string;
+  [key: string]: unknown;
+}): { process: (inputs: Record<string, unknown>) => Promise<unknown> } => ({
+  async process() {
+    if (node.type === "test.Boom") throw new Error("node exploded");
+    const props =
+      typeof node.properties === "object" && node.properties !== null
+        ? (node.properties as Record<string, unknown>)
+        : {};
+    return { output: props.value ?? "" };
+  }
+});
+
+describe("run_node through the chat tool router", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("runs a single node and returns its output to the provider", async () => {
+    const results: unknown[] = [];
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveExecutor: echoExecutor,
+        resolveProvider: async () =>
+          fakeProvider({
+            generateLoop: async function* (args: GenerateLoopArgs) {
+              results.push(
+                await args.executeTool?.({
+                  id: "call_run",
+                  name: "run_node",
+                  args: {
+                    node_type: "test.Echo",
+                    inputs: { value: "hello node" }
+                  }
+                })
+              );
+              results.push(
+                await args.executeTool?.({
+                  id: "call_boom",
+                  name: "run_node",
+                  args: { node_type: "test.Boom" }
+                })
+              );
+              yield { type: "chunk", content: "ok", done: true };
+            }
+          })
+      }
+    });
+    const stop = autoApprove(harness);
+    try {
+      await harness.handler.handleChatMessage(chatTurn("t-runnode"));
+    } finally {
+      stop();
+    }
+    expect(String(results[0])).toContain("hello node");
+    // A failing node answers with an error bag, not a thrown turn.
+    expect(String(results[1])).toContain("error");
+    expect(String(results[1])).toContain("node exploded");
+  });
+
+  it("answers preparation failures without starting the kernel", async () => {
+    const results: unknown[] = [];
+    let beforeRunJobCalls = 0;
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveExecutor: echoExecutor,
+        resolveProvider: async () =>
+          fakeProvider({
+            generateLoop: async function* (args: GenerateLoopArgs) {
+              results.push(
+                await args.executeTool?.({
+                  id: "call_prep",
+                  name: "run_node",
+                  args: { node_type: "test.Echo" }
+                })
+              );
+              yield { type: "chunk", content: "ok", done: true };
+            }
+          })
+      },
+      deps: {
+        hydrateGraph: async () => {
+          throw new Error("registry offline");
+        },
+        beforeRunJob: async () => {
+          beforeRunJobCalls++;
+        }
+      }
+    });
+    const stop = autoApprove(harness);
+    try {
+      await harness.handler.handleChatMessage(chatTurn("t-runnode-prep"));
+    } finally {
+      stop();
+    }
+    expect(String(results[0])).toContain(
+      "Failed to prepare node 'test.Echo'"
+    );
+    expect(String(results[0])).toContain("registry offline");
+    // Hydration failed first, so prerequisites never ran.
+    expect(beforeRunJobCalls).toBe(0);
+  });
+
+  it("answers a failing prerequisite check as an error bag", async () => {
+    const results: unknown[] = [];
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveExecutor: echoExecutor,
+        resolveProvider: async () =>
+          fakeProvider({
+            generateLoop: async function* (args: GenerateLoopArgs) {
+              results.push(
+                await args.executeTool?.({
+                  id: "call_before",
+                  name: "run_node",
+                  args: { node_type: "test.Echo" }
+                })
+              );
+              yield { type: "chunk", content: "ok", done: true };
+            }
+          })
+      },
+      deps: {
+        beforeRunJob: async () => {
+          throw new Error("python bridge down");
+        }
+      }
+    });
+    const stop = autoApprove(harness);
+    try {
+      await harness.handler.handleChatMessage(chatTurn("t-runnode-before"));
+    } finally {
+      stop();
+    }
+    expect(String(results[0])).toContain("Node prerequisites failed");
+    expect(String(results[0])).toContain("python bridge down");
+  });
+});
+
+describe("provider session resume", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  async function seedResumableThread(threadId: string): Promise<void> {
+    await Message.create({
+      thread_id: threadId,
+      user_id: "1",
+      role: "user",
+      content: "first question",
+      provider: "mock",
+      model: "m"
+    });
+    await Message.create({
+      thread_id: threadId,
+      user_id: "1",
+      role: "assistant",
+      content: "first answer",
+      provider: "mock",
+      model: "m",
+      provider_session: {
+        providerId: "mock",
+        model: "m",
+        token: "resume-token",
+        systemHash: "h1",
+        checkpoint: 3
+      }
+    });
+  }
+
+  it("hands the provider a delta plus a working loadFullHistory fallback", async () => {
+    const threadId = "t-resume";
+    await seedResumableThread(threadId);
+
+    let receivedSession: Record<string, unknown> | null = null;
+    let fullHistory: GenerateLoopArgs["messages"] = [];
+    let deltaMessages: GenerateLoopArgs["messages"] = [];
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            generateLoop: async function* (args: GenerateLoopArgs) {
+              deltaMessages = args.messages;
+              receivedSession =
+                (args.providerSession as Record<string, unknown> | null) ??
+                null;
+              // A priming fallback: the provider decides it must reload.
+              fullHistory = (await args.loadFullHistory?.()) ?? [];
+              yield { type: "chunk", content: "resumed", done: true };
+            }
+          })
+      }
+    });
+    await harness.handler.handleChatMessage(chatTurn(threadId, "and then?"));
+
+    // Fast path: only the turns since the session ride the wire (system +
+    // the new user message), not the whole thread.
+    expect(
+      deltaMessages.filter((m) => m.role === "assistant")
+    ).toHaveLength(0);
+    expect(receivedSession).toMatchObject({
+      token: "resume-token",
+      checkpoint: 1
+    });
+    // The fallback loads the full thread behind a fresh system prompt.
+    expect(fullHistory[0].role).toBe("system");
+    const flat = JSON.stringify(fullHistory);
+    expect(flat).toContain("first question");
+    expect(flat).toContain("first answer");
+  });
+});
+
+describe("assistant message persistence branches", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("persists array content, captures session updates, and logs informational tool calls", async () => {
+    const threadId = "t-persist-array";
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            generateLoop: async function* () {
+              // Continuity token arrives first.
+              yield {
+                type: "session",
+                session: {
+                  providerId: "mock",
+                  model: "m",
+                  token: "tok-2",
+                  systemHash: "h2",
+                  checkpoint: 5
+                }
+              };
+              // Informational tool-call item (executed by the loop itself).
+              yield { id: "call_info", name: "some_tool", args: {} };
+              // Assistant message whose content is an array of blocks.
+              yield {
+                type: "message",
+                message: {
+                  role: "assistant",
+                  content: [
+                    { type: "text", text: "part one " },
+                    { type: "text", text: "and part two" }
+                  ],
+                  toolCalls: null
+                }
+              };
+              yield { type: "chunk", content: "", done: true };
+            }
+          })
+      }
+    });
+    await harness.handler.handleChatMessage(chatTurn(threadId));
+
+    const [rows] = await Message.paginate(threadId, { limit: 10 });
+    const assistant = rows.find((m) => m.role === "assistant");
+    expect(assistant).toBeDefined();
+    expect(assistant?.provider_session).toMatchObject({ token: "tok-2" });
+    const frames = harness.session
+      .messagesOfType("message")
+      .filter((m) => m.role === "assistant");
+    expect(JSON.stringify(frames[0].content)).toContain("part one");
+  });
+});
+
+describe("thread bootstrap", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("creates a thread when the message carries none", async () => {
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            generateLoop: async function* () {
+              yield { type: "chunk", content: "ok", done: true };
+            }
+          }),
+        // Present so the turn resolves its workspace through the thread
+        // binding rather than skipping the lookup.
+        workspaceResolver: async () => null
+      }
+    });
+    await harness.handler.handleChatMessage({
+      content: "hi",
+      provider: "mock",
+      model: "m"
+    });
+    const done = harness.session
+      .messagesOfType("chunk")
+      .find((c) => c.done === true);
+    const threadId = String(done?.thread_id ?? "");
+    expect(threadId).not.toBe("");
+    const thread = await Thread.find("1", threadId);
+    expect(thread).not.toBeNull();
+  });
+
+  it("reuses an existing thread on the next turn", async () => {
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            generateLoop: async function* () {
+              yield { type: "chunk", content: "ok", done: true };
+            }
+          }),
+        workspaceResolver: async () => null
+      }
+    });
+    await harness.handler.handleChatMessage(chatTurn("t-reuse"));
+    await harness.handler.handleChatMessage(chatTurn("t-reuse", "again"));
+    const threads = await Thread.find("1", "t-reuse");
+    expect(threads).not.toBeNull();
+    const [rows] = await Message.paginate("t-reuse", { limit: 10 });
+    expect(rows.filter((m) => m.role === "user")).toHaveLength(2);
+  });
+});

--- a/packages/websocket/tests/chat-turn-handler-workflow.test.ts
+++ b/packages/websocket/tests/chat-turn-handler-workflow.test.ts
@@ -1,0 +1,283 @@
+/**
+ * handleWorkflowMessage's job interaction through the ChatJobAccess seam.
+ *
+ * The contract under test: a chat-driven workflow run registers against the
+ * connection's concurrency slots, drops without draining on the superseded
+ * early return, and always releases (delete + drain) in the `finally` — a
+ * missed release permanently shrinks the connection's job cap.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { initTestDb, Job, Message, Workflow } from "@nodetool-ai/models";
+import {
+  makeChatTurnHarness,
+  fakeProvider
+} from "./chat-turn-test-harness.js";
+
+const tick = (): Promise<void> => new Promise((r) => setImmediate(r));
+
+/** A one-node graph whose executor echoes its `value` property. */
+const echoGraph = {
+  nodes: [{ id: "n1", type: "test.Echo", data: { value: "hello" } }],
+  edges: []
+};
+
+interface EchoExecutorControls {
+  /** Resolves once the node's process() has been entered. */
+  started: Promise<void>;
+  /** Release a gated node. */
+  release: () => void;
+}
+
+function makeExecutors(behavior: "echo" | "throw" | "gated"): {
+  resolveExecutor: (node: {
+    id: string;
+    type: string;
+    [key: string]: unknown;
+  }) => { process: (inputs: Record<string, unknown>) => Promise<unknown> };
+  controls: EchoExecutorControls;
+} {
+  let started!: () => void;
+  const startedPromise = new Promise<void>((r) => {
+    started = r;
+  });
+  let release!: () => void;
+  const gate = new Promise<void>((r) => {
+    release = r;
+  });
+  return {
+    resolveExecutor: (node) => ({
+      async process() {
+        started();
+        if (behavior === "throw") throw new Error("node exploded");
+        if (behavior === "gated") {
+          // A safety valve so a broken cancellation cannot hang the suite.
+          await Promise.race([gate, new Promise((r) => setTimeout(r, 8000))]);
+        }
+        const props =
+          typeof node.properties === "object" && node.properties !== null
+            ? (node.properties as Record<string, unknown>)
+            : {};
+        return { output: props.value ?? "" };
+      }
+    }),
+    controls: { started: startedPromise, release }
+  };
+}
+
+async function seedWorkflow(id: string): Promise<void> {
+  await Workflow.create({
+    id,
+    user_id: "1",
+    name: "wf",
+    graph: echoGraph,
+    access: "private"
+  });
+}
+
+function workflowTurnData(
+  threadId: string,
+  workflowId: string | null
+): Record<string, unknown> {
+  const data: Record<string, unknown> = {
+    thread_id: threadId,
+    content: "run it",
+    workflow_target: "workflow",
+    provider: "mock",
+    model: "m"
+  };
+  if (workflowId) data.workflow_id = workflowId;
+  return data;
+}
+
+describe("handleWorkflowMessage job accounting", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("registers, streams, and releases on a completed run", async () => {
+    const { resolveExecutor } = makeExecutors("echo");
+    const { handler, session, jobs } = makeChatTurnHarness({
+      session: {
+        resolveExecutor,
+        resolveProvider: async () => fakeProvider({})
+      }
+    });
+    await seedWorkflow("wf-ok");
+
+    await handler.handleChatMessage(workflowTurnData("t-wf-ok", "wf-ok"));
+
+    expect(jobs.ops()).toEqual(["register", "release"]);
+    const jobId = jobs.calls[0].jobId;
+    expect(jobs.calls[1].jobId).toBe(jobId);
+    // The slot is empty afterwards.
+    expect(jobs.active.size).toBe(0);
+
+    const updates = session.messagesOfType("job_update");
+    expect(updates[0].status).toBe("running");
+    expect(updates[updates.length - 1].status).toBe("completed");
+    // Completion chunk carries the job id.
+    const done = session
+      .messagesOfType("chunk")
+      .find((c) => c.done === true);
+    expect(done?.job_id).toBe(jobId);
+    // The turn ends with a persisted assistant response.
+    const finalMsg = session
+      .messagesOfType("message")
+      .find((m) => m.role === "assistant");
+    expect(finalMsg).toBeDefined();
+    const job = await Job.get(jobId);
+    expect(job?.status).toBe("completed");
+  });
+
+  it("releases the slot and reports failure when a node throws", async () => {
+    const { resolveExecutor } = makeExecutors("throw");
+    const { handler, session, jobs } = makeChatTurnHarness({
+      session: {
+        resolveExecutor,
+        resolveProvider: async () => fakeProvider({})
+      }
+    });
+    await seedWorkflow("wf-boom");
+
+    await handler.handleChatMessage(workflowTurnData("t-wf-boom", "wf-boom"));
+
+    expect(jobs.ops()).toEqual(["register", "release"]);
+    const updates = session.messagesOfType("job_update");
+    expect(updates[updates.length - 1].status).toBe("failed");
+    const job = await Job.get(jobs.calls[0].jobId);
+    expect(job?.status).toBe("failed");
+    expect(job?.error).toContain("node exploded");
+  });
+
+  it("releases even when the workflow does not exist, without registering", async () => {
+    const { handler, session, jobs } = makeChatTurnHarness({
+      session: {
+        resolveExecutor: () => ({
+          async process() {
+            return {};
+          }
+        }),
+        resolveProvider: async () => fakeProvider({})
+      }
+    });
+
+    await handler.handleChatMessage(workflowTurnData("t-wf-miss", "wf-nope"));
+
+    // No register — the run never started — but the finally still releases.
+    expect(jobs.ops()).toEqual(["release"]);
+    const [err] = session.messagesOfType("error");
+    expect(String(err.message)).toContain("Workflow wf-nope not found");
+    // Done chunk still arrives so the client stops spinning.
+    expect(
+      session.messagesOfType("chunk").some((c) => c.done === true)
+    ).toBe(true);
+  });
+
+  it("refuses a workflow turn with no workflow_id", async () => {
+    const { handler, session, jobs } = makeChatTurnHarness({
+      session: {
+        resolveExecutor: () => ({
+          async process() {
+            return {};
+          }
+        }),
+        resolveProvider: async () => fakeProvider({})
+      }
+    });
+
+    await handler.handleChatMessage(workflowTurnData("t-wf-noid", null));
+
+    expect(jobs.ops()).toEqual(["release"]);
+    const [err] = session.messagesOfType("error");
+    expect(String(err.message)).toContain("workflow_id is required");
+  });
+
+  it("drops and releases a run superseded mid-flight, and stops streaming", async () => {
+    const { resolveExecutor, controls } = makeExecutors("gated");
+    const { handler, session, jobs } = makeChatTurnHarness({
+      session: {
+        resolveExecutor,
+        resolveProvider: async () => fakeProvider({})
+      }
+    });
+    await seedWorkflow("wf-super");
+
+    const turn = handler.beginTurn();
+    const running = handler.handleChatMessage(
+      workflowTurnData("t-wf-super", "wf-super"),
+      turn.seq,
+      turn.signal
+    );
+    await controls.started;
+
+    // A new message supersedes the turn: seq moves on and the old signal fires.
+    handler.beginTurn();
+    controls.release();
+    await running;
+
+    expect(jobs.ops()).toEqual(["register", "drop", "release"]);
+    const jobId = jobs.calls[0].jobId;
+    // The superseded return path: no terminal job_update, no done chunk, no
+    // assistant response — the user has moved on.
+    const updates = session.messagesOfType("job_update");
+    expect(updates.filter((u) => u.status === "completed")).toHaveLength(0);
+    expect(
+      session.messagesOfType("chunk").filter((c) => c.done === true)
+    ).toHaveLength(0);
+    expect(
+      session
+        .messagesOfType("message")
+        .filter((m) => m.role === "assistant")
+    ).toHaveLength(0);
+    const job = await Job.get(jobId);
+    expect(job?.status).toBe("cancelled");
+  });
+
+  it("cancels the run when the turn signal is already aborted", async () => {
+    const { resolveExecutor, controls } = makeExecutors("gated");
+    const { handler, session, jobs } = makeChatTurnHarness({
+      session: {
+        resolveExecutor,
+        resolveProvider: async () => fakeProvider({})
+      }
+    });
+    await seedWorkflow("wf-aborted");
+
+    const controller = new AbortController();
+    controller.abort();
+    const running = handler.handleChatMessage(
+      workflowTurnData("t-wf-aborted", "wf-aborted"),
+      undefined,
+      controller.signal
+    );
+    controls.release();
+    await running;
+
+    // The seq still matches (undefined), so the run tears down through the
+    // normal path with a cancelled status rather than the superseded return.
+    expect(jobs.ops()).toEqual(["register", "release"]);
+    await vi.waitFor(async () => {
+      const job = await Job.get(jobs.calls[0].jobId);
+      expect(job?.status).toBe("cancelled");
+    });
+    const updates = session.messagesOfType("job_update");
+    expect(updates[updates.length - 1].status).toBe("cancelled");
+  });
+
+  it("keeps the user message persisted before routing to the workflow", async () => {
+    const { resolveExecutor } = makeExecutors("echo");
+    const { handler } = makeChatTurnHarness({
+      session: {
+        resolveExecutor,
+        resolveProvider: async () => fakeProvider({})
+      }
+    });
+    await seedWorkflow("wf-persist");
+    await handler.handleChatMessage(
+      workflowTurnData("t-wf-persist", "wf-persist")
+    );
+    const [rows] = await Message.paginate("t-wf-persist", { limit: 10 });
+    expect(rows.some((m) => m.role === "user")).toBe(true);
+    expect(rows.some((m) => m.role === "assistant")).toBe(true);
+  });
+});

--- a/packages/websocket/tests/chat-turn-test-harness.ts
+++ b/packages/websocket/tests/chat-turn-test-harness.ts
@@ -1,0 +1,186 @@
+/**
+ * Direct-construction harness for {@link ChatTurnHandler}: a
+ * {@link FakeClientSession} instead of a socket, real {@link ToolBridge}
+ * instances (they hold no socket either), and a recording {@link ChatJobAccess}
+ * so a suite can assert the register/drop/release accounting a workflow-bound
+ * chat run performs.
+ */
+import type { HydratedGraphData } from "@nodetool-ai/protocol";
+import type { BaseProvider } from "@nodetool-ai/runtime";
+import {
+  ChatTurnHandler,
+  type ChatJobAccess,
+  type ChatTurnDeps
+} from "../src/session/chat-turn.js";
+import type { ActiveJob } from "../src/session/job-execution.js";
+import { ToolBridge } from "../src/unified-websocket-runner.js";
+import {
+  FakeClientSession,
+  type FakeClientSessionOptions
+} from "./fake-client-session.js";
+
+/** One job-accounting call, in the order the handler made it. */
+export interface JobAccessCall {
+  op: "register" | "drop" | "release";
+  jobId: string;
+}
+
+export class RecordingJobs implements ChatJobAccess {
+  readonly calls: JobAccessCall[] = [];
+  readonly active = new Map<string, ActiveJob>();
+  readonly costEvents: Array<Record<string, unknown>> = [];
+
+  registerJob(jobId: string, job: ActiveJob): void {
+    this.calls.push({ op: "register", jobId });
+    this.active.set(jobId, job);
+  }
+
+  dropJob(jobId: string): void {
+    this.calls.push({ op: "drop", jobId });
+    this.active.delete(jobId);
+  }
+
+  releaseJob(jobId: string): void {
+    this.calls.push({ op: "release", jobId });
+    this.active.delete(jobId);
+  }
+
+  handleNodeProviderCost(
+    _active: ActiveJob,
+    outbound: Record<string, unknown>
+  ): void {
+    this.costEvents.push(outbound);
+  }
+
+  runMeasuredCost(): number | null {
+    return null;
+  }
+
+  ops(): string[] {
+    return this.calls.map((c) => c.op);
+  }
+}
+
+function isRecordValue(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * The minimal hydration the tests need: `data` moved to `properties`, the
+ * behavior flags explicitly off. Matches what `JobExecutionManager.hydrateGraph`
+ * produces for a plain saved graph with no registry resolver.
+ */
+export async function minimalHydrateGraph(graph: {
+  nodes: Array<Record<string, unknown>>;
+  edges: Array<Record<string, unknown>>;
+}): Promise<HydratedGraphData> {
+  return {
+    nodes: graph.nodes.map((n) => ({
+      id: String(n.id ?? ""),
+      type: String(n.type ?? ""),
+      properties: isRecordValue(n.data)
+        ? n.data
+        : isRecordValue(n.properties)
+          ? n.properties
+          : {},
+      dynamic_properties: {},
+      is_streaming_input: false,
+      is_streaming_output: false,
+      is_controlled: false,
+      is_join_node: false,
+      retry_safe: false
+    })),
+    edges: graph.edges.map((e) => ({
+      id: String(e.id ?? ""),
+      source: String(e.source ?? ""),
+      sourceHandle: String(e.sourceHandle ?? ""),
+      target: String(e.target ?? ""),
+      targetHandle: String(e.targetHandle ?? "")
+    }))
+  };
+}
+
+export interface ChatTurnHarness {
+  handler: ChatTurnHandler;
+  session: FakeClientSession;
+  jobs: RecordingJobs;
+  toolBridge: ToolBridge;
+  approvalBridge: ToolBridge;
+  deps: ChatTurnDeps;
+}
+
+export function makeChatTurnHarness(
+  overrides: {
+    session?: FakeClientSessionOptions;
+    deps?: Partial<ChatTurnDeps>;
+  } = {}
+): ChatTurnHarness {
+  const session = new FakeClientSession(overrides.session);
+  const jobs = new RecordingJobs();
+  const toolBridge = new ToolBridge();
+  const approvalBridge = new ToolBridge();
+  const deps: ChatTurnDeps = {
+    jobs,
+    toolBridge,
+    approvalBridge,
+    clientTools: () => ({}),
+    authToken: () => null,
+    defaults: { provider: "", model: "" },
+    hydrateGraph: minimalHydrateGraph,
+    configuredProviders: async () => ({}),
+    entityRefResolver: () => ({ getAssetInfo: async () => null }),
+    resolveEntityReferenceImages: async () => [],
+    resolveSourceImageBytes: async () => null,
+    ...overrides.deps
+  };
+  const handler = new ChatTurnHandler(session, deps);
+  return { handler, session, jobs, toolBridge, approvalBridge, deps };
+}
+
+/** What a chat-turn provider double may implement. All members optional. */
+export interface FakeProviderShape {
+  provider?: string;
+  cost?: number;
+  unpricedReason?: string | null;
+  setMessageEmitter?: (emit: (msg: unknown) => void) => void;
+  generateLoop?: (args: GenerateLoopArgs) => AsyncGenerator<unknown>;
+  textToImages?: (...args: unknown[]) => Promise<Uint8Array[]>;
+  imageToImages?: (...args: unknown[]) => Promise<Uint8Array[]>;
+  textToVideo?: (...args: unknown[]) => Promise<Uint8Array>;
+  imageToVideo?: (...args: unknown[]) => Promise<Uint8Array>;
+  textToSpeechEncoded?: (
+    ...args: unknown[]
+  ) => Promise<{ data: Uint8Array; mimeType: string } | null>;
+  textToSpeech?: (
+    ...args: unknown[]
+  ) => AsyncGenerator<{ samples: Int16Array; sampleRate?: number }>;
+}
+
+/** The slice of the provider `generateLoop` contract the fakes read. */
+export interface GenerateLoopArgs {
+  messages: Array<{ role: string; content: unknown }>;
+  signal?: AbortSignal;
+  providerSession?: unknown;
+  loadFullHistory?: () => Promise<Array<{ role: string; content: unknown }>>;
+  executeTool?: (toolCall: {
+    id: string;
+    name: string;
+    args: Record<string, unknown>;
+  }) => Promise<unknown>;
+}
+
+/**
+ * Build a provider double. The handler reads only the members a given path
+ * touches, so the cast is over a structurally honest partial.
+ */
+export function fakeProvider(shape: FakeProviderShape): BaseProvider {
+  const base: FakeProviderShape = {
+    provider: "mock",
+    cost: 0,
+    setMessageEmitter: () => {},
+    ...shape
+  };
+  // SAFETY: BaseProvider is a class with many members; the chat turn reads
+  // only the ones the double provides, and a missing one fails the test loudly.
+  return base as unknown as BaseProvider;
+}


### PR DESCRIPTION
## What changed

Branch-coverage tests for `packages/websocket/src/session/chat-turn.ts` — the worst-covered file in the runner split, and the one whose current coverage arrives only through delegators the next task deletes. Five new suites plus a harness (`tests/chat-turn-test-harness.ts`) construct `ChatTurnHandler` directly against `FakeClientSession` (its first consumer), real `ToolBridge` instances, and a recording `ChatJobAccess` double — no socket, no `vi.mock`, no `any` in test code. `chat-turn.ts` moves from **56.34% stmts / 41.79% branch / 59.78% funcs** to **87.70% / 71.51% / 77.17%** on the full-suite command.

Behaviours now covered:

- **Turn lifecycle**: `beginTurn` aborting the superseded turn and bumping the seq; `bumpRequestSeq`; idempotent `cancel`; `endTurn` retiring only the current controller.
- **Permission/approval**: `set_permission_mode` auto releasing a thread's waiting approvals (and only that thread's); `resolveToolResult`; `requestPlanApproval` serialization, approve/reject/trimmed-feedback/cancelled-wait branches.
- **`_logProviderCall`**: priced row, unpriced-null posture, missing provider/model, throwing cost accessor.
- **`handleMediaGenerationMessage`** (previously ~570 uncovered lines): no-model / empty-prompt / unsupported-mode / provider-failure refusals; image with variation clamp and asset references; entity-reference routing to `imageToImages`; cancellation before persist; video text and image-to-video routes; `image_edit` including the zero-length source guard; audio encoded, streamed-PCM→WAV, and raw-PCM paths.
- **Provider error classification**: connection errors (ECONNREFUSED, ENOTFOUND), HTTP 400/401/403/404/429/503/418, body-message extraction, non-Error throw — each asserting frame fields plus the persisted assistant error row.
- **Tool router**: client-tool round trip via the bridge, renderer preference for workflow-document tools, `tools.`-prefix normalization, unroutable-tool answer.
- **Superseded drain cap**: a flooding provider is cut off near 200 items, no done chunk is sent, and the open tool call gets its `SUPERSEDED_TOOL_RESULT` stand-in row.
- **`handleWorkflowMessage` job accounting through `ChatJobAccess`**: register→release on completion and failure, release-without-register on preparation errors, register→drop→release with no further streaming on mid-flight supersede, cancellation from an already-aborted signal.
- **`run_node`**: node output returned to the provider, failed-node error bag, hydration and `beforeRunJob` preparation failures.
- **Resume fast path**: delta-only history with checkpoint 1, and the `loadFullHistory` priming fallback.
- **Persistence branches**: array-content assistant messages, `session` events landing as `provider_session`, informational tool-call items; thread bootstrap (create-on-missing, reuse-on-existing); the volatile memory block reaching the last user message (this thread's content in full, other threads' never by content).

Not reached, and why: `requestSecretEntry` (only a capability raising a `secretPrompt` mid-turn reaches it), `emitSyntheticToolCallCard` (fires only on forwarded `run_subtask` child events), the `view_image` pixel-injection branch (needs a resolvable stored image inside the same turn's context), Google-Workspace registration (env-gated), and a few best-effort catch arms (`threadWorkspaceWorkflowId`/`buildMemoryBlock`/`loadUserSkills` DB-hiccup paths).

**CI caveat**: the repo's `test.yml` runs on `pull_request: branches: [main]` only, so the Quality Gate does not run against this base branch. The local results below are the real evidence.

## Verification

- [x] Full websocket suite: `npx vitest run --root packages/websocket --coverage.enabled --coverage.provider=v8 --coverage.reporter=text --coverage.include='src/session/**' --coverage.include='src/unified-websocket-runner.ts'` → **243 files / 2,683 tests, 0 failures** (238 / 2,621 before). `chat-turn.ts`: 87.70% stmts / 71.51% branch / 77.17% funcs (baseline 56.34 / 41.79 / 59.78).
- [x] `npm run lint --workspace=packages/websocket` (`tsc --noEmit`) — clean.
- [x] Diff is test-only: no production file, config, or existing test changed, so `test:affected`/`harness gate` reduce to the suite above.

## New checks

- [x] Every meaningful test was proven able to fail: the production code was mutated once per behaviour, the targeted test observed red, and the mutation reverted. 18 mutations, each `Tests 1 failed` (or 6 failed for the finally-release one):

| # | Mutation in `chat-turn.ts` | Test that went red |
|---|---|---|
| M1 | `beginTurn` no longer calls `this.cancel()` | beginTurn aborts the previous turn |
| M2 | `endTurn` clears the controller unconditionally | endTurn retires only the current controller |
| M3 | auto mode no longer calls `approvalBridge.resolveScope` | switching a thread to auto releases every approval |
| M4 | cancelled plan wait returns approve | treats a cancelled wait as a rejection |
| M5 | unpriced cost written as `0` instead of `null` | records an unpriced call as a null cost |
| M6b | `cancelled()` stops reading the abort signal | stops persisting when the turn is cancelled |
| M7 | zero-length source check reduced to `!sourceBytes` | refuses a zero-length source image |
| M8 | `errorType = "connection_error"` assignment dropped | classifies ECONNREFUSED as a connection error |
| M9a | `status_code` dropped from the error frame | formats HTTP 401 |
| M9b | body-message extraction disabled | prefers the message the response body carried |
| M10 | `MAX_SUPERSEDED_DRAIN_ITEMS` → Infinity | stops reading a provider that keeps producing |
| M11 | finally no longer writes stand-in tool rows | same drain test (stand-in assertion) |
| M12 | workflow `finally` no longer calls `releaseJob` | 6 of 7 workflow tests fail |
| M13 | supersede path no longer calls `dropJob` | drops and releases a run superseded mid-flight |
| M14 | workflow `superseded()` hardwired false | same supersede test |
| M15 | `runSingleNode` failed-run error bag removed | runs a single node and returns its output |
| M16 | resume probe match hardwired false | hands the provider a delta plus loadFullHistory |
| M17 | memory block never pushed into volatile context | pastes this thread's memories |
| M18 | renderer preference for document tools disabled | round-trips a client tool through the bridge |

Example failing output (M10, drain cap removed):

```
FAIL  tests/chat-turn-handler-errors.test.ts > superseded turn drain cap
  > stops reading a provider that keeps producing and stands in for the open call
AssertionError: expected 1000 to be less than 300
 Tests  1 failed | 14 skipped (15)
```

One mutation survived and was strengthened rather than kept: dropping only the first post-`textToImages` `cancelled()` check is masked by the per-variation guard on the next line, so the mutation was moved to the `cancelled()` predicate itself (M6b), which the test catches.

## Agent capabilities

Skipped — no capability added, no capability contract changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrkYim9kcnJnvqhC8RWNoc

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrkYim9kcnJnvqhC8RWNoc)_