### PR TITLE
perf(marketing): stop the model marquees running off screen

### DIFF
--- a/marketing/src/app/globals.css
+++ b/marketing/src/app/globals.css
@@ -532,3 +532,8 @@
 .legal-article ul li::marker {
   color: rgb(100 116 139);
 }
+
+/* A flick past the end of the mobile menu must not chain to the page behind. */
+.mobile-menu-panel {
+  overscroll-behavior: contain;
+}

--- a/marketing/src/components/ModelSupportSection.tsx
+++ b/marketing/src/components/ModelSupportSection.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import { Cpu, Zap, Layers, Box, Sparkles, Cloud, Bot, ShieldCheck } from "lucide-react";
 import {
@@ -69,10 +69,34 @@ const frontierModels = [
 export default function ModelSupportSection({
     reducedMotion = false,
 }: ModelSupportSectionProps) {
+    const sectionRef = useRef<HTMLElement>(null);
+    // Chrome cannot hand these marquees to the compositor, so every frame they
+    // run costs a style recalculation over ~50 moving cards — measured at 1.2s
+    // of the main thread per 3s on a 4x-throttled phone, whether or not the
+    // section is on screen. That is the tax that made the rest of the page
+    // (the hamburger menu among it) feel stuck. Run them only while visible.
+    const [onScreen, setOnScreen] = useState(false);
+
+    useEffect(() => {
+        const section = sectionRef.current;
+        if (!section || reducedMotion) return;
+        const observer = new IntersectionObserver(
+            ([entry]) => setOnScreen(entry.isIntersecting),
+            { rootMargin: "200px" }
+        );
+        observer.observe(section);
+        return () => observer.disconnect();
+    }, [reducedMotion]);
+
+    const marqueesRunning = onScreen && !reducedMotion;
+
     return (
         <section
+            ref={sectionRef}
             aria-labelledby="model-support-title"
-            className="relative py-16 overflow-clip-safe"
+            className={`relative py-16 overflow-clip-safe${
+                marqueesRunning ? "" : " marquees-paused"
+            }`}
         >
             {/* Background Glow */}
             <div className="absolute top-1/2 left-0 -translate-y-1/2 w-[800px] h-[500px] bg-emerald-900/20 blur-[120px] rounded-full pointer-events-none" />
@@ -233,6 +257,11 @@ export default function ModelSupportSection({
                 }
                 .animate-marquee-models {
                     animation: marquee-models 25s linear infinite;
+                }
+                .marquees-paused .animate-marquee,
+                .marquees-paused .animate-marquee-reverse,
+                .marquees-paused .animate-marquee-models {
+                    animation-play-state: paused;
                 }
             `}</style>
         </section>

--- a/marketing/src/components/SiteHeader.tsx
+++ b/marketing/src/components/SiteHeader.tsx
@@ -57,12 +57,37 @@ export default function SiteHeader() {
   const [mobileOpen, setMobileOpen] = useState(false);
   const stars = useGithubStars();
 
+  // Opening the panel pins the page rather than only setting `overflow:
+  // hidden`, which iOS Safari ignores — without the pin a flick inside the menu
+  // scrolls the document behind it.
   useEffect(() => {
     if (!mobileOpen) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
+    const { body, documentElement: html } = document;
+    const scrollY = window.scrollY;
+    const restore = {
+      position: body.style.position,
+      top: body.style.top,
+      left: body.style.left,
+      right: body.style.right,
+      overflow: body.style.overflow,
+    };
+    body.style.position = "fixed";
+    body.style.top = `-${scrollY}px`;
+    body.style.left = "0";
+    body.style.right = "0";
+    body.style.overflow = "hidden";
+
     return () => {
-      document.body.style.overflow = prev;
+      body.style.position = restore.position;
+      body.style.top = restore.top;
+      body.style.left = restore.left;
+      body.style.right = restore.right;
+      body.style.overflow = restore.overflow;
+      // `html { scroll-behavior: smooth }` would animate this restore.
+      const behavior = html.style.scrollBehavior;
+      html.style.scrollBehavior = "auto";
+      window.scrollTo(0, scrollY);
+      html.style.scrollBehavior = behavior;
     };
   }, [mobileOpen]);
 
@@ -149,7 +174,7 @@ export default function SiteHeader() {
 
       {mobileOpen && (
         <div
-          className="md:hidden fixed inset-0 z-50"
+          className="md:hidden fixed inset-0 z-[70]"
           role="dialog"
           aria-modal="true"
         >
@@ -159,7 +184,7 @@ export default function SiteHeader() {
             onClick={() => setMobileOpen(false)}
             aria-label="Close menu"
           />
-          <div className="absolute inset-y-0 right-0 w-full overflow-y-auto bg-gradient-to-b from-slate-900 to-slate-950 px-6 py-6 sm:max-w-sm border-l border-slate-800/60">
+          <div className="mobile-menu-panel absolute inset-y-0 right-0 w-full overflow-y-auto bg-gradient-to-b from-slate-900 to-slate-950 px-6 py-6 sm:max-w-sm border-l border-slate-800/60">
             <div className="flex items-center justify-between">
               <Wordmark />
               <button

--- a/marketing/tests/e2e/mobile-menu.spec.ts
+++ b/marketing/tests/e2e/mobile-menu.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Two things the landing page has to get right on a phone, both asserted as
+ * mechanism rather than as a frame time.
+ *
+ * The menu pins the page while it is open: `overflow: hidden` on the body
+ * alone is ignored by iOS Safari, so a flick inside the panel scrolled the
+ * document behind it.
+ *
+ * The model marquees do not animate while their section is off screen. Chrome
+ * cannot composite them, so every frame they run costs a style recalculation
+ * over ~50 moving cards — 1.2s of the main thread per 3s on a 4x-throttled
+ * phone, measured with the section nowhere near the viewport. That is what
+ * made every interaction on the page, the menu included, feel stuck.
+ */
+test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
+
+const SCROLL_Y = 1200;
+
+test.describe("landing page on a phone", () => {
+  test("the menu pins the page while open and restores the scroll position", async ({
+    page,
+  }) => {
+    await page.goto("/", { waitUntil: "load" });
+    await page.evaluate((y) => window.scrollTo(0, y), SCROLL_Y);
+    await expect
+      .poll(() => page.evaluate(() => Math.round(window.scrollY)))
+      .toBe(SCROLL_Y);
+
+    await page.getByRole("button", { name: "Open menu" }).click();
+    const panel = page.getByRole("dialog");
+    await expect(panel).toBeVisible();
+
+    expect(await page.evaluate(() => document.body.style.position)).toBe(
+      "fixed"
+    );
+
+    // A wheel over the open panel must not move the document behind it.
+    await page.mouse.move(195, 600);
+    await page.mouse.wheel(0, 800);
+    await page.waitForTimeout(200);
+    expect(await page.evaluate(() => Math.round(window.scrollY))).toBe(0);
+
+    await page.getByRole("button", { name: "Close menu" }).last().click();
+    await expect(panel).toBeHidden();
+    await expect
+      .poll(() => page.evaluate(() => Math.round(window.scrollY)))
+      .toBe(SCROLL_Y);
+    expect(await page.evaluate(() => document.body.style.position)).toBe("");
+  });
+
+  test("the model marquees stay paused while their section is off screen", async ({
+    page,
+  }) => {
+    await page.goto("/", { waitUntil: "load" });
+
+    const track = page.locator(".animate-marquee").first();
+    await expect(track).toHaveCount(1);
+
+    // Top of the page: the model section is far below, so nothing should run.
+    await expect
+      .poll(() =>
+        track.evaluate((el) => getComputedStyle(el).animationPlayState)
+      )
+      .toBe("paused");
+
+    await track.scrollIntoViewIfNeeded();
+    await expect
+      .poll(() =>
+        track.evaluate((el) => getComputedStyle(el).animationPlayState)
+      )
+      .toBe("running");
+  });
+});


### PR DESCRIPTION
## What changed

The mobile hamburger menu was reported as laggy, and it isn't the menu. A devtools trace of the landing page sitting idle at 4x CPU throttle on a phone viewport spends **1359ms of every 3s in style recalculation** with the menu closed and nothing happening; with the menu open it measures the same (1268ms). The tap just lands on a main thread that is already saturated. Bisecting that recalculation names the three infinite marquees in `ModelSupportSection`, which ran at all times regardless of where the section was. They now run only while the section is on screen, and not at all under `prefers-reduced-motion` — the component already took a `reducedMotion` prop it never used. Two corrections on the menu itself came out of the same investigation and are labelled as correctness, not speed, because they measured neutral: the scroll lock now pins the body (`overflow: hidden` alone is ignored by iOS Safari, so a flick inside the panel scrolled the page behind it), and the overlay moves to `z-[70]` because the announcement bar is `z-[60]` and was painting over the open panel.

Idle style recalculation per 3s sample, landing page, 4x CPU throttle, 390x844, section off screen:

| variant | idle style recalc |
|---|---|
| as shipped | **1315ms** |
| marquees disabled | **87ms** |
| `will-change: transform` on the tracks | 1271ms |
| `translate3d` keyframes | 1269ms |
| cards' `transition` removed | 1242ms |
| cards' `backdrop-blur` removed | 1241ms |
| section glows hidden | 1238ms |
| `scroll-fade` (`animation-timeline: view()`) disabled | 1207ms |

Chrome will not composite these animations and nothing done to the elements changes that — only stopping them removes the cost, which is why the fix is an `IntersectionObserver` rather than a compositing hint.

## Verification

`marketing/` is not a root workspace and none of the monorepo checks reach it — root `lint` is `oxlint packages/*/src web/src electron mobile/src`, `typecheck` is web + electron + mobile, and `npm run dev:nodetool -- affected` cannot run here without a full `build:packages` for a diff that touches no package. The checks below are the ones that cover this diff.

- [x] `npx tsc --noEmit -p tsconfig.json` (in `marketing/`) — clean
- [x] `npx next lint --file src/components/ModelSupportSection.tsx --file src/components/SiteHeader.tsx` — `✔ No ESLint warnings or errors`
- [ ] `npx playwright test tests/e2e/mobile-menu.spec.ts` — results and the inverted-run output to follow in a comment
- [ ] `npm run test:affected` / `npm run typecheck` / `npm run lint` — n/a, see above
- [ ] `npm run dev:nodetool -- harness gate --base main` — n/a, no surface in the harness registry covers `marketing/`

## Agent capabilities

No capability added or re-declared.

## New checks

`marketing/tests/e2e/mobile-menu.spec.ts` asserts both mechanisms rather than a frame time: the page stays pinned while the menu is open and its scroll position is restored on close, and the marquee's computed `animation-play-state` is `paused` at the top of the page and `running` once its section is scrolled into view.

- [ ] The check was inverted once and observed failing — output to follow in a comment
- [x] Both assertions read live computed state, so neither can pass by matching nothing

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwVFPovWAwem4U2zSanWRJ)_