### PR TITLE
feat(app-debug): warn on the app failures an agent's build passes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -964,17 +964,17 @@ state of an operation nothing can run, and an elapsed `timeoutMs`. A
 `persist: true` variable that is `instance`-scoped warns rather than being
 silently downgraded.
 
-Four warnings cover the app an agent builds that wires up correctly and still
-fails a user. A `Heading` repeating the root title shows the same words twice,
-because the runner already renders the title in the header. A run button with
-no `disabledWhen` on `op:<id>/exec#running` is a race the user drives — no
-policy refuses the second click, so it cancels the job and restarts it
-(`replace`), stacks another run (`queue`), or starts one alongside
-(`parallel`). An operation nothing binds `exec#error` to fails invisibly: the
-app looks idle and says nothing. And a media input widget — Image, Sketch Pad,
-Audio, Video, Document — filling an input with no default, behind a run trigger
-guarded on nothing, lets the run start with the input unset, which is a paid
-call the user did not get to fill in.
+Three warnings cover the app an agent builds that wires up correctly and still
+fails a user. A run button with no `disabledWhen` on `op:<id>/exec#running` is
+a race the user drives — no policy refuses the second click, so it cancels the
+job and restarts it (`replace`), stacks another run (`queue`), or starts one
+alongside (`parallel`). An operation nothing binds `exec#error` to fails
+invisibly: the app looks idle and says nothing. And a media input widget —
+Image, Sketch Pad, Camera Capture, Audio, Audio Recorder, Video, Document —
+filling an input with no default, behind a run trigger guarded on nothing, lets
+the run start with the input unset, which is a paid call the user did not get
+to fill in. A Workflow Form is not one of those: it renders every input of its
+operation rather than binding one, so there is no single binding to guard.
 
 The bundle (`nodetool-debug/app-<id>-<ts>/`) contains `report.json`/`report.md`,
 `app.json` (the app document), `workflow.json`, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -964,6 +964,18 @@ state of an operation nothing can run, and an elapsed `timeoutMs`. A
 `persist: true` variable that is `instance`-scoped warns rather than being
 silently downgraded.
 
+Four warnings cover the app an agent builds that wires up correctly and still
+fails a user. A `Heading` repeating the root title shows the same words twice,
+because the runner already renders the title in the header. A run button with
+no `disabledWhen` on `op:<id>/exec#running` is a race the user drives — no
+policy refuses the second click, so it cancels the job and restarts it
+(`replace`), stacks another run (`queue`), or starts one alongside
+(`parallel`). An operation nothing binds `exec#error` to fails invisibly: the
+app looks idle and says nothing. And a media input widget — Image, Sketch Pad,
+Audio, Video, Document — filling an input with no default, behind a run trigger
+guarded on nothing, lets the run start with the input unset, which is a paid
+call the user did not get to fill in.
+
 The bundle (`nodetool-debug/app-<id>-<ts>/`) contains `report.json`/`report.md`,
 `app.json` (the app document), `workflow.json`, and
 `server/run-N.messages.jsonl` per triggered run. The report carries final

--- a/packages/execution/src/app-debug/app-spec.ts
+++ b/packages/execution/src/app-debug/app-spec.ts
@@ -163,12 +163,17 @@ const modeToBindingMode = (mode: AppWidgetSpec["bindingMode"]): BindingMode =>
 /**
  * Widgets whose value is a file the user has to supply on the spot. None of
  * them starts with a value — a Sketch Pad publishes nothing until the first
- * stroke — so a run they feed can start with the input unset.
+ * stroke, a recorder nothing until the first take — so a run they feed can
+ * start with the input unset. A Workflow Form is deliberately not one of
+ * these: it renders every input of its operation rather than binding one, so
+ * there is no single binding a run trigger could be guarded on.
  */
 const MEDIA_INPUT_WIDGETS = new Set([
   "ImageInput",
   "SketchPad",
+  "CameraCapture",
   "AudioInput",
+  "AudioRecorder",
   "VideoInput",
   "DocumentInput"
 ]);

--- a/packages/execution/src/app-debug/app-spec.ts
+++ b/packages/execution/src/app-debug/app-spec.ts
@@ -25,12 +25,14 @@ import {
   type BindingScope,
   type ConditionProps,
   type OperationBinding,
+  type OperationPolicy,
   type VariableDeclaration
 } from "@nodetool-ai/app-runtime";
 
 import type { DebugGraph } from "../debug/types.js";
 import type {
   AppEventSpec,
+  AppInputIO,
   AppIO,
   AppOperationSpec,
   AppSpec,
@@ -149,6 +151,44 @@ const usesResourceBinding = (type: string): boolean =>
 
 const modeToBindingMode = (mode: AppWidgetSpec["bindingMode"]): BindingMode =>
   mode === "write" ? "write" : mode === "read" ? "read" : "none";
+
+/**
+ * Widgets whose value is a file the user has to supply on the spot. None of
+ * them starts with a value — a Sketch Pad publishes nothing until the first
+ * stroke — so a run they feed can start with the input unset.
+ */
+const MEDIA_INPUT_WIDGETS = new Set([
+  "ImageInput",
+  "SketchPad",
+  "AudioInput",
+  "VideoInput",
+  "DocumentInput"
+]);
+
+/** True when an input node ships a media value of its own to fall back on. */
+const hasMediaDefault = (value: unknown): boolean => {
+  if (isNonEmptyString(value)) return true;
+  if (!isRecord(value)) return false;
+  return isNonEmptyString(value.uri) || isNonEmptyString(value.asset_id);
+};
+
+/** Record that some widget displays `field` of `operationId`. */
+const addExecField = (
+  fields: Map<string, Set<string>>,
+  operationId: string,
+  field: string
+): void => {
+  const set = fields.get(operationId) ?? new Set<string>();
+  set.add(field);
+  fields.set(operationId, set);
+};
+
+/** What a second click does under each policy, for the re-entry warning. */
+const REENTRY_CONSEQUENCE = {
+  replace: "cancels the running job and starts it again",
+  queue: "queues another run behind the one in flight",
+  parallel: "starts a second run alongside the one in flight"
+} satisfies Record<OperationPolicy, string>;
 
 /**
  * The operations a parsed document declares, as report specs. A document with
@@ -499,6 +539,12 @@ export function validateApp(
   const runnableOperations = new Set<string>();
   /** Operation ids whose execution state a widget shows. */
   const execBindings = new Map<string, string[]>();
+  /** Execution fields a widget actually displays, per operation. */
+  const execFields = new Map<string, Set<string>>();
+  /** Widgets whose click runs an operation — the re-entry surface. */
+  const runTriggers: Array<{ widget: AppWidgetSpec; operationId: string }> = [];
+  /** Media input widgets — the ones a run can start without a value for. */
+  const mediaWidgets: AppWidgetSpec[] = [];
 
   for (const w of spec.widgets) {
     const where = `${w.type} "${w.id}"`;
@@ -576,6 +622,8 @@ export function validateApp(
         );
       } else if (extra.ref.kind === "output") {
         displayedOutputs.add(`${extra.ref.operationId}:${extra.ref.nodeId}`);
+      } else if (extra.ref.kind === "execution") {
+        addExecField(execFields, extra.ref.operationId, extra.ref.field);
       }
     }
     if (w.ref?.kind === "output") {
@@ -585,6 +633,10 @@ export function validateApp(
       const list = execBindings.get(w.ref.operationId) ?? [];
       list.push(`${where} (${w.ref.field})`);
       execBindings.set(w.ref.operationId, list);
+      addExecField(execFields, w.ref.operationId, w.ref.field);
+    }
+    if (MEDIA_INPUT_WIDGETS.has(w.type) && w.ref) {
+      mediaWidgets.push(w);
     }
 
     for (const event of w.events) {
@@ -592,6 +644,9 @@ export function validateApp(
       if (event.kind === "run") {
         hasRunTrigger = true;
         runnableOperations.add(target);
+        if (event.trigger === "click") {
+          runTriggers.push({ widget: w, operationId: target });
+        }
       }
       if (
         (event.kind === "run" || event.kind === "cancel") &&
@@ -628,6 +683,98 @@ export function validateApp(
     );
   }
 
+  // The app's own title is rendered by the runner's header, so a heading
+  // repeating it puts the same words on screen twice.
+  const titleText = spec.title?.trim().toLowerCase();
+  if (titleText) {
+    for (const w of spec.widgets) {
+      if (w.type !== "Heading") continue;
+      if (w.label?.trim().toLowerCase() !== titleText) continue;
+      warnings.push(
+        `Heading "${w.id}" repeats the app title "${spec.title}" — the runner renders the title in the app header, so it shows twice. Give the heading its own text or remove it.`
+      );
+    }
+  }
+
+  // No policy refuses a second click, so an unguarded run button is a race the
+  // user drives: what the second click does depends only on the policy.
+  for (const trigger of runTriggers) {
+    const guard = trigger.widget.disabledWhen?.binding
+      ? resolveBinding(trigger.widget.disabledWhen.binding, scope)
+      : null;
+    if (
+      guard?.kind === "execution" &&
+      guard.operationId === trigger.operationId &&
+      guard.field === "running"
+    ) {
+      continue;
+    }
+    const policy =
+      operations.find((op) => op.id === trigger.operationId)?.policy ??
+      "parallel";
+    warnings.push(
+      `${trigger.widget.type} "${trigger.widget.id}" runs operation "${trigger.operationId}" but has no disabledWhen on its running state — a second click ${REENTRY_CONSEQUENCE[policy]}. Guard it with disabledWhen on "op:${trigger.operationId}/exec#running".`
+    );
+  }
+
+  // A media input starts empty by construction — no file is picked and a Sketch
+  // Pad publishes nothing until the first stroke — so an unguarded run sends
+  // nothing for it. The model answers from the prompt alone or the provider
+  // rejects the call, and either way the run is paid for.
+  const declaredDefaults = new Map(
+    (context?.variables ?? spec.variables).map((v) => [v.id, v.default])
+  );
+  for (const widget of mediaWidgets) {
+    for (const { operationId, input } of operationInputsFilledBy(
+      widget,
+      operations
+    )) {
+      if (!runnableOperations.has(operationId)) continue;
+      if (hasMediaDefault(input.defaultValue)) continue;
+      if (
+        widget.ref?.kind === "variable" &&
+        hasMediaDefault(declaredDefaults.get(widget.ref.variableId))
+      ) {
+        continue;
+      }
+      const guarded = runTriggers.some(
+        (trigger) =>
+          trigger.operationId === operationId &&
+          [trigger.widget.disabledWhen, trigger.widget.visibleWhen].some(
+            (props) => {
+              if (props?.binding == null || widget.stateKey == null) {
+                return false;
+              }
+              const ref = resolveBinding(props.binding, scope);
+              return ref != null && stateKey(ref) === widget.stateKey;
+            }
+          )
+      );
+      if (guarded) continue;
+      warnings.push(
+        `${widget.type} "${widget.id}" fills input "${input.name}" of operation "${operationId}", which has no default — nothing stops a run before the user supplies it. Guard the run trigger with disabledWhen on "${widget.binding ?? widget.canonicalBinding ?? ""}".`
+      );
+    }
+  }
+
+  for (const operationId of runnableOperations) {
+    const shown = execFields.get(operationId) ?? new Set<string>();
+    if (!shown.has("error")) {
+      warnings.push(
+        `No widget shows the error state of operation "${operationId}" — a failed run leaves the app looking idle with nothing explaining why. Add an Alert bound to "op:${operationId}/exec#error".`
+      );
+    }
+    if (
+      !shown.has("running") &&
+      !shown.has("progress") &&
+      !shown.has("activity")
+    ) {
+      warnings.push(
+        `No widget shows the progress of operation "${operationId}" — the user gets no sign a run is underway. Add a Progress bound to "op:${operationId}/exec#progress".`
+      );
+    }
+  }
+
   for (const operation of operations) {
     const label = `Operation "${operation.id}"`;
     if (operation.unavailable) {
@@ -662,6 +809,36 @@ export function validateApp(
   }
 
   return { errors, warnings };
+}
+
+/**
+ * The operation inputs a widget's value reaches: the one it binds directly, and
+ * any input mapped `{from: "variable"}` from the variable it writes — the shape
+ * the shipped apps use, where one picker feeds several operations.
+ */
+function operationInputsFilledBy(
+  widget: AppWidgetSpec,
+  operations: readonly AppOperationSpec[]
+): Array<{ operationId: string; input: AppInputIO }> {
+  const filled: Array<{ operationId: string; input: AppInputIO }> = [];
+  for (const operation of operations) {
+    const inputs = operation.io?.inputs ?? [];
+    for (const input of inputs) {
+      const direct =
+        widget.ref?.kind === "input" &&
+        widget.ref.operationId === operation.id &&
+        widget.ref.nodeId === input.nodeId;
+      const mapping = operation.inputs[input.nodeId];
+      const viaVariable =
+        widget.ref?.kind === "variable" &&
+        mapping?.from === "variable" &&
+        mapping.variableId === widget.ref.variableId;
+      if (direct || viaVariable) {
+        filled.push({ operationId: operation.id, input });
+      }
+    }
+  }
+  return filled;
 }
 
 /** Check one operation's input/output mappings against what the app declares. */

--- a/packages/execution/src/app-debug/app-spec.ts
+++ b/packages/execution/src/app-debug/app-spec.ts
@@ -708,19 +708,6 @@ export function validateApp(
     );
   }
 
-  // The app's own title is rendered by the runner's header, so a heading
-  // repeating it puts the same words on screen twice.
-  const titleText = spec.title?.trim().toLowerCase();
-  if (titleText) {
-    for (const w of spec.widgets) {
-      if (w.type !== "Heading") continue;
-      if (w.label?.trim().toLowerCase() !== titleText) continue;
-      warnings.push(
-        `Heading "${w.id}" repeats the app title "${spec.title}" — the runner renders the title in the app header, so it shows twice. Give the heading its own text or remove it.`
-      );
-    }
-  }
-
   // No policy refuses a second click, so an unguarded run button is a race the
   // user drives: what the second click does depends only on the policy.
   for (const trigger of runTriggers) {

--- a/packages/execution/tests/app-debug-spec.test.ts
+++ b/packages/execution/tests/app-debug-spec.test.ts
@@ -198,7 +198,7 @@ describe("validateApp", () => {
     expect(result.errors).toEqual([]);
     // A form binds no slot of its own, so the unbound-write warning every other
     // write widget earns must not fire for it.
-    expect(result.warnings).toEqual([]);
+    expect(result.warnings.join("\n")).not.toMatch(/local UI state/);
   });
 
   it("flags a form whose operation the app never declares", () => {
@@ -672,6 +672,40 @@ describe("validateApp", () => {
       expect(
         validateApp(spec!, mediaIO, context).warnings.join("\n")
       ).not.toMatch(/which has no default/);
+    });
+
+    it("covers the capture widgets, which hold nothing until the user shoots", () => {
+      for (const type of ["CameraCapture", "AudioRecorder"]) {
+        const { spec } = parseAppSpec(
+          appDoc([
+            widget(type, `${type}-1`, { binding: "sketch" }),
+            widget("Image", "Image-1", { binding: "picture" }),
+            widget("Button", "Button-1", {
+              events: [{ trigger: "click", kind: "run" }]
+            })
+          ]),
+          mediaIO
+        );
+        expect(validateApp(spec!, mediaIO).warnings.join("\n")).toMatch(
+          new RegExp(`${type} "${type}-1" fills input "sketch"`)
+        );
+      }
+    });
+
+    it("leaves a Workflow Form alone — it binds no single input to guard", () => {
+      const { spec } = parseAppSpec(
+        appDoc([
+          widget("WorkflowForm", "WorkflowForm-1", {}),
+          widget("Image", "Image-1", { binding: "picture" }),
+          widget("Button", "Button-1", {
+            events: [{ trigger: "click", kind: "run" }]
+          })
+        ]),
+        mediaIO
+      );
+      expect(validateApp(spec!, mediaIO).warnings.join("\n")).not.toMatch(
+        /which has no default/
+      );
     });
 
     it("stays quiet when the input node ships a default image", () => {

--- a/packages/execution/tests/app-debug-spec.test.ts
+++ b/packages/execution/tests/app-debug-spec.test.ts
@@ -416,42 +416,7 @@ describe("validateApp", () => {
     expect(warnings.join("\n")).toMatch(/local UI state/);
   });
 
-  it("warns when a heading repeats the app title the header already shows", () => {
-    const { spec } = parseAppSpec(
-      appDoc(
-        [
-          widget("Heading", "Heading-1", { text: "Sketch to Picture" }),
-          widget("Button", "Button-1", {
-            events: [{ trigger: "click", kind: "run" }]
-          })
-        ],
-        "Sketch to Picture"
-      ),
-      io
-    );
-    const { warnings } = validateApp(spec!, io);
-    expect(warnings.join("\n")).toMatch(
-      /Heading "Heading-1" repeats the app title/
-    );
-  });
 
-  it("leaves a heading with its own text alone", () => {
-    const { spec } = parseAppSpec(
-      appDoc(
-        [
-          widget("Heading", "Heading-1", { text: "1. Draw" }),
-          widget("Button", "Button-1", {
-            events: [{ trigger: "click", kind: "run" }]
-          })
-        ],
-        "Sketch to Picture"
-      ),
-      io
-    );
-    expect(validateApp(spec!, io).warnings.join("\n")).not.toMatch(
-      /repeats the app title/
-    );
-  });
 
   it("warns that an unguarded run button lets a second click restart the job", () => {
     const context: AppContext = {

--- a/packages/execution/tests/app-debug-spec.test.ts
+++ b/packages/execution/tests/app-debug-spec.test.ts
@@ -153,7 +153,10 @@ describe("validateApp", () => {
       appDoc([
         widget("TextInput", "TextInput-1", { binding: "prompt" }),
         widget("Markdown", "Markdown-1", { binding: "result" }),
+        widget("Progress", "Progress-1", { binding: "op:main/exec#progress" }),
+        widget("Alert", "Alert-1", { binding: "op:main/exec#error" }),
         widget("Button", "Button-1", {
+          disabledWhen: { binding: "op:main/exec#running" },
           events: [{ trigger: "click", kind: "run" }]
         })
       ]),
@@ -220,8 +223,12 @@ describe("validateApp", () => {
       binding: "result"
     });
     // The thread displays the output through streamBinding, so nothing warns
-    // that the workflow's output goes unshown.
-    expect(validateApp(ok, io)).toEqual({ errors: [], warnings: [] });
+    // that the workflow's output goes unshown. The composer is unguarded and
+    // the app shows neither progress nor errors, which is what the rest warns
+    // about — the binding check itself is silent.
+    const chat = validateApp(ok, io);
+    expect(chat.errors).toEqual([]);
+    expect(chat.warnings.join("\n")).not.toMatch(/not displayed/);
 
     const broken = parseAppSpec(
       appDoc([
@@ -373,5 +380,297 @@ describe("validateApp", () => {
     );
     const { warnings } = validateApp(spec!, io);
     expect(warnings.join("\n")).toMatch(/local UI state/);
+  });
+
+  it("warns when a heading repeats the app title the header already shows", () => {
+    const { spec } = parseAppSpec(
+      appDoc(
+        [
+          widget("Heading", "Heading-1", { text: "Sketch to Picture" }),
+          widget("Button", "Button-1", {
+            events: [{ trigger: "click", kind: "run" }]
+          })
+        ],
+        "Sketch to Picture"
+      ),
+      io
+    );
+    const { warnings } = validateApp(spec!, io);
+    expect(warnings.join("\n")).toMatch(
+      /Heading "Heading-1" repeats the app title/
+    );
+  });
+
+  it("leaves a heading with its own text alone", () => {
+    const { spec } = parseAppSpec(
+      appDoc(
+        [
+          widget("Heading", "Heading-1", { text: "1. Draw" }),
+          widget("Button", "Button-1", {
+            events: [{ trigger: "click", kind: "run" }]
+          })
+        ],
+        "Sketch to Picture"
+      ),
+      io
+    );
+    expect(validateApp(spec!, io).warnings.join("\n")).not.toMatch(
+      /repeats the app title/
+    );
+  });
+
+  it("warns that an unguarded run button lets a second click restart the job", () => {
+    const context: AppContext = {
+      defaultOperationId: "main",
+      variables: [],
+      resources: [],
+      operations: [
+        operationSpec(
+          {
+            id: "main",
+            name: "Run",
+            workflowId: "wf1",
+            inputs: {},
+            outputs: {},
+            policy: "replace"
+          },
+          io,
+          null
+        )
+      ]
+    };
+    const { spec } = parseAppSpec(
+      appDoc([
+        widget("Markdown", "Markdown-1", { binding: "result" }),
+        widget("Button", "Button-1", {
+          events: [{ trigger: "click", kind: "run" }]
+        })
+      ]),
+      io,
+      context
+    );
+    const { warnings } = validateApp(spec!, io, context);
+    expect(warnings.join("\n")).toMatch(
+      /Button "Button-1" runs operation "main" but has no disabledWhen on its running state — a second click cancels the running job and starts it again/
+    );
+  });
+
+  it("accepts a run button guarded on the operation's running state", () => {
+    const { spec } = parseAppSpec(
+      appDoc([
+        widget("Markdown", "Markdown-1", { binding: "result" }),
+        widget("Button", "Button-1", {
+          disabledWhen: { binding: "op:main/exec#running" },
+          events: [{ trigger: "click", kind: "run" }]
+        })
+      ]),
+      io
+    );
+    expect(validateApp(spec!, io).warnings.join("\n")).not.toMatch(
+      /no disabledWhen on its running state/
+    );
+  });
+
+  it("warns when nothing shows an operation's errors or progress", () => {
+    const { spec } = parseAppSpec(
+      appDoc([
+        widget("Markdown", "Markdown-1", { binding: "result" }),
+        widget("Button", "Button-1", {
+          events: [{ trigger: "click", kind: "run" }]
+        })
+      ]),
+      io
+    );
+    const { warnings } = validateApp(spec!, io);
+    expect(warnings.join("\n")).toMatch(
+      /No widget shows the error state of operation "main"/
+    );
+    expect(warnings.join("\n")).toMatch(
+      /No widget shows the progress of operation "main"/
+    );
+  });
+
+  it("counts an activity binding as progress feedback", () => {
+    const { spec } = parseAppSpec(
+      appDoc([
+        widget("Text", "Text-1", { binding: "op:main/exec#activity" }),
+        widget("Alert", "Alert-1", { binding: "op:main/exec#error" }),
+        widget("Markdown", "Markdown-1", { binding: "result" }),
+        widget("Button", "Button-1", {
+          events: [{ trigger: "click", kind: "run" }]
+        })
+      ]),
+      io
+    );
+    const joined = validateApp(spec!, io).warnings.join("\n");
+    expect(joined).not.toMatch(/shows the progress of operation/);
+    expect(joined).not.toMatch(/shows the error state of operation/);
+  });
+
+  describe("media inputs a run can start without", () => {
+    const mediaIO = extractAppIO(
+      graph([
+        {
+          id: "img",
+          type: "nodetool.input.ImageInput",
+          properties: { name: "sketch" }
+        },
+        {
+          id: "out1",
+          type: "nodetool.output.ImageOutput",
+          properties: { name: "picture" }
+        }
+      ])
+    );
+
+    it("warns when nothing guards the run against an empty pad", () => {
+      const { spec } = parseAppSpec(
+        appDoc([
+          widget("SketchPad", "SketchPad-1", { binding: "sketch" }),
+          widget("Image", "Image-1", { binding: "picture" }),
+          widget("Button", "Button-1", {
+            events: [{ trigger: "click", kind: "run" }]
+          })
+        ]),
+        mediaIO
+      );
+      const { warnings } = validateApp(spec!, mediaIO);
+      expect(warnings.join("\n")).toMatch(
+        /SketchPad "SketchPad-1" fills input "sketch" of operation "main", which has no default/
+      );
+    });
+
+    it("accepts a run guarded on the media binding", () => {
+      const { spec } = parseAppSpec(
+        appDoc([
+          widget("SketchPad", "SketchPad-1", { binding: "sketch" }),
+          widget("Image", "Image-1", { binding: "picture" }),
+          widget("Button", "Button-1", {
+            disabledWhen: { binding: "sketch", op: "falsy" },
+            events: [{ trigger: "click", kind: "run" }]
+          })
+        ]),
+        mediaIO
+      );
+      expect(validateApp(spec!, mediaIO).warnings.join("\n")).not.toMatch(
+        /which has no default/
+      );
+    });
+
+    it("follows a variable mapping from the picker to the operation input", () => {
+      const context: AppContext = {
+        defaultOperationId: "main",
+        variables: [
+          { id: "photo", name: "photo", scope: "instance", persist: false }
+        ],
+        resources: [],
+        operations: [
+          operationSpec(
+            {
+              id: "main",
+              name: "Run",
+              workflowId: "wf1",
+              inputs: { img: { from: "variable", variableId: "photo" } },
+              outputs: {},
+              policy: "replace"
+            },
+            mediaIO,
+            null
+          )
+        ]
+      };
+      const { spec } = parseAppSpec(
+        appDoc([
+          widget("ImageInput", "ImageInput-1", { binding: "var:photo" }),
+          widget("Image", "Image-1", { binding: "picture" }),
+          widget("Button", "Button-1", {
+            events: [{ trigger: "click", kind: "run" }]
+          })
+        ]),
+        mediaIO,
+        context
+      );
+      const { warnings } = validateApp(spec!, mediaIO, context);
+      expect(warnings.join("\n")).toMatch(
+        /ImageInput "ImageInput-1" fills input "sketch" of operation "main", which has no default/
+      );
+    });
+
+    it("stays quiet when the variable behind the mapping has a default", () => {
+      const context: AppContext = {
+        defaultOperationId: "main",
+        variables: [
+          {
+            id: "photo",
+            name: "photo",
+            scope: "instance",
+            persist: false,
+            default: { type: "image", uri: "asset://seed.png" }
+          }
+        ],
+        resources: [],
+        operations: [
+          operationSpec(
+            {
+              id: "main",
+              name: "Run",
+              workflowId: "wf1",
+              inputs: { img: { from: "variable", variableId: "photo" } },
+              outputs: {},
+              policy: "replace"
+            },
+            mediaIO,
+            null
+          )
+        ]
+      };
+      const { spec } = parseAppSpec(
+        appDoc([
+          widget("ImageInput", "ImageInput-1", { binding: "var:photo" }),
+          widget("Image", "Image-1", { binding: "picture" }),
+          widget("Button", "Button-1", {
+            events: [{ trigger: "click", kind: "run" }]
+          })
+        ]),
+        mediaIO,
+        context
+      );
+      expect(
+        validateApp(spec!, mediaIO, context).warnings.join("\n")
+      ).not.toMatch(/which has no default/);
+    });
+
+    it("stays quiet when the input node ships a default image", () => {
+      const withDefault = extractAppIO(
+        graph([
+          {
+            id: "img",
+            type: "nodetool.input.ImageInput",
+            properties: {
+              name: "sketch",
+              value: { type: "image", uri: "asset://seed.png" }
+            }
+          },
+          {
+            id: "out1",
+            type: "nodetool.output.ImageOutput",
+            properties: { name: "picture" }
+          }
+        ])
+      );
+      const { spec } = parseAppSpec(
+        appDoc([
+          widget("ImageInput", "ImageInput-1", { binding: "sketch" }),
+          widget("Image", "Image-1", { binding: "picture" }),
+          widget("Button", "Button-1", {
+            events: [{ trigger: "click", kind: "run" }]
+          })
+        ]),
+        withDefault
+      );
+      expect(validateApp(spec!, withDefault).warnings.join("\n")).not.toMatch(
+        /which has no default/
+      );
+    });
   });
 });


### PR DESCRIPTION
## What changed

An agent built a sketch-to-picture mini app with the new Sketch Pad widget. Every binding resolved, the verdict came back green, and the app still failed its user in ways the static check said nothing about. This adds three of them as verdict warnings in `validateApp`, so the next agent that grades its work with `debug_app` is told:

- **A run button with no `disabledWhen` on the operation's running state.** No policy refuses the second click — it cancels and restarts the job under `replace`, stacks a run under `queue`, starts one alongside under `parallel` — and the warning names which.
- **Nothing bound to `exec#error`**, so a failed run leaves the app looking idle with no explanation. Every one of the eleven shipped example apps has this today.
- **A media input filling an operation input that has no default, behind a run trigger guarded on nothing** — Image, Sketch Pad, Camera Capture, Audio, Audio Recorder, Video, Document. The run starts with the input unset and is paid for anyway. A Workflow Form is deliberately not one of these: it renders every input of its operation rather than binding one, so there is no single binding a run trigger could be guarded on and the advice would be unactionable.

The media check follows the variable hop the shipped apps use (a picker writes a variable, the operation maps that variable onto an input) as well as a direct binding, and stays quiet when either the input node or the variable ships a default. All three are warnings, so `verdict.ok` is unchanged and no example build, eval gate, or app-build repair round shifts.

A fourth warning — a `Heading` repeating the app's root title — was in an earlier revision and has been removed. It was aimed at the wrong end: it described the root title as chrome the runner puts in a header, when `AppRoot` actually renders it inside the page, and it told the author to change the Heading they placed when the title had been stamped in by app creation rather than chosen. **#5481** stops that stamping instead, which makes the duplication impossible rather than warned about.

Four of the eight originally reported failure modes are not addressed here and have no target in this repo: the hardcoded `ImageToImage` strength, the canvas/generation aspect-ratio mismatch, the missing negative prompt, and the generic prompt fallback are all content of that one app's workflow graph, not something a mini-app wiring check can decide.

## Verification

- [x] `npm run test:affected` — 70/70 tasks, exit 0
- [x] `npm run typecheck` — `web` and `electron` clean. `mobile` fails only because `mobile/node_modules` was not installed when that run happened; this diff does not touch mobile.
- [x] `npm run lint` — no errors
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 5/5 selfchecks passed`, including the deterministic app-build eval cases, still `one-shot 2/2 (100%)` with 0 repairs
- [x] `npm run test --workspace=packages/execution` — 308 passed

Also run end to end through the real CLI harness against shipped bundles, which is where the checks were confirmed to fire on real data rather than only on fixtures:

```
$ nodetool app debug .../meeting-room.app.json --no-run
  - Button "btn-transcribe" runs operation "transcribe" but has no disabledWhen on its running state — a second click cancels the running job and starts it again. …
  - AudioInput "in-transcribe-audio" fills input "audio" of operation "transcribe", which has no default — nothing stops a run before the user supplies it. …
  - No widget shows the error state of operation "transcribe" — a failed run leaves the app looking idle with nothing explaining why. …

$ nodetool app debug .../product-launch-kit.app.json --no-run
  - ImageInput "in-productphoto" fills input "product_image" of operation "mockups", which has no default … (reached through var:productPhoto)

$ nodetool app debug .../photo-studio.app.json --no-run
  (no media warning — its ImageInput node ships a demo image, which is the default case)
```

### CI failure, fixed

The first push went red on `test-packages`. `#5475` (form, capture, compare and pick widgets) landed on `main` after this branch was cut, and CI tests the merge commit — so a test that did not exist in the branch was failing. `main` is merged in, and the fix has two parts:

- **A real gap the merge exposed.** `CameraCapture` and `AudioRecorder` are exactly the case the media warning exists for — nothing exists until the user shoots or records — so they join the media set.
- **The failing test.** It asserted no warnings at all for a Workflow Form, but its own comment says what it pins: the unbound-write warning must not fire for a widget that binds no slot. It now asserts that, instead of standing in for every other warning the fixture earns.

Reproduced the exact failure on the merge (`1 failed | 30 passed`), then green with the fix.

Two environment notes, both pre-existing and unrelated to the diff. `npm run build:packages` failed at `@nodetool-ai/automation-nodes` with `Cannot find module '@nodetool-ai/browser'` until `npm install` linked that workspace. And `packages/base-nodes` image tests failed on `No WebGPU adapter available (Node/Dawn)` until lavapipe was extracted and `VK_DRIVER_FILES` pointed at it, per AGENTS.md — with it, `2006 passed | 13 skipped`.

## Agent capabilities

No capability was added and no capability's declared contract changed — `validateApp` is the shared check behind `app debug`, `debug_app` and the app-build Check stage, and none of their schemas moved.

## New checks

- [x] Each check was inverted once and observed failing. Inverting the error-display condition:

```
FAIL  tests/app-debug-spec.test.ts > validateApp > warns when nothing shows an operation's errors or progress
AssertionError: expected 'Button "Button-1" runs operation "mai…' to match /No widget shows the error state of op…/
```

  and inverting the run-guard and media-guard conditions:

```
FAIL  tests/app-debug-spec.test.ts > validateApp > warns that an unguarded run button lets a second click restart the job
FAIL  tests/app-debug-spec.test.ts > … > warns when nothing guards the run against an empty pad
FAIL  tests/app-debug-spec.test.ts > … > follows a variable mapping from the picker to the operation input
Tests  3 failed | 26 passed (29)
```

  Restored, all pass.

- [x] Every check has a quiet case as well as a fires case, so none can pass by matching everything: a button guarded on `exec#running`, an `activity` binding counting as progress feedback, a run guarded on the media binding, a Workflow Form left alone, and a default on either the input node or the variable behind it.