### PR TITLE
feat(sketch): let agents put images and assets on sketch layers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1352,6 +1352,15 @@ lists that under `notSimulated`. Layer bitmaps stay opaque throughout.
 The same static check is exposed to agents through the **`validate_sketch`**
 tool: pass an inline `document` to check a sketch being built, or an
 `image_document_id` to validate a saved one (scoped to the requesting user).
+**`edit_sketch`** places an image on a layer as well as editing the layer
+stack: `set_layer_image` (or `image` on `add_layer`) points a layer at an asset
+id, an `asset://` locator, a data: URL or an http(s) URL, and the editor
+resolves and draws it on load — the same reference a sketch seeded from an
+asset carries, so nothing inlines a bitmap into the document. An asset id that
+resolves to nothing is refused rather than stored, because a stored one shows
+up as an empty layer. With an editor open, **`ui_sketch_place_image`** does the
+same against the live canvas.
+
 Agents also get the version history headlessly: **`list_sketches`**,
 **`create_sketch`** (a blank canvas, then `edit_sketch`),
 **`list_sketch_versions`**, **`get_sketch_version`** (read one snapshot's

--- a/packages/agents/src/capabilities/sketches.specs.ts
+++ b/packages/agents/src/capabilities/sketches.specs.ts
@@ -122,13 +122,20 @@ export const EDIT_SKETCH_SCHEMA: JsonSchema = {
       type: "array",
       description:
         'Operations in order. Each is {"op": <name>, ...arguments}: ' +
-        'add_layer {name?, type?: "raster"|"mask", index?}, ' +
+        'add_layer {name?, type?: "raster"|"mask", index?, image?, x?, y?, width?, height?}, ' +
         "remove_layer {target}, rename_layer {target, name}, " +
         "set_layer_props {target, visible?, locked?, opacity?, blendMode?}, " +
+        "set_layer_image {target, image, x?, y?, width?, height?}, " +
         "reorder_layer {target, index}, duplicate_layer {target}, " +
         "select_layer {target}, resize_canvas {width, height}. " +
         '`target` is a layer id, its name, or "active". Layer index 0 is the ' +
-        "bottom layer.",
+        "bottom layer. " +
+        "`image` puts a picture on the layer: an asset id (from list_assets), " +
+        "an asset:// locator, a data: URL, or an http(s) URL. It is drawn at " +
+        "its natural size from the top-left of {x, y, width, height}, which " +
+        "defaults to the whole canvas — pass the image's own dimensions when " +
+        "you know them. Pass `image` to add_layer to place a picture on a new " +
+        "layer in one op.",
       items: { type: "object" }
     }
   },
@@ -218,9 +225,9 @@ export const createSketchSpec: CapabilitySpec = {
   description:
     "Create a blank sketch (image document) and return its id. This is the " +
     "first step of drawing one headlessly: create it, then add and arrange " +
-    "layers with edit_sketch. An open editor picks the new document up once " +
-    "you open it. Pixels stay empty — painting and generation happen in an " +
-    "open editor or a workflow run.",
+    "layers with edit_sketch, which also places images on them by asset id " +
+    "or URL. An open editor picks the new document up once you open it. " +
+    "Painting and generation happen in an open editor or a workflow run.",
   inputSchema: CREATE_SKETCH_SCHEMA,
   category: "write",
   userMessage: (params) => {
@@ -328,13 +335,15 @@ export const deleteSketchVersionSpec: CapabilitySpec = {
 export const editSketchSpec: CapabilitySpec = {
   name: "edit_sketch",
   description:
-    "Edit a saved sketch's layer structure headlessly: add, remove, rename, " +
-    "reorder and duplicate layers, set visibility/lock/opacity/blend mode, " +
-    "choose the active layer, and resize the canvas. Operations run in order " +
-    "against the stored document and the result is saved; an open editor " +
-    "picks the change up live. Pixels are never read or written — painting " +
-    "and generation happen in an open editor or a workflow run. Call " +
-    "list_sketches to find one and validate_sketch afterwards.",
+    "Edit a saved sketch's layers headlessly: add, remove, rename, reorder " +
+    "and duplicate layers, set visibility/lock/opacity/blend mode, put an " +
+    "image on a layer (set_layer_image, or `image` on add_layer), choose the " +
+    "active layer, and resize the canvas. Operations run in order against the " +
+    "stored document and the result is saved; an open editor picks the change " +
+    "up live. An image is placed by reference — the layer points at an asset " +
+    "or URL and the editor draws it. Pixels themselves are never read or " +
+    "written: painting and generation happen in an open editor or a workflow " +
+    "run. Call list_sketches to find one and validate_sketch afterwards.",
   inputSchema: EDIT_SKETCH_SCHEMA,
   category: "write",
   userMessage: (params) => {

--- a/packages/agents/src/capabilities/sketches.ts
+++ b/packages/agents/src/capabilities/sketches.ts
@@ -78,6 +78,7 @@ export {
   VALIDATE_SKETCH_SCHEMA
 } from "./sketches.specs.js";
 import { resolveProjectId } from "./project-scope.js";
+import { encodeSketchLayerData } from "@nodetool-ai/protocol/api-schemas/sketch.js";
 
 type ToolError = { error: string };
 
@@ -523,7 +524,8 @@ const OPS = [
   "reorder_layer",
   "duplicate_layer",
   "select_layer",
-  "resize_canvas"
+  "resize_canvas",
+  "set_layer_image"
 ] as const;
 
 type OpName = (typeof OPS)[number];
@@ -606,11 +608,108 @@ function mintLayerId(layers: SketchLayer[]): string {
   return `layer-${n}`;
 }
 
+/**
+ * The layer image references a caller may name. An asset id and an
+ * `asset://` locator both resolve through the asset's own `get_url` when the
+ * editor loads the layer; a data URL and an http(s) URL load directly.
+ */
+const IMAGE_URI_SCHEMES = ["asset://", "data:", "http://", "https://"];
+
+/**
+ * Normalize what a caller passed as an image into a locator the editor's
+ * canvas runtime resolves. A bare id becomes `asset://<id>`, which is how
+ * every other sketch surface stores a reference to a stored image.
+ */
+function normalizeImageReference(value: unknown): string | ToolError {
+  if (!isNonBlankString(value)) {
+    return {
+      error:
+        "set_layer_image needs an `image`: an asset id, an asset:// locator, a data: URL, or an http(s) URL."
+    };
+  }
+  const image = value.trim();
+  if (IMAGE_URI_SCHEMES.some((scheme) => image.startsWith(scheme))) {
+    return image;
+  }
+  if (image.includes("://")) {
+    return {
+      error: `image "${image}" uses a scheme the sketch canvas cannot load. Use an asset id, asset://, data:, or http(s)://.`
+    };
+  }
+  return `asset://${image}`;
+}
+
+/** The asset id an `asset://` locator names, ignoring any file extension. */
+function assetIdOfReference(image: string): string | null {
+  if (!image.startsWith("asset://")) return null;
+  const rest = image.slice("asset://".length).split(/[?#]/)[0];
+  const last = rest.includes("/") ? rest.slice(rest.lastIndexOf("/") + 1) : rest;
+  return last.replace(/\.[^.]+$/, "") || null;
+}
+
 interface SketchState {
   layers: SketchLayer[];
   activeLayerId: string;
   canvas: { width: number; height: number; backgroundColor?: string };
   bindings: LayerBinding[];
+}
+
+/**
+ * Point a layer at an image. The bitmap is not inlined: `data` holds the
+ * locator plus the bounds it occupies, and the editor's canvas runtime
+ * resolves and draws it on load. That is the same shape a sketch seeded from
+ * an asset carries, so a layer written here opens exactly like one the editor
+ * itself produced.
+ *
+ * Bounds default to the whole canvas. The image is drawn at its natural size
+ * anchored at the bounds' top-left, so a caller that knows the image's
+ * dimensions should pass them rather than leave the layer canvas oversized.
+ */
+function setLayerImage(
+  layer: SketchLayer,
+  args: Record<string, unknown>,
+  canvasWidth: number,
+  canvasHeight: number
+): {
+  layer: SketchLayer;
+  image: string;
+  bounds: { x: number; y: number; width: number; height: number };
+} {
+  const image = normalizeImageReference(args["image"]);
+  if (isError(image)) {
+    throw new Error(image.error);
+  }
+  const dimension = (value: unknown, fallback: number, name: string): number => {
+    if (value === undefined || value === null) return fallback;
+    const n = Number(value);
+    if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
+      throw new Error(`set_layer_image needs a positive integer \`${name}\`.`);
+    }
+    return n;
+  };
+  const offset = (value: unknown, name: string): number => {
+    if (value === undefined || value === null) return 0;
+    const n = Number(value);
+    if (!Number.isFinite(n) || !Number.isInteger(n)) {
+      throw new Error(`set_layer_image needs an integer \`${name}\`.`);
+    }
+    return n;
+  };
+  const bounds = {
+    x: offset(args["x"], "x"),
+    y: offset(args["y"], "y"),
+    width: dimension(args["width"], canvasWidth, "width"),
+    height: dimension(args["height"], canvasHeight, "height")
+  };
+  return {
+    layer: {
+      ...layer,
+      data: encodeSketchLayerData(image, bounds),
+      contentBounds: bounds
+    },
+    image,
+    bounds
+  };
 }
 
 /** Apply one operation. Returns the result summary, or throws with the reason. */
@@ -628,13 +727,25 @@ function applyOp(
           ? args["name"].trim()
           : `Layer ${layers.length + 1}`;
       const type = args["type"] === "mask" ? "mask" : "raster";
-      const layer = makeLayer(
+      let layer = makeLayer(
         mintLayerId(layers),
         name,
         type,
         state.canvas.width,
         state.canvas.height
       );
+      // An `image` makes this one op instead of add_layer + set_layer_image,
+      // which is how a caller places a picture on a fresh layer.
+      const placed =
+        args["image"] === undefined
+          ? null
+          : setLayerImage(
+              layer,
+              args,
+              state.canvas.width,
+              state.canvas.height
+            );
+      if (placed) layer = placed.layer;
       // Layers are ordered bottom-to-top, so a new one goes on top unless the
       // caller pins an index.
       const at =
@@ -643,7 +754,18 @@ function applyOp(
           : layers.length;
       layers.splice(at, 0, layer);
       state.activeLayerId = layer.id;
-      return { id: layer.id, name: layer.name, index: at };
+      const summary: {
+        id: string;
+        name: string;
+        index: number;
+        image?: string;
+        bounds?: { x: number; y: number; width: number; height: number };
+      } = { id: layer.id, name: layer.name, index: at };
+      if (placed) {
+        summary.image = placed.image;
+        summary.bounds = placed.bounds;
+      }
+      return summary;
     }
 
     case "remove_layer": {
@@ -748,6 +870,25 @@ function applyOp(
       return { activeLayerId: state.activeLayerId };
     }
 
+    case "set_layer_image": {
+      const index = findLayerIndex(layers, state.activeLayerId, args["target"]);
+      if (index < 0)
+        throw new Error(`No layer matches "${String(args["target"])}".`);
+      const applied = setLayerImage(
+        layers[index],
+        args,
+        state.canvas.width,
+        state.canvas.height
+      );
+      layers[index] = applied.layer;
+      return {
+        id: applied.layer.id,
+        name: applied.layer.name,
+        image: applied.image,
+        bounds: applied.bounds
+      };
+    }
+
     case "resize_canvas": {
       const width = Number(args["width"] ?? state.canvas.width);
       const height = Number(args["height"] ?? state.canvas.height);
@@ -775,6 +916,34 @@ interface OpRecord {
   error?: string;
 }
 
+/**
+ * Asset ids named by an op's `image` that this user has no asset for. Reading
+ * them up front turns "the layer is empty" into a message naming the id.
+ */
+async function missingAssetReferences(
+  run: CapabilityRun,
+  ops: ParsedOp[]
+): Promise<string[]> {
+  const ids = new Set<string>();
+  for (const { op, args } of ops) {
+    if (op !== "set_layer_image" && op !== "add_layer") continue;
+    const image = normalizeImageReference(args["image"]);
+    if (isError(image)) continue;
+    const assetId = assetIdOfReference(image);
+    if (assetId) ids.add(assetId);
+  }
+  if (ids.size === 0) return [];
+  const userId = run.context.userId;
+  if (!userId) return [...ids];
+  // `findMany` is user-scoped, so another user's asset reads as missing — the
+  // same rule the rest of this module applies to sketches.
+  const { Asset } = await import("@nodetool-ai/models");
+  const found = new Set(
+    (await Asset.findMany(userId, [...ids])).map((asset) => asset.id)
+  );
+  return [...ids].filter((id) => !found.has(id));
+}
+
 const editSketch: CapabilityExport = {
   spec: editSketchSpec,
   impl: async (run, params) => {
@@ -798,6 +967,18 @@ const editSketch: CapabilityExport = {
       return { error: `Sketch ${sketchId} was not found.` };
     }
 
+    // Verify every referenced asset before writing. An id that resolves to
+    // nothing would otherwise be stored happily and show up as an empty layer
+    // in the editor — the failure this reports instead.
+    const missing = await missingAssetReferences(run, ops);
+    if (missing.length > 0) {
+      return {
+        error:
+          `No asset matches ${missing.map((id) => `"${id}"`).join(", ")}. ` +
+          "Use list_assets to find one, and pass its id as `image`."
+      };
+    }
+
     let records: OpRecord[] = [];
     let layerSummary: { id: string; name: string; index: number }[] = [];
     let activeLayerId = "";
@@ -811,6 +992,7 @@ const editSketch: CapabilityExport = {
         if (
           typeof rawTarget === "string" &&
           (parsed.op === "set_layer_props" ||
+            parsed.op === "set_layer_image" ||
             parsed.op === "rename_layer" ||
             parsed.op === "duplicate_layer" ||
             parsed.op === "remove_layer" ||

--- a/packages/agents/src/evals/surfaces/sketch.ts
+++ b/packages/agents/src/evals/surfaces/sketch.ts
@@ -21,7 +21,10 @@
  * shapes — minus the `sketch_id` param, since this bridge addresses a single
  * implicit document rather than a registry of open editors.
  *
- * `ui_sketch_render_to_asset` stays excluded: it needs an asset-upload service,
+ * `ui_sketch_place_image` records the locator it is given without fetching the
+ * bytes — there is no asset store here — so it moves the layer's reference,
+ * not its pixels. `ui_sketch_render_to_asset` stays excluded: it needs an
+ * asset-upload service,
  * which has no meaningful headless equivalent. To look at what a run drew, take
  * the composite PNG off the bridge instead ({@link SketchToolBridge.compositePng},
  * or {@link getLastSketchToolBridge} when the eval runner owns the instance).
@@ -254,6 +257,8 @@ export interface SketchBridgeFinalState {
     provider?: string;
     model?: string;
     fillColor?: string;
+    imageRef?: string;
+    imageBounds?: { x: number; y: number; width: number; height: number };
   }[];
 }
 
@@ -276,6 +281,14 @@ interface Layer {
   bindingStatus?: string;
   /** Solid fill applied to the bitmap when it is first materialized. */
   fillColor?: string;
+  /**
+   * Locator of an image placed on this layer. Recorded, not decoded: the
+   * surface has no asset store to fetch bytes from, so a placement changes
+   * what the layer references rather than what it contains.
+   */
+  imageRef?: string;
+  /** Where a placed image sits on the canvas. */
+  imageBounds?: { x: number; y: number; width: number; height: number };
   /** Strokes committed to this layer, so a fill and a drawing stay tellable apart. */
   strokeCount: number;
   /**
@@ -288,6 +301,27 @@ interface Layer {
 
 /** Serializable view handed back to the model — the bitmap never crosses. */
 type LayerView = Omit<Layer, "raster">;
+
+/**
+ * Normalize what a caller named as an image into the locator form the editor
+ * stores. A bare id becomes `asset://<id>`; a scheme the canvas cannot load is
+ * refused here the way the live bridge refuses it.
+ */
+function normalizePlacedImage(value: unknown): string {
+  const image = isString(value) ? value.trim() : "";
+  if (!image) {
+    throw new Error(
+      "place_image needs an `image`: an asset id, an asset:// locator, a data: URL, or an http(s) URL."
+    );
+  }
+  if (/^(asset:\/\/|data:|https?:\/\/)/.test(image)) return image;
+  if (image.includes("://")) {
+    throw new Error(
+      `image "${image}" uses a scheme the sketch canvas cannot load. Use an asset id, asset://, data:, or http(s)://.`
+    );
+  }
+  return `asset://${image}`;
+}
 
 function tool<TResult>(
   name: string,
@@ -825,6 +859,52 @@ export function createSketchToolBridge(
           result.note = "Generation not started (autoGenerate=false).";
         }
         return result;
+      }
+    ),
+
+    tool(
+      "ui_sketch_place_image",
+      "Put an existing image onto a layer — an asset from the library, or a URL. `image` is an asset id (find one with the asset tools), an asset:// locator, a data: URL, or an http(s) URL. Omit `target` to place it on a new layer, or name a layer to replace what it shows. The image is drawn at its own size from (`x`, `y`) unless `width`/`height` say otherwise. This is how a picture gets onto a canvas; ui_sketch_generate makes a new one from a prompt instead.",
+      z.object({
+        image: z.string(),
+        target: targetParam.optional(),
+        name: z.string().optional(),
+        x: z.number().optional(),
+        y: z.number().optional(),
+        width: z.number().optional(),
+        height: z.number().optional()
+      }),
+      async (args) => {
+        const image = normalizePlacedImage(args["image"]);
+        const layer = isString(args["target"]) && args["target"]
+          ? resolveTarget(args["target"])
+          : (() => {
+              const id = nextLayerId();
+              const created = makeLayer(
+                id,
+                (isString(args["name"]) && args["name"]) || `Layer ${layerSeq}`,
+                "raster"
+              );
+              const idx = activeLayerId
+                ? indexOf(activeLayerId) + 1
+                : layers.length;
+              layers.splice(idx, 0, created);
+              activeLayerId = id;
+              return created;
+            })();
+        const num = (value: unknown, fallback: number) =>
+          typeof value === "number" && Number.isFinite(value)
+            ? value
+            : fallback;
+        layer.imageRef = image;
+        layer.imageBounds = {
+          x: num(args["x"], 0),
+          y: num(args["y"], 0),
+          width: num(args["width"], width),
+          height: num(args["height"], height)
+        };
+        activeLayerId = layer.id;
+        return { ok: true, layer: serialize(layer) };
       }
     ),
 
@@ -1425,6 +1505,8 @@ export function createSketchToolBridge(
           if (l.provider !== undefined) entry.provider = l.provider;
           if (l.model !== undefined) entry.model = l.model;
           if (l.fillColor !== undefined) entry.fillColor = l.fillColor;
+          if (l.imageRef !== undefined) entry.imageRef = l.imageRef;
+          if (l.imageBounds !== undefined) entry.imageBounds = l.imageBounds;
           return entry;
         })
       };
@@ -1441,7 +1523,7 @@ Use the ui_sketch_* tools to inspect and modify the open image document:
 - Call ui_sketch_get_state first to see the layer stack, active layer, colors, and tool.
 - Layers are addressed by id, by (case-insensitive) name, or the literal "active" for the active layer.
 - Add layers with ui_sketch_add_layer, adjust them with ui_sketch_set_layer_props (opacity, blend mode, name, visibility, lock).
-- Generate imagery with ui_sketch_generate; recolor with ui_sketch_set_color; resize the canvas with ui_sketch_resize_canvas; shape the pixel selection with ui_sketch_selection or ui_sketch_set_selection_shape.
+- Put an existing image (an asset id or a URL) on a layer with ui_sketch_place_image; generate a new one with ui_sketch_generate; recolor with ui_sketch_set_color; resize the canvas with ui_sketch_resize_canvas; shape the pixel selection with ui_sketch_selection or ui_sketch_set_selection_shape.
 - Paint regions with ui_sketch_fill, ui_sketch_gradient, and ui_sketch_draw_shape. Transform or grade a layer with ui_sketch_transform and ui_sketch_adjust_layer. Crop with ui_sketch_crop. Sample a pixel with ui_sketch_pick_color.
 
 You can draw. ui_sketch_stroke paints real pixels with the editor's brush, pencil and eraser:

--- a/packages/agents/tests/capabilities-sketches.test.ts
+++ b/packages/agents/tests/capabilities-sketches.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { ImageDocument, ModelObserver, initTestDb } from "@nodetool-ai/models";
+import { decodeSketchLayerData } from "@nodetool-ai/protocol/api-schemas/sketch.js";
 import { module as sketches } from "../src/capabilities/sketches.js";
 import { createCapabilityRun, UNGATED } from "../src/capabilities/invoke.js";
 import { capabilityModuleIssues } from "../src/capabilities/registry.js";
@@ -279,6 +280,88 @@ describe("sketches capability behaviour", () => {
     expect(result).toMatchObject({ applied: 1, failed: 0 });
     expect(result.layers.map((l) => l.name)).toEqual(["Background", "Shadow"]);
     expect(result.active_layer_id).not.toBe("layer-1");
+  });
+
+  it("puts an asset on a layer, so the editor has something to draw", async () => {
+    const { Asset } = await import("@nodetool-ai/models");
+    const asset = await Asset.create<InstanceType<typeof Asset>>({
+      user_id: "u1",
+      name: "photo.png",
+      content_type: "image/png"
+    });
+    const row = await makeSketch();
+
+    const result = (await run().invoke("edit_sketch", {
+      image_document_id: row.id,
+      ops: [
+        { op: "add_layer", name: "Photo", image: asset.id, width: 640, height: 480 },
+        { op: "set_layer_image", target: "Background", image: `asset://${asset.id}.png` }
+      ]
+    })) as { applied: number; failed: number; ops: Array<{ error?: string }> };
+    expect(result).toMatchObject({ applied: 2, failed: 0 });
+
+    const stored = await ImageDocument.findById(row.id);
+    const layers = stored!.toDocumentData().sketch.layers as Array<{
+      name: string;
+      data: string | null;
+      contentBounds?: { width: number; height: number };
+    }>;
+
+    const photo = layers.find((l) => l.name === "Photo")!;
+    expect(decodeSketchLayerData(photo.data, 1024, 768)).toEqual({
+      image: `asset://${asset.id}`,
+      bounds: { x: 0, y: 0, width: 640, height: 480 }
+    });
+    expect(photo.contentBounds).toMatchObject({ width: 640, height: 480 });
+
+    // No bounds given: the layer covers the canvas.
+    const background = layers.find((l) => l.name === "Background")!;
+    expect(decodeSketchLayerData(background.data, 1, 1)).toEqual({
+      image: `asset://${asset.id}.png`,
+      bounds: { x: 0, y: 0, width: 1024, height: 768 }
+    });
+  });
+
+  it("refuses an image reference no asset backs, instead of writing an empty layer", async () => {
+    const row = await makeSketch();
+    const result = (await run().invoke("edit_sketch", {
+      image_document_id: row.id,
+      ops: [{ op: "set_layer_image", target: "Background", image: "no-such-asset" }]
+    })) as { error?: string };
+    expect(result.error).toContain("no-such-asset");
+
+    const stored = await ImageDocument.findById(row.id);
+    const layers = stored!.toDocumentData().sketch.layers as Array<{
+      data: string | null;
+    }>;
+    expect(layers[0].data).toBeNull();
+  });
+
+  it("hides another user's asset from set_layer_image", async () => {
+    const { Asset } = await import("@nodetool-ai/models");
+    const theirs = await Asset.create<InstanceType<typeof Asset>>({
+      user_id: "u2",
+      name: "secret.png",
+      content_type: "image/png"
+    });
+    const row = await makeSketch();
+    const result = (await run().invoke("edit_sketch", {
+      image_document_id: row.id,
+      ops: [{ op: "set_layer_image", target: "Background", image: theirs.id }]
+    })) as { error?: string };
+    expect(result.error).toContain(theirs.id);
+  });
+
+  it("rejects an image scheme the sketch canvas cannot load", async () => {
+    const row = await makeSketch();
+    const result = (await run().invoke("edit_sketch", {
+      image_document_id: row.id,
+      ops: [
+        { op: "set_layer_image", target: "Background", image: "ftp://host/x.png" }
+      ]
+    })) as { failed: number; ops: Array<{ error?: string }> };
+    expect(result.failed).toBe(1);
+    expect(result.ops[0].error).toContain("scheme the sketch canvas cannot load");
   });
 
   it("rejects a blend mode the compositor does not ship", async () => {

--- a/packages/agents/tests/sketch-tool-loop.test.ts
+++ b/packages/agents/tests/sketch-tool-loop.test.ts
@@ -133,6 +133,61 @@ describe("createSketchToolBridge", () => {
     expect(state.activeLayerId).toBe(result.layer.id);
   });
 
+  it("place_image puts an asset on a new layer, sized to the canvas by default", async () => {
+    const bridge = createSketchToolBridge({ width: 800, height: 600 });
+    const byName = Object.fromEntries(bridge.tools.map((t) => [t.name, t]));
+
+    const result = (await byName["ui_sketch_place_image"].execute({
+      image: "asset-42",
+      name: "Photo"
+    })) as { ok: boolean; layer: { id: string; name: string } };
+    expect(result.ok).toBe(true);
+
+    const state = bridge.finalState();
+    const layer = state.layers.find((l) => l.id === result.layer.id);
+    expect(layer?.name).toBe("Photo");
+    expect(layer?.imageRef).toBe("asset://asset-42");
+    expect(layer?.imageBounds).toEqual({
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600
+    });
+    expect(state.activeLayerId).toBe(result.layer.id);
+  });
+
+  it("place_image targets an existing layer and honors explicit bounds", async () => {
+    const bridge = createSketchToolBridge({ layers: [{ name: "Base" }] });
+    const byName = Object.fromEntries(bridge.tools.map((t) => [t.name, t]));
+
+    await byName["ui_sketch_place_image"].execute({
+      target: "Base",
+      image: "https://example.com/pic.png",
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 50
+    });
+
+    const state = bridge.finalState();
+    expect(state.layers).toHaveLength(1);
+    expect(state.layers[0].imageRef).toBe("https://example.com/pic.png");
+    expect(state.layers[0].imageBounds).toEqual({
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 50
+    });
+  });
+
+  it("place_image refuses a scheme the canvas cannot load", async () => {
+    const bridge = createSketchToolBridge();
+    const byName = Object.fromEntries(bridge.tools.map((t) => [t.name, t]));
+    await expect(
+      byName["ui_sketch_place_image"].execute({ image: "ftp://host/pic.png" })
+    ).rejects.toThrow(/scheme the sketch canvas cannot load/);
+  });
+
   it("generate with autoGenerate false does not start generation", async () => {
     const bridge = createSketchToolBridge();
     const byName = Object.fromEntries(bridge.tools.map((t) => [t.name, t]));

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -1840,7 +1840,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "create_sketch",
     module: "sketches",
     impl: "packages/agents/src/capabilities/sketches.ts",
-    contract: "e507b2c7a329",
+    contract: "72b119db3396",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-sketches.test.ts",
@@ -1910,7 +1910,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "edit_sketch",
     module: "sketches",
     impl: "packages/agents/src/capabilities/sketches.ts",
-    contract: "5ccbf0eab2c9",
+    contract: "8592a69488a7",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-sketches.test.ts",

--- a/packages/protocol/src/api-schemas/sketch.ts
+++ b/packages/protocol/src/api-schemas/sketch.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { isNumber, isString } from "../predicates.js";
+
 // ── Layer version ──────────────────────────────────────────────────────────
 
 export const layerVersion = z.object({
@@ -300,3 +302,106 @@ export const deleteSketchVersionInput = z.object({
   version: z.number().int()
 });
 export type DeleteSketchVersionInput = z.infer<typeof deleteSketchVersionInput>;
+
+// ── Layer raster payload codec ─────────────────────────────────────────────
+
+/**
+ * A layer's `data` field carries `ntlayer:<base64 JSON>` — the image (a data
+ * URL, an `asset://` locator, or an http(s) URL) plus the bounds it occupies
+ * on the canvas. It lives here because four surfaces read and write it: the
+ * editor's serializer, the canvas runtime, the `nodetool.image` sketch nodes,
+ * and the headless `edit_sketch` capability. A format they each re-derived is
+ * a format they can each get subtly wrong.
+ */
+export const SERIALIZED_LAYER_DATA_PREFIX = "ntlayer:";
+
+export interface SketchLayerBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface SerializedSketchLayerData {
+  version: 1;
+  image: string | null;
+  bounds: SketchLayerBounds;
+}
+
+/**
+ * Base64 of a UTF-8 string. `btoa`/`atob` are globals in Node and in the
+ * browser, and the byte dance around them is what keeps a non-Latin-1
+ * character from throwing.
+ */
+function toBase64(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+/** Inverse of {@link toBase64}. */
+function fromBase64(base64: string): string {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+/** Encode a layer image plus its canvas bounds into the `data` field. */
+export function encodeSketchLayerData(
+  image: string | null,
+  bounds: SketchLayerBounds
+): string {
+  const payload: SerializedSketchLayerData = { version: 1, image, bounds };
+  return `${SERIALIZED_LAYER_DATA_PREFIX}${toBase64(JSON.stringify(payload))}`;
+}
+
+const numberOr = (value: unknown, fallback: number): number =>
+  isNumber(value) && Number.isFinite(value) ? value : fallback;
+
+/**
+ * Decode a layer `data` field. Anything without the prefix is a legacy bare
+ * image (a data URL or a locator) and is returned as the image with the
+ * fallback bounds, which is what every reader did before the envelope existed.
+ */
+export function decodeSketchLayerData(
+  data: string | null | undefined,
+  fallbackWidth: number,
+  fallbackHeight: number
+): { image: string | null; bounds: SketchLayerBounds } {
+  const fallbackBounds: SketchLayerBounds = {
+    x: 0,
+    y: 0,
+    width: fallbackWidth,
+    height: fallbackHeight
+  };
+  if (!data) {
+    return { image: null, bounds: fallbackBounds };
+  }
+  if (!data.startsWith(SERIALIZED_LAYER_DATA_PREFIX)) {
+    return { image: data, bounds: fallbackBounds };
+  }
+  try {
+    const decoded: unknown = JSON.parse(
+      fromBase64(data.slice(SERIALIZED_LAYER_DATA_PREFIX.length))
+    );
+    const payload = (decoded ?? {}) as Partial<SerializedSketchLayerData>;
+    const bounds = payload.bounds;
+    return {
+      image: isString(payload.image) ? payload.image : null,
+      bounds: {
+        x: numberOr(bounds?.x, fallbackBounds.x),
+        y: numberOr(bounds?.y, fallbackBounds.y),
+        width: numberOr(bounds?.width, fallbackBounds.width),
+        height: numberOr(bounds?.height, fallbackBounds.height)
+      }
+    };
+  } catch {
+    return { image: data, bounds: fallbackBounds };
+  }
+}

--- a/packages/protocol/tests/api-schemas-sketch.test.ts
+++ b/packages/protocol/tests/api-schemas-sketch.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
+  decodeSketchLayerData,
+  encodeSketchLayerData,
   layerVersion,
   layerBindingKind,
   layerWorkflowBinding,
@@ -316,5 +318,65 @@ describe("sketch document version schemas", () => {
     expect(
       restoreSketchVersionInput.safeParse({ id: "d1", version: 1.5 }).success
     ).toBe(false);
+  });
+});
+
+describe("layer data codec", () => {
+  const bounds = { x: 10, y: 20, width: 640, height: 480 };
+
+  it("round-trips an asset locator with its bounds", () => {
+    const encoded = encodeSketchLayerData("asset://a1.png", bounds);
+    expect(encoded.startsWith("ntlayer:")).toBe(true);
+    expect(decodeSketchLayerData(encoded, 1, 1)).toEqual({
+      image: "asset://a1.png",
+      bounds
+    });
+  });
+
+  it("decodes the envelope the editor writes", () => {
+    // The exact bytes the editor's serializer produces: base64 of the payload,
+    // behind the prefix. A decoder that stopped matching this would silently
+    // blank every stored layer.
+    const payload = btoa(
+      JSON.stringify({ version: 1, image: "asset://a1", bounds })
+    );
+    expect(decodeSketchLayerData(`ntlayer:${payload}`, 1, 1)).toEqual({
+      image: "asset://a1",
+      bounds
+    });
+  });
+
+  it("survives a non-Latin-1 image reference", () => {
+    const image = "https://example.com/café-日本.png";
+    const encoded = encodeSketchLayerData(image, bounds);
+    expect(decodeSketchLayerData(encoded, 1, 1).image).toBe(image);
+  });
+
+  it("reads a bare image as legacy data at the fallback bounds", () => {
+    expect(decodeSketchLayerData("data:image/png;base64,AAA", 800, 600)).toEqual(
+      {
+        image: "data:image/png;base64,AAA",
+        bounds: { x: 0, y: 0, width: 800, height: 600 }
+      }
+    );
+  });
+
+  it("falls back on missing, empty, and unparseable data", () => {
+    const fallback = { x: 0, y: 0, width: 4, height: 3 };
+    expect(decodeSketchLayerData(null, 4, 3)).toEqual({
+      image: null,
+      bounds: fallback
+    });
+    expect(decodeSketchLayerData("ntlayer:@@@", 4, 3).bounds).toEqual(fallback);
+  });
+
+  it("fills in bounds the payload omits", () => {
+    const partial = btoa(JSON.stringify({ version: 1, image: "x", bounds: {} }));
+    expect(decodeSketchLayerData(`ntlayer:${partial}`, 7, 9).bounds).toEqual({
+      x: 0,
+      y: 0,
+      width: 7,
+      height: 9
+    });
   });
 });

--- a/web/src/components/sketch/serialization/index.ts
+++ b/web/src/components/sketch/serialization/index.ts
@@ -18,11 +18,10 @@ import {
 } from "../types";
 import { blendModeToComposite } from "../drawingUtils";
 import {
-  isNumber,
-  isString
-} from "../../../utils/typePredicates";
-
-const SERIALIZED_LAYER_DATA_PREFIX = "ntlayer:";
+  decodeSketchLayerData,
+  encodeSketchLayerData
+} from "@nodetool-ai/protocol/api-schemas/sketch.js";
+import { isNumber } from "../../../utils/typePredicates";
 
 export type LayerRasterBounds = {
   x: number;
@@ -37,20 +36,6 @@ interface ExportedRasterLayerData {
   imageDataUrl: string;
   byteLength: number;
   sourceMetadata: ExportedRasterLayerSourceMetadata;
-}
-
-type SerializedLayerData = {
-  version: 1;
-  image: string | null;
-  bounds: LayerRasterBounds;
-};
-
-function getDefaultBounds(width: number, height: number): LayerRasterBounds {
-  return { x: 0, y: 0, width, height };
-}
-
-function numberOr(value: unknown, fallback: number): number {
-  return isNumber(value) && Number.isFinite(value) ? value : fallback;
 }
 
 function getDataUrlByteLength(dataUrl: string): number {
@@ -80,12 +65,7 @@ export function serializeLayerData(
   image: string | null,
   bounds: LayerRasterBounds
 ): string {
-  const payload: SerializedLayerData = {
-    version: 1,
-    image,
-    bounds
-  };
-  return `${SERIALIZED_LAYER_DATA_PREFIX}${window.btoa(JSON.stringify(payload))}`;
+  return encodeSketchLayerData(image, bounds);
 }
 
 export function deserializeLayerData(
@@ -93,31 +73,7 @@ export function deserializeLayerData(
   fallbackWidth: number,
   fallbackHeight: number
 ) {
-  const fallbackBounds = getDefaultBounds(fallbackWidth, fallbackHeight);
-  if (!data) {
-    return { image: null, bounds: fallbackBounds };
-  }
-  if (!data.startsWith(SERIALIZED_LAYER_DATA_PREFIX)) {
-    return { image: data, bounds: fallbackBounds };
-  }
-  try {
-    const decoded: unknown = JSON.parse(
-      window.atob(data.slice(SERIALIZED_LAYER_DATA_PREFIX.length))
-    );
-    const payload = (decoded ?? {}) as Partial<SerializedLayerData>;
-    const bounds = payload.bounds;
-    return {
-      image: isString(payload.image) ? payload.image : null,
-      bounds: {
-        x: numberOr(bounds?.x, fallbackBounds.x),
-        y: numberOr(bounds?.y, fallbackBounds.y),
-        width: numberOr(bounds?.width, fallbackBounds.width),
-        height: numberOr(bounds?.height, fallbackBounds.height)
-      }
-    };
-  } catch {
-    return { image: data, bounds: fallbackBounds };
-  }
+  return decodeSketchLayerData(data, fallbackWidth, fallbackHeight);
 }
 
 export function serializeDocument(doc: SketchDocument): string {

--- a/web/src/components/sketch/sketchAgentBridge.ts
+++ b/web/src/components/sketch/sketchAgentBridge.ts
@@ -332,6 +332,36 @@ interface SketchPickColorResult {
   rgba: { r: number; g: number; b: number; a: number };
 }
 
+export interface SketchPlaceImageOptions {
+  /**
+   * Image to place: an asset id, an `asset://` locator, a data: URL, or an
+   * http(s) URL.
+   */
+  image: string;
+  /** Layer to place it on. Omit to create a new one. */
+  target?: string | null;
+  /** Name for the layer created when `target` is omitted. */
+  name?: string;
+  /** Top-left corner on the canvas. Defaults to (0, 0). */
+  x?: number;
+  /** Drawn size. Defaults to the image's own dimensions. */
+  width?: number;
+  height?: number;
+  y?: number;
+}
+
+export interface SketchPlaceImageResult {
+  layerId: string;
+  layerName: string;
+  /** The locator stored on the layer. */
+  image: string;
+  /** Where the image sits on the canvas. */
+  bounds: { x: number; y: number; width: number; height: number };
+  /** The image's own pixel dimensions, as loaded. */
+  naturalWidth: number;
+  naturalHeight: number;
+}
+
 /**
  * Operations the live {@link SketchEditor} exposes to the agent tooling layer.
  * Layers are addressed by id, by (case-insensitive) name, or the literal
@@ -352,6 +382,12 @@ export interface SketchAgentHandler {
   mergeLayerDown: (target: string) => SketchLayerNode | null;
   flattenVisible: () => SketchLayerNode;
   generate: (opts: SketchGenerateOptions) => Promise<SketchGenerateResult>;
+  /**
+   * Put an existing image — an asset or a URL — onto a layer. The layer stores
+   * the locator, not the pixels, so the document stays small and the canvas
+   * resolves and draws it the way a sketch seeded from an asset loads.
+   */
+  placeImage: (opts: SketchPlaceImageOptions) => Promise<SketchPlaceImageResult>;
   setForegroundColor: (color: string) => string;
   setBackgroundColor: (color: string) => string;
   setActiveTool: (tool: SketchToolName) => SketchToolName;

--- a/web/src/hooks/sketch/useSketchAgentBridge.ts
+++ b/web/src/hooks/sketch/useSketchAgentBridge.ts
@@ -39,6 +39,8 @@ import {
   renderLayersMerged
 } from "../../lib/sketch/renderLayerToAsset";
 import { getRememberedModel } from "../../stores/lastModelStore";
+import { resolveMediaUri } from "../../utils/resolveMediaUri";
+import { serializeLayerData } from "../../components/sketch/serialization";
 import type { Layer, SketchDocument } from "../../components/sketch/types";
 import type { LayerWorkflowBinding } from "@nodetool-ai/image-editor";
 import { CoordinateMapper } from "../../components/sketch/painting/CoordinateMapper";
@@ -97,6 +99,44 @@ function toLayerNode(
     model: binding?.model,
     bindingStatus: binding?.status
   };
+}
+
+/**
+ * Normalize what a caller named as an image into a locator the canvas runtime
+ * resolves. A bare id becomes `asset://<id>` — the form every sketch surface
+ * stores a reference to a stored image in.
+ */
+function normalizeImageReference(image: string): string {
+  const trimmed = image.trim();
+  if (!trimmed) {
+    throw new Error(
+      "place_image needs an `image`: an asset id, an asset:// locator, a data: URL, or an http(s) URL."
+    );
+  }
+  if (/^(asset:\/\/|data:|https?:\/\/)/.test(trimmed)) {
+    return trimmed;
+  }
+  if (trimmed.includes("://")) {
+    throw new Error(
+      `image "${trimmed}" uses a scheme the sketch canvas cannot load. Use an asset id, asset://, data:, or http(s)://.`
+    );
+  }
+  return `asset://${trimmed}`;
+}
+
+/** Load an image to learn its dimensions, so a placed layer is sized to it. */
+async function measureImage(
+  url: string
+): Promise<{ width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.onload = () =>
+      resolve({ width: img.naturalWidth, height: img.naturalHeight });
+    img.onerror = () =>
+      reject(new Error(`Could not load the image at ${url}.`));
+    img.src = url;
+  });
 }
 
 export const useSketchAgentBridge = (documentId: string | null): void => {
@@ -381,6 +421,49 @@ export const useSketchAgentBridge = (documentId: string | null): void => {
           layer: layerNode(reReadLayer(layerId)),
           generationStarted,
           note
+        };
+      },
+
+      async placeImage(opts) {
+        const image = normalizeImageReference(opts.image);
+        // Resolve and load before touching the document: an unreachable image
+        // must fail here rather than leave an empty layer behind, which is
+        // exactly the failure this tool exists to end.
+        const url = await resolveMediaUri(image);
+        if (!url) {
+          throw new Error(
+            `Could not resolve ${image}. Use list_assets to find an asset id.`
+          );
+        }
+        const natural = await measureImage(url);
+
+        const bounds = {
+          x: opts.x ?? 0,
+          y: opts.y ?? 0,
+          width: opts.width ?? natural.width,
+          height: opts.height ?? natural.height
+        };
+
+        const state = editor.getState();
+        const layerId = opts.target
+          ? requireLayer(opts.target).id
+          : state.addLayer(uniqueLayerName(opts.name ?? "Image"));
+
+        // The layer stores the locator, not the pixels: hydration resolves it
+        // and draws it, and the persisted document stays small.
+        state.updateLayerData(layerId, serializeLayerData(image, bounds));
+        state.setLayerContentBounds(layerId, bounds);
+        state.setActiveLayer(layerId);
+        state.pushHistory("place image");
+
+        const layer = reReadLayer(layerId);
+        return {
+          layerId,
+          layerName: layer.name,
+          image,
+          bounds,
+          naturalWidth: natural.width,
+          naturalHeight: natural.height
         };
       },
 

--- a/web/src/lib/tools/__tests__/sketchTools.test.ts
+++ b/web/src/lib/tools/__tests__/sketchTools.test.ts
@@ -54,6 +54,7 @@ const createMockHandler = (): jest.Mocked<SketchAgentHandler> => ({
   mergeLayerDown: jest.fn(),
   flattenVisible: jest.fn(),
   generate: jest.fn(),
+  placeImage: jest.fn(),
   setForegroundColor: jest.fn(),
   setBackgroundColor: jest.fn(),
   setActiveTool: jest.fn(),
@@ -95,6 +96,7 @@ describe("ui_sketch_* tools", () => {
         "ui_sketch_merge_down",
         "ui_sketch_flatten_visible",
         "ui_sketch_generate",
+        "ui_sketch_place_image",
         "ui_sketch_set_color",
         "ui_sketch_set_tool",
         "ui_sketch_resize_canvas",
@@ -128,6 +130,34 @@ describe("ui_sketch_* tools", () => {
     expect(schema.required).toContain("target");
     expect(schema.properties).toHaveProperty("sketch_id");
     expect(schema.required).toContain("sketch_id");
+  });
+
+  it("passes a placement through to the handler and links the layer", async () => {
+    const handler = createMockHandler();
+    handler.placeImage.mockResolvedValue({
+      layerId: "layer-9",
+      layerName: "Photo",
+      image: "asset://asset-42",
+      bounds: { x: 0, y: 0, width: 640, height: 480 },
+      naturalWidth: 640,
+      naturalHeight: 480
+    });
+    setSketchAgentHandler(DOC, handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_sketch_place_image",
+      { sketch_id: DOC, image: "asset-42", name: "Photo" },
+      "sk-place",
+      ctx
+    )) as { ok: boolean; layerId: string; image: string; url: string };
+
+    expect(handler.placeImage).toHaveBeenCalledWith({
+      image: "asset-42",
+      name: "Photo"
+    });
+    expect(result.ok).toBe(true);
+    expect(result.image).toBe("asset://asset-42");
+    expect(result.url).toContain("layer-9");
   });
 
   it("rejects with a descriptive error when the document is not open", async () => {

--- a/web/src/lib/tools/builtin/sketch.ts
+++ b/web/src/lib/tools/builtin/sketch.ts
@@ -259,6 +259,39 @@ FrontendToolRegistry.register({
 });
 
 FrontendToolRegistry.register({
+  name: "ui_sketch_place_image",
+  description:
+    "Put an existing image onto a layer — an asset from the library, or a URL. `image` is an asset id (find one with the asset tools), an asset:// locator, a data: URL, or an http(s) URL. Omit `target` to place it on a new layer, or name a layer to replace what it shows. The image is drawn at its own size from (`x`, `y`) unless `width`/`height` say otherwise. This is how a picture gets onto a canvas; ui_sketch_generate makes a new one from a prompt instead.",
+  parameters: z.object({
+    sketch_id: sketchIdParam,
+    image: z
+      .string()
+      .describe(
+        "An asset id, an asset:// locator, a data: URL, or an http(s) URL."
+      ),
+    target: targetParam
+      .optional()
+      .describe("Layer to place it on. Omit to create a new one."),
+    name: z
+      .string()
+      .optional()
+      .describe("Name for the layer created when `target` is omitted."),
+    x: z.number().optional(),
+    y: z.number().optional(),
+    width: z.number().optional(),
+    height: z.number().optional()
+  }),
+  async execute({ sketch_id, ...args }) {
+    const result = await getSketchAgentHandler(sketch_id).placeImage(args);
+    return {
+      ok: true,
+      ...result,
+      url: docUrl("sketch", sketch_id, { key: "layer", value: result.layerId })
+    };
+  }
+});
+
+FrontendToolRegistry.register({
   name: "ui_sketch_set_color",
   description:
     "Set the specified image document's foreground and/or background color (hex). The foreground color is used by the brush, fill, and shape tools.",


### PR DESCRIPTION
## What changed

Asking an agent to make a sketch and set its layers to images or assets left the layers empty, because no tool could do it. `edit_sketch` only moved layer structure around — and its own description told the model so ("Pixels are never read or written") — while the `ui_sketch_*` surface could generate a new image but not place an existing one. An `image` argument a model reached for was dropped silently, so nothing said why the canvas stayed blank. Placement now exists on both surfaces, by reference rather than by inlining pixels: the layer stores an `asset://` locator or a URL and the canvas resolves and draws it on load, which is the shape a sketch seeded from an asset already carried, so the document stays small. `edit_sketch` gains `set_layer_image {target, image, x?, y?, width?, height?}` and takes the same `image` on `add_layer`, refusing an asset id that resolves to nothing or belongs to another user *before* the write — storing one produces exactly the empty layer this fixes. `ui_sketch_place_image` does the same against a live editor, loading the image first so an unreachable one fails instead of leaving a blank layer behind. The `ntlayer:` layer-data codec moves into `@nodetool-ai/protocol` and the editor's serializer delegates to it, so the two surfaces cannot drift on the format the fix depends on.

## Verification

- [x] `npm run test:affected` — ran the suites it selects for this diff: `packages/agents` full (236 files, 3690 passed, 1 skipped), `packages/protocol` full (55 files, 988 passed), and web's sketch + tool trees (`src/components/sketch`, `src/lib/tools`, `src/hooks/sketch`, `src/stores/sketch` — 152 files, 2292 passed).
- [x] `npm run typecheck` — output is byte-identical to the same command on a stashed clean tree (442 pre-existing errors in this sandbox, all `TS2307` for packages it has not installed or built: `mobile/`'s react-native tree, `@nodetool-ai/base-nodes`, `@nodetool-ai/transformers-js-nodes`). No error in any file this diff touches.
- [x] `npm run lint` — 0 errors. Three the change introduced were fixed rather than waived: `anti-slop(no-conditional-empty-object-spread)` in `add_layer`'s return, and two `anti-slop(no-runtime-typeof)` in the new codec (now `isNumber`/`isString` from `packages/protocol/src/predicates.ts`, and the `typeof Buffer` probe replaced by `btoa`/`atob`, which are globals in both runtimes).
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 12/12 selfchecks passed`.

The new tests fail against the old code, which is what makes them a reproduction: "puts an asset on a layer" reports `applied: 0, failed: 2` without `set_layer_image`, since the op name is rejected.

## Agent capabilities

- [x] `npm run capabilities:check` passes (after `capabilities:sync`, whose whole diff is the two contract hashes below).
- [x] `create_sketch` and `edit_sketch` re-declare their contract; both already name `packages/agents/tests/capabilities-sketches.test.ts` and the `sketch-tools` eval in `capability-table.ts`, and both gained cases there — placement, a missing asset, another user's asset, and a scheme the canvas cannot load. `ui_sketch_place_image` is covered by `packages/agents/tests/sketch-tool-loop.test.ts` and `web/src/lib/tools/__tests__/sketchTools.test.ts`.

## New checks

- [x] The codec's format test was inverted once by changing `SERIALIZED_LAYER_DATA_PREFIX` to `"ntlayerX:"`, and observed failing:

```
 × round-trips an asset locator with its bounds 7ms
 × decodes the envelope the editor writes 3ms
 Tests  2 failed | 34 passed (36)
```

  The prefix was restored and the suite is green. That test decodes the literal bytes the editor's serializer produces rather than only round-tripping this module's own output, so a decoder that stopped matching the stored format — which would silently blank every saved layer — cannot pass it.

- [x] `missingAssetReferences` is asserted to actually find its target, not merely to return an empty list: one case gives it an id no asset backs and one gives it another user's asset, and both expect the named id back in the refusal.

## Note for review

The eval surface's `ui_sketch_place_image` records the locator it is given without fetching the bytes — that surface has no asset store, the same reason `ui_sketch_render_to_asset` is excluded from it — so it moves the layer's reference, not its pixels. The header comment says so.

---
_Generated by [Claude Code](https://claude.ai/code/session_018JqHxT3wEz9mTC9aRjmBYK)_