### PR TITLE
fix(agents): mount create_timeline on the built-in belt

### DIFF
--- a/packages/agents/src/tools/builtin-tools.ts
+++ b/packages/agents/src/tools/builtin-tools.ts
@@ -109,6 +109,7 @@ export const BUILTIN_TOOL_NAMES: readonly string[] = [
 
   // Timeline snapshot history (find a cut, pin a state, roll one back)
   "list_timelines",
+  "create_timeline",
   "get_timeline",
   "list_timeline_versions",
   "get_timeline_version",

--- a/packages/agents/tests/document-edit-tools.test.ts
+++ b/packages/agents/tests/document-edit-tools.test.ts
@@ -62,6 +62,26 @@ describe("document edit tools", () => {
     }
   });
 
+  /**
+   * The create half of the same four surfaces. `edit_*` on the belt without
+   * `create_*` is worse than neither: the namespace lights up, so
+   * `nodetool.<surface>.create()` is documented and reachable, and it throws
+   * "not in this toolbelt" — leaving a blank document only obtainable by
+   * editing one the user already has.
+   */
+  it("registers the create half of each surface too", () => {
+    const creates = [
+      "create_timeline",
+      "create_sketch",
+      "create_script",
+      "create_storyboard"
+    ];
+    expect(BUILTIN_TOOL_NAMES).toEqual(expect.arrayContaining(creates));
+    for (const name of creates) {
+      expect(permissionCategoryFor(name)).toBe("write");
+    }
+  });
+
   describe("edit_timeline", () => {
     it("applies ops and persists the new document", async () => {
       const sequence = await makeTimeline();


### PR DESCRIPTION
## What changed

`create_timeline` was implemented, tested, permissioned and documented, but its name was never added to `BUILTIN_TOOL_NAMES`, so no host mounted it. `list_timelines` *is* on the belt, and one name is enough to light a `nodetool.*` namespace up, so `nodetool.timelines.create()` was documented and reachable and threw `tool "create_timeline" is not in this toolbelt`. A headless session's only remaining routes to a timeline were editing a sequence the user already had open, or `assemble_storyboard_timeline` / `assemble_script_timeline`, which build one only out of media they rendered themselves. The capability needs nothing a run must carry — a user id and the models package, exactly like `create_sketch` — so this adds the one missing name beside its siblings. `edit_timeline` and the version family were already there; `delete_timeline` stays off, consistently with `delete_sketch`, `delete_script` and `delete_storyboard`.

## Verification

```
npm run test:affected                                → All affected suites passed (exit 0)
npm run test --workspace=packages/agents             → 236 files, 3691 passed, 5 skipped
npm run typecheck                                    → web ✅ electron ✅ (mobile leg cannot run
                                                        in this container: mobile/node_modules
                                                        is absent, so every import is TS2307;
                                                        this diff touches no mobile file)
npm run lint                                         → clean
npm run dev:nodetool -- harness gate --base origin/main
                                                     → 255/255 graphs validate; 1/1 selfchecks passed
npm run capabilities:check                           → capability table is current (250 capabilities)
```

The new guard was inverted by running it against the unfixed belt:

```
 FAIL  tests/document-edit-tools.test.ts > document edit tools >
       registers the create half of each surface too
 → expected BUILTIN_TOOL_NAMES to contain "create_timeline"
   ❯ tests/document-edit-tools.test.ts:79:32
 Test Files  1 failed (1)
      Tests  1 failed | 12 passed (13)
```

Two unrelated environment gaps had to be closed first, neither touched by the diff: `node_modules/@nodetool-ai/browser` was missing its workspace link (which also fails the `automation-nodes` build), and the image suites needed `mesa-vulkan-drivers` per the documented headless-WebGPU note.

- [x] `npm run test:affected`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run dev:nodetool -- harness gate --base main`

## Agent capabilities

No capability is added and no declared contract changes — `create_timeline`'s spec, schema and permission category are untouched. `npm run capabilities:check` passes.

## New checks

The guard sits next to the existing test that pins the `edit_*` half of the four document surfaces as built-ins, and asserts the same for the `create_*` half. It names its four targets explicitly, so it cannot pass by matching nothing, and its failing output on the unfixed belt is above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TndEWXknvqs5zKQymxSjr7)_