### PR TITLE
fix(cost-estimate): close the coverage gaps — model-aware pickers, unread duration enums, published tier rungs

### DIFF
--- a/packages/fal-codegen/src/schema-parser.ts
+++ b/packages/fal-codegen/src/schema-parser.ts
@@ -285,17 +285,28 @@ export class SchemaParser {
       // Check for enum — either top-level or inside anyOf/oneOf variants
       let enumRef: string | undefined;
       let enumValues: string[] | undefined;
-      if ("enum" in (prop as AnyRecord)) {
-        enumValues = (prop as AnyRecord)["enum"] as string[];
-      } else {
+      const declaredOptions = (schema: AnyRecord): string[] | undefined => {
+        if ("enum" in schema) return schema["enum"] as string[];
+        // JSON Schema `const` is an enum of one, and FAL uses it where an
+        // endpoint accepts a single value: `fal-ai/veo3.1/reference-to-video`
+        // declares `duration: {const: "8s"}` where its image-to-video sibling
+        // declares `enum: ["4s", "6s", "8s"]`. Read as no options at all, the
+        // endpoint looked unconstrained and the app offered clip lengths FAL
+        // does not sell there.
+        if ("const" in schema) return [schema["const"] as string];
+        return undefined;
+      };
+      enumValues = declaredOptions(prop as AnyRecord);
+      if (!enumValues) {
         // Look for enum inside anyOf/oneOf (common FAL pattern:
         // anyOf: [{$ref: "#/.../ImageSize"}, {type: "string", enum: [...]}])
         const variants = ((prop as AnyRecord)["anyOf"] ??
           (prop as AnyRecord)["oneOf"]) as AnyRecord[] | undefined;
         if (variants) {
           for (const variant of variants) {
-            if ("enum" in variant) {
-              enumValues = variant["enum"] as string[];
+            const options = declaredOptions(variant);
+            if (options) {
+              enumValues = options;
               break;
             }
           }

--- a/packages/fal-codegen/tests/schema-parser.test.ts
+++ b/packages/fal-codegen/tests/schema-parser.test.ts
@@ -1118,3 +1118,79 @@ describe("parse() — synthetic schema edge cases", () => {
     expect(spec.outputType).toBe("image");
   });
 });
+
+// ---------------------------------------------------------------------------
+// JSON Schema `const` — an enum of one
+// ---------------------------------------------------------------------------
+
+/** A minimal FAL-shaped OpenAPI document around one Input schema. */
+const schemaAround = (properties: Record<string, unknown>) => ({
+  info: { "x-fal-metadata": { endpointId: "fal-ai/test/const" } },
+  paths: {
+    "/": {
+      post: {
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/Input" }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {
+      Input: { type: "object", properties },
+      Output: { type: "object", properties: { video: { type: "object" } } }
+    }
+  }
+});
+
+describe("const-valued properties", () => {
+  it("reads `const` as a one-value enum", () => {
+    // What `fal-ai/veo3.1/reference-to-video` publishes: the endpoint sells
+    // exactly one clip length, stated as a const rather than a one-item enum.
+    const spec = parser.parse(
+      schemaAround({
+        duration: {
+          title: "Duration",
+          const: "8s",
+          type: "string",
+          description: "The duration of the generated video.",
+          default: "8s"
+        }
+      })
+    );
+    const field = spec.inputFields.find((f) => f.name === "duration");
+    expect(field?.tsType).toBe("enum");
+    const enumDef = spec.enums.find((e) => e.name === field?.enumRef);
+    expect(enumDef?.values.map(([, v]) => v)).toEqual(["8s"]);
+  });
+
+  it("reads `const` nested in an anyOf variant", () => {
+    const spec = parser.parse(
+      schemaAround({
+        duration: {
+          title: "Duration",
+          anyOf: [{ type: "null" }, { type: "string", const: "5s" }],
+          default: "5s"
+        }
+      })
+    );
+    const field = spec.inputFields.find((f) => f.name === "duration");
+    const enumDef = spec.enums.find((e) => e.name === field?.enumRef);
+    expect(enumDef?.values.map(([, v]) => v)).toEqual(["5s"]);
+  });
+
+  it("still prefers an explicit enum over a sibling const", () => {
+    const spec = parser.parse(
+      schemaAround({
+        duration: { type: "string", enum: ["4s", "6s", "8s"], default: "8s" }
+      })
+    );
+    const field = spec.inputFields.find((f) => f.name === "duration");
+    const enumDef = spec.enums.find((e) => e.name === field?.enumRef);
+    expect(enumDef?.values.map(([, v]) => v)).toEqual(["4s", "6s", "8s"]);
+  });
+});

--- a/packages/model-pricing/package.json
+++ b/packages/model-pricing/package.json
@@ -21,6 +21,7 @@
     "@nodetool-ai/protocol": "*"
   },
   "devDependencies": {
+    "@nodetool-ai/atlascloud-nodes": "*",
     "typescript": "^5.7.2",
     "vitest": "^4.1.2"
   },

--- a/packages/model-pricing/src/generated/genspend-pricing.json
+++ b/packages/model-pricing/src/generated/genspend-pricing.json
@@ -2,8 +2,8 @@
   "schemaVersion": 3,
   "source": "https://genspend.io/api/v1/export",
   "attribution": "Prices via genspend.io",
-  "updatedAt": "2026-08-30T15:32:26.276Z",
-  "catalogGeneratedAt": "2026-08-30T15:32:25.319Z",
+  "updatedAt": "2026-08-31T18:03:18.084Z",
+  "catalogGeneratedAt": "2026-08-31T18:02:47.610Z",
   "etag": "\"363cbe11286573b29e5168540f6d2da959d39eab\"",
   "catalogModels": 142,
   "catalogOfferings": 478,
@@ -18,7 +18,7 @@
     "replicate",
     "together"
   ],
-  "pricedModels": 325,
+  "pricedModels": 328,
   "prices": {
     "atlascloud:alibaba/happyhorse-1.1/image-to-video": {
       "unit_price": 0.07,
@@ -1110,14 +1110,39 @@
         "max": 8
       }
     },
+    "atlascloud:ideogram/v4/quality/text-to-image": {
+      "unit_price": 0.025,
+      "billing_unit": "images",
+      "unit_class": "per-image",
+      "model_slug": "ideogram-4",
+      "match": "alias",
+      "live": true,
+      "source_url": "https://www.atlascloud.ai/models/ideogram/v4/turbo/text-to-image",
+      "tier": "quality",
+      "variants": [
+        {
+          "price_usd": 0.008,
+          "unit_class": "per-image",
+          "tier": "turbo",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.025,
+          "unit_class": "per-image",
+          "tier": "quality",
+          "is_base": false
+        }
+      ]
+    },
     "atlascloud:ideogram/v4/turbo/text-to-image": {
       "unit_price": 0.008,
       "billing_unit": "images",
       "unit_class": "per-image",
       "model_slug": "ideogram-4",
-      "match": "provider-id",
+      "match": "alias",
       "live": true,
       "source_url": "https://www.atlascloud.ai/models/ideogram/v4/turbo/text-to-image",
+      "tier": "turbo",
       "variants": [
         {
           "price_usd": 0.008,
@@ -1608,14 +1633,70 @@
       "live": true,
       "source_url": "https://www.atlascloud.ai/models/xai/grok-imagine-image-2.0/text-to-image"
     },
+    "atlascloud:xai/grok-imagine-image-quality/edit": {
+      "unit_price": 0.05,
+      "billing_unit": "images",
+      "unit_class": "per-image",
+      "model_slug": "grok-imagine",
+      "match": "alias",
+      "live": true,
+      "source_url": "https://www.atlascloud.ai/models/xai/grok-imagine-image/edit",
+      "tier": "quality",
+      "resolution": "1K",
+      "variants": [
+        {
+          "price_usd": 0.02,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "tier": "standard",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "tier": "quality",
+          "is_base": false
+        }
+      ]
+    },
+    "atlascloud:xai/grok-imagine-image-quality/text-to-image": {
+      "unit_price": 0.05,
+      "billing_unit": "images",
+      "unit_class": "per-image",
+      "model_slug": "grok-imagine",
+      "match": "alias",
+      "live": true,
+      "source_url": "https://www.atlascloud.ai/models/xai/grok-imagine-image/edit",
+      "tier": "quality",
+      "resolution": "1K",
+      "variants": [
+        {
+          "price_usd": 0.02,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "tier": "standard",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "tier": "quality",
+          "is_base": false
+        }
+      ]
+    },
     "atlascloud:xai/grok-imagine-image/edit": {
       "unit_price": 0.02,
       "billing_unit": "images",
       "unit_class": "per-image",
       "model_slug": "grok-imagine",
-      "match": "provider-id",
+      "match": "alias",
       "live": true,
       "source_url": "https://www.atlascloud.ai/models/xai/grok-imagine-image/edit",
+      "tier": "standard",
+      "resolution": "1K",
       "variants": [
         {
           "price_usd": 0.02,
@@ -1638,9 +1719,11 @@
       "billing_unit": "images",
       "unit_class": "per-image",
       "model_slug": "grok-imagine",
-      "match": "catalog",
+      "match": "alias",
       "live": true,
       "source_url": "https://www.atlascloud.ai/models/xai/grok-imagine-image/edit",
+      "tier": "standard",
+      "resolution": "1K",
       "variants": [
         {
           "price_usd": 0.02,

--- a/packages/model-pricing/tests/duration-enum-receipts.test.ts
+++ b/packages/model-pricing/tests/duration-enum-receipts.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Audit: a video endpoint's declared duration enum never offers a clip length
+ * the provider does not publish a price for.
+ *
+ * The generated manifests state what each endpoint accepts; the GenSpend
+ * catalog records `clip_seconds` — the lengths the provider's own published
+ * price grid quotes. Where both exist they must agree in one direction: every
+ * duration the node can be put into is one the catalog can price. The reverse
+ * is allowed — a provider may receipt a length its API does not expose.
+ *
+ * The audit asserts it found its targets before asserting they pass, so it
+ * cannot go green by matching nothing: a manifest rename, a `duration` field
+ * that stops being read, or a catalog refresh that drops `clip_seconds` all
+ * fail here rather than quietly reducing the audit to zero comparisons.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import genspend from "../src/generated/genspend-pricing.json" with { type: "json" };
+
+const manifest = (pkg: string, file: string): ManifestNode[] =>
+  JSON.parse(
+    readFileSync(new URL(`../../${pkg}/src/${file}`, import.meta.url), "utf8")
+  ) as ManifestNode[];
+
+interface ManifestNode {
+  outputType?: string;
+  endpointId?: string;
+  modelId?: string;
+  inputFields?: Array<{
+    name?: string;
+    apiParamName?: string;
+    enumValues?: unknown[];
+  }>;
+  fields?: Array<{ name?: string; values?: unknown[] }>;
+}
+
+const SOURCES: Array<[string, ManifestNode[], "endpointId" | "modelId"]> = [
+  ["fal_ai", manifest("fal-nodes", "fal-manifest.json"), "endpointId"],
+  ["kie", manifest("kie-nodes", "kie-manifest.json"), "modelId"],
+  [
+    "atlascloud",
+    manifest("atlascloud-nodes", "atlascloud-manifest.json"),
+    "modelId"
+  ]
+];
+
+/**
+ * Seconds from one declared option, mirroring `videoConstraints()` in
+ * `@nodetool-ai/runtime` — which is what turns these enums into the durations
+ * a picker offers. Kept in step deliberately: an audit that parsed the enum
+ * more strictly than the app does would pass over the values users can reach.
+ */
+function durationSeconds(value: unknown): number | undefined {
+  const trimmed = String(value).trim();
+  if (trimmed === "") return undefined;
+  const digits =
+    /^(\d+(?:\.\d+)?)\s*s(?:ec(?:onds?)?)?$/i.exec(trimmed)?.[1] ?? trimmed;
+  const parsed = Number(digits);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function declaredDurations(node: ManifestNode): number[] {
+  const fromInput = (node.inputFields ?? []).find(
+    (f) => (f.apiParamName ?? f.name) === "duration"
+  )?.enumValues;
+  const fromField = (node.fields ?? []).find((f) => f.name === "duration")
+    ?.values;
+  const raw = fromInput?.length ? fromInput : (fromField ?? []);
+  return raw
+    .map(durationSeconds)
+    .filter((d): d is number => d !== undefined && d > 0);
+}
+
+const prices = (genspend as { prices: Record<string, { clip_seconds?: { set?: number[] } }> }).prices;
+
+interface Audited {
+  key: string;
+  declared: number[];
+  receipted: number[];
+}
+
+function auditedEndpoints(): Audited[] {
+  const audited: Audited[] = [];
+  for (const [provider, nodes, idKey] of SOURCES) {
+    const seen = new Set<string>();
+    for (const node of nodes) {
+      if (node.outputType !== "video") continue;
+      const id = node[idKey];
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      const declared = declaredDurations(node);
+      if (declared.length === 0) continue;
+      const receipted = prices[`${provider}:${id}`]?.clip_seconds?.set;
+      if (!Array.isArray(receipted) || receipted.length === 0) continue;
+      audited.push({ key: `${provider}:${id}`, declared, receipted });
+    }
+  }
+  return audited;
+}
+
+/**
+ * The audit's floor, not its target. It was 20 when written — every video
+ * endpoint carrying both a duration enum and a receipted clip-length set.
+ * A drop below this means the pairing stopped being found, which is the
+ * failure this audit exists to catch; a rise is fine and needs no edit.
+ */
+const MIN_AUDITED_ENDPOINTS = 20;
+
+describe("declared durations against receipted clip lengths", () => {
+  const audited = auditedEndpoints();
+
+  it("finds the endpoints it is meant to check", () => {
+    expect(audited.length).toBeGreaterThanOrEqual(MIN_AUDITED_ENDPOINTS);
+    // Both halves of the pairing must really be present, or the subset
+    // assertion below is vacuous.
+    expect(audited.every((a) => a.declared.length > 0)).toBe(true);
+    expect(audited.every((a) => a.receipted.length > 0)).toBe(true);
+    // All three manifests must be represented — a single provider passing is
+    // not evidence the other two are still wired in.
+    const providers = new Set(audited.map((a) => a.key.split(":")[0]));
+    expect([...providers].sort()).toEqual(["atlascloud", "fal_ai", "kie"]);
+  });
+
+  it("offers no duration the provider publishes no price for", () => {
+    const unpublished = audited
+      .map(({ key, declared, receipted }) => ({
+        key,
+        extra: declared.filter((d) => !receipted.includes(d)),
+        receipted
+      }))
+      .filter(({ extra }) => extra.length > 0);
+    expect(unpublished).toEqual([]);
+  });
+});

--- a/packages/model-pricing/tests/genspend-sync.test.ts
+++ b/packages/model-pricing/tests/genspend-sync.test.ts
@@ -379,6 +379,92 @@ describe("resolveOfferingPrices", () => {
     ]);
   });
 
+  it("prices each pinned id at the published rung the alias names", () => {
+    // AtlasCloud sells Ideogram 4.0 at two rungs and GenSpend records both,
+    // but as prose the automatic `variant` route cannot verify as a model id.
+    // Each endpoint must take its own rung, not the headline.
+    const result = resolve(
+      model({ slug: "ideogram-4", modality: "image" }),
+      offering({
+        priceUsd: 0.008,
+        unitClass: "per-image",
+        variants: [
+          { spec: "Turbo rendering tier", priceUsd: 0.008, unitClass: "per-image", tier: "turbo", isBase: true },
+          { spec: "Quality rendering tier", priceUsd: 0.025, unitClass: "per-image", tier: "quality" }
+        ]
+      }),
+      {
+        atlascloud: {
+          "ideogram-4": {
+            "ideogram/v4/turbo/text-to-image": "Turbo rendering tier",
+            "ideogram/v4/quality/text-to-image": "Quality rendering tier"
+          }
+        }
+      }
+    );
+    expect(result.entries).toEqual([
+      expect.objectContaining({
+        modelId: "ideogram/v4/turbo/text-to-image",
+        unitPrice: 0.008,
+        unitClass: "per-image",
+        match: "alias"
+      }),
+      expect.objectContaining({
+        modelId: "ideogram/v4/quality/text-to-image",
+        unitPrice: 0.025,
+        unitClass: "per-image",
+        match: "alias"
+      })
+    ]);
+  });
+
+  it("refuses a pin whose variant the offering no longer publishes", () => {
+    // Falling back to the headline here would quote the Quality endpoint at
+    // Turbo's rate — a number the provider does not publish for it. The sync
+    // must stop so the pin gets re-read against what GenSpend now ships.
+    expect(() =>
+      resolve(
+        model({ slug: "ideogram-4", modality: "image" }),
+        offering({
+          priceUsd: 0.008,
+          variants: [{ spec: "Turbo rendering tier", priceUsd: 0.008 }]
+        }),
+        {
+          atlascloud: {
+            "ideogram-4": {
+              "ideogram/v4/quality/text-to-image": "Quality rendering tier"
+            }
+          }
+        }
+      )
+    ).toThrow(/does not publish/);
+  });
+
+  it("falls back to the headline for a pin whose variant carries no price", () => {
+    const result = resolve(
+      model({ slug: "ideogram-4", modality: "image" }),
+      offering({
+        priceUsd: 0.008,
+        unitClass: "per-image",
+        variants: [{ spec: "Quality rendering tier", tier: "quality" }]
+      }),
+      {
+        atlascloud: {
+          "ideogram-4": {
+            "ideogram/v4/quality/text-to-image": "Quality rendering tier"
+          }
+        }
+      }
+    );
+    expect(result.entries).toEqual([
+      expect.objectContaining({
+        modelId: "ideogram/v4/quality/text-to-image",
+        unitPrice: 0.008,
+        match: "alias"
+      })
+    ]);
+  });
+
   it("blocks a model an alias pins to null", () => {
     const result = resolve(model(), offering(), { atlascloud: { "seedance-2": null } });
     expect(result).toMatchObject({ entries: [], reason: "blocked" });

--- a/packages/node-sdk/src/cost-estimate.ts
+++ b/packages/node-sdk/src/cost-estimate.ts
@@ -147,6 +147,26 @@ const PER_MEGAPIXEL_UNITS = new Set([
  * Units carrying no fixed amount of anything: a credit has no USD value here,
  * and a bare count names no deliverable. Priced as a per-run figure they would
  * read as a real number, so the caller is told why there is none.
+ *
+ * Reading `"units"` as one run is the obvious-looking shortcut, and it is
+ * wrong. Measured over the 56 FAL image/video/audio endpoints billed this way
+ * (2026-08-31), the figure spans $0.001 to $1.50 — 1,500× — and the two ends
+ * cannot both be a run: `fal-ai/minimax/hailuo-2.3/standard/image-to-video` at
+ * $0.28 reads as a video, `bytedance/seedance-2.0/image-to-video` at $0.014
+ * does not, and `krea/v2/large/text-to-image` at $0.001 is a fraction of a
+ * cent for an image GenSpend prices at $0.06. The unit means something
+ * different per endpoint, and FAL does not say what: its pricing API
+ * (`https://api.fal.ai/v1/models/pricing`) returns exactly `endpoint_id`,
+ * `unit_price`, `unit` and `currency` per row — no grid, no variants, no
+ * per-parameter breakdown — so there is nothing further to read there either.
+ *
+ * The route that does work is GenSpend: since a scalar decline stopped hiding
+ * a GenSpend entry for the same model, any of these endpoints GenSpend prices
+ * under `fal_ai` already resolves that way. None of the 248 endpoints
+ * currently declining on an ambiguous or unstated unit carries one, so that
+ * path is exhausted rather than unexplored — they are upstream gaps in
+ * GenSpend's FAL coverage, and they close when GenSpend adds the model, not
+ * when this set is loosened.
  */
 const UNCONVERTIBLE_UNITS = new Set(["", "unit", "units", "credit", "credits"]);
 

--- a/packages/runtime/src/providers/manifest-models.ts
+++ b/packages/runtime/src/providers/manifest-models.ts
@@ -134,12 +134,35 @@ export function enumValuesFor(
   return fromField && fromField.length > 0 ? fromField.map(String) : undefined;
 }
 
+/**
+ * Seconds from one declared duration option.
+ *
+ * The manifests spell a clip length three ways, because the providers do:
+ * a bare number (`8`), a numeric string (`"8"`), and — across the FAL Veo and
+ * Marey families — a unit-suffixed string (`"8s"`). A bare `Number("8s")` is
+ * `NaN`, so the suffixed spelling used to drop the whole enum and leave those
+ * endpoints looking unconstrained: 22 FAL video endpoints, the Veo 3.1
+ * image-to-video and first-last-frame families among them, offered the app's
+ * full duration ladder when FAL sells them only 4, 6 and 8 seconds.
+ *
+ * Only a plain count of seconds is read. `"auto"` (FAL's Seedance rows) and
+ * `-1` (AtlasCloud's) name no length, and neither does a range or a frame
+ * count, so they stay out rather than becoming a number nothing published.
+ */
+function durationSeconds(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (trimmed === "") return undefined;
+  const digits = /^(\d+(?:\.\d+)?)\s*s(?:ec(?:onds?)?)?$/i.exec(trimmed)?.[1] ?? trimmed;
+  const parsed = Number(digits);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 /** Option constraints (duration/resolution/aspect) for a video endpoint. */
 export function videoConstraints(n: ManifestNode) {
   const durationEnum = enumValuesFor(n, "duration");
   const durations = durationEnum
-    ?.map((v) => Number(v))
-    .filter((v) => Number.isFinite(v));
+    ?.map(durationSeconds)
+    .filter((v): v is number => v !== undefined);
   return {
     durations: durations && durations.length > 0 ? durations : undefined,
     resolutions: enumValuesFor(n, "resolution"),

--- a/packages/runtime/tests/providers/manifest-models-hardening.test.ts
+++ b/packages/runtime/tests/providers/manifest-models-hardening.test.ts
@@ -93,6 +93,31 @@ describe("videoConstraints", () => {
     };
     expect(videoConstraints(n).durations).toBeUndefined();
   });
+  it("reads FAL's unit-suffixed duration spellings", () => {
+    // The Veo 3.1 image-to-video and first-last-frame families, and Marey,
+    // declare `["4s", "6s", "8s"]`. `Number("4s")` is NaN, so the whole enum
+    // used to drop and the endpoint looked unconstrained.
+    const n = {
+      inputFields: [
+        { name: "duration", propType: "x", enumValues: ["4s", "6s", "8s"] }
+      ]
+    };
+    expect(videoConstraints(n).durations).toEqual([4, 6, 8]);
+  });
+
+  it("reads a mixed bag of spellings and drops what names no length", () => {
+    const n = {
+      inputFields: [
+        {
+          name: "duration",
+          propType: "x",
+          enumValues: ["auto", "5", "8s", "2.5s", "10 seconds", "", "s"]
+        }
+      ]
+    };
+    expect(videoConstraints(n).durations).toEqual([5, 8, 2.5, 10]);
+  });
+
   it("passes resolution and aspect_ratio enums through", () => {
     const n = {
       inputFields: [

--- a/scripts/genspend/aliases.json
+++ b/scripts/genspend/aliases.json
@@ -1,12 +1,27 @@
 {
-  "_comment": "Hand-maintained overrides for the GenSpend price sync. Keyed <provider_id> → <genspend model slug> → array of NodeTool model ids to price, or null to block the model for that provider. Use an array to pin a match the name comparison cannot see; use null to kill a match that is wrong. Every unresolved offering is listed by `npm run sync:genspend`.",
+  "_comment": "Hand-maintained overrides for the GenSpend price sync. Keyed <provider_id> → <genspend model slug> → an array of NodeTool model ids to price at the offering's headline rate, an object mapping each NodeTool model id to the exact `variants[]` spec whose published price it takes, or null to block the model for that provider. Use an array to pin a match the name comparison cannot see; use the object form when the provider publishes several rungs and the headline is the wrong one for that endpoint — a pinned spec GenSpend no longer publishes fails the sync rather than quietly falling back to the headline; use null to kill a match that is wrong. Every unresolved offering is listed by `npm run sync:genspend`.",
   "fal_ai": {},
   "replicate": {},
   "kie": {
-    "eleven-multilingual-v2": ["elevenlabs/text-to-speech-multilingual-v2"],
-    "eleven-turbo-v2.5": ["elevenlabs/text-to-speech-turbo-2-5"]
+    "eleven-multilingual-v2": [
+      "elevenlabs/text-to-speech-multilingual-v2"
+    ],
+    "eleven-turbo-v2.5": [
+      "elevenlabs/text-to-speech-turbo-2-5"
+    ]
   },
-  "atlascloud": {},
+  "atlascloud": {
+    "grok-imagine": {
+      "xai/grok-imagine-image/text-to-image": "standard mode (xai/grok-imagine-image, 1k or 2k)",
+      "xai/grok-imagine-image/edit": "standard mode (xai/grok-imagine-image, 1k or 2k)",
+      "xai/grok-imagine-image-quality/text-to-image": "quality mode (xai/grok-imagine-image-quality, 1k or 2k)",
+      "xai/grok-imagine-image-quality/edit": "quality mode (xai/grok-imagine-image-quality, 1k or 2k)"
+    },
+    "ideogram-4": {
+      "ideogram/v4/turbo/text-to-image": "Turbo rendering tier",
+      "ideogram/v4/quality/text-to-image": "Quality rendering tier"
+    }
+  },
   "together": {},
   "gemini": {},
   "openai": {},

--- a/scripts/genspend/match.mjs
+++ b/scripts/genspend/match.mjs
@@ -122,17 +122,67 @@ function verifyId(index, providerId, claimedId) {
 }
 
 /**
- * Alias overrides, keyed `<provider_id>` → `<genspend slug>` → array of model
- * ids, or `null` to block the model for that provider. Hand-maintained: it is
- * how a maintainer pins a match the name comparison cannot see, and how a bad
- * match gets killed without weakening the rules for everything else.
+ * Alias overrides, keyed `<provider_id>` → `<genspend slug>` → one of:
+ *
+ *   - `null` — block the model for that provider.
+ *   - `string[]` — pin these model ids at the offering's headline price.
+ *   - `{ [modelId]: variantSpec }` — pin each model id to the published
+ *     `variants[]` row whose `spec` matches, and price it at *that* row.
+ *
+ * The object form exists because a tier is sometimes a rung the provider
+ * publishes and sometimes prose. AtlasCloud sells Ideogram 4.0 at $0.008
+ * (Turbo) and $0.025 (Quality), and GenSpend records both — but as
+ * `"Quality rendering tier"`, not as a model id the automatic `variant` route
+ * can verify. Pinning the id to the headline price would have quoted the
+ * Quality endpoint at Turbo's rate: a number the provider does not publish
+ * for it. Naming the row keeps the figure the provider's own.
+ *
+ * Hand-maintained: it is how a maintainer pins a match the name comparison
+ * cannot see, and how a bad match gets killed without weakening the rules for
+ * everything else.
  */
 function aliasIdsFor(aliases, providerId, slug) {
   const provider = aliases?.[providerId];
   if (!provider || !(slug in provider)) return undefined;
   const value = provider[slug];
   if (value === null) return null;
-  return Array.isArray(value) ? value.filter((id) => typeof id === "string") : undefined;
+  if (Array.isArray(value)) {
+    return {
+      pins: value
+        .filter((id) => typeof id === "string")
+        .map((id) => ({ id, spec: null }))
+    };
+  }
+  if (value && typeof value === "object") {
+    return {
+      pins: Object.entries(value)
+        .filter(([, spec]) => typeof spec === "string")
+        .map(([id, spec]) => ({ id, spec }))
+    };
+  }
+  return undefined;
+}
+
+/**
+ * The published `variants[]` row an alias pin names, by exact `spec`.
+ *
+ * A pin that names no row throws rather than falling back to the headline
+ * price: the whole point of the object form is that the headline is the wrong
+ * number for that endpoint, so a spec GenSpend has renamed or dropped must
+ * stop the sync and be re-pinned, not silently become a figure nobody
+ * published.
+ */
+function pinnedVariant(offering, slug, providerId, pin) {
+  const variants = Array.isArray(offering.variants) ? offering.variants : [];
+  const found = variants.find((v) => v?.spec === pin.spec);
+  if (!found) {
+    const available = variants.map((v) => JSON.stringify(v?.spec)).join(", ");
+    throw new Error(
+      `aliases.json pins ${providerId}/${slug} → ${pin.id} to variant ${JSON.stringify(pin.spec)}, ` +
+        `which this offering does not publish. Available specs: ${available || "(none)"}`
+    );
+  }
+  return found;
 }
 
 /**
@@ -197,12 +247,23 @@ export function resolveOfferingPrices({
   if (alias === null) {
     return { providerId, entries: [], reason: "blocked" };
   }
-  if (alias && alias.length > 0) {
+  if (alias && alias.pins.length > 0) {
     return {
       providerId,
-      entries: alias.map((id) =>
-        priceEntry(id, headlinePrice, headlineClass, "alias")
-      ),
+      entries: alias.pins.map((pin) => {
+        if (pin.spec === null) {
+          return priceEntry(pin.id, headlinePrice, headlineClass, "alias");
+        }
+        const variant = pinnedVariant(offering, model.slug, providerId, pin);
+        const price = isFiniteNumber(variant.priceUsd)
+          ? variant.priceUsd
+          : headlinePrice;
+        const unitClass =
+          typeof variant.unitClass === "string" && variant.unitClass
+            ? variant.unitClass
+            : headlineClass;
+        return priceEntry(pin.id, price, unitClass, "alias", variant);
+      }),
       reason: null
     };
   }

--- a/web/src/components/chat/composer/__tests__/videoModelOptions.test.ts
+++ b/web/src/components/chat/composer/__tests__/videoModelOptions.test.ts
@@ -36,6 +36,22 @@ describe("videoModelConstraints", () => {
     expect(result.durations).toEqual([3, 5, 10]);
   });
 
+  it("drops sentinel durations that name no length", () => {
+    // `-1` on the AtlasCloud Seedance 2.0 family and `0` on
+    // `fal-ai/wan/v2.7/edit-video` mean "let the model choose". The duration
+    // chips render `${d} Sec`, so a sentinel would read as "-1 Sec", and no
+    // catalog can price a clip whose length is unstated.
+    const result = videoModelConstraints(
+      makeVideoModel({ durations: [-1, 4, 5, 6] })
+    );
+    expect(result.durations).toEqual([4, 5, 6]);
+  });
+
+  it("treats an all-sentinel duration enum as no constraint", () => {
+    const result = videoModelConstraints(makeVideoModel({ durations: [-1, 0] }));
+    expect(result.durations).toBeUndefined();
+  });
+
   it("filters non-finite durations", () => {
     const result = videoModelConstraints(
       makeVideoModel({ durations: [3, NaN, Infinity, 5] })

--- a/web/src/components/chat/composer/videoModelOptions.tsx
+++ b/web/src/components/chat/composer/videoModelOptions.tsx
@@ -21,7 +21,14 @@ import {
 
 /** Extract per-model option constraints (manifest enums) from a raw model. */
 export function videoModelConstraints(model: VideoModel) {
-  const durations = model.durations?.filter((d) => Number.isFinite(d));
+  // Positive only: a handful of manifests declare a sentinel duration — `-1`
+  // on the AtlasCloud Seedance 2.0 family, `0` on `fal-ai/wan/v2.7/edit-video`
+  // — meaning "let the model choose". The duration controls render every
+  // option as `${d} Sec`, so a sentinel reaches the user as "-1 Sec", and no
+  // catalog can price a run whose length is unstated. Dropping it leaves the
+  // real durations; a model whose enum is nothing but sentinels falls back to
+  // the full static list, same as a model that declares no enum at all.
+  const durations = model.durations?.filter((d) => Number.isFinite(d) && d > 0);
   const resolutions = model.resolutions ?? undefined;
   const aspectRatios = model.aspect_ratios ?? undefined;
   return {

--- a/web/src/components/properties/MediaPickerProperties.tsx
+++ b/web/src/components/properties/MediaPickerProperties.tsx
@@ -21,6 +21,37 @@ import {
   IMAGE_EDIT_STRENGTHS,
   type AspectRatioOption
 } from "../../stores/MediaGenerationStore";
+import {
+  buildAspectOptions,
+  clampToAllowed
+} from "../chat/composer/videoModelOptions";
+import {
+  useNodeImageModelConstraints,
+  useNodeVideoModelConstraints
+} from "../../hooks/useMediaModelConstraints";
+
+/**
+ * Keep only the values the node's own enum can express, and fall back to the
+ * whole vocabulary when that leaves nothing.
+ *
+ * A manifest states resolutions in the provider's spelling — `480p`,
+ * `720p-SR`, `1080p`, `4k` — while these properties are declared over a fixed
+ * ladder (`720p`/`1080p`/`1440p`/`4K` for video, `1K`/`2K`/`4K` for images)
+ * that the runtime maps onto each provider. Offering a rung outside that
+ * ladder would write a value the node cannot round-trip; offering none at all
+ * would leave the user with an empty menu. So: narrow where the two agree,
+ * and treat "no overlap" as "unknown", exactly as `imageModelConstraints`
+ * already does for the composer.
+ */
+function narrowToVocabulary<T extends string>(
+  declared: string[] | undefined,
+  vocabulary: readonly T[]
+): readonly T[] {
+  const allowed = (declared ?? []).filter((r): r is T =>
+    (vocabulary as readonly string[]).includes(r)
+  );
+  return allowed.length > 0 ? allowed : vocabulary;
+}
 
 interface AspectRatioBaseProps extends PropertyProps {
   options: AspectRatioOption[];
@@ -38,7 +69,10 @@ const AspectRatioPicker: React.FC<AspectRatioBaseProps> = ({
   const ref = useRef<HTMLButtonElement>(null);
   const [open, setOpen] = useState(false);
   const id = `media-aspect-${property.name}-${propertyIndex}`;
-  const current = String(value ?? defaultId);
+  // Show a ratio the offered list actually contains. The stored value is left
+  // alone until the user picks — see the note on OptionPicker below.
+  const optionIds = useMemo(() => options.map((o) => o.id), [options]);
+  const current = clampToAllowed(String(value ?? defaultId), optionIds);
   return (
     <div className="media-aspect-ratio-property">
       <PropertyLabel
@@ -66,34 +100,34 @@ const AspectRatioPicker: React.FC<AspectRatioBaseProps> = ({
   );
 };
 
-// Full static image aspect ratios: this generic per-property input receives
-// only PropertyProps (this field's own value), not the node's selected image
-// model, so it can't constrain the list per-model. Given the model object,
-// derive the options with buildImageModelOptions() and snap the current value
-// with clampToAllowed() from ../chat/composer/imageModelOptions (mirroring the
-// video controls' videoModelOptions usage).
-export const MediaAspectRatioImageProperty = memo<PropertyProps>(
-  (props) => (
-    <AspectRatioPicker
-      {...props}
-      options={IMAGE_ASPECT_RATIOS}
-      defaultId="1:1"
-    />
-  ),
-  isEqual
-);
+export const MediaAspectRatioImageProperty = memo<PropertyProps>((props) => {
+  const { aspectRatios } = useNodeImageModelConstraints(props.nodeId);
+  const options = useMemo(
+    () =>
+      aspectRatios && aspectRatios.length > 0
+        ? buildAspectOptions(aspectRatios, IMAGE_ASPECT_RATIOS)
+        : IMAGE_ASPECT_RATIOS,
+    [aspectRatios]
+  );
+  return (
+    <AspectRatioPicker {...props} options={options} defaultId="1:1" />
+  );
+}, isEqual);
 MediaAspectRatioImageProperty.displayName = "MediaAspectRatioImageProperty";
 
-export const MediaAspectRatioVideoProperty = memo<PropertyProps>(
-  (props) => (
-    <AspectRatioPicker
-      {...props}
-      options={VIDEO_ASPECT_RATIOS}
-      defaultId="16:9"
-    />
-  ),
-  isEqual
-);
+export const MediaAspectRatioVideoProperty = memo<PropertyProps>((props) => {
+  const { aspectRatios } = useNodeVideoModelConstraints(props.nodeId);
+  const options = useMemo(
+    () =>
+      aspectRatios && aspectRatios.length > 0
+        ? buildAspectOptions(aspectRatios, VIDEO_ASPECT_RATIOS)
+        : VIDEO_ASPECT_RATIOS,
+    [aspectRatios]
+  );
+  return (
+    <AspectRatioPicker {...props} options={options} defaultId="16:9" />
+  );
+}, isEqual);
 MediaAspectRatioVideoProperty.displayName = "MediaAspectRatioVideoProperty";
 
 interface OptionPickerProps<T extends string | number> extends PropertyProps {
@@ -117,7 +151,15 @@ function OptionPicker<T extends string | number>({
 }: OptionPickerProps<T>) {
   const [anchor, setAnchor] = useState<HTMLButtonElement | null>(null);
   const id = `media-option-${property.name}-${propertyIndex}`;
-  const current = (value ?? defaultValue) as T;
+  const optionIds = useMemo(() => options.map((o) => o.id), [options]);
+  // Snap only what is shown. A node saved before its model narrowed the list —
+  // 5 seconds on a Veo 3.1 that sells 4, 6 and 8 — displays the nearest
+  // offered option, but its stored value is rewritten only when the user
+  // picks one: silently editing a saved workflow on render would change what
+  // the node runs without anyone asking for it. Until then the cost row for
+  // that node stays blank, which is the honest answer — the provider
+  // publishes no price for the duration the node still holds.
+  const current = clampToAllowed((value ?? defaultValue) as T, optionIds);
   const labelText = formatLabel
     ? formatLabel(current)
     : String(current);
@@ -148,20 +190,16 @@ function OptionPicker<T extends string | number>({
   );
 }
 
-// Full static image resolutions: like the image aspect-ratio control above,
-// this per-property input has no access to the selected image model object, so
-// it can't constrain the list per-model. Given the model, source the options
-// from buildImageModelOptions() and snap the value with clampToAllowed()
-// (../chat/composer/imageModelOptions).
 export const MediaResolutionImageProperty = memo<PropertyProps>((props) => {
+  const { resolutions } = useNodeImageModelConstraints(props.nodeId);
   const options = useMemo<MediaOption<string>[]>(
     () =>
-      IMAGE_RESOLUTIONS.map((r) => ({
+      narrowToVocabulary(resolutions, IMAGE_RESOLUTIONS).map((r) => ({
         id: r,
         label: r,
         icon: <DisplaySettingsIcon fontSize="small" />
       })),
-    []
+    [resolutions]
   );
   return (
     <OptionPicker<string>
@@ -176,14 +214,15 @@ export const MediaResolutionImageProperty = memo<PropertyProps>((props) => {
 MediaResolutionImageProperty.displayName = "MediaResolutionImageProperty";
 
 export const MediaResolutionVideoProperty = memo<PropertyProps>((props) => {
+  const { resolutions } = useNodeVideoModelConstraints(props.nodeId);
   const options = useMemo<MediaOption<string>[]>(
     () =>
-      VIDEO_RESOLUTIONS.map((r) => ({
+      narrowToVocabulary(resolutions, VIDEO_RESOLUTIONS).map((r) => ({
         id: r,
         label: r,
         icon: <DisplaySettingsIcon fontSize="small" />
       })),
-    []
+    [resolutions]
   );
   return (
     <OptionPicker<string>
@@ -198,14 +237,21 @@ export const MediaResolutionVideoProperty = memo<PropertyProps>((props) => {
 MediaResolutionVideoProperty.displayName = "MediaResolutionVideoProperty";
 
 export const MediaDurationProperty = memo<PropertyProps>((props) => {
+  const { durations } = useNodeVideoModelConstraints(props.nodeId);
+  // Durations are not narrowed to the node's static list the way resolutions
+  // are: the property is a plain integer of seconds, so every length the model
+  // declares is expressible — including the 7, 9, 11, 13 and 14 second clips
+  // the static ladder skips.
   const options = useMemo<MediaOption<number>[]>(
     () =>
-      VIDEO_DURATIONS.map((d) => ({
-        id: d,
-        label: `${d} Sec`,
-        icon: <AccessTimeIcon fontSize="small" />
-      })),
-    []
+      (durations && durations.length > 0 ? durations : VIDEO_DURATIONS).map(
+        (d) => ({
+          id: d,
+          label: `${d} Sec`,
+          icon: <AccessTimeIcon fontSize="small" />
+        })
+      ),
+    [durations]
   );
   return (
     <OptionPicker<number>

--- a/web/src/components/properties/__tests__/MediaPickerProperties.test.tsx
+++ b/web/src/components/properties/__tests__/MediaPickerProperties.test.tsx
@@ -1,0 +1,169 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+const mockVideoConstraints = jest.fn();
+const mockImageConstraints = jest.fn();
+
+jest.mock("../../../hooks/useMediaModelConstraints", () => ({
+  useNodeVideoModelConstraints: (nodeId: string) =>
+    mockVideoConstraints(nodeId),
+  useNodeImageModelConstraints: (nodeId: string) => mockImageConstraints(nodeId)
+}));
+
+jest.mock("../../../config/data_types", () => ({}));
+
+import {
+  MediaDurationProperty,
+  MediaResolutionVideoProperty,
+  MediaAspectRatioVideoProperty,
+  MediaResolutionImageProperty
+} from "../MediaPickerProperties";
+
+const props = (overrides: Record<string, unknown> = {}) => ({
+  property: {
+    name: "duration",
+    type: { type: "int", optional: false, type_args: [] }
+  } as any,
+  propertyIndex: "0",
+  value: 5,
+  onChange: jest.fn(),
+  nodeId: "node1",
+  nodeType: "nodetool.video.TextToVideo",
+  ...overrides
+});
+
+const renderIn = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>);
+
+/** Open the chip popover and read back the options it offers. */
+const openMenu = () => {
+  fireEvent.click(screen.getByRole("button"));
+  return screen
+    .getAllByRole("menuitemradio")
+    .map((el) => el.textContent?.trim() ?? "");
+};
+
+beforeEach(() => {
+  mockVideoConstraints.mockReturnValue({});
+  mockImageConstraints.mockReturnValue({});
+});
+
+describe("MediaDurationProperty", () => {
+  it("offers the full static ladder when the model declares no durations", () => {
+    renderIn(<MediaDurationProperty {...props()} />);
+    expect(openMenu()).toEqual([
+      "2 Sec",
+      "3 Sec",
+      "4 Sec",
+      "5 Sec",
+      "6 Sec",
+      "8 Sec",
+      "10 Sec",
+      "12 Sec",
+      "15 Sec"
+    ]);
+  });
+
+  it("offers only the durations the selected model sells", () => {
+    // Veo 3.1 sells 4, 6 and 8 seconds — the 5 the static ladder offers is
+    // the value that left the cost row blank.
+    mockVideoConstraints.mockReturnValue({ durations: [4, 6, 8] });
+    renderIn(<MediaDurationProperty {...props()} />);
+    expect(openMenu()).toEqual(["4 Sec", "6 Sec", "8 Sec"]);
+  });
+
+  it("surfaces durations the static ladder skips", () => {
+    mockVideoConstraints.mockReturnValue({ durations: [7, 9, 11] });
+    renderIn(<MediaDurationProperty {...props()} />);
+    expect(openMenu()).toEqual(["7 Sec", "9 Sec", "11 Sec"]);
+  });
+
+  it("displays a snapped option for an out-of-range stored value", () => {
+    mockVideoConstraints.mockReturnValue({ durations: [4, 6, 8] });
+    renderIn(<MediaDurationProperty {...props({ value: 5 })} />);
+    expect(screen.getByRole("button")).toHaveTextContent("4 Sec");
+  });
+
+  it("does not rewrite the stored value on render", () => {
+    mockVideoConstraints.mockReturnValue({ durations: [4, 6, 8] });
+    const onChange = jest.fn();
+    renderIn(<MediaDurationProperty {...props({ value: 5, onChange })} />);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("writes the value the user picks", () => {
+    mockVideoConstraints.mockReturnValue({ durations: [4, 6, 8] });
+    const onChange = jest.fn();
+    renderIn(<MediaDurationProperty {...props({ value: 5, onChange })} />);
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(screen.getByText("6 Sec"));
+    expect(onChange).toHaveBeenCalledWith(6);
+  });
+});
+
+describe("MediaResolutionVideoProperty", () => {
+  const resProps = props({
+    property: {
+      name: "resolution",
+      type: { type: "str", optional: false, type_args: [] }
+    } as any,
+    value: "1080p"
+  });
+
+  it("keeps the full ladder when the model declares nothing", () => {
+    renderIn(<MediaResolutionVideoProperty {...resProps} />);
+    expect(openMenu()).toEqual(["720p", "1080p", "1440p", "4K"]);
+  });
+
+  it("narrows to the rungs the model declares", () => {
+    mockVideoConstraints.mockReturnValue({ resolutions: ["720p", "1080p"] });
+    renderIn(<MediaResolutionVideoProperty {...resProps} />);
+    expect(openMenu()).toEqual(["720p", "1080p"]);
+  });
+
+  it("keeps the full ladder when no declared rung is expressible", () => {
+    // The provider spells its rungs outside the node's own enum; narrowing to
+    // nothing would leave an empty menu, so "no overlap" reads as "unknown".
+    mockVideoConstraints.mockReturnValue({
+      resolutions: ["480p", "720p-SR", "1440p-SR"]
+    });
+    renderIn(<MediaResolutionVideoProperty {...resProps} />);
+    expect(openMenu()).toEqual(["720p", "1080p", "1440p", "4K"]);
+  });
+});
+
+describe("MediaResolutionImageProperty", () => {
+  it("narrows to the model's declared image rungs", () => {
+    mockImageConstraints.mockReturnValue({ resolutions: ["1K", "2K"] });
+    renderIn(
+      <MediaResolutionImageProperty
+        {...props({
+          property: {
+            name: "resolution",
+            type: { type: "str", optional: false, type_args: [] }
+          } as any,
+          value: "1K",
+          nodeType: "nodetool.image.TextToImage"
+        })}
+      />
+    );
+    expect(openMenu()).toEqual(["1K", "2K"]);
+  });
+});
+
+describe("MediaAspectRatioVideoProperty", () => {
+  const arProps = props({
+    property: {
+      name: "aspect_ratio",
+      type: { type: "str", optional: false, type_args: [] }
+    } as any,
+    value: "21:9"
+  });
+
+  it("narrows to the model's declared ratios and snaps the display", () => {
+    mockVideoConstraints.mockReturnValue({ aspectRatios: ["16:9", "9:16"] });
+    renderIn(<MediaAspectRatioVideoProperty {...arProps} />);
+    expect(screen.getByRole("button")).toHaveTextContent("16:9");
+  });
+});

--- a/web/src/hooks/__tests__/useMediaModelConstraints.test.tsx
+++ b/web/src/hooks/__tests__/useMediaModelConstraints.test.tsx
@@ -1,0 +1,154 @@
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { trpc } from "../../lib/trpc";
+import {
+  readStoredModelRef,
+  useNodeVideoModelConstraints,
+  useNodeImageModelConstraints
+} from "../useMediaModelConstraints";
+
+jest.mock("../../lib/trpc", () => ({
+  trpc: {
+    models: {
+      videoByProvider: { query: jest.fn() },
+      imageByProvider: { query: jest.fn() }
+    }
+  }
+}));
+
+let storedProperties: Record<string, unknown> = {};
+
+jest.mock("../../contexts/NodeContext", () => ({
+  useNodes: (selector: (state: unknown) => unknown) =>
+    selector({
+      findNode: (id: string) =>
+        id === "node1" ? { id, data: { properties: storedProperties } } : undefined
+    })
+}));
+
+const videoQuery = jest.mocked(trpc.models.videoByProvider.query);
+const imageQuery = jest.mocked(trpc.models.imageByProvider.query);
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider
+    client={
+      new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+    }
+  >
+    {children}
+  </QueryClientProvider>
+);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  storedProperties = {};
+});
+
+describe("readStoredModelRef", () => {
+  it("reads a stored provider-model ref", () => {
+    expect(
+      readStoredModelRef({
+        type: "video_model",
+        provider: "fal_ai",
+        id: "fal-ai/veo3.1"
+      })
+    ).toEqual({ provider: "fal_ai", id: "fal-ai/veo3.1" });
+  });
+
+  it.each([
+    ["null", null],
+    ["a string", "fal-ai/veo3.1"],
+    ["a ref with no id", { provider: "fal_ai" }],
+    ["a ref with no provider", { id: "fal-ai/veo3.1" }],
+    ["a ref with blank fields", { provider: "  ", id: "  " }]
+  ])("returns null for %s", (_label, value) => {
+    expect(readStoredModelRef(value)).toBeNull();
+  });
+});
+
+describe("useNodeVideoModelConstraints", () => {
+  it("returns no constraints and queries nothing when no model is selected", () => {
+    const { result } = renderHook(() => useNodeVideoModelConstraints("node1"), {
+      wrapper
+    });
+    expect(result.current).toEqual({});
+    expect(videoQuery).not.toHaveBeenCalled();
+  });
+
+  it("resolves the selected model's declared constraints", async () => {
+    storedProperties = {
+      model: { type: "video_model", provider: "atlascloud", id: "google/veo3.1/text-to-video" }
+    };
+    videoQuery.mockResolvedValue([
+      { id: "some/other-model", durations: [2, 3] },
+      {
+        id: "google/veo3.1/text-to-video",
+        durations: [4, 6, 8],
+        resolutions: ["720p", "1080p"],
+        aspect_ratios: ["16:9", "9:16"]
+      }
+    ] as never);
+
+    const { result } = renderHook(() => useNodeVideoModelConstraints("node1"), {
+      wrapper
+    });
+    await waitFor(() =>
+      expect(result.current.durations).toEqual([4, 6, 8])
+    );
+    expect(result.current.resolutions).toEqual(["720p", "1080p"]);
+    expect(result.current.aspectRatios).toEqual(["16:9", "9:16"]);
+    expect(videoQuery).toHaveBeenCalledWith({ provider: "atlascloud" });
+  });
+
+  it("leaves constraints unknown when the provider list omits the model", async () => {
+    storedProperties = {
+      model: { type: "video_model", provider: "fal_ai", id: "not/in-the-list" }
+    };
+    videoQuery.mockResolvedValue([{ id: "other", durations: [5] }] as never);
+
+    const { result } = renderHook(() => useNodeVideoModelConstraints("node1"), {
+      wrapper
+    });
+    await waitFor(() => expect(videoQuery).toHaveBeenCalled());
+    expect(result.current).toEqual({});
+  });
+
+  it("leaves constraints unknown when the provider list cannot be fetched", async () => {
+    storedProperties = {
+      model: { type: "video_model", provider: "fal_ai", id: "fal-ai/veo3.1" }
+    };
+    videoQuery.mockRejectedValue(new Error("offline"));
+
+    const { result } = renderHook(() => useNodeVideoModelConstraints("node1"), {
+      wrapper
+    });
+    await waitFor(() => expect(videoQuery).toHaveBeenCalled());
+    expect(result.current).toEqual({});
+  });
+});
+
+describe("useNodeImageModelConstraints", () => {
+  it("resolves the selected image model's declared constraints", async () => {
+    storedProperties = {
+      model: { type: "image_model", provider: "fal_ai", id: "fal-ai/flux" }
+    };
+    imageQuery.mockResolvedValue([
+      {
+        id: "fal-ai/flux",
+        resolutions: ["1K", "2K", "480p"],
+        aspect_ratios: ["1:1", "16:9"]
+      }
+    ] as never);
+
+    const { result } = renderHook(() => useNodeImageModelConstraints("node1"), {
+      wrapper
+    });
+    // "480p" is outside the app's image vocabulary and is dropped by
+    // imageModelConstraints before it can reach a picker.
+    await waitFor(() =>
+      expect(result.current.resolutions).toEqual(["1K", "2K"])
+    );
+    expect(result.current.aspectRatios).toEqual(["1:1", "16:9"]);
+  });
+});

--- a/web/src/hooks/useMediaModelConstraints.ts
+++ b/web/src/hooks/useMediaModelConstraints.ts
@@ -1,0 +1,161 @@
+/**
+ * Per-model option constraints for the media picker properties.
+ *
+ * The generic per-property editors (`MediaDurationProperty`,
+ * `MediaResolutionVideoProperty`, …) receive only `PropertyProps` — this
+ * field's own value — so on their own they can only offer the node's full
+ * static enum. That is how a Veo 3.1 node came to offer a 5-second clip: a
+ * duration the picker lists and Veo does not sell, which the cost panel then
+ * has no published price for and renders as a blank row.
+ *
+ * These hooks close that gap the same way the chat composer does. They read
+ * the node's sibling `model` property, resolve it against the provider's model
+ * list — the same `["video-models", provider]` / `["image-models", provider]`
+ * React Query entries `useModelsByProvider` fills, so a canvas that already
+ * loaded the model menu pays nothing extra — and hand back the constraints the
+ * provider manifest declares (`videoConstraints()` in
+ * `@nodetool-ai/runtime`'s `manifest-models`).
+ *
+ * Unknown is not empty. A node with no model selected, a model the provider
+ * list does not carry, a query still in flight, or a model that declares no
+ * enum all return `{}`, and `buildVideoModelOptions` / `buildImageModelOptions`
+ * then fall back to the full static list. Narrowing only ever happens on a
+ * stated constraint.
+ */
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { trpc } from "../lib/trpc";
+import { useNodes } from "../contexts/NodeContext";
+import type { ImageModel, VideoModel } from "../stores/ApiTypes";
+import { videoModelConstraints } from "../components/chat/composer/videoModelOptions";
+import { imageModelConstraints } from "../components/chat/composer/imageModelOptions";
+import { MODEL_STALE_TIME } from "./useModelsByProvider";
+
+/** The property name every media node carries its provider-model on. */
+const MODEL_PROPERTY = "model";
+
+/** A `{ type: "video_model", provider, id }` value as stored on a node. */
+interface StoredModelRef {
+  provider: string;
+  id: string;
+}
+
+/** Read a usable provider+id off a node's stored model property, else null. */
+export function readStoredModelRef(value: unknown): StoredModelRef | null {
+  if (typeof value !== "object" || value === null) return null;
+  const ref = value as { provider?: unknown; id?: unknown };
+  const provider = typeof ref.provider === "string" ? ref.provider.trim() : "";
+  const id = typeof ref.id === "string" ? ref.id.trim() : "";
+  return provider !== "" && id !== "" ? { provider, id } : null;
+}
+
+/** The model ref stored on `nodeId`'s `model` property, or null. */
+function useStoredModelRef(nodeId: string): StoredModelRef | null {
+  const findNode = useNodes((state) => state.findNode);
+  const stored = findNode(nodeId)?.data?.properties?.[MODEL_PROPERTY];
+  // Keyed on provider+id so a re-render that rebuilds the ref object — node
+  // data is replaced wholesale on every property edit — does not churn the
+  // query key or the constraint memos downstream.
+  const ref = readStoredModelRef(stored);
+  const provider = ref?.provider;
+  const id = ref?.id;
+  return useMemo(
+    () => (provider && id ? { provider, id } : null),
+    [provider, id]
+  );
+}
+
+/**
+ * The selected model's own entry from its provider's model list.
+ *
+ * Shares `useModelsByProvider`'s query keys and shape, so this resolves off
+ * cache whenever the model menu or composer has already loaded that provider,
+ * and otherwise costs one request for the one provider the node selected —
+ * not the fan-out across every provider that `use*ModelsByProvider` performs.
+ */
+function useProviderModel<T extends { id: string }>(
+  ref: StoredModelRef | null,
+  queryKeyPrefix: "video-models" | "image-models",
+  fetchModels: (provider: string) => Promise<T[]>
+): T | undefined {
+  const provider = ref?.provider;
+  const { data } = useQuery({
+    queryKey: [queryKeyPrefix, provider],
+    queryFn: async () => ({
+      provider: provider as string,
+      models: await fetchModels(provider as string)
+    }),
+    enabled: !!provider,
+    staleTime: MODEL_STALE_TIME,
+    refetchOnWindowFocus: false
+  });
+  const models = data?.models;
+  return useMemo(
+    () => (ref ? models?.find((m) => m.id === ref.id) : undefined),
+    [models, ref]
+  );
+}
+
+const fetchVideoModels = async (provider: string): Promise<VideoModel[]> => {
+  try {
+    return ((await trpc.models.videoByProvider.query({ provider })) ||
+      []) as VideoModel[];
+  } catch {
+    // A provider that cannot be listed leaves the constraints unknown, which
+    // keeps the full static list — never an empty picker.
+    return [];
+  }
+};
+
+const fetchImageModels = async (provider: string): Promise<ImageModel[]> => {
+  try {
+    return ((await trpc.models.imageByProvider.query({ provider })) ||
+      []) as ImageModel[];
+  } catch {
+    return [];
+  }
+};
+
+export interface VideoOptionConstraints {
+  durations?: number[];
+  resolutions?: string[];
+  aspectRatios?: string[];
+}
+
+export interface ImageOptionConstraints {
+  resolutions?: string[];
+  aspectRatios?: string[];
+}
+
+/** Duration / resolution / aspect constraints of `nodeId`'s selected video model. */
+export function useNodeVideoModelConstraints(
+  nodeId: string
+): VideoOptionConstraints {
+  const ref = useStoredModelRef(nodeId);
+  const model = useProviderModel<VideoModel>(
+    ref,
+    "video-models",
+    fetchVideoModels
+  );
+  return useMemo(
+    () => (model ? videoModelConstraints(model) : {}),
+    [model]
+  );
+}
+
+/** Resolution / aspect constraints of `nodeId`'s selected image model. */
+export function useNodeImageModelConstraints(
+  nodeId: string
+): ImageOptionConstraints {
+  const ref = useStoredModelRef(nodeId);
+  const model = useProviderModel<ImageModel>(
+    ref,
+    "image-models",
+    fetchImageModels
+  );
+  return useMemo(
+    () => (model ? imageModelConstraints(model) : {}),
+    [model]
+  );
+}

--- a/web/src/hooks/useModelsByProvider.ts
+++ b/web/src/hooks/useModelsByProvider.ts
@@ -62,7 +62,12 @@ interface AggregatedProviderModels<T> {
   refetch: () => Promise<void>;
 }
 
-const MODEL_STALE_TIME = 5 * 60 * 1000;
+/**
+ * How long a provider's model list stays fresh. Exported so the per-node
+ * constraint hooks (`useMediaModelConstraints`) can register a query that
+ * shares these cache entries exactly rather than fighting them over staleness.
+ */
+export const MODEL_STALE_TIME = 5 * 60 * 1000;
 
 /**
  * Fan one per-provider fetch out across `providers` and flatten the results.


### PR DESCRIPTION
Four workstreams on one branch. They are independent and would have been three shippable PRs plus an investigation; they are stacked here because this task pinned a single branch. Commits are split cleanly along those lines, so reviewing commit-by-commit gives you the separate PRs.

| commit | workstream |
|---|---|
| `02b2ce0` | 1 — model-aware duration / resolution pickers (web) |
| `b86e554` | 2 — duration options the providers declare but nothing read |
| `0c96069` | 3 — catalog coverage: pin the published rung, not just the model |
| `fa2da5a` | 4 — FAL ambiguous units: investigation, no behavior change |

Every figure below is from a throwaway probe over the `fal-nodes`, `kie-nodes` and `atlascloud-nodes` manifests (`outputType` ∈ image/video/audio, deduplicated by endpoint id — 1,635 endpoints), calling the real `getModelUnitPrice`. It reproduces the stated baseline exactly on all eight rows. The probe is deleted; nothing in this diff depends on it.

## What changed

**1 — The picker offered clip lengths the model does not sell.** The duration and resolution chips on `TextToVideo` / `ImageToVideo`, and the aspect and resolution chips on `TextToImage` / `ImageToImage`, were rendered from the node's static enum: nine durations, four rungs, the same nine and four whatever model was selected. Pick 5 seconds on a Veo 3.1 and the node states a job Veo does not sell, so the cost panel has no published price and the row goes blank. The picker offered the value; the catalog was right to refuse it.

`MediaPickerProperties` receives only `PropertyProps`, so it could not see the node's model — the gap the comment above `MediaAspectRatioImageProperty` described, naming the intended fix. `useMediaModelConstraints` closes it: it reads the node's sibling `model` property and resolves it against that one provider's model list, reusing the `["video-models", provider]` / `["image-models", provider]` React Query entries `useModelsByProvider` already fills. A canvas that has opened the model menu pays nothing extra; a cold one pays a single request for the one provider the node selected, not the fan-out across every provider. Options then come from `videoModelConstraints()` / `imageModelConstraints()` — the same derivation the chat composer and timeline header use.

**2 — Two ways a declared duration was thrown away before it could constrain anything.** `videoConstraints()` turned each option into a number with `Number(v)`, and FAL spells them with the unit attached: `["4s", "6s", "8s"]`. `Number("4s")` is `NaN`, so the filter dropped every value and the enum with it. Twenty-two FAL video endpoints looked unconstrained as a result — the Veo 3.1 image-to-video and first-last-frame families among them. Separately, the FAL schema parser read `enum` but not `const`, which is JSON Schema's enum of one; FAL uses it where an endpoint sells a single value.

**3 — Three AtlasCloud endpoints went unpriced next to a price AtlasCloud publishes for them.** GenSpend records the provider's rungs in `variants[]`, and the matcher binds a variant only when its `spec` is a model id it can verify. Some rungs are prose — `"Quality rendering tier"` — so the rows sat unread. `aliases.json` could not fix it: its array form pins ids at the *headline* rate, which for Ideogram 4.0 on AtlasCloud is the $0.008 Turbo rung, so pinning the Quality endpoint that way would have quoted a number AtlasCloud does not publish for it. An alias value may now also be an object mapping each model id to the exact `variants[]` spec whose published price it takes.

**4 — Investigation only.** See the section at the end; nothing was loosened.

## Coverage

Catalog coverage, before → after. Only workstream 3 moves it; 1 and 2 change which options a user can put a node into, and 4 changes nothing.

| provider · modality | priced | declined | no row |
|---|--:|--:|--:|
| fal_ai · image / video / audio | 410 / 441 / 62 | 124 / 105 / 61 | 40 / 72 / 4 |
| kie · image / video / audio | 37 / 51 / 0 | 1 / 0 / 3 | 14 / 28 / 25 |
| atlascloud · image | 45 → **48** | 0 | 31 → **28** |
| atlascloud · video | 47 | 2 | 32 |

The metric workstreams 1 and 2 move is whether an offered option corresponds to a job the model sells. Counted over video models the catalog can already price, before → after:

| provider | priceable models | declare a duration enum | phantom options removed | …that priced as a blank | real lengths newly offered | …still blank |
|---|--:|--:|--:|--:|--:|--:|
| fal_ai | 546 | 127 → **149** | 682 | 142 | 323 | 129 |
| kie | 51 | 18 | 116 | 13 | 5 | 0 |
| atlascloud | 49 | 31 | 98 | 78 | 150 | 0 |

896 (model, duration) options the model does not sell are no longer offered, 233 of which priced as a blank row. 478 lengths the static ladder skipped are now reachable — the 7, 9, 11, 13 and 14 second clips the Seedance 2.0 family sells, among others. `fal_ai`'s enum count rising 127 → 149 is the `"4s"` fix: those 22 endpoints were invisible to the constraint layer entirely.

Models whose every offered duration prices: fal_ai 417 → **430**, kie 38 → **41**, atlascloud 14 → **40** — 469 → 511 overall. The whole Veo 3.1 family is now exactly its published lengths.

Total blank options across the three providers: 1,201 → **1,097**. Workstream 1 alone would have moved fal_ai's own count the wrong way (1,055 → 1,085), because narrowing surfaces 318 genuinely sellable FAL durations the catalog has no row for; workstream 2 more than absorbs that (→ 1,042). Those 129 remaining blanks are catalog gaps this deliberately exposes rather than papers over.

## Deliberate limits, and what stays unpriced

**Unknown stays unknown, never empty.** No model selected, a model the provider list does not carry, a query in flight, a failed fetch, or a model declaring no enum all leave the full static list in place. Narrowing only ever happens on a stated constraint. Resolutions are additionally narrowed to the ladder the property is declared over (`720p`/`1080p`/`1440p`/`4K`, `1K`/`2K`/`4K`), since a rung like `720p-SR` is a value the node cannot round-trip — and "no overlap" reads as unknown, not as an empty menu.

**A stored value the new list excludes is snapped for display only.** Rewriting a saved workflow's duration on render would change what the node runs without anyone asking. The residual, stated plainly: an existing node holding 5 s on a Veo shows `4 Sec` while its stored value is still 5, and its row stays blank until the user touches the chip. That is the honest reading — the provider publishes no price for the duration the node still holds — but it is a divergence between chip and stored value, and it is the one thing here I would happily flip to write-on-model-change if you'd rather.

**Sentinel durations are dropped** where declared: `-1` on the AtlasCloud Seedance 2.0 family (18 endpoints) and `0` on `fal-ai/wan/v2.7/edit-video` mean "let the model choose", and the chips render `${d} Sec`, so they reached users as "-1 Sec". The filter lives in `videoModelConstraints`, so the composer loses them too — it could not display them meaningfully either.

**The manifest is deliberately not regenerated.** A plain regeneration today rewrites 1,425 of 1,576 endpoints: 1,028 differ only in the order the generator emits `inputFields`, and 382 carry real upstream drift since the last sync. Burying a 33-endpoint fix in that is not a reviewable diff. Verified out of tree instead — regenerating with and without the parser change differs in **exactly 33 endpoints**, seven of them video durations: `veo3.1/reference-to-video` and its fast sibling at **8s**, `kandinsky5-pro` text- and image-to-video at 5s, `veo3.1/lite/first-last-frame-to-video` at 8s, and both `veo3.1/extend-video` at 7s. The generator's field ordering is worth making deterministic before that refresh lands. Until it does, the `const` fix is correct but dormant.

⚠️ **A correction to the brief.** It gives `fal-ai/veo3.1/reference-to-video` and its fast sibling a receipted `[4, 6, 8]`. FAL's live schema declares `duration: {const: "8s"}` for both — **8s only**. The `[4, 6, 8]` is the model-level clip-length receipt for veo-3.1 generally; pinning it on these two endpoints would have offered 4 s and 6 s that FAL does not sell there.

**Two of the five named models genuinely declare nothing, and were left alone rather than filled in:**

- `atlascloud:minimax/hailuo-2.3/{t2v,i2v}-pro` — AtlasCloud's published schema for both lists `model`, `prompt` and `enable_prompt_expansion`, and **no duration input at all**. `sync-atlascloud-manifest.mjs --check` reports the manifest already in sync, so there is nothing upstream to pick up.
- `fal_ai:fal-ai/wan/v2.2-a14b/image-to-video` — FAL's schema declares no `duration` property either; the endpoint is fixed-length.

Their receipted clip lengths (`[6, 10]` and `[5]`) live in the price catalog, not in any schema the provider publishes as an input, so writing them into a generated manifest would state a capability no provider documents. Both Hailuo 2.3 Pro endpoints therefore still fall back to the full static ladder.

**Nothing else in the unresolved report can be pinned.** The sync reports 29 offerings GenSpend cannot place. Every one is unpinnable, and `fal_ai` is already **73/73 offerings resolved** — there is no cheap alias win there at all. The 29 break down as:

- *A version we do not ship.* GenSpend carries AtlasCloud's `hailuo-02` (we ship 2.3), `wan-2.5` (we ship 2.6 / 2.7 / 3.0), `seedance-1-pro` (we ship 2.0 / 2.5 / v1.5-pro), `seedream-4` (v4.5 / v5.0), `kling-2.5-turbo-pro` (v2.6 / v3.0 / o3), `qwen-image` (2.0 / 3.0), `pixverse-c1` (v6), `happyhorse-1` (1.1). Pinning any of them prices one version at another's rate.
- *A tier whose rate is not the base's.* `kie:qwen-image-2` names a **text-to-image** rung ($0.028) and our only kie `qwen2` endpoint is an **edit** — and on qwen-image v1, kie's edit is $0.03 against $0.02 for text-to-image, so the two are demonstrably not interchangeable.
- *Already covered.* `kie:qwen-image-3` is listed unresolved but every `qwen3/*` endpoint already prices at $0.024 off the kie scalar catalog — the same figure GenSpend carries.
- *A provider GenSpend does not track for that model.* `kie:veo-3.1` / `veo-3.1-fast` (our kie manifest ships no Veo at all), and the `gemini`, `together`, `elevenlabs` and `xai` rows.

Named holes from the brief, resolved to a cause: **AtlasCloud Wan 3.0 / 3.0 Prime, Kling O3 (pro/std/4k), Kling v3.0-4K, Kling v2.6 Pro, LTX 2.3 Quality, Youchuan v8.1/8.2, Reve 2.1, HiDream O1 1.5** — GenSpend carries no such model under any provider. **PixVerse v6** — GenSpend has `pixverse-v6-t2v`/`-i2v`, but offered by deepinfra, fal and pixverse, with **no atlascloud and no kie offering**; same shape as the confirmed `gemini-omni-flash` example, which GenSpend carries under fal, google and wavespeed only. **Qwen Image 2.0/3.0 Pro, Wan 2.7 Pro, GPT Image 1 Mini** — GenSpend has the base model on atlascloud but no Pro/Mini rung. **Cosmos 3 Super** — GenSpend has it, as an *image* model; our unpriced endpoint is `image-to-video`. **kie Seedream 3.0/4.0, Bytedance V1 Pro/Lite, Kling 3.0 Omni, Wan 3.0, grok-imagine-image-2.0** — no kie offering upstream. These are upstream gaps: they close when GenSpend adds the offering, not by anything we can pin.

**kie's 25 unpriced audio endpoints are out of scope**, as suspected. They are Suno *operations* — `generate-music`, `extend-music`, `add-vocals`, `separate-vocals`, `generate-lyrics`, `convert-to-wav` — against GenSpend's single `suno` offering. Applying one rate to every operation would invent a per-operation price nobody publishes.

## Workstream 4 — FAL's ambiguous units: findings and recommendation

**Recommendation: change nothing.** The evidence is not unambiguous per endpoint, and the brief's instruction not to reinterpret `"units"` is right. The finding is recorded next to `UNCONVERTIBLE_UNITS` in `cost-estimate.ts` so the shortcut is not re-proposed.

248 FAL endpoints decline on an ambiguous or unstated unit, matching the stated split exactly: 193 priced per something the node never states (177 compute-seconds, 11 tokens, 2 steps, 2 frames, 1 input-seconds) and 55 per a unit naming no fixed amount (41 `units`, 9 `credits`, 5 `unit`).

1. **Is `"units"` per-run?** No, and it cannot be made so. Across the 56 FAL image/video/audio endpoints billed this way the figure spans **$0.001 to $1.50 — 1,500×**. The two ends cannot both be a run: `fal-ai/minimax/hailuo-2.3/standard/image-to-video` at $0.28 reads as a video, `bytedance/seedance-2.0/image-to-video` at $0.014 does not, and `krea/v2/large/text-to-image` at $0.001 is a fraction of a cent for an image GenSpend prices at $0.06. The unit means something different per endpoint, and FAL does not say what.

2. **Does FAL expose a richer pricing shape?** No. `https://api.fal.ai/v1/models/pricing` returns exactly `endpoint_id`, `unit_price`, `unit` and `currency` per row — no grid, no variants, no per-parameter breakdown. (Unauthenticated it returns 401; the shape is from the client in `fal-pricing-fetch.ts`, which mirrors the runtime route.)

3. **Does GenSpend cover them under `fal_ai`?** That path already works and is exhausted, not unexplored. Since a scalar decline stopped hiding a GenSpend entry for the same model, any such endpoint GenSpend prices under `fal_ai` already resolves that way — which is why `krea/v2` prices today. **Zero of the 248** carries a GenSpend `fal_ai` entry. They close when GenSpend adds FAL coverage for those models.

## Verification

- [x] `npm run test:affected` — 92 of 104 tasks green. The only failure is `packages/runtime`'s `tests/providers/video-frame-fallback.test.ts`; run alone it fails with `Error: spawn ffmpeg ENOENT`, and `which ffmpeg` finds nothing here. The known environment gap.
- [x] `npm run typecheck` — `typecheck:web` and `typecheck:electron` both exit 0 and print nothing. `typecheck:mobile` fails in this environment only: `mobile/node_modules` is empty, so every `react-native` / `expo` / `@trpc/react-query` import is unresolved. No file in this diff is under `mobile/`.
- [x] `npm run lint` — exit 0 (oxlint + `lint:anti-slop:enforced` + `lint:design`). The one warning naming a file I touched (`schema-parser.ts`, unused `enumName` parameter) is pre-existing, at line 666 on `main` and 677 here — same warning, shifted by the 11 lines I added.
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 5/5 selfchecks passed`, including `generate:fal:check` and `generate:kie:check` (`fal: 5 generated output(s) match the checked-in fixtures`, `kie: 7`), which is what confirms the `const` parser change does not disturb the checked-in codegen fixtures.
- [x] `npm run sync:genspend:check` — `genspend-pricing.json is up to date (328 prices)`, exit 0. Up from 325.
- [x] `node scripts/genspend/parity-check.mjs` — `17/19 case(s) priced and matched against https://genspend.io/api/v1/quote`, the other 2 declined by both. No pricing rule changed here — this is the matcher, not the arithmetic — so `genspend-calc.ts` needs no counterpart.
- [x] `npx turbo run test` for `@nodetool-ai/model-pricing` (163 tests), `@nodetool-ai/node-sdk` (1,218), `@nodetool-ai/websocket`, `@nodetool-ai/fal-codegen`, `@nodetool-ai/kie-codegen`, `@nodetool-ai/runtime` (3,117 passed) — 53 of 55 tasks green, the same ffmpeg test the only failure. A first run also flaked `tests/providers/together-provider.test.ts`; it passed on re-run.
- [x] `npx jest src/components/properties src/components/costs src/hooks` in `web/` — `Test Suites: 184 passed, 184 total / Tests: 1568 passed, 1568 total`

New tests, each observed failing against the pre-change code:

- `web/src/components/properties/__tests__/MediaPickerProperties.test.tsx` (11) — the full ladder survives an unconstrained model; a `[4, 6, 8]` model offers exactly three options and not the 5 that blanked the row; `[7, 9, 11]` surfaces lengths the static ladder omits; an out-of-range stored value displays snapped and is **not** written (`onChange` asserted not called on render) but is written on a pick; a resolution set with no overlap keeps the full ladder rather than emptying.
- `web/src/hooks/__tests__/useMediaModelConstraints.test.tsx` (11) — ref parsing, no query when no model is selected, constraints resolved off the right provider's list, unknown-not-empty for a model missing from the list and for a failed fetch.
- `packages/runtime/.../manifest-models-hardening.test.ts` (+2) — `["4s","6s","8s"]` reads as `[4,6,8]`; a mixed bag drops what names no length.
- `packages/fal-codegen/tests/schema-parser.test.ts` (+3) — `const` as a one-value enum, `const` nested in `anyOf`, and an explicit `enum` still winning. Confirmed: reverting `schema-parser.ts` fails the first two.
- `packages/model-pricing/tests/genspend-sync.test.ts` (+3) — each pinned id takes its own published rung; a pin naming a spec the offering no longer publishes **throws**; a pinned variant carrying no price falls back to the headline.
- `web/src/components/chat/composer/__tests__/videoModelOptions.test.ts` (+2) — the sentinel filter, including an all-sentinel enum falling back to no constraint.

## Agent capabilities

No capability added or re-declared.

## New checks

`packages/model-pricing/tests/duration-enum-receipts.test.ts` — every duration a manifest offers must be one the catalog receipts a price for.

- [x] **Inverted once and observed failing.** Injecting a fake 99-second option into the audited set fails with the offending endpoints named — `fal_ai:fal-ai/veo3.1/image-to-video`, `…/first-last-frame-to-video`, `fal-ai/sora-2/image-to-video` and others — then passes again on restore. That the Veo `"4s"` endpoints appear in that failure is itself the proof the parsing fix put them in scope.
- [x] **The audit proves it found its targets.** A separate case asserts the pairing count before any judgement is made: at least 20 endpoints carrying both a duration enum and a receipted clip-length set, both halves non-empty, and all three manifests represented. It cannot pass by matching nothing. That pairing is **14 before the parsing fix and 20 after** — the stated "all 20 models" is only reachable once `"4s"` parses. Zero endpoints offer an unpublished length either way.