### PR TITLE
Extend timeline rubber-band selection across tracks

### DIFF
--- a/web/src/components/timeline/Tracks/RubberBandOverlay.tsx
+++ b/web/src/components/timeline/Tracks/RubberBandOverlay.tsx
@@ -1,0 +1,51 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * RubberBandOverlay
+ *
+ * Draws the in-progress rubber-band marquee. It renders in the lanes
+ * container rather than in the lane the gesture started on: a band may span
+ * several tracks, and each lane clips its own overflow.
+ */
+
+import React, { memo, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+
+import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
+import { Z_INDEX } from "../../ui_primitives";
+
+const rubberBandStyles = (theme: Theme) =>
+  css({
+    position: "absolute",
+    border: `1px solid ${theme.vars.palette.secondary.main}`,
+    backgroundColor: `${theme.vars.palette.secondary.main}22`,
+    pointerEvents: "none",
+    zIndex: Z_INDEX.sticky
+  });
+
+export const RubberBandOverlay: React.FC = memo(() => {
+  const theme = useTheme();
+  const rubberBand = useTimelineUIStore((s) => s.rubberBand);
+  const rubberBandCss = useMemo(() => rubberBandStyles(theme), [theme]);
+
+  if (!rubberBand) {
+    return null;
+  }
+
+  return (
+    <div
+      css={rubberBandCss}
+      data-testid="timeline-rubber-band"
+      style={{
+        left: rubberBand.left,
+        top: rubberBand.top,
+        width: rubberBand.width,
+        height: rubberBand.height
+      }}
+      aria-hidden="true"
+    />
+  );
+});
+
+RubberBandOverlay.displayName = "RubberBandOverlay";

--- a/web/src/components/timeline/Tracks/TrackLane.tsx
+++ b/web/src/components/timeline/Tracks/TrackLane.tsx
@@ -9,7 +9,8 @@
  *
  * Supports:
  *   - Click on empty space → clear selection
- *   - Rubber-band selection (pointer drag on empty space)
+ *   - Rubber-band selection (pointer drag on empty space), which extends
+ *     across every lane the band covers, not just this one
  *   - Drop target for clips dragged from other tracks
  *   - Drop target for assets dragged from AssetExplorer (NOD-304)
  */
@@ -93,22 +94,6 @@ const laneStyles = (
     transition: `opacity ${MOTION.fast}`
   });
 
-const rubberBandStyles = (theme: Theme) =>
-  css({
-    position: "absolute",
-    border: `1px solid ${theme.vars.palette.secondary.main}`,
-    backgroundColor: `${theme.vars.palette.secondary.main}22`,
-    pointerEvents: "none",
-    zIndex: Z_INDEX.sticky
-  });
-
-interface RubberBandRect {
-  left: number;
-  top: number;
-  width: number;
-  height: number;
-}
-
 interface TrackLaneProps {
   track: TimelineTrack;
 }
@@ -133,6 +118,7 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
   const clearSelection = useTimelineUIStore((s) => s.clearSelection);
   const seek = useTimelinePlaybackStore((s) => s.seek);
   const setSelection = useTimelineUIStore((s) => s.setSelection);
+  const setRubberBand = useTimelineUIStore((s) => s.setRubberBand);
   const addImportedClip = useTimelineStore((s) => s.addImportedClip);
   const addClip = useTimelineStore((s) => s.addClip);
   const importVideoWithAudio = useVideoAudioImport();
@@ -141,26 +127,41 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
 
   const laneRef = useRef<HTMLDivElement>(null);
   const isRubberBandingRef = useRef(false);
+  /** Band origin in lanes-content space. */
   const rbStartRef = useRef({ x: 0, y: 0 });
   /** Selection snapshot taken at pointerdown when Shift is held (union mode). */
   const rbBaseSelectionRef = useRef<Set<string> | null>(null);
-  /** This track's clips snapshotted at pointerdown — the clip list doesn't
-   *  change during a rubber-band gesture, so we avoid filtering the full clip
-   *  array twice on every pointermove. */
-  const rbTrackClipsRef = useRef<
-    Array<{ id: string; startMs: number; durationMs: number }>
+  /** Every clip, snapshotted at pointerdown. The band can reach any lane, so
+   *  the hit-test is not limited to this track; the clip list doesn't change
+   *  during the gesture, so the full array is read once instead of per move. */
+  const rbClipsRef = useRef<
+    Array<{
+      id: string;
+      trackId: string;
+      startMs: number;
+      durationMs: number;
+    }>
   >([]);
+  /** Each lane's vertical extent in lanes-content space, snapshotted at
+   *  pointerdown alongside the clips. Lanes don't move during the gesture. */
+  const rbTrackBoundsRef = useRef<
+    Map<string, { top: number; bottom: number }>
+  >(new Map());
   /** Coalesces selection updates to one per animation frame. */
-  const rbLastAppliedRef = useRef<{ startMs: number; endMs: number } | null>(
-    null
-  );
-  /** Lane's bounding rect, captured once at pointerdown. The lane can't move
-   *  during a captured rubber-band gesture, so pointermove reuses this instead
-   *  of calling getBoundingClientRect() (forces layout) on every move. */
-  const rbLaneRectRef = useRef<DOMRect | null>(null);
-  const [rubberBand, setRubberBand] = React.useState<RubberBandRect | null>(
-    null
-  );
+  const rbLastAppliedRef = useRef<{
+    startMs: number;
+    endMs: number;
+    topPx: number;
+    bottomPx: number;
+  } | null>(null);
+  /** Lanes container rect, captured once at pointerdown. The container can't
+   *  move during a captured rubber-band gesture, so pointermove reuses this
+   *  instead of calling getBoundingClientRect() (forces layout) per move. */
+  const rbContainerRectRef = useRef<DOMRect | null>(null);
+  /** True while this lane owns a band gesture — drives the lane cursor only,
+   *  the band rect itself lives in the UI store so the overlay can draw it
+   *  across lanes. */
+  const [isRubberBanding, setIsRubberBanding] = useState(false);
 
   const [isDragOver, setIsDragOver] = useState(false);
   const [isDragReject, setIsDragReject] = useState(false);
@@ -343,10 +344,11 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
         // The hold became a menu, not a band — drop the gesture pointerdown
         // started so releasing doesn't re-select.
         isRubberBandingRef.current = false;
+        setIsRubberBanding(false);
         setRubberBand(null);
         openLaneMenuAt(point.clientX, point.clientY, laneEl);
       },
-      [openLaneMenuAt]
+      [openLaneMenuAt, setRubberBand]
     )
   );
 
@@ -383,34 +385,57 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
         );
       }
 
-      // Snapshot this track's clips once — they don't move during the band
-      // gesture, so the hit-test on pointermove reads from this list instead of
-      // re-filtering the global clip array each frame.
-      rbTrackClipsRef.current = useTimelineStore
-        .getState()
-        .clips.filter((c) => c.trackId === track.id)
-        .map((c) => ({
-          id: c.id,
-          startMs: c.startMs,
-          durationMs: c.durationMs
-        }));
+      const laneEl = e.currentTarget;
+      // The band is measured against the lanes container so it can cross into
+      // the lanes above and below this one. Standalone renders (tests) have no
+      // container, in which case the starting lane is the whole space.
+      const containerEl =
+        laneEl.closest<HTMLElement>("[data-timeline-lanes]") ??
+        laneEl.parentElement ??
+        laneEl;
+      const containerRect = containerEl.getBoundingClientRect();
+      rbContainerRectRef.current = containerRect;
 
-      e.currentTarget.setPointerCapture(e.pointerId);
-      const rect = e.currentTarget.getBoundingClientRect();
-      rbLaneRectRef.current = rect;
-      const localX = e.clientX - rect.left;
+      // Snapshot the clips and each lane's vertical extent once — neither
+      // changes during the band gesture, so the hit-test on pointermove reads
+      // these instead of touching the DOM or re-filtering clips each frame.
+      rbClipsRef.current = useTimelineStore.getState().clips.map((c) => ({
+        id: c.id,
+        trackId: c.trackId,
+        startMs: c.startMs,
+        durationMs: c.durationMs
+      }));
+
+      const bounds = new Map<string, { top: number; bottom: number }>();
+      containerEl
+        .querySelectorAll<HTMLElement>("[data-track-lane-id]")
+        .forEach((el) => {
+          const laneTrackId = el.dataset.trackLaneId;
+          if (!laneTrackId) {
+            return;
+          }
+          const laneRect = el.getBoundingClientRect();
+          bounds.set(laneTrackId, {
+            top: laneRect.top - containerRect.top,
+            bottom: laneRect.bottom - containerRect.top
+          });
+        });
+      rbTrackBoundsRef.current = bounds;
+
+      laneEl.setPointerCapture(e.pointerId);
+      const localX = e.clientX - containerRect.left;
       rbStartRef.current = {
         x: localX,
-        y: e.clientY - rect.top
+        y: e.clientY - containerRect.top
       };
       isRubberBandingRef.current = true;
 
-      // Move the playhead to the clicked position. The lane is inside the
-      // scrolling container, so localX is already content-space.
+      // Move the playhead to the clicked position. The lanes container is
+      // inside the scrolling element, so localX is already content-space.
       const timeMs = Math.round(localX * msPerPx);
       seek(timeMs);
     },
-    [clearSelection, laneLongPress, msPerPx, seek, track.id]
+    [clearSelection, laneLongPress, msPerPx, seek]
   );
 
   // Apply the rubber-band selection for the given content-space range. Deduped
@@ -418,15 +443,34 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
   // browser already coalesces moves to ~one per frame) skip the O(n) overlap
   // filter and the setSelection call entirely.
   const applyRubberBandSelection = useCallback(
-    (startMs: number, endMs: number) => {
+    (startMs: number, endMs: number, topPx: number, bottomPx: number) => {
       const last = rbLastAppliedRef.current;
-      if (last && last.startMs === startMs && last.endMs === endMs) {
+      if (
+        last &&
+        last.startMs === startMs &&
+        last.endMs === endMs &&
+        last.topPx === topPx &&
+        last.bottomPx === bottomPx
+      ) {
         return;
       }
-      rbLastAppliedRef.current = { startMs, endMs };
+      rbLastAppliedRef.current = { startMs, endMs, topPx, bottomPx };
 
-      const selected = rbTrackClipsRef.current
+      const trackBounds = rbTrackBoundsRef.current;
+      const selected = rbClipsRef.current
         .filter((c) => {
+          // A clip counts when the band covers both its lane vertically and
+          // its span horizontally. Lane bounds are compared inclusively so a
+          // lane the band only grazes still takes part, and so a lane that
+          // measured zero-height (jsdom, display:none) is not dropped.
+          const laneBounds = trackBounds.get(c.trackId);
+          if (
+            !laneBounds ||
+            laneBounds.top > bottomPx ||
+            laneBounds.bottom < topPx
+          ) {
+            return false;
+          }
           const clipEnd = c.startMs + c.durationMs;
           return clipEnd > startMs && c.startMs < endMs;
         })
@@ -446,7 +490,7 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
       if (!isRubberBandingRef.current || e.buttons !== 1) {
         return;
       }
-      const rect = rbLaneRectRef.current;
+      const rect = rbContainerRectRef.current;
       if (!rect) {
         return;
       }
@@ -458,15 +502,21 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
       const width = Math.abs(curX - rbStartRef.current.x);
       const height = Math.abs(curY - rbStartRef.current.y);
 
+      setIsRubberBanding(true);
       setRubberBand({ left, top, width, height });
 
-      // Compute which clips overlap the rubber-band. The lane renders inside
-      // the scrolling lanes container, so lane-local coordinates are already
-      // content-space — no scroll offset.
+      // Compute which clips the rubber-band covers. The lanes container
+      // renders inside the scrolling element, so container-local coordinates
+      // are already content-space — no scroll offset.
       const rbStartMs = left * msPerPx;
-      applyRubberBandSelection(rbStartMs, rbStartMs + width * msPerPx);
+      applyRubberBandSelection(
+        rbStartMs,
+        rbStartMs + width * msPerPx,
+        top,
+        top + height
+      );
     },
-    [laneLongPress, msPerPx, applyRubberBandSelection]
+    [laneLongPress, msPerPx, applyRubberBandSelection, setRubberBand]
   );
 
   const handleLanePointerUp = useCallback(() => {
@@ -474,10 +524,12 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
     isRubberBandingRef.current = false;
     rbBaseSelectionRef.current = null;
     rbLastAppliedRef.current = null;
-    rbTrackClipsRef.current = [];
-    rbLaneRectRef.current = null;
+    rbClipsRef.current = [];
+    rbTrackBoundsRef.current = new Map();
+    rbContainerRectRef.current = null;
+    setIsRubberBanding(false);
     setRubberBand(null);
-  }, [laneLongPress]);
+  }, [laneLongPress, setRubberBand]);
 
   const handleLaneContextMenu = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -532,9 +584,6 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
     setAddClipAnchorEl(null);
   }, []);
 
-  // A rubber-band gesture re-renders the lane per pointermove; only the band's
-  // own inline rect changes during it.
-  const isRubberBanding = rubberBand !== null;
   const laneCss = useMemo(
     () =>
       laneStyles(
@@ -547,13 +596,13 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
       ),
     [theme, heightPx, track.visible, isRubberBanding, isDragOver, isDragReject]
   );
-  const rubberBandCss = useMemo(() => rubberBandStyles(theme), [theme]);
 
   return (
     <div
       ref={laneRef}
       css={laneCss}
       data-testid={`track-lane-${track.id}`}
+      data-track-lane-id={track.id}
       onPointerDown={handleLanePointerDown}
       onPointerMove={handleLanePointerMove}
       onPointerUp={handleLanePointerUp}
@@ -570,20 +619,6 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
       {clipIds.map((id) => (
         <Clip key={id} clipId={id} />
       ))}
-
-      {/* Rubber-band selection rect */}
-      {rubberBand && (
-        <div
-          css={rubberBandCss}
-          style={{
-            left: rubberBand.left,
-            top: rubberBand.top,
-            width: rubberBand.width,
-            height: rubberBand.height
-          }}
-          aria-hidden="true"
-        />
-      )}
 
       {/* Right-click context menu (lane background) */}
       <ContextMenu

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -73,6 +73,7 @@ import {
 } from "./TrackHeader";
 import { TrackHeader } from "./TrackHeader";
 import { TrackLane } from "./TrackLane";
+import { RubberBandOverlay } from "./RubberBandOverlay";
 import { TimeRuler } from "./TimeRuler";
 import { Playhead } from "./Playhead";
 import { AddTrackButton } from "./AddTrackButton";
@@ -1041,6 +1042,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
             <div
               css={lanesContainerStyles}
               style={{ minWidth: totalWidthPx, width: "100%", height: totalTracksHeight }}
+              data-timeline-lanes="true"
             >
               {tracks.map((track) => (
                 <React.Fragment key={track.id}>
@@ -1066,6 +1068,9 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
               {hasScript && scriptBeforeTrackId === null && (
                 <ScriptLane />
               )}
+              {/* Marquee rect — drawn here, above every lane, because a band
+                  started on one lane may cover several. */}
+              <RubberBandOverlay />
             </div>
           </div>
         </FlexRow>

--- a/web/src/components/timeline/__tests__/TrackLaneCrossTrackMarquee.test.tsx
+++ b/web/src/components/timeline/__tests__/TrackLaneCrossTrackMarquee.test.tsx
@@ -1,0 +1,272 @@
+/**
+ * Cross-track rubber-band selection.
+ *
+ * A marquee started on one lane selects clips on every lane it covers, not
+ * only the lane the gesture began on. The band is measured in the coordinate
+ * space of the lanes container, so these tests stub the lane rects that jsdom
+ * reports as all-zero.
+ */
+
+import { installGlobal } from "../../../test-utils/doubles";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+// Polyfill PointerEvent for jsdom (which doesn't support it natively).
+if (typeof window !== "undefined" && !window.PointerEvent) {
+  installGlobal(
+    "PointerEvent",
+    class PointerEvent extends MouseEvent {
+      readonly pointerId: number;
+      readonly pointerType: string;
+      readonly isPrimary: boolean;
+
+      constructor(type: string, params: PointerEventInit & MouseEventInit = {}) {
+        super(type, params);
+        this.pointerId = params.pointerId ?? 0;
+        this.pointerType = params.pointerType ?? "";
+        this.isPrimary = params.isPrimary ?? false;
+      }
+    });
+}
+
+// ── Heavy media hooks → no-op mocks ─────────────────────────────────────────
+
+jest.mock("../Tracks/useClipThumbnails", () => ({
+  useClipThumbnails: () => null
+}));
+jest.mock("../Tracks/useAudioPeaks", () => ({
+  useAudioPeaks: () => ({ peaks: null, durationMs: null })
+}));
+
+// ── Stores that pull in network/api dependencies → light mocks ─────────────
+
+jest.mock("../../../stores/AssetStore", () => ({
+  useAssetStore: <T,>(sel: (s: { get: () => Promise<null> }) => T) =>
+    sel({ get: () => Promise.resolve(null) })
+}));
+jest.mock("../../../stores/WorkflowRunsStore", () => ({
+  __esModule: true,
+  default: <T,>(sel: (s: { focusedJob: Record<string, string> }) => T) =>
+    sel({ focusedJob: {} })
+}));
+jest.mock("../../../stores/ErrorStore", () => ({
+  __esModule: true,
+  default: <T,>(sel: (s: { errors: Record<string, unknown> }) => T) =>
+    sel({ errors: {} }),
+  hasNodeError: () => false,
+  nodeErrorToDisplayString: () => ""
+}));
+jest.mock("../../../stores/timeline/TimelineGenerationStore", () => ({
+  useTimelineGenerationStore: <T,>(
+    sel: (s: { clipJobs: Record<string, unknown> }) => T
+  ) => sel({ clipJobs: {} })
+}));
+
+import type { TimelineClip, TimelineTrack } from "@nodetool-ai/timeline";
+import { TrackLane } from "../Tracks/TrackLane";
+import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
+import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
+
+// jsdom does not implement pointer capture.
+beforeAll(() => {
+  HTMLElement.prototype.setPointerCapture = jest.fn();
+  HTMLElement.prototype.releasePointerCapture = jest.fn();
+});
+
+const trackA: TimelineTrack = {
+  id: "t1",
+  name: "Video 1",
+  type: "video",
+  index: 0,
+  visible: true,
+  locked: false
+};
+
+const trackB: TimelineTrack = {
+  id: "t2",
+  name: "Video 2",
+  type: "video",
+  index: 1,
+  visible: true,
+  locked: false
+};
+
+const makeClip = (
+  id: string,
+  trackId: string,
+  startMs: number,
+  durationMs: number
+): TimelineClip => ({
+  id,
+  trackId,
+  name: id,
+  startMs,
+  durationMs,
+  mediaType: "video",
+  sourceType: "imported",
+  status: "draft",
+  locked: false,
+  versions: []
+});
+
+const MS_PER_PX = 10;
+const LANE_HEIGHT_PX = 64;
+
+/** Give an element a fixed rect — jsdom reports every rect as all-zero. */
+const stubRect = (el: HTMLElement, top: number, bottom: number) => {
+  el.getBoundingClientRect = () =>
+    ({
+      x: 0,
+      y: top,
+      left: 0,
+      right: 1000,
+      top,
+      bottom,
+      width: 1000,
+      height: bottom - top,
+      toJSON: () => ({})
+    }) as DOMRect;
+};
+
+/** Two stacked lanes inside a lanes container, with realistic rects. */
+const renderLanes = () => {
+  const view = render(
+    <ThemeProvider theme={mockTheme}>
+      <div data-timeline-lanes="true">
+        <TrackLane track={trackA} />
+        <TrackLane track={trackB} />
+      </div>
+    </ThemeProvider>
+  );
+  const laneA = screen.getByTestId("track-lane-t1");
+  const laneB = screen.getByTestId("track-lane-t2");
+  const container = laneA.parentElement as HTMLElement;
+  stubRect(container, 0, LANE_HEIGHT_PX * 2);
+  stubRect(laneA, 0, LANE_HEIGHT_PX);
+  stubRect(laneB, LANE_HEIGHT_PX, LANE_HEIGHT_PX * 2);
+  return { ...view, laneA, laneB };
+};
+
+beforeEach(() => {
+  useTimelineStore.setState({
+    tracks: [trackA, trackB],
+    clips: [
+      makeClip("a1", trackA.id, 2000, 1000),
+      makeClip("a2", trackA.id, 6000, 1000),
+      makeClip("b1", trackB.id, 2000, 1000),
+      makeClip("b2", trackB.id, 6000, 1000)
+    ],
+    durationMs: 10_000
+  });
+  useTimelineUIStore.setState({
+    msPerPx: MS_PER_PX,
+    scrollLeftPx: 0,
+    selectedClipIds: new Set<string>(),
+    rubberBand: null
+  });
+  useTimelinePlaybackStore.setState({ currentTimeMs: 0 });
+});
+
+describe("rubber-band selection across tracks", () => {
+  it("selects clips on every lane the band covers", () => {
+    const { laneA } = renderLanes();
+    // Band x 150→250 (1500–2500 ms), y 10→100: covers both lanes.
+    fireEvent.pointerDown(laneA, {
+      button: 0,
+      clientX: 150,
+      clientY: 10,
+      pointerId: 1
+    });
+    fireEvent.pointerMove(laneA, {
+      buttons: 1,
+      clientX: 250,
+      clientY: 100,
+      pointerId: 1
+    });
+    const selected = useTimelineUIStore.getState().selectedClipIds;
+    expect([...selected].sort()).toEqual(["a1", "b1"]);
+  });
+
+  it("leaves other lanes alone when the band stays inside one", () => {
+    const { laneA } = renderLanes();
+    // Same time range, but y 10→30 never leaves lane A.
+    fireEvent.pointerDown(laneA, {
+      button: 0,
+      clientX: 150,
+      clientY: 10,
+      pointerId: 1
+    });
+    fireEvent.pointerMove(laneA, {
+      buttons: 1,
+      clientX: 250,
+      clientY: 30,
+      pointerId: 1
+    });
+    expect([...useTimelineUIStore.getState().selectedClipIds]).toEqual(["a1"]);
+  });
+
+  it("selects upwards when the band is dragged from a lower lane", () => {
+    const { laneB } = renderLanes();
+    fireEvent.pointerDown(laneB, {
+      button: 0,
+      clientX: 250,
+      clientY: 100,
+      pointerId: 1
+    });
+    fireEvent.pointerMove(laneB, {
+      buttons: 1,
+      clientX: 150,
+      clientY: 10,
+      pointerId: 1
+    });
+    const selected = useTimelineUIStore.getState().selectedClipIds;
+    expect([...selected].sort()).toEqual(["a1", "b1"]);
+  });
+
+  it("publishes the band rect in lanes-content space", () => {
+    const { laneA } = renderLanes();
+    fireEvent.pointerDown(laneA, {
+      button: 0,
+      clientX: 150,
+      clientY: 10,
+      pointerId: 1
+    });
+    fireEvent.pointerMove(laneA, {
+      buttons: 1,
+      clientX: 250,
+      clientY: 100,
+      pointerId: 1
+    });
+    expect(useTimelineUIStore.getState().rubberBand).toEqual({
+      left: 150,
+      top: 10,
+      width: 100,
+      height: 90
+    });
+    fireEvent.pointerUp(laneA, { pointerId: 1 });
+    expect(useTimelineUIStore.getState().rubberBand).toBeNull();
+  });
+
+  it("shift+band unions the cross-track hits with the prior selection", () => {
+    useTimelineUIStore.setState({ selectedClipIds: new Set(["b2"]) });
+    const { laneA } = renderLanes();
+    fireEvent.pointerDown(laneA, {
+      button: 0,
+      clientX: 150,
+      clientY: 10,
+      pointerId: 1,
+      shiftKey: true
+    });
+    fireEvent.pointerMove(laneA, {
+      buttons: 1,
+      clientX: 250,
+      clientY: 100,
+      pointerId: 1,
+      shiftKey: true
+    });
+    const selected = useTimelineUIStore.getState().selectedClipIds;
+    expect([...selected].sort()).toEqual(["a1", "b1", "b2"]);
+  });
+});

--- a/web/src/stores/timeline/TimelineUIStore.ts
+++ b/web/src/stores/timeline/TimelineUIStore.ts
@@ -16,6 +16,17 @@ import { create, type StoreApi, type UseBoundStore } from "zustand";
 
 export type TimelineTool = "select" | "cut";
 
+/**
+ * Rubber-band marquee rectangle in lanes-content space (the coordinate space
+ * of the lanes container, so the band can span several track lanes).
+ */
+export interface TimelineRubberBand {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
 /** A reference to one transcript word: its clip and the word index within it. */
 interface WordRef {
   clipId: string;
@@ -77,6 +88,14 @@ export interface TimelineUIState {
   clearSelection: () => void;
   /** Replace the selection with a new set of IDs (rubber-band). */
   setSelection: (ids: string[]) => void;
+  /**
+   * The in-progress rubber-band rect, or null when no band gesture is active.
+   * The band starts on one lane but is drawn and hit-tested across all of
+   * them, so it lives here rather than in the lane that owns the gesture.
+   */
+  rubberBand: TimelineRubberBand | null;
+  /** Set (or clear, with null) the rubber-band rect. */
+  setRubberBand: (rect: TimelineRubberBand | null) => void;
 
   // ── Transcript word selection ──────────────────────────────────────────────
 
@@ -182,6 +201,10 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
   clearSelection: () => set({ selectedClipIds: new Set() }),
 
   setSelection: (ids) => set({ selectedClipIds: new Set(ids) }),
+
+  rubberBand: null,
+
+  setRubberBand: (rect) => set({ rubberBand: rect }),
 
   wordSelection: null,
 


### PR DESCRIPTION
## What changed

Dragging a marquee in the timeline editor only ever selected clips on the lane the drag started on. `TrackLane` snapshotted `clips.filter(c => c.trackId === track.id)` at pointerdown and measured the band against that lane's own rect, so no amount of dragging up or down could reach another track's clips. The gesture now measures against the lanes container and snapshots every clip plus each lane's vertical extent, and a clip is selected when the band covers both its lane vertically and its span horizontally. Shift+band still unions with the selection held at pointerdown. The band rect moved to `TimelineUIStore` and is drawn by a new `RubberBandOverlay` rendered in the lanes container, because each lane clips its own overflow and a cross-track band has to escape it.

## Verification

- [x] `npx jest src/components/timeline src/stores/timeline --forceExit` in `web/` — 66 suites, 624 tests, all pass. Includes 5 new cases in `TrackLaneCrossTrackMarquee.test.tsx` covering a downward band, an upward band, a band confined to one lane (which must not reach the other), the published band rect, and shift-union across lanes.
- [x] `npx tsc --noEmit -p tsconfig.json` in `web/` — no errors in any changed file. The run reports pre-existing errors elsewhere (`browserRunnerCore.ts`, `generationCostEstimate.ts`) from workspace packages whose declarations are not built in this checkout; they are untouched by this diff.
- [x] `npx oxlint src/components/timeline src/stores/timeline`, `npx eslint` and `npx eslint --config eslint.design.config.mjs` on the changed files — clean, no new warnings.
- [ ] `npm run dev:nodetool -- harness gate --base main` — not run.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyB4qGXYb4Y943C65dytF4)_