### PR TITLE
feat(svg): open SVG as its own document, and let agents see what they draw

### DIFF
--- a/packages/agents/src/capabilities/assets.specs.ts
+++ b/packages/agents/src/capabilities/assets.specs.ts
@@ -200,7 +200,7 @@ export const getAssetSpec: CapabilitySpec = {
 export const saveAssetSpec: CapabilitySpec = {
   name: "save_asset",
   description:
-    "Save content as an asset in the library. Use this for any artifact you want to keep or surface in the chat (text reports, JSON, manifests, images, audio, video). Pass `content` for text, `content_base64` for binary bytes you produced, or `source` for a file that already exists — the asset_url / /api/storage/ key another tool returned, an asset:// URI, or an http(s) URL — so the bytes are copied host-side instead of round-tripping through base64. Returns an asset_id and an `asset://` URI (`asset_uri` / `url`). Embed images, video, and audio in your reply as a markdown image: `![label](asset_uri)`.",
+    "Save content as an asset in the library. Use this for any artifact you want to keep or surface in the chat (text reports, JSON, manifests, images, audio, video). Pass `content` for text, `content_base64` for binary bytes you produced, or `source` for a file that already exists — the asset_url / /api/storage/ key another tool returned, an asset:// URI, or an http(s) URL — so the bytes are copied host-side instead of round-tripping through base64. Returns an asset_id and an `asset://` URI (`asset_uri` / `url`). Without an explicit content_type the filename extension decides it, so name an SVG `<something>.svg` and it is stored as image/svg+xml — openable and editable in the app, and readable back with read_asset. Embed images, video, and audio in your reply as a markdown image: `![label](asset_uri)`.",
   inputSchema: SAVE_ASSET_SCHEMA,
   category: "write",
   userMessage: (params) => {
@@ -288,7 +288,9 @@ export const viewImageSpec: CapabilitySpec = {
     "Load the actual pixels of an image into your view so you can inspect it. " +
     "You normally hold only image handles (id, size, type) — call view_image " +
     "when you genuinely need to see one. Pass a region to zoom into part of it, " +
-    "or detail:'low' to save tokens. The image appears in your next turn.",
+    "or detail:'low' to save tokens. SVG is rendered before you see it, so this " +
+    "is how you check what an SVG you wrote actually looks like. The image " +
+    "appears in your next turn.",
   inputSchema: zodToJsonSchema(VIEW_IMAGE_SCHEMA),
   zodSchema: VIEW_IMAGE_SCHEMA,
   category: "read",

--- a/packages/agents/src/capabilities/assets.ts
+++ b/packages/agents/src/capabilities/assets.ts
@@ -33,9 +33,12 @@ import {
 } from "@nodetool-ai/runtime";
 import type { Asset as AssetRow } from "@nodetool-ai/models";
 import {
+  SVG_MIME,
   detectImageMime as sniffImageMime,
   isSafePublicHttpsUrl,
+  isSvgBytes,
   loadMediaRefBytes,
+  rasterizeSvg,
   safeFetch
 } from "@nodetool-ai/runtime";
 import { mimeForPath } from "../sandbox-media-ref.js";
@@ -422,12 +425,15 @@ const saveAsset: CapabilityExport = {
             error: "`content_base64` decoded to 0 bytes — nothing to save."
           };
         }
+        // The filename before the generic fallback: an agent that writes
+        // `save_asset({name: "logo.svg", content: "<svg…"})` means an SVG, and
+        // storing it as text/plain is what made it a file nothing would render.
+        // The `source` branch above already infers this way.
         mime =
-          isString(contentTypeArg) && contentTypeArg
+          (isString(contentTypeArg) && contentTypeArg
             ? contentTypeArg
-            : hasBinary
-              ? "application/octet-stream"
-              : "text/plain";
+            : mimeForPath(name)) ??
+          (hasBinary ? "application/octet-stream" : "text/plain");
       }
 
       // Prefer the model interface (DB + storage). This is what the chat
@@ -752,6 +758,14 @@ function parseDataUri(
 
 const LOW_DETAIL_MAX_SIDE = 768;
 
+/**
+ * Longest side an SVG is rendered at before any crop or downscale. A vector
+ * declares whatever size it likes — a 24px icon renders to 24 pixels, which is
+ * not something a model can read — so the render is sized for reading, not for
+ * the markup's own units.
+ */
+const SVG_RENDER_MIN_SIDE = 1536;
+
 function parseRegion(value: unknown): ImageRegion | undefined {
   if (!isObjectLike(value)) return undefined;
   const r = value as Record<string, unknown>;
@@ -816,7 +830,11 @@ export const viewImageCore: CapabilityImpl = async (run, params) => {
       const { bytes } = await context.resolveAssetBytes(imageId);
       if (bytes && bytes.length > 0) {
         sourceBytes = bytes;
-        sourceMime = sniffImageMime(bytes);
+        // `sniffImageMime` falls back to PNG for anything it does not
+        // recognize, and SVG has no magic number — so an SVG asset arrived
+        // labeled `image/png`, passed the provider-safe check below, and was
+        // shipped to the model as markup wearing a PNG label.
+        sourceMime = isSvgBytes(bytes) ? SVG_MIME : sniffImageMime(bytes);
       }
     } catch (e) {
       // Keep why. A caller that passed a perfectly good asset id — one
@@ -848,6 +866,32 @@ export const viewImageCore: CapabilityImpl = async (run, params) => {
   let width = 0;
   let height = 0;
   const notes: string[] = [];
+
+  if (sourceBytes && sourceMime === SVG_MIME) {
+    // A vector has no pixels until something renders it, and no vision provider
+    // renders one. Rasterize here so an agent can look at the SVG it just
+    // wrote; a crop or a downscale then applies to the render, exactly as for
+    // any other source.
+    try {
+      const raster = await rasterizeSvg(sourceBytes, {
+        minSide: maxSide ?? SVG_RENDER_MIN_SIDE
+      });
+      sourceBytes = raster.data;
+      sourceMime = "image/png";
+      // Carry the render's size into the result even when nothing downstream
+      // re-encodes: "how big is what I am looking at" is the SVG's own answer
+      // only until it is rasterized.
+      width = raster.width;
+      height = raster.height;
+      notes.push(`Rendered SVG at ${raster.width}×${raster.height}.`);
+    } catch (e) {
+      return {
+        error:
+          `Could not render the SVG "${imageId}": ` +
+          `${e instanceof Error ? e.message : String(e)}`
+      };
+    }
+  }
 
   if (sourceBytes) {
     // Vision providers only accept these formats; anything else must be

--- a/packages/agents/src/capabilities/files.ts
+++ b/packages/agents/src/capabilities/files.ts
@@ -1087,7 +1087,11 @@ const grep: CapabilityExport = {
       });
     }
 
-    // Filter out binary-looking files by extension
+    // Filter out binary-looking files by extension. `.svg` is deliberately not
+    // here: it is XML, an agent writes and edits it as text, and skipping it
+    // meant a grep for a path or a gradient id in a drawing found nothing. The
+    // per-file null-byte check below still catches anything that really is
+    // binary.
     const binaryExts = new Set([
       ".png",
       ".jpg",
@@ -1095,7 +1099,6 @@ const grep: CapabilityExport = {
       ".gif",
       ".bmp",
       ".ico",
-      ".svg",
       ".webp",
       ".mp3",
       ".mp4",

--- a/packages/agents/tests/capabilities-assets.test.ts
+++ b/packages/agents/tests/capabilities-assets.test.ts
@@ -183,6 +183,39 @@ describe("assets capabilities against the database", () => {
     expect(read.content).toBe("# hello");
   });
 
+  it("types text content from the filename when no content_type is given", async () => {
+    // An SVG saved as text/plain is a file nothing renders: the asset grid
+    // shows a document icon, the workspace opens it in the text editor, and
+    // `view_image` will not rasterize it. The name is the declaration.
+    let created = 1;
+    const ctx = makeContext({
+      hasModelInterface: (name: string) => name === "createAsset",
+      createAsset: async () => ({ id: `as_${created++}` })
+    });
+
+    const svg = (await asTool("save_asset", ctx).process(ctx, {
+      name: "logo.svg",
+      content: '<svg xmlns="http://www.w3.org/2000/svg"/>'
+    })) as Record<string, unknown>;
+    expect(svg.content_type).toBe("image/svg+xml");
+    expect(svg.asset_uri).toBe(`asset://${String(svg.asset_id)}.svg`);
+
+    // An explicit content_type still wins.
+    const forced = (await asTool("save_asset", ctx).process(ctx, {
+      name: "logo.svg",
+      content: "<svg/>",
+      content_type: "text/plain"
+    })) as Record<string, unknown>;
+    expect(forced.content_type).toBe("text/plain");
+
+    // A name that declares nothing keeps the old fallback.
+    const plain = (await asTool("save_asset", ctx).process(ctx, {
+      name: "report",
+      content: "hello"
+    })) as Record<string, unknown>;
+    expect(plain.content_type).toBe("text/plain");
+  });
+
   it("returns an asset_uri that carries the file extension", async () => {
     let created = 1;
     // `asset://<id>` alone types nothing: a chat embed of a saved mp4 rendered

--- a/packages/agents/tests/edit-search-tools.test.ts
+++ b/packages/agents/tests/edit-search-tools.test.ts
@@ -153,6 +153,26 @@ describe("GrepTool", () => {
     expect(Date.now() - started).toBeLessThan(2000);
   });
 
+  it("searches .svg, and still skips a raster file with the same content", async () => {
+    // An SVG is XML an agent writes and edits. It used to be filtered out with
+    // the raster formats, so a grep for a gradient id in a drawing found
+    // nothing; the null-byte check is what keeps real binaries out.
+    await writeFile(
+      join(workspace, "logo.svg"),
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect id="badge"/></svg>\n'
+    );
+    await writeFile(
+      join(workspace, "logo.png"),
+      Buffer.concat([Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00]), Buffer.from("badge\n")])
+    );
+    const res: any = await toolForCapabilityName("grep").process(ctxFor(workspace), {
+      pattern: "badge"
+    });
+    expect(res.success).toBe(true);
+    expect(res.matches.some((m: any) => m.file === "logo.svg")).toBe(true);
+    expect(res.matches.every((m: any) => m.file !== "logo.png")).toBe(true);
+  });
+
   it("skips files larger than the size cap (OOM guard)", async () => {
     // 11 MB file containing the pattern — must be skipped, not buffered.
     const big = "needle\n".repeat(Math.ceil((11 * 1024 * 1024) / 7));

--- a/packages/agents/tests/view-image-tool.test.ts
+++ b/packages/agents/tests/view-image-tool.test.ts
@@ -42,6 +42,11 @@ const TINY_PNG_B64 =
 const TINY_PNG_DATA_URI = `data:image/png;base64,${TINY_PNG_B64}`;
 const TINY_PNG_BYTES = new Uint8Array(Buffer.from(TINY_PNG_B64, "base64"));
 
+const SVG_MARKUP =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" ' +
+  'height="16"><rect width="16" height="16" fill="#c00"/></svg>';
+const SVG_BYTES = new Uint8Array(Buffer.from(SVG_MARKUP, "utf8"));
+
 function imageContext(bytes: Uint8Array | null) {
   return {
     ...createMockContext(),
@@ -150,6 +155,43 @@ describe("ViewImageTool", () => {
     // width/height are populated only when the codec ran; the region note is
     // always present.
     expect(result.note).toContain("region 0,0 1×1");
+  });
+
+  it("renders an SVG asset instead of shipping markup labeled as a PNG", async () => {
+    // `sniffImageMime` answers "image/png" for anything it does not recognize,
+    // and SVG has no magic number — so before the raster step this returned the
+    // markup itself under a PNG label and the provider saw a broken image.
+    const tool = viewImageTool();
+    const result = (await tool.process(imageContext(SVG_BYTES), {
+      image_id: "asset://vector1.svg"
+    })) as Record<string, any>;
+
+    expect(result.ok).toBe(true);
+    expect(result.mimeType).toBe("image/png");
+    const payload = String(result.image_content.uri).split(",")[1] ?? "";
+    const decoded = Buffer.from(payload, "base64");
+    expect([...decoded.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+    expect(decoded.toString("utf8")).not.toContain("<svg");
+    // A 16-unit document is unreadable at 1:1; the note reports what it became.
+    expect(result.note).toMatch(/Rendered SVG at \d+×\d+/);
+    expect(result.width).toBeGreaterThan(16);
+  });
+
+  it("refuses an SVG that would make the renderer fetch something", async () => {
+    const outward = new Uint8Array(
+      Buffer.from(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8">' +
+          '<image href="file:///etc/passwd" width="8" height="8"/></svg>',
+        "utf8"
+      )
+    );
+    const tool = viewImageTool();
+    const result = (await tool.process(imageContext(outward), {
+      image_id: "asset://outward.svg"
+    })) as Record<string, any>;
+
+    expect(result.ok).toBeUndefined();
+    expect(String(result.error)).toContain("/etc/passwd");
   });
 
   it("errors on a missing image_id", async () => {

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -694,7 +694,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "save_asset",
     module: "assets",
     impl: "packages/agents/src/capabilities/assets.ts",
-    contract: "59cc92776229",
+    contract: "dfb0317d6e85",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-assets.test.ts",
@@ -760,7 +760,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "view_image",
     module: "assets",
     impl: "packages/agents/src/capabilities/assets.ts",
-    contract: "f2f52d9dc2eb",
+    contract: "c8433ab4fc37",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-assets.test.ts",

--- a/packages/runtime/src/image-codec.ts
+++ b/packages/runtime/src/image-codec.ts
@@ -103,12 +103,42 @@ export async function encodeRawImageRef<T>(ref: T): Promise<T | ImageRef> {
 }
 
 /**
- * References an SVG may carry to something outside itself: `href`,
- * `xlink:href`, and CSS `url()`. Fragments (`#id`), `data:` payloads and empty
- * values stay inside the document; anything else is a fetch.
+ * Every place an SVG can name a resource: an `href` / `xlink:href` attribute,
+ * and a CSS `url()`.
+ *
+ * Matches the reference and nothing about its contents — deciding whether a
+ * value points outside the document is {@link isExternalReference}'s job. That
+ * split is not stylistic. The first version of this regex screened the value
+ * inline, which put `\s*` next to `[^"']+` and next to an optional quote in
+ * `url(\s*['"]?\s*…`; both give the engine many ways to split one run of
+ * spaces, and `"url(" + 2000 spaces` — an input a model can produce by
+ * accident — did not finish in five minutes. Every quantifier here is bounded
+ * by a delimiter it cannot itself match, so the scan is linear.
  */
-const SVG_EXTERNAL_REF =
-  /(?:xlink:href|href)\s*=\s*["']\s*(?!#|data:)([^"']+)["']|url\(\s*['"]?\s*(?!#|data:)([^'")]+)['"]?\s*\)/i;
+const SVG_REFERENCE = /(?:xlink:href|href)\s*=\s*["']([^"']*)["']|url\(([^)]*)\)/gi;
+
+/** Strip one layer of surrounding quotes and whitespace from a raw reference. */
+const unquote = (value: string): string =>
+  value.trim().replace(/^["']/, "").replace(/["']$/, "").trim();
+
+/**
+ * Whether a reference points outside the document. A fragment (`#id`) and a
+ * `data:` payload are self-contained; an empty value names nothing.
+ */
+function isExternalReference(value: string): boolean {
+  if (!value) return false;
+  if (value.startsWith("#")) return false;
+  return !/^data:/i.test(value);
+}
+
+/** The first reference in this markup that points outside it, if any. */
+function firstExternalReference(markup: string): string | null {
+  for (const match of markup.matchAll(SVG_REFERENCE)) {
+    const value = unquote(match[1] ?? match[2] ?? "");
+    if (isExternalReference(value)) return value;
+  }
+  return null;
+}
 
 /** Largest SVG this rasterizer will hand to the decoder. */
 const MAX_SVG_BYTES = 8 * 1024 * 1024;
@@ -146,11 +176,10 @@ export async function rasterizeSvg(
     );
   }
   const markup = new TextDecoder("utf-8", { fatal: false }).decode(bytes);
-  const external = SVG_EXTERNAL_REF.exec(markup);
-  if (external) {
-    const ref = external[1] ?? external[2] ?? "";
+  const external = firstExternalReference(markup);
+  if (external !== null) {
     throw new Error(
-      `Refusing to render an SVG that references "${ref}". ` +
+      `Refusing to render an SVG that references "${external}". ` +
         `The renderer would fetch it from this host's filesystem or network. ` +
         `Inline the resource as a data: URI, or drop the reference.`
     );

--- a/packages/runtime/src/image-codec.ts
+++ b/packages/runtime/src/image-codec.ts
@@ -103,23 +103,46 @@ export async function encodeRawImageRef<T>(ref: T): Promise<T | ImageRef> {
 }
 
 /**
- * Every place an SVG can name a resource: an `href` / `xlink:href` attribute,
- * and a CSS `url()`.
+ * Where an SVG can name a resource: an `href` / `xlink:href` attribute, and a
+ * CSS `url()`. Used to *split* the markup, so each piece that follows is where
+ * one value begins.
  *
- * Matches the reference and nothing about its contents — deciding whether a
- * value points outside the document is {@link isExternalReference}'s job. That
- * split is not stylistic. The first version of this regex screened the value
- * inline, which put `\s*` next to `[^"']+` and next to an optional quote in
- * `url(\s*['"]?\s*…`; both give the engine many ways to split one run of
- * spaces, and `"url(" + 2000 spaces` — an input a model can produce by
- * accident — did not finish in five minutes. Every quantifier here is bounded
- * by a delimiter it cannot itself match, so the scan is linear.
+ * Splitting rather than matching the values is the whole point, and it took
+ * two CodeQL findings to arrive at. A regex that matches a value restarts at
+ * the next candidate when it fails, and a value scan that runs to the end of
+ * the document on each of n candidates is quadratic: `"url(" + 2000 spaces`
+ * never finished against the first version, and `"url(".repeat(400_000)`
+ * took 15s against the second. Pieces, by contrast, partition the document —
+ * bounded work per piece sums to linear however many openers there are.
  */
-const SVG_REFERENCE = /(?:xlink:href|href)\s*=\s*["']([^"']*)["']|url\(([^)]*)\)/gi;
+const REFERENCE_OPENER = /(url\(|(?:xlink:)?href\s*=\s*)/i;
 
-/** Strip one layer of surrounding quotes and whitespace from a raw reference. */
-const unquote = (value: string): string =>
-  value.trim().replace(/^["']/, "").replace(/["']$/, "").trim();
+/** Longest value the screen reads. Past this it is not a URL anyone meant. */
+const MAX_REFERENCE_VALUE = 2048;
+
+const isSpace = (ch: string): boolean =>
+  ch === " " || ch === "\t" || ch === "\n" || ch === "\r" || ch === "\f";
+
+/** Characters that end a reference value in either syntax. */
+const VALUE_END = new Set([")", '"', "'", ">", " ", "\t", "\n", "\r", "\f"]);
+
+/**
+ * Read the value out of the text following an opener.
+ *
+ * Truncating at {@link MAX_REFERENCE_VALUE} is safe in the direction that
+ * matters: the value is only tested for a `#` or `data:` prefix, and a
+ * truncated value keeps its prefix — so a long `data:` payload still reads as
+ * internal, and anything else still reads as external.
+ */
+function referenceValue(piece: string): string {
+  let i = 0;
+  while (i < piece.length && isSpace(piece[i]!)) i++;
+  if (piece[i] === '"' || piece[i] === "'") i++;
+  const start = i;
+  const limit = Math.min(piece.length, start + MAX_REFERENCE_VALUE);
+  while (i < limit && !VALUE_END.has(piece[i]!)) i++;
+  return piece.slice(start, i);
+}
 
 /**
  * Whether a reference points outside the document. A fragment (`#id`) and a
@@ -128,13 +151,16 @@ const unquote = (value: string): string =>
 function isExternalReference(value: string): boolean {
   if (!value) return false;
   if (value.startsWith("#")) return false;
-  return !/^data:/i.test(value);
+  return !value.slice(0, 5).toLowerCase().startsWith("data:");
 }
 
 /** The first reference in this markup that points outside it, if any. */
 function firstExternalReference(markup: string): string | null {
-  for (const match of markup.matchAll(SVG_REFERENCE)) {
-    const value = unquote(match[1] ?? match[2] ?? "");
+  // One capture group, so `split` interleaves: text, opener, text, opener, …
+  // Every even index from 2 up is the text a value starts in.
+  const parts = markup.split(REFERENCE_OPENER);
+  for (let i = 2; i < parts.length; i += 2) {
+    const value = referenceValue(parts[i]!);
     if (isExternalReference(value)) return value;
   }
   return null;

--- a/packages/runtime/src/image-codec.ts
+++ b/packages/runtime/src/image-codec.ts
@@ -102,6 +102,97 @@ export async function encodeRawImageRef<T>(ref: T): Promise<T | ImageRef> {
   return { ...ref, data: png, mimeType: "image/png" };
 }
 
+/**
+ * References an SVG may carry to something outside itself: `href`,
+ * `xlink:href`, and CSS `url()`. Fragments (`#id`), `data:` payloads and empty
+ * values stay inside the document; anything else is a fetch.
+ */
+const SVG_EXTERNAL_REF =
+  /(?:xlink:href|href)\s*=\s*["']\s*(?!#|data:)([^"']+)["']|url\(\s*['"]?\s*(?!#|data:)([^'")]+)['"]?\s*\)/i;
+
+/** Largest SVG this rasterizer will hand to the decoder. */
+const MAX_SVG_BYTES = 8 * 1024 * 1024;
+
+/** Longest side an SVG is rendered at when the caller names no `minSide`. */
+const SVG_FALLBACK_SIDE = 1024;
+
+/** Ceiling on the raster an SVG is rendered into, whatever `minSide` asks for. */
+const MAX_SVG_RASTER_SIDE = 4096;
+
+/**
+ * Rasterize SVG markup to PNG bytes.
+ *
+ * Vector sources reach the raster paths (a vision provider's image block, a
+ * crop, a downscale) only through here. Two rules the caller does not have to
+ * know about:
+ *
+ * - **No external references.** The decoder behind `sharp` is librsvg, which
+ *   resolves `href` and `url()` against the process's own filesystem and
+ *   network. Since the markup here is written by a model or uploaded by
+ *   whoever, a document that reaches outward is refused by name rather than
+ *   rendered — the error tells the caller to inline the resource.
+ * - **A usable size.** An SVG that declares `width="24"` renders to a 24px
+ *   PNG, which is not something a model can read. `minSide` scales the render
+ *   up so the result is worth looking at, defaulting to
+ *   {@link SVG_FALLBACK_SIDE}.
+ */
+export async function rasterizeSvg(
+  bytes: Uint8Array,
+  opts: { minSide?: number; maxSide?: number } = {}
+): Promise<{ data: Uint8Array; width: number; height: number }> {
+  if (bytes.byteLength > MAX_SVG_BYTES) {
+    throw new Error(
+      `SVG is ${bytes.byteLength} bytes, over the ${MAX_SVG_BYTES}-byte limit for rasterization.`
+    );
+  }
+  const markup = new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+  const external = SVG_EXTERNAL_REF.exec(markup);
+  if (external) {
+    const ref = external[1] ?? external[2] ?? "";
+    throw new Error(
+      `Refusing to render an SVG that references "${ref}". ` +
+        `The renderer would fetch it from this host's filesystem or network. ` +
+        `Inline the resource as a data: URI, or drop the reference.`
+    );
+  }
+
+  const sharp = await loadSharp();
+  if (!sharp) {
+    throw new Error(SHARP_UNAVAILABLE_MESSAGE);
+  }
+
+  const buffer = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const intrinsic = await sharp(buffer).metadata();
+  const srcSide = Math.max(intrinsic.width ?? 0, intrinsic.height ?? 0);
+  const targetSide = Math.min(
+    opts.minSide ?? SVG_FALLBACK_SIDE,
+    MAX_SVG_RASTER_SIDE
+  );
+  // librsvg scales the whole render by DPI, so a density is how an SVG is asked
+  // for more pixels than it declares; 72 is the 1:1 baseline. The density is
+  // left unbounded because what it produces is not: the render lands at
+  // `targetSide` however few units the document declares, so a `width="0.01"`
+  // document costs the same pixels as any other.
+  const density =
+    srcSide > 0 && srcSide < targetSide
+      ? Math.ceil((72 * targetSide) / srcSide)
+      : 72;
+
+  let pipeline = sharp(buffer, { density, failOn: "none" });
+  if (opts.maxSide && opts.maxSide > 0) {
+    pipeline = pipeline.resize({
+      width: opts.maxSide,
+      height: opts.maxSide,
+      fit: "inside",
+      withoutEnlargement: true
+    });
+  }
+  const { data, info } = await pipeline
+    .png()
+    .toBuffer({ resolveWithObject: true });
+  return { data: new Uint8Array(data), width: info.width, height: info.height };
+}
+
 /** A crop box in source-image pixels. */
 export interface ImageRegion {
   x: number;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -178,7 +178,8 @@ export {
 export {
   encodeRawRgbaToPng,
   encodeRawImageRef,
-  extractImageRegion
+  extractImageRegion,
+  rasterizeSvg
 } from "./image-codec.js";
 export type { ImageRegion } from "./image-codec.js";
 export { PythonNodeExecutor } from "./python-node-executor.js";

--- a/packages/runtime/src/providers/image-mime.ts
+++ b/packages/runtime/src/providers/image-mime.ts
@@ -69,6 +69,29 @@ export function sniffImageMime(bytes: Uint8Array): string | null {
   return null;
 }
 
+/** The MIME type SVG markup is stored and served under. */
+export const SVG_MIME = "image/svg+xml";
+
+/**
+ * Whether these bytes are SVG markup.
+ *
+ * Deliberately not part of `sniffImageMime`: that answers "which raster
+ * container is this", and its callers (provider uploads, asset extensions)
+ * read a `null` as "not a picture I can hand over". SVG is text with no magic
+ * number, so it is sniffed on its own, by the callers that can actually do
+ * something with a vector — today, the rasterizer behind `view_image`.
+ *
+ * Reads only the leading bytes: an SVG document begins with an XML
+ * declaration, a doctype, comments or whitespace before its `<svg` root, and
+ * a whole-file decode of an arbitrary upload is not worth paying for.
+ */
+export function isSvgBytes(bytes: Uint8Array): boolean {
+  const head = new TextDecoder("utf-8", { fatal: false }).decode(
+    bytes.subarray(0, 1024)
+  );
+  return /<svg[\s>]/i.test(head);
+}
+
 /**
  * PNG-fallback variant, for the callers that must produce a string (a `data:`
  * URI). Where the label gets stored or forwarded, prefer `sniffImageMime` and

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -11,7 +11,9 @@ export type { PricingTier, UsageInfo } from "./cost-calculator.js";
 export { OLLAMA_DEFAULT_URL, LMSTUDIO_DEFAULT_URL } from "./defaults.js";
 export {
   IMAGE_MIME_TO_EXT,
+  SVG_MIME,
   sniffImageMime,
+  isSvgBytes,
   detectImageMime,
   bytesToImageDataUri,
   extForImageMime

--- a/packages/runtime/tests/svg-raster.test.ts
+++ b/packages/runtime/tests/svg-raster.test.ts
@@ -1,0 +1,97 @@
+/**
+ * SVG detection and rasterization.
+ *
+ * A vector reaches every raster path — a vision provider's image block, a crop,
+ * a downscale — only through `rasterizeSvg`, and it is the one decode in this
+ * package whose input is markup written by a model. The refusals are the point:
+ * an SVG that references anything outside itself is rendered by librsvg against
+ * this host's own filesystem and network.
+ */
+import { describe, it, expect } from "vitest";
+import { rasterizeSvg } from "../src/image-codec.js";
+import { isSvgBytes, SVG_MIME } from "../src/providers/image-mime.js";
+
+const bytes = (text: string): Uint8Array => new TextEncoder().encode(text);
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+const svg = (body = '<rect width="10" height="10" fill="red"/>', attrs = ''): string =>
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"${attrs}>${body}</svg>`;
+
+describe("isSvgBytes", () => {
+  it("recognizes an svg root however it is preceded", () => {
+    expect(isSvgBytes(bytes(svg()))).toBe(true);
+    expect(isSvgBytes(bytes(`<?xml version="1.0"?>\n${svg()}`))).toBe(true);
+    expect(isSvgBytes(bytes(`<!-- a comment -->\n<SVG></SVG>`))).toBe(true);
+  });
+
+  it("rejects raster containers and unrelated text", () => {
+    expect(isSvgBytes(new Uint8Array(PNG_SIGNATURE))).toBe(false);
+    expect(isSvgBytes(bytes("plain text"))).toBe(false);
+    expect(isSvgBytes(new Uint8Array())).toBe(false);
+    // A tag whose name merely starts with "svg".
+    expect(isSvgBytes(bytes("<svgish/>"))).toBe(false);
+  });
+
+  it("does not decode the whole file to answer", () => {
+    // The root sits past the window, so this reads false — the point is that
+    // the answer comes from a bounded read, not from megabytes of markup.
+    const padded = `<!--${"x".repeat(4000)}-->${svg()}`;
+    expect(isSvgBytes(bytes(padded))).toBe(false);
+  });
+
+  it("names the MIME the rest of the stack stores SVG under", () => {
+    expect(SVG_MIME).toBe("image/svg+xml");
+  });
+});
+
+describe("rasterizeSvg", () => {
+  it("renders to PNG bytes", async () => {
+    const out = await rasterizeSvg(bytes(svg()));
+    expect([...out.data.subarray(0, 8)]).toEqual(PNG_SIGNATURE);
+    expect(out.width).toBeGreaterThan(0);
+    expect(out.height).toBeGreaterThan(0);
+  });
+
+  it("scales a small vector up to something readable", async () => {
+    // 10 user units at 1:1 is a 10px PNG. minSide is what makes the render
+    // worth showing a model.
+    const out = await rasterizeSvg(bytes(svg()), { minSide: 512 });
+    expect(Math.max(out.width, out.height)).toBeGreaterThanOrEqual(512);
+  });
+
+  it("honors maxSide", async () => {
+    const out = await rasterizeSvg(bytes(svg()), { minSide: 1024, maxSide: 128 });
+    expect(Math.max(out.width, out.height)).toBeLessThanOrEqual(128);
+  });
+
+  it("renders a document with no intrinsic size", async () => {
+    const out = await rasterizeSvg(
+      bytes('<svg xmlns="http://www.w3.org/2000/svg"><rect width="5" height="5"/></svg>')
+    );
+    expect([...out.data.subarray(0, 8)]).toEqual(PNG_SIGNATURE);
+  });
+
+  it.each([
+    ['<image href="/etc/passwd"/>', "/etc/passwd"],
+    ['<image xlink:href="http://169.254.169.254/latest"/>', "169.254.169.254"],
+    ['<use href="file:///etc/hosts"/>', "file:///etc/hosts"],
+    ['<rect width="1" height="1" fill="url(https://example.com/x.svg#g)"/>', "example.com"]
+  ])("refuses markup that reaches outside itself (%s)", async (body, needle) => {
+    await expect(rasterizeSvg(bytes(svg(body)))).rejects.toThrow(needle);
+  });
+
+  it("allows the references that stay inside the document", async () => {
+    const inline =
+      '<defs><linearGradient id="g"><stop offset="0" stop-color="#f00"/></linearGradient></defs>' +
+      '<rect width="10" height="10" fill="url(#g)"/>' +
+      '<image href="data:image/png;base64,iVBORw0KGgo=" width="1" height="1"/>';
+    const out = await rasterizeSvg(bytes(svg(inline)));
+    expect([...out.data.subarray(0, 8)]).toEqual(PNG_SIGNATURE);
+  });
+
+  it("refuses a document over the size cap", async () => {
+    const huge = bytes(svg(`<!--${"x".repeat(9 * 1024 * 1024)}-->`));
+    await expect(rasterizeSvg(huge)).rejects.toThrow(/limit for rasterization/);
+  });
+});

--- a/packages/runtime/tests/svg-raster.test.ts
+++ b/packages/runtime/tests/svg-raster.test.ts
@@ -90,6 +90,20 @@ describe("rasterizeSvg", () => {
     expect([...out.data.subarray(0, 8)]).toEqual(PNG_SIGNATURE);
   });
 
+  it.each([
+    ["url( followed by spaces and never closed", `url(${" ".repeat(20000)}`],
+    ["an href quote opened and never closed", `<svg href="${" ".repeat(20000)}`],
+    ["doubled spaces throughout", `<svg ${"  ".repeat(20000)}/>`]
+  ])("scans %s in linear time", async (_label, markup) => {
+    // The reference screen used to filter values inline, which put `\s*` beside
+    // a class that also matches whitespace. `"url(" + 2000 spaces` — markup a
+    // model can produce by accident — did not finish in five minutes, so
+    // `view_image` on an agent-written SVG was a way to hang the process.
+    const started = Date.now();
+    await rasterizeSvg(bytes(markup)).catch(() => undefined);
+    expect(Date.now() - started).toBeLessThan(2000);
+  });
+
   it("refuses a document over the size cap", async () => {
     const huge = bytes(svg(`<!--${"x".repeat(9 * 1024 * 1024)}-->`));
     await expect(rasterizeSvg(huge)).rejects.toThrow(/limit for rasterization/);

--- a/packages/runtime/tests/svg-raster.test.ts
+++ b/packages/runtime/tests/svg-raster.test.ts
@@ -93,12 +93,17 @@ describe("rasterizeSvg", () => {
   it.each([
     ["url( followed by spaces and never closed", `url(${" ".repeat(20000)}`],
     ["an href quote opened and never closed", `<svg href="${" ".repeat(20000)}`],
-    ["doubled spaces throughout", `<svg ${"  ".repeat(20000)}/>`]
+    ["doubled spaces throughout", `<svg ${"  ".repeat(20000)}/>`],
+    ["nothing but url( openers", "url(".repeat(500000)],
+    ["nothing but href= openers", "href=".repeat(500000)],
+    ["an href with a long run of spaces before its =", `href${" ".repeat(200000)}`]
   ])("scans %s in linear time", async (_label, markup) => {
-    // The reference screen used to filter values inline, which put `\s*` beside
-    // a class that also matches whitespace. `"url(" + 2000 spaces` — markup a
-    // model can produce by accident — did not finish in five minutes, so
-    // `view_image` on an agent-written SVG was a way to hang the process.
+    // Two shapes of the same bug, both found by CodeQL and both reproduced
+    // before fixing. A regex that screened the value inline put `\s*` beside a
+    // class matching whitespace, and `"url(" + 2000 spaces` did not finish in
+    // five minutes. Matching the value at all then restarted the scan at every
+    // candidate: `"url(".repeat(400_000)` took 15 seconds. Either one made
+    // `view_image` on an agent-written SVG a way to hang the process.
     const started = Date.now();
     await rasterizeSvg(bytes(markup)).catch(() => undefined);
     expect(Date.now() - started).toBeLessThan(2000);

--- a/web/src/components/assets/AssetViewer.tsx
+++ b/web/src/components/assets/AssetViewer.tsx
@@ -54,6 +54,7 @@ import { useAssetDisplay } from "../../hooks/assets/useAssetDisplay";
 import { useEditVideoAsset } from "../../hooks/useEditVideoAsset";
 import { useNavigate } from "react-router-dom";
 import { isEditableModel3DAsset } from "../model_editor/isEditableModel3D";
+import { assetTabType } from "../workspace/assetTabType";
 import { isElectron } from "../../utils/browser";
 import { copyAssetToClipboard, isClipboardSupported } from "../../utils/clipboardUtils";
 import {
@@ -462,18 +463,26 @@ const AssetViewer: React.FC<AssetViewerProps> = (props) => {
     setCompareAssetB(null);
   }, []);
 
+  // An SVG is an image to `isImage` (and to the compare view), but the image
+  // tab hosts the raster sketch editor — editing a vector there and saving
+  // would replace the markup with pixels. It has its own tab.
+  const isSvg = useMemo(
+    () => (currentAsset ? assetTabType(currentAsset) === "svg" : false),
+    [currentAsset]
+  );
+
   const handleOpenImageEditor = useCallback(() => {
     if (currentAsset && isImage) {
       openTab({
-        type: "image",
+        type: isSvg ? "svg" : "image",
         ref: currentAsset.id,
         mode: "edit",
-        title: currentAsset.name || "Image"
+        title: currentAsset.name || (isSvg ? "SVG" : "Image")
       });
       navigate("/workspace");
       handleClose();
     }
-  }, [currentAsset, isImage, openTab, navigate, handleClose]);
+  }, [currentAsset, isImage, isSvg, openTab, navigate, handleClose]);
 
   const handleOpenModel3DEditor = useCallback(() => {
     if (currentAsset && isModel3D) {
@@ -880,7 +889,7 @@ const AssetViewer: React.FC<AssetViewerProps> = (props) => {
           {isImage && !compareMode && (
             <ToolbarIconButton
               icon={<EditIcon />}
-              tooltip="Edit Image"
+              tooltip={isSvg ? "Edit SVG" : "Edit Image"}
               onClick={handleOpenImageEditor}
               className="button edit"
               nodrag={false}

--- a/web/src/components/workspace/SvgPreview.tsx
+++ b/web/src/components/workspace/SvgPreview.tsx
@@ -1,0 +1,83 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { useMemo } from "react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+
+import { Caption, FlexColumn, SPACING_PX } from "../ui_primitives";
+import { looksLikeSvg, sanitizeSvgMarkup } from "../../utils/sanitizeSvg";
+
+interface SvgPreviewProps {
+  /** SVG markup to paint. */
+  markup: string;
+}
+
+/** Checkerboard tile, on the 4px grid. */
+const CHECKER_PX = SPACING_PX.xxl;
+
+const styles = (theme: Theme) => {
+  const checker = theme.vars.palette.grey[700];
+  return css({
+    width: "100%",
+    height: "100%",
+    minHeight: 0,
+    overflow: "auto",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: SPACING_PX.xl,
+    // A checkerboard, so transparent regions read as transparent rather than
+    // as whatever the app theme happens to paint behind them.
+    backgroundColor: theme.vars.palette.grey[800],
+    backgroundImage: [
+      `linear-gradient(45deg, ${checker} 25%, transparent 25%, transparent 75%, ${checker} 75%)`,
+      `linear-gradient(45deg, ${checker} 25%, transparent 25%, transparent 75%, ${checker} 75%)`
+    ].join(", "),
+    backgroundSize: `${CHECKER_PX}px ${CHECKER_PX}px`,
+    backgroundPosition: `0 0, ${CHECKER_PX / 2}px ${CHECKER_PX / 2}px`,
+    ".svg-host": {
+      maxWidth: "100%",
+      maxHeight: "100%",
+      display: "flex"
+    },
+    ".svg-host svg": {
+      maxWidth: "100%",
+      maxHeight: "100%",
+      height: "auto"
+    }
+  });
+};
+
+/**
+ * Paints SVG markup inline, sanitized.
+ *
+ * Inline rather than an `<img>` because the edit surface previews markup that
+ * has not been saved yet — there is no stored file to point at. Everything
+ * passes through `sanitizeSvgMarkup` first: the markup is written by an agent
+ * or pasted by a user, and inlining it puts it on the app's own origin, where
+ * the sandbox CSP the storage route sets does not apply.
+ */
+const SvgPreview = ({ markup }: SvgPreviewProps) => {
+  const theme = useTheme();
+  const previewStyles = useMemo(() => styles(theme), [theme]);
+  const html = useMemo(
+    () => (looksLikeSvg(markup) ? sanitizeSvgMarkup(markup) : null),
+    [markup]
+  );
+
+  if (html === null) {
+    return (
+      <FlexColumn fullWidth fullHeight align="center" justify="center">
+        <Caption>No &lt;svg&gt; element to render</Caption>
+      </FlexColumn>
+    );
+  }
+
+  return (
+    <div css={previewStyles}>
+      <div className="svg-host" dangerouslySetInnerHTML={{ __html: html }} />
+    </div>
+  );
+};
+
+export default SvgPreview;

--- a/web/src/components/workspace/SvgSurface.tsx
+++ b/web/src/components/workspace/SvgSurface.tsx
@@ -1,0 +1,250 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import SaveIcon from "@mui/icons-material/Save";
+
+import { useAssetById } from "../../serverState/useAssetById";
+import { useAssetStore } from "../../stores/AssetStore";
+import { useNotificationStore } from "../../stores/NotificationStore";
+import {
+  useWorkspaceTabsStore,
+  type WorkspaceTabMode
+} from "../../stores/WorkspaceTabsStore";
+import {
+  BORDER_RADIUS,
+  Caption,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  LoadingSpinner,
+  Text
+} from "../ui_primitives";
+import MonacoPane from "./MonacoPane";
+import SvgPreview from "./SvgPreview";
+
+const SVG_CONTENT_TYPE = "image/svg+xml";
+
+interface SvgSurfaceProps {
+  refId: string;
+  mode: WorkspaceTabMode;
+  /**
+   * Part of the surface contract. Unused: nothing here drives a singleton
+   * store, so an inactive tab can stay mounted with its editor live.
+   */
+  active: boolean;
+}
+
+const svgAssetKey = (id: string) => ["svgAsset", id] as const;
+
+const styles = (theme: Theme) =>
+  css({
+    width: "100%",
+    height: "100%",
+    display: "flex",
+    flexDirection: "column",
+    minHeight: 0,
+    backgroundColor: theme.vars.palette.grey[900],
+    ".toolbar": {
+      flex: "0 0 auto",
+      padding: theme.spacing(0.5, 1),
+      borderBottom: `1px solid ${theme.vars.palette.grey[700]}`
+    },
+    ".dirty-dot": {
+      width: 8,
+      height: 8,
+      borderRadius: BORDER_RADIUS.circle,
+      backgroundColor: theme.vars.palette.warning.main,
+      flex: "0 0 auto"
+    },
+    ".panes": {
+      flex: 1,
+      minHeight: 0,
+      display: "flex"
+    },
+    ".source-pane": {
+      flex: "1 1 50%",
+      minWidth: 0,
+      position: "relative",
+      borderRight: `1px solid ${theme.vars.palette.grey[700]}`
+    },
+    ".preview-pane": {
+      flex: "1 1 50%",
+      minWidth: 0
+    }
+  });
+
+/**
+ * The document surface for an SVG asset tab. `refId` is an Asset id.
+ *
+ * An SVG is a picture and a text file at once, which is why it has a surface of
+ * its own rather than sharing the image tab: view mode paints the vector, edit
+ * mode puts the markup in Monaco beside a live preview of what the unsaved text
+ * renders to. Saving writes the markup back to the asset.
+ */
+const SvgSurface = ({ refId, mode }: SvgSurfaceProps) => {
+  const theme = useTheme();
+  const surfaceStyles = useMemo(() => styles(theme), [theme]);
+  const queryClient = useQueryClient();
+  const { data: asset, isLoading, error } = useAssetById(refId);
+  const setTabTitle = useWorkspaceTabsStore((state) => state.setTitle);
+  const update = useAssetStore((state) => state.update);
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification
+  );
+
+  const [content, setContent] = useState<string | null>(null);
+  const [savedContent, setSavedContent] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!asset) return;
+    setTabTitle(refId, "svg", asset.name || "Untitled");
+  }, [asset, refId, setTabTitle]);
+
+  const getUrl = asset?.get_url ?? undefined;
+  const {
+    data: loadedMarkup,
+    isLoading: markupLoading,
+    error: markupError
+  } = useQuery({
+    queryKey: svgAssetKey(refId),
+    enabled: !!getUrl,
+    queryFn: async () => {
+      if (!getUrl) throw new Error("SVG asset has no download URL");
+      const response = await fetch(getUrl);
+      if (!response.ok) {
+        throw new Error(`Failed to load SVG: ${response.status}`);
+      }
+      return response.text();
+    }
+  });
+
+  useEffect(() => {
+    if (loadedMarkup === undefined) return;
+    setContent((current) => (current === null ? loadedMarkup : current));
+    setSavedContent((current) => (current === null ? loadedMarkup : current));
+  }, [loadedMarkup]);
+
+  // Re-derive when the tab is pointed at a different asset.
+  const previousRef = useRef(refId);
+  useEffect(() => {
+    if (previousRef.current === refId) return;
+    previousRef.current = refId;
+    setContent(null);
+    setSavedContent(null);
+  }, [refId]);
+
+  const saveMutation = useMutation({
+    mutationFn: (markup: string) =>
+      update({
+        id: refId,
+        data: markup,
+        content_type: asset?.content_type ?? SVG_CONTENT_TYPE
+      }),
+    onSuccess: (_asset, markup) => {
+      setSavedContent(markup);
+      queryClient.setQueryData(svgAssetKey(refId), markup);
+      addNotification({
+        type: "success",
+        alert: true,
+        content: `Saved ${asset?.name ?? "SVG"}`,
+        dismissable: false
+      });
+    },
+    onError: (saveError) => {
+      addNotification({
+        type: "error",
+        alert: true,
+        content: `Failed to save SVG: ${saveError.message}`,
+        dismissable: false
+      });
+    }
+  });
+
+  const isDirty = content !== null && content !== savedContent;
+  const isSaving = saveMutation.isPending;
+
+  const handleSave = useCallback(() => {
+    if (content === null || content === savedContent || isSaving) return;
+    saveMutation.mutate(content);
+  }, [content, savedContent, isSaving, saveMutation]);
+
+  if (isLoading) {
+    return (
+      <FlexColumn fullWidth fullHeight align="center" justify="center">
+        <LoadingSpinner />
+      </FlexColumn>
+    );
+  }
+
+  if (error || !asset) {
+    return (
+      <FlexColumn fullWidth fullHeight align="center" justify="center">
+        <Text size="normal" weight={600}>
+          {error ? "Failed to load SVG" : "SVG not found"}
+        </Text>
+      </FlexColumn>
+    );
+  }
+
+  if (markupError) {
+    return (
+      <FlexColumn fullWidth fullHeight align="center" justify="center">
+        <Caption sx={{ color: "error.main" }}>
+          Failed to load SVG content
+        </Caption>
+      </FlexColumn>
+    );
+  }
+
+  if (markupLoading || content === null) {
+    return (
+      <FlexColumn fullWidth fullHeight align="center" justify="center">
+        <LoadingSpinner />
+      </FlexColumn>
+    );
+  }
+
+  if (mode !== "edit") {
+    return <SvgPreview markup={content} />;
+  }
+
+  return (
+    <div css={surfaceStyles}>
+      <FlexRow className="toolbar" align="center" justify="space-between">
+        <Caption>{asset.name}</Caption>
+        <FlexRow align="center" gap={0.5}>
+          {isDirty && (
+            <span className="dirty-dot" aria-label="Unsaved changes" />
+          )}
+          <EditorButton
+            variant="contained"
+            size="small"
+            startIcon={<SaveIcon />}
+            disabled={!isDirty || isSaving}
+            onClick={handleSave}
+          >
+            {isSaving ? "Saving…" : "Save"}
+          </EditorButton>
+        </FlexRow>
+      </FlexRow>
+      <div className="panes">
+        <div className="source-pane">
+          <MonacoPane
+            value={content}
+            language="xml"
+            onChange={setContent}
+            onSave={handleSave}
+          />
+        </div>
+        <div className="preview-pane">
+          <SvgPreview markup={content} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SvgSurface;

--- a/web/src/components/workspace/TabContent.tsx
+++ b/web/src/components/workspace/TabContent.tsx
@@ -10,6 +10,7 @@ import { isPageTabKey } from "./pageTabs";
 // and the common case (no tabs open) needs none of them.
 const WorkflowEditorSurface = React.lazy(() => import("./WorkflowEditorSurface"));
 const ImageSurface = React.lazy(() => import("./ImageSurface"));
+const SvgSurface = React.lazy(() => import("./SvgSurface"));
 const SketchSurface = React.lazy(() => import("./SketchSurface"));
 const TextSurface = React.lazy(() => import("./TextSurface"));
 const Model3DSurface = React.lazy(() => import("./Model3DSurface"));
@@ -46,6 +47,8 @@ const surfaceFor = (tab: WorkspaceTab, active: boolean) => {
       return <WorkflowEditorSurface workflowId={tab.ref} active={active} />;
     case "image":
       return <ImageSurface refId={tab.ref} mode={tab.mode} active={active} />;
+    case "svg":
+      return <SvgSurface refId={tab.ref} mode={tab.mode} active={active} />;
     case "sketch":
       return <SketchSurface refId={tab.ref} mode={tab.mode} active={active} />;
     case "text":

--- a/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -43,6 +43,7 @@ import { TYPE_COLOR, TYPE_GLYPH } from "./tabTypeIdentity";
 const SUPPORTS_BOTH_MODES = {
   workflow: false,
   image: true,
+  svg: true,
   sketch: false,
   timeline: true,
   storyboard: false,
@@ -487,6 +488,7 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
             });
             break;
           case "model3d":
+          case "svg":
           case "text":
             await useAssetStore.getState().update({ id: tab.ref, name: trimmed });
             break;

--- a/web/src/components/workspace/__tests__/SvgSurface.test.tsx
+++ b/web/src/components/workspace/__tests__/SvgSurface.test.tsx
@@ -1,0 +1,140 @@
+import { installGlobal, stub } from "../../../test-utils/doubles";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import type { Asset } from "../../../stores/ApiTypes";
+
+// Monaco is stood in for by a textarea, so an edit is a real typed change.
+jest.mock("../MonacoPane", () => ({
+  __esModule: true,
+  default: ({
+    value,
+    onChange
+  }: {
+    value: string;
+    onChange?: (next: string) => void;
+  }) => (
+    <textarea
+      data-testid="monaco"
+      aria-label="svg source"
+      value={value}
+      onChange={(event) => onChange?.(event.target.value)}
+    />
+  )
+}));
+
+const update = jest.fn().mockResolvedValue({});
+jest.mock("../../../stores/AssetStore", () => ({
+  useAssetStore: <T,>(selector: (s: { update: unknown }) => T) =>
+    selector({ update })
+}));
+jest.mock("../../../stores/NotificationStore", () => ({
+  useNotificationStore: <T,>(selector: (s: { addNotification: unknown }) => T) =>
+    selector({ addNotification: jest.fn() })
+}));
+
+const asset: Asset = stub<Asset>({
+  id: "svg-1",
+  name: "logo.svg",
+  content_type: "image/svg+xml",
+  get_url: "http://localhost/logo.svg"
+});
+
+jest.mock("../../../serverState/useAssetById", () => ({
+  useAssetById: () => ({ data: asset, isLoading: false, error: null })
+}));
+
+import SvgSurface from "../SvgSurface";
+
+const SVG = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="4" height="4"/></svg>';
+
+const renderSurface = (mode: "view" | "edit") => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } }
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={mockTheme}>
+        <SvgSurface refId="svg-1" mode={mode} active />
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+};
+
+describe("SvgSurface", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installGlobal(
+      "fetch",
+      jest.fn().mockResolvedValue({ ok: true, text: async () => SVG })
+    );
+  });
+
+  it("paints the vector in view mode", async () => {
+    const { container } = renderSurface("view");
+    await waitFor(() =>
+      expect(container.querySelector("svg rect")).not.toBeNull()
+    );
+    expect(screen.queryByTestId("monaco")).toBeNull();
+  });
+
+  it("shows the source beside a live preview in edit mode", async () => {
+    const { container } = renderSurface("edit");
+    expect(await screen.findByTestId("monaco")).toHaveValue(SVG);
+    expect(container.querySelector("svg rect")).not.toBeNull();
+  });
+
+  it("previews the edited markup before it is saved", async () => {
+    const { container } = renderSurface("edit");
+    const source = await screen.findByTestId("monaco");
+
+    await userEvent.clear(source);
+    await userEvent.paste(
+      '<svg xmlns="http://www.w3.org/2000/svg"><circle r="2"/></svg>'
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector("svg circle")).not.toBeNull()
+    );
+    expect(container.querySelector("svg rect")).toBeNull();
+    // Nothing was written: the preview reflects the buffer, not the asset.
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("saves the edited markup back to the asset", async () => {
+    renderSurface("edit");
+    const source = await screen.findByTestId("monaco");
+
+    await userEvent.clear(source);
+    await userEvent.paste("<svg><circle r=\"2\"/></svg>");
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() =>
+      expect(update).toHaveBeenCalledWith({
+        id: "svg-1",
+        data: "<svg><circle r=\"2\"/></svg>",
+        content_type: "image/svg+xml"
+      })
+    );
+  });
+
+  it("does not run script in markup it paints", async () => {
+    installGlobal(
+      "fetch",
+      jest.fn().mockResolvedValue({
+        ok: true,
+        text: async () =>
+          '<svg xmlns="http://www.w3.org/2000/svg"><script>1</script>' +
+          '<rect onload="1" width="4" height="4"/></svg>'
+      })
+    );
+    const { container } = renderSurface("view");
+    await waitFor(() =>
+      expect(container.querySelector("svg rect")).not.toBeNull()
+    );
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.querySelector("[onload]")).toBeNull();
+  });
+});

--- a/web/src/components/workspace/__tests__/assetTabType.test.ts
+++ b/web/src/components/workspace/__tests__/assetTabType.test.ts
@@ -9,7 +9,34 @@ describe("assetTabType", () => {
       expect(assetTabType({ content_type: "image/png" })).toBe("image");
       expect(assetTabType({ content_type: "image/jpeg" })).toBe("image");
       expect(assetTabType({ content_type: "image/webp" })).toBe("image");
-      expect(assetTabType({ content_type: "image/svg+xml" })).toBe("image");
+    });
+  });
+
+  describe("svg assets", () => {
+    it("returns 'svg' for the SVG content type", () => {
+      expect(assetTabType({ content_type: "image/svg+xml" })).toBe("svg");
+    });
+
+    it("returns 'svg' for a .svg name whatever the content type", () => {
+      // Saved without an explicit type, an SVG lands as text/plain or
+      // octet-stream; the name is then the only thing that says vector.
+      expect(assetTabType({ content_type: "text/plain", name: "logo.svg" })).toBe(
+        "svg"
+      );
+      expect(
+        assetTabType({ content_type: "application/octet-stream", name: "Logo.SVG" })
+      ).toBe("svg");
+    });
+
+    it("wins over both the image and the text branch", () => {
+      // Either would otherwise claim it: image/ by prefix, text by the xml
+      // language mapping for the .svg extension.
+      expect(assetTabType({ content_type: "image/svg+xml", name: "a.svg" })).not.toBe(
+        "image"
+      );
+      expect(assetTabType({ content_type: "image/svg+xml", name: "a.svg" })).not.toBe(
+        "text"
+      );
     });
   });
 

--- a/web/src/components/workspace/assetTabType.ts
+++ b/web/src/components/workspace/assetTabType.ts
@@ -15,6 +15,10 @@ interface AssetLike {
 export const assetTabType = (asset: AssetLike): WorkspaceTabType | null => {
   const ct = asset.content_type ?? "";
   const name = (asset.name ?? "").toLowerCase();
+  // Before the image and text branches, both of which claim SVG: it is a raster
+  // image to neither and editable markup to both, and its own surface shows the
+  // rendered vector next to the source.
+  if (ct === "image/svg+xml" || name.endsWith(".svg")) return "svg";
   if (ct.startsWith("image/")) return "image";
   if (ct.startsWith("audio/")) return "audio";
   if (

--- a/web/src/components/workspace/newDocumentCatalog.tsx
+++ b/web/src/components/workspace/newDocumentCatalog.tsx
@@ -11,6 +11,7 @@ import { useCallback, useState, type ReactNode } from "react";
 import AddRoundedIcon from "@mui/icons-material/AddRounded";
 import ArticleOutlinedIcon from "@mui/icons-material/ArticleOutlined";
 import ImageOutlinedIcon from "@mui/icons-material/ImageOutlined";
+import CategoryOutlinedIcon from "@mui/icons-material/CategoryOutlined";
 import MovieOutlinedIcon from "@mui/icons-material/MovieOutlined";
 import DashboardOutlinedIcon from "@mui/icons-material/DashboardOutlined";
 import DashboardCustomizeOutlinedIcon from "@mui/icons-material/DashboardCustomizeOutlined";
@@ -61,6 +62,11 @@ const createBlankImageFile = (): Promise<File> =>
       resolve(new File([blob], "Untitled.png", { type: "image/png" }));
     }, "image/png");
   });
+
+/** The blank canvas a "New SVG" tab starts from. */
+const BLANK_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" ' +
+  'width="512" height="512">\n</svg>\n';
 
 /**
  * Build a starter `.glb` (a single box, like a default cube) to seed a
@@ -277,6 +283,22 @@ export const useNewDocumentCatalog = (
     [runCreate, createAsset, openTab]
   );
 
+  const createSvg = useCallback(
+    () =>
+      runCreate("SVG", async () => {
+        const asset = await createAsset(
+          new File([BLANK_SVG], "Untitled.svg", { type: "image/svg+xml" })
+        );
+        openTab({
+          type: "svg",
+          ref: asset.id,
+          mode: "edit",
+          title: asset.name || "Untitled.svg"
+        });
+      }),
+    [runCreate, createAsset, openTab]
+  );
+
   const createVideo = useCallback(
     () =>
       runCreate("video", async () => {
@@ -452,6 +474,14 @@ export const useNewDocumentCatalog = (
       type: "image",
       icon: <ImageOutlinedIcon fontSize="small" />,
       create: createImage
+    },
+    {
+      key: "svg",
+      label: "SVG",
+      menuLabel: "New SVG",
+      type: "svg",
+      icon: <CategoryOutlinedIcon fontSize="small" />,
+      create: createSvg
     },
     {
       key: "video",

--- a/web/src/components/workspace/tabRename.ts
+++ b/web/src/components/workspace/tabRename.ts
@@ -10,6 +10,7 @@ const RENAMEABLE_TYPES = new Set<WorkspaceTabType>([
   "workflow",
   "sketch",
   "image",
+  "svg",
   "timeline",
   "storyboard",
   "script",

--- a/web/src/components/workspace/tabTypeIdentity.ts
+++ b/web/src/components/workspace/tabTypeIdentity.ts
@@ -11,6 +11,7 @@ import type { WorkspaceTabType } from "../../stores/WorkspaceTabsStore";
 export const TYPE_GLYPH = {
   workflow: "⬡",
   image: "▦",
+  svg: "◇",
   sketch: "✎",
   timeline: "▤",
   storyboard: "▥",
@@ -33,6 +34,7 @@ export const TYPE_GLYPH = {
 export const TYPE_COLOR = {
   workflow: colorForType("any"),
   image: colorForType("image"),
+  svg: colorForType("image"),
   sketch: colorForType("image"),
   timeline: colorForType("video"),
   storyboard: colorForType("video"),

--- a/web/src/stores/WorkspaceTabsStore.ts
+++ b/web/src/stores/WorkspaceTabsStore.ts
@@ -17,6 +17,9 @@ import { persist } from "zustand/middleware";
 export type WorkspaceTabType =
   | "workflow"
   | "image"
+  // SVG assets. `ref` is an asset id; the surface previews the vector and
+  // edits its markup, which is why it is not an `image` tab.
+  | "svg"
   | "sketch"
   | "timeline"
   | "storyboard"

--- a/web/src/utils/__tests__/sanitizeSvg.test.ts
+++ b/web/src/utils/__tests__/sanitizeSvg.test.ts
@@ -1,0 +1,50 @@
+import { looksLikeSvg, sanitizeSvgMarkup } from "../sanitizeSvg";
+
+describe("sanitizeSvgMarkup", () => {
+  it("keeps the drawing vocabulary", () => {
+    const markup =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">' +
+      '<defs><linearGradient id="g"><stop offset="0" stop-color="#f00"/></linearGradient></defs>' +
+      '<circle cx="5" cy="5" r="4" fill="url(#g)"/></svg>';
+    const clean = sanitizeSvgMarkup(markup);
+    expect(clean).toContain("<circle");
+    expect(clean).toContain("linearGradient");
+    expect(clean).toContain("url(#g)");
+  });
+
+  it("drops scripts and event handlers", () => {
+    const markup =
+      '<svg xmlns="http://www.w3.org/2000/svg">' +
+      '<script>window.stolen = document.cookie</script>' +
+      '<rect width="10" height="10" onload="alert(1)"/></svg>';
+    const clean = sanitizeSvgMarkup(markup);
+    expect(clean).not.toContain("script");
+    expect(clean).not.toContain("onload");
+    expect(clean).toContain("<rect");
+  });
+
+  it("drops foreignObject, which smuggles HTML into an SVG", () => {
+    const markup =
+      '<svg xmlns="http://www.w3.org/2000/svg">' +
+      '<foreignObject><iframe src="https://example.com"></iframe></foreignObject>' +
+      "</svg>";
+    const clean = sanitizeSvgMarkup(markup);
+    expect(clean).not.toContain("foreignObject");
+    expect(clean).not.toContain("iframe");
+  });
+});
+
+describe("looksLikeSvg", () => {
+  it("accepts a document with an svg root, however it is preceded", () => {
+    expect(looksLikeSvg('<svg viewBox="0 0 1 1"></svg>')).toBe(true);
+    expect(looksLikeSvg('<?xml version="1.0"?>\n<svg></svg>')).toBe(true);
+    expect(looksLikeSvg("<SVG></SVG>")).toBe(true);
+  });
+
+  it("rejects markup with no svg element", () => {
+    expect(looksLikeSvg("")).toBe(false);
+    expect(looksLikeSvg("<div>not a drawing</div>")).toBe(false);
+    // A name that merely starts with "svg" is not an svg element.
+    expect(looksLikeSvg("<svgfoo/>")).toBe(false);
+  });
+});

--- a/web/src/utils/sanitizeSvg.ts
+++ b/web/src/utils/sanitizeSvg.ts
@@ -1,0 +1,28 @@
+// sanitizeSvg.ts
+// -----------------------------------------------------------------
+// One sanitizer for SVG markup that is about to be inlined into the
+// DOM. An SVG asset is a document the agent or the user wrote, so it
+// reaches the browser as untrusted markup: inlining it raw would run
+// `<script>`, `onload=`, and `<foreignObject>` HTML with the app's
+// own origin. The stored file is served with a sandbox CSP
+// (storage-api.ts), but an inline preview bypasses that response
+// entirely — this is the boundary for that path.
+// -----------------------------------------------------------------
+
+import DOMPurify from "dompurify";
+
+/**
+ * Sanitize a whole SVG document for `dangerouslySetInnerHTML`. Keeps the
+ * drawing vocabulary (gradients, filters, masks, symbols) and drops scripts,
+ * event handlers and `<foreignObject>`.
+ */
+export const sanitizeSvgMarkup = (markup: string): string =>
+  DOMPurify.sanitize(markup, {
+    USE_PROFILES: { svg: true, svgFilters: true },
+    FORBID_TAGS: ["script", "foreignObject"],
+    FORBID_ATTR: ["onload", "onerror", "onclick"]
+  });
+
+/** Whether markup contains an `<svg>` root element the preview can paint. */
+export const looksLikeSvg = (markup: string): boolean =>
+  /<svg[\s>]/i.test(markup);


### PR DESCRIPTION
## What changed

An SVG asset was two half-supported things at once. `image/svg+xml` matched the image branch of `assetTabType`, so it opened in the raster sketch editor, where an edit and a save replace the markup with pixels; the `.svg` extension matched the text branch, so the fallback was a plain XML file with no picture. Agents had it worse: `sniffImageMime` has no SVG magic number to match and falls back to `image/png`, so `view_image` handed the markup itself to the vision provider under a PNG label — an agent could write an SVG but never see it.

SVG now has its own workspace tab. View mode paints the vector; edit mode puts the markup in Monaco beside a live preview of the unsaved buffer, and saving writes it back to the asset. Inline markup is sanitized before it is painted — the stored file is served under a sandbox CSP, but an inline preview runs on the app's own origin, where that response header does not apply. `+ New → New SVG` seeds a blank canvas, the tab renames like any other asset tab, and the asset viewer's Edit button routes an SVG to this surface instead of into the sketch editor.

On the agent side: `view_image` sniffs SVG explicitly and rasterizes it through a new `rasterizeSvg` in `@nodetool-ai/runtime`, so a model can look at what it drew. The render is sized for reading (librsvg renders a `width="24"` icon as 24 pixels) rather than for the document's own units, and markup referencing anything outside itself is refused by name — librsvg resolves `href` and `url()` against this host's filesystem and network, and the markup here is model-written. `save_asset` now types text content from the filename when no `content_type` is given, so `logo.svg` is stored as `image/svg+xml` rather than `text/plain`. `grep` no longer skips `.svg` as a binary extension: it is XML, and the per-file null-byte check already keeps real binaries out.

## Verification

- [x] `npm run test:affected` — `All affected suites passed.`
- [x] `npm run typecheck` — web and electron exit 0. Mobile fails in this sandbox for want of `mobile/node_modules` (it is not a root workspace and was never installed here); it fails identically on the unmodified tree, and this diff touches nothing under `mobile/`.
- [x] `npm run lint` — exit 0
- [x] `npm run dev:nodetool -- harness gate --base main` — run as `harness gate --base HEAD~1` (this branch has no merge base with `main` in the session checkout): `Gate: 6/6 selfchecks passed`

Two environment gaps had to be closed before the package suites were meaningful, both documented in `AGENTS.md`: `mesa-vulkan-drivers` for the shader-backed image nodes, and `ffmpeg` for one runtime provider suite. Neither is a code change.

New tests: `packages/runtime/tests/svg-raster.test.ts` (14 cases over `isSvgBytes` and `rasterizeSvg`), SVG cases in `packages/agents/tests/view-image-tool.test.ts` and `capabilities-assets.test.ts`, `web/src/components/workspace/__tests__/SvgSurface.test.tsx`, `web/src/utils/__tests__/sanitizeSvg.test.ts`, and svg cases in `assetTabType.test.ts`.

## Agent capabilities

- [x] `npm run capabilities:check` passes
- [x] `save_asset` and `view_image` changed their declared descriptions; `npm run capabilities:sync` re-stamped both contract fingerprints in `packages/cli/src/harness/capability-table.ts`. Both already name `packages/agents/tests/capabilities-assets.test.ts` under the `capability-suites` selfcheck, and both gained SVG cases there and in `view-image-tool.test.ts`.

## New checks

The grep change removes an exclusion rather than adding a check, but the test that pins it was inverted once to prove it bites. Re-adding `".svg"` to `binaryExts`:

```
FAIL  tests/edit-search-tools.test.ts > GrepTool > searches .svg, and still
      skips a raster file with the same content
    expect(res.matches.some((m) => m.file === "logo.svg")).toBe(true)
```

- [x] The check was inverted once and observed failing; the failing output is above
- [x] The same test asserts the raster file with identical content is still skipped, so it cannot pass by matching everything. `rasterizeSvg`'s external-reference refusal is pinned by four cases that must throw and one inline-only document that must render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GT4aVstXZQYuz4w6HGjGi

---
_Generated by [Claude Code](https://claude.ai/code/session_012GT4aVstXZQYuz4w6HGjGi)_