### PR TITLE
fix(cost-estimate): name rows by node title, scope prices to the selected provider

### DIFF
--- a/packages/model-pricing/src/genspend-catalog.ts
+++ b/packages/model-pricing/src/genspend-catalog.ts
@@ -166,9 +166,10 @@ let offeringsByModelId: Map<string, GenspendOffering[]> | null = null;
  *
  * Resellers list the vendor's own id verbatim — AtlasCloud and fal both call
  * it `google/gemini-omni-flash/image-to-video` — so a model the catalog knows
- * under one provider is usually the same model under another. Callers use this
- * only when the exact `<provider>:<id>` key is untracked, and must say whose
- * rate they ended up quoting.
+ * under one provider is usually the same model under another. That is a fact
+ * to *explain* an untracked offering with, never one to price it with: a
+ * caller quotes `getGenspendPrice` for the provider it was asked about and
+ * uses this only to say which providers the catalog does carry.
  */
 export function getGenspendPricesByModelId(
   modelId: string

--- a/packages/model-pricing/src/genspend-catalog.ts
+++ b/packages/model-pricing/src/genspend-catalog.ts
@@ -151,4 +151,41 @@ export function getGenspendPrice(
   return genspendPricingCatalog.prices[`${provider}:${modelId}`] ?? null;
 }
 
+/** One provider's offering of a model, as {@link getGenspendPricesByModelId} returns it. */
+export interface GenspendOffering {
+  /** The NodeTool provider id the price belongs to. */
+  provider: string;
+  price: GenspendPrice;
+}
+
+/** Built once on first use: model id → every provider that publishes a price. */
+let offeringsByModelId: Map<string, GenspendOffering[]> | null = null;
+
+/**
+ * Every tracked offering of one provider-native model id, across providers.
+ *
+ * Resellers list the vendor's own id verbatim — AtlasCloud and fal both call
+ * it `google/gemini-omni-flash/image-to-video` — so a model the catalog knows
+ * under one provider is usually the same model under another. Callers use this
+ * only when the exact `<provider>:<id>` key is untracked, and must say whose
+ * rate they ended up quoting.
+ */
+export function getGenspendPricesByModelId(
+  modelId: string
+): readonly GenspendOffering[] {
+  if (!offeringsByModelId) {
+    offeringsByModelId = new Map();
+    for (const [key, price] of Object.entries(genspendPricingCatalog.prices)) {
+      const separator = key.indexOf(":");
+      if (separator <= 0) continue;
+      const id = key.slice(separator + 1);
+      const offerings = offeringsByModelId.get(id);
+      const offering = { provider: key.slice(0, separator), price };
+      if (offerings) offerings.push(offering);
+      else offeringsByModelId.set(id, [offering]);
+    }
+  }
+  return offeringsByModelId.get(modelId) ?? [];
+}
+
 export default genspendPricingCatalog;

--- a/packages/model-pricing/src/index.ts
+++ b/packages/model-pricing/src/index.ts
@@ -1,8 +1,8 @@
 /**
  * Look up a unit price for a model chosen on a generic node's provider-model
  * property (e.g. `model` on `nodetool.image.TextToImage`), given what the node
- * states about the job. The catalogs answer in this order, and every step
- * before the last quotes the selected provider's own published price:
+ * states about the job. The catalogs answer in this order, each of them for
+ * the provider the node selected and no other:
  *
  * - The GenSpend catalog (`genspend-catalog.ts`, refreshed nightly from
  *   genspend.io) whenever it carries a *parameter-priceable* entry for the
@@ -18,11 +18,12 @@
  * - The GenSpend base-spec scalar, for a flat entry with no grid. It also
  *   answers when the provider's own scalar row cannot be converted to a run,
  *   so a model the catalog does price is never reported unpriced.
- * - Last, the same model id on a provider the catalog *does* track, since
- *   resellers reuse the vendor's id. That figure is another vendor's margin,
- *   so it comes back with an assumption naming whose rate it is and the cost
- *   views render it as "~$X" — a named borrowing beats a blank row for a node
- *   that has already stated its model, duration and resolution.
+ *
+ * Every answer is the selected provider's own published price, and there is no
+ * fallback that quotes another's: a reseller's margin is its own, and a figure
+ * that is not the price of the run the node will make is worse than no figure.
+ * A model the catalog carries only for other providers comes back as a decline
+ * naming them, which the cost views show in place of a number.
  *
  * Shared on purpose: the web cost preview and the server-side pre-run budget
  * estimate (`estimateRunCost`) both call this, so a run is gated on the same
@@ -178,88 +179,33 @@ function flatGenspendPrice(entry: GenspendPrice): ModelParamPrice {
 }
 
 /**
- * The price of the same model on a provider the catalog does track, for a
- * provider it does not.
+ * Why a model the catalogs know went unpriced here: the provider the node
+ * selected publishes no price for it.
  *
- * Resellers publish the vendor's own model id (AtlasCloud and fal both sell
- * `google/gemini-omni-flash/image-to-video`), so an untracked offering of a
- * tracked model is the common case, not a coincidence — and a node stating a
- * model, a duration and a resolution deserves a figure rather than a blank.
- * What it is not is a quote: the margin is the reseller's own, so the figure
- * comes back with an assumption naming whose rate it is, which the cost views
- * render as "~$X" rather than an exact price.
- *
- * Two guards keep it from inventing a number. The offerings must agree on a
- * unit class — a per-second rate and a per-generation rate are not comparable,
- * and picking either would be arbitrary — and the cheapest of them is quoted,
- * so a model sold at four prices reports the one that overstates least.
+ * A reseller lists the vendor's own model id verbatim — AtlasCloud and fal both
+ * sell `google/gemini-omni-flash/image-to-video` — so the id alone would happily
+ * find another vendor's number. That number is another vendor's margin, and an
+ * estimate is only worth showing when it is the price of the run the node will
+ * actually make, so it is never quoted. What travels instead is the reason,
+ * which the cost views show in place of the figure: the model is tracked, just
+ * not for this provider, which is a gap in the catalog someone can close.
  */
-function borrowedPrice(
-  model: SelectedModel,
-  params?: ModelPriceParams
-): ModelParamPrice | null {
-  return (
-    borrowedGenspendPrice(model, params) ?? borrowedScalarPrice(model, params)
-  );
-}
-
-/** {@link borrowedPrice} off a GenSpend offering of the same model id. */
-function borrowedGenspendPrice(
-  model: SelectedModel,
-  params?: ModelPriceParams
-): ModelParamPrice | null {
+function untrackedProviderPrice(model: SelectedModel): ModelParamPrice | null {
   if (!model.provider) return null;
-  const offerings = getGenspendPricesByModelId(model.id).filter(
-    (offering) => offering.provider !== model.provider
-  );
-  if (offerings.length === 0) return null;
-  const unitClass = offerings[0].price.unit_class;
-  if (offerings.some((offering) => offering.price.unit_class !== unitClass)) {
-    return null;
-  }
-  const cheapest = offerings.reduce((best, offering) =>
-    offering.price.unit_price < best.price.unit_price ? offering : best
-  );
-
-  const priced = isParameterPriceable(cheapest.price)
-    ? priceGenspendEntry(cheapest.price, params ?? {})
-    : flatGenspendPrice(cheapest.price);
-  if (priced.declined) return priced;
-  return borrowed(priced, model.provider, cheapest.provider);
-}
-
-/**
- * {@link borrowedPrice} off the FAL or kie scalar catalog, for a reseller that
- * lists the same endpoint id. Last, because those rows are one number for a
- * whole endpoint where a GenSpend offering carries the grid.
- */
-function borrowedScalarPrice(
-  model: SelectedModel,
-  params?: ModelPriceParams
-): ModelParamPrice | null {
-  if (!model.provider) return null;
-  const fal = falPrice(model.id);
-  const scalar = fal ?? kiePrice(model.id);
-  if (!scalar) return null;
-  const priced = priceScalarUnit(scalar.price, params, {
-    tierCount: scalar.tierCount
-  });
-  if (priced.declined) return priced;
-  return borrowed(priced, model.provider, fal ? PROVIDER_FAL_AI : PROVIDER_KIE);
-}
-
-/** Say whose rate a figure is, when it is not the selected provider's own. */
-function borrowed(
-  priced: ModelParamPrice,
-  provider: string,
-  source: string
-): ModelParamPrice {
+  const elsewhere = [
+    ...new Set(
+      getGenspendPricesByModelId(model.id)
+        .map((offering) => offering.provider)
+        .filter((provider) => provider !== model.provider)
+    )
+  ].sort();
+  if (elsewhere.length === 0) return null;
   return {
-    ...priced,
-    assumptions: [
-      `no published price for this model on ${provider} — priced at ${source}'s rate for the same model`,
-      ...(priced.assumptions ?? [])
-    ]
+    unit_price: 0,
+    billing_unit: "",
+    currency: GENSPEND_CURRENCY,
+    source: "bundle",
+    declined: `the catalog has no ${model.provider} price for this model — it prices the same model on ${elsewhere.join(", ")}, and one provider's rate is not another's`
   };
 }
 
@@ -313,9 +259,9 @@ export function getModelUnitPrice(
     });
     if (!priced.declined) return priced;
     if (entry) return flatGenspendPrice(entry);
-    // Keep the refusal when nothing else can price the model: the reason it
-    // carries is what the cost views show instead of a bare "unknown".
-    return borrowedPrice(model, params) ?? priced;
+    // Keep the refusal: the reason it carries is what the cost views show
+    // instead of a bare "unknown".
+    return priced;
   }
 
   if (entry) {
@@ -323,7 +269,7 @@ export function getModelUnitPrice(
     return flatGenspendPrice(entry);
   }
 
-  return borrowedPrice(model, params);
+  return untrackedProviderPrice(model);
 }
 
 export {

--- a/packages/model-pricing/src/index.ts
+++ b/packages/model-pricing/src/index.ts
@@ -1,7 +1,8 @@
 /**
  * Look up a unit price for a model chosen on a generic node's provider-model
  * property (e.g. `model` on `nodetool.image.TextToImage`), given what the node
- * states about the job. Three catalogs answer, in this order:
+ * states about the job. The catalogs answer in this order, and every step
+ * before the last quotes the selected provider's own published price:
  *
  * - The GenSpend catalog (`genspend-catalog.ts`, refreshed nightly from
  *   genspend.io) whenever it carries a *parameter-priceable* entry for the
@@ -10,7 +11,18 @@
  *   the run rather than one unit of it.
  * - The FAL (`endpoint_id`) and kie (`model_id`) codegen catalogs otherwise,
  *   with their one scalar per endpoint converted to a per-run figure here.
- * - The GenSpend base-spec scalar last, for a flat entry with no grid.
+ *   Those catalogs are keyed by bare endpoint id and are consulted only for
+ *   their own provider: a reseller lists the vendor's id verbatim, and an
+ *   unscoped lookup was quoting FAL's rate — or FAL's refusal to convert a
+ *   "units" row — for models FAL does not sell.
+ * - The GenSpend base-spec scalar, for a flat entry with no grid. It also
+ *   answers when the provider's own scalar row cannot be converted to a run,
+ *   so a model the catalog does price is never reported unpriced.
+ * - Last, the same model id on a provider the catalog *does* track, since
+ *   resellers reuse the vendor's id. That figure is another vendor's margin,
+ *   so it comes back with an assumption naming whose rate it is and the cost
+ *   views render it as "~$X" — a named borrowing beats a blank row for a node
+ *   that has already stated its model, duration and resolution.
  *
  * Shared on purpose: the web cost preview and the server-side pre-run budget
  * estimate (`estimateRunCost`) both call this, so a run is gated on the same
@@ -32,8 +44,17 @@ import {
 } from "./genspend-calc.js";
 import falUnitPricingCatalog from "@nodetool-ai/fal-nodes/unit-pricing-catalog";
 import kieUnitPricingCatalog from "@nodetool-ai/kie-nodes/unit-pricing-catalog";
-import { getGenspendPrice, GENSPEND_CURRENCY } from "./genspend-catalog.js";
-import { resolveNodetoolDelegate } from "@nodetool-ai/protocol";
+import {
+  getGenspendPrice,
+  getGenspendPricesByModelId,
+  GENSPEND_CURRENCY,
+  type GenspendPrice
+} from "./genspend-catalog.js";
+import { PROVIDER_IDS, resolveNodetoolDelegate } from "@nodetool-ai/protocol";
+
+/** Providers whose scalar catalogs this module carries, keyed by their own id. */
+const PROVIDER_FAL_AI: string = PROVIDER_IDS.FAL_AI;
+const PROVIDER_KIE: string = PROVIDER_IDS.KIE;
 
 interface CatalogPrice {
   unit_price?: unknown;
@@ -126,6 +147,123 @@ function kiePrice(modelId: string): ScalarPrice | null {
 }
 
 /**
+ * The scalar catalog that belongs to a provider. The FAL and kie catalogs are
+ * keyed by bare endpoint id, and resellers list the vendor's id verbatim, so an
+ * unscoped lookup answers for models that are not theirs: an AtlasCloud
+ * `google/gemini-omni-flash/image-to-video` was priced — and, because FAL bills
+ * that endpoint in "units", declined — off FAL's row. A provider whose id we do
+ * not know still gets the id-keyed lookup: those ids are FAL/kie-shaped and
+ * nothing else can answer for them.
+ */
+function ownScalarPrice(model: SelectedModel): ScalarPrice | null {
+  const provider = model.provider;
+  if (provider === null || provider === PROVIDER_FAL_AI) {
+    const fal = falPrice(model.id);
+    if (fal) return fal;
+  }
+  if (provider === null || provider === PROVIDER_KIE) {
+    return kiePrice(model.id);
+  }
+  return null;
+}
+
+/** A flat GenSpend entry: one number per generation, nothing to narrow. */
+function flatGenspendPrice(entry: GenspendPrice): ModelParamPrice {
+  return {
+    unit_price: entry.unit_price,
+    billing_unit: entry.billing_unit,
+    currency: GENSPEND_CURRENCY,
+    source: "bundle"
+  };
+}
+
+/**
+ * The price of the same model on a provider the catalog does track, for a
+ * provider it does not.
+ *
+ * Resellers publish the vendor's own model id (AtlasCloud and fal both sell
+ * `google/gemini-omni-flash/image-to-video`), so an untracked offering of a
+ * tracked model is the common case, not a coincidence — and a node stating a
+ * model, a duration and a resolution deserves a figure rather than a blank.
+ * What it is not is a quote: the margin is the reseller's own, so the figure
+ * comes back with an assumption naming whose rate it is, which the cost views
+ * render as "~$X" rather than an exact price.
+ *
+ * Two guards keep it from inventing a number. The offerings must agree on a
+ * unit class — a per-second rate and a per-generation rate are not comparable,
+ * and picking either would be arbitrary — and the cheapest of them is quoted,
+ * so a model sold at four prices reports the one that overstates least.
+ */
+function borrowedPrice(
+  model: SelectedModel,
+  params?: ModelPriceParams
+): ModelParamPrice | null {
+  return (
+    borrowedGenspendPrice(model, params) ?? borrowedScalarPrice(model, params)
+  );
+}
+
+/** {@link borrowedPrice} off a GenSpend offering of the same model id. */
+function borrowedGenspendPrice(
+  model: SelectedModel,
+  params?: ModelPriceParams
+): ModelParamPrice | null {
+  if (!model.provider) return null;
+  const offerings = getGenspendPricesByModelId(model.id).filter(
+    (offering) => offering.provider !== model.provider
+  );
+  if (offerings.length === 0) return null;
+  const unitClass = offerings[0].price.unit_class;
+  if (offerings.some((offering) => offering.price.unit_class !== unitClass)) {
+    return null;
+  }
+  const cheapest = offerings.reduce((best, offering) =>
+    offering.price.unit_price < best.price.unit_price ? offering : best
+  );
+
+  const priced = isParameterPriceable(cheapest.price)
+    ? priceGenspendEntry(cheapest.price, params ?? {})
+    : flatGenspendPrice(cheapest.price);
+  if (priced.declined) return priced;
+  return borrowed(priced, model.provider, cheapest.provider);
+}
+
+/**
+ * {@link borrowedPrice} off the FAL or kie scalar catalog, for a reseller that
+ * lists the same endpoint id. Last, because those rows are one number for a
+ * whole endpoint where a GenSpend offering carries the grid.
+ */
+function borrowedScalarPrice(
+  model: SelectedModel,
+  params?: ModelPriceParams
+): ModelParamPrice | null {
+  if (!model.provider) return null;
+  const fal = falPrice(model.id);
+  const scalar = fal ?? kiePrice(model.id);
+  if (!scalar) return null;
+  const priced = priceScalarUnit(scalar.price, params, {
+    tierCount: scalar.tierCount
+  });
+  if (priced.declined) return priced;
+  return borrowed(priced, model.provider, fal ? PROVIDER_FAL_AI : PROVIDER_KIE);
+}
+
+/** Say whose rate a figure is, when it is not the selected provider's own. */
+function borrowed(
+  priced: ModelParamPrice,
+  provider: string,
+  source: string
+): ModelParamPrice {
+  return {
+    ...priced,
+    assumptions: [
+      `no published price for this model on ${provider} — priced at ${source}'s rate for the same model`,
+      ...(priced.assumptions ?? [])
+    ]
+  };
+}
+
+/**
  * The unit price for a selected model, as the whole per-run figure with the
  * reasoning attached.
  *
@@ -160,28 +298,32 @@ export function getModelUnitPrice(
   }
 
   const entry = getGenspendPrice(model.provider, model.id);
-  const grid = entry !== null && isParameterPriceable(entry);
-  if (entry && grid) {
+  if (entry && isParameterPriceable(entry)) {
     return priceGenspendEntry(entry, params ?? {});
   }
 
-  const scalar = falPrice(model.id) ?? kiePrice(model.id);
+  // The provider's own scalar row. A row billed in a unit that names no fixed
+  // amount ("units", "credits") declines, and a decline is not a price: fall
+  // through to whatever else prices this model rather than reporting the node
+  // unpriced next to a catalog that does carry a number for it.
+  const scalar = ownScalarPrice(model);
   if (scalar) {
-    return priceScalarUnit(scalar.price, params, {
+    const priced = priceScalarUnit(scalar.price, params, {
       tierCount: scalar.tierCount
     });
+    if (!priced.declined) return priced;
+    if (entry) return flatGenspendPrice(entry);
+    // Keep the refusal when nothing else can price the model: the reason it
+    // carries is what the cost views show instead of a bare "unknown".
+    return borrowedPrice(model, params) ?? priced;
   }
 
   if (entry) {
     // A flat GenSpend entry: one number per generation, nothing to narrow.
-    return {
-      unit_price: entry.unit_price,
-      billing_unit: entry.billing_unit,
-      currency: GENSPEND_CURRENCY,
-      source: "bundle"
-    };
+    return flatGenspendPrice(entry);
   }
-  return null;
+
+  return borrowedPrice(model, params);
 }
 
 export {

--- a/packages/model-pricing/tests/model-pricing.test.ts
+++ b/packages/model-pricing/tests/model-pricing.test.ts
@@ -88,12 +88,131 @@ describe("getModelUnitPrice", () => {
     });
   });
 
-  it("does not price a GenSpend model against the wrong provider", () => {
-    const [key] = Object.entries(genspendPricingCatalog.prices).find(([k]) =>
-      k.startsWith("replicate:")
+  it("does not let an unconvertible FAL unit hide a GenSpend price", () => {
+    // FAL bills a slice of its endpoints in "units" — a word naming no fixed
+    // amount, so the scalar path refuses to turn it into a run. That refusal
+    // is not a price: where GenSpend carries a real number for the same
+    // endpoint, that number is the answer.
+    const id = Object.entries(falUnitPricingCatalog.prices ?? {}).find(
+      ([endpoint, entry]) => {
+        const unit = (entry as { billing_unit?: unknown }).billing_unit;
+        const genspend = genspendPricingCatalog.prices[`fal_ai:${endpoint}`];
+        return (
+          typeof unit === "string" &&
+          /^units?$/i.test(unit.trim()) &&
+          genspend !== undefined &&
+          !isParameterPriceable(genspend)
+        );
+      }
+    )?.[0];
+    if (!id) return; // No such overlap in today's catalogs — nothing to pin.
+
+    const priced = getModelUnitPrice({ id, provider: "fal_ai" });
+    expect(priced?.declined).toBeUndefined();
+    expect(priced?.unit_price).toBe(
+      genspendPricingCatalog.prices[`fal_ai:${id}`].unit_price
+    );
+  });
+
+  it("says whose rate it quoted when the selected provider publishes none", () => {
+    // Only-offering ids, so the borrowed figure can only be this one.
+    const offerings = new Map<string, number>();
+    for (const id of Object.keys(genspendPricingCatalog.prices)) {
+      const model = id.slice(id.indexOf(":") + 1);
+      offerings.set(model, (offerings.get(model) ?? 0) + 1);
+    }
+    const [key, price] = Object.entries(genspendPricingCatalog.prices).find(
+      ([k, entry]) =>
+        k.startsWith("replicate:") &&
+        !isParameterPriceable(entry) &&
+        offerings.get(k.slice("replicate:".length)) === 1
     )!;
     const id = key.slice("replicate:".length);
-    expect(getModelUnitPrice({ id, provider: "together" })).toBeNull();
+    // A reseller lists the vendor's own id, so the same id under another
+    // provider is the same model — priced, but never passed off as that
+    // provider's own quote.
+    const borrowed = getModelUnitPrice({ id, provider: "together" });
+    expect(borrowed?.unit_price).toBe(price.unit_price);
+    expect(borrowed?.assumptions).toEqual([
+      "no published price for this model on together — priced at replicate's rate for the same model"
+    ]);
+    // The provider that does publish it gets the figure with nothing attached.
+    expect(
+      getModelUnitPrice({ id, provider: "replicate" })?.assumptions
+    ).toBeUndefined();
+  });
+
+  it("quotes the cheapest tracked offering, and only within one unit class", () => {
+    const byId = new Map<string, { provider: string; unitClass: string; price: number }[]>();
+    for (const [key, entry] of Object.entries(genspendPricingCatalog.prices)) {
+      const at = key.indexOf(":");
+      const id = key.slice(at + 1);
+      const rows = byId.get(id) ?? [];
+      rows.push({
+        provider: key.slice(0, at),
+        unitClass: entry.unit_class,
+        price: entry.unit_price
+      });
+      byId.set(id, rows);
+    }
+
+    const mixed = [...byId].find(
+      ([, rows]) => new Set(rows.map((r) => r.unitClass)).size > 1
+    );
+    if (mixed) {
+      // Per-second and per-generation rates are not comparable, so there is no
+      // cheapest one to quote: the model stays unpriced for a third provider.
+      expect(
+        getModelUnitPrice({ id: mixed[0], provider: "no-such-provider" })
+      ).toBeNull();
+    }
+
+    const shared = [...byId].find(
+      ([id, rows]) =>
+        rows.length > 1 &&
+        new Set(rows.map((r) => r.unitClass)).size === 1 &&
+        new Set(rows.map((r) => r.price)).size > 1 &&
+        !falUnitPricingCatalog.prices?.[id] &&
+        !kieUnitPricingCatalog.prices?.[id]
+    );
+    if (shared) {
+      const cheapest = Math.min(...shared[1].map((r) => r.price));
+      const quoted = getModelUnitPrice({
+        id: shared[0],
+        provider: "no-such-provider"
+      });
+      expect(quoted?.unit_price).toBe(cheapest);
+    }
+  });
+
+  it("prices a reseller off the FAL row only as a named borrowing", () => {
+    // An endpoint GenSpend tracks under no provider at all, so the FAL scalar
+    // is the only row that can answer for either lookup.
+    const tracked = new Set(
+      Object.keys(genspendPricingCatalog.prices).map((key) =>
+        key.slice(key.indexOf(":") + 1)
+      )
+    );
+    const id = Object.entries(falUnitPricingCatalog.prices ?? {}).find(
+      ([endpoint, entry]) => {
+        const row = entry as Record<string, unknown>;
+        const unit =
+          typeof row.billing_unit === "string" ? row.billing_unit.trim() : "";
+        return (
+          !tracked.has(endpoint) &&
+          typeof row.unit_price === "number" &&
+          row.unit_price > 0 &&
+          PER_RUN_UNITS.has(unit)
+        );
+      }
+    )?.[0];
+    if (!id) throw new Error("no untracked per-run FAL endpoint");
+
+    const own = getModelUnitPrice({ id, provider: "fal_ai" });
+    const reseller = getModelUnitPrice({ id, provider: "atlascloud" });
+    expect(own?.assumptions).toBeUndefined();
+    expect(reseller?.unit_price).toBe(own?.unit_price);
+    expect(reseller?.assumptions?.[0]).toContain("fal_ai");
   });
 
   it("returns null for a model in no catalog", () => {

--- a/packages/model-pricing/tests/model-pricing.test.ts
+++ b/packages/model-pricing/tests/model-pricing.test.ts
@@ -114,80 +114,48 @@ describe("getModelUnitPrice", () => {
     );
   });
 
-  it("says whose rate it quoted when the selected provider publishes none", () => {
-    // Only-offering ids, so the borrowed figure can only be this one.
-    const offerings = new Map<string, number>();
-    for (const id of Object.keys(genspendPricingCatalog.prices)) {
-      const model = id.slice(id.indexOf(":") + 1);
-      offerings.set(model, (offerings.get(model) ?? 0) + 1);
-    }
+  it("never prices a model at another provider's rate", () => {
     const [key, price] = Object.entries(genspendPricingCatalog.prices).find(
-      ([k, entry]) =>
-        k.startsWith("replicate:") &&
-        !isParameterPriceable(entry) &&
-        offerings.get(k.slice("replicate:".length)) === 1
+      ([k, entry]) => k.startsWith("replicate:") && !isParameterPriceable(entry)
     )!;
     const id = key.slice("replicate:".length);
-    // A reseller lists the vendor's own id, so the same id under another
-    // provider is the same model — priced, but never passed off as that
-    // provider's own quote.
-    const borrowed = getModelUnitPrice({ id, provider: "together" });
-    expect(borrowed?.unit_price).toBe(price.unit_price);
-    expect(borrowed?.assumptions).toEqual([
-      "no published price for this model on together — priced at replicate's rate for the same model"
-    ]);
-    // The provider that does publish it gets the figure with nothing attached.
+
+    // The provider that publishes the price gets it.
+    expect(getModelUnitPrice({ id, provider: "replicate" })?.unit_price).toBe(
+      price.unit_price
+    );
+    // Another provider selling the same model id does not: its own margin is
+    // not Replicate's, and a figure that is not the price of the run this node
+    // will make is worse than no figure.
+    const other = getModelUnitPrice({ id, provider: "together" });
+    expect(other?.unit_price).not.toBe(price.unit_price);
+    expect(other?.declined).toBeTruthy();
+  });
+
+  it("says which providers the catalog does price, when this one has none", () => {
+    const [key] = Object.entries(genspendPricingCatalog.prices).find(([k]) =>
+      k.startsWith("replicate:")
+    )!;
+    const id = key.slice("replicate:".length);
+
+    const declined = getModelUnitPrice({ id, provider: "no-such-provider" });
+    // A decline, not a price: nothing here can enter a total.
+    expect(declined?.unit_price).toBe(0);
+    expect(declined?.declined).toContain("no no-such-provider price");
+    expect(declined?.declined).toContain("replicate");
+  });
+
+  it("does not answer for a model no catalog carries under any provider", () => {
     expect(
-      getModelUnitPrice({ id, provider: "replicate" })?.assumptions
-    ).toBeUndefined();
+      getModelUnitPrice({ id: "no-such/model", provider: "atlascloud" })
+    ).toBeNull();
   });
 
-  it("quotes the cheapest tracked offering, and only within one unit class", () => {
-    const byId = new Map<string, { provider: string; unitClass: string; price: number }[]>();
-    for (const [key, entry] of Object.entries(genspendPricingCatalog.prices)) {
-      const at = key.indexOf(":");
-      const id = key.slice(at + 1);
-      const rows = byId.get(id) ?? [];
-      rows.push({
-        provider: key.slice(0, at),
-        unitClass: entry.unit_class,
-        price: entry.unit_price
-      });
-      byId.set(id, rows);
-    }
-
-    const mixed = [...byId].find(
-      ([, rows]) => new Set(rows.map((r) => r.unitClass)).size > 1
-    );
-    if (mixed) {
-      // Per-second and per-generation rates are not comparable, so there is no
-      // cheapest one to quote: the model stays unpriced for a third provider.
-      expect(
-        getModelUnitPrice({ id: mixed[0], provider: "no-such-provider" })
-      ).toBeNull();
-    }
-
-    const shared = [...byId].find(
-      ([id, rows]) =>
-        rows.length > 1 &&
-        new Set(rows.map((r) => r.unitClass)).size === 1 &&
-        new Set(rows.map((r) => r.price)).size > 1 &&
-        !falUnitPricingCatalog.prices?.[id] &&
-        !kieUnitPricingCatalog.prices?.[id]
-    );
-    if (shared) {
-      const cheapest = Math.min(...shared[1].map((r) => r.price));
-      const quoted = getModelUnitPrice({
-        id: shared[0],
-        provider: "no-such-provider"
-      });
-      expect(quoted?.unit_price).toBe(cheapest);
-    }
-  });
-
-  it("prices a reseller off the FAL row only as a named borrowing", () => {
-    // An endpoint GenSpend tracks under no provider at all, so the FAL scalar
-    // is the only row that can answer for either lookup.
+  it("reads the FAL and kie scalar catalogs only for their own provider", () => {
+    // Those catalogs are keyed by bare endpoint id, and a reseller lists the
+    // vendor's id verbatim — an unscoped lookup priced an AtlasCloud model off
+    // FAL's row. Pick an endpoint GenSpend tracks under no provider at all, so
+    // the FAL scalar is the only row that could answer either lookup.
     const tracked = new Set(
       Object.keys(genspendPricingCatalog.prices).map((key) =>
         key.slice(key.indexOf(":") + 1)
@@ -208,11 +176,8 @@ describe("getModelUnitPrice", () => {
     )?.[0];
     if (!id) throw new Error("no untracked per-run FAL endpoint");
 
-    const own = getModelUnitPrice({ id, provider: "fal_ai" });
-    const reseller = getModelUnitPrice({ id, provider: "atlascloud" });
-    expect(own?.assumptions).toBeUndefined();
-    expect(reseller?.unit_price).toBe(own?.unit_price);
-    expect(reseller?.assumptions?.[0]).toContain("fal_ai");
+    expect(getModelUnitPrice({ id, provider: "fal_ai" })?.unit_price).toBeGreaterThan(0);
+    expect(getModelUnitPrice({ id, provider: "atlascloud" })).toBeNull();
   });
 
   it("returns null for a model in no catalog", () => {

--- a/packages/node-sdk/src/cost-estimate.ts
+++ b/packages/node-sdk/src/cost-estimate.ts
@@ -51,6 +51,8 @@ export interface NodePropertyLike {
 
 /** Minimal slice of `NodeMetadata` this estimator reads. */
 export interface NodeMetadataLike {
+  /** The node's registered display name ("Image To Video"). */
+  title?: string | null;
   fal_unit_pricing?: FalUnitPricingLike | null;
   kie_unit_pricing?: KieUnitPricingLike | null;
   /** Properties, used to find a provider-model selection on generic nodes. */
@@ -423,10 +425,38 @@ export function priceScalarUnit(
  * instead of parsing them back out of `breakdown` prose.
  */
 export interface NodeCostEstimateDetail extends NodeCostEstimate {
+  /**
+   * What to call this node in a cost table: the title the user gave it, else
+   * the node's registered title, else its class name spaced out. `node_type`
+   * stays the identity — a reader who needs `nodetool.video.ImageToVideo`
+   * still has it — but a column of dotted paths reads as one repeated prefix,
+   * and the four `nodetool.agents.Agent` rows of a real graph are told apart
+   * by their titles, not their type.
+   */
+  node_title?: string;
   /** Output duration the price was multiplied by, when one applied. */
   seconds?: number;
   /** Rung the price was read off ("720p", "1MP"). */
   resolution?: string;
+}
+
+/**
+ * A node type's class name, spaced: `nodetool.video.ImageToVideo` → "Image To
+ * Video". The last resort behind a user title and the registered metadata
+ * title, for a node type whose metadata a caller could not supply.
+ */
+export function humanizeNodeType(nodeType: string): string {
+  const leaf = nodeType.split(".").pop() ?? nodeType;
+  return (
+    leaf
+      // `ImageToVideo` → `Image To Video`, `TextToImage2` → `Text To Image 2`,
+      // `HTTPRequest` → `HTTP Request`: split before a capital that starts a
+      // new word and between a letter run and a digit run.
+      .replace(/([a-z\d])([A-Z])/g, "$1 $2")
+      .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+      .replace(/([A-Za-z])(\d)/g, "$1 $2")
+      .trim() || nodeType
+  );
 }
 
 /** {@link estimateWorkflowCost}'s result, with the detailed items. */
@@ -534,6 +564,12 @@ export interface CostEstimateInput {
   /** Optional per-node expected run count (fan-out). Defaults to 1. */
   quantities?: Record<string, number>;
   /**
+   * Optional per-node display title, keyed by node id — the name the user gave
+   * the node on the canvas. Falls back to the metadata title, then to the node
+   * type's spaced class name.
+   */
+  titles?: Record<string, string>;
+  /**
    * Explicitly identifies graph plumbing or local utility nodes known not to
    * create a billable provider request. Excluded nodes do not become
    * misleading unknown-cost items.
@@ -550,6 +586,19 @@ const DEFAULT_CURRENCY = "USD";
 
 function positiveQuantity(value: number | undefined): number {
   return isFiniteNumber(value) && value > 0 ? value : 1;
+}
+
+/** What to call a node in the table: user title, registered title, class name. */
+function nodeTitle(
+  userTitle: string | undefined,
+  metadata: NodeMetadataLike | undefined,
+  nodeType: string
+): string {
+  const given = userTitle?.trim();
+  if (given) return given;
+  const registered = metadata?.title?.trim();
+  if (registered) return registered;
+  return humanizeNodeType(nodeType);
 }
 
 function confidenceFromSource(
@@ -809,6 +858,7 @@ export function estimateWorkflowCost(
 ): WorkflowCostEstimateDetail {
   const currency = input.currency ?? DEFAULT_CURRENCY;
   const quantities = input.quantities ?? {};
+  const titles = input.titles ?? {};
 
   const items: NodeCostEstimateDetail[] = [];
   let total = 0;
@@ -819,8 +869,10 @@ export function estimateWorkflowCost(
       continue;
     }
     const quantity = positiveQuantity(quantities[node.id]);
+    const metadata = input.getMetadata(node.type);
+    const title = nodeTitle(titles[node.id], metadata, node.type);
     const price = resolvePrice(
-      input.getMetadata(node.type),
+      metadata,
       node.data,
       input.getModelPrice,
       input.getParams?.(node)
@@ -831,6 +883,7 @@ export function estimateWorkflowCost(
       const unknownItem: UnknownItemFields = {
         node_id: node.id,
         node_type: node.type,
+        node_title: title,
         provider: price?.provider ?? null,
         model: price?.model ?? null,
         quantity,
@@ -854,6 +907,7 @@ export function estimateWorkflowCost(
     const item: ItemFields = {
       node_id: node.id,
       node_type: node.type,
+      node_title: title,
       provider: price.provider,
       model: price.model,
       unit_price: price.unitPrice,

--- a/packages/node-sdk/tests/cost-estimate.test.ts
+++ b/packages/node-sdk/tests/cost-estimate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   estimateWorkflowCost,
+  humanizeNodeType,
   nodeExpectedQuantity,
   usesAiModel,
   type CostEstimateInput,
@@ -559,6 +560,53 @@ describe("estimateWorkflowCost with pricing parameters", () => {
 
     expect(estimate.items[0].confidence).toBe("unknown");
     expect(estimate.items[0].warnings).toEqual(["the figure is a lower bound"]);
+  });
+});
+
+describe("node titles", () => {
+  it("spaces a class name apart, so a row is not a dotted path", () => {
+    expect(humanizeNodeType("nodetool.video.ImageToVideo")).toBe(
+      "Image To Video"
+    );
+    expect(humanizeNodeType("nodetool.agents.Agent")).toBe("Agent");
+    expect(humanizeNodeType("fal.text_to_image.GptImage2")).toBe("Gpt Image 2");
+    expect(humanizeNodeType("HTTPRequest")).toBe("HTTP Request");
+    expect(humanizeNodeType("")).toBe("");
+  });
+
+  it("prefers the user's title, then the metadata title, then the type", () => {
+    const estimate = estimateWorkflowCost({
+      nodes: [
+        { id: "named", type: FAL_TYPE },
+        { id: "registered", type: KIE_TYPE },
+        { id: "bare", type: "nodetool.video.ImageToVideo" }
+      ],
+      getMetadata: (type) =>
+        type === KIE_TYPE
+          ? { ...metadataByType[type], title: "Veo Clip" }
+          : metadataByType[type],
+      titles: { named: "Hero shot", registered: "   " }
+    });
+
+    const byId = Object.fromEntries(
+      estimate.items.map((item) => [item.node_id, item.node_title])
+    );
+    expect(byId.named).toBe("Hero shot");
+    // A blank title is not a title — fall through to the registered one.
+    expect(byId.registered).toBe("Veo Clip");
+    expect(byId.bare).toBe("Image To Video");
+  });
+
+  it("titles a node it could not price, which is where the name matters", () => {
+    const estimate = estimateWorkflowCost({
+      nodes: [{ id: "n1", type: LLM_TYPE }],
+      getMetadata,
+      titles: { n1: "Script writer" }
+    });
+
+    expect(estimate.unknown_count).toBe(1);
+    expect(estimate.items[0].node_title).toBe("Script writer");
+    expect(estimate.items[0].node_type).toBe(LLM_TYPE);
   });
 });
 

--- a/web/src/components/costs/CostEstimateSummary.tsx
+++ b/web/src/components/costs/CostEstimateSummary.tsx
@@ -181,7 +181,7 @@ const CostEstimateSummaryInternal: React.FC<CostEstimateSummaryProps> = ({
           const rowEl = (
             <div className="cost-row">
               <span className="cost-cell-node" title={row.nodeType}>
-                {row.nodeType}
+                {row.nodeTitle}
               </span>
               {row.unknown ? (
                 <Tooltip title={row.unknownReason} arrow>

--- a/web/src/components/costs/__tests__/WorkflowCostEstimatePanel.test.tsx
+++ b/web/src/components/costs/__tests__/WorkflowCostEstimatePanel.test.tsx
@@ -76,6 +76,25 @@ describe("WorkflowCostEstimatePanel", () => {
     });
   });
 
+  it("names a row by the node's title, keeping the type as its hover text", () => {
+    mockHook.mockReturnValue({
+      ...estimate,
+      items: [{ ...estimate.items[0], node_title: "Hero shot" }]
+    } as never);
+    renderPanel();
+
+    const cell = screen.getByText("Hero shot");
+    expect(cell).toHaveAttribute("title", "nodetool.image.TextToImage");
+    expect(screen.queryByText("nodetool.image.TextToImage")).toBeNull();
+  });
+
+  it("falls back to the type's spaced class name when no title travelled", () => {
+    mockHook.mockReturnValue(estimate as never);
+    renderPanel();
+
+    expect(screen.getByText("Text To Image")).toBeInTheDocument();
+  });
+
   it("reads fan-out, clip length and rung as one units phrase from the structured fields", () => {
     mockHook.mockReturnValue({
       ...estimate,

--- a/web/src/components/costs/costLine.ts
+++ b/web/src/components/costs/costLine.ts
@@ -54,7 +54,7 @@ export function workflowCostLine(
   }
   const lines = priced.map((item) =>
     [
-      `${item.node_type}: ${formatUsd(item.estimated_cost)}`,
+      `${item.node_title ?? item.node_type}: ${formatUsd(item.estimated_cost)}`,
       item.breakdown,
       ...(item.warnings ?? [])
     ]

--- a/web/src/components/costs/useCostEstimateSummary.ts
+++ b/web/src/components/costs/useCostEstimateSummary.ts
@@ -10,9 +10,10 @@
  */
 
 import { useMemo } from "react";
-import type {
-  NodeCostEstimateDetail,
-  WorkflowCostEstimateDetail
+import {
+  humanizeNodeType,
+  type NodeCostEstimateDetail,
+  type WorkflowCostEstimateDetail
 } from "@nodetool-ai/node-sdk/cost-estimate";
 import { formatUsd } from "@nodetool-ai/model-pricing";
 
@@ -58,6 +59,9 @@ const isApproximate = (item: NodeCostEstimateDetail): boolean =>
 
 export interface CostEstimateRow {
   key: string;
+  /** What the row is labeled with: the node's title, not its dotted type. */
+  nodeTitle: string;
+  /** The full node type, kept for the row's hover title. */
   nodeType: string;
   unknown: boolean;
   /** Why the price could not be quoted, for an unknown row's tooltip. */
@@ -96,6 +100,7 @@ export function useCostEstimateSummary(
       const unknown = item.confidence === "unknown";
       return {
         key: item.node_id,
+        nodeTitle: item.node_title ?? humanizeNodeType(item.node_type),
         nodeType: item.node_type,
         unknown,
         unknownReason:

--- a/web/src/hooks/__tests__/useWorkflowCostEstimate.test.tsx
+++ b/web/src/hooks/__tests__/useWorkflowCostEstimate.test.tsx
@@ -267,6 +267,37 @@ describe("useWorkflowCostEstimate", () => {
     ).toBeCloseTo(0.8, 5);
   });
 
+  it("carries the node's own title, so the table is not a column of types", () => {
+    mockNodes = [
+      {
+        id: "t2v",
+        type: "nodetool.video.TextToVideo",
+        data: {
+          title: "Establishing shot",
+          properties: {
+            model: {
+              type: "video_model",
+              provider: "genspend_provider",
+              id: "video/per-second"
+            },
+            duration: 5
+          }
+        }
+      },
+      // Untitled: falls back to the type's spaced class name, since the mocked
+      // metadata carries no `title` either.
+      { id: "n1", type: "fal.Image", data: {} }
+    ];
+
+    const { result } = renderHook(() => useWorkflowCostEstimate("wf1"));
+
+    const byId = Object.fromEntries(
+      result.current!.items.map((item) => [item.node_id, item.node_title])
+    );
+    expect(byId.t2v).toBe("Establishing shot");
+    expect(byId.n1).toBe("Image");
+  });
+
   it("multiplies a node's cost by its fan-out output count", () => {
     // fal.Image at 0.05/image with num_images: 3 → quantity 3, cost 0.15.
     mockNodes = [{ id: "n1", type: "fal.Image", data: { num_images: 3 } }];

--- a/web/src/hooks/useGraphCostEstimate.ts
+++ b/web/src/hooks/useGraphCostEstimate.ts
@@ -46,6 +46,19 @@ function propertyValues(data: unknown): Record<string, unknown> | undefined {
     : outer;
 }
 
+/**
+ * The title the user put on the node, which lives beside `properties` rather
+ * than in it. Absent, the estimator falls back to the node type's registered
+ * title.
+ */
+function userTitle(data: unknown): string | undefined {
+  if (!data || typeof data !== "object") {
+    return undefined;
+  }
+  const title = (data as { title?: unknown }).title;
+  return typeof title === "string" && title.trim() !== "" ? title : undefined;
+}
+
 /** Price a graph. Pure but for the metadata lookup the caller supplies. */
 export function estimateGraphCost(
   nodes: readonly CostEstimateNode[],
@@ -62,6 +75,13 @@ export function estimateGraphCost(
       nodeExpectedQuantity(propertyValues(node.data))
     ])
   );
+  // A renamed node is named that way in the cost table too — four Agent nodes
+  // are only told apart by what the user called them.
+  const titles: Record<string, string> = Object.fromEntries(
+    aiNodes
+      .map((node) => [node.id, userTitle(node.data)] as const)
+      .filter((entry): entry is readonly [string, string] => !!entry[1])
+  );
   return estimateWorkflowCost({
     nodes: aiNodes.map((node) => ({
       id: node.id,
@@ -74,6 +94,7 @@ export function estimateGraphCost(
     // audio), so a per-second model prices the clip and not one second.
     getParams: (node) => extractPricingParams(node.data),
     quantities,
+    titles,
     currency: "USD"
   });
 }


### PR DESCRIPTION
## What changed

The workflow cost panel labelled every row with its dotted node type, so a real graph read as four identical `nodetool.agents.Agent` rows over one repeated prefix; rows now carry the node's title (the name the user gave it on the canvas, else the node's registered metadata title, else the class name spaced out — `Image To Video`), with the full type kept as the row's hover text.

The same panel refused to price `nodetool.video.ImageToVideo` nodes that had already stated their model, duration and resolution, claiming *"the catalog prices this model per units, which has no fixed value per run"*. The cause: the FAL and kie scalar catalogs are keyed by bare endpoint id and were consulted for every provider, so an AtlasCloud `google/gemini-omni-flash/image-to-video` was answered by FAL's row for the identical id — and FAL bills that endpoint in "units", which the converter rightly refuses. Those catalogs now answer only for their own provider. Two further fixes follow from the same principle: a scalar row that cannot be converted no longer hides a GenSpend price for the same model (`krea/v2/large/text-to-image` sat unpriced next to a $0.06/image row), and a model the catalog carries only under *other* providers now comes back declined **naming them** rather than as a bare "price unknown" — a catalog gap someone can close.

The rule this settles: an estimate is always the price the selected provider publishes, or no estimate. A reseller's margin is its own, so no lookup ever falls back to another vendor's rate — a figure that is not the price of the run the node will make is worse than no figure, however it is labelled. (The first commit here did borrow across providers behind a disclosure; the second removes that. `nodetool`'s managed models still resolve through their declared delegate, which is a stated mapping, not a fallback.)

Measured against the shipped catalogs, with `{ seconds: 4, resolution: "1080p" }`:

| model | before | after |
|---|---|---|
| `fal_ai:krea/v2/large/text-to-image` | declined ("units") | `$0.06` (GenSpend flat, previously shadowed) |
| `atlascloud:google/gemini-omni-flash/image-to-video` | declined ("units" — FAL's row) | declined: no atlascloud price; the catalog prices it on fal_ai |
| `atlascloud:nvidia/cosmos-3-super/image-to-video` | `$0.20`, silently FAL's rate | no price |
| `fal_ai:google/gemini-omni-flash/image-to-video` | `$0.52` | `$0.52` (unchanged) |
| `atlascloud:google/veo3.1/image-to-video`, `atlascloud:openai/gpt-image-2/text-to-image`, `gemini:veo-3.1-generate-preview`, `fal_ai:fal-ai/veo3.1/image-to-video` | unchanged | unchanged |

The two rows that lose a number are the point of the change: neither figure was AtlasCloud's, and one of them was being shown as a real price with nothing saying so.

## Verification

Ran per-package rather than the full sweep; `npm run test:affected` was not used because this checkout is a fresh clone with no baseline to diff against.

- [x] `npx turbo run test` for `@nodetool-ai/model-pricing` (158), `@nodetool-ai/node-sdk` (1218, 2 skipped), `@nodetool-ai/websocket` (2815), `@nodetool-ai/agents` (3656, 5 skipped), `@nodetool-ai/execution` (295) — all pass
- [x] `npx vitest run --config vitest.config.ts scripts/__tests__` — 8 passed
- [x] `npx jest src/components/costs src/hooks` (in `web/`) — 1474 passed (168 suites)
- [x] `npx tsc --noEmit -p packages/model-pricing/tsconfig.json` — clean
- [x] `npx tsc --noEmit` in `web/` — no diagnostics in any touched file (the run reports pre-existing `TS2307` for node packages not built in this checkout)
- [x] `npx oxlint` over the touched paths, and the same paths under `.oxlintrc.anti-slop-enforced.json` — clean
- [ ] `npm run dev:nodetool -- harness gate --base main` — not run

CI on the first commit went green after a re-run: the one red leg was `reliability/harness`'s `client-reconnect-mid-run.test.ts` failing with `Hook timed out in 10000ms` in the `beforeEach` that binds a loopback UI server — no assertion, a path this diff does not touch, and it passes on this branch locally in 22 s. See the comment thread for the full trace.

New tests pinning the behaviour: model-pricing asserts that a model priced under one provider is *not* priced for another, that the decline names the providers the catalog does carry, that the FAL/kie scalar catalogs answer only for their own provider, and that an unconvertible FAL unit no longer hides a GenSpend price; node-sdk covers `humanizeNodeType` and the user-title → metadata-title → class-name fallback (including on an unpriced node, where the name matters most); the web panel and the graph hook cover the rendered title and its hover text.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.