### PR TITLE
fix(storyboard): keep an agent's still on offer through a render batch

### DIFF
--- a/web/src/components/appbuilder/ApplicationAppBuilder.tsx
+++ b/web/src/components/appbuilder/ApplicationAppBuilder.tsx
@@ -305,7 +305,7 @@ const ApplicationAppBuilder: React.FC<ApplicationAppBuilderProps> = ({
       const draft = handler.document();
       if (!base) return;
 
-      const { doc: merged, conflicts } = mergeAppDocuments(
+      const { doc: merged, conflicts, nextBase } = mergeAppDocuments(
         appDocumentToMerge(base),
         appDocumentToMerge(draft),
         appDocumentToMerge(fresh.document),
@@ -340,12 +340,33 @@ const ApplicationAppBuilder: React.FC<ApplicationAppBuilderProps> = ({
       // leaves the draft branched off the old base, and moving the base under
       // it would make every unit the server wrote read as a draft edit.
       revisionRef.current = fresh.updatedAt;
-      if (!replaced) lastSyncedRef.current = JSON.stringify(fresh.document);
+      if (!replaced) {
+        // The server copy, except in the units the draft refused, which keep
+        // the base they had. Rolling those forward too makes the refusal
+        // permanent and silent: the next write reads a refused unit as
+        // unchanged on the server, so the draft wins with nothing listed and
+        // the external value can never be taken again.
+        // SAFETY: same widening as the apply above — `ui` is an open record
+        // and only the keys the merge resolved are replaced.
+        const freshUi = fresh.document.ui as unknown as Record<string, unknown>;
+        lastSyncedRef.current = JSON.stringify({
+          ...fresh.document,
+          ui: {
+            ...freshUi,
+            content: nextBase.content,
+            zones: nextBase.zones,
+            root: { props: nextBase.rootProps }
+          } as AppDocument["ui"],
+          operations: nextBase.operations as AppDocument["operations"],
+          variables: nextBase.variables as AppDocument["variables"],
+          resources: nextBase.resources as AppDocument["resources"]
+        } satisfies AppDocument);
+      }
 
       const listed = conflicts.map((c) =>
         c.unit.id ? c : { ...c, unit: { ...c.unit, id: c.unit.kind } }
       );
-      useConflictStore.getState().setConflicts(`application:${applicationId}`, listed, {
+      useConflictStore.getState().addConflicts(`application:${applicationId}`, listed, {
         onAccept: (unitId) => {
           const entry =
             useConflictStore.getState().byKey[`application:${applicationId}`];

--- a/web/src/components/appbuilder/merge.ts
+++ b/web/src/components/appbuilder/merge.ts
@@ -310,6 +310,7 @@ export function mergeAppDocuments(
   );
   return {
     doc: result.doc,
+    nextBase: result.nextBase,
     conflicts: [...surviving, ...dangling]
   };
 }

--- a/web/src/hooks/jsScript/useJsScriptServerSync.ts
+++ b/web/src/hooks/jsScript/useJsScriptServerSync.ts
@@ -329,7 +329,7 @@ export const useJsScriptServerSync = (
       if (!base || !draft || base === draft) return;
 
       const serverEntry = responseToEntry(res);
-      const { doc: merged, conflicts } = mergeJsScriptDocuments(
+      const { doc: merged, conflicts, nextBase } = mergeJsScriptDocuments(
         toMergeDoc(base),
         toMergeDoc(draft),
         toMergeDoc(serverEntry),
@@ -344,10 +344,15 @@ export const useJsScriptServerSync = (
       });
       revisionRef.current = res.updatedAt;
       store.getState().setServerRevision(scriptId, res.updatedAt);
+      // The server copy, except in the units the draft refused, which keep the
+      // base they had — otherwise the next external write reads a refused unit
+      // as unchanged on the server and the draft wins with nothing listed, so
+      // the external value can never be taken again.
+      const nextBaseEntry = documentFromMerge(nextBase);
       syncedRef.current = {
         id: scriptId,
-        name: serverEntry.name,
-        document: serverEntry.document,
+        name: nextBaseEntry.name,
+        document: nextBaseEntry.document,
         updatedAt: Date.now()
       };
 
@@ -356,7 +361,7 @@ export const useJsScriptServerSync = (
           ? conflict
           : { ...conflict, unit: { ...conflict.unit, id: conflict.unit.kind } }
       );
-      useConflictStore.getState().setConflicts(`jsscript:${scriptId}`, listed, {
+      useConflictStore.getState().addConflicts(`jsscript:${scriptId}`, listed, {
         onAccept: (unitId) => {
           const entry =
             useConflictStore.getState().byKey[`jsscript:${scriptId}`];

--- a/web/src/hooks/script/useScriptServerSync.ts
+++ b/web/src/hooks/script/useScriptServerSync.ts
@@ -401,7 +401,7 @@ export const useScriptServerSync = (
         updatedAt: Date.now()
       };
 
-      const { doc: merged, conflicts } = mergeScriptDocuments(
+      const { doc: merged, conflicts, nextBase } = mergeScriptDocuments(
         base,
         draft,
         serverScript,
@@ -419,14 +419,24 @@ export const useScriptServerSync = (
       );
       revisionRef.current = res.updatedAt;
       store.getState().setServerRevision(scriptId, res.updatedAt);
-      syncedRef.current = serverScript;
+      // The server copy, except in the units the draft refused, which keep the
+      // base they had — otherwise the next external write reads a refused unit
+      // as unchanged on the server and the draft wins with nothing listed, so
+      // the external value can never be taken again.
+      // SAFETY: same widening as `merged` above — the engine's document view
+      // and `ScriptDraft` are the same fields.
+      syncedRef.current = {
+        ...(nextBase as unknown as ScriptDraft),
+        id: scriptId,
+        updatedAt: Date.now()
+      };
 
       const listed = conflicts.map((conflict) =>
         conflict.unit.id
           ? conflict
           : { ...conflict, unit: { ...conflict.unit, id: conflict.unit.kind } }
       );
-      useConflictStore.getState().setConflicts(`script:${scriptId}`, listed, {
+      useConflictStore.getState().addConflicts(`script:${scriptId}`, listed, {
         onAccept: (unitId) => {
           const entry = useConflictStore.getState().byKey[`script:${scriptId}`];
           const conflict = entry?.conflicts.find((c) => c.unit.id === unitId);

--- a/web/src/hooks/storyboard/__tests__/useStoryboardServerSync.test.tsx
+++ b/web/src/hooks/storyboard/__tests__/useStoryboardServerSync.test.tsx
@@ -247,7 +247,11 @@ describe("flushStoryboardSave", () => {
 });
 
 describe("useStoryboardServerSync — external changes merge into a dirty draft", () => {
-  const shot = (id: string, index: number, action: string) => ({
+  const shot = (
+    id: string,
+    index: number,
+    action: string
+  ): Record<string, unknown> => ({
     type: "shot",
     id,
     index,
@@ -255,7 +259,7 @@ describe("useStoryboardServerSync — external changes merge into a dirty draft"
     status: "planned"
   });
 
-  const docWith = (shots: ReturnType<typeof shot>[]) => ({
+  const docWith = (shots: Record<string, unknown>[]) => ({
     ...emptyDocument,
     shots
   });
@@ -529,6 +533,142 @@ describe("useStoryboardServerSync — external changes merge into a dirty draft"
     expect(shots.find((s) => s.id === "s3")?.action).toBe("Three — draft");
     expect(conflictsFor()).toEqual([]);
     expect(useStoryboardStore.getState().serverRevisions["board-1"]).toBe("rev-10");
+
+    rendered.unmount();
+    useConflictStore.getState().clear("storyboard:board-1");
+  });
+
+  it("keeps a refused still on offer through the rest of a render batch", async () => {
+    // A batch render is one write per shot. Each merge used to replace the
+    // banner's whole list, so the offer carrying shot 1's still vanished when
+    // shot 2's write landed — and the base rolled past the refusal, so nothing
+    // ever offered it again. The still was unreachable from the UI.
+    const still = (id: string) => ({
+      type: "image",
+      asset_id: id,
+      uri: `asset://${id}.png`
+    });
+    const rendered_ = await (async () => {
+      getQuery.mockResolvedValue(
+        serverResponse(docWith([shot("s1", 0, "One"), shot("s2", 1, "Two")]))
+      );
+      return mountLoaded();
+    })();
+
+    // The user is rewriting shot 1 while the batch runs.
+    act(() =>
+      useStoryboardStore
+        .getState()
+        .updateShot("board-1", "s1", { action: "One — draft" })
+    );
+
+    getQuery.mockResolvedValue(
+      serverResponse(
+        docWith([
+          { ...shot("s1", 0, "One"), status: "keyframe_ready", keyframe: still("a1") },
+          shot("s2", 1, "Two")
+        ]),
+        "rev-9"
+      )
+    );
+    await act(async () => {
+      handleDocumentResourceChange("storyboard", {
+        event: "updated",
+        id: "board-1",
+        updatedAt: "rev-9",
+        ops: [{ tool: "update_shot", input: { id: "s1" } }]
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(conflictsFor()).toEqual(["s1"]);
+
+    // Shot 2's render lands before the user answers the banner.
+    getQuery.mockResolvedValue(
+      serverResponse(
+        docWith([
+          { ...shot("s1", 0, "One"), status: "keyframe_ready", keyframe: still("a1") },
+          { ...shot("s2", 1, "Two"), status: "keyframe_ready", keyframe: still("a2") }
+        ]),
+        "rev-10"
+      )
+    );
+    await act(async () => {
+      handleDocumentResourceChange("storyboard", {
+        event: "updated",
+        id: "board-1",
+        updatedAt: "rev-10",
+        ops: [{ tool: "update_shot", input: { id: "s2" } }]
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const shotsAfter = useStoryboardStore.getState().boards["board-1"]?.shots ?? [];
+    // Shot 2 was untouched by the draft, so its still merged straight in.
+    expect(shotsAfter.find((s) => s.id === "s2")?.keyframe).toEqual(still("a2"));
+    // Shot 1's still is still on offer, and taking it works.
+    expect(conflictsFor()).toContain("s1");
+    act(() => useConflictStore.getState().accept("storyboard:board-1", "s1"));
+    expect(
+      useStoryboardStore
+        .getState()
+        .boards["board-1"]?.shots.find((s) => s.id === "s1")?.keyframe
+    ).toEqual(still("a1"));
+
+    rendered_.unmount();
+    useConflictStore.getState().clear("storyboard:board-1");
+  });
+
+  it("re-offers a refused shot on the next write that touches it", async () => {
+    // The merge base must not roll past a refusal. When it did, the next
+    // write naming the same shot read its server value as unchanged, so the
+    // draft won in silence and the refused value became unreachable.
+    getQuery.mockResolvedValue(serverResponse(docWith([shot("s1", 0, "One")])));
+    const rendered = await mountLoaded();
+
+    act(() =>
+      useStoryboardStore
+        .getState()
+        .updateShot("board-1", "s1", { action: "One — draft" })
+    );
+
+    const rendered_s1 = docWith([
+      {
+        ...shot("s1", 0, "One"),
+        status: "keyframe_ready",
+        keyframe: { type: "image", asset_id: "a1", uri: "asset://a1.png" }
+      }
+    ]);
+    const deliver = async (updatedAt: string) => {
+      getQuery.mockResolvedValue(serverResponse(rendered_s1, updatedAt));
+      await act(async () => {
+        handleDocumentResourceChange("storyboard", {
+          event: "updated",
+          id: "board-1",
+          updatedAt,
+          ops: [{ tool: "update_shot", input: { id: "s1" } }]
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    };
+
+    await deliver("rev-9");
+    expect(conflictsFor()).toEqual(["s1"]);
+    // The user reads the banner and keeps their own line for now.
+    act(() => useConflictStore.getState().discard("storyboard:board-1", "s1"));
+    expect(conflictsFor()).toEqual([]);
+
+    // The shot is written again, with the same content the draft refused.
+    await deliver("rev-10");
+    expect(conflictsFor()).toEqual(["s1"]);
+    act(() => useConflictStore.getState().accept("storyboard:board-1", "s1"));
+    expect(
+      useStoryboardStore
+        .getState()
+        .boards["board-1"]?.shots.find((s) => s.id === "s1")?.keyframe
+    ).toEqual({ type: "image", asset_id: "a1", uri: "asset://a1.png" });
 
     rendered.unmount();
     useConflictStore.getState().clear("storyboard:board-1");

--- a/web/src/hooks/storyboard/useStoryboardServerSync.ts
+++ b/web/src/hooks/storyboard/useStoryboardServerSync.ts
@@ -196,10 +196,6 @@ export const useStoryboardServerSync = (
       });
     };
 
-    // The server copy behind the newest merge, for a conflict accept that
-    // takes the whole external document ("replaced").
-    let externalBoard: StoryboardBoard | null = null;
-
     /**
      * Take one refused external value into the draft through the store's own
      * actions, so the accept is an undoable user edit (ADR 0001).
@@ -298,16 +294,23 @@ export const useStoryboardServerSync = (
         id: boardId,
         updatedAt: Date.now()
       };
-      externalBoard = serverBoard;
-
-      const { doc: merged, conflicts } = mergeByUnits(base, draft, serverBoard, storyboardMergeAdapter, { ops: notice.ops });
+      const { doc: merged, conflicts, nextBase } = mergeByUnits(
+        base,
+        draft,
+        serverBoard,
+        storyboardMergeAdapter,
+        { ops: notice.ops }
+      );
       store.getState().applyMerged(boardId, merged);
       revisionRef.current = res.updatedAt;
       store.getState().setServerRevision(boardId, res.updatedAt);
-      // Roll the merge base to what the server now holds, not the merged draft.
-      // Without this, a second external write on the same unit reads as "both
-      // changed" and the agent's second edit is refused.
-      syncedRef.current = serverBoard;
+      // Roll the merge base to what the server now holds, except in the shots
+      // the draft refused, which keep theirs. Rolling everything forward made
+      // a refusal permanent and silent — the next write in a render batch read
+      // the refused shot as unchanged on the server, so its still could never
+      // be offered again. Keeping the merged draft instead would refuse the
+      // agent's *second* edit to a shot it had already merged.
+      syncedRef.current = { ...nextBase, id: boardId, updatedAt: Date.now() };
 
       // A whole-document replacement has no unit id; name it "document" so
       // the banner's accept/discard can address it.
@@ -316,11 +319,14 @@ export const useStoryboardServerSync = (
           ? conflict
           : { ...conflict, unit: { ...conflict.unit, id: conflict.unit.kind } }
       );
-      useConflictStore.getState().setConflicts(`storyboard:${boardId}`, listed, {
+      useConflictStore.getState().addConflicts(`storyboard:${boardId}`, listed, {
         onAccept: (unitId) => {
           const entry = useConflictStore.getState().byKey[`storyboard:${boardId}`];
           const conflict = entry?.conflicts.find((c) => c.unit.id === unitId);
-          if (conflict) acceptConflict(conflict, externalBoard);
+          // `serverBoard` from this merge, not the newest one: offers
+          // outlive the merge that made them, and a whole-document accept
+          // must apply the copy the user was shown.
+          if (conflict) acceptConflict(conflict, serverBoard);
         },
         onDiscard: () => {}
       });

--- a/web/src/hooks/timeline/__tests__/useTimelineExternalSync.test.tsx
+++ b/web/src/hooks/timeline/__tests__/useTimelineExternalSync.test.tsx
@@ -472,7 +472,7 @@ describe("useTimelineExternalSync conflict resolution", () => {
 
     const undoCountBefore = getTimelineTemporal().pastStates.length;
     act(() => {
-      entry?.onAccept?.("T1");
+      useConflictStore.getState().accept("timelinesequence:seq-1", "T1");
     });
     expect(useTimelineStore.getState().tracks[0]?.name).toBe("Agent video");
     // Accepting is the user's own edit: it goes on the undo stack (ADR 0001).

--- a/web/src/hooks/timeline/useTimelineExternalSync.ts
+++ b/web/src/hooks/timeline/useTimelineExternalSync.ts
@@ -251,7 +251,7 @@ export function useTimelineExternalSync(sequenceId: string | null): void {
           const base: TimelineMergeDoc =
             before.syncedDocument ?? draft;
 
-          const { doc, conflicts } = mergeTimelineDocuments(
+          const { doc, conflicts, nextBase } = mergeTimelineDocuments(
             base,
             draft,
             serverDoc,
@@ -277,22 +277,27 @@ export function useTimelineExternalSync(sequenceId: string | null): void {
             temporal.resume();
           }
           // The merge base for the next external change is what the SERVER
-          // now holds — not the merged draft. Snapshotting the draft here
-          // would let a second external write clobber local clip edits.
+          // now holds — not the merged draft; snapshotting the draft here
+          // would let a second external write clobber local clip edits —
+          // except in the units the draft refused, which keep the base they
+          // had. Rolling those forward too makes the refusal permanent and
+          // silent: the next write reads them as unchanged on the server, so
+          // the draft wins with nothing listed and the external value can
+          // never be taken again.
           store
             .getState()
             .setBaseUpdatedAt(sequence.updatedAt, {
-              tracks: serverDoc.tracks as TimelineStoreState["tracks"],
-              clips: serverDoc.clips as TimelineStoreState["clips"],
-              markers: serverDoc.markers as TimelineStoreState["markers"],
-              transcript: serverDoc.transcript as TimelineStoreState["transcript"],
-              scriptEnabled: serverDoc.scriptEnabled,
-              fps: serverDoc.fps,
-              width: serverDoc.width,
-              height: serverDoc.height
+              tracks: nextBase.tracks as TimelineStoreState["tracks"],
+              clips: nextBase.clips as TimelineStoreState["clips"],
+              markers: nextBase.markers as TimelineStoreState["markers"],
+              transcript: nextBase.transcript as TimelineStoreState["transcript"],
+              scriptEnabled: nextBase.scriptEnabled,
+              fps: nextBase.fps,
+              width: nextBase.width,
+              height: nextBase.height
             });
 
-          useConflictStore.getState().setConflicts(
+          useConflictStore.getState().addConflicts(
             conflictKey(sequenceId),
             listable(conflicts),
             {

--- a/web/src/stores/ConflictStore.ts
+++ b/web/src/stores/ConflictStore.ts
@@ -8,17 +8,27 @@
  * It is the user's own edit: each surface registers an accept callback that
  * applies the value through its own store mutation, so the accept lands on
  * the undo stack. `discard` keeps the draft version and drops the offer.
+ *
+ * Resolvers are held per offer, not per document. A batch of external writes
+ * arrives as several merges and the user answers at their own pace, so an
+ * offer must stay resolvable by the merge that made it — its callback closes
+ * over the server document that offer came from.
  */
 import { create } from "zustand";
 import type { MergeConflict } from "./documentMerge";
 import { setDocumentConflictReporter } from "./documentConflictReporter";
 
-interface RegisteredConflicts {
-  conflicts: MergeConflict[];
+interface ConflictResolvers {
   /** Take the external value into the draft through the surface's own mutation. */
   onAccept: (unitId: string) => void;
   /** Keep the draft version; drop the offered value. */
   onDiscard: (unitId: string) => void;
+}
+
+interface RegisteredConflicts {
+  conflicts: MergeConflict[];
+  /** The resolvers each offer was registered with, by `kind:id`. */
+  resolvers: Record<string, ConflictResolvers>;
 }
 
 interface ConflictState {
@@ -30,10 +40,20 @@ interface ConflictState {
   setConflicts(
     key: string,
     conflicts: MergeConflict[],
-    resolvers: {
-      onAccept: (unitId: string) => void;
-      onDiscard: (unitId: string) => void;
-    }
+    resolvers: ConflictResolvers
+  ): void;
+  /**
+   * Fold one merge's conflicts into what is already offered.
+   *
+   * Replacing the list on every merge dropped every offer the user had not
+   * reached yet: an agent rendering six stills onto a dirty board left five of
+   * them unreachable, with no sign anything had been refused. A unit offered
+   * again carries the newer external value and the newer resolver.
+   */
+  addConflicts(
+    key: string,
+    conflicts: MergeConflict[],
+    resolvers: ConflictResolvers
   ): void;
   /** Drop every conflict for one document without resolving them. */
   clear: (key: string) => void;
@@ -43,49 +63,94 @@ interface ConflictState {
   discard: (key: string, unitId: string) => void;
 }
 
+const unitKey = (conflict: MergeConflict): string =>
+  `${conflict.unit.kind}:${conflict.unit.id}`;
+
+/** Drop one unit's offer and its resolver; returns null when none is left. */
 const withoutUnit = (
   entry: RegisteredConflicts,
   unitId: string
-): MergeConflict[] => entry.conflicts.filter((c) => c.unit.id !== unitId);
+): RegisteredConflicts | null => {
+  const conflicts = entry.conflicts.filter((c) => c.unit.id !== unitId);
+  if (conflicts.length === 0) return null;
+  const keep = new Set(conflicts.map(unitKey));
+  return {
+    conflicts,
+    resolvers: Object.fromEntries(
+      Object.entries(entry.resolvers).filter(([k]) => keep.has(k))
+    )
+  };
+};
+
+/** The resolver registered for one unit, whichever merge registered it. */
+const resolverFor = (
+  entry: RegisteredConflicts,
+  unitId: string
+): ConflictResolvers | undefined => {
+  const conflict = entry.conflicts.find((c) => c.unit.id === unitId);
+  return conflict ? entry.resolvers[unitKey(conflict)] : undefined;
+};
+
+const replaceEntry = (
+  state: ConflictState,
+  key: string,
+  entry: RegisteredConflicts | null
+): Pick<ConflictState, "byKey"> => {
+  const byKey = { ...state.byKey };
+  if (entry) byKey[key] = entry;
+  else delete byKey[key];
+  return { byKey };
+};
 
 export const useConflictStore = create<ConflictState>((set, get) => ({
   byKey: {},
   setConflicts: (key, conflicts, resolvers) =>
+    set((state) =>
+      replaceEntry(
+        state,
+        key,
+        conflicts.length === 0
+          ? null
+          : {
+              conflicts,
+              resolvers: Object.fromEntries(
+                conflicts.map((c) => [unitKey(c), resolvers])
+              )
+            }
+      )
+    ),
+  addConflicts: (key, conflicts, resolvers) =>
     set((state) => {
-      const next = { ...state.byKey };
-      if (conflicts.length === 0) {
-        delete next[key];
-      } else {
-        next[key] = { conflicts, ...resolvers };
+      const existing = state.byKey[key];
+      if (conflicts.length === 0) return state;
+      const byUnit = new Map(
+        (existing?.conflicts ?? []).map((c) => [unitKey(c), c])
+      );
+      const merged = { ...(existing?.resolvers ?? {}) };
+      for (const conflict of conflicts) {
+        byUnit.set(unitKey(conflict), conflict);
+        merged[unitKey(conflict)] = resolvers;
       }
-      return { byKey: next };
+      return replaceEntry(state, key, {
+        conflicts: [...byUnit.values()],
+        resolvers: merged
+      });
     }),
   clear: (key) =>
-    set((state) => {
-      if (!(key in state.byKey)) return state;
-      const next = { ...state.byKey };
-      delete next[key];
-      return { byKey: next };
-    }),
+    set((state) =>
+      key in state.byKey ? replaceEntry(state, key, null) : state
+    ),
   accept: (key, unitId) => {
     const entry = get().byKey[key];
     if (!entry) return;
-    entry.onAccept(unitId);
-    const remaining = withoutUnit(entry, unitId);
-    get().setConflicts(key, remaining, {
-      onAccept: entry.onAccept,
-      onDiscard: entry.onDiscard
-    });
+    resolverFor(entry, unitId)?.onAccept(unitId);
+    set((state) => replaceEntry(state, key, withoutUnit(entry, unitId)));
   },
   discard: (key, unitId) => {
     const entry = get().byKey[key];
     if (!entry) return;
-    entry.onDiscard(unitId);
-    const remaining = withoutUnit(entry, unitId);
-    get().setConflicts(key, remaining, {
-      onAccept: entry.onAccept,
-      onDiscard: entry.onDiscard
-    });
+    resolverFor(entry, unitId)?.onDiscard(unitId);
+    set((state) => replaceEntry(state, key, withoutUnit(entry, unitId)));
   }
 }));
 
@@ -97,7 +162,8 @@ export function clearAllConflicts(): void {
 // This store is the one writer of merge-conflict state. Producers (other
 // stores, sync hooks) report through the documentConflictReporter registry,
 // which wires here — installed once at module load, so every entry point and
-// test gets it without composition-root plumbing.
+// test gets it without composition-root plumbing. They are all merge
+// producers, so they fold into what is already offered rather than replacing.
 setDocumentConflictReporter((key, conflicts, handlers) => {
-  useConflictStore.getState().setConflicts(key, conflicts, handlers);
+  useConflictStore.getState().addConflicts(key, conflicts, handlers);
 });

--- a/web/src/stores/WorkflowManagerStore.ts
+++ b/web/src/stores/WorkflowManagerStore.ts
@@ -62,6 +62,14 @@ import type { NodeData } from "./NodeData";
  * Merge one external graph write into a dirty canvas: run the engine against
  * the last known server copy, apply without an undo entry or dirty-flag
  * change, roll the sync tokens, and list what the draft refused.
+ *
+ * The base rolls wholly to `fresh`, so a refused node stays refused silently
+ * until the next write changes it again — the per-unit base the document
+ * surfaces keep (`MergeResult.nextBase`) is not used here. Reaching it would
+ * mean converting merged ReactFlow units back to graph shape, and that round
+ * trip is lossy: it made the *second* agent write to an untouched node read
+ * as a contest, which "takes a second agent write to a node the draft never
+ * touched" pins.
  */
 function mergeExternalGraph(
   store: NodeStore,

--- a/web/src/stores/__tests__/ConflictStore.test.ts
+++ b/web/src/stores/__tests__/ConflictStore.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for the conflict store — what the document conflict banner offers,
+ * and which resolver answers each offer.
+ */
+import { useConflictStore, clearAllConflicts } from "../ConflictStore";
+import type { MergeConflict } from "../documentMerge";
+
+const conflict = (id: string, external: unknown): MergeConflict => ({
+  unit: { kind: "shot", id, label: id },
+  external,
+  reason: "edited"
+});
+
+const noop = { onAccept: () => {}, onDiscard: () => {} };
+
+const offered = (key: string): string[] =>
+  (useConflictStore.getState().byKey[key]?.conflicts ?? []).map((c) => c.unit.id);
+
+beforeEach(() => clearAllConflicts());
+
+describe("addConflicts", () => {
+  it("keeps offers the user has not answered yet", () => {
+    // A render batch is one write per shot, so the banner fills over several
+    // merges. Replacing the list left every earlier offer unreachable.
+    useConflictStore.getState().addConflicts("storyboard:b", [conflict("s1", "still-1")], noop);
+    useConflictStore.getState().addConflicts("storyboard:b", [conflict("s2", "still-2")], noop);
+
+    expect(offered("storyboard:b")).toEqual(["s1", "s2"]);
+  });
+
+  it("replaces an offer for a unit that is contested again", () => {
+    useConflictStore.getState().addConflicts("storyboard:b", [conflict("s1", "first")], noop);
+    useConflictStore.getState().addConflicts("storyboard:b", [conflict("s1", "second")], noop);
+
+    const conflicts = useConflictStore.getState().byKey["storyboard:b"]?.conflicts ?? [];
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].external).toBe("second");
+  });
+
+  it("answers each offer with the resolver that made it", () => {
+    // A resolver closes over the server document its own merge fetched, so an
+    // older offer must not be handed to a newer merge's callback.
+    const accepted: string[] = [];
+    useConflictStore.getState().addConflicts("storyboard:b", [conflict("s1", "still-1")], {
+      onAccept: (unitId) => accepted.push(`first:${unitId}`),
+      onDiscard: () => {}
+    });
+    useConflictStore.getState().addConflicts("storyboard:b", [conflict("s2", "still-2")], {
+      onAccept: (unitId) => accepted.push(`second:${unitId}`),
+      onDiscard: () => {}
+    });
+
+    useConflictStore.getState().accept("storyboard:b", "s1");
+    useConflictStore.getState().accept("storyboard:b", "s2");
+
+    expect(accepted).toEqual(["first:s1", "second:s2"]);
+    expect(useConflictStore.getState().byKey["storyboard:b"]).toBeUndefined();
+  });
+
+  it("ignores a merge that refused nothing", () => {
+    useConflictStore.getState().addConflicts("storyboard:b", [conflict("s1", "still-1")], noop);
+    useConflictStore.getState().addConflicts("storyboard:b", [], noop);
+
+    expect(offered("storyboard:b")).toEqual(["s1"]);
+  });
+});
+
+describe("discard", () => {
+  it("drops the offer and the entry once nothing is left", () => {
+    const discarded: string[] = [];
+    useConflictStore.getState().addConflicts("storyboard:b", [conflict("s1", "x")], {
+      onAccept: () => {},
+      onDiscard: (unitId) => discarded.push(unitId)
+    });
+
+    useConflictStore.getState().discard("storyboard:b", "s1");
+
+    expect(discarded).toEqual(["s1"]);
+    expect(useConflictStore.getState().byKey["storyboard:b"]).toBeUndefined();
+  });
+});
+
+describe("setConflicts", () => {
+  it("replaces the list, and an empty one clears the entry", () => {
+    useConflictStore.getState().setConflicts("storyboard:b", [conflict("s1", "x")], noop);
+    useConflictStore.getState().setConflicts("storyboard:b", [conflict("s2", "y")], noop);
+    expect(offered("storyboard:b")).toEqual(["s2"]);
+
+    useConflictStore.getState().setConflicts("storyboard:b", [], noop);
+    expect(useConflictStore.getState().byKey["storyboard:b"]).toBeUndefined();
+  });
+});

--- a/web/src/stores/__tests__/WorkflowManagerStore.merge.test.ts
+++ b/web/src/stores/__tests__/WorkflowManagerStore.merge.test.ts
@@ -381,6 +381,73 @@ describe("refreshWorkflow — the merge base follows the editor's own saves", ()
     ).toEqual([]);
   });
 
+  it("takes a second agent write to a node the draft never touched", async () => {
+    // The base a merge leaves behind is round-tripped through the graph
+    // converters. If that round trip were lossy, the second write would read
+    // the node as changed on both sides and contest what the draft never
+    // touched.
+    const queryClient = new QueryClient();
+    const store = createWorkflowManagerStore(queryClient);
+    store.getState().addWorkflow(noEdgeWorkflow);
+
+    // A canvas that folds a merge back in, the way the real store does.
+    let nodes: unknown[] = (noEdgeWorkflow.graph?.nodes ?? []).map((node) =>
+      graphNodeToReactFlowNode(noEdgeWorkflow, node)
+    );
+    const applyExternalGraph = jest.fn((merged: unknown[]) => {
+      nodes = merged;
+    });
+    const fakeStore = {
+      setState: jest.fn(),
+      getState: () => ({
+        workflowIsDirty: true,
+        nodes,
+        edges: [],
+        getWorkflow: () =>
+          ({ ...noEdgeWorkflow, updated_at: "2026-08-11T00:00:00Z" }) as Workflow,
+        setWorkflowDirty: jest.fn(),
+        applyExternalGraph,
+        findNode: (id: string) =>
+          nodes.find((n) => (n as { id: string }).id === id),
+        updateNodeData: jest.fn(),
+        updateNode: jest.fn(),
+        addNode: jest.fn(),
+        deleteNode: jest.fn(),
+        deleteEdge: jest.fn(),
+        cleanup: jest.fn()
+      })
+    } as unknown as NodeStoreApi;
+    store.setState((state: { nodeStores: Record<string, NodeStoreApi> }) => ({
+      nodeStores: { ...state.nodeStores, "wf-1": fakeStore }
+    }));
+
+    const agentWrite = async (value: string, etag: string, at: string) => {
+      fetchWorkflowById.mockResolvedValue({
+        ...noEdgeWorkflow,
+        updated_at: at,
+        etag,
+        graph: { nodes: [graphNode("A", "Input", { value })], edges: [] }
+      });
+      await store
+        .getState()
+        .refreshWorkflow("wf-1", etag, [
+          { tool: "ui_update_node_data", input: { node_id: "A" } }
+        ]);
+    };
+
+    await agentWrite("v1", "etag-1", "2026-08-12T00:00:00Z");
+    await agentWrite("v2", "etag-2", "2026-08-13T00:00:00Z");
+
+    expect(applyExternalGraph).toHaveBeenCalledTimes(2);
+    expect(
+      (nodes as { id: string; data: { properties?: Record<string, unknown> } }[])
+        .find((n) => n.id === "A")?.data.properties
+    ).toMatchObject({ properties: { value: "v2" } });
+    expect(
+      useConflictStore.getState().byKey["workflow:wf-1"]?.conflicts ?? []
+    ).toEqual([]);
+  });
+
   it("holds a foreign write during a save and reports it once the save settles", async () => {
     const queryClient = new QueryClient();
     const store = createWorkflowManagerStore(queryClient);

--- a/web/src/stores/__tests__/documentMerge.test.ts
+++ b/web/src/stores/__tests__/documentMerge.test.ts
@@ -757,6 +757,106 @@ describe("mergeByUnits", () => {
     });
   });
 
+  describe("nextBase — the base for the write after this one", () => {
+    it("rolls forward the units the draft took, and keeps the ones it refused", () => {
+      const draft: Doc = {
+        ...base,
+        units: [{ ...base.units[0], value: "draft" }, base.units[1]]
+      };
+      const server: Doc = {
+        ...base,
+        units: [
+          { ...base.units[0], value: "agent" },
+          { ...base.units[1], value: "agent-b" }
+        ]
+      };
+
+      const { conflicts, nextBase } = mergeByUnits(base, draft, server, adapter(), {
+        ops: [
+          { tool: "update_unit", input: { id: "a" } },
+          { tool: "update_unit", input: { id: "b" } }
+        ]
+      });
+
+      expect(conflicts.map((c) => c.unit.id)).toEqual(["a"]);
+      // "a" was refused, so its base stays where the contest can be found
+      // again; "b" was taken, so its base is what the server now holds.
+      expect(nextBase.units).toEqual([
+        { id: "a", label: "Unit A", value: "1" },
+        { id: "b", label: "Unit B", value: "agent-b" }
+      ]);
+    });
+
+    it("finds the same contest again when the next write repeats it", () => {
+      const draft: Doc = {
+        ...base,
+        units: [{ ...base.units[0], value: "draft" }, base.units[1]]
+      };
+      const server: Doc = {
+        ...base,
+        units: [{ ...base.units[0], value: "agent" }, base.units[1]]
+      };
+      const ops: DocumentOp[] = [{ tool: "update_unit", input: { id: "a" } }];
+
+      const first = mergeByUnits(base, draft, server, adapter(), { ops });
+      expect(first.conflicts.map((c) => c.unit.id)).toEqual(["a"]);
+
+      // The server writes "a" again without changing it. Against the rolled
+      // base this read as "only the draft changed" and the refused value was
+      // silently unreachable.
+      const second = mergeByUnits(first.nextBase, first.doc, server, adapter(), {
+        ops
+      });
+      expect(second.conflicts.map((c) => c.unit.id)).toEqual(["a"]);
+      expect(second.conflicts[0].external).toEqual({
+        id: "a",
+        label: "Unit A",
+        value: "agent"
+      });
+    });
+
+    it("keeps a unit the draft deleted, so the next write cannot resurrect it", () => {
+      const draft: Doc = { ...base, units: [base.units[0]] };
+      const server: Doc = {
+        ...base,
+        units: [base.units[0], { ...base.units[1], value: "agent-b" }]
+      };
+
+      const { nextBase } = mergeByUnits(base, draft, server, adapter(), {
+        ops: [{ tool: "update_unit", input: { id: "b" } }]
+      });
+
+      expect(nextBase.units.map((u) => u.id)).toEqual(["a", "b"]);
+    });
+
+    it("keeps the whole base when the write had no ops to merge by", () => {
+      const draft: Doc = {
+        ...base,
+        units: [{ ...base.units[0], value: "draft" }, base.units[1]]
+      };
+      const server: Doc = { ...base, name: "renamed" };
+
+      const { nextBase } = mergeByUnits(base, draft, server, adapter());
+
+      expect(nextBase).toBe(base);
+    });
+
+    it("keeps a refused scalar and rolls forward one the draft took", () => {
+      const draft: Doc = { ...base, name: "draft name" };
+      const server: Doc = { ...base, name: "agent name" };
+
+      const { nextBase } = mergeByUnits(base, draft, server, adapter(), {
+        ops: [{ tool: "set_name", input: {} }]
+      });
+      expect(nextBase.name).toBe("board");
+
+      const taken = mergeByUnits(base, base, server, adapter(), {
+        ops: [{ tool: "set_name", input: {} }]
+      });
+      expect(taken.nextBase.name).toBe("agent name");
+    });
+  });
+
   it("never mutates its inputs", () => {
     const draft: Doc = { ...base, units: [{ ...base.units[0], value: "draft" }] };
     const server: Doc = {

--- a/web/src/stores/documentMerge.ts
+++ b/web/src/stores/documentMerge.ts
@@ -44,6 +44,16 @@ export interface MergeConflict {
 export interface MergeResult<TDoc> {
   doc: TDoc;
   conflicts: MergeConflict[];
+  /**
+   * The base to merge the *next* external write against.
+   *
+   * It is the server document, except in the slots the draft refused, which
+   * keep the base they had. Rolling those forward too would make the refusal
+   * permanent and silent: the next write reads the refused slot as unchanged
+   * on the server and changed by the draft, so the draft wins with nothing
+   * listed and the external value can never be taken again.
+   */
+  nextBase: TDoc;
 }
 
 /**
@@ -235,6 +245,13 @@ function resolveSlot(
   return { value: draftValue, contested: true };
 }
 
+/** The base one slot carries into the next merge. See `MergeResult.nextBase`. */
+const nextBaseSlot = (
+  baseValue: unknown,
+  serverValue: unknown,
+  contested: boolean
+): unknown => (contested ? baseValue : serverValue);
+
 /**
  * One refused external sub-item, reported by a field spec that declares
  * `conflictKind`. Shaped like a MergeConflict minus the label bookkeeping.
@@ -270,7 +287,12 @@ function mergeByFieldSpecs(
   pathPrefix: string,
   unitIdForTouch: string,
   report?: (entry: ReportedSubConflict) => void
-): { unit: Record<string, unknown>; contested: boolean } {
+): {
+  unit: Record<string, unknown>;
+  contested: boolean;
+  /** This unit's base for the next merge. See `MergeResult.nextBase`. */
+  nextBase: Record<string, unknown>;
+} {
   const declared = new Set(fields.map((f) => f.field));
 
   const pickRest = (unit: unknown): Record<string, unknown> => {
@@ -294,6 +316,15 @@ function mergeByFieldSpecs(
   const resolved: Record<string, unknown> = {
     ...(rest.value as Record<string, unknown>)
   };
+  // A slot the draft refused keeps its base whether or not the refusal was
+  // listed: an unlisted one is just as unreachable if the base rolls past it.
+  const nextBase: Record<string, unknown> = {
+    ...(nextBaseSlot(
+      pickRest(baseUnit),
+      pickRest(serverUnit),
+      rest.contested
+    ) as Record<string, unknown>)
+  };
 
   const childPath = (field: string): string =>
     pathPrefix ? `${pathPrefix}.${field}` : field;
@@ -302,6 +333,7 @@ function mergeByFieldSpecs(
     const read = (unit: unknown): unknown =>
       (unit as Record<string, unknown> | null | undefined)?.[spec.field];
     if (spec.itemId) {
+      const itemId = spec.itemId;
       const readList = (unit: unknown): unknown[] =>
         ((read(unit) as unknown[] | undefined) ?? []);
       const baseSub = listById(readList(baseUnit), spec.itemId);
@@ -333,6 +365,11 @@ function mergeByFieldSpecs(
       // Start from the draft's items; fold in what the server did.
       const mergedItems: unknown[] = [...readList(draftUnit)];
       let subContested = false;
+      // Item ids whose external value the draft refused, so the field's next
+      // base can keep theirs instead of rolling past the refusal.
+      const refusedItems = new Set<string>();
+      // Per-item next bases from a nested field spec, which computes its own.
+      const nestedBases = new Map<string, Record<string, unknown>>();
 
       // Server additions, and server changes to an item the draft deleted.
       // Existence decides; ops do not gate these.
@@ -347,14 +384,14 @@ function mergeByFieldSpecs(
         if (!dEntry && bEntry) {
           // Draft deleted it; a changed server copy this write touched
           // contests the deletion, and the deletion stands (the draft wins).
-          if (
-            !structuralEqual(bEntry.item, sEntry.item) &&
-            touchesSlot(itemPath, id)
-          ) {
-            if (reportItem) {
-              reportItem(id, sEntry.item, undefined, sEntry.item, "deleted");
-            } else {
-              subContested = true;
+          if (!structuralEqual(bEntry.item, sEntry.item)) {
+            refusedItems.add(id);
+            if (touchesSlot(itemPath, id)) {
+              if (reportItem) {
+                reportItem(id, sEntry.item, undefined, sEntry.item, "deleted");
+              } else {
+                subContested = true;
+              }
             }
           }
         }
@@ -370,6 +407,7 @@ function mergeByFieldSpecs(
         if (!sEntry) {
           if (bEntry && !structuralEqual(bEntry.item, draftItem)) {
             // External delete against a dirty item.
+            refusedItems.add(id);
             if (reportItem) {
               if (touchesSlot(itemPath, id)) {
                 reportItem(id, draftItem, draftItem, null, "deleted");
@@ -385,6 +423,7 @@ function mergeByFieldSpecs(
         if (!bEntry) {
           // Created in the draft; the server made its own version too.
           if (!structuralEqual(draftItem, sEntry.item)) {
+            refusedItems.add(id);
             if (reportItem) {
               if (touchesSlot(itemPath, id)) {
                 reportItem(id, draftItem, draftItem, sEntry.item, "edited");
@@ -409,6 +448,7 @@ function mergeByFieldSpecs(
             report
           );
           mergedItems[i] = nested.unit;
+          nestedBases.set(id, nested.nextBase);
           if (nested.contested && touchesSlot(itemPath, id)) {
             if (reportItem) {
               reportItem(id, draftItem, draftItem, sEntry.item, "edited");
@@ -420,16 +460,27 @@ function mergeByFieldSpecs(
         }
         const outcome = resolveSlot(bEntry.item, draftItem, sEntry.item);
         mergedItems[i] = outcome.value;
-        if (outcome.contested && touchesSlot(itemPath, id)) {
-          if (reportItem) {
-            reportItem(id, outcome.value, outcome.value, sEntry.item, "edited");
-          } else {
-            subContested = true;
+        if (outcome.contested) {
+          refusedItems.add(id);
+          if (touchesSlot(itemPath, id)) {
+            if (reportItem) {
+              reportItem(id, outcome.value, outcome.value, sEntry.item, "edited");
+            } else {
+              subContested = true;
+            }
           }
         }
       }
 
       resolved[spec.field] = mergedItems;
+      // The field's next base follows the server's membership, so an item the
+      // draft deleted is not resurrected as a server-only addition next time.
+      nextBase[spec.field] = readList(serverUnit).map((item) => {
+        const id = itemId(item);
+        const nested = nestedBases.get(id);
+        if (nested) return nested;
+        return refusedItems.has(id) ? (baseSub.get(id)?.item ?? item) : item;
+      });
       contested = contested || subContested;
     } else {
       const outcome = resolveSlot(
@@ -438,11 +489,16 @@ function mergeByFieldSpecs(
         read(serverUnit)
       );
       resolved[spec.field] = outcome.value;
+      nextBase[spec.field] = nextBaseSlot(
+        read(baseUnit),
+        read(serverUnit),
+        outcome.contested
+      );
       contested = contested || (outcome.contested && unitTouched);
     }
   }
 
-  return { unit: resolved, contested };
+  return { unit: resolved, contested, nextBase };
 }
 
 /**
@@ -458,8 +514,8 @@ function mergeUnit(
   touchesSlot: (kind: string, unitId: string) => boolean,
   unitId: string,
   report?: (entry: ReportedSubConflict) => void
-): { unit: unknown; contested: boolean } {
-  const outcome = mergeByFieldSpecs(
+): { unit: unknown; contested: boolean; nextBase: unknown } {
+  return mergeByFieldSpecs(
     collection.unitFields ?? [],
     baseUnit,
     draftUnit,
@@ -469,7 +525,6 @@ function mergeUnit(
     unitId,
     report
   );
-  return { unit: outcome.unit, contested: outcome.contested };
 }
 
 /**
@@ -484,7 +539,7 @@ function mergeCollection(
   server: unknown,
   touchesSlot: (kind: string, unitId: string) => boolean,
   conflicts: MergeConflict[]
-): unknown[] {
+): { units: unknown[]; nextBase: unknown[] } {
   const baseMap = listById(collection.read(base), collection.unitId);
   const draftList = collection.read(draft) ?? [];
   const draftMap = listById(draftList, collection.unitId);
@@ -513,6 +568,10 @@ function mergeCollection(
   };
 
   const result: unknown[] = [];
+  // Units whose external value the draft refused, and the merged base of a
+  // unit that resolved field by field. Both feed the next-merge base below.
+  const refused = new Set<string>();
+  const mergedBases = new Map<string, unknown>();
 
   for (const [id, dEntry] of draftMap) {
     const bEntry = baseMap.get(id);
@@ -530,6 +589,7 @@ function mergeCollection(
       if (!draftChanged) continue; // external delete, draft untouched
       // External delete against a dirty draft unit: the draft survives. A
       // delete this write did not touch keeps the draft silently.
+      refused.add(id);
       if (touchesSlot(collection.kind, id)) {
         conflict(
           id,
@@ -546,17 +606,17 @@ function mergeCollection(
     if (!bEntry) {
       // Created on both sides. Same value → done; otherwise draft wins, and
       // only a unit this write touched is listed.
-      if (
-        !structuralEqual(dEntry.item, sEntry.item) &&
-        touchesSlot(collection.kind, id)
-      ) {
-        conflict(
-          id,
-          collection.unitLabel(dEntry.item),
-          sEntry.item,
-          "edited",
-          dEntry.item
-        );
+      if (!structuralEqual(dEntry.item, sEntry.item)) {
+        refused.add(id);
+        if (touchesSlot(collection.kind, id)) {
+          conflict(
+            id,
+            collection.unitLabel(dEntry.item),
+            sEntry.item,
+            "edited",
+            dEntry.item
+          );
+        }
       }
       result.push(dEntry.item);
       continue;
@@ -568,10 +628,17 @@ function mergeCollection(
         result.push(dEntry.item);
         continue;
       }
-      result.push(
-        mergeUnit(collection, bEntry.item, dEntry.item, sEntry.item, touchesSlot, id, report)
-          .unit
+      const takenFromServer = mergeUnit(
+        collection,
+        bEntry.item,
+        dEntry.item,
+        sEntry.item,
+        touchesSlot,
+        id,
+        report
       );
+      result.push(takenFromServer.unit);
+      mergedBases.set(id, takenFromServer.nextBase);
       continue;
     }
 
@@ -595,6 +662,7 @@ function mergeCollection(
       report
     );
     result.push(merged.unit);
+    mergedBases.set(id, merged.nextBase);
     if (merged.contested) {
       conflict(
         id,
@@ -615,7 +683,17 @@ function mergeCollection(
     placed.add(id);
   }
 
-  return result;
+  // The next base follows the server's membership — a unit the draft deleted
+  // must stay in it, or the next merge reads it as a server-only addition and
+  // resurrects it — and keeps the base of every unit the draft refused.
+  const nextBase = [...serverMap.values()].map(({ item }) => {
+    const id = collection.unitId(item);
+    const fieldMerged = mergedBases.get(id);
+    if (fieldMerged !== undefined) return fieldMerged;
+    return refused.has(id) ? (baseMap.get(id)?.item ?? item) : item;
+  });
+
+  return { units: result, nextBase };
 }
 
 /**
@@ -644,6 +722,8 @@ export function mergeByUnits<TDoc>(
   if (!hasOps) {
     return {
       doc: draft,
+      // The draft took none of it, so none of it becomes the next base.
+      nextBase: base,
       conflicts: [
         {
           unit: { kind: "document", id: "document", label: "document" },
@@ -656,6 +736,7 @@ export function mergeByUnits<TDoc>(
 
   const conflicts: MergeConflict[] = [];
   let doc = draft;
+  let nextBase = server;
 
   for (const collection of adapter.collections) {
     const original = collection.read(draft);
@@ -667,14 +748,15 @@ export function mergeByUnits<TDoc>(
       touchesSlot,
       conflicts
     );
+    nextBase = collection.write(nextBase, merged.nextBase);
     if (
       original &&
-      merged.length === original.length &&
-      merged.every((unit, i) => unit === original[i])
+      merged.units.length === original.length &&
+      merged.units.every((unit, i) => unit === original[i])
     ) {
       continue;
     }
-    doc = collection.write(doc, merged);
+    doc = collection.write(doc, merged.units);
   }
 
   for (const scalar of adapter.scalars ?? []) {
@@ -684,6 +766,10 @@ export function mergeByUnits<TDoc>(
       scalar.read(server)
     );
     doc = scalar.write(doc, outcome.value);
+    nextBase = scalar.write(
+      nextBase,
+      nextBaseSlot(scalar.read(base), scalar.read(server), outcome.contested)
+    );
     if (outcome.contested && touchesSlot("field", scalar.name)) {
       conflicts.push({
         unit: { kind: "field", id: scalar.name, label: scalar.name },
@@ -694,5 +780,5 @@ export function mergeByUnits<TDoc>(
     }
   }
 
-  return { doc, conflicts };
+  return { doc, conflicts, nextBase };
 }

--- a/web/src/stores/sketch/SketchSessionStore.ts
+++ b/web/src/stores/sketch/SketchSessionStore.ts
@@ -1106,7 +1106,7 @@ export function useStandaloneSketchDocument(
           canvas: serverSketch.canvas ?? draftSketch.canvas
         };
 
-        const { doc, conflicts } = mergeSketchDocuments(
+        const { doc, conflicts, nextBase } = mergeSketchDocuments(
           baseDoc,
           draftDoc,
           serverDoc,
@@ -1144,7 +1144,12 @@ export function useStandaloneSketchDocument(
         );
         // Roll the merge base to what the server now holds, not the merged
         // draft, and advance the CAS token. The next autosave then persists
-        // the merged document on top of the external write.
+        // the merged document on top of the external write. The units the
+        // draft refused keep the base they had: rolling those forward too
+        // makes the refusal permanent and silent, because the next write
+        // reads them as unchanged on the server and the draft wins with
+        // nothing listed. The hash stays the server's — it answers "has this
+        // editor drifted from the row", not "what did the merge take".
         const serverHash = computeImageDocumentHash(
           toPersistedSketchEditorState(
             fromPersistedSketchEditorState(
@@ -1154,8 +1159,12 @@ export function useStandaloneSketchDocument(
           fresh.document.layerBindings ?? []
         );
         sessionStore.getState().markSaved(fresh.updatedAt, serverHash, {
-          sketch: serverSketch as unknown as Record<string, unknown>,
-          layerBindings: fresh.document.layerBindings ?? []
+          sketch: {
+            ...(serverSketch as unknown as Record<string, unknown>),
+            layers: nextBase.layers,
+            canvas: nextBase.canvas
+          },
+          layerBindings: nextBase.layerBindings as LayerWorkflowBinding[]
         });
         const replaced = conflicts.some(
           (conflict) => conflict.reason === "replaced"

--- a/web/src/stores/sketch/merge.ts
+++ b/web/src/stores/sketch/merge.ts
@@ -107,6 +107,8 @@ export function mergeSketchDocuments(
   if (ops?.some((op) => SKETCH_WHOLE_DOCUMENT_OPS.has(op.tool))) {
     return {
       doc: draft,
+      // The draft took none of it, so none of it becomes the next base.
+      nextBase: base,
       conflicts: [
         {
           unit: { kind: "document", id: "document", label: "document" },

--- a/web/src/stores/timeline/merge.ts
+++ b/web/src/stores/timeline/merge.ts
@@ -210,6 +210,7 @@ export function mergeTimelineDocuments(
       ...result.doc,
       clips: clips.filter((c) => !dropped.has(c.id))
     },
+    nextBase: result.nextBase,
     conflicts
   };
 }

--- a/web/src/stores/workflowMerge.ts
+++ b/web/src/stores/workflowMerge.ts
@@ -209,6 +209,7 @@ export function mergeWorkflowDocuments(
   );
   const result: MergeResult<WorkflowMergeDoc> = {
     conflicts: merged.conflicts,
+    nextBase: merged.nextBase,
     doc: {
       nodes: restoreRuntime(merged.doc.nodes, draft.nodes, "node"),
       edges: restoreRuntime(merged.doc.edges, draft.edges, "edge")
@@ -237,6 +238,7 @@ export function mergeWorkflowDocuments(
       ...result.doc,
       edges: result.doc.edges.filter((e) => !dropped.has(nodeIdOf(e)))
     },
+    nextBase: result.nextBase,
     conflicts,
     danglingEdges
   };


### PR DESCRIPTION
## What changed

When an agent renders stills or clips onto a storyboard the user has open with unsaved edits, the media stopped reaching the board: a conflict dialog appeared, accepting it changed nothing visible, and the rest of the batch was lost silently. A render batch is one write per shot, so a dirty board merges it as several external writes, and two things dropped the stills in between. First, the banner replaced its whole conflict list on every merge — the offer carrying shot 1's still vanished the moment shot 2's write landed, so the user accepted whatever was left and the earlier stills were unreachable with no sign anything had been refused. Offers now fold together, and each is answered by the resolver that made it (a resolver closes over the server document its own merge fetched, so an older offer must not be handed to a newer one). Second, the merge base rolled wholly forward to the server copy, past the shots the draft had just refused; the next write then read a refused shot as unchanged on the server and changed by the draft, so the draft won with nothing listed and the still could never be offered again. `mergeByUnits` now returns `nextBase` — the server document, except in the slots the draft refused, which keep the base they had. Keeping the merged draft instead would refuse the agent's *second* edit to a shot it had already merged, which is what rolling forward was for. Storyboard, script, JS script, timeline, sketch and app builder take the new base; the workflow editor does not, because reaching it there means converting merged ReactFlow units back to graph shape and that round trip is lossy — it made the second agent write to an untouched node read as a contest. The workflow editor keeps the conflict-list fix, and the round trip is now pinned by a test.

## Verification

- [x] `npm run test:affected` — 240 suites, 2275 passed, 3 skipped
- [x] `npm run typecheck` — no errors under `web/src`. The run also reports `Cannot find module '@nodetool-ai/*'` in `packages/websocket` and `web/src/lib/workflow/browserRunnerCore.ts`; those are this container missing the `node_modules/@nodetool-ai/browser` workspace link, which fails `automation-nodes` and `base-nodes` in `npm run build:packages`. The same errors reproduce on `main` with the diff stashed, and this diff touches no file under `packages/`.
- [x] `npm run lint` — exit 0
- [ ] `npm run dev:nodetool -- harness gate --base main` — could not run here: `ERR_MODULE_NOT_FOUND` on `@nodetool-ai/base-nodes/dist/index.js`, from the same unbuilt-packages gap above.

Each new test was inverted against the half of the fix it covers, and observed failing:

- `keeps a refused still on offer through the rest of a render batch`, with `addConflicts` put back to `setConflicts`:
  ```
  expect(received).toContain(expected) // indexOf
  Expected value: "s1"
  Received array: []
  ```
- `re-offers a refused shot on the next write that touches it`, with `syncedRef.current` put back to `serverBoard`:
  ```
  ✕ re-offers a refused shot on the next write that touches it
  ```
- `takes a second agent write to a node the draft never touched` fails with the workflow store converting `nextBase` back to graph shape, which is why that surface was left alone:
  ```
  Object { "properties": Object { - "value": "v2", + "value": "v1" } }
  ```

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added — the additions are tests, and each was observed failing as recorded above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMKFrGDmn9i8Zukb1HfUUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMKFrGDmn9i8Zukb1HfUUU)_