### PR TITLE
feat(appbuilder): add a Sketch Pad widget for mini apps

### DIFF
--- a/docs/mini-apps-mobile.md
+++ b/docs/mini-apps-mobile.md
@@ -57,6 +57,7 @@ enough to be worth knowing:
 | --- | --- |
 | **Columns** | Stacks vertically. Two columns side by side are unusable at phone width. |
 | **ImageInput / AudioInput / VideoInput / DocumentInput** | Opens the system photo or file picker. The pick is uploaded to the server so the workflow gets a URL it can fetch; if the upload fails the local file is used, which still previews on the device. |
+| **Sketch Pad** | An image picker. The app bundles no drawing surface, so the pad offers the camera and photo library for the same binding and says drawing needs the desktop app. |
 | **ResourcePicker / ResourceGallery** | A list of rows rather than a grid of tiles. Tapping one opens that document in the screen its kind already has — a storyboard in the storyboard editor, a sketch in the sketch viewer, an asset in the asset viewer. |
 | **ChatThread / ChatComposer / ModelSelect** | Native bubbles, a multiline composer, and a two-step provider-then-model picker. |
 

--- a/docs/mini-apps-reference.md
+++ b/docs/mini-apps-reference.md
@@ -57,6 +57,7 @@ That's what makes on-release pacing possible — see
 | Switch | On or off. | no |
 | Select | One option from a fixed list. | no |
 | Image Input | An image. | no |
+| Sketch Pad | A drawing the user makes on the spot. Canvas size, white or transparent paper. | yes |
 | Audio Input | An audio file. | no |
 | Video Input | A video. | no |
 | Document Input | A document. | no |
@@ -64,6 +65,16 @@ That's what makes on-release pacing possible — see
 | Resource Picker | Picks which document a resource points at. | no |
 | Resource Gallery | The same, from a grid of tiles. Tile size. | no |
 | Storyboard Scenes | Edits the bound storyboard directly. Fires no event. | no |
+
+The Sketch Pad is the sketch editor's canvas with a four-tool chrome — brush,
+pencil, eraser, fill, plus colors, stroke size, undo and clear. Each finished
+stroke flattens the drawing to a PNG and writes it as `{type: "image", uri}`, so
+bind it to an Image Input and the workflow reads it the way it reads an upload.
+White paper is the default because an image model is fed an opaque picture;
+transparent keeps the alpha for a mask or an overlay. Nothing is written until
+the user draws, so a pad wired to a run does not fire it on load. The drawing
+travels inline as a data URI, so keep the canvas near its 512×384 default
+rather than at the 2048px ceiling.
 
 ### Chat and AI
 

--- a/mobile/src/components/app_runtime/__tests__/newWidgets.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/newWidgets.test.tsx
@@ -121,6 +121,20 @@ describe("catalog coverage", () => {
   });
 });
 
+describe("sketch pad fallback", () => {
+  it("offers an image picker and says the pad needs the desktop app", () => {
+    // The app bundles no drawing surface, so the honest affordance for an
+    // image binding is the one the phone already has.
+    renderApp("wf-sketchpad", appDoc("SketchPad", { label: "Your drawing" }));
+
+    expect(screen.getByText("Your drawing")).toBeTruthy();
+    expect(screen.getByText("Choose image")).toBeTruthy();
+    expect(
+      screen.getByText("Drawing needs the desktop app — pick an image here instead.")
+    ).toBeTruthy();
+  });
+});
+
 describe("display fallbacks", () => {
   it("names a 3D model and offers to open it", async () => {
     renderApp(

--- a/mobile/src/components/app_runtime/widgets.tsx
+++ b/mobile/src/components/app_runtime/widgets.tsx
@@ -1443,6 +1443,24 @@ const MediaInputWidget: React.FC<WidgetProps & { kind: MediaKind }> = ({
 };
 
 /**
+ * A Sketch Pad, without the pad. The app bundles no drawing surface — no
+ * react-native-svg, no Skia — and the web pad's canvas is a DOM one, so there
+ * is nothing here to paint on. The binding is an image either way, so this
+ * offers the camera and photo library for it and says why the pad is missing.
+ */
+const SketchPadWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  return (
+    <View>
+      <MediaInputWidget {...widget} kind="image" />
+      <Text style={[styles.hint, { color: colors.textTertiary }]}>
+        Drawing needs the desktop app — pick an image here instead.
+      </Text>
+    </View>
+  );
+};
+
+/**
  * A typed path rather than a browser: a phone sandbox has no user-visible
  * filesystem to walk, and the path a `FilePathInput`/`FolderPathInput` feeds is
  * read by the server running the workflow, not by the device. So the control is
@@ -2410,6 +2428,7 @@ export const RENDERERS: Record<string, React.FC<WidgetProps>> = {
   DateInput: DateInputWidget,
   ColorInput: ColorInputWidget,
   ImageInput: (props) => <MediaInputWidget {...props} kind="image" />,
+  SketchPad: SketchPadWidget,
   AudioInput: (props) => <MediaInputWidget {...props} kind="audio" />,
   VideoInput: (props) => <MediaInputWidget {...props} kind="video" />,
   DocumentInput: (props) => <MediaInputWidget {...props} kind="document" />,

--- a/packages/app-runtime/src/widgets.ts
+++ b/packages/app-runtime/src/widgets.ts
@@ -366,6 +366,24 @@ export const WIDGET_CATALOG: Readonly<Record<string, WidgetDescriptor>> = {
     commits: false,
     fields: { binding: "custom", label: "text", events: "array" }
   },
+  // Draws the image instead of picking one: the sketch editor's canvas, trimmed
+  // to brush, pencil, eraser and fill, writing the flattened PNG as the same
+  // `{type: "image", uri}` value `ImageInput` writes. A stroke settles on
+  // pointer-up, so unlike the pickers this one commits.
+  SketchPad: {
+    label: "Sketch Pad",
+    mode: "write",
+    trigger: "change",
+    commits: true,
+    fields: {
+      binding: "custom",
+      label: "text",
+      width: "number",
+      height: "number",
+      background: "select",
+      events: "array"
+    }
+  },
   AudioInput: {
     label: "Audio Input",
     mode: "write",

--- a/packages/app-runtime/tests/widgets.test.ts
+++ b/packages/app-runtime/tests/widgets.test.ts
@@ -62,6 +62,24 @@ describe("widget catalog", () => {
     }
   });
 
+  it("declares the sketch pad as an image input that settles", () => {
+    // The pad is a write widget like the pickers, but unlike them a stroke ends
+    // on pointer-up — which is what makes "on release" pacing offerable.
+    expect(widgetMode("SketchPad")).toBe("write");
+    expect(WIDGET_CATALOG.SketchPad.trigger).toBe("change");
+    expect(WIDGET_CATALOG.SketchPad.commits).toBe(true);
+    expect(widgetBindingProps("SketchPad")).toEqual([]);
+    // It draws rather than renders text, so a format template has nothing to
+    // rewrite and the editor must not offer one.
+    expect(WIDGET_CATALOG.SketchPad.format).toBeUndefined();
+    expect(widgetFields("SketchPad")).not.toHaveProperty("format");
+    expect(widgetFields("SketchPad")).toMatchObject({
+      width: "number",
+      height: "number",
+      background: "select"
+    });
+  });
+
   it("reports no extra bindings for a widget that binds once", () => {
     expect(widgetBindingProps("Text")).toEqual([]);
     expect(widgetBindingProps("Bogus")).toEqual([]);

--- a/web/src/components/appbuilder/README.md
+++ b/web/src/components/appbuilder/README.md
@@ -100,6 +100,14 @@ the existing worker path.
     to every widget in one place.
   - `ResourcePickerWidget.tsx` — chooses a member of a bound resource
     collection through the `resources` provider router.
+  - `SketchPadWidget.tsx` / `SketchPadSurface.tsx` — the sketch editor's canvas
+    as an image input: the editor's own `useEditorSession` and
+    `SketchCanvasPane` under a four-tool chrome, writing the flattened PNG to
+    the binding. The surface is lazy so the editor stays out of the bundle of
+    every app that places no pad.
+  - `sketchPadDocument.ts` — the pad's starting document (paper layer, ink) and
+    the value it reads and writes; `sketchPadOptions.ts` holds the canvas
+    options both halves need, so the eager half imports no sketch module.
   - `useWidgetRuntime.ts` — binds a widget's props to reactive state + events.
   - `BuilderWorkflowContext.tsx` — supplies the bindable surface to fields.
   - `PuckAppEditor.tsx` — the `<Puck>` editor wrapper.

--- a/web/src/components/appbuilder/puck/SketchPadSurface.tsx
+++ b/web/src/components/appbuilder/puck/SketchPadSurface.tsx
@@ -1,0 +1,406 @@
+/**
+ * The Sketch Pad's working parts — the half that pulls in the sketch editor, so
+ * `SketchPadWidget` can keep it out of the bundle of every app without a pad.
+ *
+ * Everything below the toolbar is the sketch editor: `useEditorSession` owns
+ * the session (history, layers, stroke lifecycle, export), `SketchCanvasPane`
+ * is the same canvas the editor mounts, and the four tools are the editor's own
+ * definitions. What the pad adds is the binding — each committed change
+ * flattens the document to a PNG and writes `{type: "image", uri}`, the value
+ * an Image Input writes — so a workflow reads a drawing the way it reads an
+ * uploaded photo.
+ *
+ * The full `SketchEditor` deliberately does not mount here. Its layers panel,
+ * assistant, generation popover and workflow-freshness check all belong to a
+ * document that lives in the library; a pad's drawing lives in the app's state
+ * and nowhere else.
+ */
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import RedoIcon from "@mui/icons-material/Redo";
+import UndoIcon from "@mui/icons-material/Undo";
+
+import {
+  Box,
+  Caption,
+  FlexColumn,
+  FlexRow,
+  IconButton,
+  Slider,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  BORDER_RADIUS,
+  SPACING
+} from "../../ui_primitives";
+import {
+  SketchCanvasPane,
+  SKETCH_PRESET_SWATCHES,
+  getToolDefinition,
+  useColorIntentRouter,
+  useEditorSession,
+  useResolvedToolSettings,
+  useSketchStore,
+  useToolChromeActions,
+  type SketchTool
+} from "../../sketch";
+import { SketchProvider } from "../../../stores/sketch/SketchInstance";
+import { useWidgetRuntime } from "./useWidgetRuntime";
+import type { SketchPadWidgetProps } from "./SketchPadWidget";
+import {
+  createSketchPadDocument,
+  padInkColor,
+  sketchPadImageUri,
+  sketchPadValue
+} from "./sketchPadDocument";
+import {
+  clampPadSide,
+  DEFAULT_PAD_HEIGHT,
+  DEFAULT_PAD_WIDTH,
+  type SketchPadBackground
+} from "./sketchPadOptions";
+
+/** The pad's tools: paint, erase, flood-fill. Nothing that needs a layer stack. */
+const PAD_TOOLS: readonly SketchTool[] = ["brush", "pencil", "eraser", "fill"];
+
+/** Fill has no radius, so the size slider only follows the other three. */
+const SIZED_TOOLS: readonly SketchTool[] = ["brush", "pencil", "eraser"];
+
+const MIN_STROKE_SIZE = 1;
+const MAX_STROKE_SIZE = 96;
+
+/**
+ * How long after a committed change the pad flattens. An undo restores layer
+ * pixels from a PNG snapshot, which the canvas decodes asynchronously, so
+ * reading the composite in the same tick can catch the pre-undo image.
+ */
+const FLATTEN_DELAY_MS = 200;
+
+const SWATCH_SIZE = 16;
+const SIZE_SLIDER_WIDTH = 96;
+
+const swatchStyles = (color: string, selected: boolean) => ({
+  width: SWATCH_SIZE,
+  height: SWATCH_SIZE,
+  padding: 0,
+  borderRadius: BORDER_RADIUS.circle,
+  backgroundColor: color,
+  border: "2px solid",
+  borderColor: selected ? "primary.main" : "divider",
+  "&:hover": { backgroundColor: color, borderColor: "primary.light" }
+});
+
+interface PadToolbarProps {
+  onUndo: () => void;
+  onRedo: () => void;
+  onClear: () => void;
+}
+
+/**
+ * Tool, color and size, read straight off the sketch store — the same
+ * subscriptions the editor's own tool rail makes, minus the tools a pad has no
+ * layer stack for.
+ */
+const PadToolbar: React.FC<PadToolbarProps> = ({ onUndo, onRedo, onClear }) => {
+  const activeTool = useSketchStore((s) => s.activeTool);
+  const canUndo = useSketchStore((s) => s.canUndo());
+  const canRedo = useSketchStore((s) => s.canRedo());
+  const setActiveTool = useSketchStore((s) => s.setActiveTool);
+  const foregroundColor = useSketchStore((s) => s.foregroundColor);
+  const setColor = useColorIntentRouter();
+  const toolSettings = useResolvedToolSettings();
+  const { setBrushSettings, setPencilSettings, setEraserSettings } =
+    useToolChromeActions();
+
+  const size =
+    activeTool === "eraser"
+      ? toolSettings.eraser.size
+      : activeTool === "pencil"
+        ? toolSettings.pencil.size
+        : toolSettings.brush.size;
+
+  const setSize = (next: number) => {
+    if (activeTool === "eraser") {
+      setEraserSettings({ size: next });
+    } else if (activeTool === "pencil") {
+      setPencilSettings({ size: next });
+    } else {
+      setBrushSettings({ size: next });
+    }
+  };
+
+  return (
+    <FlexRow
+      align="center"
+      gap={SPACING.sm}
+      sx={{
+        flexWrap: "wrap",
+        px: SPACING.sm,
+        py: SPACING.xs,
+        borderBottom: "1px solid",
+        borderColor: "divider"
+      }}
+    >
+      <ToggleButtonGroup
+        exclusive
+        size="small"
+        value={activeTool}
+        onChange={(_, tool) => {
+          if (tool) setActiveTool(tool as SketchTool);
+        }}
+      >
+        {PAD_TOOLS.map((tool) => {
+          const { label, Icon } = getToolDefinition(tool);
+          return (
+            <ToggleButton key={tool} value={tool} aria-label={label}>
+              <Tooltip title={label}>
+                <Icon fontSize="small" />
+              </Tooltip>
+            </ToggleButton>
+          );
+        })}
+      </ToggleButtonGroup>
+
+      <FlexRow align="center" gap={SPACING.xs} sx={{ flexWrap: "wrap" }}>
+        {SKETCH_PRESET_SWATCHES.map((color) => (
+          <IconButton
+            key={color}
+            aria-label={`Color ${color}`}
+            onClick={() => setColor(color)}
+            sx={swatchStyles(color, foregroundColor === color)}
+          />
+        ))}
+      </FlexRow>
+
+      {SIZED_TOOLS.includes(activeTool) ? (
+        <Slider
+          aria-label="Stroke size"
+          size="small"
+          value={size}
+          min={MIN_STROKE_SIZE}
+          max={MAX_STROKE_SIZE}
+          valueLabelDisplay="auto"
+          onChange={(_, next) =>
+            setSize(Array.isArray(next) ? next[0] : next)
+          }
+          sx={{ width: SIZE_SLIDER_WIDTH, mx: SPACING.sm }}
+        />
+      ) : null}
+
+      <FlexRow align="center" gap={SPACING.xs} sx={{ marginLeft: "auto" }}>
+        <Tooltip title="Undo">
+          <span>
+            <IconButton
+              size="small"
+              aria-label="Undo"
+              disabled={!canUndo}
+              onClick={onUndo}
+            >
+              <UndoIcon fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
+        <Tooltip title="Redo">
+          <span>
+            <IconButton
+              size="small"
+              aria-label="Redo"
+              disabled={!canRedo}
+              onClick={onRedo}
+            >
+              <RedoIcon fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
+        <Tooltip title="Clear">
+          <IconButton size="small" aria-label="Clear" onClick={onClear}>
+            <DeleteOutlineIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </FlexRow>
+    </FlexRow>
+  );
+};
+
+const PadSurface: React.FC<SketchPadWidgetProps> = (props) => {
+  const { value, setValue, emit, designMode } = useWidgetRuntime({
+    id: props.id,
+    bindingMode: "write",
+    binding: props.binding,
+    events: props.events
+  });
+
+  const width = clampPadSide(props.width, DEFAULT_PAD_WIDTH);
+  const height = clampPadSide(props.height, DEFAULT_PAD_HEIGHT);
+  const background: SketchPadBackground =
+    props.background === "transparent" ? "transparent" : "white";
+
+  // Only what the binding held when the pad mounted seeds the canvas: the
+  // values it writes from then on are its own output, and re-seeding from them
+  // would rebuild the document under the user's hand mid-drawing.
+  const seedRef = useRef<string | null>(sketchPadImageUri(value));
+  const initialDocument = useMemo(
+    () =>
+      createSketchPadDocument({
+        width,
+        height,
+        background,
+        image: seedRef.current
+      }),
+    [width, height, background]
+  );
+
+  const interactive = !designMode && !props.disabled;
+
+  const handleExportImage = useCallback(
+    (dataUrl: string) => {
+      if (!dataUrl) return;
+      setValue(sketchPadValue(dataUrl));
+      // A finished stroke is both the live change and the settled value, so a
+      // pad drives "live" and "on release" pacing alike.
+      emit("change");
+      emit("change", "commit");
+    },
+    [setValue, emit]
+  );
+
+  const session = useEditorSession({
+    initialDocument,
+    onExportImage: handleExportImage
+  });
+  const sessionRef = useRef(session);
+  sessionRef.current = session;
+
+  // Nothing reaches the binding until the user acts on the pad. A pad that
+  // published its blank canvas on mount would fire its change event — and any
+  // run wired to it — before anyone touched the app.
+  const flattenTimer = useRef<number | null>(null);
+  const scheduleFlatten = useCallback(() => {
+    if (flattenTimer.current !== null) {
+      window.clearTimeout(flattenTimer.current);
+    }
+    flattenTimer.current = window.setTimeout(() => {
+      flattenTimer.current = null;
+      sessionRef.current.canvasActions.syncSketchOutputsNow();
+    }, FLATTEN_DELAY_MS);
+  }, []);
+  useEffect(
+    () => () => {
+      if (flattenTimer.current !== null) {
+        window.clearTimeout(flattenTimer.current);
+      }
+    },
+    []
+  );
+
+  const handleStrokeEnd = useCallback<typeof session.canvasActions.handleStrokeEnd>(
+    (layerId, data, committedBounds, options) => {
+      sessionRef.current.canvasActions.handleStrokeEnd(
+        layerId,
+        data,
+        committedBounds,
+        options
+      );
+      scheduleFlatten();
+    },
+    [scheduleFlatten]
+  );
+
+  const handleUndo = useCallback(() => {
+    sessionRef.current.handleUndo();
+    scheduleFlatten();
+  }, [scheduleFlatten]);
+
+  const handleRedo = useCallback(() => {
+    sessionRef.current.handleRedo();
+    scheduleFlatten();
+  }, [scheduleFlatten]);
+
+  const handleClear = useCallback(() => {
+    sessionRef.current.canvasActions.handleClearLayer();
+    scheduleFlatten();
+  }, [scheduleFlatten]);
+
+  const canvasReady = session.canvasReady;
+
+  // The pad's box is smaller than its canvas more often than not, so start at
+  // the zoom that shows the whole thing.
+  useEffect(() => {
+    if (!canvasReady) return;
+    const frame = window.requestAnimationFrame(() => {
+      sessionRef.current.canvasActions.handleZoomFit();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [canvasReady, width, height]);
+
+  // The document seeds each tool's own color; the foreground swatch is separate
+  // store state, so point it at the same ink.
+  const setForegroundColor = useSketchStore((s) => s.setForegroundColor);
+  useEffect(() => {
+    setForegroundColor(padInkColor(background));
+  }, [background, setForegroundColor]);
+
+  return (
+    <FlexColumn gap={SPACING.micro} fullWidth>
+      {props.label ? <Caption color="secondary">{props.label}</Caption> : null}
+      <FlexColumn
+        fullWidth
+        sx={{
+          border: "1px solid",
+          borderColor: "divider",
+          borderRadius: BORDER_RADIUS.md,
+          overflow: "hidden",
+          opacity: props.disabled ? 0.6 : 1
+        }}
+      >
+        <PadToolbar
+          onUndo={handleUndo}
+          onRedo={handleRedo}
+          onClear={handleClear}
+        />
+        <Box
+          sx={{
+            position: "relative",
+            width: "100%",
+            height,
+            // In the builder the canvas would capture the pointer the editor
+            // needs for selecting and dragging the widget.
+            pointerEvents: interactive ? "auto" : "none"
+          }}
+        >
+          <SketchCanvasPane
+            canvasReady={session.canvasReady}
+            canvasRef={session.canvasRef}
+            document={session.document}
+            activeTool={session.activeTool}
+            interactionTool={session.interactionTool}
+            onZoomChange={session.canvasStore.setZoom}
+            onPanChange={session.canvasStore.setPan}
+            onStrokeStart={session.canvasActions.handleStrokeStart}
+            onStrokeEnd={handleStrokeEnd}
+            onCanvasLeave={session.canvasActions.flushLayerThumbnailsWhenIdle}
+            onLayerTransformChange={
+              session.canvasActions.handleCommitLayerTransform
+            }
+            onLayerContentBoundsChange={session.layerStore.setLayerContentBounds}
+            onBrushSizeChange={session.colorActions.handleBrushSizeChange}
+            onEyedropperPick={session.colorActions.handleEyedropperPick}
+            segmentation={session.segmentation}
+          />
+        </Box>
+      </FlexColumn>
+    </FlexColumn>
+  );
+};
+
+/**
+ * Each pad owns an isolated bundle of sketch stores, so two pads in one app
+ * keep separate documents, histories and viewports.
+ */
+export const SketchPadSurface: React.FC<SketchPadWidgetProps> = (props) => (
+  <SketchProvider>
+    <PadSurface {...props} />
+  </SketchProvider>
+);
+
+export default SketchPadSurface;

--- a/web/src/components/appbuilder/puck/SketchPadWidget.tsx
+++ b/web/src/components/appbuilder/puck/SketchPadWidget.tsx
@@ -1,0 +1,61 @@
+/**
+ * A drawing pad the app's user paints in, bound like any other image input.
+ *
+ * The pad is the sketch editor's own canvas and session, so it is also the
+ * heaviest thing in the widget catalog — several hundred KB of tools, painting
+ * and rendering runtimes. Every mini app loads this config, but almost none
+ * place a pad, so the surface is behind a lazy import and only an app that
+ * actually places one pays for it. `SketchPadSurface` holds the working parts.
+ */
+import React from "react";
+
+import {
+  FlexColumn,
+  LoadingSpinner,
+  BORDER_RADIUS
+} from "../../ui_primitives";
+import { AppEvent } from "../types";
+import {
+  clampPadSide,
+  DEFAULT_PAD_HEIGHT,
+  type SketchPadBackground
+} from "./sketchPadOptions";
+
+export interface SketchPadWidgetProps {
+  id: string;
+  binding?: string;
+  events?: AppEvent[];
+  label?: string;
+  disabled?: boolean;
+  width?: number;
+  height?: number;
+  background?: SketchPadBackground;
+}
+
+const LazySketchPadSurface = React.lazy(
+  async () => import("./SketchPadSurface")
+);
+
+export const SketchPadWidget: React.FC<SketchPadWidgetProps> = (props) => (
+  <React.Suspense
+    fallback={
+      <FlexColumn
+        align="center"
+        justify="center"
+        fullWidth
+        sx={{
+          // The chrome the surface will fill, so loading it does not shift the
+          // widgets under the pad.
+          height: clampPadSide(props.height, DEFAULT_PAD_HEIGHT),
+          border: "1px solid",
+          borderColor: "divider",
+          borderRadius: BORDER_RADIUS.md
+        }}
+      >
+        <LoadingSpinner size="small" text="Loading pad" />
+      </FlexColumn>
+    }
+  >
+    <LazySketchPadSurface {...props} />
+  </React.Suspense>
+);

--- a/web/src/components/appbuilder/puck/__tests__/sketchPadDocument.test.ts
+++ b/web/src/components/appbuilder/puck/__tests__/sketchPadDocument.test.ts
@@ -1,0 +1,159 @@
+/**
+ * The document a Sketch Pad starts from: its layer stack, its ink, the sides it
+ * accepts, and which stored values it will redraw from.
+ */
+import {
+  createSketchPadDocument,
+  padInkColor,
+  sketchPadImageUri,
+  sketchPadValue,
+  DRAWING_LAYER_NAME,
+  PAPER_LAYER_NAME
+} from "../sketchPadDocument";
+import {
+  clampPadSide,
+  DEFAULT_PAD_HEIGHT,
+  DEFAULT_PAD_WIDTH
+} from "../sketchPadOptions";
+
+const pad = (overrides: Partial<Parameters<typeof createSketchPadDocument>[0]> = {}) =>
+  createSketchPadDocument({
+    width: 320,
+    height: 240,
+    background: "white",
+    ...overrides
+  });
+
+/**
+ * jsdom has no 2D context, so the paper fill is exercised against a stub that
+ * records what was painted — otherwise every assertion about paper passes on a
+ * layer that is silently empty.
+ */
+const withStubbedCanvas = <T,>(run: () => T): { result: T; fills: string[] } => {
+  const fills: string[] = [];
+  const getContext = HTMLCanvasElement.prototype.getContext;
+  const toDataURL = HTMLCanvasElement.prototype.toDataURL;
+  HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+    set fillStyle(color: string) {
+      fills.push(color);
+    },
+    fillRect: jest.fn()
+  })) as unknown as typeof getContext;
+  HTMLCanvasElement.prototype.toDataURL = jest.fn(
+    () => "data:image/png;base64,PAPER"
+  ) as unknown as typeof toDataURL;
+  try {
+    return { result: run(), fills };
+  } finally {
+    HTMLCanvasElement.prototype.getContext = getContext;
+    HTMLCanvasElement.prototype.toDataURL = toDataURL;
+  }
+};
+
+describe("createSketchPadDocument", () => {
+  it("puts a paper layer under the drawing layer", () => {
+    // Erasing has to reveal paper, not the transparency checkerboard, and the
+    // flattened PNG a workflow reads has to be opaque.
+    const document = pad();
+
+    expect(document.layers.map((layer) => layer.name)).toEqual([
+      PAPER_LAYER_NAME,
+      DRAWING_LAYER_NAME
+    ]);
+    expect(document.layers[0].locked).toBe(true);
+    expect(document.activeLayerId).toBe(document.layers[1].id);
+  });
+
+  it("fills the paper layer white", () => {
+    const { result, fills } = withStubbedCanvas(() => pad());
+
+    expect(fills).toEqual(["#ffffff"]);
+    expect(result.layers[0].data).toBe("data:image/png;base64,PAPER");
+    expect(result.layers[1].data).toBeNull();
+  });
+
+  it("leaves the pad drawable where no canvas encoder exists", () => {
+    // A headless renderer with no 2D context must still get a usable document
+    // rather than a thrown error.
+    expect(() => pad()).not.toThrow();
+    expect(pad().layers).toHaveLength(2);
+  });
+
+  it("drops the paper layer when the pad is transparent", () => {
+    const document = pad({ background: "transparent" });
+
+    expect(document.layers.map((layer) => layer.name)).toEqual([
+      DRAWING_LAYER_NAME
+    ]);
+    expect(document.activeLayerId).toBe(document.layers[0].id);
+  });
+
+  it("inks each painting tool to suit the background", () => {
+    // The editor's default brush is white, which on paper draws nothing.
+    const paper = pad();
+    expect(paper.toolSettings.brush.color).toBe(padInkColor("white"));
+    expect(paper.toolSettings.pencil.color).toBe(padInkColor("white"));
+    expect(paper.toolSettings.fill.color).toBe(padInkColor("white"));
+
+    const transparent = pad({ background: "transparent" });
+    expect(transparent.toolSettings.brush.color).toBe(
+      padInkColor("transparent")
+    );
+    expect(padInkColor("white")).not.toBe(padInkColor("transparent"));
+  });
+
+  it("redraws a previous drawing onto the drawing layer", () => {
+    const document = pad({ image: "data:image/png;base64,AAA" });
+
+    expect(document.layers[1].data).toBe("data:image/png;base64,AAA");
+    expect(document.layers[0].data).not.toBe("data:image/png;base64,AAA");
+  });
+
+  it("sizes the canvas to what was asked", () => {
+    const document = pad({ width: 800, height: 600 });
+    expect(document.canvas.width).toBe(800);
+    expect(document.canvas.height).toBe(600);
+  });
+});
+
+describe("clampPadSide", () => {
+  it("falls back when the author left the field empty", () => {
+    expect(clampPadSide(undefined, DEFAULT_PAD_WIDTH)).toBe(DEFAULT_PAD_WIDTH);
+    expect(clampPadSide(Number.NaN, DEFAULT_PAD_HEIGHT)).toBe(
+      DEFAULT_PAD_HEIGHT
+    );
+  });
+
+  it("keeps the canvas inside what a browser draws well", () => {
+    expect(clampPadSide(4, 512)).toBe(64);
+    expect(clampPadSide(99999, 512)).toBe(2048);
+    expect(clampPadSide(300.4, 512)).toBe(300);
+  });
+});
+
+describe("sketchPadValue / sketchPadImageUri", () => {
+  it("writes the shape an image input writes", () => {
+    expect(sketchPadValue("data:image/png;base64,AAA")).toEqual({
+      type: "image",
+      uri: "data:image/png;base64,AAA"
+    });
+  });
+
+  it("reads back an inline PNG, whether bare or wrapped in a ref", () => {
+    expect(sketchPadImageUri("data:image/png;base64,AAA")).toBe(
+      "data:image/png;base64,AAA"
+    );
+    expect(
+      sketchPadImageUri({ type: "image", uri: "data:image/png;base64,BBB" })
+    ).toBe("data:image/png;base64,BBB");
+  });
+
+  it("refuses a reference the canvas cannot draw from", () => {
+    // Seeding from these would need a fetch the canvas has no same-origin path
+    // for; a blank pad beats a tainted one.
+    expect(sketchPadImageUri("asset://abc")).toBeNull();
+    expect(sketchPadImageUri({ uri: "https://cdn.test/a.png" })).toBeNull();
+    expect(sketchPadImageUri(undefined)).toBeNull();
+    expect(sketchPadImageUri({ type: "image" })).toBeNull();
+  });
+});

--- a/web/src/components/appbuilder/puck/__tests__/sketchPadWidget.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/sketchPadWidget.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * The Sketch Pad's binding: when it writes, what it writes, and what it does
+ * before anyone has drawn. The surface is mounted directly — `SketchPadWidget`
+ * is the lazy wrapper around exactly this component.
+ *
+ * The editor session and its canvas are stubbed — they need a real WebGL/2D
+ * context that jsdom does not have, and neither is what this file is about. The
+ * stub keeps the one seam that matters: the `onExportImage` callback the pad
+ * hands the session, which is how a flattened drawing reaches the binding.
+ */
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import { makeTestRuntime, INPUT_KEY } from "../../__tests__/testRuntime";
+
+const handleClearLayer = jest.fn();
+const handleUndo = jest.fn();
+const syncSketchOutputsNow = jest.fn();
+/** The export callback the pad handed the session on its last render. */
+let exportImage: ((dataUrl: string) => void) | undefined;
+/** The document the pad seeded the session with. */
+let seededDocument: { layers: { name: string; data: string | null }[] } | undefined;
+
+const sketchStoreState = {
+  activeTool: "brush",
+  setActiveTool: jest.fn(),
+  foregroundColor: "#111111",
+  setForegroundColor: jest.fn(),
+  canUndo: () => true,
+  canRedo: () => false
+};
+
+jest.mock("../../../sketch", () => {
+  // The document helpers are pure and the pad's own tests cover them, so they
+  // stay real; everything that needs a canvas is replaced.
+  const types = jest.requireActual("../../../sketch/types");
+  return {
+    __esModule: true,
+    createDefaultDocument: types.createDefaultDocument,
+    createDefaultLayer: types.createDefaultLayer,
+    SKETCH_PRESET_SWATCHES: ["#111111", "#ef4444"],
+    SketchCanvasPane: () => <div data-testid="sketch-canvas" />,
+    getToolDefinition: (tool: string) => ({
+      tool,
+      label: tool,
+      Icon: () => null
+    }),
+    useColorIntentRouter: () => jest.fn(),
+    useResolvedToolSettings: () => ({
+      brush: { size: 8 },
+      pencil: { size: 2 },
+      eraser: { size: 16 }
+    }),
+    useToolChromeActions: () => ({
+      setBrushSettings: jest.fn(),
+      setPencilSettings: jest.fn(),
+      setEraserSettings: jest.fn()
+    }),
+    useSketchStore: (selector: (s: typeof sketchStoreState) => unknown) =>
+      selector(sketchStoreState),
+    useEditorSession: ({
+      initialDocument,
+      onExportImage
+    }: {
+      initialDocument: { layers: { name: string; data: string | null }[] };
+      onExportImage: (dataUrl: string) => void;
+    }) => {
+      exportImage = onExportImage;
+      seededDocument = initialDocument;
+      return {
+        canvasReady: true,
+        canvasRef: { current: null },
+        document: { layers: [], canvas: { width: 1, height: 1 } },
+        activeTool: "brush",
+        interactionTool: "brush",
+        handleUndo,
+        handleRedo: jest.fn(),
+        canvasActions: {
+          handleStrokeStart: jest.fn(),
+          handleStrokeEnd: jest.fn(),
+          handleClearLayer,
+          handleCommitLayerTransform: jest.fn(),
+          flushLayerThumbnailsWhenIdle: jest.fn(),
+          syncSketchOutputsNow,
+          handleZoomFit: jest.fn()
+        },
+        canvasStore: { setZoom: jest.fn(), setPan: jest.fn() },
+        layerStore: { setLayerContentBounds: jest.fn() },
+        colorActions: {
+          handleBrushSizeChange: jest.fn(),
+          handleEyedropperPick: jest.fn()
+        },
+        segmentation: {}
+      };
+    }
+  };
+});
+
+// The provider builds a real store bundle the stubbed session never reads.
+jest.mock("../../../../stores/sketch/SketchInstance", () => ({
+  __esModule: true,
+  SketchProvider: ({ children }: { children: React.ReactNode }) => children
+}));
+
+// eslint-disable-next-line import/first
+import { SketchPadSurface } from "../SketchPadSurface";
+
+const PNG = "data:image/png;base64,AAA";
+
+const renderPad = (props: Record<string, unknown> = {}) => {
+  const runtime = makeTestRuntime();
+  const view = render(
+    <ThemeProvider theme={mockTheme}>
+      <runtime.wrapper>
+        <SketchPadSurface id="pad-1" binding="prompt" {...props} />
+      </runtime.wrapper>
+    </ThemeProvider>
+  );
+  return { ...runtime, view };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  exportImage = undefined;
+  seededDocument = undefined;
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("SketchPadWidget", () => {
+  it("writes the flattened drawing as the image ref an input takes", () => {
+    const { value } = renderPad();
+
+    act(() => exportImage?.(PNG));
+
+    expect(value.write).toHaveBeenCalledWith(expect.anything(), {
+      type: "image",
+      uri: PNG
+    });
+  });
+
+  it("fires its change event once per finished drawing", () => {
+    // A stroke is both the live change and the settled value, so the pad emits
+    // both phases — an event must still run the operation exactly once.
+    const { value } = renderPad({
+      events: [{ trigger: "change", kind: "run" }]
+    });
+
+    act(() => exportImage?.(PNG));
+
+    expect(value.dispatch).toHaveBeenCalledTimes(1);
+    expect(value.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "run" })
+    );
+  });
+
+  it("writes nothing before the user has drawn", () => {
+    // A pad that published its blank canvas on mount would fire the run wired
+    // to it before anyone touched the app.
+    const { value } = renderPad();
+
+    jest.advanceTimersByTime(2000);
+
+    expect(syncSketchOutputsNow).not.toHaveBeenCalled();
+    expect(value.write).not.toHaveBeenCalled();
+  });
+
+  it("flattens after a clear, so erasing the drawing updates the binding", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    renderPad();
+
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(handleClearLayer).toHaveBeenCalled();
+    expect(syncSketchOutputsNow).toHaveBeenCalled();
+  });
+
+  it("offers undo but not redo when only undo is available", () => {
+    renderPad();
+
+    expect(screen.getByRole("button", { name: "Undo" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Redo" })).toBeDisabled();
+  });
+
+  it("flattens after an undo, so rewinding updates the binding too", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    renderPad();
+
+    await user.click(screen.getByRole("button", { name: "Undo" }));
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(handleUndo).toHaveBeenCalled();
+    expect(syncSketchOutputsNow).toHaveBeenCalled();
+  });
+
+  it("does not take the pointer in the builder", () => {
+    // In design mode the canvas would swallow the drag Puck needs to move the
+    // widget.
+    const runtime = makeTestRuntime({}, { designMode: true });
+    const { container } = render(
+      <ThemeProvider theme={mockTheme}>
+        <runtime.wrapper>
+          <SketchPadSurface id="pad-1" binding="prompt" />
+        </runtime.wrapper>
+      </ThemeProvider>
+    );
+
+    const pane = screen.getByTestId("sketch-canvas").parentElement;
+    expect(pane).toHaveStyle({ pointerEvents: "none" });
+    expect(container).toBeTruthy();
+  });
+
+  it("labels the pad when the author gave it one", () => {
+    renderPad({ label: "Draw a shape" });
+    expect(screen.getByText("Draw a shape")).toBeInTheDocument();
+  });
+});
+
+describe("SketchPadWidget seeding", () => {
+  const renderBound = (initial: unknown) => {
+    const runtime = makeTestRuntime({
+      inputs: { [INPUT_KEY]: { value: initial, dirty: true, revision: 1 } }
+    });
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <runtime.wrapper>
+          <SketchPadSurface id="pad-1" binding="prompt" />
+        </runtime.wrapper>
+      </ThemeProvider>
+    );
+  };
+
+  it("redraws the drawing the binding already held", () => {
+    // Switching away from the app's page and back remounts the pad; without
+    // this the canvas comes back blank while the binding still holds a drawing.
+    renderBound({ type: "image", uri: PNG });
+
+    const drawing = seededDocument?.layers.at(-1);
+    expect(drawing?.name).toBe("Drawing");
+    expect(drawing?.data).toBe(PNG);
+  });
+
+  it("starts blank when the binding holds a reference it cannot draw", () => {
+    renderBound({ type: "image", uri: "https://cdn.test/a.png" });
+
+    expect(seededDocument?.layers.at(-1)?.data).toBeNull();
+  });
+});

--- a/web/src/components/appbuilder/puck/config.tsx
+++ b/web/src/components/appbuilder/puck/config.tsx
@@ -66,6 +66,7 @@ import {
 } from "./WorkflowInputWidget";
 import { ChatThreadWidget, ChatComposerWidget } from "./ChatWidgets";
 import { SketchWidget, TimelineWidget } from "./DocumentWidgets";
+import { SketchPadWidget } from "./SketchPadWidget";
 import { GalleryWidget, Model3DWidget, PDFWidget } from "./MediaWidgets";
 import { ChartWidget } from "./ChartWidget";
 
@@ -333,6 +334,7 @@ export const appConfig: Config = {
         "ResourceGallery",
         "StoryboardSceneList",
         "ImageInput",
+        "SketchPad",
         "AudioInput",
         "VideoInput",
         "DocumentInput",
@@ -997,6 +999,33 @@ export const appConfig: Config = {
       render: withConditions((props) => <ModelSelectWidget {...props} />)
     },
     ImageInput: fixedInputEntry("Image Input", "image"),
+    SketchPad: {
+      label: "Sketch Pad",
+      fields: {
+        binding: bindingField("write"),
+        label: { type: "text", label: "Label" },
+        width: { type: "number", label: "Canvas width (px)" },
+        height: { type: "number", label: "Canvas height (px)" },
+        background: {
+          type: "select",
+          label: "Background",
+          options: [
+            { label: "White", value: "white" },
+            { label: "Transparent", value: "transparent" }
+          ]
+        },
+        events: eventsField("change"),
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: {
+        binding: "",
+        label: "",
+        width: 512,
+        height: 384,
+        background: "white"
+      },
+      render: withConditions((props) => <SketchPadWidget {...props} />)
+    },
     AudioInput: fixedInputEntry("Audio Input", "audio"),
     VideoInput: fixedInputEntry("Video Input", "video"),
     DocumentInput: fixedInputEntry("Document Input", "document"),

--- a/web/src/components/appbuilder/puck/sketchPadDocument.ts
+++ b/web/src/components/appbuilder/puck/sketchPadDocument.ts
@@ -1,0 +1,132 @@
+/**
+ * The document a Sketch Pad starts from, and the value it writes back.
+ *
+ * A pad is a two-layer sketch document: an opaque paper layer the user never
+ * paints on, and the drawing layer above it. Erasing then reveals paper rather
+ * than the transparency checkerboard, and the flattened export is opaque —
+ * which is what an image model downstream expects. A transparent pad drops the
+ * paper layer and keeps the alpha.
+ */
+// Deep import, not the sketch index: the index re-exports the whole editor —
+// canvas, tools, rendering runtimes — and this module is on the path of the
+// widget every mini app loads.
+import {
+  createDefaultDocument,
+  createDefaultLayer,
+  type Layer,
+  type SketchDocument
+} from "../../sketch/types";
+import { isObjectLike, isString } from "../../../utils/typePredicates";
+import type { SketchPadBackground } from "./sketchPadOptions";
+
+export const PAPER_LAYER_NAME = "Paper";
+export const DRAWING_LAYER_NAME = "Drawing";
+
+const PAPER_COLOR = "#ffffff";
+
+/**
+ * The ink a pad starts with. The editor's default is white, which is invisible
+ * on paper, so a paper pad flips it and a transparent one keeps it.
+ */
+export const padInkColor = (background: SketchPadBackground): string =>
+  background === "white" ? "#111111" : "#ffffff";
+
+/**
+ * A PNG data URL of one flat color. Returns null where the environment has no
+ * real 2D canvas (jsdom), which leaves the paper layer empty rather than
+ * failing the whole document.
+ */
+const solidPng = (
+  width: number,
+  height: number,
+  color: string
+): string | null => {
+  try {
+    const canvas = window.document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return null;
+    ctx.fillStyle = color;
+    ctx.fillRect(0, 0, width, height);
+    return canvas.toDataURL("image/png");
+  } catch {
+    // No canvas encoder here — the pad still draws, just without paper.
+    return null;
+  }
+};
+
+interface SketchPadDocumentOptions {
+  width: number;
+  height: number;
+  background: SketchPadBackground;
+  /** A PNG data URL to restore onto the drawing layer, from a previous session. */
+  image?: string | null;
+}
+
+export const createSketchPadDocument = ({
+  width,
+  height,
+  background,
+  image
+}: SketchPadDocumentOptions): SketchDocument => {
+  const base = createDefaultDocument(width, height);
+  const ink = padInkColor(background);
+  const layers: Layer[] = [];
+
+  if (background === "white") {
+    const paper = createDefaultLayer(PAPER_LAYER_NAME, "raster", width, height);
+    paper.data = solidPng(width, height, PAPER_COLOR);
+    // Nothing in the pad's chrome selects a layer, but a locked paper layer
+    // also refuses the tools that pick one on their own.
+    paper.locked = true;
+    layers.push(paper);
+  }
+
+  const drawing = createDefaultLayer(
+    DRAWING_LAYER_NAME,
+    "raster",
+    width,
+    height
+  );
+  drawing.data = image ?? null;
+  layers.push(drawing);
+
+  return {
+    ...base,
+    canvas: {
+      ...base.canvas,
+      backgroundColor:
+        background === "white" ? PAPER_COLOR : base.canvas.backgroundColor
+    },
+    // `setDocument` hydrates the store's tool settings from these, so the ink
+    // is right before the first stroke rather than after the first swatch.
+    toolSettings: {
+      ...base.toolSettings,
+      brush: { ...base.toolSettings.brush, color: ink },
+      pencil: { ...base.toolSettings.pencil, color: ink },
+      fill: { ...base.toolSettings.fill, color: ink }
+    },
+    layers,
+    activeLayerId: drawing.id
+  };
+};
+
+/** The pad writes the `{type, uri}` shape an Image Input writes. */
+export const sketchPadValue = (
+  dataUrl: string
+): { type: "image"; uri: string } => ({ type: "image", uri: dataUrl });
+
+/**
+ * A value the pad wrote earlier, back as a data URL so a remount redraws it.
+ * Only inline PNGs qualify: a stored `asset://` locator or an http URL would
+ * need a fetch the canvas cannot make same-origin.
+ */
+export const sketchPadImageUri = (value: unknown): string | null => {
+  const uri = isString(value)
+    ? value
+    : isObjectLike(value) && isString(value.uri)
+      ? value.uri
+      : null;
+  return uri !== null && uri.startsWith("data:image/") ? uri : null;
+};

--- a/web/src/components/appbuilder/puck/sketchPadOptions.ts
+++ b/web/src/components/appbuilder/puck/sketchPadOptions.ts
@@ -1,0 +1,19 @@
+/**
+ * The Sketch Pad's canvas options, kept apart from `sketchPadDocument` so the
+ * eagerly-loaded widget can read them without pulling the sketch editor's
+ * modules into every mini app's bundle.
+ */
+export type SketchPadBackground = "white" | "transparent";
+
+export const DEFAULT_PAD_WIDTH = 512;
+export const DEFAULT_PAD_HEIGHT = 384;
+
+const MIN_PAD_SIDE = 64;
+const MAX_PAD_SIDE = 2048;
+
+/** Author-supplied canvas sides, kept inside what a browser canvas draws well. */
+export const clampPadSide = (value: unknown, fallback: number): number => {
+  const side =
+    typeof value === "number" && Number.isFinite(value) ? value : fallback;
+  return Math.min(MAX_PAD_SIDE, Math.max(MIN_PAD_SIDE, Math.round(side)));
+};

--- a/web/src/components/sketch/index.ts
+++ b/web/src/components/sketch/index.ts
@@ -25,8 +25,14 @@ export {
   useLayerActions,
   useCanvasActions,
   useColorActions,
+  useColorIntentRouter,
+  useToolChromeActions,
+  useEditorSession,
   useSegmentation
 } from "./hooks";
+
+/** The store-connected canvas, for a surface that composes its own chrome. */
+export { SketchCanvasPane } from "./editor-shell";
 
 export {
   useCompositing,
@@ -105,6 +111,7 @@ export {
   DEFAULT_BLUR_SETTINGS,
   DEFAULT_TOOL_SETTINGS,
   DEFAULT_SWATCHES,
+  SKETCH_PRESET_SWATCHES,
   DEFAULT_SEGMENT_SETTINGS,
   CANVAS_PRESETS,
   createDefaultDocument,


### PR DESCRIPTION
## What changed

A mini app could take an image from a file picker but not from the user's hand. The **Sketch Pad** closes that: the sketch editor's own canvas, bound like any other image input. It reuses the editor rather than reimplementing it — `useEditorSession` owns the session (history, layers, stroke lifecycle, export), `SketchCanvasPane` is the canvas the editor mounts, and the four tools are the editor's own definitions. What the pad adds is a compact chrome (brush, pencil, eraser, fill, colors, stroke size, undo, clear) and the binding: each committed change flattens the document to a PNG and writes `{type: "image", uri}`, the value an Image Input writes, so a workflow reads a drawing the way it reads an upload. The full `SketchEditor` deliberately does not mount — its layers panel, assistant, generation popover and workflow-freshness check belong to a document in the library, and a pad's drawing lives in the app's state.

Details worth knowing: a white paper layer sits under the drawing layer so erasing reveals paper and the flattened PNG is opaque (transparent drops it and keeps the alpha); the editor's default ink is white and invisible on paper, so the pad's starting document inks brush, pencil and fill to suit the background; nothing is written until the user draws, since a pad that published its blank canvas on mount would fire any run wired to it on load; the surface is behind a lazy import, because every mini app loads the widget config, almost none place a pad, and the editor is several hundred KB. On mobile the pad renders the image picker and says drawing needs the desktop app — React Native ships no drawing surface here, and the binding is an image either way.

## Verification

All 22 checks are green on `a853495`, including the Quality Gate `typecheck`, `lint`, `test-packages`, `test-app`, `docker` and `bundle` legs.

- [x] `npm run test:affected` — the appbuilder suites (36 files, 394 tests), `@nodetool-ai/app-runtime` (211), mobile `newWidgets` (19) and `@nodetool-ai/kernel` (70 files) all pass. One kernel run failed mid-session on `Failed to resolve entry for package "@nodetool-ai/node-sdk"`; that was an unbuilt `dist/`, and kernel is green after `npm run build:packages`.
- [x] `npm run typecheck` — green in CI. Locally, `typecheck:mobile` failed on `GraphEditorStore.ts`, `WorkflowRunner.ts`, `trpc/client.ts` and `types/graphEditor.ts` (`sync_mode`, `expose_as_tool`, `TRPC_MAX_BATCH_SIZE`) — a sandbox artifact, not this diff: the environment shipped without `mobile/node_modules`, I installed them mid-session, and the same errors reproduce identically on a stashed clean tree. None of those files are in this diff, and CI's `typecheck` leg (which runs the same root script with mobile deps) passes.
- [x] `npm run lint` — exit 0.
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 8/8 selfchecks passed`.

Falsifiability of the new tests: the emit assertion was inverted by dropping the `emit("change")` phase from `handleExportImage`, and the suite went red on exactly that case —

```
✕ fires its change event once per finished drawing
  Expected number of calls: 1
  Received number of calls: 0
Tests: 1 failed, 9 passed, 10 total
```

The paper-fill assertion runs against a stubbed 2D context that records what was painted, so it cannot pass on a silently empty layer (jsdom has no canvas encoder), and the seeding behaviour is pinned in both directions — an inline PNG is redrawn, an `https://` ref starts blank.

## Agent capabilities

Not applicable — no agent capability is added and no capability contract changes. The widget reaches agents through `WIDGET_CATALOG`, which the existing `configCatalog` parity test and the mobile catalog-coverage test already gate.

## New checks

Not applicable — no new check, rule or audit. The added tests are covered under **Verification** above.