### PR TITLE
fix(chat): render bare resource URIs in chat markdown

### DIFF
--- a/web/src/components/chat/message/ChatMarkdown.tsx
+++ b/web/src/components/chat/message/ChatMarkdown.tsx
@@ -20,6 +20,7 @@ import { useResolvedMedia } from "../../../hooks/useResolvedMediaUri";
 import ResourceChip from "./ResourceChip";
 import { EntityMentionChip } from "../../node_types/editing/promptComposer/EntityMentionChip";
 import { remarkEntityMentions } from "./remarkEntityMentions";
+import { remarkResourceMentions } from "./remarkResourceMentions";
 import { isNumber, isString } from "../../../utils/typePredicates";
 import "../../../styles/markdown/github-markdown.css";
 
@@ -90,7 +91,8 @@ const markdownStyles = css({
 
 const REMARK_PLUGINS: Options["remarkPlugins"] = [
   remarkGfm,
-  remarkEntityMentions
+  remarkEntityMentions,
+  remarkResourceMentions
 ];
 const REHYPE_PLUGINS: Options["rehypePlugins"] = [rehypeRaw];
 

--- a/web/src/components/chat/message/__tests__/remarkResourceMentions.test.ts
+++ b/web/src/components/chat/message/__tests__/remarkResourceMentions.test.ts
@@ -1,0 +1,159 @@
+import {
+  codeSpanMention,
+  remarkResourceMentions,
+  splitResourceMentions
+} from "../remarkResourceMentions";
+
+interface MdastNode {
+  type: string;
+  value?: string;
+  url?: string;
+  children?: MdastNode[];
+}
+
+const paragraph = (children: MdastNode[]): MdastNode => ({
+  type: "root",
+  children: [{ type: "paragraph", children }]
+});
+
+const transform = (tree: MdastNode): MdastNode => {
+  remarkResourceMentions()(tree);
+  return tree;
+};
+
+describe("splitResourceMentions", () => {
+  it("returns null for text with no resource URI", () => {
+    expect(splitResourceMentions("just prose")).toBeNull();
+  });
+
+  it("splits a URI out of the surrounding text", () => {
+    expect(splitResourceMentions("added storyboard://sb_1 to the board")).toEqual([
+      { type: "text", value: "added " },
+      {
+        type: "link",
+        url: "storyboard://sb_1",
+        children: [{ type: "text", value: "sb_1" }]
+      },
+      { type: "text", value: " to the board" }
+    ]);
+  });
+
+  it("keeps a sub-target fragment", () => {
+    const parts = splitResourceMentions("see storyboard://sb_1#shot=s3 here");
+    expect(parts?.[1]).toEqual({
+      type: "link",
+      url: "storyboard://sb_1#shot=s3",
+      children: [{ type: "text", value: "sb_1#shot=s3" }]
+    });
+  });
+
+  it("treats a trailing dot as sentence punctuation", () => {
+    const parts = splitResourceMentions("the track is asset://a1.mp3.");
+    expect(parts).toEqual([
+      { type: "text", value: "the track is " },
+      {
+        type: "link",
+        url: "asset://a1.mp3",
+        children: [{ type: "text", value: "a1.mp3" }]
+      },
+      { type: "text", value: "." }
+    ]);
+  });
+
+  it("splits every URI in the value", () => {
+    const parts = splitResourceMentions("asset://a1.png and timeline://tl_7");
+    expect(
+      parts?.filter((part) => part.type === "link").map((part) => part.url)
+    ).toEqual(["asset://a1.png", "timeline://tl_7"]);
+  });
+
+  it("ignores a scheme that is not a resource kind", () => {
+    expect(splitResourceMentions("open https://nodetool.ai/docs")).toBeNull();
+    expect(splitResourceMentions("a bundle://clip.mp4 ref")).toBeNull();
+  });
+
+  it("ignores a documentation placeholder", () => {
+    expect(splitResourceMentions("write asset://<id>.<ext> verbatim")).toBeNull();
+  });
+});
+
+describe("codeSpanMention", () => {
+  it("rewrites a code span that is only a resource URI", () => {
+    expect(codeSpanMention("asset://a1.mp3")).toEqual({
+      type: "link",
+      url: "asset://a1.mp3",
+      children: [{ type: "text", value: "a1.mp3" }]
+    });
+  });
+
+  it("leaves a code span carrying anything else", () => {
+    expect(codeSpanMention("![clip](asset://a1.mp4)")).toBeNull();
+    expect(codeSpanMention("asset://<id>.<ext>")).toBeNull();
+    expect(codeSpanMention("npm run dev")).toBeNull();
+  });
+});
+
+describe("remarkResourceMentions", () => {
+  it("rewrites text nodes anywhere in the tree", () => {
+    const tree = transform(
+      paragraph([
+        {
+          type: "strong",
+          children: [{ type: "text", value: "track storyboard://sb_1 done" }]
+        }
+      ])
+    );
+    const strong = tree.children?.[0].children?.[0];
+    expect(strong?.children?.map((child) => child.type)).toEqual([
+      "text",
+      "link",
+      "text"
+    ]);
+  });
+
+  it("replaces a bare code span with a link", () => {
+    const tree = transform(
+      paragraph([{ type: "inlineCode", value: "asset://a1.mp3" }])
+    );
+    expect(tree.children?.[0].children).toEqual([
+      {
+        type: "link",
+        url: "asset://a1.mp3",
+        children: [{ type: "text", value: "a1.mp3" }]
+      }
+    ]);
+  });
+
+  it("leaves a fenced code block untouched", () => {
+    const tree = transform({
+      type: "root",
+      children: [{ type: "code", value: "const uri = 'asset://a1.mp3';" }]
+    });
+    expect(tree.children?.[0]).toEqual({
+      type: "code",
+      value: "const uri = 'asset://a1.mp3';"
+    });
+  });
+
+  it("does not nest a link inside an existing link", () => {
+    const tree = transform(
+      paragraph([
+        {
+          type: "link",
+          url: "asset://a1.mp3",
+          children: [{ type: "text", value: "asset://a1.mp3" }]
+        }
+      ])
+    );
+    expect(tree.children?.[0].children?.[0].children).toEqual([
+      { type: "text", value: "asset://a1.mp3" }
+    ]);
+  });
+
+  it("leaves a tree with no URIs alone", () => {
+    const tree = transform(paragraph([{ type: "text", value: "nothing here" }]));
+    expect(tree.children?.[0].children).toEqual([
+      { type: "text", value: "nothing here" }
+    ]);
+  });
+});

--- a/web/src/components/chat/message/remarkResourceMentions.ts
+++ b/web/src/components/chat/message/remarkResourceMentions.ts
@@ -1,0 +1,127 @@
+/**
+ * remarkResourceMentions — turn a bare resource URI (`asset://…`,
+ * `storyboard://…`, `timeline://…`) in chat prose into an mdast link, so
+ * ChatMarkdown's `a` override renders it as a resource chip or an inline
+ * player.
+ *
+ * The system prompt asks the agent to write `[Beach intro](storyboard://sb_1)`.
+ * Models routinely write the raw URI instead — often inside backticks — and the
+ * reader was left with the URN as text: no chip, no audio player, nothing to
+ * click. A code span whose entire value is one resource URI is a reference too,
+ * so it is rewritten as well; a fenced block, and a code span carrying anything
+ * else, stay literal.
+ *
+ * Like remarkEntityMentions it runs on the tree, so a URI a link already points
+ * at is not re-wrapped, which mdast forbids.
+ */
+import { RESOURCE_KINDS, isResourceUri } from "@nodetool-ai/protocol";
+
+/** The subset of mdast this plugin reads. */
+interface MdastNode {
+  type: string;
+  value?: string;
+  url?: string;
+  children?: MdastNode[];
+}
+
+/**
+ * One `<kind>://<id>[#<key>=<value>]` token. The id charset is deliberately
+ * narrow: it keeps a documentation example (`asset://<id>.<ext>`) out of the
+ * match, and stops trailing punctuation from being read as part of the id.
+ */
+const SEGMENT = "[A-Za-z0-9._~-]+";
+const RESOURCE_URI_PATTERN = `(?:${RESOURCE_KINDS.join(
+  "|"
+)})://${SEGMENT}(?:#${SEGMENT}=${SEGMENT})?`;
+const RESOURCE_URI_RE = new RegExp(RESOURCE_URI_PATTERN, "g");
+const RESOURCE_URI_EXACT_RE = new RegExp(`^${RESOURCE_URI_PATTERN}$`);
+
+/** Node types whose text is literal and must not be rewritten. */
+const OPAQUE_TYPES = new Set(["code", "link", "linkReference"]);
+
+/** Trailing dots are sentence punctuation, not part of the id. */
+const trimTrailingDots = (token: string): string => {
+  let end = token.length;
+  while (end > 0 && token[end - 1] === ".") {
+    end--;
+  }
+  return token.slice(0, end);
+};
+
+/** The chip/player label: the URI without its scheme. */
+const labelFor = (uri: string): string =>
+  uri.slice(uri.indexOf("://") + "://".length);
+
+const linkNode = (uri: string): MdastNode => ({
+  type: "link",
+  url: uri,
+  children: [{ type: "text", value: labelFor(uri) }]
+});
+
+/**
+ * Split one text value into text and link nodes, or `null` when it carries no
+ * resource URI (so the caller can leave the node untouched).
+ */
+export const splitResourceMentions = (value: string): MdastNode[] | null => {
+  const out: MdastNode[] = [];
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  RESOURCE_URI_RE.lastIndex = 0;
+  while ((match = RESOURCE_URI_RE.exec(value)) !== null) {
+    const uri = trimTrailingDots(match[0]);
+    if (!isResourceUri(uri)) {
+      continue;
+    }
+    if (match.index > cursor) {
+      out.push({ type: "text", value: value.slice(cursor, match.index) });
+    }
+    out.push(linkNode(uri));
+    cursor = match.index + uri.length;
+  }
+  if (out.length === 0) {
+    return null;
+  }
+  if (cursor < value.length) {
+    out.push({ type: "text", value: value.slice(cursor) });
+  }
+  return out;
+};
+
+/** A code span that is nothing but one resource URI, as a link node. */
+export const codeSpanMention = (value: string): MdastNode | null => {
+  const uri = value.trim();
+  return uri && RESOURCE_URI_EXACT_RE.test(uri) && isResourceUri(uri)
+    ? linkNode(uri)
+    : null;
+};
+
+const walk = (node: MdastNode): void => {
+  const children = node.children;
+  if (!children || OPAQUE_TYPES.has(node.type)) {
+    return;
+  }
+  let index = 0;
+  while (index < children.length) {
+    const child = children[index];
+    if (child.type === "text" && child.value) {
+      const replacement = splitResourceMentions(child.value);
+      if (replacement) {
+        children.splice(index, 1, ...replacement);
+        index += replacement.length;
+        continue;
+      }
+    } else if (child.type === "inlineCode" && child.value) {
+      const link = codeSpanMention(child.value);
+      if (link) {
+        children.splice(index, 1, link);
+      }
+    } else {
+      walk(child);
+    }
+    index++;
+  }
+};
+
+export const remarkResourceMentions = () => (tree: MdastNode): void => {
+  walk(tree);
+};


### PR DESCRIPTION
## What changed

The chat prompt asks the agent to link a resource it produced (`[Beach intro](storyboard://sb_1)`), and `ChatMarkdown`'s `a` override turns such a link into a resource chip or an inline audio/video player. Models routinely write the raw URI instead, usually inside backticks, and those replies rendered the URN as text — no chip, no player, nothing to click. A new remark plugin, `remarkResourceMentions`, rewrites a bare `<kind>://<id>[#key=value]` token in prose, and a code span whose entire value is one such URI, into an mdast link, so the existing `a` override renders it. Fenced blocks, links that already exist, and code spans carrying anything else stay literal; the id charset is narrow enough that a documentation placeholder (`asset://<id>.<ext>`) is not matched.

## Verification

- [x] `npm run test:affected` — 190 suites, 1653 passed
- [x] `npm run typecheck` — web and electron clean. The mobile leg fails in this sandbox because `mobile/node_modules` is not installed (every error is `Cannot find module 'react-native' | 'expo' | …`); no mobile file is touched by this diff.
- [x] `npm run lint` — exit 0, no findings on the changed files
- [x] `npm run dev:nodetool -- harness gate --base main` — 8/8 selfchecks passed (run from `dist` as `npm run nodetool`)

Ran against the reported message through the real `remark-parse` + `remark-gfm` pipeline: both the backticked `asset://…mp3` and `storyboard://…` became link nodes, an already-labeled link kept its label, and a fenced block carrying a URI was untouched.

`remarkResourceMentions.test.ts` covers the negative side directly — a non-resource scheme, a documentation placeholder, a fenced block, and an existing link all leave the tree unchanged.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QENskemmvPb8VvWdyWdpWQ)_