### PR TITLE
fix(storyboard): carry a screenplay's entityIds onto the board

### DIFF
--- a/.claude/skills/storyboard-core/SKILL.md
+++ b/.claude/skills/storyboard-core/SKILL.md
@@ -51,7 +51,8 @@ Bridge the two with `ui_open_document {type: "storyboard", id}`.
 2. **Cast the entities.** `list_entities` first. A new one needs an image asset —
    `generate_image` or the user's upload — then
    `create_entity {asset_id, kind, name, descriptor}`. **There is no create-from-text.**
-3. **Attach the cast to the board:** `edit_storyboard` → `{op: "set_board", entity_ids: [...]}`.
+3. **Attach the cast to the board:** `edit_storyboard` → `{op: "set_board", entity_ids: [...]}`,
+   or `ui_storyboard_set_entities {storyboard_id, entity_ids}` on an open board.
    An entity not on the board seasons nothing, no matter what the shots say.
 4. **Pin the models.** `find_model` with `capability` `text_to_image`, then
    `image_to_video` or `text_to_video`; write both through

--- a/.claude/skills/storyboard-core/references/tool-contract.md
+++ b/.claude/skills/storyboard-core/references/tool-contract.md
@@ -63,6 +63,7 @@ shot id, index as a string, or `"selected"`. **Slugs are not resolved here.**
 |---|---|
 | `ui_storyboard_get_state` | `storyboard_id` |
 | `ui_storyboard_set_screenplay` | `storyboard_id`, `screenplay` |
+| `ui_storyboard_set_entities` | `storyboard_id`, `entity_ids` (replaces the cast; `[]` clears it) |
 | `ui_storyboard_add_shot` | `storyboard_id`, `action`, `camera?`, `motion?`, `durationSeconds?`, `index?` |
 | `ui_storyboard_update_shot` | `storyboard_id`, `target`, `action?`, `camera?`, `motion?`, `status?` |
 | `ui_storyboard_generate_keyframe` | `storyboard_id`, `target` |
@@ -113,6 +114,13 @@ sets it. Do not use it as a gate.)
 
 Ids, indexes and statuses are filled in. `style` is accepted as an alias of
 `styleBible`. Only `action` is required per shot.
+
+The top-level `entityIds` casts those entities on the **board** — that cast is what
+seasons every shot's still and clip prompt. Use `ui_storyboard_set_entities` to
+recast without replacing the shots; `ui_storyboard_get_state` reports the current
+cast as `entityIds`. A shot's own `entityIds` overrides the board cast for that shot
+(`[]` means "no entities on this shot"); without one, styles and locations apply to
+every shot and characters and props apply to the shots whose text names them.
 
 ## Entities
 

--- a/packages/agents/src/evals/surfaces/storyboard.ts
+++ b/packages/agents/src/evals/surfaces/storyboard.ts
@@ -285,6 +285,7 @@ export function createStoryboardToolBridge(
   const brief = initial.brief ?? "";
   const style = initial.style ?? "";
   const aspectRatio = initial.aspectRatio ?? "16:9";
+  let entityIds: string[] = [];
   let hasScreenplay = false;
   let selectedShotId: string | null = null;
   let shotSeq = 0;
@@ -363,6 +364,7 @@ export function createStoryboardToolBridge(
       brief,
       style,
       aspectRatio,
+      entityIds,
       hasScreenplay,
       selectedShotId,
       shots: shots.map(serialize)
@@ -372,14 +374,14 @@ export function createStoryboardToolBridge(
   const tools: HeadlessTool[] = [
     tool(
       "ui_storyboard_get_state",
-      "Read the specified storyboard: title, brief, style, aspect ratio, whether a screenplay is loaded, the selected shot, and every shot with its index, slug, action, camera, motion, duration, status, and whether it has a rendered keyframe/clip. Call this first to discover the shot ids/indexes the other tools need.",
+      "Read the specified storyboard: title, brief, style, aspect ratio, the entity ids cast on the board, whether a screenplay is loaded, the selected shot, and every shot with its index, slug, action, camera, motion, duration, status, and whether it has a rendered keyframe/clip. Call this first to discover the shot ids/indexes the other tools need.",
       z.object({}),
       async () => ({ ok: true, ...snapshot() })
     ),
 
     tool(
       "ui_storyboard_set_screenplay",
-      "Load a full screenplay onto the specified storyboard, replacing its shots. `screenplay` is a Screenplay object ({ type:'screenplay', title, shots: Shot[], ... }) — typically the output of the Director node. Shot ids, indexes and statuses are filled in for you; every shot needs an `action`.",
+      "Load a full screenplay onto the specified storyboard, replacing its shots. `screenplay` is a Screenplay object ({ type:'screenplay', title, shots: Shot[], ... }) — typically the output of the Director node. Shot ids, indexes and statuses are filled in for you; every shot needs an `action`. A top-level `entityIds` casts those entities on the board (use ui_storyboard_set_entities to change the cast without replacing the shots); a shot's own `entityIds` overrides the board cast for that shot.",
       z.object({ screenplay: screenplayParam }),
       async ({ screenplay }) => {
         const play = storyboards.normalizeStoryboardScreenplay(screenplay, {
@@ -390,7 +392,22 @@ export function createStoryboardToolBridge(
         hasScreenplay = true;
         screenplayId = play.id;
         if (play.title) title = play.title;
+        if (play.entity_ids) entityIds = play.entity_ids;
         selectedShotId = null;
+        return { ok: true, ...snapshot() };
+      }
+    ),
+
+    tool(
+      "ui_storyboard_set_entities",
+      "Cast library entities (characters, locations, styles, props) on the specified storyboard, replacing the current selection. Their descriptors and reference images season every shot's still and clip prompt — a style or location applies to every shot, a character or prop applies to the shots whose text names it. Pass an empty array to clear the cast. Discover ids with ui_entity_list.",
+      z.object({ entity_ids: z.array(z.string()) }),
+      async ({ entity_ids }) => {
+        // The headless tool signature erases the parsed shape to `unknown`;
+        // the schema above has already refused anything but a string array.
+        entityIds = (Array.isArray(entity_ids) ? entity_ids : []).filter(
+          isString
+        );
         return { ok: true, ...snapshot() };
       }
     ),

--- a/packages/agents/tests/storyboard-tool-loop.test.ts
+++ b/packages/agents/tests/storyboard-tool-loop.test.ts
@@ -56,13 +56,14 @@ function createScriptedProvider(script: ScriptedCall[]): BaseProvider {
 // --- createStoryboardToolBridge ----------------------------------------------
 
 describe("createStoryboardToolBridge", () => {
-  it("exposes exactly the 11 ui_storyboard_* tools", () => {
+  it("exposes exactly the 12 ui_storyboard_* tools", () => {
     const bridge = createStoryboardToolBridge();
     const names = bridge.tools.map((t) => t.name).sort();
     expect(names).toEqual(
       [
         "ui_storyboard_get_state",
         "ui_storyboard_set_screenplay",
+        "ui_storyboard_set_entities",
         "ui_storyboard_add_shot",
         "ui_storyboard_update_shot",
         "ui_storyboard_generate_keyframe",
@@ -74,7 +75,7 @@ describe("createStoryboardToolBridge", () => {
         "ui_storyboard_select_shot"
       ].sort()
     );
-    expect(names).toHaveLength(11);
+    expect(names).toHaveLength(12);
   });
 
   it("rejects a set_screenplay call with an invalid object", async () => {
@@ -320,6 +321,29 @@ describe("createStoryboardToolBridge", () => {
     await expect(
       byName["ui_storyboard_extract_script"].execute({})
     ).rejects.toThrow(/nothing to extract/);
+  });
+
+  it("casts entities from a screenplay and from set_entities", async () => {
+    const bridge = createStoryboardToolBridge();
+    const byName = Object.fromEntries(bridge.tools.map((t) => [t.name, t]));
+
+    const loaded = (await byName["ui_storyboard_set_screenplay"].execute({
+      screenplay: {
+        ...SAMPLE_SCREENPLAY,
+        entityIds: ["ent-buddy", "ent-winston"]
+      } as unknown as Record<string, unknown>
+    })) as { entityIds: string[] };
+    expect(loaded.entityIds).toEqual(["ent-buddy", "ent-winston"]);
+
+    const recast = (await byName["ui_storyboard_set_entities"].execute({
+      entity_ids: ["ent-coco"]
+    })) as { entityIds: string[] };
+    expect(recast.entityIds).toEqual(["ent-coco"]);
+
+    const state = (await byName["ui_storyboard_get_state"].execute({})) as {
+      entityIds: string[];
+    };
+    expect(state.entityIds).toEqual(["ent-coco"]);
   });
 
   it("loads a valid screenplay, replacing existing shots", async () => {

--- a/web/src/components/storyboard/__tests__/storyboardAgentBridge.test.ts
+++ b/web/src/components/storyboard/__tests__/storyboardAgentBridge.test.ts
@@ -9,6 +9,7 @@ import type { StoryboardAgentHandler } from "../storyboardAgentBridge";
 const makeMockHandler = (): StoryboardAgentHandler => ({
   getSnapshot: jest.fn(),
   setScreenplay: jest.fn(),
+  setEntityIds: jest.fn(),
   addShot: jest.fn(),
   updateShot: jest.fn(),
   generateKeyframe: jest.fn(),

--- a/web/src/components/storyboard/storyboardAgentBridge.ts
+++ b/web/src/components/storyboard/storyboardAgentBridge.ts
@@ -47,6 +47,11 @@ export interface StoryboardSnapshot {
   brief: string;
   style: string;
   aspectRatio: string;
+  /**
+   * Library entity (asset) ids cast on this board. Their descriptors season
+   * every shot prompt, subject to each shot's own `entity_ids` override.
+   */
+  entityIds: string[];
   /** True once a screenplay has been loaded onto the board. */
   hasScreenplay: boolean;
   /** Script this board's words come from, or null when it is unlinked. */
@@ -111,6 +116,8 @@ export interface StoryboardUpdateShotPatch {
 export interface StoryboardAgentHandler {
   getSnapshot: () => StoryboardSnapshot;
   setScreenplay: (screenplay: Screenplay) => StoryboardSnapshot;
+  /** Replace the board's entity cast. An empty array clears it. */
+  setEntityIds: (entityIds: string[]) => StoryboardSnapshot;
   addShot: (input: StoryboardAddShotInput) => StoryboardShotNode;
   updateShot: (
     target: string,

--- a/web/src/hooks/storyboard/useStoryboardAgentBridge.ts
+++ b/web/src/hooks/storyboard/useStoryboardAgentBridge.ts
@@ -101,6 +101,7 @@ export const useStoryboardAgentBridge = (boardId: string): void => {
         brief: board.brief,
         style: board.style,
         aspectRatio: board.aspectRatio,
+        entityIds: board.entityIds,
         hasScreenplay: board.screenplay !== null,
         scriptId: linkedScriptId(board),
         selectedShotId: board.activeShotId,
@@ -113,6 +114,12 @@ export const useStoryboardAgentBridge = (boardId: string): void => {
 
       setScreenplay(screenplay: Screenplay) {
         store().setScreenplay(boardId, screenplay);
+        return getSnapshot();
+      },
+
+      setEntityIds(entityIds: string[]) {
+        requireBoard();
+        store().setEntityIds(boardId, entityIds);
         return getSnapshot();
       },
 

--- a/web/src/lib/tools/__tests__/storyboardTools.test.ts
+++ b/web/src/lib/tools/__tests__/storyboardTools.test.ts
@@ -33,6 +33,7 @@ const snapshot = (): StoryboardSnapshot => ({
   brief: "A short film",
   style: "noir",
   aspectRatio: "16:9",
+  entityIds: [],
   hasScreenplay: true,
   scriptId: null,
   selectedShotId: null,
@@ -42,6 +43,7 @@ const snapshot = (): StoryboardSnapshot => ({
 const createMockHandler = (): jest.Mocked<StoryboardAgentHandler> => ({
   getSnapshot: jest.fn(),
   setScreenplay: jest.fn(),
+  setEntityIds: jest.fn(),
   addShot: jest.fn(),
   updateShot: jest.fn(),
   generateKeyframe: jest.fn(),
@@ -72,6 +74,7 @@ describe("ui_storyboard_* tools", () => {
       expect.arrayContaining([
         "ui_storyboard_get_state",
         "ui_storyboard_set_screenplay",
+        "ui_storyboard_set_entities",
         "ui_storyboard_add_shot",
         "ui_storyboard_update_shot",
         "ui_storyboard_generate_keyframe",
@@ -348,6 +351,34 @@ describe("ui_storyboard_* tools", () => {
       expect(play.style_bible).toBe("noir, high contrast");
     });
 
+    it("carries the screenplay's entityIds through as `entity_ids`", async () => {
+      const handler = createMockHandler();
+      handler.setScreenplay.mockReturnValue(snapshot());
+      setStoryboardAgentHandler(BOARD_ID, handler);
+
+      await FrontendToolRegistry.call(
+        "ui_storyboard_set_screenplay",
+        {
+          storyboard_id: BOARD_ID,
+          screenplay: {
+            ...agentScreenplay,
+            entityIds: ["ent-buddy", "ent-winston"],
+            shots: [
+              { ...agentScreenplay.shots[0], entityIds: ["ent-buddy"] },
+              agentScreenplay.shots[1]
+            ]
+          }
+        },
+        "tc-sp-entities",
+        ctx
+      );
+
+      const play = handler.setScreenplay.mock.calls[0][0];
+      expect(play.entity_ids).toEqual(["ent-buddy", "ent-winston"]);
+      expect(play.shots[0].entity_ids).toEqual(["ent-buddy"]);
+      expect(play.shots[1].entity_ids).toBeUndefined();
+    });
+
     it("rejects a shot with no action, naming its position", async () => {
       const handler = createMockHandler();
       setStoryboardAgentHandler(BOARD_ID, handler);
@@ -470,6 +501,65 @@ describe("ui_storyboard_* tools", () => {
     );
 
     expect(handler.selectShot).toHaveBeenCalledWith(null);
+  });
+
+  describe("ui_storyboard_set_entities", () => {
+    it("casts the entities through the handler and reports them back", async () => {
+      const handler = createMockHandler();
+      handler.setEntityIds.mockReturnValue({
+        ...snapshot(),
+        entityIds: ["ent-buddy", "ent-coco"]
+      });
+      setStoryboardAgentHandler(BOARD_ID, handler);
+
+      const result = (await FrontendToolRegistry.call(
+        "ui_storyboard_set_entities",
+        { storyboard_id: BOARD_ID, entity_ids: ["ent-buddy", "ent-coco"] },
+        "tc-ent-1",
+        ctx
+      )) as { ok: boolean } & StoryboardSnapshot;
+
+      expect(handler.setEntityIds).toHaveBeenCalledWith([
+        "ent-buddy",
+        "ent-coco"
+      ]);
+      expect(result.ok).toBe(true);
+      expect(result.entityIds).toEqual(["ent-buddy", "ent-coco"]);
+    });
+
+    it("clears the cast with an empty array", async () => {
+      const handler = createMockHandler();
+      handler.setEntityIds.mockReturnValue(snapshot());
+      setStoryboardAgentHandler(BOARD_ID, handler);
+
+      await FrontendToolRegistry.call(
+        "ui_storyboard_set_entities",
+        { storyboard_id: BOARD_ID, entity_ids: [] },
+        "tc-ent-2",
+        ctx
+      );
+
+      expect(handler.setEntityIds).toHaveBeenCalledWith([]);
+    });
+
+    it("fails the call when the cast does not persist", async () => {
+      const handler = createMockHandler();
+      handler.setEntityIds.mockReturnValue(snapshot());
+      setStoryboardAgentHandler(BOARD_ID, handler);
+      registerStoryboardSaver(BOARD_ID, async () => ({
+        ok: false,
+        error: "offline"
+      }));
+
+      await expect(
+        FrontendToolRegistry.call(
+          "ui_storyboard_set_entities",
+          { storyboard_id: BOARD_ID, entity_ids: ["ent-buddy"] },
+          "tc-ent-3",
+          ctx
+        )
+      ).rejects.toThrow(/entity cast.*did not persist: offline/i);
+    });
   });
 
   describe("script link tools", () => {

--- a/web/src/lib/tools/builtin/storyboard.ts
+++ b/web/src/lib/tools/builtin/storyboard.ts
@@ -121,7 +121,7 @@ const shotStatusEnum = z.enum([
 FrontendToolRegistry.register({
   name: "ui_storyboard_get_state",
   description:
-    "Read the specified storyboard: title, brief, style, aspect ratio, whether a screenplay is loaded, the selected shot, and every shot with its index, slug, action, camera, motion, duration, status, and whether it has a rendered keyframe/clip. Call this first to discover the shot ids/indexes the other tools need.",
+    "Read the specified storyboard: title, brief, style, aspect ratio, the entity ids cast on the board, whether a screenplay is loaded, the selected shot, and every shot with its index, slug, action, camera, motion, duration, status, and whether it has a rendered keyframe/clip. Call this first to discover the shot ids/indexes the other tools need.",
   parameters: z.object({ storyboard_id: storyboardIdParam }),
   async execute({ storyboard_id }) {
     const snapshot = getStoryboardAgentHandler(storyboard_id).getSnapshot();
@@ -132,7 +132,7 @@ FrontendToolRegistry.register({
 FrontendToolRegistry.register({
   name: "ui_storyboard_set_screenplay",
   description:
-    "Load a full screenplay onto the specified storyboard, replacing its shots. `screenplay` is a Screenplay object ({ type:'screenplay', title, shots: Shot[], ... }) — typically the output of the Director node. Shot ids, indexes and statuses are filled in for you; every shot needs an `action`.",
+    "Load a full screenplay onto the specified storyboard, replacing its shots. `screenplay` is a Screenplay object ({ type:'screenplay', title, shots: Shot[], ... }) — typically the output of the Director node. Shot ids, indexes and statuses are filled in for you; every shot needs an `action`. A top-level `entityIds` casts those entities on the board (use ui_storyboard_set_entities to change the cast without replacing the shots); a shot's own `entityIds` overrides the board cast for that shot.",
   parameters: z.object({
     storyboard_id: storyboardIdParam,
     screenplay: screenplayParam
@@ -144,6 +144,31 @@ FrontendToolRegistry.register({
     const snapshot =
       getStoryboardAgentHandler(storyboard_id).setScreenplay(play);
     const persisted = await persistBoard(storyboard_id, "The screenplay");
+    return {
+      ok: true,
+      ...snapshot,
+      ...persisted,
+      url: docUrl("storyboard", storyboard_id)
+    };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_storyboard_set_entities",
+  description:
+    "Cast library entities (characters, locations, styles, props) on the specified storyboard, replacing the current selection. Their descriptors and reference images season every shot's still and clip prompt — a style or location applies to every shot, a character or prop applies to the shots whose text names it. Pass an empty array to clear the cast. Discover ids with ui_entity_list.",
+  parameters: z.object({
+    storyboard_id: storyboardIdParam,
+    entity_ids: z
+      .array(z.string())
+      .describe(
+        "Entity (asset) ids to cast on the board, replacing the current selection."
+      )
+  }),
+  async execute({ storyboard_id, entity_ids }) {
+    const snapshot =
+      getStoryboardAgentHandler(storyboard_id).setEntityIds(entity_ids);
+    const persisted = await persistBoard(storyboard_id, "The entity cast");
     return {
       ok: true,
       ...snapshot,

--- a/web/src/stores/storyboard/StoryboardStore.ts
+++ b/web/src/stores/storyboard/StoryboardStore.ts
@@ -471,6 +471,10 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
         title: screenplay.title || board.title,
         aspectRatio: screenplay.aspect_ratio ?? board.aspectRatio,
         style: screenplay.style_bible ?? board.style,
+        // The screenplay's cast becomes the board's cast: `entityIds` is what
+        // seasons every shot prompt, and a screenplay that names entities the
+        // board does not carry would generate them out.
+        entityIds: screenplay.entity_ids ?? board.entityIds,
         // An explicit `brief` wins. A logline fills an empty brief only — the
         // editor directs *from* the brief, so a returned logline must never
         // overwrite what the user wrote.

--- a/web/src/stores/storyboard/__tests__/StoryboardStore.test.ts
+++ b/web/src/stores/storyboard/__tests__/StoryboardStore.test.ts
@@ -319,6 +319,41 @@ describe("setScreenplay", () => {
     expect(board?.shots[0].duration_seconds).toBe(4);
   });
 
+  it("casts the screenplay's entity_ids on the board", () => {
+    const store = useStoryboardStore.getState();
+    store.ensureBoard(BOARD);
+    store.setScreenplay(BOARD, {
+      type: "screenplay",
+      id: "sp-1",
+      title: "Four Dogs",
+      entity_ids: ["ent-buddy", "ent-winston"],
+      shots: [play()]
+    });
+
+    // `entityIds` is what seasons each shot prompt — a screenplay that names
+    // its cast and leaves the board empty generates the entities out.
+    expect(useStoryboardStore.getState().boards[BOARD]?.entityIds).toEqual([
+      "ent-buddy",
+      "ent-winston"
+    ]);
+  });
+
+  it("keeps the board's cast when the screenplay names none", () => {
+    const store = useStoryboardStore.getState();
+    store.ensureBoard(BOARD);
+    store.setEntityIds(BOARD, ["ent-buddy"]);
+    store.setScreenplay(BOARD, {
+      type: "screenplay",
+      id: "sp-1",
+      title: "T",
+      shots: [play()]
+    });
+
+    expect(useStoryboardStore.getState().boards[BOARD]?.entityIds).toEqual([
+      "ent-buddy"
+    ]);
+  });
+
   it("fills an empty brief from the logline but never overwrites one", () => {
     const store = useStoryboardStore.getState();
     store.ensureBoard(BOARD);


### PR DESCRIPTION
## What changed

`ui_storyboard_set_screenplay` accepted a top-level `entityIds` — the storyboard-core skill contract documents it — and then dropped it. `setScreenplay` copied `title`, `aspect_ratio`, `style_bible` and `brief` from the screenplay onto the board but never its cast, so `board.entityIds` stayed empty. That field is what `entitiesForShot` reads, so every still and clip generated after such a call carried no entity descriptors and no reference images: the cast was generated out, silently. The board's cast also had no tool of its own in the browser — `ui_entity_apply` only seasons a prompt string the caller then sends itself, and the headless `edit_storyboard` `set_board` op is unavailable there — so an agent driving an open board could not cast entities at all. This makes the screenplay's cast land on the board, adds `ui_storyboard_set_entities` to recast without replacing shots, and reports `entityIds` from `ui_storyboard_get_state` so the cast is readable. The eval surface mirrors all three, so the headless twin scores models against the contract the browser now has.

## Verification

- [x] `npm run test:affected` — green except two failures from missing system packages in this sandbox, both unrelated to the diff and both documented in AGENTS.md:
  - `image-nodes` failed with `No WebGPU adapter available (Node/Dawn)`. Installed the ICD (`apt-get install -y mesa-vulkan-drivers`) and re-ran: `Test Files 24 passed (24) / Tests 229 passed (229)`.
  - `runtime` failed one file on `spawn ffmpeg ENOENT` (`tests/providers/video-frame-fallback.test.ts`); the other 163 files pass — `Tests 3117 passed | 13 skipped`.
  - Targeted suites for the changed code: web `500 passed` across `src/{components,hooks,stores}/storyboard` and `src/lib/tools`; `packages/agents` `storyboard-tool-loop` `18 passed`.
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 8/8 selfchecks passed` (run from `dist` as `npm run nodetool`)

The store test was inverted to prove it catches the reported bug. With the `setScreenplay` line removed:

```
- Array [
-   "ent-buddy",
-   "ent-winston",
- ]
+ Array []

  > 335 |     expect(useStoryboardStore.getState().boards[BOARD]?.entityIds).toEqual([

Tests: 1 failed, 20 skipped, 21 total
```

## Agent capabilities

No agent capability is added and no capability's declared contract changes — `ui_storyboard_set_entities` is a frontend tool in `web/src/lib/tools/builtin/`, not a `packages/agents` capability.

- [x] `npm run capabilities:check` passes — `capability table is current (248 capabilities)`

## New checks

No check, rule, or audit is added. The new tests are behavioral tests of the fix; the store one was observed failing without it, above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHoHbaHr3cN9EEVvy2aeVi)_