### PR TITLE
feat(support): report a failed provider call from the UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53356,6 +53356,7 @@
         "@nodetool-ai/protocol": "*"
       },
       "devDependencies": {
+        "@nodetool-ai/atlascloud-nodes": "*",
         "typescript": "^5.7.2",
         "vitest": "^4.1.2"
       },

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -614,6 +614,50 @@ export const llmCallUpdateSchema = z.object({
 });
 export type LLMCallUpdate = z.infer<typeof llmCallUpdateSchema>;
 
+/**
+ * One provider call that failed, with everything a maintainer needs to
+ * reproduce it. Emitted once per failure from `BaseProvider`'s central failure
+ * paths, so chat, workflow nodes and the media surfaces all report the same
+ * record instead of each re-deriving it from the error prose.
+ */
+export const providerCallFailedSchema = z.object({
+  type: z.literal("provider_call_failed"),
+  /** Provider id as the runtime knows it (e.g. `openai`). */
+  provider: z.string(),
+  /** Model the call asked for, when it named one. */
+  model: z.string().nullable().optional(),
+  /** Provider method that threw (e.g. `generateMessages`, `textToImage`). */
+  operation: z.string(),
+  /**
+   * Failure class, derived once on the server: `auth`, `payment`,
+   * `not_found`, `rate_limit`, `timeout`, `server`, `network`, `client` or
+   * `unknown`. Surfaces branch on this instead of matching prose.
+   */
+  kind: z.string(),
+  /** HTTP status, when the failure carried one. */
+  status: z.number().nullable().optional(),
+  /** Error message as the provider wrote it, plus NodeTool's remedy hint. */
+  message: z.string(),
+  /** Error class name, when the provider threw a typed error. */
+  error_name: z.string().nullable().optional(),
+  /** Provider-side request id, when the error carried one. */
+  request_id: z.string().nullable().optional(),
+  /** Milliseconds from the call starting to the throw. */
+  duration_ms: z.number().nullable().optional(),
+  /** `wire` when the payload below is the body the provider sent. */
+  request_source: z.string().nullable().optional(),
+  /** The request, redacted and size-bounded. Secrets never reach this. */
+  request: z.unknown().nullable().optional(),
+  /**
+   * The run the call belonged to. Stamped downstream by the relay, not by the
+   * provider — which knows nothing about workflows.
+   */
+  workflow_id: z.string().nullable().optional(),
+  job_id: z.string().nullable().optional(),
+  timestamp: z.string()
+});
+export type ProviderCallFailed = z.infer<typeof providerCallFailedSchema>;
+
 // ---------------------------------------------------------------------------
 // Unified websocket command/control/update types
 // ---------------------------------------------------------------------------
@@ -933,6 +977,7 @@ export const processingMessageSchema = z.discriminatedUnion("type", [
   chunkSchema,
   predictionSchema,
   llmCallUpdateSchema,
+  providerCallFailedSchema,
   todoUpdateSchema,
   supervisorEscalationSchema,
   supervisorDecisionSchema
@@ -981,6 +1026,7 @@ export const processingMessageSchemas = {
   chunk: chunkSchema,
   prediction: predictionSchema,
   llm_call: llmCallUpdateSchema,
+  provider_call_failed: providerCallFailedSchema,
   todo_update: todoUpdateSchema,
   supervisor_escalation: supervisorEscalationSchema,
   supervisor_decision: supervisorDecisionSchema
@@ -1062,6 +1108,11 @@ export function isPrediction(value: unknown): value is Prediction {
 }
 export function isLLMCallUpdate(value: unknown): value is LLMCallUpdate {
   return hasType(value, "llm_call");
+}
+export function isProviderCallFailed(
+  value: unknown
+): value is ProviderCallFailed {
+  return hasType(value, "provider_call_failed");
 }
 export function isTodoUpdate(value: unknown): value is TodoUpdate {
   return hasType(value, "todo_update");

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -65,6 +65,10 @@ import {
 } from "../type-predicates.js";
 import { logProviderRequestFailure } from "./provider-request-log.js";
 import { annotateProviderError } from "./provider-error.js";
+import {
+  buildProviderCallFailure,
+  type ProviderCallFailureInput
+} from "./provider-call-failure.js";
 import { applyEntityReferences } from "./entity-references.js";
 import {
   expandVideoContentAsFrames,
@@ -316,6 +320,31 @@ export abstract class BaseProvider {
   }
 
   /**
+   * Record a failed provider call: a server-side log with the exact request,
+   * and a `provider_call_failed` message so the surface showing the failure
+   * can report it without the user copying a status code out of a toast.
+   *
+   * One call, so the log and the report can never disagree about what failed.
+   * Public because the modality generator wrapper below is a free function.
+   * @internal
+   */
+  recordCallFailure(input: Omit<ProviderCallFailureInput, "provider">): void {
+    logProviderRequestFailure({
+      provider: this.provider,
+      model: input.model ?? "unknown",
+      request: input.request,
+      nodetoolArgs: input.nodetoolArgs,
+      error: input.error
+    });
+    if (!this._emitMessage) return;
+    const failure = buildProviderCallFailure({
+      ...input,
+      provider: this.provider
+    });
+    if (failure) this.emitMessage(failure);
+  }
+
+  /**
    * Record the exact payload this provider is about to send to the upstream
    * API. Call this right before the network request in `generateMessage` /
    * `generateMessages`. On failure, the traced wrappers log precisely what was
@@ -362,6 +391,7 @@ export abstract class BaseProvider {
           // Central entity expansion: descriptors into the prompt, reference
           // images onto the source list, before the concrete provider runs.
           const args = applyEntityReferences(name, rawArgs);
+          const startedAt = Date.now();
           try {
             return await original.apply(this, args);
           } catch (err) {
@@ -370,12 +400,13 @@ export abstract class BaseProvider {
               model: extractModelId(args)
             });
             if (!alreadyActive) {
-              logProviderRequestFailure({
-                provider: this.provider,
+              this.recordCallFailure({
                 model: extractModelId(args),
+                operation: name,
                 request: peekLastRequest(),
                 nodetoolArgs: args,
-                error: err
+                error: err,
+                startedAt
               });
             }
             throw err;
@@ -391,7 +422,7 @@ export abstract class BaseProvider {
       }
       const original = fn as (...args: unknown[]) => AsyncGenerator<unknown>;
       Reflect.set(this, name, (...args: unknown[]): AsyncGenerator<unknown> =>
-        wrapModalityGenerator(this, original, args)
+        wrapModalityGenerator(this, original, args, name)
       );
     }
   }
@@ -779,6 +810,7 @@ export abstract class BaseProvider {
     let error: string | undefined;
     let usage: LlmUsage | null = null;
     let requestPayload: unknown = null;
+    const startedAt = Date.now();
     try {
       // withUsageCapture creates a per-call AsyncLocalStorage slot so
       // trackUsage() in the provider hands its numbers back to us.
@@ -799,16 +831,17 @@ export abstract class BaseProvider {
         model: args.model
       });
       error = String(err);
-      logProviderRequestFailure({
-        provider: this.provider,
+      this.recordCallFailure({
         model: args.model,
+        operation: "generateMessage",
         request: requestPayload,
         nodetoolArgs: {
           model: args.model,
           messages: args.messages,
           tools: args.tools
         },
-        error: err
+        error: err,
+        startedAt
       });
       throw err;
     } finally {
@@ -899,6 +932,7 @@ export abstract class BaseProvider {
       ? this._tracedStream(args, tracer)
       : this.generateMessages(args);
     let exhausted = false;
+    const startedAt = Date.now();
 
     try {
       while (true) {
@@ -932,16 +966,17 @@ export abstract class BaseProvider {
         model: args.model
       });
       error = String(err);
-      logProviderRequestFailure({
-        provider: this.provider,
+      this.recordCallFailure({
         model: args.model,
+        operation: "generateMessages",
         request: getRequest(),
         nodetoolArgs: {
           model: args.model,
           messages: args.messages,
           tools: args.tools
         },
-        error: err
+        error: err,
+        startedAt
       });
       throw err;
     } finally {
@@ -1792,9 +1827,11 @@ function extractModelId(args: unknown[]): string {
 async function* wrapModalityGenerator(
   provider: BaseProvider,
   original: (...args: unknown[]) => AsyncGenerator<unknown>,
-  args: unknown[]
+  args: unknown[],
+  operationName: string
 ): AsyncGenerator<unknown> {
   const { runInSlot, getRequest } = createUsageSlot();
+  const startedAt = Date.now();
   const source = original.apply(provider, args);
   let exhausted = false;
   try {
@@ -1811,12 +1848,13 @@ async function* wrapModalityGenerator(
       provider: provider.provider,
       model: extractModelId(args)
     });
-    logProviderRequestFailure({
-      provider: provider.provider,
+    provider.recordCallFailure({
       model: extractModelId(args),
+      operation: operationName,
       request: getRequest(),
       nodetoolArgs: args,
-      error: err
+      error: err,
+      startedAt
     });
     throw err;
   } finally {

--- a/packages/runtime/src/providers/provider-call-failure.ts
+++ b/packages/runtime/src/providers/provider-call-failure.ts
@@ -1,0 +1,160 @@
+/**
+ * Turns a thrown provider error into the `provider_call_failed` message the
+ * UI reports with.
+ *
+ * A user who hits a 429 sees prose. What a maintainer needs is the provider,
+ * the model, the status, the request id and the payload that was sent — and
+ * asking the user to reconstruct that from a toast is how bug reports arrive
+ * useless. {@link buildProviderCallFailure} assembles it once, at the same
+ * place {@link logProviderRequestFailure} logs it, so every surface reports
+ * the same record.
+ */
+
+import type { ProviderCallFailed } from "@nodetool-ai/protocol";
+import { isObjectLike, isString } from "../type-predicates.js";
+import { httpStatusFromError } from "./provider-error.js";
+import { sanitizeForLog } from "./provider-request-log.js";
+
+/** Strings in the reported request are capped harder than in a server log. */
+const WIRE_SANITIZE = {
+  maxStringLength: 400,
+  maxArrayLength: 40,
+  maxDepth: 8
+} as const;
+
+/**
+ * Failure classes a surface can branch on. Derived from the status when there
+ * is one, otherwise from the error's `code`/`name`.
+ */
+export type ProviderFailureKind =
+  | "auth"
+  | "payment"
+  | "not_found"
+  | "rate_limit"
+  | "timeout"
+  | "server"
+  | "network"
+  | "client"
+  | "unknown";
+
+const NETWORK_CODES = new Set([
+  "ENOTFOUND",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EAI_AGAIN",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ETIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "CERT_HAS_EXPIRED"
+]);
+
+export function providerFailureKind(error: unknown): ProviderFailureKind {
+  const status = httpStatusFromError(error);
+  if (status !== null) {
+    if (status === 401 || status === 403) return "auth";
+    if (status === 402) return "payment";
+    if (status === 404) return "not_found";
+    if (status === 429) return "rate_limit";
+    if (status === 408 || status === 504) return "timeout";
+    if (status >= 500) return "server";
+    if (status >= 400) return "client";
+  }
+  if (!isObjectLike(error)) return "unknown";
+  const candidate = error as { code?: unknown; name?: unknown; message?: unknown };
+  const code = isString(candidate.code) ? candidate.code : "";
+  if (NETWORK_CODES.has(code)) return "network";
+  const name = isString(candidate.name) ? candidate.name : "";
+  if (name === "TimeoutError") return "timeout";
+  const message = isString(candidate.message) ? candidate.message : "";
+  if (/fetch failed|network error|socket hang up/i.test(message)) {
+    return "network";
+  }
+  return "unknown";
+}
+
+/**
+ * Provider-side request id, under any of the names the SDKs use for it. It is
+ * what a provider's support asks for first, so it is worth digging out.
+ */
+export function providerRequestId(error: unknown): string | null {
+  if (!isObjectLike(error)) return null;
+  const candidate = error as Record<string, unknown>;
+  const headers = isObjectLike(candidate.headers)
+    ? (candidate.headers as Record<string, unknown>)
+    : undefined;
+  const sources: unknown[] = [
+    candidate.request_id,
+    candidate.requestID,
+    candidate.requestId,
+    headers?.["x-request-id"],
+    headers?.["x-amzn-requestid"],
+    headers?.["cf-ray"]
+  ];
+  for (const value of sources) {
+    if (isString(value) && value.trim() !== "") return value;
+  }
+  return null;
+}
+
+export interface ProviderCallFailureInput {
+  provider: string;
+  model?: string;
+  /** Provider method that threw (e.g. `generateMessages`, `textToImage`). */
+  operation: string;
+  /** The wire payload the provider recorded, when it recorded one. */
+  request?: unknown;
+  /** NodeTool-level args, reported when no wire payload exists. */
+  nodetoolArgs?: unknown;
+  error: unknown;
+  /** `Date.now()` when the call started, for the elapsed time. */
+  startedAt?: number;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** The message a surface reports with. `null` for a caller cancellation. */
+export function buildProviderCallFailure(
+  input: ProviderCallFailureInput,
+  now: Date = new Date()
+): ProviderCallFailed | null {
+  if (isAbort(input.error)) return null;
+
+  const hasWire = input.request !== undefined && input.request !== null;
+  const payload = hasWire ? input.request : input.nodetoolArgs;
+  const status = httpStatusFromError(input.error);
+  const name = isObjectLike(input.error)
+    ? (input.error as { name?: unknown }).name
+    : undefined;
+
+  return {
+    type: "provider_call_failed",
+    provider: input.provider,
+    model: input.model && input.model !== "unknown" ? input.model : null,
+    operation: input.operation,
+    kind: providerFailureKind(input.error),
+    status,
+    message: errorMessage(input.error),
+    error_name: isString(name) ? name : null,
+    request_id: providerRequestId(input.error),
+    duration_ms:
+      input.startedAt !== undefined ? Date.now() - input.startedAt : null,
+    request_source: payload === undefined ? null : hasWire ? "wire" : "nodetool-args",
+    request: payload === undefined ? null : sanitizeForLog(payload, WIRE_SANITIZE),
+    // Left null: the relay stamps the run onto every outbound message, and a
+    // provider has no idea which workflow or job called it.
+    workflow_id: null,
+    job_id: null,
+    timestamp: now.toISOString()
+  };
+}
+
+/** A cancelled call is not a failure to report. */
+function isAbort(error: unknown): boolean {
+  if (!isObjectLike(error)) return false;
+  const candidate = error as { name?: unknown; code?: unknown };
+  if (isString(candidate.name) && /abort/i.test(candidate.name)) return true;
+  return candidate.code === 20 || candidate.code === "ABORT_ERR";
+}

--- a/packages/runtime/tests/providers/base-provider-call-failure.test.ts
+++ b/packages/runtime/tests/providers/base-provider-call-failure.test.ts
@@ -1,0 +1,135 @@
+/**
+ * BaseProvider emits one `provider_call_failed` per failed call, from every
+ * failure path it wraps — chat and the media modalities alike. That message is
+ * what the bug reporter attaches, so a surface never has to re-derive the
+ * provider, model and status from the error prose.
+ */
+import { describe, it, expect } from "vitest";
+import { BaseProvider } from "../../src/providers/base-provider.js";
+import type {
+  ImageBytes,
+  Message,
+  ProviderStreamItem,
+  ProviderTool
+} from "../../src/providers/types.js";
+
+function rateLimited(): Error {
+  return Object.assign(new Error("429 Too Many Requests"), {
+    status: 429,
+    request_id: "req_zz"
+  });
+}
+
+class FailingProvider extends BaseProvider {
+  constructor() {
+    super("test");
+  }
+
+  async generateMessage(_args: {
+    messages: Message[];
+    model: string;
+    tools?: ProviderTool[];
+  }): Promise<Message> {
+    throw rateLimited();
+  }
+
+  async *generateMessages(_args: {
+    messages: Message[];
+    model: string;
+    tools?: ProviderTool[];
+  }): AsyncGenerator<ProviderStreamItem> {
+    throw rateLimited();
+    yield { type: "chunk", content: "", done: true };
+  }
+
+  async textToImage(_params: {
+    model: { id: string };
+    prompt: string;
+  }): Promise<ImageBytes> {
+    throw rateLimited();
+  }
+}
+
+function collect(provider: BaseProvider): Record<string, unknown>[] {
+  const messages: Record<string, unknown>[] = [];
+  provider.setMessageEmitter((msg) =>
+    messages.push(msg as Record<string, unknown>)
+  );
+  return messages;
+}
+
+const chatArgs = {
+  messages: [{ role: "user", content: "hi" }] as Message[],
+  model: "test-model"
+};
+
+describe("BaseProvider provider_call_failed", () => {
+  it("reports a failed non-streaming chat call", async () => {
+    const provider = new FailingProvider();
+    const messages = collect(provider);
+
+    await expect(provider.generateMessageTraced(chatArgs)).rejects.toThrow();
+
+    const failure = messages.find(
+      (msg) => msg.type === "provider_call_failed"
+    );
+    expect(failure).toMatchObject({
+      provider: "test",
+      model: "test-model",
+      operation: "generateMessage",
+      kind: "rate_limit",
+      status: 429,
+      request_id: "req_zz"
+    });
+  });
+
+  it("reports a failed streaming chat call", async () => {
+    const provider = new FailingProvider();
+    const messages = collect(provider);
+
+    await expect(async () => {
+      for await (const _item of provider.generateMessagesTraced(chatArgs)) {
+        // drain
+      }
+    }).rejects.toThrow();
+
+    expect(
+      messages.find((msg) => msg.type === "provider_call_failed")
+    ).toMatchObject({ operation: "generateMessages", status: 429 });
+  });
+
+  it("reports a failed media call, naming the modality", async () => {
+    const provider = new FailingProvider();
+    const messages = collect(provider);
+
+    await expect(
+      provider.textToImage({ model: { id: "flux" }, prompt: "a red fox" })
+    ).rejects.toThrow();
+
+    expect(
+      messages.find((msg) => msg.type === "provider_call_failed")
+    ).toMatchObject({
+      operation: "textToImage",
+      model: "flux",
+      kind: "rate_limit"
+    });
+  });
+
+  it("reports nothing when the caller cancelled", async () => {
+    class AbortingProvider extends FailingProvider {
+      async textToImage(): Promise<ImageBytes> {
+        throw Object.assign(new Error("aborted"), { name: "AbortError" });
+      }
+    }
+    const provider = new AbortingProvider();
+    const messages = collect(provider);
+
+    await expect(
+      provider.textToImage({ model: { id: "flux" }, prompt: "x" })
+    ).rejects.toThrow();
+
+    expect(messages.some((msg) => msg.type === "provider_call_failed")).toBe(
+      false
+    );
+  });
+});

--- a/packages/runtime/tests/providers/provider-call-failure.test.ts
+++ b/packages/runtime/tests/providers/provider-call-failure.test.ts
@@ -1,0 +1,149 @@
+/**
+ * The `provider_call_failed` record a surface reports with. What matters is
+ * that the fields a maintainer asks for — status, failure class, provider
+ * request id, elapsed — survive, that a cancelled call produces nothing, and
+ * that no credential rides along in the request.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  buildProviderCallFailure,
+  providerFailureKind,
+  providerRequestId
+} from "../../src/providers/provider-call-failure.js";
+
+function httpError(status: number, message = "upstream said no"): Error {
+  return Object.assign(new Error(message), { status });
+}
+
+describe("providerFailureKind", () => {
+  it.each([
+    [401, "auth"],
+    [403, "auth"],
+    [402, "payment"],
+    [404, "not_found"],
+    [429, "rate_limit"],
+    [408, "timeout"],
+    [504, "timeout"],
+    [500, "server"],
+    [503, "server"],
+    [422, "client"]
+  ])("classifies %i as %s", (status, kind) => {
+    expect(providerFailureKind(httpError(status))).toBe(kind);
+  });
+
+  it("classifies a dropped connection as a network failure", () => {
+    expect(
+      providerFailureKind(Object.assign(new Error("boom"), { code: "ECONNRESET" }))
+    ).toBe("network");
+    expect(providerFailureKind(new Error("fetch failed"))).toBe("network");
+  });
+
+  it("reads a status out of the message when the error carries no field", () => {
+    expect(providerFailureKind(new Error("429 Too Many Requests"))).toBe(
+      "rate_limit"
+    );
+  });
+
+  it("says unknown rather than guessing", () => {
+    expect(providerFailureKind(new Error("something went sideways"))).toBe(
+      "unknown"
+    );
+  });
+});
+
+describe("providerRequestId", () => {
+  it("reads the id under any of the names the SDKs use", () => {
+    expect(
+      providerRequestId(Object.assign(new Error("x"), { request_id: "req_1" }))
+    ).toBe("req_1");
+    expect(
+      providerRequestId(Object.assign(new Error("x"), { requestID: "req_2" }))
+    ).toBe("req_2");
+    expect(
+      providerRequestId(
+        Object.assign(new Error("x"), { headers: { "x-request-id": "req_3" } })
+      )
+    ).toBe("req_3");
+  });
+
+  it("is null when the error carries none", () => {
+    expect(providerRequestId(new Error("x"))).toBeNull();
+  });
+});
+
+describe("buildProviderCallFailure", () => {
+  const base = {
+    provider: "openai",
+    model: "gpt-5.4-mini",
+    operation: "generateMessages"
+  };
+
+  it("carries the whole call", () => {
+    const error = Object.assign(new Error("429 slow down"), {
+      status: 429,
+      name: "RateLimitError",
+      request_id: "req_abc"
+    });
+    const failure = buildProviderCallFailure(
+      {
+        ...base,
+        error,
+        request: { model: "gpt-5.4-mini", messages: [] },
+        startedAt: Date.now() - 50
+      },
+      new Date("2026-01-02T03:04:05.000Z")
+    );
+
+    expect(failure).not.toBeNull();
+    expect(failure).toMatchObject({
+      type: "provider_call_failed",
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      operation: "generateMessages",
+      kind: "rate_limit",
+      status: 429,
+      error_name: "RateLimitError",
+      request_id: "req_abc",
+      request_source: "wire",
+      timestamp: "2026-01-02T03:04:05.000Z"
+    });
+    expect(failure?.message).toContain("slow down");
+    expect(failure?.duration_ms).toBeGreaterThanOrEqual(50);
+  });
+
+  it("reports nothing for a cancelled call", () => {
+    const aborted = Object.assign(new Error("aborted"), { name: "AbortError" });
+    expect(buildProviderCallFailure({ ...base, error: aborted })).toBeNull();
+  });
+
+  it("redacts credentials out of the reported request", () => {
+    const failure = buildProviderCallFailure({
+      ...base,
+      error: httpError(401),
+      request: { api_key: "sk-live-abcdefghijklmnop", prompt: "a red fox" }
+    });
+    expect(JSON.stringify(failure?.request)).not.toContain(
+      "sk-live-abcdefghijklmnop"
+    );
+    expect(JSON.stringify(failure?.request)).toContain("a red fox");
+  });
+
+  it("marks the NodeTool args when no wire payload was recorded", () => {
+    const failure = buildProviderCallFailure({
+      ...base,
+      error: httpError(500),
+      nodetoolArgs: { model: "gpt-5.4-mini" }
+    });
+    expect(failure?.request_source).toBe("nodetool-args");
+  });
+
+  it("drops the placeholder model id rather than naming a model called unknown", () => {
+    const failure = buildProviderCallFailure({
+      provider: "fal_ai",
+      model: "unknown",
+      operation: "textToImage",
+      error: httpError(500)
+    });
+    expect(failure?.model).toBeNull();
+  });
+});

--- a/web/src/components/panels/FloatingToolBar.tsx
+++ b/web/src/components/panels/FloatingToolBar.tsx
@@ -5,7 +5,7 @@ import type { Theme } from "@mui/material/styles";
 import React, { memo, useCallback, useEffect } from "react";
 import { useMediaQuery } from "@mui/material";
 import { EditorMenu } from "../ui_primitives";
-import { Tooltip, AlertBanner, MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
+import { Tooltip, AlertBanner, FlexRow, MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
 import AddCircleIcon from "@mui/icons-material/AddCircle";
 import PlayArrow from "@mui/icons-material/PlayArrow";
 import StopIcon from "@mui/icons-material/Stop";
@@ -40,6 +40,7 @@ import { useFloatingToolbarPosition } from "../../hooks/useFloatingToolbarPositi
 import { useRunningTime } from "../../hooks/useRunningTime";
 import { formatRunningTime } from "../../utils/timeFormat";
 import useGlobalChatStore from "../../stores/GlobalChatStore";
+import ProviderFailureReportButton from "../support/ProviderFailureReportButton";
 import useCanvasChatDockStore, {
   MAX_DOCK_WIDTH,
   MIN_DOCK_WIDTH,
@@ -670,7 +671,10 @@ const FloatingToolBar: React.FC = memo(function FloatingToolBar() {
               onClose={clearChatError}
               sx={{ borderRadius: BORDER_RADIUS.xl }}
             >
-              {chatError}
+              <FlexRow align="center" gap={SPACING.sm}>
+                <span>{chatError}</span>
+                <ProviderFailureReportButton errorText={chatError} />
+              </FlexRow>
             </AlertBanner>
           )}
           <CanvasMediaComposer

--- a/web/src/components/support/BugReportDialog.tsx
+++ b/web/src/components/support/BugReportDialog.tsx
@@ -22,6 +22,11 @@ import {
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import useLogsStore from "../../stores/LogStore";
 import { useNotificationStore } from "../../stores/NotificationStore";
+import {
+  failuresForRun,
+  useProviderCallFailureStore
+} from "../../stores/ProviderCallFailureStore";
+import { formatProviderCallFailures } from "../../utils/providerCallReport";
 import { getConsoleEntries, formatConsoleEntries } from "../../utils/consoleCapture";
 import { getSystemInfo } from "../../utils/systemInfo";
 import {
@@ -72,6 +77,9 @@ const BugReportDialog = ({ context, onClose }: BugReportDialogProps) => {
     (state) => state.getCurrentWorkflow
   );
   const logs = useLogsStore((state) => state.logs);
+  const providerFailures = useProviderCallFailureStore(
+    (state) => state.failures
+  );
   const addNotification = useNotificationStore(
     (state) => state.addNotification
   );
@@ -95,11 +103,26 @@ const BugReportDialog = ({ context, onClose }: BugReportDialogProps) => {
     const consoleText =
       consoleEntries.length > 0 ? formatConsoleEntries(consoleEntries) : undefined;
 
+    // A surface that knows the failed call passes it in. One that only knows
+    // the run — a node error, a failed job — gets the calls that run made,
+    // so every report names the provider, model and status without the
+    // reporter digging them out.
+    const runFailures = failuresForRun(providerFailures, {
+      jobId: context.jobId,
+      workflowId: context.workflowId
+    });
+    const providerCallDetail =
+      context.providerCallDetail ??
+      (runFailures.length > 0
+        ? formatProviderCallFailures(runFailures)
+        : undefined);
+
     return buildBundleSections({
       context,
       systemInfo,
       workflow,
       nodeDetail: context.nodeDetail,
+      providerCallDetail,
       logText: logText || undefined,
       consoleText
     });

--- a/web/src/components/support/ProviderFailureReportButton.tsx
+++ b/web/src/components/support/ProviderFailureReportButton.tsx
@@ -1,0 +1,58 @@
+/**
+ * Report button for an error banner that shows only prose — the chat dock's,
+ * above all. When a provider call failed just before, the report carries that
+ * call: provider, model, HTTP status, the provider's request id, how long it
+ * ran, and the request that was sent.
+ *
+ * With no recent provider failure the button still works; the report is then
+ * the error text alone, which is what a transport failure has to offer.
+ */
+import { memo, useMemo } from "react";
+import ReportBugButton from "./ReportBugButton";
+import {
+  latestRecentFailure,
+  useProviderCallFailureStore
+} from "../../stores/ProviderCallFailureStore";
+import {
+  formatProviderCallFailure,
+  providerCallSummary
+} from "../../utils/providerCallReport";
+import type { BugReportContext } from "../../utils/bugReportBundle";
+
+interface ProviderFailureReportButtonProps {
+  /** The message the surface is showing. */
+  errorText: string;
+  label?: string;
+  className?: string;
+}
+
+const ProviderFailureReportButton = ({
+  errorText,
+  label,
+  className
+}: ProviderFailureReportButtonProps) => {
+  const failures = useProviderCallFailureStore((state) => state.failures);
+
+  const context = useMemo<BugReportContext>(() => {
+    const failure = latestRecentFailure(failures);
+    if (!failure) {
+      return { source: "manual", summary: errorText, errorText };
+    }
+    return {
+      source: "provider-call",
+      summary: providerCallSummary(failure),
+      errorText,
+      provider: failure.provider,
+      model: failure.model ?? undefined,
+      workflowId: failure.workflow_id ?? undefined,
+      jobId: failure.job_id ?? undefined,
+      providerCallDetail: formatProviderCallFailure(failure)
+    };
+  }, [failures, errorText]);
+
+  return (
+    <ReportBugButton context={context} label={label} className={className} />
+  );
+};
+
+export default memo(ProviderFailureReportButton);

--- a/web/src/components/support/__tests__/BugReportDialog.test.tsx
+++ b/web/src/components/support/__tests__/BugReportDialog.test.tsx
@@ -10,6 +10,10 @@ import {
   recordConsoleEntry,
   clearConsoleEntries
 } from "../../../utils/consoleCapture";
+import {
+  recordProviderCallFailure,
+  useProviderCallFailureStore
+} from "../../../stores/ProviderCallFailureStore";
 
 const workflow = {
   id: "wf-1",
@@ -64,6 +68,7 @@ describe("BugReportDialog", () => {
     downloaded = null;
     addNotification.mockClear();
     clearConsoleEntries();
+    useProviderCallFailureStore.getState().clear();
     window.URL.createObjectURL = jest.fn((blob: Blob) => {
       downloaded = blob;
       return "blob:mock";
@@ -116,6 +121,67 @@ describe("BugReportDialog", () => {
     // The graph travels with the report; the key inside it does not.
     expect(entries["workflow.json"]).toContain("My workflow");
     expect(entries["workflow.json"]).not.toContain("hunter2");
+  });
+
+  it("attaches the failed provider call the run made", async () => {
+    const user = userEvent.setup();
+    recordProviderCallFailure({
+      type: "provider_call_failed",
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      operation: "generateMessages",
+      kind: "rate_limit",
+      status: 429,
+      message: "429 Too Many Requests",
+      request_id: "req_abc123",
+      duration_ms: 812,
+      request_source: "wire",
+      request: { api_key: "sk-live-abcdefghijklmnopqr", prompt: "a red fox" },
+      workflow_id: "wf-1",
+      timestamp: "2026-01-02T03:04:05.000Z"
+    });
+
+    renderDialog({
+      source: "node-error",
+      errorText: "Agent failed",
+      nodeType: "nodetool.agents.Agent",
+      workflowId: "wf-1"
+    });
+
+    await user.type(screen.getByLabelText(/what went wrong/i), "the agent 429s");
+    await user.click(screen.getByRole("button", { name: /save report bundle/i }));
+
+    await waitFor(() => expect(downloaded).not.toBeNull());
+    const entries = await bundleEntries(downloaded!);
+
+    const call = entries["provider-call.txt"];
+    expect(call).toContain("Provider: openai");
+    expect(call).toContain("Model: gpt-5.4-mini");
+    expect(call).toContain("HTTP status: 429");
+    expect(call).toContain("Provider request id: req_abc123");
+    expect(call).toContain("a red fox");
+    expect(call).not.toContain("sk-live-abcdefghijklmnopqr");
+  });
+
+  it("attaches no provider call when the failure belongs to another run", async () => {
+    const user = userEvent.setup();
+    recordProviderCallFailure({
+      type: "provider_call_failed",
+      provider: "openai",
+      operation: "generateMessages",
+      kind: "server",
+      message: "500",
+      workflow_id: "wf-other",
+      timestamp: "2026-01-02T03:04:05.000Z"
+    });
+
+    renderDialog({ source: "node-error", errorText: "boom", workflowId: "wf-1" });
+    await user.type(screen.getByLabelText(/what went wrong/i), "unrelated");
+    await user.click(screen.getByRole("button", { name: /save report bundle/i }));
+
+    await waitFor(() => expect(downloaded).not.toBeNull());
+    const entries = await bundleEntries(downloaded!);
+    expect(Object.keys(entries)).not.toContain("provider-call.txt");
   });
 
   it("leaves out a section the reporter unchecks", async () => {

--- a/web/src/components/support/__tests__/ProviderFailureReportButton.test.tsx
+++ b/web/src/components/support/__tests__/ProviderFailureReportButton.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import ProviderFailureReportButton from "../ProviderFailureReportButton";
+import { useBugReportStore } from "../../../stores/BugReportStore";
+import {
+  recordProviderCallFailure,
+  useProviderCallFailureStore
+} from "../../../stores/ProviderCallFailureStore";
+
+const renderButton = (errorText: string) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ProviderFailureReportButton errorText={errorText} />
+    </ThemeProvider>
+  );
+
+beforeEach(() => {
+  useProviderCallFailureStore.getState().clear();
+  useBugReportStore.getState().close();
+});
+
+describe("ProviderFailureReportButton", () => {
+  it("reports the provider call behind the banner", async () => {
+    const user = userEvent.setup();
+    recordProviderCallFailure({
+      type: "provider_call_failed",
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      operation: "generateMessages",
+      kind: "auth",
+      status: 401,
+      message: "401 invalid x-api-key",
+      request_id: "req_9",
+      job_id: "job-7",
+      timestamp: "2026-01-02T03:04:05.000Z"
+    });
+
+    renderButton("401 invalid x-api-key");
+    await user.click(screen.getByRole("button", { name: /report/i }));
+
+    const context = useBugReportStore.getState().context;
+    expect(context).toMatchObject({
+      source: "provider-call",
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      jobId: "job-7"
+    });
+    expect(context?.summary).toBe(
+      "anthropic/claude-sonnet-5 401 — credentials rejected"
+    );
+    expect(context?.providerCallDetail).toContain("Provider request id: req_9");
+  });
+
+  it("still reports when no provider call was recorded", async () => {
+    const user = userEvent.setup();
+    renderButton("Failed to connect to chat service");
+    await user.click(screen.getByRole("button", { name: /report/i }));
+
+    expect(useBugReportStore.getState().context).toMatchObject({
+      source: "manual",
+      errorText: "Failed to connect to chat service"
+    });
+  });
+});

--- a/web/src/lib/websocket/GlobalWebSocketManager.ts
+++ b/web/src/lib/websocket/GlobalWebSocketManager.ts
@@ -11,10 +11,12 @@ import { FrontendToolRegistry } from "../tools/frontendTools";
 import { getFrontendToolRuntimeState } from "../tools/frontendToolRuntimeState";
 import { validateInboundMessage } from "./validateInboundMessage";
 import { getAppSessionToken } from "../appSession";
-import type {
-  RendererRegisteredMessage,
-  RendererToolCallMessage
+import {
+  isProviderCallFailed,
+  type RendererRegisteredMessage,
+  type RendererToolCallMessage
 } from "@nodetool-ai/protocol";
+import { recordProviderCallFailure } from "../../stores/ProviderCallFailureStore";
 
 /**
  * Base shape of every message routed through the WebSocket.
@@ -328,6 +330,12 @@ class GlobalWebSocketManager extends EventEmitter<GlobalWebSocketEvents> {
         console.error("GlobalWebSocketManager: Error handling system stats:", error);
       }
       return;
+    }
+
+    // Recorded centrally, then routed on: a failure from a chat turn carries
+    // no routing key, so a per-key subscriber would never see it.
+    if (isProviderCallFailed(message)) {
+      recordProviderCallFailure(message);
     }
 
     const routingKeys = new Set<string>();

--- a/web/src/lib/websocket/__tests__/GlobalWebSocketManager.providerFailure.test.ts
+++ b/web/src/lib/websocket/__tests__/GlobalWebSocketManager.providerFailure.test.ts
@@ -1,0 +1,59 @@
+import { globalWebSocketManager } from "../GlobalWebSocketManager";
+import { useProviderCallFailureStore } from "../../../stores/ProviderCallFailureStore";
+
+/**
+ * A provider failure from a chat turn carries no routing key, so recording it
+ * has to happen before routing — otherwise nothing on the frontend ever sees
+ * the call that broke.
+ */
+describe("GlobalWebSocketManager provider failures", () => {
+  beforeEach(() => {
+    useProviderCallFailureStore.getState().clear();
+  });
+
+  it("records a failure that names no run", () => {
+    globalWebSocketManager.deliverLocal({
+      type: "provider_call_failed",
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      operation: "generateMessages",
+      kind: "rate_limit",
+      status: 429,
+      message: "429 Too Many Requests",
+      timestamp: "2026-01-02T03:04:05.000Z"
+    });
+
+    const { failures } = useProviderCallFailureStore.getState();
+    expect(failures).toHaveLength(1);
+    expect(failures[0].provider).toBe("openai");
+  });
+
+  it("still routes the failure to a run's subscribers", () => {
+    const handler = jest.fn();
+    const unsubscribe = globalWebSocketManager.subscribe("job-3", handler);
+
+    globalWebSocketManager.deliverLocal({
+      type: "provider_call_failed",
+      provider: "fal_ai",
+      operation: "textToImage",
+      kind: "server",
+      message: "500",
+      job_id: "job-3",
+      timestamp: "2026-01-02T03:04:05.000Z"
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(useProviderCallFailureStore.getState().failures).toHaveLength(1);
+    unsubscribe();
+  });
+
+  it("leaves other message types alone", () => {
+    globalWebSocketManager.deliverLocal({
+      type: "node_update",
+      workflow_id: "wf-x",
+      node_id: "n1",
+      status: "completed"
+    });
+    expect(useProviderCallFailureStore.getState().failures).toHaveLength(0);
+  });
+});

--- a/web/src/stores/ProviderCallFailureStore.ts
+++ b/web/src/stores/ProviderCallFailureStore.ts
@@ -1,0 +1,86 @@
+/**
+ * Recent failed provider calls, kept so a bug report can carry the call
+ * itself — provider, model, HTTP status, the provider's request id, how long
+ * it ran and the (redacted) request — instead of the one line of prose that
+ * reaches the screen.
+ *
+ * Every `provider_call_failed` frame lands here, from any surface: a workflow
+ * node, a chat turn, a direct media generation. `GlobalWebSocketManager`
+ * records them centrally because the message carries no routing key of its
+ * own on the chat path.
+ */
+import { create } from "zustand";
+import type { ProviderCallFailed } from "@nodetool-ai/protocol";
+
+/** A run rarely fails more than a handful of calls; older ones are noise. */
+const MAX_FAILURES = 25;
+
+/**
+ * The frame plus when this browser saw it. `timestamp` is the server's clock;
+ * freshness checks here need the client's, so a skewed server cannot make a
+ * stale failure look current.
+ */
+export type RecordedProviderCallFailure = ProviderCallFailed & {
+  receivedAt: number;
+};
+
+interface ProviderCallFailureState {
+  /** Oldest first. */
+  failures: RecordedProviderCallFailure[];
+  record: (failure: ProviderCallFailed) => void;
+  clear: () => void;
+}
+
+export const useProviderCallFailureStore = create<ProviderCallFailureState>(
+  (set) => ({
+    failures: [],
+    record: (failure) =>
+      set((state) => ({
+        failures: [
+          ...state.failures,
+          { ...failure, receivedAt: Date.now() }
+        ].slice(-MAX_FAILURES)
+      })),
+    clear: () => set({ failures: [] })
+  })
+);
+
+/** Record from outside React — the websocket manager is not a component. */
+export const recordProviderCallFailure = (
+  failure: ProviderCallFailed
+): void => {
+  useProviderCallFailureStore.getState().record(failure);
+};
+
+/**
+ * The failures belonging to one run, newest last. A call that failed before
+ * the relay could stamp a job is matched on the workflow instead, so an
+ * editor run still reports the call that broke it.
+ */
+export function failuresForRun(
+  failures: RecordedProviderCallFailure[],
+  run: { jobId?: string; workflowId?: string }
+): RecordedProviderCallFailure[] {
+  if (!run.jobId && !run.workflowId) return [];
+  return failures.filter(
+    (failure) =>
+      (run.jobId !== undefined && failure.job_id === run.jobId) ||
+      (run.workflowId !== undefined && failure.workflow_id === run.workflowId)
+  );
+}
+
+/** How long a failure stays attachable to an error banner that names no run. */
+const RECENT_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * The last provider call to fail, if it failed recently enough to plausibly
+ * be what the caller is looking at. Surfaces that show a bare error string —
+ * the chat banner — have nothing else to key on.
+ */
+export function latestRecentFailure(
+  failures: RecordedProviderCallFailure[],
+  now = Date.now()
+): RecordedProviderCallFailure | undefined {
+  const last = failures[failures.length - 1];
+  return last && now - last.receivedAt <= RECENT_WINDOW_MS ? last : undefined;
+}

--- a/web/src/stores/__tests__/ProviderCallFailureStore.test.ts
+++ b/web/src/stores/__tests__/ProviderCallFailureStore.test.ts
@@ -1,0 +1,98 @@
+import type { ProviderCallFailed } from "@nodetool-ai/protocol";
+import {
+  failuresForRun,
+  latestRecentFailure,
+  recordProviderCallFailure,
+  useProviderCallFailureStore,
+  type RecordedProviderCallFailure
+} from "../ProviderCallFailureStore";
+
+function failure(overrides: Partial<ProviderCallFailed> = {}): ProviderCallFailed {
+  return {
+    type: "provider_call_failed",
+    provider: "openai",
+    model: "gpt-5.4-mini",
+    operation: "generateMessages",
+    kind: "rate_limit",
+    status: 429,
+    message: "slow down",
+    timestamp: "2026-01-02T03:04:05.000Z",
+    ...overrides
+  };
+}
+
+function recorded(
+  overrides: Partial<RecordedProviderCallFailure> = {}
+): RecordedProviderCallFailure {
+  return { ...failure(), receivedAt: Date.now(), ...overrides };
+}
+
+beforeEach(() => {
+  useProviderCallFailureStore.getState().clear();
+});
+
+describe("useProviderCallFailureStore", () => {
+  it("keeps recorded failures newest last", () => {
+    recordProviderCallFailure(failure({ provider: "openai" }));
+    recordProviderCallFailure(failure({ provider: "anthropic" }));
+    const { failures } = useProviderCallFailureStore.getState();
+    expect(failures.map((f) => f.provider)).toEqual(["openai", "anthropic"]);
+  });
+
+  it("stamps when this browser saw the failure", () => {
+    recordProviderCallFailure(failure());
+    expect(
+      useProviderCallFailureStore.getState().failures[0].receivedAt
+    ).toBeGreaterThan(0);
+  });
+
+  it("drops the oldest past the cap", () => {
+    for (let i = 0; i < 30; i++) {
+      recordProviderCallFailure(failure({ message: `failure ${i}` }));
+    }
+    const { failures } = useProviderCallFailureStore.getState();
+    expect(failures).toHaveLength(25);
+    expect(failures[0].message).toBe("failure 5");
+  });
+});
+
+describe("failuresForRun", () => {
+  const failures = [
+    recorded({ job_id: "job-1", workflow_id: "wf-1" }),
+    recorded({ job_id: "job-2", workflow_id: "wf-2" }),
+    recorded({ job_id: null, workflow_id: "wf-1" })
+  ];
+
+  it("matches on the job", () => {
+    expect(failuresForRun(failures, { jobId: "job-2" })).toHaveLength(1);
+  });
+
+  it("falls back to the workflow for a call the relay never stamped", () => {
+    expect(failuresForRun(failures, { workflowId: "wf-1" })).toHaveLength(2);
+  });
+
+  it("returns nothing when the caller names no run", () => {
+    expect(failuresForRun(failures, {})).toEqual([]);
+  });
+});
+
+describe("latestRecentFailure", () => {
+  it("returns the last failure inside the window", () => {
+    const now = 1_000_000;
+    const last = recorded({ receivedAt: now - 1000, provider: "anthropic" });
+    expect(
+      latestRecentFailure([recorded({ receivedAt: now - 2000 }), last], now)
+    ).toBe(last);
+  });
+
+  it("returns nothing when the last failure is stale", () => {
+    const now = 1_000_000;
+    expect(
+      latestRecentFailure([recorded({ receivedAt: now - 10 * 60 * 1000 })], now)
+    ).toBeUndefined();
+  });
+
+  it("returns nothing when nothing failed", () => {
+    expect(latestRecentFailure([])).toBeUndefined();
+  });
+});

--- a/web/src/utils/__tests__/providerCallReport.test.ts
+++ b/web/src/utils/__tests__/providerCallReport.test.ts
@@ -1,0 +1,90 @@
+import type { ProviderCallFailed } from "@nodetool-ai/protocol";
+import {
+  formatProviderCallFailure,
+  formatProviderCallFailures,
+  providerCallSummary,
+  providerCallTarget
+} from "../providerCallReport";
+
+function failure(
+  overrides: Partial<ProviderCallFailed> = {}
+): ProviderCallFailed {
+  return {
+    type: "provider_call_failed",
+    provider: "openai",
+    model: "gpt-5.4-mini",
+    operation: "generateMessages",
+    kind: "rate_limit",
+    status: 429,
+    message: "429 Too Many Requests",
+    error_name: "RateLimitError",
+    request_id: "req_abc123",
+    duration_ms: 812,
+    request_source: "wire",
+    request: { model: "gpt-5.4-mini", prompt: "a red fox" },
+    workflow_id: "wf-1",
+    job_id: "job-1",
+    timestamp: "2026-01-02T03:04:05.000Z",
+    ...overrides
+  };
+}
+
+describe("providerCallTarget / providerCallSummary", () => {
+  it("names provider and model", () => {
+    expect(providerCallTarget(failure())).toBe("openai/gpt-5.4-mini");
+    expect(providerCallSummary(failure())).toBe(
+      "openai/gpt-5.4-mini 429 — rate limited or out of quota"
+    );
+  });
+
+  it("names the provider alone when no model was chosen", () => {
+    expect(providerCallTarget(failure({ model: null }))).toBe("openai");
+  });
+});
+
+describe("formatProviderCallFailure", () => {
+  it("carries every field a maintainer asks for", () => {
+    const text = formatProviderCallFailure(failure());
+    expect(text).toContain("Provider: openai");
+    expect(text).toContain("Model: gpt-5.4-mini");
+    expect(text).toContain("Operation: generateMessages");
+    expect(text).toContain("HTTP status: 429");
+    expect(text).toContain("Error class: RateLimitError");
+    expect(text).toContain("Provider request id: req_abc123");
+    expect(text).toContain("Elapsed: 812 ms");
+    expect(text).toContain("Job: job-1");
+    expect(text).toContain("429 Too Many Requests");
+    expect(text).toContain("a red fox");
+  });
+
+  it("omits fields the failure does not carry", () => {
+    const text = formatProviderCallFailure(
+      failure({ request_id: null, duration_ms: null, request: null })
+    );
+    expect(text).not.toContain("Provider request id");
+    expect(text).not.toContain("Elapsed");
+    expect(text).not.toContain("--- Request");
+  });
+
+  it("redacts credentials out of the request and the message", () => {
+    const text = formatProviderCallFailure(
+      failure({
+        message: "401 with sk-live-abcdefghijklmnopqr",
+        request: { api_key: "sk-live-abcdefghijklmnopqr" }
+      })
+    );
+    expect(text).not.toContain("sk-live-abcdefghijklmnopqr");
+  });
+});
+
+describe("formatProviderCallFailures", () => {
+  it("lists every call, newest first", () => {
+    const text = formatProviderCallFailures([
+      failure({ provider: "openai" }),
+      failure({ provider: "anthropic" })
+    ]);
+    expect(text).toContain("Failed provider call 1 of 2");
+    expect(text).toContain("Failed provider call 2 of 2");
+    expect(text.indexOf("anthropic")).toBeLessThan(text.indexOf("openai"));
+  });
+});

--- a/web/src/utils/bugReportBundle.ts
+++ b/web/src/utils/bugReportBundle.ts
@@ -93,6 +93,7 @@ type BugReportSource =
   | "app-crash"
   | "panel-crash"
   | "job-failure"
+  | "provider-call"
   | "notification"
   | "manual";
 
@@ -101,6 +102,7 @@ const SOURCE_LABELS: Record<BugReportSource, string> = {
   "app-crash": "App crash",
   "panel-crash": "Panel crash",
   "job-failure": "Job failure",
+  "provider-call": "Failed provider call",
   notification: "Error notification",
   manual: "Manual report"
 };
@@ -126,6 +128,16 @@ export interface BugReportContext {
    * cannot read them itself — the node store is scoped to the editor.
    */
   nodeDetail?: string;
+  /**
+   * The provider calls behind this failure, already formatted — provider,
+   * model, status, request id, timing and the redacted request. Set by any
+   * surface that can name the run the calls belong to.
+   */
+  providerCallDetail?: string;
+  /** Provider named in the failure, for the issue title. */
+  provider?: string;
+  /** Model named in the failure, for the issue title. */
+  model?: string;
 }
 
 /** One attachable file, shown as its own consent row in the dialog. */
@@ -147,6 +159,8 @@ interface BundleInput {
   workflow?: unknown;
   /** Node configuration and wiring, when a node failed. */
   nodeDetail?: string;
+  /** The failed provider calls, when the failure came from one. */
+  providerCallDetail?: string;
   logText?: string;
   consoleText?: string;
   notificationText?: string;
@@ -190,6 +204,18 @@ export function buildBundleSections(input: BundleInput): BundleSection[] {
         "The failing node's settings and the nodes wired into it. API keys are removed.",
       fileName: "node.txt",
       content: redactSecretsInText(input.nodeDetail),
+      defaultIncluded: true
+    });
+  }
+
+  if (input.providerCallDetail) {
+    sections.push({
+      id: "provider-call",
+      label: "Failed provider call",
+      description:
+        "Provider, model, HTTP status, the provider's request id, how long the call ran, and the request that was sent. API keys are removed.",
+      fileName: "provider-call.txt",
+      content: redactSecretsInText(input.providerCallDetail),
       defaultIncluded: true
     });
   }
@@ -268,6 +294,11 @@ export function buildIssueBody(input: IssueBodyInput): string {
       `Node: \`${context.nodeType}\`${context.nodeTitle ? ` ("${context.nodeTitle}")` : ""}`
     );
   }
+  if (context.provider) {
+    contextLines.push(
+      `Provider: \`${context.provider}\`${context.model ? ` model \`${context.model}\`` : ""}`
+    );
+  }
   if (context.workflowId) {
     contextLines.push(`Workflow: \`${context.workflowId}\``);
   }
@@ -329,7 +360,11 @@ export function buildIssueTitle(
     context.summary ||
     context.errorText?.split("\n")[0] ||
     sourceLabel(context.source);
-  const prefix = context.nodeType ? `${context.nodeType}: ` : "";
+  const prefix = context.nodeType
+    ? `${context.nodeType}: `
+    : context.provider
+      ? `${context.provider}: `
+      : "";
   return `[Bug]: ${prefix}${subject}`.slice(0, 120);
 }
 

--- a/web/src/utils/providerCallReport.ts
+++ b/web/src/utils/providerCallReport.ts
@@ -1,0 +1,91 @@
+/**
+ * Renders failed provider calls for the bug-report bundle.
+ *
+ * A provider failure reaches the screen as one line of prose — "429 rate
+ * limited" — and a maintainer reading the issue then has to ask for the
+ * provider, the model, the status, the request id and what was sent. The
+ * `provider_call_failed` frame carries all of it; this turns it into the text
+ * that travels with the report.
+ */
+import type { ProviderCallFailed } from "@nodetool-ai/protocol";
+import { redactSecretsInText, redactDeep } from "./bugReportBundle";
+
+const KIND_LABELS: Record<string, string> = {
+  auth: "credentials rejected",
+  payment: "out of credit",
+  not_found: "model not available",
+  rate_limit: "rate limited or out of quota",
+  timeout: "timed out",
+  server: "provider-side failure",
+  network: "could not reach the provider",
+  client: "request refused",
+  unknown: "unclassified"
+};
+
+/** `openai/gpt-5.4-mini` — what a reporter and a maintainer both name it by. */
+export function providerCallTarget(failure: ProviderCallFailed): string {
+  return failure.model ? `${failure.provider}/${failure.model}` : failure.provider;
+}
+
+/** One line for a banner or an issue title. */
+export function providerCallSummary(failure: ProviderCallFailed): string {
+  const status = failure.status != null ? ` ${failure.status}` : "";
+  const kind = KIND_LABELS[failure.kind] ?? failure.kind;
+  return `${providerCallTarget(failure)}${status} — ${kind}`;
+}
+
+function line(label: string, value: unknown): string | null {
+  if (value === null || value === undefined || value === "") return null;
+  return `${label}: ${String(value)}`;
+}
+
+/** The full record of one call, as it appears in `provider-call.txt`. */
+export function formatProviderCallFailure(failure: ProviderCallFailed): string {
+  const header = [
+    line("Provider", failure.provider),
+    line("Model", failure.model),
+    line("Operation", failure.operation),
+    line("Failure", KIND_LABELS[failure.kind] ?? failure.kind),
+    line("HTTP status", failure.status),
+    line("Error class", failure.error_name),
+    line("Provider request id", failure.request_id),
+    line("Elapsed", failure.duration_ms != null ? `${failure.duration_ms} ms` : null),
+    line("When", failure.timestamp),
+    line("Workflow", failure.workflow_id),
+    line("Job", failure.job_id)
+  ].filter((entry): entry is string => entry !== null);
+
+  const parts = [
+    header.join("\n"),
+    "",
+    "--- Message ---",
+    redactSecretsInText(failure.message)
+  ];
+
+  if (failure.request != null) {
+    const source =
+      failure.request_source === "wire"
+        ? "the body sent to the provider"
+        : "the arguments NodeTool passed";
+    parts.push(
+      "",
+      `--- Request (${source}, redacted and truncated) ---`,
+      JSON.stringify(redactDeep(failure.request), null, 2)
+    );
+  }
+
+  return parts.join("\n");
+}
+
+/** Every failed call in the report, newest first, separated for reading. */
+export function formatProviderCallFailures(
+  failures: ProviderCallFailed[]
+): string {
+  return [...failures]
+    .reverse()
+    .map(
+      (failure, index) =>
+        `=== Failed provider call ${index + 1} of ${failures.length} ===\n${formatProviderCallFailure(failure)}`
+    )
+    .join("\n\n");
+}


### PR DESCRIPTION
## What changed

A provider failure reached the screen as one line of prose, and a maintainer reading the resulting issue then had to ask for the provider, the model, the HTTP status, the request id and what was actually sent — none of which crossed the process boundary. `BaseProvider` now emits one `provider_call_failed` message per failed call, from the four failure paths it already wraps (non-streaming chat, streaming chat, the media modality methods, the modality generator), carrying the failure class, HTTP status, provider request id, elapsed time and the redacted, size-bounded request. It rides the same emitter `llm_call` uses, so both the workflow relay and the chat session forward it. On the frontend `GlobalWebSocketManager` records every such frame *before* routing — a chat turn's failure carries no routing key — and the bug-report dialog attaches the calls the reported run made, so every existing Report button (node error, failed job, notification) now names the provider and status without the reporter digging them out. The chat error banner, which had no report path at all, gets a `ProviderFailureReportButton` that attaches the last call to fail within five minutes. Nothing new leaves the machine unasked: the attachment is one more consent row in the dialog, redacted the same way the rest of the bundle already is.

Two cleanups came with it: the four sites that called `logProviderRequestFailure` and then the new emit are collapsed into one `recordCallFailure`, so the server log and the reported record can never disagree about what failed; and the message carries no `node_id`, because a provider knows nothing about the node that called it and a field nothing can populate is worse than an absent one.

## Verification

- [x] `npm run test:affected`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run dev:nodetool -- harness gate --base main` — run as `--base HEAD~1`; `main` is not in this shallow clone, so `main...HEAD` has no merge base. `Gate: 4/4 selfchecks passed` (255/255 example graphs validate, all 5 Ring 0 reliability journeys, node-run, 50 provider-contract probes).

`test:affected` selected 53 packages plus the full web/electron/mobile suites (the protocol change fans out). Two failures in that pass were environmental, not from this diff, and both were confirmed and fixed rather than waved away:

- `@nodetool-ai/automation-nodes` — `Cannot find package '@nodetool-ai/browser'`; the workspace was never symlinked into `node_modules`. Reproduced on a clean tree with the diff stashed. Fixed with `npm install --ignore-scripts --no-audit --no-fund`.
- `@nodetool-ai/image-nodes` — 52 failures, all `vkCreateInstance failed with VK_ERROR_INCOMPATIBLE_DRIVER`; the WebGPU/Dawn driver gap AGENTS.md documents. After `apt-get install -y mesa-vulkan-drivers`: `Test Files 24 passed (24)`, `Tests 229 passed (229)`.

Inverted once to prove the new coverage bites — passing `providerCallDetail: undefined` into `buildBundleSections`:

```
✕ attaches the failed provider call the run made (1387 ms)
Tests:       1 failed, 6 skipped, 7 total
```

51 tests added: `provider-call-failure.test.ts` (failure-class table for every status, request-id extraction, abort → no record, credential redaction), `base-provider-call-failure.test.ts` (one record from each of the four paths, none on cancel), `ProviderCallFailureStore.test.ts` (cap, run scoping, recency window), `providerCallReport.test.ts` (formatting, omitted fields, redaction), `GlobalWebSocketManager.providerFailure.test.ts` (recorded when there is no routing key, still routed when there is), and two dialog cases (attached for this run, not attached for another).

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added — the inverted case above is a test, listed under **Verification** for the same reason.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMjnPKkGT3Qp1NzPToUDEa)_