### PR TITLE
fix(chat): drop the field surface behind composer model pickers

### DIFF
--- a/web/src/components/chat/composer/MediaControlChip.tsx
+++ b/web/src/components/chat/composer/MediaControlChip.tsx
@@ -34,10 +34,9 @@ interface MediaControlChipProps {
   truncate?: boolean;
   /**
    * Let the chip claim the row's leftover width (up to `maxWidth`) instead of
-   * hugging its label. A grown chip also takes a field surface and pins its
-   * caret to the right edge, so the extra width reads as a select rather than
-   * a label with a gap after it. For the one chip in a row that deserves the
-   * space — the model select.
+   * hugging its label, pinning its caret to the right edge so the extra width
+   * reads as a select rather than a label with a gap after it. For the one
+   * chip in a row that deserves the space — the model select.
    */
   grow?: boolean;
   /** Max width in px when truncating or growing. Defaults to 200. */
@@ -71,7 +70,7 @@ const createStyles = (
     border: "1px solid transparent",
     backgroundColor: active
       ? theme.vars.palette.c_overlay_strong
-      : emphasis === "primary" || grow
+      : emphasis === "primary"
         ? theme.vars.palette.c_overlay
         : "transparent",
     color: theme.vars.palette.grey[100],


### PR DESCRIPTION
## What changed

`MediaControlChip` gave any chip with `grow` a `c_overlay` background at rest, on the reasoning that a widened pill should read as a field. In practice `grow` is only ever the model picker (all six call sites in `MediaChatComposer` — chat, image, image_edit, video, image_to_video, audio), so the model picker was the only filled control in a row of transparent ones. It now sits transparent at rest like its neighbours; the growth, the right-pinned caret, hover, and the open-popover background are unchanged, so the select affordance and the interaction feedback survive.

## Verification

- [x] `npm run test:affected` — 185 suites, 1616 passed, 3 skipped
- [ ] `npm run typecheck` — fails, but identically on a clean tree (`git stash` + re-run reproduces it). `Cannot find module '@nodetool-ai/*-nodes/...'`: `npm run build:packages` fails at `@nodetool-ai/automation-nodes#build` in this environment, so several packages have no `dist`. Not reachable from this diff.
- [x] `npm run lint` — clean, design-token lint included
- [ ] `npm run dev:nodetool -- harness gate --base main` — not runnable here: same missing `dist`, the CLI dies on `ERR_MODULE_NOT_FOUND` for `@nodetool-ai/base-nodes/dist/index.js` before selecting anything

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNRNwK8HtqsGXwSa8k8LCu)_