### PR TITLE
feat(chat): add attach button to the media composer

### DIFF
--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -11,6 +11,7 @@ import React, {
 import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import AddIcon from "@mui/icons-material/Add";
 import AspectRatioIcon from "@mui/icons-material/CropOriginal";
 import AppsIcon from "@mui/icons-material/Apps";
 import DisplaySettingsIcon from "@mui/icons-material/Tv";
@@ -28,7 +29,7 @@ import AudiotrackIcon from "@mui/icons-material/Audiotrack";
 import TuneIcon from "@mui/icons-material/Tune";
 import LayersIcon from "@mui/icons-material/Layers";
 
-import { FlexRow, Text } from "../../ui_primitives";
+import { FlexRow, LoadingSpinner, Text } from "../../ui_primitives";
 import useGlobalChatStore from "../../../stores/GlobalChatStore";
 import useMediaGenerationStore, {
   IMAGE_VARIATIONS,
@@ -81,6 +82,7 @@ import { VoiceInputControl } from "./voice/VoiceInputControl";
 import { FilePreview } from "./FilePreview";
 import { useFileHandling } from "../hooks/useFileHandling";
 import { useDragAndDrop } from "../hooks/useDragAndDrop";
+import { useComposerAssetUpload } from "../hooks/useComposerAssetUpload";
 import { usePromptHistory } from "../hooks/usePromptHistory";
 import { useMessageQueue } from "../../../hooks/useMessageQueue";
 import { createMediaComposerStyles } from "./MediaChatComposer.styles";
@@ -273,6 +275,25 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     useFileHandling();
   const { isDragging, handleDragOver, handleDragLeave, handleDrop } =
     useDragAndDrop(addFiles, addDroppedFiles);
+
+  // The + button uploads what it picks to the asset library and attaches the
+  // resulting `asset://` reference, so the file survives the turn instead of
+  // riding along as inline bytes.
+  const attachInputRef = useRef<HTMLInputElement>(null);
+  const { uploadFiles, isUploading } = useComposerAssetUpload(addDroppedFiles);
+
+  const openAttachPicker = useCallback(() => {
+    attachInputRef.current?.click();
+  }, []);
+
+  const handleAttachPicked = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      uploadFiles(Array.from(e.target.files ?? []));
+      // Reset so picking the same file twice fires change again.
+      e.target.value = "";
+    },
+    [uploadFiles]
+  );
 
   // Typing `@` opens the asset picker; a picked asset is attached as an
   // `asset://` reference (like a drag from the asset library) rather than
@@ -1050,6 +1071,27 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
           {leadingActions}
           {/* Chip cluster: mode/model chips. */}
           <div className="media-chip-main">
+          {/* Attach: uploads to the asset library and attaches the asset. */}
+          <input
+            ref={attachInputRef}
+            type="file"
+            hidden
+            multiple
+            onChange={handleAttachPicked}
+          />
+          <MediaControlChip
+            icon={
+              isUploading ? (
+                <LoadingSpinner inline size={16} color="inherit" />
+              ) : (
+                <AddIcon fontSize="small" />
+              )
+            }
+            title={isUploading ? "Uploading…" : "Attach files"}
+            onClick={openAttachPicker}
+            disabled={disabled}
+            showChevron={false}
+          />
           {/* Mode selector chip */}
           {!hideModePicker && (
             <>

--- a/web/src/components/chat/hooks/__tests__/useComposerAssetUpload.test.tsx
+++ b/web/src/components/chat/hooks/__tests__/useComposerAssetUpload.test.tsx
@@ -1,0 +1,115 @@
+import "@testing-library/jest-dom";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useComposerAssetUpload } from "../useComposerAssetUpload";
+import useAssetUpload from "../../../../serverState/useAssetUpload";
+import { useNotificationStore } from "../../../../stores/NotificationStore";
+import type { Asset } from "../../../../stores/ApiTypes";
+
+const asset = (id: string): Asset =>
+  ({
+    id,
+    user_id: "u1",
+    name: `${id}.png`,
+    content_type: "image/png",
+    thumb_url: `https://example.test/${id}-thumb.png`,
+    get_url: `https://example.test/${id}.png`
+  }) as Asset;
+
+const pickedFile = (name: string) =>
+  new File(["bytes"], name, { type: "image/png" });
+
+/** Replace the upload queue's action so no network or asset store is involved. */
+const stubUploads = (
+  handler: (input: {
+    file: File;
+    onCompleted?: (asset: Asset) => void;
+    onFailed?: (error: string) => void;
+  }) => void
+) => {
+  useAssetUpload.setState({ uploadAsset: handler });
+};
+
+beforeEach(() => {
+  useNotificationStore.setState({ notifications: [] });
+});
+
+describe("useComposerAssetUpload", () => {
+  it("attaches each uploaded file as an asset reference", async () => {
+    stubUploads(({ file, onCompleted }) =>
+      onCompleted?.(asset(file.name.replace(".png", "")))
+    );
+    const onAssetsUploaded = jest.fn();
+    const { result } = renderHook(() =>
+      useComposerAssetUpload(onAssetsUploaded)
+    );
+
+    act(() => {
+      result.current.uploadFiles([pickedFile("a.png"), pickedFile("b.png")]);
+    });
+
+    await waitFor(() => expect(onAssetsUploaded).toHaveBeenCalledTimes(2));
+    expect(onAssetsUploaded.mock.calls[0][0][0]).toMatchObject({
+      name: "a.png",
+      type: "image/png",
+      assetUri: "asset://a.png",
+      dataUri: "https://example.test/a-thumb.png"
+    });
+    expect(onAssetsUploaded.mock.calls[1][0][0]).toMatchObject({
+      assetUri: "asset://b.png"
+    });
+  });
+
+  it("reports uploading until every file settles", async () => {
+    const completions: Array<() => void> = [];
+    stubUploads(({ file, onCompleted }) =>
+      completions.push(() => onCompleted?.(asset(file.name.replace(".png", ""))))
+    );
+    const { result } = renderHook(() => useComposerAssetUpload(jest.fn()));
+
+    expect(result.current.isUploading).toBe(false);
+    act(() => {
+      result.current.uploadFiles([pickedFile("a.png"), pickedFile("b.png")]);
+    });
+    expect(result.current.isUploading).toBe(true);
+
+    act(() => completions[0]());
+    expect(result.current.isUploading).toBe(true);
+
+    act(() => completions[1]());
+    expect(result.current.isUploading).toBe(false);
+  });
+
+  it("notifies and attaches nothing when an upload fails", async () => {
+    stubUploads(({ onFailed }) => onFailed?.("disk full"));
+    const onAssetsUploaded = jest.fn();
+    const { result } = renderHook(() =>
+      useComposerAssetUpload(onAssetsUploaded)
+    );
+
+    act(() => {
+      result.current.uploadFiles([pickedFile("a.png")]);
+    });
+
+    await waitFor(() =>
+      expect(useNotificationStore.getState().notifications).toHaveLength(1)
+    );
+    expect(useNotificationStore.getState().notifications[0].content).toContain(
+      "Failed to upload a.png: disk full"
+    );
+    expect(onAssetsUploaded).not.toHaveBeenCalled();
+    expect(result.current.isUploading).toBe(false);
+  });
+
+  it("does nothing when the picker is dismissed with no files", () => {
+    const uploadAsset = jest.fn();
+    stubUploads(uploadAsset);
+    const { result } = renderHook(() => useComposerAssetUpload(jest.fn()));
+
+    act(() => {
+      result.current.uploadFiles([]);
+    });
+
+    expect(uploadAsset).not.toHaveBeenCalled();
+    expect(result.current.isUploading).toBe(false);
+  });
+});

--- a/web/src/components/chat/hooks/useComposerAssetUpload.ts
+++ b/web/src/components/chat/hooks/useComposerAssetUpload.ts
@@ -1,0 +1,53 @@
+import { useCallback, useState } from "react";
+import { DroppedFile } from "../types/chat.types";
+import { assetToDroppedFile } from "./useDragAndDrop";
+import useAssetUpload from "../../../serverState/useAssetUpload";
+import { useNotificationStore } from "../../../stores/NotificationStore";
+
+/**
+ * Upload picked files to the asset library and hand each finished asset back
+ * as a {@link DroppedFile} carrying its `asset://` reference — the same shape a
+ * drag from the asset library produces, so the composer attaches a reference
+ * instead of inlining the bytes.
+ *
+ * @param onAssetsUploaded receives each uploaded asset as it finishes, so the
+ * first file appears in the composer without waiting for the rest.
+ */
+export const useComposerAssetUpload = (
+  onAssetsUploaded: (files: DroppedFile[]) => void
+) => {
+  const [pending, setPending] = useState(0);
+  const uploadAsset = useAssetUpload((state) => state.uploadAsset);
+  const addNotification = useNotificationStore((state) => state.addNotification);
+
+  const uploadFiles = useCallback(
+    (files: File[]) => {
+      if (files.length === 0) {
+        return;
+      }
+      setPending((count) => count + files.length);
+      const settle = () => setPending((count) => Math.max(0, count - 1));
+
+      for (const file of files) {
+        uploadAsset({
+          file,
+          onCompleted: (asset) => {
+            settle();
+            onAssetsUploaded([assetToDroppedFile(asset)]);
+          },
+          onFailed: (error) => {
+            settle();
+            addNotification({
+              type: "error",
+              content: `Failed to upload ${file.name}: ${error}`,
+              alert: true
+            });
+          }
+        });
+      }
+    },
+    [uploadAsset, onAssetsUploaded, addNotification]
+  );
+
+  return { uploadFiles, isUploading: pending > 0 };
+};

--- a/web/src/components/chat/hooks/useDragAndDrop.ts
+++ b/web/src/components/chat/hooks/useDragAndDrop.ts
@@ -21,7 +21,7 @@ const generateFileId = () => `file_${Date.now()}_${Math.random().toString(36).su
  * a video). The asset's `get_url` rides along as `dataUri` purely so the file
  * preview tile can render a thumbnail.
  */
-function assetToDroppedFile(asset: Asset): DroppedFile {
+export function assetToDroppedFile(asset: Asset): DroppedFile {
   const mimeType = asset.content_type || "application/octet-stream";
   return {
     id: generateFileId(),


### PR DESCRIPTION
## What changed

The media composer could only take an attachment by drag-and-drop, paste, or an `@` mention — there was no button to pick a file. A `+` chip now sits at the head of the chip row and opens the file picker. A picked file is uploaded to the asset library and attached by its `asset://` reference, the same shape a drag from the library produces, so a reference goes over the wire instead of megabytes of inline bytes and the file is still there after the turn. The chip shows a spinner while uploads are in flight; a failed upload raises a notification and attaches nothing. The upload path is a new `useComposerAssetUpload` hook over the existing `useAssetUpload` queue, and `assetToDroppedFile` is now exported from `useDragAndDrop` so the two paths build the same attachment.

## Verification

```
npm run test:affected   → 185 suites, 1614 passed, 3 skipped
npm run typecheck       → web ✓, electron ✓ (mobile fails: its Expo dependency
                          tree isn't installed in this container — pre-existing,
                          no mobile file touched)
npm run lint            → exit 0
npm run dev:nodetool -- harness gate --base main → Gate: 8/8 selfchecks passed
```

The new hook test was inverted once to prove it bites — dropping `assetUri` from the attachment the hook hands back:

```
✕ attaches each uploaded file as an asset reference (26 ms)
✓ reports uploading until every file settles (5 ms)
✓ notifies and attaches nothing when an upload fails (46 ms)
✓ does nothing when the picker is dismissed with no files (3 ms)
Tests: 1 failed, 3 passed, 4 total
```

- [x] `npm run test:affected`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run dev:nodetool -- harness gate --base main`

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added — only the hook's unit tests, inverted above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fwru6wC33UmQDfqLFqx668)_