### PR TITLE
fix(atlascloud): never put a resolution tier in a free-string `size`

### DIFF
--- a/packages/runtime/src/providers/atlascloud-provider.ts
+++ b/packages/runtime/src/providers/atlascloud-provider.ts
@@ -413,7 +413,11 @@ function parseSize(value: string): { w: number; h: number } | null {
  * The field is a free string on some models and a fixed enum on others, and
  * the separator differs by family (`1024x1024` on GPT Image, `1024*1024` on
  * Seedream / Qwen / Wan). Free-string fields take the requested dimensions
- * verbatim under the separator the model's own default uses; enum fields get
+ * verbatim under the separator the model's own default uses — `*` when the
+ * default declares none, which is what every free-string `size` on AtlasCloud
+ * wants: the `x` form is an OpenAI-family enum, and Qwen Image 3 rejects it
+ * outright (`invalid qwen image size "1024x1024"; use width*height`) while
+ * FLUX 2 fails evaluating its per-megapixel price. Enum fields get
  * the declared option closest in aspect ratio, then in area. Enums with no
  * parseable dimensions at all (Wan's `1K`/`2K`) yield null — the caller leaves
  * the model default in place instead of sending an option that would 422.
@@ -421,7 +425,7 @@ function parseSize(value: string): { w: number; h: number } | null {
 function renderSize(field: FieldInfo, w: number, h: number): string | null {
   const allowed = field.values;
   if (!allowed || allowed.length === 0) {
-    const sep = String(field.default ?? "").includes("*") ? "*" : "x";
+    const sep = String(field.default ?? "").includes("x") ? "x" : "*";
     return `${w}${sep}${h}`;
   }
   const exact = allowed.find(
@@ -456,14 +460,21 @@ function mapImageParams(
 ) {
   const input: Record<string, unknown> = { prompt: params.prompt };
   setIfDeclared(input, info, params.aspectRatio, "aspect_ratio", "ratio");
-  // Wan expresses resolution as a `size` enum (`1K`/`2K`/`4K`); the membership
-  // check in setIfDeclared keeps the fallback from firing on pixel-size models.
-  setIfDeclared(input, info, params.resolution, "resolution", "size");
+  setIfDeclared(input, info, params.resolution, "resolution");
   setIfDeclared(input, info, params.quality, "quality");
   setIfDeclared(input, info, params.negativePrompt, "negative_prompt");
   setIfDeclared(input, info, params.seed, "seed");
   setIfDeclared(input, info, params.guidanceScale, "cfg_scale");
   const sizeField = info.fields.get("size");
+  // Wan expresses resolution as a `size` enum (`1K`/`2K`/`4K`), so a named tier
+  // belongs there — but only when the enum declares it. A free-string `size`
+  // takes `width*height` and nothing else: AtlasCloud prices FLUX 2 by
+  // megapixels parsed out of that string, so a `size: "1K"` it never declared
+  // is rejected before the job exists ("failed to evaluate price: … asFloat:
+  // cannot convert 1K"). Leave that field to the pixel renderer below.
+  if (sizeField?.values && sizeField.values.length > 0) {
+    setIfDeclared(input, info, params.resolution, "size");
+  }
   if (sizeField && input.size === undefined) {
     const w =
       (params as TextToImageParams).width ??

--- a/packages/runtime/tests/providers/atlascloud-provider.test.ts
+++ b/packages/runtime/tests/providers/atlascloud-provider.test.ts
@@ -315,6 +315,39 @@ describe("AtlasCloudProvider — textToImage", () => {
     expect(capture.submitBody!.size).toBe("1K");
   });
 
+  it("keeps a resolution tier out of a free-string `size`", async () => {
+    const capture: { submitBody?: Record<string, unknown> } = {};
+    mockAtlasFetch({ capture });
+    const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
+    // FLUX 2 Pro's `size` is a free string of pixel dimensions, and AtlasCloud
+    // parses its per-megapixel price out of it: a `size: "1K"` is rejected at
+    // submit with "failed to evaluate price: … asFloat: cannot convert 1K".
+    // The named tier belongs to the pixel pair the caller sent with it.
+    await p.textToImage({
+      model: imageModel("black-forest-labs/flux-2-pro/text-to-image"),
+      prompt: "a cat",
+      resolution: "1K",
+      width: 1024,
+      height: 1024
+    });
+    expect(capture.submitBody!.size).toBe("1024*1024");
+  });
+
+  it("renders a separator-less `size` default with `*`", async () => {
+    const capture: { submitBody?: Record<string, unknown> } = {};
+    mockAtlasFetch({ capture });
+    const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
+    // Qwen Image 3 declares `size` with an empty default, and rejects the `x`
+    // form outright: `invalid qwen image size "1024x1024"; use width*height`.
+    await p.textToImage({
+      model: imageModel("qwen-image-3.0/text-to-image"),
+      prompt: "a cat",
+      width: 1024,
+      height: 1024
+    });
+    expect(capture.submitBody!.size).toBe("1024*1024");
+  });
+
   it("drops an aspect ratio the model does not declare", async () => {
     const capture: { submitBody?: Record<string, unknown> } = {};
     mockAtlasFetch({ capture });


### PR DESCRIPTION
## What changed

Rendering a still on AtlasCloud with a named resolution failed at submit with `400 failed to evaluate price: expression evaluate failed: asFloat: cannot convert 1K (type string) to float64`. `mapImageParams` offered the caller's `resolution` to `resolution` and then to `size`, and `setIfDeclared` only checks membership on an *enum* — a free-string `size` accepted `"1K"` verbatim, and setting it also suppressed the width/height renderer that would have produced the pixel pair the model actually wants. The named tier now reaches `size` only when that field is an enum declaring it (the four Wan 2.7 image models), and everything else falls through to the pixel renderer. Second defect on the same path: the renderer read its separator off the field's default and fell back to `x`, so the six models whose default is empty got `1024x1024`, which AtlasCloud also rejects. Every free-string `size` there wants `*`; the `x` form only appears in the GPT Image enums, which take the enum branch.

Reproduced against AtlasCloud's own `POST /api/v1/model/calculate`, which accepts the same body as `generateImage` and needs no key. With `size: "1K"`: the exact 400 above on `flux-2-pro` and `flux-2-flex` (they price by megapixels parsed out of the string), `invalid qwen image size "1K"; use width*height` on `qwen-image-3.0` and `-pro`, and priced-but-silently-ignored on the other 14 shipped models with a free-string `size`. With `size: "1024x1024"`: `asFloat: cannot convert 1024x1024` on flux-2-pro, and the same qwen rejection. Both forms price correctly as `1024*1024`. The value the UI sends is `MediaGenerationStore`'s `"1K" | "2K" | "4K"`, alongside the width/height it derives from the same picker.

## Verification

- [x] `npm run test:affected` — passes apart from `image-nodes`, which fails on `CheckVkSuccessImpl` (no Vulkan ICD in this container; CI installs `mesa-vulkan-drivers`) and `runtime/tests/providers/video-frame-fallback.test.ts`, which fails on `spawn ffmpeg ENOENT`. Neither is touched by this diff. `packages/runtime`: 3115 passed, 13 skipped.
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run dev:nodetool -- harness gate --base main` — 8/8 selfchecks passed

Both new tests were run against the unpatched provider and observed failing:

```
AssertionError: expected '1K' to be '1024*1024' // Object.is equality
AssertionError: expected '1024x1024' to be '1024*1024' // Object.is equality
      Tests  2 failed | 28 passed (30)
```

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added — two provider unit tests, whose failing output against the unpatched code is above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaT2ke4msSVM2teNFkvfbU)_