### PR TITLE
fix(appbuilder): stop stamping the app's name into the page

### DIFF
--- a/mobile/src/components/app_runtime/ApplicationAppView.tsx
+++ b/mobile/src/components/app_runtime/ApplicationAppView.tsx
@@ -68,16 +68,13 @@ interface ApplicationAppViewProps {
    * the app's budget. Absent only where no application backs the document.
    */
   application?: ApplicationRunIdentity;
-  /** Falls back to the app's name when the document's root has no title. */
-  title?: string;
 }
 
 const ApplicationAppView: React.FC<ApplicationAppViewProps> = ({
   document,
   applicationId,
   workflow,
-  application,
-  title
+  application
 }) => {
   const { colors } = useTheme();
   const runtimeOptions: Parameters<typeof useAppRuntime>[1] = { document };
@@ -89,7 +86,10 @@ const ApplicationAppView: React.FC<ApplicationAppViewProps> = ({
   }
   const runtime = useAppRuntime(workflow, runtimeOptions);
 
-  const heading = String(document.ui.root.props?.title ?? title ?? "");
+  // Only what the document says. The screen's own navigation header already
+  // shows the application name (AppScreen sets it), so falling back to it here
+  // printed the name twice on one screen.
+  const heading = String(document.ui.root.props?.title ?? "");
   const content = document.ui.content as ComponentNode[];
 
   return (

--- a/mobile/src/components/app_runtime/__tests__/ApplicationAppView.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/ApplicationAppView.test.tsx
@@ -237,7 +237,7 @@ describe("ApplicationAppView", () => {
     expect(screen.queryByText("leaked")).toBeNull();
   });
 
-  it("falls back to the app's name when the document has no title", () => {
+  it("shows no heading of its own when the document has no title", () => {
     const untitled: ApplicationDocument = {
       ...document,
       ui: { ...document.ui, root: { props: {} } },
@@ -246,10 +246,11 @@ describe("ApplicationAppView", () => {
       <ApplicationAppView
         document={untitled}
         workflow={makeWorkflow("wf-untitled")}
-        title="Published app"
       />
     );
 
-    expect(screen.getByText("Published app")).toBeTruthy();
+    // AppScreen puts the application name in the navigation header, so a
+    // fallback here printed it twice on one screen.
+    expect(screen.queryByText("Greeter")).toBeNull();
   });
 });

--- a/mobile/src/screens/AppScreen.tsx
+++ b/mobile/src/screens/AppScreen.tsx
@@ -59,7 +59,6 @@ export default function AppScreen({ route, navigation }: Props) {
       applicationId={applicationId}
       workflow={workflow}
       {...(application ? { application } : {})}
-      title={name}
     />
   );
 }

--- a/packages/agents/src/capabilities/apps.ts
+++ b/packages/agents/src/capabilities/apps.ts
@@ -160,7 +160,11 @@ const createApp: CapabilityExport = {
       }
       document = parsed;
     } else {
-      document = createEmptyDocument(name.trim());
+      // No title: the application row already carries the name, and the
+      // runtime renders `root.props.title` as a heading at the top of the
+      // page. Stamping the name there gave every new app a heading nothing
+      // asked for, which the first Heading widget then repeated.
+      document = createEmptyDocument();
       const fromWorkflowId = params["from_workflow_id"];
       if (isString(fromWorkflowId) && fromWorkflowId) {
         const workflow = await Workflow.find(userId, fromWorkflowId);

--- a/packages/agents/tests/capabilities-apps.test.ts
+++ b/packages/agents/tests/capabilities-apps.test.ts
@@ -95,6 +95,21 @@ describe("apps capability module", () => {
 });
 
 describe("create_app and edit_app", () => {
+  it("creates the app untitled — the name lives on the row, not in the page", async () => {
+    const created = (await asTool("create_app").process(ctx, {
+      name: "Note drafter"
+    })) as Record<string, unknown>;
+    const read = (await asTool("get_app").process(ctx, {
+      application_id: String(created.application_id)
+    })) as Record<string, unknown>;
+    const document = read.document as {
+      ui: { root: { props: Record<string, unknown> } };
+    };
+    // The runtime renders a root title as a heading of its own, so stamping the
+    // name here gave every new app a heading nobody placed.
+    expect(document.ui.root.props.title).toBeUndefined();
+  });
+
   /** The whole authoring loop a headless agent has: create, edit, read back. */
   it("creates an app and edits it through the App Builder tools", async () => {
     const created = (await asTool("create_app").process(ctx, {

--- a/packages/base-nodes/nodetool/examples/apps/ask-your-documents.app.json
+++ b/packages/base-nodes/nodetool/examples/apps/ask-your-documents.app.json
@@ -6,9 +6,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Ask Your Documents"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/packages/base-nodes/nodetool/examples/apps/brand-and-social.app.json
+++ b/packages/base-nodes/nodetool/examples/apps/brand-and-social.app.json
@@ -6,9 +6,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Brand & Social"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/packages/base-nodes/nodetool/examples/apps/concept-studio.app.json
+++ b/packages/base-nodes/nodetool/examples/apps/concept-studio.app.json
@@ -6,9 +6,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Concept Studio"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/packages/base-nodes/nodetool/examples/apps/dataset-builder.app.json
+++ b/packages/base-nodes/nodetool/examples/apps/dataset-builder.app.json
@@ -6,9 +6,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Dataset Builder"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/packages/base-nodes/nodetool/examples/apps/film-studio.app.json
+++ b/packages/base-nodes/nodetool/examples/apps/film-studio.app.json
@@ -6,9 +6,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Film Studio"
-        }
+        "props": {}
       },
       "content": [
         {
@@ -1386,6 +1384,17 @@
             "targetHandle": "image",
             "ui_properties": {
               "className": "image"
+            },
+            "edge_type": "data"
+          },
+          {
+            "id": "e_shots_animate",
+            "source": "shots",
+            "sourceHandle": "shot_prompt",
+            "target": "animate",
+            "targetHandle": "prompt",
+            "ui_properties": {
+              "className": "str"
             },
             "edge_type": "data"
           },

--- a/packages/base-nodes/nodetool/examples/apps/meeting-room.app.json
+++ b/packages/base-nodes/nodetool/examples/apps/meeting-room.app.json
@@ -6,9 +6,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Meeting Room"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/packages/base-nodes/nodetool/examples/apps/model-arena.app.json
+++ b/packages/base-nodes/nodetool/examples/apps/model-arena.app.json
@@ -6,9 +6,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Model Arena"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/packages/base-nodes/nodetool/examples/apps/photo-studio.app.json
+++ b/packages/base-nodes/nodetool/examples/apps/photo-studio.app.json
@@ -6,9 +6,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Photo Studio"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/packages/base-nodes/nodetool/examples/apps/product-launch-kit.app.json
+++ b/packages/base-nodes/nodetool/examples/apps/product-launch-kit.app.json
@@ -6,9 +6,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Product Launch Kit"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/packages/base-nodes/nodetool/examples/apps/research-desk.app.json
+++ b/packages/base-nodes/nodetool/examples/apps/research-desk.app.json
@@ -6,9 +6,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Research Desk"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/packages/base-nodes/nodetool/examples/apps/study-buddy.app.json
+++ b/packages/base-nodes/nodetool/examples/apps/study-buddy.app.json
@@ -6,9 +6,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Study Buddy"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/scripts/build-example-apps.mjs
+++ b/scripts/build-example-apps.mjs
@@ -554,7 +554,10 @@ function buildApp(app, templates) {
 
   const document = {
     schemaVersion: APP_SCHEMA_VERSION,
-    ui: { root: { props: { title: app.name } }, content, zones: {} },
+    // No root title: the first widget is already a Heading carrying the app's
+    // emoji and name, and the runtime renders a root title as a heading of its
+    // own — so setting both printed the name twice on every example.
+    ui: { root: { props: {} }, content, zones: {} },
     operations: documentOperations,
     resources: [],
     variables: (app.variables ?? []).map((variable) => ({

--- a/web/public/app-preview/ask-your-documents.json
+++ b/web/public/app-preview/ask-your-documents.json
@@ -11,9 +11,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Ask Your Documents"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/web/public/app-preview/brand-and-social.json
+++ b/web/public/app-preview/brand-and-social.json
@@ -11,9 +11,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Brand & Social"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/web/public/app-preview/concept-studio.json
+++ b/web/public/app-preview/concept-studio.json
@@ -11,9 +11,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Concept Studio"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/web/public/app-preview/dataset-builder.json
+++ b/web/public/app-preview/dataset-builder.json
@@ -11,9 +11,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Dataset Builder"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/web/public/app-preview/film-studio.json
+++ b/web/public/app-preview/film-studio.json
@@ -11,9 +11,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Film Studio"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/web/public/app-preview/meeting-room.json
+++ b/web/public/app-preview/meeting-room.json
@@ -11,9 +11,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Meeting Room"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/web/public/app-preview/model-arena.json
+++ b/web/public/app-preview/model-arena.json
@@ -11,9 +11,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Model Arena"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/web/public/app-preview/photo-studio.json
+++ b/web/public/app-preview/photo-studio.json
@@ -11,9 +11,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Photo Studio"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/web/public/app-preview/product-launch-kit.json
+++ b/web/public/app-preview/product-launch-kit.json
@@ -11,9 +11,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Product Launch Kit"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/web/public/app-preview/research-desk.json
+++ b/web/public/app-preview/research-desk.json
@@ -11,9 +11,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Research Desk"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/web/public/app-preview/study-buddy.json
+++ b/web/public/app-preview/study-buddy.json
@@ -11,9 +11,7 @@
     "schemaVersion": 3,
     "ui": {
       "root": {
-        "props": {
-          "title": "Study Buddy"
-        }
+        "props": {}
       },
       "content": [
         {

--- a/web/src/components/appbuilder/ApplicationAppBuilder.tsx
+++ b/web/src/components/appbuilder/ApplicationAppBuilder.tsx
@@ -401,7 +401,9 @@ const ApplicationAppBuilder: React.FC<ApplicationAppBuilderProps> = ({
     if (!application) return null;
     return (
       parseApplicationDocument(application.document) ??
-      createEmptyDocument(application.name)
+      // Untitled on purpose — see createEmptyDocument's caller in
+      // `capabilities/apps.ts`. The name lives on the row, not in the page.
+      createEmptyDocument()
     );
   }, [application]);
 


### PR DESCRIPTION
## What changed

Creating an app wrote its name into `root.props.title`, and the runtime renders that as a heading at the top of the page — `AppRoot` puts it in the same flex column as the widgets, so it is content, not chrome. Every new app therefore arrived with a heading nobody placed, and the first `Heading` an author added repeated it. All eleven shipped examples show their name twice today. This stops the automatic stamp in the three places that did it, and regenerates the bundles.

The name belongs on the application row. A page that wants a title has a Heading widget — one the author controls and can word, style and reorder. `createEmptyDocument` keeps its optional `title` parameter: a document built with one is still valid, tests use it to construct titled fixtures, and the editor's **App title** field and `ui_app_set_title` still set it. Nothing sets it behind the author's back any more.

The three stamps:

- **`create_app`** seeded the document with the name it was given. The server paths (`applications-service`, the model's own default) never did, so an imported app already had no root title and an agent-created one did — the behavior was already inconsistent.
- **The web builder** seeded the same name when an application had no stored document yet.
- **The example-app generator** wrote both a root title and a `Heading` carrying the app's emoji and name. The Heading stays, since it is the nicer of the two and the one an author would edit; the eleven bundles and their previews are regenerated.

Mobile had a third copy: `ApplicationAppView` fell back to the application name when the document had no title, while `AppScreen` already sets that name as the navigation header. That fallback and the now-unused `title` prop are gone, so mobile renders exactly what the document says.

## Verification

- [x] `npm run test:affected` — every task passed except `@nodetool-ai/runtime#test`, which fails on `spawn ffmpeg ENOENT` in `tests/providers/video-frame-fallback.test.ts`. That is a missing system binary in this container, not this change: the diff touches no file under `packages/runtime`, and the same test fails identically on a clean `main` checkout here. Its 3141 other tests passed.
- [x] `npm run typecheck` — `web` and `electron` clean. `mobile` reports 36 errors, the same 36 on clean `main` (test fixtures missing a `sync_mode` field); none are in files this change touches.
- [x] `npm run lint` — no errors
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 7/7 selfchecks passed`
- [x] `node scripts/build-example-apps.mjs` — 11 bundles rebuilt and revalidated, `validated 11 bundle(s)`
- [x] `npm run test --workspace=packages/agents -- example-apps-regen` (11 passed) and `--workspace=packages/websocket -- example-apps` (8 passed)
- [x] `npm --prefix mobile run test -- ApplicationAppView` — 5 passed

After regenerating, every bundle carries no root title and one Heading:

```
ask-your-documents.app.json    rootTitle=None   firstWidget=Heading:'📄 Ask Your Documents'
brand-and-social.app.json      rootTitle=None   firstWidget=Heading:'🎨 Brand & Social'
…all 11, same shape
```

## New checks

Not a check, but three behaviors are newly pinned by tests, and each was inverted once and observed failing:

- `create_app` leaves `root.props.title` undefined (`packages/agents/tests/capabilities-apps.test.ts`).
- `ApplicationAppView` renders no heading of its own when the document has no title. Inverting the fallback to a literal name gives `✕ shows no heading of its own when the document has no title` / `Tests: 1 failed, 4 passed`; restored, 5 passed.
- The generator's output is covered by the existing `example-apps-regen` suite, which passes against the regenerated bundles.

## Follow-up

This makes the duplication impossible for newly created apps and for the shipped examples. An app a user already saved keeps whatever title was stamped into it — there is no migration here, and nothing rewrites stored documents.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPF9hspZMtodNXTLN1nsFq)_