### PR TITLE
feat(appbuilder): add form, capture, compare and pick widgets

### DIFF
--- a/docs/mini-apps-mobile.md
+++ b/docs/mini-apps-mobile.md
@@ -50,7 +50,7 @@ Outputs fill in as the run streams them.
 ## Widgets
 
 Every widget in the builder's catalog has a native renderer. The document
-decides layout and behavior; only the controls differ. Four render differently
+decides layout and behavior; only the controls differ. These render differently
 enough to be worth knowing:
 
 | Widget | On the phone |
@@ -58,6 +58,10 @@ enough to be worth knowing:
 | **Columns** | Stacks vertically. Two columns side by side are unusable at phone width. |
 | **ImageInput / AudioInput / VideoInput / DocumentInput** | Opens the system photo or file picker. The pick is uploaded to the server so the workflow gets a URL it can fetch; if the upload fails the local file is used, which still previews on the device. |
 | **Sketch Pad** | An image picker. The app bundles no drawing surface, so the pad offers the camera and photo library for the same binding and says drawing needs the desktop app. |
+| **Audio Recorder / Camera Capture** | Records for real: the microphone through a record/stop control with elapsed time and playback, the camera through the system camera sheet. Both upload the take, so the workflow reads the same `{type, uri, asset_id}` an upload writes. A denied permission says so and leaves the file picker as the way through. |
+| **Workflow Form** | One row per workflow input, in graph order. |
+| **Gallery** | Tapping a tile opens the pager; when the app wired a `selectionBinding`, tapping picks and a long press previews. |
+| **Image Compare** | Two labelled panes, before above after — a wipe handle needs more width than a phone has, and a thumb would cover it. |
 | **ResourcePicker / ResourceGallery** | A list of rows rather than a grid of tiles. Tapping one opens that document in the screen its kind already has — a storyboard in the storyboard editor, a sketch in the sketch viewer, an asset in the asset viewer. |
 | **ChatThread / ChatComposer / ModelSelect** | Native bubbles, a multiline composer, and a two-step provider-then-model picker. |
 

--- a/docs/mini-apps-reference.md
+++ b/docs/mini-apps-reference.md
@@ -34,6 +34,8 @@ its own settings.
 | Table | A list, as rows. Max height, placeholder. |
 | Output | A value whose type varies; picks a display based on what arrives. |
 | Progress | How far along the run is. |
+| Gallery | A list of images as tiles. Tile size, placeholder. Set `selectionBinding` and a tap picks one. |
+| Image Compare | Two images under one wipe handle. `binding` is before, `compareBinding` after. Max height, placeholder. |
 
 Sketch and Timeline take a document reference — `{type: "sketch", id}` or
 `{type: "timeline", id}` — which is what the nodes that produce them emit. They
@@ -50,6 +52,7 @@ That's what makes on-release pacing possible — see
 
 | Widget | Takes | Commits |
 | --- | --- | --- |
+| Workflow Form | Every input of one operation at once, each rendered to match. | no |
 | Workflow Input | Whatever the bound Input node declares, rendered to match. | no |
 | Text Input | Text. Single-line or multiline. | yes |
 | Number Input | A number. Min, max, step. | yes |
@@ -59,12 +62,31 @@ That's what makes on-release pacing possible — see
 | Image Input | An image. | no |
 | Sketch Pad | A drawing the user makes on the spot. Canvas size, white or transparent paper. | yes |
 | Audio Input | An audio file. | no |
+| Audio Recorder | Audio recorded from the microphone, then and there. | no |
 | Video Input | A video. | no |
+| Camera Capture | Video recorded from the camera, then and there. | no |
 | Document Input | A document. | no |
 | Color Input | A color. | no |
 | Resource Picker | Picks which document a resource points at. | no |
 | Resource Gallery | The same, from a grid of tiles. Tile size. | no |
 | Storyboard Scenes | Edits the bound storyboard directly. Fires no event. | no |
+
+A Workflow Form is one widget where placing each input by hand would be several.
+It renders the inputs of the operation it names — the app's only operation
+unless you pick another — so an Input node added to the workflow shows up in the
+app with no edit. Place the inputs one by one instead when the layout matters:
+a form renders them in graph order, top to bottom.
+
+The Audio Recorder and Camera Capture write the same `{type, uri, asset_id}` ref
+an upload writes, so bind them to an Audio or Video Input and the workflow reads
+one value either way. The recording uploads as an asset when it finishes. On the
+builder canvas they show a placeholder instead of asking for the microphone or
+camera, so laying out an app never raises a permission prompt.
+
+A Gallery with a `selectionBinding` is the generate-then-pick loop: bind the
+gallery to a run's list of images, the selection to the input of the next step,
+and wire a run event to the selection so picking a tile starts it. What lands in
+the binding is the item the run emitted, not the URL it rendered.
 
 The Sketch Pad is the sketch editor's canvas with a four-tool chrome — brush,
 pencil, eraser, fill, plus colors, stroke size, undo and clear. Each finished

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -25,7 +25,8 @@
           }
         ],
         "NSSpeechRecognitionUsageDescription": "NodeTool transcribes your speech on-device to fill the chat composer.",
-        "NSMicrophoneUsageDescription": "NodeTool uses the microphone so you can dictate messages to the assistant."
+        "NSMicrophoneUsageDescription": "NodeTool uses the microphone so you can dictate messages to the assistant.",
+        "NSCameraUsageDescription": "NodeTool uses the camera so a Mini App can record video you feed to a workflow."
       }
     },
     "android": {
@@ -38,6 +39,7 @@
       "predictiveBackGestureEnabled": false,
       "permissions": [
         "android.permission.RECORD_AUDIO",
+        "android.permission.CAMERA",
         "android.permission.READ_EXTERNAL_STORAGE",
         "android.permission.WRITE_EXTERNAL_STORAGE",
         "android.permission.READ_MEDIA_VISUAL_USER_SELECTED",
@@ -84,6 +86,13 @@
           "savePhotosPermission": "NodeTool saves generated images and video to your photo library.",
           "photosPermission": "NodeTool reads photos you pick as workflow input.",
           "isAccessMediaLocationEnabled": false
+        }
+      ],
+      [
+        "expo-image-picker",
+        {
+          "photosPermission": "NodeTool reads photos and videos you pick as workflow input.",
+          "cameraPermission": "NodeTool uses the camera so a Mini App can record video you feed to a workflow."
         }
       ],
       "expo-video",

--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -69,7 +69,10 @@ jest.mock('expo-video', () => ({
   }),
 }));
 
-// Mock expo-audio for audio playback
+// Mock expo-audio for audio playback and recording. The recording half is here
+// because the app_runtime `AudioRecorder` widget reads `RecordingPresets` at
+// module scope, so every suite that imports the widget file needs it; a suite
+// that drives a recording mocks the module itself.
 jest.mock('expo-audio', () => ({
   useAudioPlayer: jest.fn(() => ({
     play: jest.fn(),
@@ -86,6 +89,29 @@ jest.mock('expo-audio', () => ({
     didJustFinish: false,
   })),
   setAudioModeAsync: jest.fn(),
+  RecordingPresets: {
+    HIGH_QUALITY: { extension: '.m4a' },
+    LOW_QUALITY: { extension: '.m4a' },
+  },
+  requestRecordingPermissionsAsync: jest
+    .fn()
+    .mockResolvedValue({ status: 'granted', granted: true, canAskAgain: true }),
+  getRecordingPermissionsAsync: jest
+    .fn()
+    .mockResolvedValue({ status: 'granted', granted: true, canAskAgain: true }),
+  useAudioRecorder: jest.fn(() => ({
+    uri: null,
+    prepareToRecordAsync: jest.fn().mockResolvedValue(undefined),
+    record: jest.fn(),
+    stop: jest.fn().mockResolvedValue(undefined),
+  })),
+  useAudioRecorderState: jest.fn(() => ({
+    canRecord: true,
+    isRecording: false,
+    durationMillis: 0,
+    mediaServicesDidReset: false,
+    url: null,
+  })),
 }));
 
 // Mock react-syntax-highlighter. The app deep-imports the two themes it uses

--- a/mobile/src/components/app_runtime/__tests__/captureInputs.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/captureInputs.test.tsx
@@ -1,0 +1,516 @@
+/**
+ * `AudioRecorder` and `CameraCapture`.
+ *
+ * The contract worth pinning is the value: whatever the phone captures must be
+ * exactly what `AudioInput` / `VideoInput` write, so one document runs on both
+ * surfaces and a workflow reads one shape either way. Each case therefore fills
+ * the capture widget — from the microphone, from the camera, or from the file
+ * picker — and its upload twin from the picker, then compares the two run
+ * params: a divergence in either field fails here.
+ *
+ * The other half is what happens when capture is refused or impossible. A
+ * denied permission has to be stated on screen, and the file picker has to
+ * still work, or the widget is a dead end.
+ */
+import { act, fireEvent, render, screen } from "@testing-library/react-native";
+
+import {
+  parseApplicationDocument,
+  type ApplicationDocument,
+} from "@nodetool-ai/app-runtime";
+
+import type { Workflow } from "../../../types/workflow";
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+const mockRun = jest.fn().mockResolvedValue(undefined);
+
+jest.mock("../../../stores/WorkflowRunner", () => ({
+  useWorkflowRunner: () => ({
+    getState: () => ({ job_id: null, run: mockRun, cancel: jest.fn() }),
+    subscribe: () => () => {},
+  }),
+}));
+
+jest.mock("../../../trpc/client", () => ({
+  trpc: {
+    assets: { get: { useQuery: () => ({ data: undefined, isLoading: false }) } },
+    useQueries: () => [],
+  },
+}));
+
+// The shared setup mock omits `MediaTypeOptions`, which `pickMediaValue` reads,
+// and the camera calls the capture path makes; the video paths would throw on
+// them before reaching the picker.
+jest.mock("expo-image-picker", () => ({
+  MediaTypeOptions: { Images: "Images", Videos: "Videos" },
+  launchImageLibraryAsync: jest.fn().mockResolvedValue({
+    canceled: false,
+    assets: [
+      { uri: "file:///test/clip.mp4", fileName: "clip.mp4", mimeType: "video/mp4" },
+    ],
+  }),
+  requestCameraPermissionsAsync: jest
+    .fn()
+    .mockResolvedValue({ status: "granted", granted: true, canAskAgain: true }),
+  launchCameraAsync: jest.fn().mockResolvedValue({
+    canceled: false,
+    assets: [
+      { uri: "file:///test/shot.mp4", fileName: "shot.mp4", mimeType: "video/mp4" },
+    ],
+  }),
+}));
+
+jest.mock("expo-document-picker", () => ({
+  getDocumentAsync: jest.fn().mockResolvedValue({
+    canceled: false,
+    assets: [
+      { uri: "file:///test/take.m4a", name: "take.m4a", mimeType: "audio/mp4" },
+    ],
+  }),
+}));
+
+/**
+ * A recorder that behaves like the real one for the two things the widget
+ * depends on: the state hook re-renders while a take runs, and `uri` is only
+ * set once `stop()` has resolved. The shared setup mock has no recorder at all.
+ */
+jest.mock("expo-audio", () => {
+  const React = require("react");
+
+  /**
+   * A tiny observable snapshot, so the state hooks re-render on a change.
+   *
+   * The listeners are `Function` rather than a named callback type because
+   * babel's `jest.mock` scope check reads a parameter name inside a type
+   * annotation (`(snapshot: Snapshot) => void`) as an out-of-scope variable and
+   * refuses to compile the factory.
+   */
+  const publish = (initial: Record<string, unknown>) => {
+    const listeners = new Set<Function>();
+    let current = initial;
+    return {
+      set: (patch: Record<string, unknown>) => {
+        current = { ...current, ...patch };
+        listeners.forEach((listener) => listener(current));
+      },
+      use: () => {
+        const [snapshot, setSnapshot] = React.useState(current);
+        React.useEffect(() => {
+          listeners.add(setSnapshot);
+          setSnapshot(current);
+          return () => {
+            listeners.delete(setSnapshot);
+          };
+        }, []);
+        return snapshot;
+      },
+    };
+  };
+
+  const recorderState = publish({
+    canRecord: true,
+    isRecording: false,
+    durationMillis: 0,
+    mediaServicesDidReset: false,
+    url: null,
+  });
+  const playerState = publish({
+    isLoaded: true,
+    playing: false,
+    currentTime: 0,
+    duration: 7,
+    didJustFinish: false,
+  });
+
+  const recorder = {
+    uri: null as string | null,
+    prepareToRecordAsync: jest.fn().mockResolvedValue(undefined),
+    record: jest.fn(() => {
+      recorder.uri = null;
+      recorderState.set({ isRecording: true, durationMillis: 7000 });
+    }),
+    stop: jest.fn(async () => {
+      recorder.uri = "file:///test/recording.m4a";
+      recorderState.set({ isRecording: false });
+    }),
+  };
+
+  const player = {
+    play: jest.fn(() => playerState.set({ playing: true })),
+    pause: jest.fn(() => playerState.set({ playing: false })),
+    seekTo: jest.fn(),
+    replace: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  return {
+    RecordingPresets: { HIGH_QUALITY: { extension: ".m4a" }, LOW_QUALITY: {} },
+    requestRecordingPermissionsAsync: jest
+      .fn()
+      .mockResolvedValue({ status: "granted", granted: true, canAskAgain: true }),
+    setAudioModeAsync: jest.fn().mockResolvedValue(undefined),
+    useAudioRecorder: () => recorder,
+    useAudioRecorderState: () => recorderState.use(),
+    useAudioPlayer: () => player,
+    useAudioPlayerStatus: () => playerState.use(),
+    __recorder: recorder,
+    __player: player,
+    __reset: () => {
+      recorder.uri = null;
+      recorderState.set({ isRecording: false, durationMillis: 0 });
+      playerState.set({ playing: false });
+    },
+  };
+});
+
+import * as ImagePicker from "expo-image-picker";
+import * as Audio from "expo-audio";
+
+import { webSocketService } from "../../../services/WebSocketService";
+
+jest.spyOn(webSocketService, "subscribe").mockReturnValue(() => {});
+
+import { apiService } from "../../../services/api";
+
+jest.spyOn(apiService, "resolveUrl").mockImplementation((uri) => uri ?? null);
+jest.spyOn(apiService, "getApiHost").mockReturnValue("http://localhost:7777");
+// Whatever was captured or picked is uploaded; the asset id is what the stored
+// value carries, so it is pinned rather than dialled for.
+jest
+  .spyOn(apiService, "uploadAsset")
+  .mockResolvedValue({ id: "asset-9" } as never);
+
+import ApplicationAppView from "../ApplicationAppView";
+
+/** Escape hatches the recorder mock exposes to the test. */
+const audioMock = Audio as unknown as {
+  __recorder: { record: jest.Mock; stop: jest.Mock; prepareToRecordAsync: jest.Mock };
+  __player: { play: jest.Mock; pause: jest.Mock; seekTo: jest.Mock };
+  __reset: () => void;
+  requestRecordingPermissionsAsync: jest.Mock;
+};
+
+const cameraMock = ImagePicker as unknown as {
+  launchCameraAsync: jest.Mock;
+  requestCameraPermissionsAsync: jest.Mock;
+};
+
+/** The capture widget and its upload twin over one workflow, plus Run. */
+const appDoc = (captureType: string, uploadType: string) => ({
+  schemaVersion: 3,
+  ui: {
+    root: { props: { title: "Capture" } },
+    content: [
+      { type: captureType, props: { id: "cap-1", binding: "op:main/in:n1" } },
+      { type: uploadType, props: { id: "up-1", binding: "op:main/in:n2" } },
+      {
+        type: "Button",
+        props: {
+          id: "btn-run",
+          label: "Run",
+          events: [{ trigger: "click", kind: "run" }],
+        },
+      },
+    ],
+    zones: {},
+  },
+  operations: [
+    {
+      id: "main",
+      name: "Run",
+      workflowId: "wf-capture",
+      inputs: {},
+      outputs: {},
+      policy: "replace",
+    },
+  ],
+  resources: [],
+  variables: [],
+});
+
+const workflow = (id: string, nodeType: string): Workflow =>
+  ({
+    id,
+    name: "Capture",
+    description: "",
+    graph: {
+      nodes: [
+        { id: "n1", type: nodeType, data: { name: "captured" } },
+        { id: "n2", type: nodeType, data: { name: "uploaded" } },
+      ],
+      edges: [],
+    },
+    access: "private",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    // The fixtures carry only the fields the widgets read.
+  }) as unknown as Workflow;
+
+const renderCapture = (
+  id: string,
+  captureType: string,
+  uploadType: string,
+  nodeType: string
+) =>
+  render(
+    <ApplicationAppView
+      document={
+        parseApplicationDocument(appDoc(captureType, uploadType)) as ApplicationDocument
+      }
+      workflow={workflow(id, nodeType)}
+    />
+  );
+
+const press = async (label: string) => {
+  await act(async () => {
+    fireEvent.press(screen.getByText(label));
+  });
+};
+
+/** The first of two identically-labelled buttons is the capture widget's. */
+const pressFirst = async (label: string) => {
+  await act(async () => {
+    fireEvent.press(screen.getAllByText(label)[0]);
+  });
+};
+
+const runNow = async () => {
+  await act(async () => {
+    fireEvent.press(screen.getByText("Run"));
+  });
+  return mockRun.mock.calls[0][0] as Record<string, unknown>;
+};
+
+/** Fill the capture widget from the file picker, then its twin, then run. */
+const fillBothFromPickerAndRun = async (button: string) => {
+  await pressFirst(button);
+  await press(button);
+  return runNow();
+};
+
+beforeEach(() => {
+  mockRun.mockClear();
+  audioMock.__reset();
+  audioMock.__recorder.record.mockClear();
+  audioMock.__recorder.stop.mockClear();
+  audioMock.__player.play.mockClear();
+  audioMock.__player.pause.mockClear();
+  audioMock.requestRecordingPermissionsAsync.mockResolvedValue({
+    status: "granted",
+    granted: true,
+    canAskAgain: true,
+  });
+  cameraMock.launchCameraAsync.mockClear();
+  cameraMock.requestCameraPermissionsAsync.mockResolvedValue({
+    status: "granted",
+    granted: true,
+    canAskAgain: true,
+  });
+});
+
+const AUDIO_VALUE = {
+  type: "audio",
+  uri: "http://localhost:7777/api/storage/asset-9.m4a",
+  asset_id: "asset-9",
+};
+
+const VIDEO_VALUE = {
+  type: "video",
+  uri: "http://localhost:7777/api/storage/asset-9.mp4",
+  asset_id: "asset-9",
+};
+
+describe("AudioRecorder", () => {
+  it("records with the microphone and writes what AudioInput writes", async () => {
+    renderCapture(
+      "wf-audio-record",
+      "AudioRecorder",
+      "AudioInput",
+      "nodetool.input.AudioInput"
+    );
+
+    await press("Record");
+    await press("Stop recording");
+    // The capture widget's own picker button now reads "Replace audio", so this
+    // one is the twin's.
+    await press("Choose audio");
+    const params = await runNow();
+
+    expect(audioMock.__recorder.prepareToRecordAsync).toHaveBeenCalled();
+    expect(audioMock.__recorder.record).toHaveBeenCalled();
+    expect(params.captured).toEqual(AUDIO_VALUE);
+    expect(params.captured).toEqual(params.uploaded);
+  });
+
+  it("counts the take up while recording and holds its length after", async () => {
+    renderCapture(
+      "wf-audio-elapsed",
+      "AudioRecorder",
+      "AudioInput",
+      "nodetool.input.AudioInput"
+    );
+
+    await press("Record");
+    expect(screen.getByText("Recording 0:07")).toBeTruthy();
+
+    await press("Stop recording");
+    expect(screen.getByText("Take 0:07")).toBeTruthy();
+  });
+
+  it("plays the take back", async () => {
+    renderCapture(
+      "wf-audio-playback",
+      "AudioRecorder",
+      "AudioInput",
+      "nodetool.input.AudioInput"
+    );
+
+    await press("Record");
+    await press("Stop recording");
+    await press("Play");
+
+    expect(audioMock.__player.play).toHaveBeenCalled();
+
+    await press("Pause");
+    expect(audioMock.__player.pause).toHaveBeenCalled();
+  });
+
+  it("says the microphone was refused, and still takes a file", async () => {
+    audioMock.requestRecordingPermissionsAsync.mockResolvedValue({
+      status: "denied",
+      granted: false,
+      canAskAgain: true,
+    });
+    renderCapture(
+      "wf-audio-denied",
+      "AudioRecorder",
+      "AudioInput",
+      "nodetool.input.AudioInput"
+    );
+
+    await press("Record");
+
+    expect(audioMock.__recorder.record).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(
+        "Microphone access is needed to record. Allow it, or pick an existing file."
+      )
+    ).toBeTruthy();
+
+    const params = await fillBothFromPickerAndRun("Choose audio");
+    expect(params.captured).toEqual(AUDIO_VALUE);
+    expect(params.captured).toEqual(params.uploaded);
+  });
+
+  it("writes what AudioInput writes when the file comes from the picker", async () => {
+    renderCapture(
+      "wf-audio-capture",
+      "AudioRecorder",
+      "AudioInput",
+      "nodetool.input.AudioInput"
+    );
+
+    const params = await fillBothFromPickerAndRun("Choose audio");
+
+    expect(params.captured).toEqual(AUDIO_VALUE);
+    expect(params.captured).toEqual(params.uploaded);
+  });
+
+  it("names the slot and offers both ways to fill it", () => {
+    renderCapture(
+      "wf-audio-copy",
+      "AudioRecorder",
+      "AudioInput",
+      "nodetool.input.AudioInput"
+    );
+
+    expect(screen.getByText("Audio recording")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Record with the microphone, or pick an audio file you already have."
+      )
+    ).toBeTruthy();
+  });
+});
+
+describe("CameraCapture", () => {
+  it("records with the camera and writes what VideoInput writes", async () => {
+    renderCapture(
+      "wf-video-record",
+      "CameraCapture",
+      "VideoInput",
+      "nodetool.input.VideoInput"
+    );
+
+    await press("Record video");
+    await press("Choose video");
+    const params = await runNow();
+
+    expect(cameraMock.requestCameraPermissionsAsync).toHaveBeenCalled();
+    expect(cameraMock.launchCameraAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ mediaTypes: ["videos"] })
+    );
+    expect(params.captured).toEqual(VIDEO_VALUE);
+    expect(params.captured).toEqual(params.uploaded);
+  });
+
+  it("says the camera was refused, and still takes a file", async () => {
+    cameraMock.requestCameraPermissionsAsync.mockResolvedValue({
+      status: "denied",
+      granted: false,
+      canAskAgain: false,
+    });
+    renderCapture(
+      "wf-video-denied",
+      "CameraCapture",
+      "VideoInput",
+      "nodetool.input.VideoInput"
+    );
+
+    await press("Record video");
+
+    expect(cameraMock.launchCameraAsync).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(
+        "Camera access is off for NodeTool. Turn it on in Settings, or pick an existing clip."
+      )
+    ).toBeTruthy();
+
+    const params = await fillBothFromPickerAndRun("Choose video");
+    expect(params.captured).toEqual(VIDEO_VALUE);
+    expect(params.captured).toEqual(params.uploaded);
+  });
+
+  it("writes what VideoInput writes when the clip comes from the picker", async () => {
+    renderCapture(
+      "wf-video-capture",
+      "CameraCapture",
+      "VideoInput",
+      "nodetool.input.VideoInput"
+    );
+
+    const params = await fillBothFromPickerAndRun("Choose video");
+
+    expect(params.captured).toEqual(VIDEO_VALUE);
+    expect(params.captured).toEqual(params.uploaded);
+  });
+
+  it("names the slot and offers both ways to fill it", () => {
+    renderCapture(
+      "wf-video-copy",
+      "CameraCapture",
+      "VideoInput",
+      "nodetool.input.VideoInput"
+    );
+
+    expect(screen.getByText("Camera capture")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Record with the camera, or pick a clip you already have."
+      )
+    ).toBeTruthy();
+  });
+});

--- a/mobile/src/components/app_runtime/__tests__/newWidgets.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/newWidgets.test.tsx
@@ -7,7 +7,7 @@
  * card names the value and offers to open it, not that it draws it.
  */
 import { Dimensions } from "react-native";
-import { fireEvent, render, screen } from "@testing-library/react-native";
+import { act, fireEvent, render, screen } from "@testing-library/react-native";
 
 /** The pager pages by window width, so a scripted swipe offsets by it. */
 const WINDOW_WIDTH = Dimensions.get("window").width;
@@ -33,11 +33,15 @@ jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({ navigate: jest.fn() }),
 }));
 
+// Captured so a widget that writes into an input slot can be checked through
+// the run params — the name-keyed bag the server receives.
+const mockRun = jest.fn().mockResolvedValue(undefined);
+
 jest.mock("../../../stores/WorkflowRunner", () => ({
   useWorkflowRunner: () => ({
     getState: () => ({
       job_id: null,
-      run: jest.fn().mockResolvedValue(undefined),
+      run: mockRun,
       cancel: jest.fn().mockResolvedValue(undefined),
     }),
     subscribe: () => () => {},
@@ -93,16 +97,17 @@ const appDoc = (
   ],
 });
 
-const makeWorkflow = (id: string): Workflow =>
+const makeWorkflow = (id: string, nodes: unknown[] = []): Workflow =>
   ({
     id,
     name: "Catalog",
     description: "",
-    graph: { nodes: [], edges: [] },
+    graph: { nodes, edges: [] },
     access: "private",
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
-  });
+    // The fixtures carry only the fields the widgets read.
+  }) as unknown as Workflow;
 
 const renderApp = (id: string, doc: unknown) =>
   render(
@@ -111,6 +116,65 @@ const renderApp = (id: string, doc: unknown) =>
       workflow={makeWorkflow(id)}
     />
   );
+
+/** A document of several widgets over one variable, plus a Run button. */
+const runnableDoc = (content: unknown[], value?: unknown) => ({
+  schemaVersion: 3,
+  ui: {
+    root: { props: { title: "Catalog" } },
+    content: [
+      ...content,
+      {
+        type: "Button",
+        props: {
+          id: "btn-run",
+          label: "Run",
+          events: [{ trigger: "click", kind: "run" }],
+        },
+      },
+    ],
+    zones: {},
+  },
+  operations: [
+    {
+      id: "main",
+      name: "Run",
+      workflowId: "wf-new",
+      inputs: {},
+      outputs: {},
+      policy: "replace",
+    },
+  ],
+  resources: [],
+  variables: [
+    {
+      id: "data",
+      name: "data",
+      scope: "instance",
+      persist: false,
+      default: value,
+    },
+  ],
+});
+
+const renderRunnable = (
+  id: string,
+  content: unknown[],
+  value: unknown,
+  nodes: unknown[]
+) =>
+  render(
+    <ApplicationAppView
+      document={
+        parseApplicationDocument(runnableDoc(content, value)) as ApplicationDocument
+      }
+      workflow={makeWorkflow(id, nodes)}
+    />
+  );
+
+beforeEach(() => {
+  mockRun.mockClear();
+});
 
 describe("catalog coverage", () => {
   it("has a native renderer for every catalog type", () => {
@@ -255,6 +319,175 @@ describe("display fallbacks", () => {
     renderApp("wf-gallery-empty", appDoc("Gallery", { placeholder: "Nothing" }, []));
 
     expect(screen.getByText("Nothing")).toBeTruthy();
+  });
+});
+
+describe("gallery selection", () => {
+  const IMAGES = [
+    { type: "image", uri: "https://x.test/a.png" },
+    { type: "image", uri: "https://x.test/b.png" },
+  ];
+
+  const gallery = (props: Record<string, unknown> = {}) => [
+    {
+      type: "Gallery",
+      props: { id: "gal-1", binding: "var:data", ...props },
+    },
+  ];
+
+  const PICKED_NODE = [
+    { id: "n1", type: "nodetool.input.ImageInput", data: { name: "picked" } },
+  ];
+
+  it("writes the tapped tile's original item, not its resolved URL", async () => {
+    renderRunnable(
+      "wf-gallery-pick",
+      gallery({ selectionBinding: "op:main/in:n1" }),
+      IMAGES,
+      PICKED_NODE
+    );
+
+    fireEvent.press((await screen.findAllByTestId("gallery-tile"))[1]);
+    await act(async () => {
+      fireEvent.press(screen.getByText("Run"));
+    });
+
+    // The array element verbatim: a workflow that expects an ImageRef gets one,
+    // not the string the tile happened to render from.
+    expect(mockRun.mock.calls[0][0]).toEqual({ picked: IMAGES[1] });
+  });
+
+  it("marks the tile the selection binding currently holds", async () => {
+    renderRunnable(
+      "wf-gallery-marked",
+      gallery({ selectionBinding: "op:main/in:n1" }),
+      IMAGES,
+      PICKED_NODE
+    );
+
+    const tiles = await screen.findAllByTestId("gallery-tile");
+    expect(tiles[0].props.accessibilityState.selected).toBe(false);
+
+    fireEvent.press(tiles[0]);
+
+    const marked = screen.getAllByTestId("gallery-tile");
+    expect(marked[0].props.accessibilityState.selected).toBe(true);
+    expect(marked[1].props.accessibilityState.selected).toBe(false);
+  });
+
+  it("picks instead of previewing, and keeps the preview on a long press", async () => {
+    renderRunnable(
+      "wf-gallery-longpress",
+      gallery({ selectionBinding: "op:main/in:n1" }),
+      IMAGES,
+      PICKED_NODE
+    );
+
+    const tiles = await screen.findAllByTestId("gallery-tile");
+    fireEvent.press(tiles[1]);
+    expect(screen.queryByTestId("gallery-pager")).toBeNull();
+
+    fireEvent(tiles[1], "longPress");
+    expect(screen.getByTestId("gallery-pager")).toBeTruthy();
+  });
+
+  it("leaves an unselectable gallery opening the viewer on tap", async () => {
+    renderRunnable("wf-gallery-plain", gallery(), IMAGES, PICKED_NODE);
+
+    const tiles = await screen.findAllByTestId("gallery-tile");
+    expect(tiles[0].props.accessibilityState.selected).toBe(false);
+
+    fireEvent.press(tiles[0]);
+
+    expect(screen.getByTestId("gallery-pager")).toBeTruthy();
+    // Nothing is written, so nothing is ever marked.
+    expect(
+      screen.getAllByTestId("gallery-tile")[0].props.accessibilityState.selected
+    ).toBe(false);
+  });
+});
+
+describe("image compare", () => {
+  /**
+   * Two bindings, so the widget needs a document of its own: `before` on
+   * `binding`, `after` on `compareBinding`. Each case gets its own workflow id —
+   * the runtime store is cached per instance, so a shared one would carry the
+   * previous case's values.
+   */
+  const compareDoc = (before?: unknown, after?: unknown, props = {}) => ({
+    schemaVersion: 3,
+    ui: {
+      root: { props: { title: "Catalog" } },
+      content: [
+        {
+          type: "ImageCompare",
+          props: {
+            id: "cmp-1",
+            binding: "var:before",
+            compareBinding: "var:after",
+            ...props,
+          },
+        },
+      ],
+      zones: {},
+    },
+    operations: [
+      {
+        id: "main",
+        name: "Run",
+        workflowId: "wf-new",
+        inputs: {},
+        outputs: {},
+        policy: "replace",
+      },
+    ],
+    resources: [],
+    variables: [
+      { id: "before", name: "before", scope: "instance", persist: false, default: before },
+      { id: "after", name: "after", scope: "instance", persist: false, default: after },
+    ],
+  });
+
+  const BEFORE = { type: "image", uri: "https://x.test/before.png" };
+  const AFTER = { type: "image", uri: "https://x.test/after.png" };
+
+  it("labels both bound images before and after", async () => {
+    renderApp("wf-compare-both", compareDoc(BEFORE, AFTER, { label: "Edit" }));
+
+    expect(await screen.findByText("Edit")).toBeTruthy();
+    expect(screen.getByLabelText("Before").props.source.uri).toBe(BEFORE.uri);
+    expect(screen.getByLabelText("After").props.source.uri).toBe(AFTER.uri);
+  });
+
+  it("renders only the half that is bound", async () => {
+    renderApp("wf-compare-one", compareDoc(BEFORE));
+
+    expect(await screen.findByLabelText("Before")).toBeTruthy();
+    expect(screen.queryByLabelText("After")).toBeNull();
+  });
+
+  it("renders the after half on its own", async () => {
+    renderApp("wf-compare-after", compareDoc(undefined, AFTER));
+
+    expect(await screen.findByLabelText("After")).toBeTruthy();
+    expect(screen.queryByLabelText("Before")).toBeNull();
+  });
+
+  it("caps each pane at the widget's height", async () => {
+    renderApp("wf-compare-height", compareDoc(BEFORE, AFTER, { height: 120 }));
+
+    const pane = await screen.findByLabelText("Before");
+    expect(pane.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ height: 120 })])
+    );
+  });
+
+  it("shows the placeholder when neither half is bound", () => {
+    renderApp("wf-compare-empty", compareDoc(undefined, undefined, {
+      placeholder: "Run it first",
+    }));
+
+    expect(screen.getByText("Run it first")).toBeTruthy();
   });
 });
 

--- a/mobile/src/components/app_runtime/__tests__/workflowForm.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/workflowForm.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * `WorkflowForm`: every input of one operation in one widget.
+ *
+ * What the rows are worth is which slot each one writes, so the assertions go
+ * through the run params — the same name-keyed bag the server receives — rather
+ * than through the store. A row that wrote the wrong slot renders identically
+ * and would pass a render-only test.
+ */
+import { act, fireEvent, render, screen } from "@testing-library/react-native";
+
+import {
+  parseApplicationDocument,
+  type ApplicationDocument,
+} from "@nodetool-ai/app-runtime";
+
+import type { Workflow } from "../../../types/workflow";
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+const mockRun = jest.fn().mockResolvedValue(undefined);
+
+jest.mock("../../../stores/WorkflowRunner", () => ({
+  useWorkflowRunner: () => ({
+    getState: () => ({ job_id: null, run: mockRun, cancel: jest.fn() }),
+    subscribe: () => () => {},
+  }),
+}));
+
+jest.mock("../../../trpc/client", () => ({
+  trpc: {
+    assets: { get: { useQuery: () => ({ data: undefined, isLoading: false }) } },
+    useQueries: () => [],
+  },
+}));
+
+import { webSocketService } from "../../../services/WebSocketService";
+
+jest.spyOn(webSocketService, "subscribe").mockReturnValue(() => {});
+
+import { apiService } from "../../../services/api";
+
+jest.spyOn(apiService, "resolveUrl").mockImplementation((uri) => uri ?? null);
+jest.spyOn(apiService, "getApiHost").mockReturnValue("http://localhost:7777");
+
+import ApplicationAppView from "../ApplicationAppView";
+
+const RUN_BUTTON = {
+  type: "Button",
+  props: {
+    id: "btn-run",
+    label: "Run",
+    events: [{ trigger: "click", kind: "run" }],
+  },
+};
+
+const appDoc = (formProps: Record<string, unknown>, extra: unknown[] = []) => ({
+  schemaVersion: 3,
+  ui: {
+    root: { props: { title: "Form" } },
+    content: [
+      { type: "WorkflowForm", props: { id: "form-1", ...formProps } },
+      RUN_BUTTON,
+      ...extra,
+    ],
+    zones: {},
+  },
+  operations: [
+    {
+      id: "main",
+      name: "Run",
+      workflowId: "wf-form",
+      inputs: {},
+      outputs: {},
+      policy: "replace",
+    },
+  ],
+  resources: [],
+  variables: [],
+});
+
+/** Three inputs of three kinds, so each row has to pick its own control. */
+const NODES = [
+  {
+    id: "n1",
+    type: "nodetool.input.StringInput",
+    data: { name: "prompt", label: "Prompt", description: "What to write" },
+  },
+  {
+    id: "n2",
+    type: "nodetool.input.IntegerInput",
+    data: { name: "count", label: "Count" },
+  },
+  {
+    id: "n3",
+    type: "nodetool.input.BooleanInput",
+    data: { name: "loud", label: "Loud" },
+  },
+];
+
+const workflow = (nodes: unknown[]): Workflow =>
+  ({
+    id: "wf-form",
+    name: "Form",
+    description: "",
+    graph: { nodes, edges: [] },
+    access: "private",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    // The fixtures carry only the fields the widgets read.
+  }) as unknown as Workflow;
+
+const renderForm = (
+  formProps: Record<string, unknown> = {},
+  nodes: unknown[] = NODES
+) =>
+  render(
+    <ApplicationAppView
+      document={parseApplicationDocument(appDoc(formProps)) as ApplicationDocument}
+      workflow={workflow(nodes)}
+    />
+  );
+
+beforeEach(() => {
+  mockRun.mockClear();
+});
+
+describe("WorkflowForm", () => {
+  it("renders one row per input, with the control each kind needs", () => {
+    renderForm({ label: "Settings" });
+
+    expect(screen.getByText("Settings")).toBeTruthy();
+    expect(screen.getByText("Prompt")).toBeTruthy();
+    expect(screen.getByText("Count")).toBeTruthy();
+    expect(screen.getByText("Loud")).toBeTruthy();
+    // Boolean renders a switch, not a text box.
+    expect(screen.getByRole("switch")).toBeTruthy();
+  });
+
+  it("writes each row to its own input slot", async () => {
+    renderForm();
+
+    fireEvent.changeText(screen.getByDisplayValue(""), "hello");
+    fireEvent(screen.getByRole("switch"), "valueChange", true);
+
+    await act(async () => {
+      fireEvent.press(screen.getByText("Run"));
+    });
+
+    // Bindings key on node ids; the run protocol wants each node's name — so a
+    // row that wrote another node's slot lands under the wrong key here.
+    expect(mockRun).toHaveBeenCalledTimes(1);
+    expect(mockRun.mock.calls[0][0]).toMatchObject({
+      prompt: "hello",
+      loud: true,
+    });
+  });
+
+  it("fires the form's change events on any row change", async () => {
+    renderForm({ events: [{ trigger: "change", kind: "run" }] });
+
+    await act(async () => {
+      fireEvent(screen.getByRole("switch"), "valueChange", true);
+    });
+
+    expect(mockRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("captions each row with the input's description", () => {
+    renderForm();
+
+    expect(screen.getByText("What to write")).toBeTruthy();
+  });
+
+  it("hides the descriptions when the author turned them off", () => {
+    renderForm({ showDescriptions: "no" });
+
+    expect(screen.queryByText("What to write")).toBeNull();
+  });
+
+  it("says so when the operation has no inputs", () => {
+    renderForm({ label: "Settings" }, []);
+
+    expect(screen.getByText("Settings")).toBeTruthy();
+    expect(screen.getByText("This operation has no inputs.")).toBeTruthy();
+  });
+
+  it("picks up an Input node the app document never mentions", () => {
+    // The form binds no node, so a graph edit reaches it with no app edit.
+    renderForm({}, [
+      ...NODES,
+      {
+        id: "n4",
+        type: "nodetool.input.StringInput",
+        data: { name: "tone", label: "Tone" },
+      },
+    ]);
+
+    expect(screen.getByText("Tone")).toBeTruthy();
+  });
+});

--- a/mobile/src/components/app_runtime/audioCapture.tsx
+++ b/mobile/src/components/app_runtime/audioCapture.tsx
@@ -1,0 +1,224 @@
+/**
+ * Recording audio on the phone, for the `AudioRecorder` widget.
+ *
+ * Its own module because a recorder is a small state machine — permission,
+ * prepare, record, stop, play back the take — and none of that belongs in the
+ * widget file. What it hands back is a `CapturedFile`; the widget uploads it
+ * through `uploadCapturedFile`, so a recording and a picked file reach the
+ * workflow as the same `{type, uri, asset_id}`.
+ *
+ * expo-audio's recorder is prepared before every take: `record()` on a recorder
+ * that was already stopped does nothing until `prepareToRecordAsync()` runs
+ * again, and iOS needs `allowsRecording` on the audio session while the take is
+ * in progress and off afterwards, or playback comes out through the earpiece.
+ */
+import React, { useCallback, useState } from "react";
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import {
+  RecordingPresets,
+  requestRecordingPermissionsAsync,
+  setAudioModeAsync,
+  useAudioPlayer,
+  useAudioPlayerStatus,
+  useAudioRecorder,
+  useAudioRecorderState,
+} from "expo-audio";
+
+import { formatDuration } from "@nodetool-ai/app-runtime";
+
+import type { ThemeColors } from "../../utils/theme";
+import type { CapturedFile } from "./mediaPicker";
+
+const PRESET = RecordingPresets.HIGH_QUALITY;
+
+/** How often the elapsed counter refreshes while a take runs. */
+const TICK_MS = 250;
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+  ".m4a": "audio/mp4",
+  ".mp4": "audio/mp4",
+  ".caf": "audio/x-caf",
+  ".3gp": "audio/3gpp",
+  ".webm": "audio/webm",
+  ".wav": "audio/wav",
+};
+
+/**
+ * The recorder names the file it wrote, and its extension is what says which
+ * container came out — the preset differs per platform (`.m4a`, `.3gp` on an
+ * Android low-quality take), so reading the URI beats assuming.
+ */
+export const describeRecording = (uri: string): CapturedFile => {
+  const path = uri.split("?")[0];
+  const dot = path.lastIndexOf(".");
+  const extension =
+    dot > path.lastIndexOf("/") ? path.slice(dot).toLowerCase() : PRESET.extension ?? ".m4a";
+  return {
+    uri,
+    name: `recording_${Date.now()}${extension}`,
+    mimeType: MIME_BY_EXTENSION[extension] ?? "audio/mp4",
+  };
+};
+
+interface AudioCaptureControlProps {
+  colors: ThemeColors;
+  disabled?: boolean;
+  /** Set while the widget uploads the take — the controls stay put, but inert. */
+  busy?: boolean;
+  onCaptured: (file: CapturedFile) => void;
+}
+
+/**
+ * Record / stop, the elapsed time, and playback of the take just recorded.
+ * A refused microphone permission is stated here rather than swallowed.
+ */
+export const AudioCaptureControl: React.FC<AudioCaptureControlProps> = ({
+  colors,
+  disabled,
+  busy,
+  onCaptured,
+}) => {
+  const recorder = useAudioRecorder(PRESET);
+  const recorderState = useAudioRecorderState(recorder, TICK_MS);
+  const [takeUri, setTakeUri] = useState<string | null>(null);
+  const [takeMillis, setTakeMillis] = useState(0);
+  const [notice, setNotice] = useState<string | null>(null);
+  const player = useAudioPlayer(takeUri);
+  const playerStatus = useAudioPlayerStatus(player);
+
+  const start = useCallback(async () => {
+    setNotice(null);
+    const permission = await requestRecordingPermissionsAsync();
+    if (!permission.granted) {
+      setNotice(
+        permission.canAskAgain
+          ? "Microphone access is needed to record. Allow it, or pick an existing file."
+          : "Microphone access is off for NodeTool. Turn it on in Settings, or pick an existing file."
+      );
+      return;
+    }
+    try {
+      await setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true });
+      await recorder.prepareToRecordAsync();
+      recorder.record();
+      setTakeUri(null);
+      setTakeMillis(0);
+    } catch (error) {
+      console.error("Failed to start recording:", error);
+      setNotice("This device could not start recording. Pick an existing file instead.");
+    }
+  }, [recorder]);
+
+  const stop = useCallback(async () => {
+    const elapsed = recorderState.durationMillis;
+    try {
+      await recorder.stop();
+    } catch (error) {
+      console.error("Failed to stop recording:", error);
+      setNotice("The recording could not be saved. Try again, or pick an existing file.");
+      return;
+    } finally {
+      await setAudioModeAsync({ allowsRecording: false });
+    }
+    const uri = recorder.uri;
+    if (!uri) {
+      setNotice("The recording came back empty. Try again, or pick an existing file.");
+      return;
+    }
+    setTakeUri(uri);
+    setTakeMillis(elapsed);
+    onCaptured(describeRecording(uri));
+  }, [onCaptured, recorder, recorderState.durationMillis]);
+
+  const togglePlayback = useCallback(() => {
+    if (playerStatus.playing) {
+      player.pause();
+      return;
+    }
+    player.seekTo(0);
+    player.play();
+  }, [player, playerStatus.playing]);
+
+  const recording = recorderState.isRecording;
+  const elapsed = recording ? recorderState.durationMillis : takeMillis;
+
+  return (
+    <View style={styles.control}>
+      <View style={styles.row}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          disabled={disabled || busy}
+          onPress={() => void (recording ? stop() : start())}
+          style={[
+            styles.button,
+            styles.grow,
+            {
+              borderColor: recording ? colors.error : colors.border,
+              backgroundColor: colors.inputBg,
+            },
+          ]}
+        >
+          {busy ? (
+            <ActivityIndicator color={colors.primary} size="small" />
+          ) : (
+            <Text style={{ color: recording ? colors.error : colors.primary }}>
+              {recording ? "Stop recording" : takeUri ? "Record again" : "Record"}
+            </Text>
+          )}
+        </TouchableOpacity>
+        {takeUri && !recording ? (
+          <TouchableOpacity
+            accessibilityRole="button"
+            disabled={disabled || busy}
+            onPress={togglePlayback}
+            style={[
+              styles.button,
+              { borderColor: colors.border, backgroundColor: colors.inputBg },
+            ]}
+          >
+            <Text style={{ color: colors.primary }}>
+              {playerStatus.playing ? "Pause" : "Play"}
+            </Text>
+          </TouchableOpacity>
+        ) : null}
+      </View>
+      {recording || elapsed > 0 ? (
+        <Text style={[styles.meta, { color: recording ? colors.error : colors.textTertiary }]}>
+          {recording ? `Recording ${formatDuration(elapsed)}` : `Take ${formatDuration(elapsed)}`}
+        </Text>
+      ) : null}
+      {notice ? (
+        <Text style={[styles.meta, { color: colors.error }]}>{notice}</Text>
+      ) : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  control: {
+    gap: 8,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  grow: {
+    flex: 1,
+  },
+  button: {
+    alignItems: "center",
+    padding: 12,
+    borderRadius: 10,
+    borderWidth: 1,
+  },
+  meta: {
+    fontSize: 12,
+  },
+});

--- a/mobile/src/components/app_runtime/mediaPicker.ts
+++ b/mobile/src/components/app_runtime/mediaPicker.ts
@@ -1,8 +1,11 @@
 /**
- * Picking a media value for a media input widget.
+ * Producing a media value for a media input widget — by picking a file, or by
+ * capturing one with the camera or the microphone.
  *
- * Picked files are uploaded so the workflow gets a URL the server can fetch;
- * if the upload fails the local URI is used, which still previews on device.
+ * Files are uploaded so the workflow gets a URL the server can fetch; if the
+ * upload fails the local URI is used, which still previews on device. A capture
+ * goes through that same upload, so a recorder writes exactly what an upload
+ * writes and one app document behaves the same on web and on the phone.
  * Mirrors the media widgets in `graph_editor/PropertyField.tsx`.
  */
 import * as DocumentPicker from "expo-document-picker";
@@ -16,11 +19,29 @@ import { apiService } from "../../services/api";
  */
 export type MediaKind = "image" | "audio" | "video" | "document" | "model_3d";
 
-interface MediaValue {
+export interface MediaValue {
   type: MediaKind;
   uri: string;
   asset_id?: string;
 }
+
+/** A file the device just produced: a camera clip, a finished recording. */
+export interface CapturedFile {
+  uri: string;
+  name: string;
+  mimeType: string;
+}
+
+/**
+ * What a capture attempt ended as. `denied` and `unavailable` carry the line the
+ * widget shows: a permission the user turned down must be visible, not a button
+ * that silently does nothing.
+ */
+export type CaptureResult =
+  | { status: "captured"; value: MediaValue }
+  | { status: "canceled" }
+  | { status: "denied"; message: string }
+  | { status: "unavailable"; message: string };
 
 const DEFAULTS = {
   image: { ext: ".jpg", mime: "image/jpeg" },
@@ -54,6 +75,61 @@ const upload = async (
   } catch (error) {
     console.error(`Failed to upload ${kind}:`, error);
     return { type: kind, uri };
+  }
+};
+
+/**
+ * Upload a captured file. The one path a capture and an upload share, so both
+ * write the same `{type, uri, asset_id}`.
+ */
+export const uploadCapturedFile = (
+  kind: MediaKind,
+  file: CapturedFile
+): Promise<MediaValue> => upload(kind, file.uri, file.name, file.mimeType);
+
+/**
+ * Record a clip with the camera and upload it.
+ *
+ * Permission follows `chat/ChatComposer.tsx`: request, and treat anything but
+ * `granted` as a refusal the caller shows. A device with no usable camera makes
+ * `launchCameraAsync` throw, which becomes `unavailable` rather than a crash —
+ * either way the widget still offers the library.
+ */
+export const captureVideoValue = async (): Promise<CaptureResult> => {
+  const permission = await ImagePicker.requestCameraPermissionsAsync();
+  if (permission.status !== "granted") {
+    return {
+      status: "denied",
+      message: permission.canAskAgain
+        ? "Camera access is needed to record. Allow it, or pick an existing clip."
+        : "Camera access is off for NodeTool. Turn it on in Settings, or pick an existing clip.",
+    };
+  }
+
+  try {
+    const result = await ImagePicker.launchCameraAsync({
+      mediaTypes: ["videos"],
+      quality: 0.8,
+    });
+    const shot = result.canceled ? undefined : result.assets[0];
+    if (!shot) {
+      return { status: "canceled" };
+    }
+    const fallback = DEFAULTS.video;
+    return {
+      status: "captured",
+      value: await uploadCapturedFile("video", {
+        uri: shot.uri,
+        name: shot.fileName ?? `video_${Date.now()}${fallback.ext}`,
+        mimeType: shot.mimeType ?? fallback.mime,
+      }),
+    };
+  } catch (error) {
+    console.error("Failed to record video:", error);
+    return {
+      status: "unavailable",
+      message: "This device could not open the camera. Pick an existing clip instead.",
+    };
   }
 };
 

--- a/mobile/src/components/app_runtime/widgets.tsx
+++ b/mobile/src/components/app_runtime/widgets.tsx
@@ -32,6 +32,7 @@ import {
 } from "react-native";
 import {
   composeUserMessage,
+  encodeBinding,
   formatDuration,
   messagesFrom,
   messageText,
@@ -69,8 +70,17 @@ import {
 import { useWidgetRuntime } from "./useWidgetRuntime";
 import { SliderControl } from "./SliderControl";
 import { RESOURCE_RENDERERS } from "./resourceWidgets";
+import type { WorkflowInputIO } from "./workflowIO";
 import { ModelSelectWidget } from "./ModelSelectWidget";
-import { pickMediaValue, type MediaKind } from "./mediaPicker";
+import {
+  captureVideoValue,
+  pickMediaValue,
+  uploadCapturedFile,
+  type CapturedFile,
+  type MediaKind,
+  type MediaValue,
+} from "./mediaPicker";
+import { AudioCaptureControl } from "./audioCapture";
 import { clampNumber } from "./inputKinds";
 import { isFiniteNumber, isNumber, isRecord, isString } from "../../utils/typePredicates";
 
@@ -895,18 +905,60 @@ const GalleryViewer: React.FC<{
 };
 
 /**
+ * Whether a tile holds the value the selection binding currently points at.
+ *
+ * The bound array holds whatever the run emitted — a ref, a locator string, a
+ * data URI — and the selection binding stores that item verbatim, so the
+ * comparison has to work on the item rather than on the URL it resolved to.
+ * Two refs for one asset differ by field order alone, which is why the locator
+ * is tried before the structural compare.
+ */
+const sameBoundItem = (a: unknown, b: unknown): boolean => {
+  if (a === b) {return true;}
+  const left = mediaLocator(a);
+  const right = mediaLocator(b);
+  if (left !== null && right !== null) {return left === right;}
+  if (isRecord(a) && isRecord(b)) {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+  return false;
+};
+
+/**
  * A tiled grid of a bound array of media refs. Unlike the three cards above this
  * one renders for real: the tiles are the same `Image` the `Image` widget draws.
- * Tapping a tile opens `GalleryViewer`, where the images are swiped through.
+ *
+ * With no `selectionBinding` a tap opens `GalleryViewer`, where the images are
+ * swiped through. With one, a tap picks — it writes the tile's original item
+ * (the array element, not the resolved URL) to that binding and fires "change",
+ * which is the generate-N-pick-one loop. Preview stays reachable there on a
+ * long press: a phone has one gesture per tile, and when picking is what the app
+ * asked for it gets the primary one.
  */
 const GalleryWidget: React.FC<WidgetProps> = (widget) => {
   const { colors } = useTheme();
-  const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
+  const { write } = useAppRuntimeContext();
+  const { value, emit } = useWidgetRuntime({ ...widget, bindingMode: "read" });
   const tileSize = numOr(widget.props.tileSize, 120);
-  const uris = useMediaUris(asItems(value));
   const [openedAt, setOpenedAt] = useState<number | null>(null);
 
-  if (uris.length === 0) {
+  const selectionRef = useBindingRef(
+    isString(widget.props.selectionBinding)
+      ? widget.props.selectionBinding
+      : undefined,
+    "write"
+  );
+  const selected = useBindingValue(selectionRef);
+
+  // Resolution is positional, so the resolved URL keeps the item it came from —
+  // which is the item a tap has to write.
+  const items = asItems(value);
+  const resolved = useResolvedMediaUris(items.map(mediaLocator));
+  const tiles = items
+    .map((item, index) => ({ item, uri: resolved[index] }))
+    .filter((tile): tile is { item: unknown; uri: string } => tile.uri !== null);
+
+  if (tiles.length === 0) {
     return (
       <Placeholder
         text={str(widget.props.placeholder) || "No images yet"}
@@ -918,38 +970,122 @@ const GalleryWidget: React.FC<WidgetProps> = (widget) => {
     <View style={styles.field}>
       <FieldLabel text={str(widget.props.label)} colors={colors} />
       <View style={styles.tileGrid}>
-        {uris.map((uri, index) => (
-          <TouchableOpacity
-            key={`${uri}-${index}`}
-            testID="gallery-tile"
-            accessibilityRole="imagebutton"
-            accessibilityLabel={`Image ${index + 1} of ${uris.length}`}
-            disabled={widget.disabled}
-            onPress={() => setOpenedAt(index)}
-          >
-            <Image
-              accessibilityRole="image"
-              source={{ uri }}
-              style={[
-                styles.tile,
-                {
-                  width: tileSize,
-                  height: tileSize,
-                  borderColor: colors.border,
-                },
-              ]}
-              resizeMode="cover"
-            />
-          </TouchableOpacity>
-        ))}
+        {tiles.map(({ item, uri }, index) => {
+          const isSelected =
+            selectionRef !== null && sameBoundItem(selected, item);
+          return (
+            <TouchableOpacity
+              key={`${uri}-${index}`}
+              testID="gallery-tile"
+              accessibilityRole="imagebutton"
+              accessibilityLabel={`Image ${index + 1} of ${tiles.length}`}
+              accessibilityState={{ selected: isSelected }}
+              disabled={widget.disabled}
+              onPress={() => {
+                if (!selectionRef) {
+                  setOpenedAt(index);
+                  return;
+                }
+                write(selectionRef, item);
+                emit("change");
+              }}
+              onLongPress={() => setOpenedAt(index)}
+            >
+              <Image
+                accessibilityRole="image"
+                source={{ uri }}
+                style={[
+                  styles.tile,
+                  {
+                    width: tileSize,
+                    height: tileSize,
+                    borderColor: isSelected ? colors.primary : colors.border,
+                    borderWidth: isSelected ? 2 : StyleSheet.hairlineWidth,
+                  },
+                ]}
+                resizeMode="cover"
+              />
+            </TouchableOpacity>
+          );
+        })}
       </View>
       {openedAt !== null && (
         <GalleryViewer
-          uris={uris}
+          uris={tiles.map((tile) => tile.uri)}
           initialIndex={openedAt}
           onClose={() => setOpenedAt(null)}
         />
       )}
+    </View>
+  );
+};
+
+/**
+ * Two bound images, before and after. The web widget puts them under one wipe
+ * handle; a wipe at phone width gives each side a few hundred pixels and a
+ * handle the thumb covers, so this labels them and stacks them instead — the
+ * same two values, read the way a phone can read them. `height` caps each pane.
+ * One binding filled renders that one, named; neither renders the placeholder.
+ */
+const ImageComparePane: React.FC<{
+  title: string;
+  uri: string;
+  height: number;
+  colors: ThemeColors;
+}> = ({ title, uri, height, colors }) => (
+  <View style={styles.field}>
+    <Text style={[styles.hint, { color: colors.textTertiary }]}>{title}</Text>
+    <Image
+      accessibilityRole="image"
+      accessibilityLabel={title}
+      source={{ uri }}
+      style={[styles.image, { height }]}
+      resizeMode="contain"
+    />
+  </View>
+);
+
+const ImageCompareWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
+  const compareRef = useBindingRef(
+    isString(widget.props.compareBinding)
+      ? widget.props.compareBinding
+      : undefined,
+    "read"
+  );
+  const compareValue = useBindingValue(compareRef);
+  const height = numOr(widget.props.height, 240);
+  const beforeUri = useMediaUri(asItems(value)[0]);
+  const afterUri = useMediaUri(asItems(compareValue)[0]);
+
+  if (!beforeUri && !afterUri) {
+    return (
+      <Placeholder
+        text={str(widget.props.placeholder) || "Nothing to compare yet"}
+        colors={colors}
+      />
+    );
+  }
+  return (
+    <View style={styles.field}>
+      <FieldLabel text={str(widget.props.label)} colors={colors} />
+      {beforeUri ? (
+        <ImageComparePane
+          title="Before"
+          uri={beforeUri}
+          height={height}
+          colors={colors}
+        />
+      ) : null}
+      {afterUri ? (
+        <ImageComparePane
+          title="After"
+          uri={afterUri}
+          height={height}
+          colors={colors}
+        />
+      ) : null}
     </View>
   );
 };
@@ -1438,6 +1574,155 @@ const MediaInputWidget: React.FC<WidgetProps & { kind: MediaKind }> = ({
           {uri}
         </Text>
       ) : null}
+    </View>
+  );
+};
+
+/**
+ * Capture instead of upload — `AudioRecorder` and `CameraCapture`.
+ *
+ * The value is the point: both write the same `{type, uri, asset_id}` an
+ * `AudioInput` / `VideoInput` writes, because the captured file goes through
+ * the same upload the picker uses. One document therefore runs on both surfaces
+ * and a workflow reads one shape either way.
+ *
+ * The capture itself is real: the camera through `launchCameraAsync`, the
+ * microphone through expo-audio. Both need a permission the user can refuse, so
+ * a refusal is stated inline, and the file picker stays on the widget as the
+ * way out when the device has no camera or the permission is off for good.
+ */
+const CAPTURE_COPY = {
+  audio: {
+    label: "Audio recording",
+    action: "Record",
+    hint: "Record with the microphone, or pick an audio file you already have.",
+  },
+  video: {
+    label: "Camera capture",
+    action: "Record video",
+    hint: "Record with the camera, or pick a clip you already have.",
+  },
+} satisfies Record<"audio" | "video", { label: string; action: string; hint: string }>;
+
+const CaptureInputWidget: React.FC<
+  WidgetProps & { kind: "audio" | "video" }
+> = ({ kind, ...widget }) => {
+  const { colors } = useTheme();
+  const { value, setValue, emit } = useWidgetRuntime({
+    ...widget,
+    bindingMode: "write",
+  });
+  const uri = useMediaUri(value);
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+  const copy = CAPTURE_COPY[kind];
+
+  /** One writer for every source, so the stored shape cannot drift by path. */
+  const store = useCallback(
+    async (produce: () => Promise<MediaValue | null>) => {
+      setBusy(true);
+      try {
+        const stored = await produce();
+        if (stored) {
+          setValue(stored);
+          emit("change");
+        }
+      } finally {
+        setBusy(false);
+      }
+    },
+    [emit, setValue]
+  );
+
+  const recordVideo = useCallback(async () => {
+    setNotice(null);
+    await store(async () => {
+      const outcome = await captureVideoValue();
+      if (outcome.status === "captured") {
+        return outcome.value;
+      }
+      if (outcome.status !== "canceled") {
+        setNotice(outcome.message);
+      }
+      return null;
+    });
+  }, [store]);
+
+  const captureAudio = useCallback(
+    (file: CapturedFile) => {
+      setNotice(null);
+      void store(() => uploadCapturedFile("audio", file));
+    },
+    [store]
+  );
+
+  const pick = useCallback(() => {
+    setNotice(null);
+    void store(() => pickMediaValue(kind));
+  }, [kind, store]);
+
+  return (
+    <View style={styles.field}>
+      <FieldLabel
+        text={str(widget.props.label) || copy.label}
+        colors={colors}
+      />
+      {kind === "audio" ? (
+        <AudioCaptureControl
+          colors={colors}
+          disabled={widget.disabled}
+          busy={busy}
+          onCaptured={captureAudio}
+        />
+      ) : (
+        <TouchableOpacity
+          accessibilityRole="button"
+          disabled={widget.disabled || busy}
+          onPress={() => void recordVideo()}
+          style={[
+            styles.secondaryButton,
+            { borderColor: colors.border, backgroundColor: colors.inputBg },
+          ]}
+        >
+          {busy ? (
+            <ActivityIndicator color={colors.primary} size="small" />
+          ) : (
+            <Text style={{ color: colors.primary }}>
+              {uri ? "Record again" : copy.action}
+            </Text>
+          )}
+        </TouchableOpacity>
+      )}
+      {notice ? (
+        <Text style={[styles.hint, { color: colors.error }]}>{notice}</Text>
+      ) : null}
+      {/* The way out: no camera, no microphone, or a permission turned off for
+          good still leaves the user a file to choose — the same button, and the
+          same stored value, an `AudioInput` / `VideoInput` offers. */}
+      <TouchableOpacity
+        accessibilityRole="button"
+        disabled={widget.disabled || busy}
+        onPress={pick}
+        style={[
+          styles.secondaryButton,
+          { borderColor: colors.border, backgroundColor: colors.inputBg },
+        ]}
+      >
+        <Text style={{ color: colors.primary }}>
+          {uri ? `Replace ${MEDIA_LABEL[kind]}` : `Choose ${MEDIA_LABEL[kind]}`}
+        </Text>
+      </TouchableOpacity>
+      {uri ? (
+        <Text
+          numberOfLines={1}
+          style={[styles.hint, { color: colors.textTertiary }]}
+        >
+          {uri}
+        </Text>
+      ) : null}
+      <Text style={[styles.hint, { color: colors.textTertiary }]}>
+        {copy.hint}
+      </Text>
     </View>
   );
 };
@@ -1966,6 +2251,17 @@ const WorkflowInputWidget: React.FC<WidgetProps> = (widget) => {
     return <UnknownWidget label={`Unbound input: ${widget.binding ?? ""}`} />;
   }
 
+  return <WorkflowInputControl {...widget} input={input} />;
+};
+
+/**
+ * The control one Input node needs, given where its value lives. Split out of
+ * `WorkflowInputWidget` so `WorkflowForm` can render the same control per row
+ * without going through a binding string it would have to invent twice.
+ */
+const WorkflowInputControl: React.FC<
+  WidgetProps & { input: WorkflowInputIO }
+> = ({ input, ...widget }) => {
   const props = {
     ...widget,
     props: {
@@ -2044,6 +2340,90 @@ const WorkflowInputWidget: React.FC<WidgetProps> = (widget) => {
     default:
       return <TextInputWidget {...props} />;
   }
+};
+
+/**
+ * One row of `WorkflowForm`: the control for one Input node, writing that
+ * node's own slot. Hooks cannot run in a loop, so a row is its own component —
+ * that is the only reason this exists.
+ *
+ * The row builds its binding rather than reading one off the document, which is
+ * what makes an Input node added to the graph appear here with no edit to the
+ * app. The form's events ride along on the control, so a row change fires them
+ * with the same pacing every other input widget uses.
+ */
+const WorkflowFormRow: React.FC<{
+  formId: string;
+  input: WorkflowInputIO;
+  operationId: string;
+  showDescription: boolean;
+  events?: AppEvent[];
+  disabled?: boolean;
+}> = ({ formId, input, operationId, showDescription, events, disabled }) => {
+  const { colors } = useTheme();
+  const binding = encodeBinding({
+    kind: "input",
+    operationId,
+    nodeId: input.nodeId,
+  });
+  return (
+    <View style={styles.field}>
+      <WorkflowInputControl
+        id={`${formId}:${input.nodeId}`}
+        binding={binding}
+        events={events}
+        disabled={disabled}
+        props={{}}
+        input={input}
+      />
+      {showDescription && input.description ? (
+        <Text style={[styles.hint, { color: colors.textTertiary }]}>
+          {input.description}
+        </Text>
+      ) : null}
+    </View>
+  );
+};
+
+/**
+ * Every input of one operation in one widget. `WorkflowInput` binds one node;
+ * this binds none and resolves the operation's inputs from the graph at render
+ * time.
+ *
+ * A screen holds exactly one workflow (see `useAppRuntime`), so the context's
+ * `io` is that operation's bindable surface: `operationId` selects which
+ * operation's state slots the rows write, not which graph they read.
+ */
+const WorkflowFormWidget: React.FC<WidgetProps> = (widget) => {
+  const { colors } = useTheme();
+  const { io, scope } = useAppRuntimeContext();
+  const operationId =
+    (isString(widget.props.operationId) && widget.props.operationId) ||
+    scope.defaultOperationId;
+  const label = str(widget.props.label);
+
+  return (
+    <View style={styles.stack}>
+      <FieldLabel text={label} colors={colors} />
+      {io.inputs.length === 0 ? (
+        <Text style={[styles.hint, { color: colors.textTertiary }]}>
+          This operation has no inputs.
+        </Text>
+      ) : (
+        io.inputs.map((input) => (
+          <WorkflowFormRow
+            key={input.nodeId}
+            formId={widget.id}
+            input={input}
+            operationId={operationId}
+            showDescription={widget.props.showDescriptions !== "no"}
+            events={widget.events}
+            disabled={widget.disabled}
+          />
+        ))
+      )}
+    </View>
+  );
 };
 
 // ── Actions ─────────────────────────────────────────────────────────────────
@@ -2417,6 +2797,8 @@ export const RENDERERS: Record<string, React.FC<WidgetProps>> = {
   Chart: ChartWidget,
   PDF: PDFWidget,
   Gallery: GalleryWidget,
+  ImageCompare: ImageCompareWidget,
+  WorkflowForm: WorkflowFormWidget,
   WorkflowInput: WorkflowInputWidget,
   TextInput: TextInputWidget,
   NumberInput: NumberInputWidget,
@@ -2431,6 +2813,8 @@ export const RENDERERS: Record<string, React.FC<WidgetProps>> = {
   SketchPad: SketchPadWidget,
   AudioInput: (props) => <MediaInputWidget {...props} kind="audio" />,
   VideoInput: (props) => <MediaInputWidget {...props} kind="video" />,
+  AudioRecorder: (props) => <CaptureInputWidget {...props} kind="audio" />,
+  CameraCapture: (props) => <CaptureInputWidget {...props} kind="video" />,
   DocumentInput: (props) => <MediaInputWidget {...props} kind="document" />,
   Model3DInput: (props) => <MediaInputWidget {...props} kind="model_3d" />,
   DataFrameInput: DataFrameInputWidget,

--- a/packages/app-runtime/src/widgets.ts
+++ b/packages/app-runtime/src/widgets.ts
@@ -244,14 +244,51 @@ export const WIDGET_CATALOG: Readonly<Record<string, WidgetDescriptor>> = {
   Gallery: {
     label: "Gallery",
     mode: "read",
+    // Tapping a tile writes it to `selectionBinding` — the generate-N-pick-one
+    // loop, which otherwise needs a second widget the picked value cannot reach.
+    trigger: "change",
+    bindingProps: [{ prop: "selectionBinding", mode: "write" }],
     fields: {
       binding: "custom",
+      selectionBinding: "custom",
       label: "text",
       tileSize: "number",
+      placeholder: "text",
+      events: "array"
+    }
+  },
+  // Two bound images under one wipe handle — what an edit-an-image run needs to
+  // show, since `Image` binds one value and a pair side by side hides the
+  // difference the run was asked to make.
+  ImageCompare: {
+    label: "Image Compare",
+    mode: "read",
+    bindingProps: [{ prop: "compareBinding", mode: "read" }],
+    fields: {
+      binding: "custom",
+      compareBinding: "custom",
+      label: "text",
+      height: "number",
       placeholder: "text"
     }
   },
   // Inputs
+  //
+  // Every input of one operation in a single widget, resolved from the graph at
+  // render time: an input added to the workflow shows up without an edit to the
+  // app. `WorkflowInput` stays the way to place and arrange inputs one by one.
+  WorkflowForm: {
+    label: "Workflow Form",
+    mode: "write",
+    trigger: "change",
+    commits: false,
+    fields: {
+      operationId: "custom",
+      label: "text",
+      showDescriptions: "radio",
+      events: "array"
+    }
+  },
   WorkflowInput: {
     label: "Workflow Input",
     mode: "write",
@@ -393,6 +430,22 @@ export const WIDGET_CATALOG: Readonly<Record<string, WidgetDescriptor>> = {
   },
   VideoInput: {
     label: "Video Input",
+    mode: "write",
+    trigger: "change",
+    commits: false,
+    fields: { binding: "custom", label: "text", events: "array" }
+  },
+  // Capture instead of upload. The recorder writes the same AudioRef/VideoRef
+  // an upload writes, so a workflow reads one value either way.
+  AudioRecorder: {
+    label: "Audio Recorder",
+    mode: "write",
+    trigger: "change",
+    commits: false,
+    fields: { binding: "custom", label: "text", events: "array" }
+  },
+  CameraCapture: {
+    label: "Camera Capture",
     mode: "write",
     trigger: "change",
     commits: false,

--- a/packages/app-runtime/tests/widgets.test.ts
+++ b/packages/app-runtime/tests/widgets.test.ts
@@ -127,12 +127,52 @@ describe("widget catalog", () => {
   it("declares a display widget for every result shape a run can emit", () => {
     // A 3D result, a plotted series, a PDF and a batch of images each used to
     // land in Json or Output, which render them as an opaque ref.
-    for (const type of ["Model3D", "Chart", "PDF", "Gallery"]) {
+    for (const type of ["Model3D", "Chart", "PDF", "Gallery", "ImageCompare"]) {
       expect(widgetMode(type)).toBe("read");
-      expect(WIDGET_CATALOG[type].trigger).toBeUndefined();
       // None renders formattable text, so a template would replace the preview.
       expect(WIDGET_CATALOG[type].format).toBeUndefined();
       expect(widgetFields(type)).toHaveProperty("placeholder", "text");
+    }
+    for (const type of ["Model3D", "Chart", "PDF", "ImageCompare"]) {
+      expect(WIDGET_CATALOG[type].trigger).toBeUndefined();
+    }
+  });
+
+  it("lets a gallery report which tile was picked", () => {
+    // Generate N, pick one: the gallery reads the batch and writes the choice,
+    // so a display widget carries a write binding and fires an event.
+    expect(widgetMode("Gallery")).toBe("read");
+    expect(WIDGET_CATALOG.Gallery.trigger).toBe("change");
+    expect(widgetBindingProps("Gallery")).toEqual([
+      { prop: "selectionBinding", mode: "write" }
+    ]);
+    expect(widgetFields("Gallery")).toHaveProperty("events", "array");
+  });
+
+  it("reads both sides of an image comparison", () => {
+    expect(widgetBindingProps("ImageCompare")).toEqual([
+      { prop: "compareBinding", mode: "read" }
+    ]);
+  });
+
+  it("renders one operation's whole input surface as a form", () => {
+    // A form binds no single slot: it names an operation and writes each of
+    // that operation's inputs, so it carries `operationId` where the other
+    // write widgets carry `binding`.
+    expect(widgetMode("WorkflowForm")).toBe("write");
+    expect(WIDGET_CATALOG.WorkflowForm.trigger).toBe("change");
+    expect(widgetFields("WorkflowForm")).toHaveProperty("operationId", "custom");
+    expect(widgetFields("WorkflowForm")).not.toHaveProperty("binding");
+  });
+
+  it("offers capture next to upload for audio and video", () => {
+    // A recorder writes the same ref an upload writes, so a workflow reads one
+    // value either way.
+    for (const type of ["AudioRecorder", "CameraCapture"]) {
+      expect(widgetMode(type)).toBe("write");
+      expect(WIDGET_CATALOG[type].trigger).toBe("change");
+      expect(WIDGET_CATALOG[type].commits).toBe(false);
+      expect(widgetFields(type)).toHaveProperty("binding", "custom");
     }
   });
 

--- a/packages/execution/src/app-debug/app-spec.ts
+++ b/packages/execution/src/app-debug/app-spec.ts
@@ -147,6 +147,14 @@ export function bindingScopeFor(io: AppIO, context?: AppContext): BindingScope {
 const usesResourceBinding = (type: string): boolean =>
   WIDGET_CATALOG[type]?.fields.resourceBindingId !== undefined;
 
+/**
+ * A widget that renders one operation's whole input surface rather than one
+ * slot. It carries `operationId` where the state widgets carry `binding`, so
+ * the unbound-write warning does not apply to it.
+ */
+const rendersOperationInputs = (type: string): boolean =>
+  WIDGET_CATALOG[type]?.fields.operationId !== undefined;
+
 const modeToBindingMode = (mode: AppWidgetSpec["bindingMode"]): BindingMode =>
   mode === "write" ? "write" : mode === "read" ? "read" : "none";
 
@@ -312,6 +320,9 @@ export function parseAppSpec(
           }
         ),
         label: str(item.props.label) ?? str(item.props.text) ?? null,
+        operationId: rendersOperationInputs(item.type)
+          ? str(item.props.operationId) || null
+          : null,
         events: parseEvents(item.props.events),
         parentId,
         slot
@@ -517,7 +528,8 @@ export function validateApp(
     } else if (
       !w.binding &&
       w.bindingMode === "write" &&
-      !usesResourceBinding(w.type)
+      !usesResourceBinding(w.type) &&
+      !rendersOperationInputs(w.type)
     ) {
       warnings.push(
         `${where}: not bound to an input — its value stays local UI state.`
@@ -535,6 +547,14 @@ export function validateApp(
           `${where}: bound to resource "${w.resourceBindingId}" but the app declares no such resource binding.`
         );
       }
+    }
+    // A form renders the inputs of the operation it names; a stale name renders
+    // an empty form, which a run-only check reads as an app that asks for
+    // nothing rather than one that lost its inputs.
+    if (w.operationId && !operationIds.has(w.operationId)) {
+      errors.push(
+        `${where}: renders the inputs of operation "${w.operationId}" but the app declares no such operation.`
+      );
     }
     // An explicit `op:<id>/…` token resolves on its own syntax, so a token
     // naming an operation the document never declared has to be caught here.

--- a/packages/execution/src/app-debug/types.ts
+++ b/packages/execution/src/app-debug/types.ts
@@ -110,6 +110,12 @@ export interface AppWidgetSpec {
    */
   extraBindings: Array<{ prop: string; binding: string; ref: BindingRef | null }>;
   label: string | null;
+  /**
+   * The operation a widget renders the whole input surface of (`WorkflowForm`).
+   * Null for every widget that binds one slot — those name their operation
+   * inside the binding token instead.
+   */
+  operationId: string | null;
   events: AppEventSpec[];
   parentId: string | null;
   slot: string | null;

--- a/packages/execution/tests/app-debug-spec.test.ts
+++ b/packages/execution/tests/app-debug-spec.test.ts
@@ -180,6 +180,40 @@ describe("validateApp", () => {
     );
   });
 
+  it("accepts a form that renders the default operation's inputs", () => {
+    const { spec } = parseAppSpec(
+      appDoc([
+        widget("WorkflowForm", "WorkflowForm-1", {}),
+        widget("Markdown", "Markdown-1", { binding: "result" }),
+        widget("Button", "Button-1", {
+          events: [{ trigger: "click", kind: "run" }]
+        })
+      ]),
+      io
+    );
+    const result = validateApp(spec!, io);
+    expect(result.errors).toEqual([]);
+    // A form binds no slot of its own, so the unbound-write warning every other
+    // write widget earns must not fire for it.
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("flags a form whose operation the app never declares", () => {
+    const { spec } = parseAppSpec(
+      appDoc([
+        widget("WorkflowForm", "WorkflowForm-1", { operationId: "renamed" }),
+        widget("Button", "Button-1", {
+          events: [{ trigger: "click", kind: "run" }]
+        })
+      ]),
+      io
+    );
+    const { errors } = validateApp(spec!, io);
+    expect(errors.join("\n")).toMatch(
+      /renders the inputs of operation "renamed" but the app declares no such operation/
+    );
+  });
+
   it("flags bindings that reference missing inputs/outputs/variables", () => {
     const { spec } = parseAppSpec(
       appDoc([

--- a/web/src/components/appbuilder/README.md
+++ b/web/src/components/appbuilder/README.md
@@ -35,6 +35,10 @@ framework-independent core the web runtime, the CLI `app debug` harness, and the
   default props), so `puck/__tests__/configCatalog.test.ts` asserts the two
   agree type for type and field for field — that test is what keeps the agent
   from being offered a widget the editor cannot place, or the reverse.
+- A `Gallery` can also **write**: with a `selectionBinding` set, tapping a tile
+  writes that array element to the bound slot and emits `change`, which is the
+  generate-N-pick-one loop. Selection lives in the binding, not in the
+  component, so it survives a reload.
 - **Widgets** bind one slot (read for displays, two-way for inputs) and emit
   **events** (`click` / `change`) that dispatch **actions** (`run`, `cancel`,
   `setVariable`, `toggleVariable`, `resourceCommand`, `openResource`). A `run`
@@ -108,6 +112,17 @@ the existing worker path.
   - `sketchPadDocument.ts` — the pad's starting document (paper layer, ink) and
     the value it reads and writes; `sketchPadOptions.ts` holds the canvas
     options both halves need, so the eager half imports no sketch module.
+  - `WorkflowFormWidget.tsx` — every input of one operation in a single widget,
+    resolved from the graph at render time, so an input added to the workflow
+    appears without an edit to the app. One row per input, each writing its own
+    input binding; `WorkflowInput` stays the way to place inputs one by one.
+  - `RecorderWidgets.tsx` — mic and webcam capture (`AudioRecorder`,
+    `CameraCapture`), writing the same media ref an upload writes so a workflow
+    reads one value either way. The builder canvas renders a placeholder rather
+    than asking for a device permission.
+  - `ImageComparerWidget.tsx` — two bound images under one wipe handle, reusing
+    `components/widgets/ImageComparer`. Both bindings resolve through
+    `useResolvedMediaUri`, never a raw locator.
   - `useWidgetRuntime.ts` — binds a widget's props to reactive state + events.
   - `BuilderWorkflowContext.tsx` — supplies the bindable surface to fields.
   - `PuckAppEditor.tsx` — the `<Puck>` editor wrapper.

--- a/web/src/components/appbuilder/puck/ImageComparerWidget.tsx
+++ b/web/src/components/appbuilder/puck/ImageComparerWidget.tsx
@@ -1,0 +1,179 @@
+/**
+ * `ImageCompare` — two bound images under one wipe handle.
+ *
+ * An edit-an-image run has a before and an after, and the `Image` widget binds
+ * one value: placing two of them side by side hides the very difference the run
+ * was asked to make. This binds both slots to the comparer the graph editor,
+ * the preview grid and the asset viewer already use.
+ *
+ * Each bound value is a locator — an ImageRef, an asset id, a data URI, a URL —
+ * and the comparer sets `src` from what it is handed, so both go through
+ * `useResolvedMediaUri` first. An `asset://` locator fetches nowhere.
+ */
+import React from "react";
+
+import {
+  Box,
+  Caption,
+  FlexColumn,
+  ResponsiveImage,
+  BORDER_RADIUS,
+  SPACING
+} from "../../ui_primitives";
+import ImageComparer from "../../widgets/ImageComparer";
+import {
+  useResolvedMediaUri,
+  type MediaLocator
+} from "../../../hooks/useResolvedMediaUri";
+import {
+  isFiniteNumber,
+  isObjectLike,
+  isString
+} from "../../../utils/typePredicates";
+import {
+  useBindingRef,
+  useBindingValue
+} from "../runtime/AppRuntimeContext";
+import { useWidgetRuntime } from "./useWidgetRuntime";
+
+export interface ImageComparerWidgetProps {
+  id: string;
+  /** The "before" image. */
+  binding?: string;
+  /** The "after" image. */
+  compareBinding?: string;
+  label?: string;
+  /** Caps the rendered height. */
+  height?: number;
+  placeholder?: string;
+}
+
+const DEFAULT_HEIGHT = 320;
+
+/** A bound output holds one value or the accumulated list of streamed items. */
+const lastItem = (value: unknown): unknown => {
+  if (!Array.isArray(value)) return value;
+  return value.length > 0 ? value[value.length - 1] : undefined;
+};
+
+/**
+ * The locator a bound value carries. A `*Ref` may name its asset by `asset_id`
+ * with no `uri` at all, so both halves travel to the resolver rather than only
+ * the URI the older widgets read.
+ */
+const toLocator = (value: unknown): MediaLocator => {
+  const item = lastItem(value);
+  if (isString(item)) return item.length > 0 ? item : undefined;
+  if (!isObjectLike(item)) return undefined;
+  const uri = [item.uri, item.url, item.data].find(
+    (candidate): candidate is string => isString(candidate) && candidate !== ""
+  );
+  const assetId = isString(item.asset_id) && item.asset_id !== ""
+    ? item.asset_id
+    : undefined;
+  return uri === undefined && assetId === undefined
+    ? undefined
+    : { uri, asset_id: assetId };
+};
+
+const Placeholder: React.FC<{ height: number; text: string }> = ({
+  height,
+  text
+}) => (
+  <FlexColumn
+    align="center"
+    justify="center"
+    fullWidth
+    sx={{
+      height,
+      border: "1px dashed",
+      borderColor: "divider",
+      borderRadius: BORDER_RADIUS.md
+    }}
+  >
+    <Caption color="secondary">{text}</Caption>
+  </FlexColumn>
+);
+
+export const ImageComparerWidget: React.FC<ImageComparerWidgetProps> = ({
+  id,
+  binding,
+  compareBinding,
+  label,
+  height,
+  placeholder
+}) => {
+  const { value, designMode } = useWidgetRuntime({
+    id,
+    bindingMode: "read",
+    binding
+  });
+  const compareRef = useBindingRef(compareBinding, "read");
+  const compareValue = useBindingValue(compareRef);
+
+  const beforeLocator = React.useMemo(() => toLocator(value), [value]);
+  const afterLocator = React.useMemo(
+    () => toLocator(compareValue),
+    [compareValue]
+  );
+  const before = useResolvedMediaUri(beforeLocator);
+  const after = useResolvedMediaUri(afterLocator);
+
+  const boxHeight = isFiniteNumber(height) ? height : DEFAULT_HEIGHT;
+  const single = before ?? after;
+
+  const withLabel = (body: React.ReactElement): React.ReactElement =>
+    label ? (
+      <FlexColumn gap={SPACING.xs} fullWidth>
+        <Caption color="secondary">{label}</Caption>
+        {body}
+      </FlexColumn>
+    ) : (
+      body
+    );
+
+  if (before && after) {
+    return withLabel(
+      <Box
+        sx={{
+          width: "100%",
+          height: boxHeight,
+          borderRadius: BORDER_RADIUS.md,
+          overflow: "hidden"
+        }}
+      >
+        <ImageComparer
+          imageA={before}
+          imageB={after}
+          labelA="Before"
+          labelB="After"
+        />
+      </Box>
+    );
+  }
+
+  if (single) {
+    return withLabel(
+      <ResponsiveImage
+        src={single}
+        alt=""
+        fit="contain"
+        borderRadius={BORDER_RADIUS.md}
+        sx={{ height: boxHeight }}
+      />
+    );
+  }
+
+  // In design mode nothing has run, so an author placing the widget sees what
+  // it wants rather than the empty-run copy their users will see.
+  return withLabel(
+    <Placeholder
+      height={boxHeight}
+      text={
+        designMode
+          ? "Bind two image outputs to compare them."
+          : (placeholder ?? "Nothing to compare yet")
+      }
+    />
+  );
+};

--- a/web/src/components/appbuilder/puck/MediaWidgets.tsx
+++ b/web/src/components/appbuilder/puck/MediaWidgets.tsx
@@ -22,6 +22,11 @@ import {
 import LazyModel3DViewer from "../../asset_viewer/LazyModel3DViewer";
 import LazyPDFViewer from "../../asset_viewer/LazyPDFViewer";
 import { AppEvent } from "../types";
+import {
+  useAppRuntimeContext,
+  useBindingRef,
+  useBindingValue
+} from "../runtime/AppRuntimeContext";
 import { useWidgetRuntime } from "./useWidgetRuntime";
 import { resolveImageSrc } from "./widgets";
 
@@ -116,35 +121,97 @@ export const PDFWidget: React.FC<ReadWidgetProps & { height?: number }> = (
 
 const TILE_SIZE = 140;
 
+/**
+ * One array element and the source it resolved to, kept paired so a click
+ * writes the element the run produced rather than its display URL.
+ */
+interface GalleryEntry {
+  item: unknown;
+  src: string;
+}
+
+/**
+ * Two bound values are the same choice when they carry the same data: the
+ * selection slot holds a copy of the array element (serialized on reload), so
+ * reference equality would lose the mark the moment the app is reopened.
+ */
+const sameSelection = (a: unknown, b: unknown): boolean => {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    // Cyclic or otherwise unserializable values: reference equality already lost.
+    return false;
+  }
+};
+
+interface GalleryTileProps {
+  index: number;
+  src: string;
+  size: number;
+  /** Set when the widget carries a `selectionBinding` and can write to it. */
+  selectable: boolean;
+  selected: boolean;
+  disabled?: boolean;
+  onSelect: (index: number) => void;
+}
+
+const tileSx = (size: number) => ({
+  height: size,
+  p: SPACING.xs,
+  borderRadius: BORDER_RADIUS.md,
+  border: "1px solid",
+  borderColor: "divider",
+  transition: MOTION.border,
+  "&:hover": { borderColor: "primary.light" }
+});
+
+const imageSx = {
+  width: "100%",
+  height: "100%",
+  objectFit: "cover",
+  borderRadius: BORDER_RADIUS.sm
+} as const;
+
 // The grid is fed by a streaming output that grows an item at a time, so
 // without the memo each emitted image rebuilds the styles of every tile before
 // it.
-const GalleryTile: React.FC<{ src: string; size: number }> = React.memo(
-  ({ src, size }) => (
-    <Box
-      sx={{
-        height: size,
-        p: SPACING.xs,
-        borderRadius: BORDER_RADIUS.md,
-        border: "1px solid",
-        borderColor: "divider",
-        transition: MOTION.border,
-        "&:hover": { borderColor: "primary.light" }
-      }}
-    >
+const GalleryTile: React.FC<GalleryTileProps> = React.memo(
+  ({ index, src, size, selectable, selected, disabled, onSelect }) => {
+    const image = <Box component="img" src={src} alt="" sx={imageSx} />;
+    if (!selectable) {
+      return <Box sx={tileSx(size)}>{image}</Box>;
+    }
+    return (
       <Box
-        component="img"
-        src={src}
-        alt=""
+        component="button"
+        type="button"
+        aria-pressed={selected}
+        aria-label={`Select item ${index + 1}`}
+        disabled={disabled}
+        onClick={() => onSelect(index)}
         sx={{
+          ...tileSx(size),
+          display: "block",
           width: "100%",
-          height: "100%",
-          objectFit: "cover",
-          borderRadius: BORDER_RADIUS.sm
+          background: "none",
+          font: "inherit",
+          cursor: disabled ? "default" : "pointer",
+          borderColor: selected ? "primary.main" : "divider",
+          backgroundColor: selected ? "action.selected" : "transparent",
+          transition: `${MOTION.border}, ${MOTION.background}`,
+          "&:focus-visible": {
+            outline: "2px solid",
+            outlineColor: "primary.main",
+            outlineOffset: 2
+          }
         }}
-      />
-    </Box>
-  )
+      >
+        {image}
+      </Box>
+    );
+  }
 );
 GalleryTile.displayName = "GalleryTile";
 
@@ -152,21 +219,51 @@ GalleryTile.displayName = "GalleryTile";
  * A bound array of media refs as a tiled grid — the shape a batch run that emits
  * N images has. Tiles match the resource gallery's look so the two read as one
  * component.
+ *
+ * With a `selectionBinding` the grid becomes the generate-N-pick-one loop:
+ * picking a tile writes that array element — the ref as the run emitted it, not
+ * the resolved URL — to the bound slot and emits `change`, so a wired `run`
+ * event carries the choice into the next operation. The mark is read back out
+ * of that slot, so a reopened app shows the same choice.
  */
 export const GalleryWidget: React.FC<
-  ReadWidgetProps & { label?: string; tileSize?: number }
+  ReadWidgetProps & {
+    label?: string;
+    tileSize?: number;
+    /** Write slot the picked array element lands in. */
+    selectionBinding?: string;
+  }
 > = (props) => {
-  const { value } = useReadBinding(props);
-  const sources = React.useMemo(
-    () =>
-      asItems(value)
-        .map(resolveImageSrc)
-        .filter((src): src is string => src !== null),
-    [value]
-  );
+  const { value, emit, designMode } = useReadBinding(props);
+  const { write } = useAppRuntimeContext();
+  const selectionRef = useBindingRef(props.selectionBinding, "write");
+  const selectedValue = useBindingValue(selectionRef);
+  const selectable = props.selectionBinding != null && !designMode;
+
+  const entries = React.useMemo<GalleryEntry[]>(() => {
+    const paired: GalleryEntry[] = [];
+    for (const item of asItems(value)) {
+      const src = resolveImageSrc(item);
+      // An item that resolves to nothing has no tile, so it must not take an
+      // index either — the click handler indexes into this same list.
+      if (src !== null) paired.push({ item, src });
+    }
+    return paired;
+  }, [value]);
+
   const size = props.tileSize ?? TILE_SIZE;
 
-  if (sources.length === 0) {
+  const onSelect = React.useCallback(
+    (index: number) => {
+      const entry = entries[index];
+      if (!entry || !selectionRef || !selectable) return;
+      write(selectionRef, entry.item);
+      emit("change");
+    },
+    [emit, entries, selectable, selectionRef, write]
+  );
+
+  if (entries.length === 0) {
     return (
       <Caption color="secondary">
         {props.placeholder ?? "Nothing to show yet"}
@@ -185,8 +282,17 @@ export const GalleryWidget: React.FC<
           gridTemplateColumns: `repeat(auto-fill, minmax(${size}px, 1fr))`
         }}
       >
-        {sources.map((src, index) => (
-          <GalleryTile key={index} src={src} size={size} />
+        {entries.map((entry, index) => (
+          <GalleryTile
+            key={index}
+            index={index}
+            src={entry.src}
+            size={size}
+            selectable={selectable}
+            selected={selectable && sameSelection(selectedValue, entry.item)}
+            disabled={props.disabled}
+            onSelect={onSelect}
+          />
         ))}
       </Box>
     </FlexColumn>

--- a/web/src/components/appbuilder/puck/RecorderWidgets.tsx
+++ b/web/src/components/appbuilder/puck/RecorderWidgets.tsx
@@ -1,0 +1,164 @@
+/**
+ * Capture widgets: the microphone and the camera as app inputs.
+ *
+ * They write the same `{type, uri, asset_id}` ref an upload writes
+ * (`mediaRefFromAsset`), so a workflow input reads one value whether the user
+ * dropped a file or recorded one.
+ *
+ * In design mode the recorder is not mounted at all: both `useWaveRecorder`
+ * and `useVideoRecorder` call `getUserMedia` on mount, and the builder canvas
+ * must never raise a permission prompt while an author is laying widgets out.
+ */
+import React, { useCallback, useMemo } from "react";
+
+import { Asset } from "../../../stores/ApiTypes";
+import WaveRecorder from "../../audio/WaveRecorder";
+import VideoRecorder from "../../video/VideoRecorder";
+import {
+  AudioPlayback,
+  Box,
+  Caption,
+  FlexColumn,
+  Label,
+  VideoPlayer,
+  BORDER_RADIUS,
+  SPACING
+} from "../../ui_primitives";
+import { mediaRefFromAsset } from "../../../utils/mediaRef";
+import { isRecord, isString } from "../../../utils/typePredicates";
+import { AppEvent } from "../types";
+import { useAppRuntimeContext, useBindingRef } from "../runtime/AppRuntimeContext";
+import { useWidgetRuntime } from "./useWidgetRuntime";
+
+export interface RecorderWidgetProps {
+  id: string;
+  binding?: string;
+  /** App wording for the control; the widget has no graph name to fall back on. */
+  label?: string;
+  events?: AppEvent[];
+}
+
+/** Height of the design-mode stand-in, so placing one does not shift the page. */
+const PLACEHOLDER_HEIGHT = 72;
+
+const DesignPlaceholder: React.FC<{ text: string }> = ({ text }) => (
+  <FlexColumn
+    align="center"
+    justify="center"
+    fullWidth
+    sx={{
+      height: PLACEHOLDER_HEIGHT,
+      border: "1px dashed",
+      borderColor: "divider",
+      borderRadius: BORDER_RADIUS.md
+    }}
+  >
+    <Caption color="secondary">{text}</Caption>
+  </FlexColumn>
+);
+
+/** The locator of the ref this widget wrote, once something has been captured. */
+const capturedLocator = (value: unknown): string | undefined => {
+  if (isString(value)) return value || undefined;
+  if (!isRecord(value)) return undefined;
+  const uri = value.uri;
+  return isString(uri) && uri.length > 0 ? uri : undefined;
+};
+
+/**
+ * The half both widgets share: the bound slot, the workflow the capture is
+ * attributed to, and the writer that turns a finished upload into a ref.
+ */
+const useRecorderWidget = (
+  props: RecorderWidgetProps,
+  type: "audio" | "video"
+) => {
+  const { operation, operations } = useAppRuntimeContext();
+  const ref = useBindingRef(props.binding, "write");
+  const { value, setValue, emit, designMode } = useWidgetRuntime({
+    id: props.id,
+    bindingMode: "write",
+    binding: props.binding,
+    events: props.events
+  });
+
+  // The asset belongs to the workflow the bound input lives in — the app's
+  // default operation when the binding names none. A script operation carries
+  // no workflow, so its empty id becomes "unattributed".
+  const workflowId = useMemo(() => {
+    const owner =
+      ref?.kind === "input"
+        ? operations.find((candidate) => candidate.id === ref.operationId)
+        : undefined;
+    return (owner ?? operation).workflowId || undefined;
+  }, [operation, operations, ref]);
+
+  const onChange = useCallback(
+    (asset: Asset) => {
+      setValue(mediaRefFromAsset(asset, type));
+      emit("change");
+    },
+    [emit, setValue, type]
+  );
+
+  return {
+    designMode,
+    workflowId,
+    onChange,
+    locator: capturedLocator(value)
+  };
+};
+
+export const AudioRecorderWidget: React.FC<RecorderWidgetProps> = (props) => {
+  const { designMode, workflowId, onChange, locator } = useRecorderWidget(
+    props,
+    "audio"
+  );
+
+  return (
+    <FlexColumn gap={SPACING.micro} fullWidth>
+      <Label>{props.label || "Record audio"}</Label>
+      {designMode ? (
+        <DesignPlaceholder text="Microphone capture — records when the app runs" />
+      ) : (
+        <WaveRecorder onChange={onChange} workflowId={workflowId} />
+      )}
+      {locator && !designMode ? (
+        <AudioPlayback locator={locator} label="Recorded audio" />
+      ) : null}
+    </FlexColumn>
+  );
+};
+
+/** Height of the playback surface; `VideoPlayer` fills its container. */
+const PLAYBACK_HEIGHT = 200;
+
+export const CameraCaptureWidget: React.FC<RecorderWidgetProps> = (props) => {
+  const { designMode, workflowId, onChange, locator } = useRecorderWidget(
+    props,
+    "video"
+  );
+
+  return (
+    <FlexColumn gap={SPACING.micro} fullWidth>
+      <Label>{props.label || "Record video"}</Label>
+      {designMode ? (
+        <DesignPlaceholder text="Camera capture — records when the app runs" />
+      ) : (
+        <VideoRecorder onChange={onChange} workflowId={workflowId} />
+      )}
+      {locator && !designMode ? (
+        <Box
+          sx={{
+            width: "100%",
+            height: PLAYBACK_HEIGHT,
+            borderRadius: BORDER_RADIUS.md,
+            overflow: "hidden"
+          }}
+        >
+          <VideoPlayer locator={locator} label="Recorded video" />
+        </Box>
+      ) : null}
+    </FlexColumn>
+  );
+};

--- a/web/src/components/appbuilder/puck/WorkflowFormWidget.tsx
+++ b/web/src/components/appbuilder/puck/WorkflowFormWidget.tsx
@@ -1,0 +1,133 @@
+/**
+ * One widget that renders the whole input form of one operation: a control per
+ * workflow Input node, each reading and writing its own state slot.
+ *
+ * WorkflowInput binds one node; this binds none. It resolves the operation's
+ * bindable surface with `ioFor` and builds each row's `{kind: "input"}` ref
+ * itself, so adding an Input node to the graph adds a row with no edit to the
+ * app document.
+ *
+ * Hooks cannot run in a loop, so every row is its own component — that is the
+ * only reason `WorkflowFormRow` exists.
+ */
+import React, { useMemo } from "react";
+
+import { Caption, FlexColumn, Label, SPACING } from "../../ui_primitives";
+import { AppEvent } from "../types";
+import {
+  useAppRuntimeContext,
+  useBindingValue
+} from "../runtime/AppRuntimeContext";
+import { WorkflowInputIO } from "../workflowIO";
+import { WorkflowInputControl } from "./WorkflowInputWidget";
+import { useWidgetRuntime } from "./useWidgetRuntime";
+
+export interface WorkflowFormWidgetProps {
+  id: string;
+  /** The operation whose inputs the form renders; unset means the default one. */
+  operationId?: string;
+  /** Heading above the form. */
+  label?: string;
+  /** "no" hides each input's description caption. Defaults to "yes". */
+  showDescriptions?: "yes" | "no";
+  events?: AppEvent[];
+}
+
+const WorkflowFormRow: React.FC<{
+  input: WorkflowInputIO;
+  operationId: string;
+  showDescription: boolean;
+  onChanged: () => void;
+}> = ({ input, operationId, showDescription, onChanged }) => {
+  const { write } = useAppRuntimeContext();
+  const ref = { kind: "input", operationId, nodeId: input.nodeId } as const;
+  const value = useBindingValue(ref);
+
+  // The control shows a description for some kinds and hides it in a tooltip
+  // for others; strip it there so the form captions every row the same way.
+  const controlInput = useMemo(
+    () => ({ ...input, description: undefined }),
+    [input]
+  );
+
+  return (
+    <FlexColumn gap={SPACING.micro} fullWidth>
+      <WorkflowInputControl
+        input={controlInput}
+        value={value}
+        onValue={(next) => {
+          write(ref, next);
+          onChanged();
+        }}
+      />
+      {showDescription && input.description ? (
+        <Caption color="secondary">{input.description}</Caption>
+      ) : null}
+    </FlexColumn>
+  );
+};
+
+export const WorkflowFormWidget: React.FC<WorkflowFormWidgetProps> = ({
+  id,
+  operationId,
+  label,
+  showDescriptions,
+  events
+}) => {
+  const { ioFor, scope, designMode } = useAppRuntimeContext();
+  // The form owns no single binding, so it takes "none": a "write" mode would
+  // claim a view slot of its own, which would hold a value nothing reads. All
+  // it needs from the runtime is `emit`, and with it the shared event pacing.
+  const { emit } = useWidgetRuntime({ id, bindingMode: "none", events });
+
+  const io = ioFor(operationId);
+  const targetOperationId = operationId ?? scope.defaultOperationId;
+  const heading = label ? <Label>{label}</Label> : null;
+
+  // Nothing is fetched in the builder's design surface, so the form describes
+  // itself instead of rendering controls over an empty runtime.
+  if (designMode) {
+    return (
+      <FlexColumn gap={SPACING.xs} fullWidth>
+        {heading}
+        {io.inputs.length === 0 ? (
+          <Caption color="secondary">
+            This form shows every input of its operation when the app runs.
+          </Caption>
+        ) : (
+          io.inputs.map((input) => (
+            <Caption key={input.nodeId} color="secondary">
+              {input.label || input.name} — {input.kind}
+            </Caption>
+          ))
+        )}
+      </FlexColumn>
+    );
+  }
+
+  if (io.inputs.length === 0) {
+    return (
+      <FlexColumn gap={SPACING.xs} fullWidth>
+        {heading}
+        <Caption color="secondary">This operation has no inputs.</Caption>
+      </FlexColumn>
+    );
+  }
+
+  return (
+    <FlexColumn gap={SPACING.md} fullWidth>
+      {heading}
+      {io.inputs.map((input) => (
+        <WorkflowFormRow
+          key={input.nodeId}
+          input={input}
+          operationId={targetOperationId}
+          showDescription={showDescriptions !== "no"}
+          onChanged={() => emit("change")}
+        />
+      ))}
+    </FlexColumn>
+  );
+};
+
+export default WorkflowFormWidget;

--- a/web/src/components/appbuilder/puck/__tests__/imageComparerWidget.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/imageComparerWidget.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * The `ImageCompare` widget: two read bindings under one wipe handle, each
+ * resolved before it reaches an `<img>`.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import {
+  DEFAULT_OPERATION_ID,
+  type AppInstanceState
+} from "@nodetool-ai/app-runtime";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import { makeTestRuntime } from "../../__tests__/testRuntime";
+import { ImageComparerWidget } from "../ImageComparerWidget";
+
+// Locators resolve through TanStack Query; this suite stands up no
+// QueryClientProvider, so use the manual mock — an `asset://<id>` locator comes
+// back as `https://assets.test/<id>` and everything else passes through.
+// (Resolution itself is covered by hooks/__tests__/useResolvedMediaUri.test.tsx.)
+jest.mock("../../../../hooks/useResolvedMediaUri");
+
+const BEFORE = `op:${DEFAULT_OPERATION_ID}/out:out1`;
+const AFTER = `op:${DEFAULT_OPERATION_ID}/out:out2`;
+const BEFORE_KEY = `${DEFAULT_OPERATION_ID}:out1`;
+const AFTER_KEY = `${DEFAULT_OPERATION_ID}:out2`;
+
+const SCOPED = {
+  scope: {
+    defaultOperationId: DEFAULT_OPERATION_ID,
+    operations: [
+      {
+        operationId: DEFAULT_OPERATION_ID,
+        inputs: [],
+        outputs: [
+          { nodeId: "out1", name: "before" },
+          { nodeId: "out2", name: "after" }
+        ],
+        nodeIds: ["out1", "out2"]
+      }
+    ],
+    variables: []
+  }
+};
+
+const cell = (value: unknown) => ({
+  value,
+  invocationId: "j1",
+  status: "done" as const,
+  revision: 1
+});
+
+const withOutputs = (
+  before?: unknown,
+  after?: unknown
+): Partial<AppInstanceState> => {
+  const outputs: Record<string, ReturnType<typeof cell>> = {};
+  if (before !== undefined) outputs[BEFORE_KEY] = cell(before);
+  if (after !== undefined) outputs[AFTER_KEY] = cell(after);
+  return { outputs };
+};
+
+const renderWidget = (
+  element: React.ReactElement,
+  initial: Partial<AppInstanceState> = {}
+) => {
+  const { wrapper: Wrapper } = makeTestRuntime(initial, SCOPED);
+  return render(
+    <ThemeProvider theme={mockTheme}>
+      <Wrapper>{element}</Wrapper>
+    </ThemeProvider>
+  );
+};
+
+const widget = (
+  props: Partial<React.ComponentProps<typeof ImageComparerWidget>> = {}
+) => (
+  <ImageComparerWidget
+    id="c1"
+    binding={BEFORE}
+    compareBinding={AFTER}
+    {...props}
+  />
+);
+
+describe("ImageComparerWidget", () => {
+  it("renders the comparer with both bound sources", () => {
+    const { container } = renderWidget(
+      widget(),
+      withOutputs(
+        { type: "image", uri: "https://cdn/before.png" },
+        { type: "image", uri: "https://cdn/after.png" }
+      )
+    );
+
+    expect(container.querySelector(".image-comparer")).toBeInTheDocument();
+    expect(screen.getByAltText("Before")).toHaveAttribute(
+      "src",
+      "https://cdn/before.png"
+    );
+    expect(screen.getByAltText("After")).toHaveAttribute(
+      "src",
+      "https://cdn/after.png"
+    );
+  });
+
+  it("renders the one bound image alone rather than a broken wipe", () => {
+    const { container } = renderWidget(
+      widget(),
+      withOutputs({ type: "image", uri: "https://cdn/only.png" }, undefined)
+    );
+
+    expect(container.querySelector(".image-comparer")).not.toBeInTheDocument();
+    const images = container.querySelectorAll("img");
+    expect(images).toHaveLength(1);
+    expect(images[0]).toHaveAttribute("src", "https://cdn/only.png");
+  });
+
+  it("renders the placeholder when neither binding holds an image", () => {
+    const { container } = renderWidget(
+      widget({ placeholder: "Nothing to compare yet" })
+    );
+
+    expect(screen.getByText("Nothing to compare yet")).toBeInTheDocument();
+    expect(container.querySelectorAll("img")).toHaveLength(0);
+  });
+
+  it("renders a label above the comparer", () => {
+    renderWidget(
+      widget({ label: "Retouch" }),
+      withOutputs(
+        { type: "image", uri: "https://cdn/before.png" },
+        { type: "image", uri: "https://cdn/after.png" }
+      )
+    );
+    expect(screen.getByText("Retouch")).toBeInTheDocument();
+  });
+
+  it("resolves an asset locator instead of passing it through raw", () => {
+    const { container } = renderWidget(
+      widget(),
+      withOutputs(
+        { type: "image", uri: "asset://abc123" },
+        { type: "image", asset_id: "def456" }
+      )
+    );
+
+    expect(screen.getByAltText("Before")).toHaveAttribute(
+      "src",
+      "https://assets.test/abc123"
+    );
+    expect(screen.getByAltText("After")).toHaveAttribute(
+      "src",
+      "https://assets.test/def456"
+    );
+    const raw = Array.from(container.querySelectorAll("img")).filter((img) =>
+      (img.getAttribute("src") ?? "").startsWith("asset://")
+    );
+    expect(raw).toEqual([]);
+  });
+
+  it("resolves a bare locator string and the last item of a streamed list", () => {
+    renderWidget(
+      widget(),
+      withOutputs("asset://abc123", [
+        { type: "image", uri: "https://cdn/first.png" },
+        { type: "image", uri: "https://cdn/last.png" }
+      ])
+    );
+
+    expect(screen.getByAltText("Before")).toHaveAttribute(
+      "src",
+      "https://assets.test/abc123"
+    );
+    expect(screen.getByAltText("After")).toHaveAttribute(
+      "src",
+      "https://cdn/last.png"
+    );
+  });
+});

--- a/web/src/components/appbuilder/puck/__tests__/mediaWidgets.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/mediaWidgets.test.tsx
@@ -4,6 +4,7 @@
  */
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 import type { AppInstanceState } from "@nodetool-ai/app-runtime";
 
@@ -31,12 +32,16 @@ const renderWidget = (
   element: React.ReactElement,
   initial: Partial<AppInstanceState> = {}
 ) => {
-  const { wrapper: Wrapper } = makeTestRuntime(initial);
-  return render(
-    <ThemeProvider theme={mockTheme}>
-      <Wrapper>{element}</Wrapper>
-    </ThemeProvider>
-  );
+  const runtime = makeTestRuntime(initial);
+  const { wrapper: Wrapper } = runtime;
+  return {
+    ...render(
+      <ThemeProvider theme={mockTheme}>
+        <Wrapper>{element}</Wrapper>
+      </ThemeProvider>
+    ),
+    runtime
+  };
 };
 
 const withOutput = (value: unknown): Partial<AppInstanceState> => ({
@@ -104,5 +109,151 @@ describe("GalleryWidget", () => {
     );
     expect(screen.getByText("No images")).toBeInTheDocument();
     expect(container.querySelectorAll("img")).toHaveLength(0);
+  });
+});
+
+describe("GalleryWidget selection", () => {
+  // `prompt` is the test scope's input node, so it resolves as a write slot.
+  const SELECTION = "prompt";
+  const INPUT_KEY = "main:in1";
+  const A = { type: "image", uri: "https://cdn/a.png" };
+  const B = { type: "image", uri: "https://cdn/b.png" };
+  const CHANGE_RUN = [{ trigger: "change" as const, kind: "run" }];
+
+  const withSelection = (
+    items: unknown[],
+    selected?: unknown
+  ): Partial<AppInstanceState> => {
+    const state: Partial<AppInstanceState> = withOutput(items);
+    if (selected === undefined) return state;
+    return {
+      ...state,
+      inputs: { [INPUT_KEY]: { value: selected, dirty: true, revision: 1 } }
+    };
+  };
+
+  it("leaves tiles inert when no selectionBinding is set", () => {
+    const { container, runtime } = renderWidget(
+      <GalleryWidget id="g1" binding="result" events={CHANGE_RUN} />,
+      withSelection([A, B])
+    );
+
+    expect(container.querySelectorAll("img")).toHaveLength(2);
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+    expect(runtime.value.write).not.toHaveBeenCalled();
+  });
+
+  it("writes the picked array element — not its URL — and emits change", async () => {
+    const user = userEvent.setup();
+    const { runtime } = renderWidget(
+      <GalleryWidget
+        id="g1"
+        binding="result"
+        selectionBinding={SELECTION}
+        events={CHANGE_RUN}
+      />,
+      withSelection([A, B])
+    );
+
+    await user.click(screen.getByRole("button", { name: "Select item 2" }));
+
+    expect(runtime.value.write).toHaveBeenCalledWith(
+      { kind: "input", operationId: "main", nodeId: "in1" },
+      B
+    );
+    expect(runtime.value.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "run", operationId: "main" })
+    );
+  });
+
+  it("marks the tile the bound slot already holds", () => {
+    renderWidget(
+      <GalleryWidget id="g1" binding="result" selectionBinding={SELECTION} />,
+      withSelection([A, B], { ...B })
+    );
+
+    expect(screen.getByRole("button", { name: "Select item 1" })).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+    expect(screen.getByRole("button", { name: "Select item 2" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+  });
+
+  it("re-renders the mark from the binding after a pick", async () => {
+    const user = userEvent.setup();
+    renderWidget(
+      <GalleryWidget id="g1" binding="result" selectionBinding={SELECTION} />,
+      withSelection([A, B])
+    );
+
+    await user.click(screen.getByRole("button", { name: "Select item 1" }));
+
+    expect(screen.getByRole("button", { name: "Select item 1" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+  });
+
+  it("selects with the keyboard", async () => {
+    const user = userEvent.setup();
+    const { runtime } = renderWidget(
+      <GalleryWidget id="g1" binding="result" selectionBinding={SELECTION} />,
+      withSelection([A, B])
+    );
+
+    await user.tab();
+    expect(screen.getByRole("button", { name: "Select item 1" })).toHaveFocus();
+    await user.keyboard("{Enter}");
+
+    expect(runtime.value.write).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "input", nodeId: "in1" }),
+      A
+    );
+  });
+
+  it("keeps tile and item paired when an item resolves to no image", async () => {
+    const user = userEvent.setup();
+    const { runtime } = renderWidget(
+      <GalleryWidget id="g1" binding="result" selectionBinding={SELECTION} />,
+      withSelection([{ type: "image", uri: "" }, A, B])
+    );
+
+    expect(screen.getAllByRole("button")).toHaveLength(2);
+    await user.click(screen.getByRole("button", { name: "Select item 1" }));
+
+    expect(runtime.value.write).toHaveBeenCalledWith(
+      expect.objectContaining({ nodeId: "in1" }),
+      A
+    );
+  });
+
+  it("does not write in design mode", async () => {
+    const user = userEvent.setup();
+    const runtime = makeTestRuntime(withSelection([A, B]), {
+      designMode: true
+    });
+    const { wrapper: Wrapper } = runtime;
+    const { container } = render(
+      <ThemeProvider theme={mockTheme}>
+        <Wrapper>
+          <GalleryWidget
+            id="g1"
+            binding="result"
+            selectionBinding={SELECTION}
+            events={CHANGE_RUN}
+          />
+        </Wrapper>
+      </ThemeProvider>
+    );
+
+    const tiles = container.querySelectorAll("img");
+    expect(tiles).toHaveLength(2);
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+    await user.click(tiles[0]);
+    expect(runtime.value.write).not.toHaveBeenCalled();
+    expect(runtime.value.dispatch).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/appbuilder/puck/__tests__/recorderWidgets.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/recorderWidgets.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * The capture widgets. Two things matter: a finished recording writes the same
+ * ref an upload writes (so a workflow input reads one value either way), and
+ * the builder canvas never mounts a recorder — mounting one asks the browser
+ * for the microphone or the camera.
+ */
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import type { AppInstanceState } from "@nodetool-ai/app-runtime";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import { makeTestRuntime, INPUT_KEY } from "../../__tests__/testRuntime";
+import type { AppRuntimeContextValue } from "../../runtime/AppRuntimeContext";
+import type { Asset } from "../../../../stores/ApiTypes";
+import { AudioRecorderWidget, CameraCaptureWidget } from "../RecorderWidgets";
+
+// The playback primitives resolve their locator through TanStack Query; this
+// suite stands up no QueryClientProvider.
+jest.mock("../../../../hooks/useResolvedMediaUri");
+
+/** What each recorder hook was last handed — the widget's side of the contract. */
+const waveProps = jest.fn();
+const videoProps = jest.fn();
+
+jest.mock("../../../../hooks/browser/useWaveRecorder", () => ({
+  useWaveRecorder: (props: unknown) => {
+    waveProps(props);
+    return {
+      error: null,
+      setError: jest.fn(),
+      micRef: { current: null },
+      handleRecord: jest.fn(),
+      isRecording: false,
+      isLoading: false,
+      audioInputDevices: [],
+      audioOutputDevices: [],
+      isDeviceListVisible: false,
+      toggleDeviceListVisibility: jest.fn(),
+      selectedInputDeviceId: "",
+      handleInputDeviceChange: jest.fn()
+    };
+  }
+}));
+
+jest.mock("../../../../hooks/browser/useVideoRecorder", () => ({
+  useVideoRecorder: (props: unknown) => {
+    videoProps(props);
+    return {
+      error: null,
+      setError: jest.fn(),
+      videoRef: { current: null },
+      handleRecord: jest.fn(),
+      isRecording: false,
+      isPreviewing: false,
+      isLoading: false,
+      startPreview: jest.fn(),
+      stopStream: jest.fn(),
+      videoInputDevices: [],
+      audioInputDevices: [],
+      isDeviceListVisible: false,
+      toggleDeviceListVisibility: jest.fn(),
+      selectedVideoDeviceId: "",
+      selectedAudioDeviceId: "",
+      handleVideoDeviceChange: jest.fn(),
+      handleAudioDeviceChange: jest.fn()
+    };
+  }
+}));
+
+const RECORDING: Asset = {
+  id: "asset-1",
+  user_id: "u1",
+  workflow_id: null,
+  parent_id: "root",
+  name: "recording.webm",
+  content_type: "audio/webm",
+  metadata: null,
+  created_at: "2026-01-01T00:00:00Z",
+  get_url: null,
+  thumb_url: null,
+  duration: null
+};
+
+const RUN_ON_CHANGE = [{ trigger: "change" as const, kind: "run" }];
+
+const renderWidget = (
+  element: React.ReactElement,
+  initial: Partial<AppInstanceState> = {},
+  overrides: Partial<AppRuntimeContextValue> = {}
+) => {
+  const runtime = makeTestRuntime(initial, overrides);
+  const { wrapper: Wrapper } = runtime;
+  return {
+    ...runtime,
+    ...render(
+      <ThemeProvider theme={mockTheme}>
+        <Wrapper>{element}</Wrapper>
+      </ThemeProvider>
+    )
+  };
+};
+
+/** The recorder's `onChange`, as the widget handed it to the mocked hook. */
+const lastOnChange = (mock: jest.Mock): ((asset: Asset) => void) =>
+  mock.mock.calls[mock.mock.calls.length - 1][0].onChange;
+
+const inputValue = (state: AppInstanceState): unknown =>
+  state.inputs[INPUT_KEY]?.value;
+
+beforeEach(() => {
+  waveProps.mockClear();
+  videoProps.mockClear();
+});
+
+describe("AudioRecorderWidget", () => {
+  it("writes the upload's ref shape to the bound input and emits change", () => {
+    const { store, value } = renderWidget(
+      <AudioRecorderWidget id="r1" binding="prompt" events={RUN_ON_CHANGE} />
+    );
+
+    act(() => lastOnChange(waveProps)(RECORDING));
+
+    expect(inputValue(store.getState())).toEqual({
+      type: "audio",
+      uri: "asset://asset-1",
+      asset_id: "asset-1"
+    });
+    expect(value.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "run", from: "op:main/in:in1" })
+    );
+  });
+
+  it("plays the captured recording back", () => {
+    renderWidget(<AudioRecorderWidget id="r1" binding="prompt" />, {
+      inputs: {
+        [INPUT_KEY]: {
+          value: { type: "audio", uri: "asset://asset-1", asset_id: "asset-1" },
+          dirty: true,
+          revision: 1
+        }
+      }
+    });
+
+    expect(screen.getByLabelText("Recorded audio")).toHaveAttribute(
+      "src",
+      "https://assets.test/asset-1"
+    );
+  });
+
+  it("renders a placeholder in design mode and mounts no recorder", () => {
+    renderWidget(<AudioRecorderWidget id="r1" binding="prompt" />, {}, {
+      designMode: true
+    });
+
+    expect(
+      screen.getByText(/Microphone capture .* records when the app runs/)
+    ).toBeInTheDocument();
+    expect(waveProps).not.toHaveBeenCalled();
+  });
+
+  it("attributes the capture to the bound operation's workflow", () => {
+    renderWidget(<AudioRecorderWidget id="r1" binding="prompt" />);
+    expect(waveProps).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowId: "wf1" })
+    );
+  });
+});
+
+describe("CameraCaptureWidget", () => {
+  it("writes a video ref to the bound input and emits change", () => {
+    const { store, value } = renderWidget(
+      <CameraCaptureWidget id="c1" binding="prompt" events={RUN_ON_CHANGE} />
+    );
+
+    act(() => lastOnChange(videoProps)(RECORDING));
+
+    expect(inputValue(store.getState())).toEqual({
+      type: "video",
+      uri: "asset://asset-1",
+      asset_id: "asset-1"
+    });
+    expect(value.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "run", from: "op:main/in:in1" })
+    );
+  });
+
+  it("renders a placeholder in design mode and mounts no recorder", () => {
+    renderWidget(<CameraCaptureWidget id="c1" binding="prompt" />, {}, {
+      designMode: true
+    });
+
+    expect(
+      screen.getByText(/Camera capture .* records when the app runs/)
+    ).toBeInTheDocument();
+    expect(videoProps).not.toHaveBeenCalled();
+  });
+
+  it("labels itself from the widget's own label", () => {
+    renderWidget(<CameraCaptureWidget id="c1" label="Say hello" />);
+    expect(screen.getByText("Say hello")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/appbuilder/puck/__tests__/workflowFormWidget.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/workflowFormWidget.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import { DEFAULT_OPERATION_ID } from "@nodetool-ai/app-runtime";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import { makeTestRuntime } from "../../__tests__/testRuntime";
+import { WorkflowFormWidget } from "../WorkflowFormWidget";
+import type { WorkflowFormWidgetProps } from "../WorkflowFormWidget";
+import type { WorkflowInputIO, WorkflowIO } from "../../workflowIO";
+import type { AppRuntimeContextValue } from "../../runtime/AppRuntimeContext";
+
+const PROMPT: WorkflowInputIO = {
+  nodeId: "in1",
+  nodeType: "nodetool.input.StringInput",
+  name: "prompt",
+  label: "Prompt",
+  kind: "string",
+  description: "What to write about"
+};
+
+const TITLE: WorkflowInputIO = {
+  nodeId: "in2",
+  nodeType: "nodetool.input.StringInput",
+  name: "title",
+  label: "Title",
+  kind: "string",
+  description: "Headline for the piece"
+};
+
+const PROMPT_KEY = `${DEFAULT_OPERATION_ID}:in1`;
+const TITLE_KEY = `${DEFAULT_OPERATION_ID}:in2`;
+
+const renderForm = (
+  props: Partial<WorkflowFormWidgetProps> = {},
+  io: WorkflowIO = { inputs: [PROMPT, TITLE], outputs: [] },
+  overrides: Partial<AppRuntimeContextValue> = {}
+) => {
+  const runtime = makeTestRuntime(
+    {},
+    { io, ioFor: () => io, ...overrides }
+  );
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <runtime.wrapper>
+        <WorkflowFormWidget id="form-1" {...props} />
+      </runtime.wrapper>
+    </ThemeProvider>
+  );
+  return runtime;
+};
+
+describe("WorkflowFormWidget", () => {
+  it("renders one control per workflow input", () => {
+    renderForm({ label: "Brief" });
+    expect(screen.getByText("Brief")).toBeInTheDocument();
+    expect(screen.getByLabelText("Prompt")).toBeInTheDocument();
+    expect(screen.getByLabelText("Title")).toBeInTheDocument();
+    expect(screen.getAllByRole("textbox")).toHaveLength(2);
+  });
+
+  it("writes a change to that input's own slot and no other", async () => {
+    const { store } = renderForm();
+    await userEvent.type(screen.getByLabelText("Prompt"), "hi");
+
+    expect(store.getState().inputs[PROMPT_KEY]?.value).toBe("hi");
+    expect(store.getState().inputs[TITLE_KEY]).toBeUndefined();
+  });
+
+  it("dispatches the widget's change events", async () => {
+    const { value } = renderForm({
+      events: [{ trigger: "change", kind: "run" }]
+    });
+    await userEvent.type(screen.getByLabelText("Title"), "x");
+
+    expect(value.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "run", operationId: DEFAULT_OPERATION_ID })
+    );
+  });
+
+  it("shows each input's description by default", () => {
+    renderForm();
+    expect(screen.getByText("What to write about")).toBeInTheDocument();
+    expect(screen.getByText("Headline for the piece")).toBeInTheDocument();
+  });
+
+  it("hides descriptions when showDescriptions is 'no'", () => {
+    renderForm({ showDescriptions: "no" });
+    expect(screen.queryByText("What to write about")).toBeNull();
+    expect(screen.queryByText("Headline for the piece")).toBeNull();
+    expect(screen.getByLabelText("Prompt")).toBeInTheDocument();
+  });
+
+  it("says so when the operation has no inputs", () => {
+    renderForm({}, { inputs: [], outputs: [] });
+    expect(screen.getByText("This operation has no inputs.")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+
+  it("lists the inputs as a hint in design mode instead of rendering controls", () => {
+    renderForm({ label: "Brief" }, { inputs: [PROMPT, TITLE], outputs: [] }, {
+      designMode: true
+    });
+    expect(screen.getByText("Brief")).toBeInTheDocument();
+    expect(screen.getByText("Prompt — string")).toBeInTheDocument();
+    expect(screen.getByText("Title — string")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+});

--- a/web/src/components/appbuilder/puck/config.tsx
+++ b/web/src/components/appbuilder/puck/config.tsx
@@ -68,6 +68,12 @@ import { ChatThreadWidget, ChatComposerWidget } from "./ChatWidgets";
 import { SketchWidget, TimelineWidget } from "./DocumentWidgets";
 import { SketchPadWidget } from "./SketchPadWidget";
 import { GalleryWidget, Model3DWidget, PDFWidget } from "./MediaWidgets";
+import { ImageComparerWidget } from "./ImageComparerWidget";
+import { WorkflowFormWidget } from "./WorkflowFormWidget";
+import {
+  AudioRecorderWidget,
+  CameraCaptureWidget
+} from "./RecorderWidgets";
 import { ChartWidget } from "./ChartWidget";
 
 const ACTION_OPTIONS = [
@@ -321,6 +327,7 @@ export const appConfig: Config = {
     inputs: {
       title: "Inputs",
       components: [
+        "WorkflowForm",
         "WorkflowInput",
         "TextInput",
         "NumberInput",
@@ -336,7 +343,9 @@ export const appConfig: Config = {
         "ImageInput",
         "SketchPad",
         "AudioInput",
+        "AudioRecorder",
         "VideoInput",
+        "CameraCapture",
         "DocumentInput",
         "ColorInput",
         "DataFrameInput",
@@ -376,7 +385,8 @@ export const appConfig: Config = {
         "Model3D",
         "Chart",
         "PDF",
-        "Gallery"
+        "Gallery",
+        "ImageCompare"
       ]
     },
     layout: {
@@ -700,9 +710,11 @@ export const appConfig: Config = {
       label: "Gallery",
       fields: {
         binding: bindingField("read"),
+        selectionBinding: bindingField("write", "Selection"),
         label: { type: "text", label: "Label" },
         tileSize: { type: "number", label: "Tile size (px)" },
         placeholder: { type: "text", label: "Placeholder" },
+        events: eventsField("change", { commits: false }),
         ...conditionalFields({ format: false })
       },
       defaultProps: {
@@ -712,7 +724,43 @@ export const appConfig: Config = {
       },
       render: withConditions((props) => <GalleryWidget {...props} />)
     },
+    ImageCompare: {
+      label: "Image Compare",
+      fields: {
+        binding: bindingField("read", "Before"),
+        compareBinding: bindingField("read", "After"),
+        label: { type: "text", label: "Label" },
+        height: { type: "number", label: "Max height (px)" },
+        placeholder: { type: "text", label: "Placeholder" },
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: {
+        label: "",
+        height: 320,
+        placeholder: "Nothing to compare yet"
+      },
+      render: withConditions((props) => <ImageComparerWidget {...props} />)
+    },
     // ── Inputs ──
+    WorkflowForm: {
+      label: "Workflow Form",
+      fields: {
+        operationId: operationField("Operation"),
+        label: { type: "text", label: "Label" },
+        showDescriptions: {
+          type: "radio",
+          label: "Descriptions",
+          options: [
+            { label: "Show", value: "yes" },
+            { label: "Hide", value: "no" }
+          ]
+        },
+        events: eventsField("change", { commits: false }),
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: { label: "", showDescriptions: "yes" },
+      render: withConditions((props) => <WorkflowFormWidget {...props} />)
+    },
     WorkflowInput: {
       label: "Workflow Input",
       fields: {
@@ -1028,6 +1076,28 @@ export const appConfig: Config = {
     },
     AudioInput: fixedInputEntry("Audio Input", "audio"),
     VideoInput: fixedInputEntry("Video Input", "video"),
+    AudioRecorder: {
+      label: "Audio Recorder",
+      fields: {
+        binding: bindingField("write", "Workflow input"),
+        label: { type: "text", label: "Label" },
+        events: eventsField("change", { commits: false }),
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: { binding: "", label: "Record audio" },
+      render: withConditions((props) => <AudioRecorderWidget {...props} />)
+    },
+    CameraCapture: {
+      label: "Camera Capture",
+      fields: {
+        binding: bindingField("write", "Workflow input"),
+        label: { type: "text", label: "Label" },
+        events: eventsField("change", { commits: false }),
+        ...conditionalFields({ format: false })
+      },
+      defaultProps: { binding: "", label: "Record video" },
+      render: withConditions((props) => <CameraCaptureWidget {...props} />)
+    },
     DocumentInput: fixedInputEntry("Document Input", "document"),
     ColorInput: fixedInputEntry("Color Input", "color"),
     Model3DInput: fixedInputEntry("3D Model Input", "model3d"),

--- a/web/src/components/properties/PropertyDropzone.tsx
+++ b/web/src/components/properties/PropertyDropzone.tsx
@@ -549,10 +549,10 @@ const PropertyDropzone = ({
           )}
         </div>
         {contentType.split("/")[0] === "audio" && showRecorder && (
-          <WaveRecorder onChange={onChangeAsset} />
+          <WaveRecorder onChange={onChangeAsset} workflowId={props.workflowId} />
         )}
         {contentType.split("/")[0] === "video" && showRecorder && (
-          <VideoRecorder onChange={onChangeAsset} />
+          <VideoRecorder onChange={onChangeAsset} workflowId={props.workflowId} />
         )}
       </div>
     </div>

--- a/web/src/hooks/browser/__tests__/useVideoRecorder.test.ts
+++ b/web/src/hooks/browser/__tests__/useVideoRecorder.test.ts
@@ -1,22 +1,13 @@
-import { makeNodeStore, nodeStoreRenderers } from "../../../test-utils/nodeStore";
-import { act } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { useVideoRecorder } from "../useVideoRecorder";
 
-// Mock the dependencies
+// The hook takes the workflow id as a prop, so nothing here mounts a
+// NodeProvider — a published mini app has none, and the hook must still work.
 jest.mock("../../../serverState/useAssetUpload", () => ({
   useAssetUpload: () => ({
     uploadAsset: jest.fn()
   })
 }));
-
-const { renderHook } = nodeStoreRenderers(
-  makeNodeStore({
-      workflow: {
-        id: "test-workflow-id",
-        name: "Test Workflow"
-      }
-    })
-);
 // Mock navigator.mediaDevices
 const mockGetUserMedia = jest.fn();
 const mockEnumerateDevices = jest.fn();

--- a/web/src/hooks/browser/__tests__/useWaveRecorder.test.ts
+++ b/web/src/hooks/browser/__tests__/useWaveRecorder.test.ts
@@ -5,20 +5,21 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useWaveRecorder } from "../useWaveRecorder";
 
-// Mock dependencies
+// The hook takes the workflow id as a prop, so no NodeProvider is mocked or
+// mounted anywhere in this suite — a published mini app has neither.
+const mockUploadAsset = jest.fn();
+const mockRecordHandlers = new Map<string, (blob: Blob) => void>();
+
 jest.mock("../../../serverState/useAssetUpload", () => ({
   useAssetUpload: () => ({
-    uploadAsset: jest.fn()
+    uploadAsset: mockUploadAsset
   })
 }));
 
-jest.mock("../../../contexts/NodeContext", () => ({
-  useNodes: jest.fn(() => ({
-    workflow: { id: "test-workflow-id" }
-  }))
-}));
-
+// `__esModule` matters: without it the default-import interop hands the hook
+// the whole module object and `RecordPlugin.create` is undefined.
 jest.mock("wavesurfer.js", () => ({
+  __esModule: true,
   default: {
     create: jest.fn(() => ({
       on: jest.fn(),
@@ -28,9 +29,12 @@ jest.mock("wavesurfer.js", () => ({
 }));
 
 jest.mock("wavesurfer.js/dist/plugins/record", () => ({
+  __esModule: true,
   default: {
     create: jest.fn(() => ({
-      on: jest.fn(),
+      on: jest.fn((event: string, handler: (blob: Blob) => void) => {
+        mockRecordHandlers.set(event, handler);
+      }),
       unAll: jest.fn(),
       isRecording: jest.fn(() => false),
       startRecording: jest.fn(() => Promise.resolve()),
@@ -45,6 +49,7 @@ describe("useWaveRecorder", () => {
 
   beforeEach(() => {
     mockOnChange = jest.fn();
+    mockRecordHandlers.clear();
     jest.clearAllMocks();
     
     // Mock navigator.mediaDevices
@@ -291,6 +296,48 @@ describe("useWaveRecorder", () => {
       await waitFor(() => {
         expect(result.current.error).not.toBe("Previous error");
       });
+    });
+  });
+
+  describe("Asset attribution", () => {
+    /** Mounts the waveform, which only happens once the container ref is set. */
+    const mountRecorder = (workflowId?: string) => {
+      const { result, rerender } = renderHook(
+        ({ onChange }: { onChange: () => void }) =>
+          useWaveRecorder({ onChange, workflowId }),
+        { initialProps: { onChange: mockOnChange } }
+      );
+      act(() => {
+        result.current.micRef.current = document.createElement("div");
+      });
+      // A new onChange re-runs the effect that creates the recorder, now that
+      // the container exists.
+      rerender({ onChange: jest.fn() });
+      return result;
+    };
+
+    it("stamps the given workflow id on the uploaded recording", () => {
+      mountRecorder("wf-77");
+
+      act(() => {
+        mockRecordHandlers.get("record-end")?.(new Blob(["x"]));
+      });
+
+      expect(mockUploadAsset).toHaveBeenCalledWith(
+        expect.objectContaining({ workflow_id: "wf-77" })
+      );
+    });
+
+    it("uploads without a workflow id when the app has none", () => {
+      mountRecorder();
+
+      act(() => {
+        mockRecordHandlers.get("record-end")?.(new Blob(["x"]));
+      });
+
+      expect(mockUploadAsset).toHaveBeenCalledWith(
+        expect.objectContaining({ workflow_id: undefined })
+      );
     });
   });
 

--- a/web/src/hooks/browser/useVideoRecorder.ts
+++ b/web/src/hooks/browser/useVideoRecorder.ts
@@ -1,10 +1,14 @@
 import { type Dispatch, type MutableRefObject, type SetStateAction, useEffect, useRef, useState, useCallback } from "react";
 import { useAssetUpload } from "../../serverState/useAssetUpload";
 import { Asset } from "../../stores/ApiTypes";
-import { useNodes } from "../../contexts/NodeContext";
 
 export type VideoRecorderProps = {
   onChange: (asset: Asset) => void;
+  /**
+   * Stamped on the uploaded asset. Optional because a published mini app has
+   * no graph editor around it — the recorder works without one.
+   */
+  workflowId?: string;
 };
 
 export type VideoDevice = {
@@ -32,10 +36,12 @@ interface VideoRecorderReturn {
   handleAudioDeviceChange: (deviceId: string) => void;
 }
 
-export function useVideoRecorder({ onChange }: VideoRecorderProps): Readonly<VideoRecorderReturn> {
+export function useVideoRecorder({
+  onChange,
+  workflowId
+}: VideoRecorderProps): Readonly<VideoRecorderReturn> {
   const defaultFileType = "webm";
   const { uploadAsset } = useAssetUpload();
-  const workflow = useNodes((state) => state.workflow);
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
@@ -267,7 +273,7 @@ export function useVideoRecorder({ onChange }: VideoRecorderProps): Readonly<Vid
 
         uploadAsset({
           file,
-          workflow_id: workflow.id,
+          workflow_id: workflowId,
           onCompleted: (asset: Asset) => {
             onChange(asset);
             stopStream();
@@ -295,7 +301,7 @@ export function useVideoRecorder({ onChange }: VideoRecorderProps): Readonly<Vid
     defaultFileType,
     onChange,
     uploadAsset,
-    workflow.id,
+    workflowId,
     stopStream
   ]);
 

--- a/web/src/hooks/browser/useWaveRecorder.ts
+++ b/web/src/hooks/browser/useWaveRecorder.ts
@@ -3,10 +3,14 @@ import WaveSurfer from "wavesurfer.js";
 import RecordPlugin from "wavesurfer.js/dist/plugins/record";
 import { useAssetUpload } from "../../serverState/useAssetUpload";
 import { Asset } from "../../stores/ApiTypes";
-import { useNodes } from "../../contexts/NodeContext";
 
 export type WaveRecorderProps = {
   onChange: (asset: Asset) => void;
+  /**
+   * Stamped on the uploaded asset. Optional because a published mini app has
+   * no graph editor around it — the recorder works without one.
+   */
+  workflowId?: string;
 };
 
 export type AudioDevice = {
@@ -29,10 +33,12 @@ interface WaveRecorderReturn {
   handleInputDeviceChange: (deviceId: string) => void;
 }
 
-export function useWaveRecorder({ onChange }: WaveRecorderProps): Readonly<WaveRecorderReturn> {
+export function useWaveRecorder({
+  onChange,
+  workflowId
+}: WaveRecorderProps): Readonly<WaveRecorderReturn> {
   const defaultFileType = "webm";
   const { uploadAsset } = useAssetUpload();
-  const workflow = useNodes((state) => state.workflow);
   const micRef = useRef<HTMLDivElement | null>(null);
   const waveSurferRef = useRef<WaveSurfer | null>(null);
   const recordRef = useRef<RecordPlugin | null>(null);
@@ -203,7 +209,7 @@ export function useWaveRecorder({ onChange }: WaveRecorderProps): Readonly<WaveR
         });
         uploadAsset({
           file,
-          workflow_id: workflow.id,
+          workflow_id: workflowId,
           onCompleted: (asset: Asset) => {
             onChange(asset);
           },
@@ -211,7 +217,7 @@ export function useWaveRecorder({ onChange }: WaveRecorderProps): Readonly<WaveR
         });
       });
     }
-  }, [defaultFileType, onChange, uploadAsset, workflow.id]);
+  }, [defaultFileType, onChange, uploadAsset, workflowId]);
 
   const [isDeviceListVisible, setIsDeviceListVisible] =
     useState<boolean>(false);


### PR DESCRIPTION
## What changed

Five surfaces the app already had but the builder could not place. `WorkflowForm` renders every input of one operation, resolved from the graph at render time, so an Input node added to the workflow shows up with no edit to the app document — where an author previously placed and bound each input by hand. `AudioRecorder` and `CameraCapture` capture from the microphone and camera and write the same media ref an upload writes, so a workflow reads one value either way; both recorder hooks took the workflow id from `NodeContext`, which a published app does not have, so they take it as a prop now. `ImageCompare` puts two bound images under one wipe handle, reusing the comparer `CompareImagesNode`, `PreviewImageGrid` and `AssetViewer` already use. `Gallery` gains a `selectionBinding`: tapping a tile writes that array element and emits `change`, which is the generate-N-pick-one loop — selection lives in the binding, not in the component, so it survives a reload.

All five register in `WIDGET_CATALOG`, so the Puck editor, the mobile renderer, the `app debug` harness and the `ui_app_*` tools see one list. Two app-debug consequences fell out of the form binding no slot of its own: it no longer draws the "not bound to an input" warning every other write widget earns, and a form naming an operation the app never declared is now an error rather than an empty form at run time. On mobile the recorders are real capture (expo-audio for the mic, the system camera sheet for video), which needed the `NSCameraUsageDescription` / `android.permission.CAMERA` declarations `mobile/app.json` was missing — without them `launchCameraAsync` crashes before the prompt, which also affects the existing chat composer.

## Verification

- [x] `npm run test:affected` — run as its constituent suites, since this container has no `origin/main` merge base for the differ: `packages/app-runtime` 215/215, `packages/execution` 297/297, `packages/agents` (app suites) 168/168, web `appbuilder` + `hooks/browser` + `properties` 547/547, mobile `app_runtime` 123/123.
- [x] `npm run typecheck` — clean for web, electron and every file this diff touches. Mobile reports 36 errors from stale `@nodetool-ai/protocol` in `mobile/node_modules` (`sync_mode`, `ShotStatus`, `TRPC_MAX_BATCH_SIZE`); measured at 36 on the stashed baseline and 36 with the diff, so this adds none.
- [x] `npm run lint` — no errors.
- [x] `npm run dev:nodetool -- harness gate` — `Gate: 5/5 selfchecks passed`, including the deterministic app-build cases (`green-within-budget 2/2, one-shot 2/2`). Run with `--base HEAD~1`; `--base main` aborts with `fatal: main...HEAD: no merge base` in this container.

End to end through the real CLI harness, on a shipped example bundle with a `WorkflowForm` added:

```
$ nodetool app debug form-app.json --no-run
✅ App wiring is valid (static check only — no run executed).
```

## New checks

The new app-debug rule was inverted (`if (false && w.operationId && …)`) and observed failing:

```
× flags a form whose operation the app never declares
Tests  1 failed | 19 passed (20)
```

Restored, and the same case through the CLI harness on a bundle whose form names a renamed operation:

```
❌ App has issues — WorkflowForm "WorkflowForm-probe": renders the inputs of
   operation "renamed-operation" but the app declares no such operation.
```

Sub-agents inverted their own checks the same way and reported the failures: handing the raw locator to `ImageComparer` reddens the media-resolution suite, writing `entry.src` instead of `entry.item` reddens four gallery selection cases, deleting `ImageCompare` from the mobile `RENDERERS` reddens the catalog parity test, and a local-URI shortcut in `uploadCapturedFile` reddens both mobile capture-equality cases.

## Agent capabilities

- [x] `npm run capabilities:check` passes — `capability table is current (250 capabilities)`

No capability is added or re-declared. The widgets reach agents through `WIDGET_CATALOG`, which `ui_app_list_component_types` and the app-build spec stage already enumerate.

## Known gaps

- A `change → run` event on a `WorkflowForm` triggers a full run rather than the changed input's subgraph: `useWidgetRuntime` derives `from` from a widget's single binding, which a form does not have. Pinned by a test rather than left implicit.
- Mobile's `AppRuntimeContext` exposes one `io`, not `ioFor`, so a form's `operationId` there selects which state slots the rows write, not which graph they read.
- The audio input's "needs the workflow's node store" placeholder stays: `AudioProperty` calls `useNodes(state => state.findNode)` unconditionally, verified by rendering it without a provider. The new `AudioRecorder` does not go through that path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLUwNAAj5mkEr1mhVNZt1r)_