### PR TITLE
feat(timeline): motion graphics M0 — schema landing, server render, agent surface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ RUN npm run build:packages
 
 # Bundle the backend with esbuild (scripts/bundle-backend.mjs — the same
 # bundler the Electron app uses; the server profile skips desktop-only natives
-# like webgpu/keytar). The bundle is the entire backend runtime artifact:
+# like keytar and playwright, but stages webgpu, which every profile needs).
+# The bundle is the entire backend runtime artifact:
 # server.mjs, the staged external native/lazy packages, provider manifests,
 # template examples + thumbnails, and the bundled migration runner — the image
 # ships no workspace node_modules tree. esbuild itself resolves from
@@ -99,13 +100,15 @@ ENV NODE_ENV=production \
 #   postgresql-client — psql/pg_dump for DATABASE_URL deployments
 #   jq/zip/unzip      — everyday shell plumbing for agents
 #   mesa-vulkan-drivers — lavapipe, a software Vulkan device. The image nodes
-#                     run their shaders on Dawn, which reaches the GPU only
-#                     through a Vulkan ICD and bundles no software fallback of
-#                     its own. With no ICD installed, `vkCreateInstance` fails
-#                     outright (VK_ERROR_INCOMPATIBLE_DRIVER) and every
-#                     nodetool.image.* node dies on "No WebGPU adapter
-#                     available" — crop and resize included. Containers have no
-#                     GPU, so lavapipe is what makes them runnable at all.
+#                     and the timeline compositor run their shaders on Dawn,
+#                     which reaches the GPU only through a Vulkan ICD and
+#                     bundles no software fallback of its own. With no ICD
+#                     installed, `vkCreateInstance` fails outright
+#                     (VK_ERROR_INCOMPATIBLE_DRIVER), every nodetool.image.*
+#                     node dies on "No WebGPU adapter available" — crop and
+#                     resize included — and nodetool.timeline.RenderTimeline
+#                     drops to its rough cut. Containers have no GPU, so
+#                     lavapipe is what makes all of them runnable at all.
 #                     Pinned to bookworm-backports: bookworm ships Mesa 22.3,
 #                     whose lavapipe Dawn rejects with "Vulkan
 #                     shaderUniform*ArrayDynamicIndexing required" and still

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -123,6 +123,7 @@ export const NODETOOL_API_NAMESPACE_TOOLS: Record<string, readonly string[]> = {
     "restore_timeline_version",
     "delete_timeline_version",
     "validate_timeline",
+    "preview_timeline_frame",
     "edit_timeline"
   ],
   sketches: [
@@ -1143,6 +1144,20 @@ const nodetool = (() => {
         typeof target === "string"
           ? __need("validate_timeline")({ timeline_id: target })
           : __need("validate_timeline")({ document: target }),
+      /**
+       * Composited frames at chosen timecodes — the finished picture, with
+       * every track layered, animations sampled mid-flight and transitions
+       * part way through. Takes an id or an inline document, like validate().
+       * Options: {times_ms, count, width}.
+       */
+      preview: (target, opts) =>
+        typeof target === "string"
+          ? __need("preview_timeline_frame")(
+              __merge(opts, { timeline_id: target })
+            )
+          : __need("preview_timeline_frame")(
+              __merge(opts, { document: target })
+            ),
       /** Apply document edits to a saved sequence, server-side. */
       edit: (id, ops) => __need("edit_timeline")({ timeline_id: id, ops: ops })
     },
@@ -1578,7 +1593,10 @@ const NAMESPACE_DOCS: PromptEntry[] = [
     doc: `- \`nodetool.timelines\` — \`list()\` (→ \`{timelines}\`),
   \`create(name, {fps, width, height})\` (→ \`{timeline_id}\`; make your own
   rather than editing one the user has open — vertical is 1080×1920),
-  \`validate(idOrDocument)\`, \`versions(id)\`,
+  \`validate(idOrDocument)\`,
+  \`preview(idOrDocument, {times_ms, count, width})\` (composited frames at
+  chosen timecodes — read the picture back instead of guessing at it),
+  \`versions(id)\`,
   \`getVersion(id, n)\`, \`snapshot(id, {name})\`, \`restore(id, n)\`,
   \`deleteVersion(id, n)\`, and
   \`edit(id, ops)\` — the cut itself, server-side: \`[{op: "add_track", type:

--- a/packages/agents/src/timeline-preview/frames.ts
+++ b/packages/agents/src/timeline-preview/frames.ts
@@ -26,11 +26,12 @@ import type {
   ActiveLayer,
   Canvas2DLayer,
   CompositeContext2D,
+  DroppedLayerReason,
   MaskScratch
 } from "@nodetool-ai/timeline/scene";
 import {
   clipSourceTimeSec,
-  computeActiveLayers,
+  computeActiveLayersWithHorizon,
   createAnimationCompileCache,
   drawTimelineFrame,
   resolveAnimatedLayerProps,
@@ -78,6 +79,14 @@ export interface PreviewLayerReport {
   skipped?: string;
 }
 
+/** A clip that was active at the frame's time and still did not draw. */
+export interface PreviewDroppedLayer {
+  clip_id: string;
+  clip_name: string;
+  /** Why the scene model refused it. */
+  reason: DroppedLayerReason;
+}
+
 export interface PreviewFrame {
   time_ms: number;
   /** PNG bytes of the composited frame. */
@@ -85,6 +94,12 @@ export interface PreviewFrame {
   width: number;
   height: number;
   layers: PreviewLayerReport[];
+  /**
+   * Clips the scene model left out of this frame. Empty on almost every
+   * frame; non-empty means the picture is missing a layer the document asks
+   * for, which is otherwise invisible in the pixels.
+   */
+  dropped: PreviewDroppedLayer[];
 }
 
 export interface RenderTimelineFramesResult {
@@ -138,6 +153,11 @@ function layerText(layer: ActiveLayer): string | undefined {
     return layer.caption.words.map((w) => w.text).join(" ");
   }
   return undefined;
+}
+
+/** A clip's authored name, for a report that only holds its id. */
+function clipName(sequence: TimelineSequence, clipId: string): string {
+  return sequence.clips.find((clip) => clip.id === clipId)?.name ?? clipId;
 }
 
 /**
@@ -203,7 +223,7 @@ export async function renderTimelineFrames(
   const effectsNotApplied = new Set<string>();
 
   for (const timeMs of options.timesMs) {
-    const active = computeActiveLayers(
+    const { layers: active, droppedLayers } = computeActiveLayersWithHorizon(
       sequence.tracks,
       sequence.clips,
       timeMs
@@ -365,7 +385,12 @@ export async function renderTimelineFrames(
       width,
       height,
       // Top of the stack first: the reader's question is what is on top.
-      layers: reports.sort((a, b) => b.z_index - a.z_index)
+      layers: reports.sort((a, b) => b.z_index - a.z_index),
+      dropped: droppedLayers.map((dropped) => ({
+        clip_id: dropped.clipId,
+        clip_name: clipName(sequence, dropped.clipId),
+        reason: dropped.reason
+      }))
     });
   }
 

--- a/packages/agents/tests/nodetool-api.test.ts
+++ b/packages/agents/tests/nodetool-api.test.ts
@@ -41,7 +41,11 @@ const MEDIA_TOOLS = [
   "ffmpeg",
   "yt_dlp"
 ].map(toolDef);
-const TIMELINE_TOOLS = ["list_timelines", "validate_timeline"].map(toolDef);
+const TIMELINE_TOOLS = [
+  "list_timelines",
+  "validate_timeline",
+  "preview_timeline_frame"
+].map(toolDef);
 
 /** In-memory router: records calls, plays a tiny workflow store. */
 function createFakeRouter() {
@@ -145,6 +149,8 @@ function createFakeRouter() {
         return JSON.stringify({ timelines: [] });
       case "validate_timeline":
         return JSON.stringify({ ok: true, target: args });
+      case "preview_timeline_frame":
+        return JSON.stringify({ frames: [{ time_ms: 0 }], target: args });
       default:
         return JSON.stringify({ error: `Unknown tool ${call.name}` });
     }
@@ -384,6 +390,53 @@ describe("nodetool object model", () => {
     expect(obs.ok).toBe(true);
     expect(calls[0].args).toEqual({ timeline_id: "tl1" });
     expect(calls[1].args).toEqual({ document: { tracks: [] } });
+  });
+
+  it("routes timeline preview to preview_timeline_frame by target type", async () => {
+    const { executeTool, calls } = createFakeRouter();
+    const session = makeSession(TIMELINE_TOOLS, executeTool);
+    const obs = await runAction(
+      session,
+      `const saved = await nodetool.timelines.preview("tl1", {
+         times_ms: [0, 1500],
+         width: 480
+       });
+       const inline = await nodetool.timelines.preview({ tracks: [] }, {
+         count: 2
+       });
+       return { saved, inline };`
+    );
+    expect(obs.ok).toBe(true);
+    // The method reaches the capability, not a stub: both calls land on
+    // preview_timeline_frame, and the options ride along beside the target.
+    expect(calls.map((c) => c.name)).toEqual([
+      "preview_timeline_frame",
+      "preview_timeline_frame"
+    ]);
+    expect(calls[0].args).toEqual({
+      timeline_id: "tl1",
+      times_ms: [0, 1500],
+      width: 480
+    });
+    expect(calls[1].args).toEqual({ document: { tracks: [] }, count: 2 });
+    const r = obs.result as { saved: { frames: unknown[] } };
+    expect(r.saved.frames).toHaveLength(1);
+  });
+
+  it("names preview_timeline_frame when the belt lacks it", async () => {
+    const { executeTool, calls } = createFakeRouter();
+    const session = makeSession(
+      TIMELINE_TOOLS.filter((t) => t.name !== "preview_timeline_frame"),
+      executeTool
+    );
+    const obs = await runAction(
+      session,
+      `try { await nodetool.timelines.preview("tl1"); return "called"; }
+       catch (e) { return e.message; }`
+    );
+    expect(obs.ok).toBe(true);
+    expect(String(obs.result)).toContain("preview_timeline_frame");
+    expect(calls).toEqual([]);
   });
 
   it("workflows.open explains itself when the ui_* tools are absent", async () => {

--- a/packages/execution/src/timeline-debug/validate.ts
+++ b/packages/execution/src/timeline-debug/validate.ts
@@ -21,6 +21,7 @@ import {
   resolveCustomMask,
   sourceRate
 } from "@nodetool-ai/timeline";
+import { MAX_VIDEO_LAYERS } from "@nodetool-ai/timeline/scene";
 
 import type { TimelineDebugIssue, TimelineValidation } from "./types.js";
 
@@ -362,6 +363,67 @@ function checkOverlaps(doc: TimelineDocument): TimelineDebugIssue[] {
   return issues;
 }
 
+/**
+ * Instants where more video clips overlap than the compositor will draw.
+ *
+ * The cap is applied while resolving a frame, so the clips past it never reach
+ * the picture. Sampling frames to find that would miss an overlap shorter than
+ * the sample interval, so this is a sweep over the clip windows themselves:
+ * every start raises the count and every end lowers it, ends first at a shared
+ * instant because a clip is active over `[startMs, startMs + durationMs)`. The
+ * count is therefore exact at every boundary, and the peak between boundaries
+ * is one of them.
+ *
+ * What counts is what the scene model would count: a clip on a visible video or
+ * overlay track whose media is picture the compositor holds in its video pool.
+ * Images are not capped, and audio, text, shape and group clips draw through
+ * other paths.
+ */
+function checkVideoLayerCap(doc: TimelineDocument): TimelineDebugIssue[] {
+  const cappedTrackIds = new Set(
+    doc.tracks
+      .filter(
+        (track) =>
+          track.visible && (track.type === "video" || track.type === "overlay")
+      )
+      .map((track) => track.id)
+  );
+  const capped = doc.clips.filter(
+    (clip) =>
+      cappedTrackIds.has(clip.trackId) &&
+      (clip.mediaType === "video" || clip.mediaType === "overlay") &&
+      clip.durationMs > 0
+  );
+
+  // -1 before +1 at one instant, so a clip ending where another starts does
+  // not read as two simultaneous layers.
+  const events = capped.flatMap((clip) => [
+    { timeMs: clip.startMs, delta: 1 },
+    { timeMs: clip.startMs + clip.durationMs, delta: -1 }
+  ]);
+  events.sort((a, b) => a.timeMs - b.timeMs || a.delta - b.delta);
+
+  let open = 0;
+  let peak = 0;
+  let peakAtMs = 0;
+  for (const event of events) {
+    open += event.delta;
+    if (open > peak) {
+      peak = open;
+      peakAtMs = event.timeMs;
+    }
+  }
+  if (peak <= MAX_VIDEO_LAYERS) return [];
+
+  return [
+    {
+      severity: "warning",
+      code: "layer_cap_exceeded",
+      message: `${peak} video clips overlap at ${peakAtMs}ms — the compositor draws ${MAX_VIDEO_LAYERS} and silently discards the rest, keeping the ones on the topmost tracks.`
+    }
+  ];
+}
+
 function checkDocumentLevel(doc: TimelineDocument): TimelineDebugIssue[] {
   const issues: TimelineDebugIssue[] = [];
 
@@ -475,6 +537,7 @@ export function validateTimelineSequence(
     ...checkDuplicateIds(doc),
     ...doc.clips.flatMap((clip) => checkClip(clip, trackIds, fps)),
     ...checkOverlaps(doc),
+    ...checkVideoLayerCap(doc),
     ...checkDocumentLevel(doc)
   ];
 

--- a/packages/execution/tests/timeline-caption-word-fields.test.ts
+++ b/packages/execution/tests/timeline-caption-word-fields.test.ts
@@ -1,0 +1,104 @@
+/**
+ * F16: `CaptionWord.kind` and `confidence` existed on the model type and not in
+ * the Zod schema, so every save dropped them. Filler-word removal reads `kind`,
+ * which made the feature work until the document was saved once and then find
+ * nothing.
+ *
+ * The round trip is the check. `timelineDocument` strips what it does not
+ * declare, so a fixture whose words come back with both fields intact is the
+ * evidence, and `field_stripped` is what reports the regression if either is
+ * removed from the schema again.
+ */
+import { describe, expect, it } from "vitest";
+
+import { timelineDocument } from "@nodetool-ai/protocol/api-schemas/timeline.js";
+
+import { validateTimelineSequence } from "../src/timeline-debug/index.js";
+
+/**
+ * "like" is not in the filler lexicon, so nothing but the explicit `kind`
+ * marks it — exactly the word a save used to turn back into ordinary speech.
+ */
+function captionedDocument(): Record<string, unknown> {
+  return {
+    tracks: [
+      {
+        id: "track-1",
+        name: "Voiceover",
+        type: "audio",
+        index: 0,
+        visible: true,
+        locked: false
+      }
+    ],
+    markers: [],
+    clips: [
+      {
+        id: "vo-1",
+        trackId: "track-1",
+        name: "Line 1",
+        startMs: 0,
+        durationMs: 2000,
+        mediaType: "audio",
+        sourceType: "generated",
+        prompt: "So um like yes",
+        status: "generated",
+        locked: false,
+        versions: [],
+        caption: {
+          words: [
+            { word: "So", startMs: 0, endMs: 200, kind: "word", confidence: 0.99 },
+            { word: "um", startMs: 200, endMs: 400, kind: "filler", confidence: 0.42 },
+            { word: "like", startMs: 400, endMs: 600, kind: "filler", confidence: 0.51 },
+            { word: "yes", startMs: 600, endMs: 900, kind: "word", confidence: 0.97 },
+            { word: "", startMs: 900, endMs: 1200, kind: "pause" }
+          ]
+        }
+      }
+    ]
+  };
+}
+
+describe("caption word kind and confidence survive the schema", () => {
+  it("parses every kind and keeps the confidence", () => {
+    const parsed = timelineDocument.parse(captionedDocument());
+    const words = parsed.clips[0]?.caption?.words ?? [];
+    expect(words.map((word) => word.kind)).toEqual([
+      "word",
+      "filler",
+      "filler",
+      "word",
+      "pause"
+    ]);
+    expect(words.map((word) => word.confidence)).toEqual([
+      0.99, 0.42, 0.51, 0.97, undefined
+    ]);
+  });
+
+  it("round trips the whole document unchanged", () => {
+    const raw = captionedDocument();
+    expect(timelineDocument.parse(raw)).toEqual(raw);
+  });
+
+  it("strips nothing and reports no issue", () => {
+    const result = validateTimelineSequence(captionedDocument());
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("refuses a kind the schema does not know", () => {
+    const doc = captionedDocument();
+    const clips = doc.clips as Record<string, unknown>[];
+    const caption = clips[0].caption as { words: Record<string, unknown>[] };
+    caption.words[1].kind = "disfluency";
+    expect(timelineDocument.safeParse(doc).success).toBe(false);
+  });
+
+  it("refuses a confidence outside 0..1", () => {
+    const doc = captionedDocument();
+    const clips = doc.clips as Record<string, unknown>[];
+    const caption = clips[0].caption as { words: Record<string, unknown>[] };
+    caption.words[0].confidence = 1.5;
+    expect(timelineDocument.safeParse(doc).success).toBe(false);
+  });
+});

--- a/packages/execution/tests/timeline-debug.test.ts
+++ b/packages/execution/tests/timeline-debug.test.ts
@@ -126,7 +126,7 @@ describe("validateTimelineSequence — field_stripped", () => {
               text: "Hello",
               fontSizePx: 48,
               color: "#fff",
-              letterSpacingPx: 2
+              notATextStyleField: 2
             },
             mediaType: "text"
           })
@@ -136,7 +136,7 @@ describe("validateTimelineSequence — field_stripped", () => {
     const paths = result.warnings
       .filter((w) => w.code === "field_stripped")
       .map((w) => w.path);
-    expect(paths).toEqual(["clips[*].textStyle.letterSpacingPx"]);
+    expect(paths).toEqual(["clips[*].textStyle.notATextStyleField"]);
   });
 
   it("ignores undefined values in the input", () => {

--- a/packages/execution/tests/timeline-layer-cap.test.ts
+++ b/packages/execution/tests/timeline-layer-cap.test.ts
@@ -1,0 +1,147 @@
+/**
+ * F17: `MAX_VIDEO_LAYERS` used to drop layers with a bare `continue`, so a
+ * frame quietly lost a clip and nothing said which one. Two halves are tested
+ * against one fixture: the scene model now names each clip it turned away, and
+ * the validator warns before a render that any of it happens.
+ *
+ * The validator's half is a sweep over the clip windows, not a walk over
+ * sampled frames — the last test here is an overlap one frame interval could
+ * step straight over.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { TimelineDocument } from "@nodetool-ai/protocol/api-schemas/timeline.js";
+import {
+  MAX_VIDEO_LAYERS,
+  computeActiveLayersWithHorizon
+} from "@nodetool-ai/timeline/scene";
+
+import { validateTimelineSequence } from "../src/timeline-debug/index.js";
+
+interface ClipSpec {
+  id: string;
+  startMs: number;
+  durationMs: number;
+}
+
+/** One video track per clip, so every clip competes for a video slot. */
+function document(specs: ClipSpec[]): TimelineDocument {
+  return {
+    tracks: specs.map((spec, index) => ({
+      id: `track-${spec.id}`,
+      name: `Video ${index}`,
+      type: "video" as const,
+      index,
+      visible: true,
+      locked: false
+    })),
+    clips: specs.map((spec) => ({
+      id: spec.id,
+      trackId: `track-${spec.id}`,
+      name: spec.id,
+      startMs: spec.startMs,
+      durationMs: spec.durationMs,
+      mediaType: "video" as const,
+      sourceType: "imported" as const,
+      status: "generated" as const,
+      currentAssetId: `asset-${spec.id}`,
+      locked: false,
+      versions: []
+    })),
+    markers: []
+  };
+}
+
+/** `n` video clips all live over the same window. */
+const stacked = (n: number, durationMs = 10_000): ClipSpec[] =>
+  Array.from({ length: n }, (_, i) => ({
+    id: `clip-${i}`,
+    startMs: 0,
+    durationMs
+  }));
+
+const layerCapWarnings = (doc: TimelineDocument) =>
+  validateTimelineSequence(doc).warnings.filter(
+    (issue) => issue.code === "layer_cap_exceeded"
+  );
+
+describe("video layer cap", () => {
+  it("drops one layer and warns once when nine video clips overlap", () => {
+    const doc = document(stacked(9));
+
+    const { layers, droppedLayers } = computeActiveLayersWithHorizon(
+      doc.tracks,
+      doc.clips,
+      100
+    );
+    expect(layers).toHaveLength(MAX_VIDEO_LAYERS);
+    expect(droppedLayers).toEqual([
+      { clipId: "clip-8", reason: "video_layer_cap" }
+    ]);
+
+    const warnings = layerCapWarnings(doc);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.message).toContain("9 video clips overlap at 0ms");
+    // A warning, never an error: the frame still renders, minus a layer.
+    expect(validateTimelineSequence(doc).ok).toBe(true);
+  });
+
+  // I12: the check has to be able to stay quiet, or it is reporting nothing
+  // about the document.
+  it("says nothing at exactly the cap", () => {
+    const doc = document(stacked(MAX_VIDEO_LAYERS));
+    expect(computeActiveLayersWithHorizon(doc.tracks, doc.clips, 100)
+      .droppedLayers).toEqual([]);
+    expect(layerCapWarnings(doc)).toEqual([]);
+  });
+
+  it("says nothing when nine clips never coincide", () => {
+    const doc = document(
+      Array.from({ length: 9 }, (_, i) => ({
+        id: `clip-${i}`,
+        startMs: i * 1000,
+        durationMs: 1000
+      }))
+    );
+    expect(layerCapWarnings(doc)).toEqual([]);
+  });
+
+  it("ignores image clips, which the compositor does not cap", () => {
+    const doc = document(stacked(9));
+    const imageClips = doc.clips.map((clip) => ({
+      ...clip,
+      mediaType: "image" as const
+    }));
+    expect(layerCapWarnings({ ...doc, clips: imageClips })).toEqual([]);
+  });
+
+  it("ignores clips on a hidden track", () => {
+    const doc = document(stacked(9));
+    const tracks = doc.tracks.map((track, index) =>
+      index === 0 ? { ...track, visible: false } : track
+    );
+    expect(layerCapWarnings({ ...doc, tracks })).toEqual([]);
+  });
+
+  it("catches an overlap shorter than a frame at 30fps", () => {
+    // Eight clips fill [0, 10000). The ninth opens at 9999 — a 1ms window that
+    // no 33.3ms sample lands in, so a frame-sampling implementation would call
+    // this document clean. The sweep reads the boundaries themselves.
+    const doc = document([
+      ...stacked(MAX_VIDEO_LAYERS),
+      { id: "clip-late", startMs: 9_999, durationMs: 1_000 }
+    ]);
+
+    const frameMs = 1000 / 30;
+    const sampled = Array.from({ length: 400 }, (_, i) => i * frameMs).filter(
+      (timeMs) =>
+        computeActiveLayersWithHorizon(doc.tracks, doc.clips, timeMs)
+          .droppedLayers.length > 0
+    );
+    expect(sampled).toEqual([]);
+
+    const warnings = layerCapWarnings(doc);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.message).toContain("9 video clips overlap at 9999ms");
+  });
+});

--- a/packages/execution/tests/timeline-schema-roundtrip.test.ts
+++ b/packages/execution/tests/timeline-schema-roundtrip.test.ts
@@ -1,0 +1,491 @@
+/**
+ * Schema mirror (I1): every field on `TimelineClip` and its children exists in
+ * both `packages/timeline/src/types.ts` and the Zod schema in
+ * `packages/protocol/src/api-schemas/timeline.ts`. A field missing from the Zod
+ * side is not an error — it is silent data loss on the next autosave, which is
+ * exactly what `field_stripped` reports.
+ *
+ * The fixture below is one document that sets every field the motion-graphics
+ * document model adds. `NEW_FIELD_PATHS` names them, and the first test asserts
+ * the fixture really carries each one, so a field added to the design without a
+ * fixture value cannot pass by not being exercised.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  timelineDocument,
+  type TimelineClip as WireClip
+} from "@nodetool-ai/protocol/api-schemas/timeline.js";
+import type {
+  TimelineClip as ModelClip,
+  ClipEffect as ModelClipEffect,
+  ClipTransition as ModelClipTransition
+} from "@nodetool-ai/timeline";
+
+import { validateTimelineSequence } from "../src/timeline-debug/index.js";
+
+// ── Type mirror ──────────────────────────────────────────────────────────────
+// `packages/protocol` cannot import `@nodetool-ai/timeline` (the dependency runs
+// the other way), so the two-way assignability check lives here, in the one
+// package that holds both. A field present on one side only fails to compile.
+type Extends<A, B> = A extends B ? true : false;
+/** `true` only when each side is assignable to the other. */
+type MutuallyAssignable<A, B> = Extends<A, B> & Extends<B, A>;
+
+/** The fields this schema landing adds, plus the two it widened. */
+type MotionFieldKeys =
+  | "mediaType"
+  | "parentId"
+  | "mask"
+  | "matte"
+  | "timeRemap"
+  | "compositionId"
+  | "compositionParams"
+  | "transitionIn"
+  | "effects"
+  | "textStyle"
+  | "shapeStyle"
+  | "caption";
+
+const motionFieldMirror: MutuallyAssignable<
+  Pick<WireClip, MotionFieldKeys>,
+  Pick<ModelClip, MotionFieldKeys>
+> = true;
+const effectMirror: MutuallyAssignable<
+  NonNullable<WireClip["effects"]>[number],
+  ModelClipEffect
+> = true;
+const transitionMirror: MutuallyAssignable<
+  NonNullable<WireClip["transitionIn"]>,
+  ModelClipTransition
+> = true;
+// The whole clip only holds in one direction today: the wire types
+// `ClipAnimation.easing` as a plain string and the model still narrows it to
+// `EasingId`. T6 (easing grammar) is what widens the model side.
+const wholeClipMirror: Extends<ModelClip, WireClip> = true;
+
+const clip = (overrides: Record<string, unknown>): Record<string, unknown> => ({
+  trackId: "track-1",
+  name: "Clip",
+  durationMs: 1000,
+  mediaType: "video",
+  sourceType: "imported",
+  status: "generated",
+  locked: false,
+  versions: [],
+  ...overrides
+});
+
+const solidFill = { type: "solid", color: "#101010" };
+const linearFill = {
+  type: "linear",
+  angle: 45,
+  stops: [
+    { offset: 0, color: "#ff0000" },
+    { offset: 1, color: "#0000ff" }
+  ]
+};
+const radialFill = {
+  type: "radial",
+  stops: [
+    { offset: 0, color: "#ffffff" },
+    { offset: 1, color: "#000000" }
+  ]
+};
+
+/** One document carrying every field the motion-graphics model adds. */
+function motionDocument(): Record<string, unknown> {
+  return {
+    tracks: [
+      {
+        id: "track-1",
+        name: "Video 1",
+        type: "video",
+        index: 0,
+        visible: true,
+        locked: false
+      }
+    ],
+    markers: [],
+    clips: [
+      clip({ id: "group-1", startMs: 0, mediaType: "group", name: "Rig" }),
+      clip({
+        id: "child-1",
+        startMs: 1000,
+        parentId: "group-1",
+        mask: {
+          kind: "path",
+          x: 0.1,
+          y: 0.2,
+          width: 0.6,
+          height: 0.5,
+          d: "M0 0 L1 0 L1 1 Z",
+          featherPx: 12,
+          invert: true
+        },
+        matte: { sourceClipId: "matte-src", mode: "luma", invert: true },
+        timeRemap: {
+          keyframes: [
+            { t: 0, sourceMs: 0 },
+            { t: 1, sourceMs: 500, easing: "cubic-bezier(0.42,0,0.58,1)" }
+          ]
+        },
+        compositionId: "comp-lower-third",
+        compositionParams: { title: "Ada", lines: 2, boxed: true }
+      }),
+      clip({ id: "matte-src", startMs: 2000, mediaType: "shape" }),
+      clip({
+        id: "text-1",
+        startMs: 3000,
+        mediaType: "text",
+        textStyle: {
+          text: "Title",
+          fontSizePx: 96,
+          color: "#ffffff",
+          fontStyle: "italic",
+          letterSpacingPx: 4,
+          lineHeight: 1.4,
+          verticalAlign: "top",
+          stroke: { color: "#000000", widthPx: 3 },
+          shadow: {
+            color: "#00000080",
+            blurPx: 8,
+            offsetX: 2,
+            offsetY: 4
+          },
+          background: { color: "#000000", paddingPx: 16, radiusPx: 8 },
+          fill: linearFill
+        },
+        caption: {
+          words: [
+            { word: "um", startMs: 0, endMs: 200, kind: "filler", confidence: 0.4 },
+            { word: "hello", startMs: 200, endMs: 700, kind: "word", confidence: 0.98 }
+          ],
+          style: {
+            fontFamily: "Bebas Neue",
+            fontSizeFrac: 0.07,
+            color: "#eeeeee",
+            activeColor: "#ffd60a",
+            outline: { color: "#000000", widthPx: 2 },
+            bottomMarginFrac: 0.08,
+            background: { color: "#00000099", paddingPx: 12, radiusPx: 6 }
+          }
+        }
+      }),
+      clip({
+        id: "shape-1",
+        startMs: 4000,
+        mediaType: "shape",
+        shapeStyle: {
+          kind: "star",
+          d: "M0 0 C0.5 0 0.5 1 1 1 Z",
+          sides: 5,
+          innerRadius: 0.4,
+          cornerRadius: 0.05,
+          fillStyle: radialFill,
+          dash: [0.02, 0.01],
+          lineCap: "round",
+          lineJoin: "bevel",
+          trimStart: 0.1,
+          trimEnd: 0.8
+        }
+      }),
+      clip({
+        id: "shape-2",
+        startMs: 5000,
+        mediaType: "shape",
+        shapeStyle: { kind: "polygon", sides: 6, fillStyle: solidFill }
+      }),
+      clip({
+        id: "fx-1",
+        startMs: 6000,
+        effects: [
+          { id: "e-glow", type: "glow", enabled: true, radius: 12, intensity: 0.8, color: "#ffeecc" },
+          {
+            id: "e-shadow",
+            type: "dropShadow",
+            enabled: true,
+            offsetX: 6,
+            offsetY: 8,
+            blur: 10,
+            color: "#000000",
+            opacity: 0.6
+          },
+          { id: "e-vig", type: "vignette", enabled: true, amount: 0.4, softness: 0.6 },
+          { id: "e-sharp", type: "sharpen", enabled: true, amount: 0.5, radius: 2 },
+          {
+            id: "e-key",
+            type: "chromaKey",
+            enabled: true,
+            color: "#00ff00",
+            tolerance: 0.2,
+            softness: 0.1,
+            spill: 0.5
+          },
+          {
+            id: "e-curves",
+            type: "curves",
+            enabled: true,
+            master: [
+              { x: 0, y: 0 },
+              { x: 1, y: 1 }
+            ],
+            r: [{ x: 0.5, y: 0.6 }],
+            g: [{ x: 0.5, y: 0.5 }],
+            b: [{ x: 0.5, y: 0.4 }]
+          },
+          {
+            id: "e-levels",
+            type: "levels",
+            enabled: true,
+            inBlack: 0.05,
+            inWhite: 0.95,
+            gamma: 1.2,
+            outBlack: 0,
+            outWhite: 1
+          },
+          {
+            id: "e-lgg",
+            type: "liftGammaGain",
+            enabled: true,
+            lift: [0.01, 0.02, 0.03],
+            gamma: [1, 1.1, 0.9],
+            gain: [1.05, 1, 0.95]
+          }
+        ]
+      }),
+      clip({
+        id: "tr-crossfade",
+        startMs: 7000,
+        transitionIn: { type: "crossfade", durationMs: 300, easing: "easeInOut" }
+      }),
+      clip({
+        id: "tr-dip",
+        startMs: 8000,
+        transitionIn: {
+          type: "dipToColor",
+          durationMs: 400,
+          color: "#000000",
+          easing: "linear"
+        }
+      }),
+      clip({
+        id: "tr-wipe",
+        startMs: 9000,
+        transitionIn: {
+          type: "wipe",
+          durationMs: 500,
+          direction: "left",
+          softness: 0.2,
+          easing: "easeOut"
+        }
+      }),
+      clip({
+        id: "tr-push",
+        startMs: 10000,
+        transitionIn: {
+          type: "push",
+          durationMs: 250,
+          direction: "up",
+          easing: "spring(180,12,1)"
+        }
+      }),
+      clip({
+        id: "tr-slide",
+        startMs: 11000,
+        transitionIn: {
+          type: "slide",
+          durationMs: 250,
+          direction: "right",
+          easing: "easeIn"
+        }
+      }),
+      clip({
+        id: "tr-zoom",
+        startMs: 12000,
+        transitionIn: { type: "zoom", durationMs: 250, easing: "easeOutBack" }
+      })
+    ]
+  };
+}
+
+/**
+ * Every path the motion-graphics document model adds, in the shape
+ * `field_stripped` reports (`clips[*].mask.featherPx`). The fixture must set
+ * every one of them.
+ */
+const NEW_FIELD_PATHS = [
+  "clips[*].parentId",
+  "clips[*].mask.kind",
+  "clips[*].mask.x",
+  "clips[*].mask.y",
+  "clips[*].mask.width",
+  "clips[*].mask.height",
+  "clips[*].mask.d",
+  "clips[*].mask.featherPx",
+  "clips[*].mask.invert",
+  "clips[*].matte.sourceClipId",
+  "clips[*].matte.mode",
+  "clips[*].matte.invert",
+  "clips[*].timeRemap.keyframes[*].t",
+  "clips[*].timeRemap.keyframes[*].sourceMs",
+  "clips[*].timeRemap.keyframes[*].easing",
+  "clips[*].compositionId",
+  "clips[*].compositionParams.title",
+  "clips[*].transitionIn.easing",
+  "clips[*].transitionIn.color",
+  "clips[*].transitionIn.direction",
+  "clips[*].transitionIn.softness",
+  "clips[*].effects[*].intensity",
+  "clips[*].effects[*].offsetX",
+  "clips[*].effects[*].offsetY",
+  "clips[*].effects[*].blur",
+  "clips[*].effects[*].opacity",
+  "clips[*].effects[*].amount",
+  "clips[*].effects[*].softness",
+  "clips[*].effects[*].tolerance",
+  "clips[*].effects[*].spill",
+  "clips[*].effects[*].master[*].x",
+  "clips[*].effects[*].master[*].y",
+  "clips[*].effects[*].r[*].x",
+  "clips[*].effects[*].g[*].x",
+  "clips[*].effects[*].b[*].x",
+  "clips[*].effects[*].inBlack",
+  "clips[*].effects[*].inWhite",
+  "clips[*].effects[*].gamma",
+  "clips[*].effects[*].outBlack",
+  "clips[*].effects[*].outWhite",
+  "clips[*].effects[*].lift[*]",
+  "clips[*].effects[*].gain[*]",
+  "clips[*].textStyle.fontStyle",
+  "clips[*].textStyle.letterSpacingPx",
+  "clips[*].textStyle.lineHeight",
+  "clips[*].textStyle.verticalAlign",
+  "clips[*].textStyle.stroke.color",
+  "clips[*].textStyle.stroke.widthPx",
+  "clips[*].textStyle.shadow.color",
+  "clips[*].textStyle.shadow.blurPx",
+  "clips[*].textStyle.shadow.offsetX",
+  "clips[*].textStyle.shadow.offsetY",
+  "clips[*].textStyle.background.color",
+  "clips[*].textStyle.background.paddingPx",
+  "clips[*].textStyle.background.radiusPx",
+  "clips[*].textStyle.fill.type",
+  "clips[*].textStyle.fill.angle",
+  "clips[*].textStyle.fill.stops[*].offset",
+  "clips[*].textStyle.fill.stops[*].color",
+  "clips[*].shapeStyle.d",
+  "clips[*].shapeStyle.sides",
+  "clips[*].shapeStyle.innerRadius",
+  "clips[*].shapeStyle.cornerRadius",
+  "clips[*].shapeStyle.fillStyle.type",
+  "clips[*].shapeStyle.fillStyle.stops[*].offset",
+  "clips[*].shapeStyle.fillStyle.color",
+  "clips[*].shapeStyle.dash[*]",
+  "clips[*].shapeStyle.lineCap",
+  "clips[*].shapeStyle.lineJoin",
+  "clips[*].shapeStyle.trimStart",
+  "clips[*].shapeStyle.trimEnd",
+  "clips[*].caption.style.fontFamily",
+  "clips[*].caption.style.fontSizeFrac",
+  "clips[*].caption.style.color",
+  "clips[*].caption.style.activeColor",
+  "clips[*].caption.style.outline.color",
+  "clips[*].caption.style.outline.widthPx",
+  "clips[*].caption.style.bottomMarginFrac",
+  "clips[*].caption.style.background.color",
+  "clips[*].caption.style.background.paddingPx",
+  "clips[*].caption.style.background.radiusPx",
+  "clips[*].caption.words[*].kind",
+  "clips[*].caption.words[*].confidence"
+] as const;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** Collect every path the document carries, in `field_stripped`'s shape. */
+function collectPaths(value: unknown, path: string, found: Set<string>): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const childPath = `${path}[*]`;
+      found.add(childPath);
+      collectPaths(item, childPath, found);
+    }
+    return;
+  }
+  if (!isRecord(value)) return;
+  for (const [key, child] of Object.entries(value)) {
+    if (child === undefined) continue;
+    const childPath = path ? `${path}.${key}` : key;
+    found.add(childPath);
+    collectPaths(child, childPath, found);
+  }
+}
+
+const strippedPaths = (raw: unknown): string[] =>
+  validateTimelineSequence(raw)
+    .warnings.filter((issue) => issue.code === "field_stripped")
+    .map((issue) => issue.path ?? "");
+
+describe("timeline schema round trip — motion-graphics fields", () => {
+  it("the fixture sets every field the document model adds", () => {
+    const present = new Set<string>();
+    collectPaths(motionDocument(), "", present);
+    const missing = NEW_FIELD_PATHS.filter((path) => !present.has(path));
+    expect(missing).toEqual([]);
+  });
+
+  it("parses without a schema error", () => {
+    const parsed = timelineDocument.safeParse(motionDocument());
+    expect(parsed.success ? [] : parsed.error.issues).toEqual([]);
+  });
+
+  it("strips nothing, and reports no other issue", () => {
+    const result = validateTimelineSequence(motionDocument());
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+
+  it("survives a parse round trip unchanged", () => {
+    const raw = motionDocument();
+    expect(timelineDocument.parse(raw)).toEqual(raw);
+  });
+
+  // I12: a check that has only ever been green is indistinguishable from one
+  // that examines nothing. These feed fields the schema does not carry, at the
+  // three depths the new fields live at, and the detector must name each one.
+  it("reports a stripped field on the clip", () => {
+    const doc = motionDocument();
+    const clips = doc.clips as Record<string, unknown>[];
+    clips[0].notAClipField = "lost on the next save";
+    expect(strippedPaths(doc)).toEqual(["clips[*].notAClipField"]);
+  });
+
+  it("reports a stripped field inside a new nested object", () => {
+    const doc = motionDocument();
+    const clips = doc.clips as Record<string, unknown>[];
+    (clips[1].mask as Record<string, unknown>).notAMaskField = 1;
+    expect(strippedPaths(doc)).toEqual(["clips[*].mask.notAMaskField"]);
+  });
+
+  it("reports a stripped field inside a widened style object", () => {
+    const doc = motionDocument();
+    const clips = doc.clips as Record<string, unknown>[];
+    (clips[3].textStyle as Record<string, unknown>).notATextField = true;
+    expect(strippedPaths(doc)).toEqual(["clips[*].textStyle.notATextField"]);
+  });
+
+  it("keeps the wire and model clip types mutually assignable", () => {
+    // The three constants above are compile-time assertions: each is typed
+    // `true & true` only while both directions hold, so a field on one side
+    // only stops this file compiling. Asserting them here keeps a reader from
+    // deleting them as unused.
+    expect([
+      motionFieldMirror,
+      effectMirror,
+      transitionMirror,
+      wholeClipMirror
+    ]).toEqual([true, true, true, true]);
+  });
+});

--- a/packages/execution/vitest.config.ts
+++ b/packages/execution/vitest.config.ts
@@ -49,7 +49,12 @@ export default defineConfig({
         "../app-runtime/src/index.ts"
       ),
       // Same reason: the timeline validator should check the assembly code as
-      // written, not a build of it.
+      // written, not a build of it. `/scene` is the GPU-free render surface,
+      // and must be aliased before the root (Vite alias is prefix-based).
+      "@nodetool-ai/timeline/scene": resolve(
+        __dirname,
+        "../timeline/src/scene.ts"
+      ),
       "@nodetool-ai/timeline": resolve(__dirname, "../timeline/src/index.ts")
     }
   },

--- a/packages/protocol/src/api-schemas/timeline.ts
+++ b/packages/protocol/src/api-schemas/timeline.ts
@@ -39,9 +39,37 @@ export type TimelineMarker = z.infer<typeof timelineMarker>;
 export const captionWord = z.object({
   word: z.string(),
   startMs: z.number(),
-  endMs: z.number()
+  endMs: z.number(),
+  /** Token classification; absent means a normal spoken word. Without this
+   * field Zod strips it on every PATCH, so filler-word removal — which reads
+   * `kind` — stops finding anything after one save. */
+  kind: z.enum(["word", "filler", "pause"]).optional(),
+  /** ASR confidence 0..1. Without this field Zod strips it on every PATCH. */
+  confidence: z.number().min(0).max(1).optional()
 });
 export type CaptionWord = z.infer<typeof captionWord>;
+
+/**
+ * Authored look of a caption layer. Every field is optional: an absent one
+ * keeps the drawing default, so a caption written before styling existed
+ * renders exactly as it did.
+ */
+export const captionStyle = z.object({
+  fontFamily: z.string().optional(),
+  fontSizeFrac: z.number().optional(),
+  color: z.string().optional(),
+  activeColor: z.string().optional(),
+  outline: z.object({ color: z.string(), widthPx: z.number() }).optional(),
+  bottomMarginFrac: z.number().optional(),
+  background: z
+    .object({
+      color: z.string(),
+      paddingPx: z.number(),
+      radiusPx: z.number().optional()
+    })
+    .optional()
+});
+export type CaptionStyle = z.infer<typeof captionStyle>;
 
 /**
  * Word-level caption data carried by a caption clip. Sourced from the
@@ -49,7 +77,10 @@ export type CaptionWord = z.infer<typeof captionWord>;
  * for the MVP, so no style fields are persisted yet.
  */
 export const clipCaption = z.object({
-  words: z.array(captionWord)
+  words: z.array(captionWord),
+  /** Caption look. Without this field Zod strips it on every PATCH, so a
+   * restyled caption reverts to the built-in look on the next save. */
+  style: captionStyle.optional()
 });
 export type ClipCaption = z.infer<typeof clipCaption>;
 
@@ -198,8 +229,49 @@ export const clipTransform = z.object({
 });
 export type ClipTransform = z.infer<typeof clipTransform>;
 
+/**
+ * Per-clip incoming transition. `easing` and `direction` are plain strings on
+ * the wire for the same forward compat `preset` has: a value this build cannot
+ * parse falls back rather than failing the document. Without the new members
+ * Zod strips the whole `transitionIn` of any non-crossfade transition on every
+ * PATCH, so the cut silently reverts to a hard one.
+ */
 export const clipTransition = z.discriminatedUnion("type", [
-  z.object({ type: z.literal("crossfade"), durationMs: z.number() })
+  z.object({
+    type: z.literal("crossfade"),
+    durationMs: z.number(),
+    easing: z.string().optional()
+  }),
+  z.object({
+    type: z.literal("dipToColor"),
+    durationMs: z.number(),
+    color: z.string(),
+    easing: z.string().optional()
+  }),
+  z.object({
+    type: z.literal("wipe"),
+    durationMs: z.number(),
+    direction: z.string(),
+    softness: z.number().optional(),
+    easing: z.string().optional()
+  }),
+  z.object({
+    type: z.literal("push"),
+    durationMs: z.number(),
+    direction: z.string(),
+    easing: z.string().optional()
+  }),
+  z.object({
+    type: z.literal("slide"),
+    durationMs: z.number(),
+    direction: z.string(),
+    easing: z.string().optional()
+  }),
+  z.object({
+    type: z.literal("zoom"),
+    durationMs: z.number(),
+    easing: z.string().optional()
+  })
 ]);
 export type ClipTransition = z.infer<typeof clipTransition>;
 
@@ -225,9 +297,104 @@ export const clipBlurEffect = z.object({
   sigma: z.number().optional()
 });
 
+/** One control point of a tone curve. Both axes are normalized 0..1. */
+export const curvePoint = z.object({ x: z.number(), y: z.number() });
+export type CurvePoint = z.infer<typeof curvePoint>;
+
+export const clipGlowEffect = z.object({
+  id: z.string(),
+  type: z.literal("glow"),
+  enabled: z.boolean(),
+  radius: z.number(),
+  intensity: z.number(),
+  color: z.string().optional()
+});
+
+export const clipDropShadowEffect = z.object({
+  id: z.string(),
+  type: z.literal("dropShadow"),
+  enabled: z.boolean(),
+  offsetX: z.number(),
+  offsetY: z.number(),
+  blur: z.number(),
+  color: z.string(),
+  opacity: z.number().optional()
+});
+
+export const clipVignetteEffect = z.object({
+  id: z.string(),
+  type: z.literal("vignette"),
+  enabled: z.boolean(),
+  amount: z.number(),
+  softness: z.number()
+});
+
+export const clipSharpenEffect = z.object({
+  id: z.string(),
+  type: z.literal("sharpen"),
+  enabled: z.boolean(),
+  amount: z.number(),
+  radius: z.number().optional()
+});
+
+export const clipChromaKeyEffect = z.object({
+  id: z.string(),
+  type: z.literal("chromaKey"),
+  enabled: z.boolean(),
+  color: z.string(),
+  tolerance: z.number(),
+  softness: z.number(),
+  spill: z.number().optional()
+});
+
+export const clipCurvesEffect = z.object({
+  id: z.string(),
+  type: z.literal("curves"),
+  enabled: z.boolean(),
+  master: z.array(curvePoint),
+  r: z.array(curvePoint).optional(),
+  g: z.array(curvePoint).optional(),
+  b: z.array(curvePoint).optional()
+});
+
+export const clipLevelsEffect = z.object({
+  id: z.string(),
+  type: z.literal("levels"),
+  enabled: z.boolean(),
+  inBlack: z.number(),
+  inWhite: z.number(),
+  gamma: z.number(),
+  outBlack: z.number(),
+  outWhite: z.number()
+});
+
+const rgbTriple = z.tuple([z.number(), z.number(), z.number()]);
+
+export const clipLiftGammaGainEffect = z.object({
+  id: z.string(),
+  type: z.literal("liftGammaGain"),
+  enabled: z.boolean(),
+  lift: rgbTriple,
+  gamma: rgbTriple,
+  gain: rgbTriple
+});
+
+/**
+ * The clip effect chain. Without the members below Zod drops any effect whose
+ * type it does not carry on every PATCH, so a graded clip loses that step of
+ * its chain on the next save.
+ */
 export const clipEffect = z.discriminatedUnion("type", [
   clipColorEffect,
-  clipBlurEffect
+  clipBlurEffect,
+  clipGlowEffect,
+  clipDropShadowEffect,
+  clipVignetteEffect,
+  clipSharpenEffect,
+  clipChromaKeyEffect,
+  clipCurvesEffect,
+  clipLevelsEffect,
+  clipLiftGammaGainEffect
 ]);
 export type ClipEffect = z.infer<typeof clipEffect>;
 
@@ -373,6 +540,24 @@ export const clipAnimation = z.object({
 });
 export type ClipAnimation = z.infer<typeof clipAnimation>;
 
+/**
+ * How a shape or a text run is filled. Stop offsets are normalized 0..1, so a
+ * fill is independent of the shape's size.
+ */
+export const shapeFill = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("solid"), color: z.string() }),
+  z.object({
+    type: z.literal("linear"),
+    angle: z.number(),
+    stops: z.array(z.object({ offset: z.number(), color: z.string() }))
+  }),
+  z.object({
+    type: z.literal("radial"),
+    stops: z.array(z.object({ offset: z.number(), color: z.string() }))
+  })
+]);
+export type ShapeFill = z.infer<typeof shapeFill>;
+
 export const clipTextStyle = z.object({
   text: z.string(),
   fontFamily: z.string().optional(),
@@ -380,12 +565,39 @@ export const clipTextStyle = z.object({
   fontWeight: z.number().optional(),
   color: z.string(),
   align: z.enum(["left", "center", "right"]).optional(),
-  maxWidthFrac: z.number().optional()
+  maxWidthFrac: z.number().optional(),
+  /** Every field below is styling the rasterizer reads. Without them Zod
+   * strips the styling on every PATCH, so a stroked, shadowed or backed title
+   * reverts to plain fill on the next save. */
+  fontStyle: z.string().optional(),
+  letterSpacingPx: z.number().optional(),
+  lineHeight: z.number().optional(),
+  verticalAlign: z.string().optional(),
+  stroke: z.object({ color: z.string(), widthPx: z.number() }).optional(),
+  shadow: z
+    .object({
+      color: z.string(),
+      blurPx: z.number(),
+      offsetX: z.number(),
+      offsetY: z.number()
+    })
+    .optional(),
+  background: z
+    .object({
+      color: z.string(),
+      paddingPx: z.number(),
+      radiusPx: z.number().optional()
+    })
+    .optional(),
+  fill: shapeFill.optional()
 });
 export type ClipTextStyle = z.infer<typeof clipTextStyle>;
 
 export const clipShapeStyle = z.object({
-  kind: z.enum(["rect", "ellipse", "line"]),
+  /** Widened past `rect | ellipse | line` for the path renderer. A narrower
+   * enum here would fail the whole document on a path shape rather than
+   * carrying it. */
+  kind: z.enum(["rect", "ellipse", "line", "path", "polygon", "star"]),
   fill: z.string().optional(),
   stroke: z.string().optional(),
   strokeWidthPx: z.number().optional(),
@@ -394,9 +606,62 @@ export const clipShapeStyle = z.object({
   width: z.number().optional(),
   height: z.number().optional(),
   x2: z.number().optional(),
-  y2: z.number().optional()
+  y2: z.number().optional(),
+  /** Every field below is authored geometry. Without them Zod strips the
+   * geometry on every PATCH, so a path, gradient, dash or trim reverts to a
+   * plain filled box on the next save. */
+  d: z.string().optional(),
+  sides: z.number().optional(),
+  innerRadius: z.number().optional(),
+  cornerRadius: z.number().optional(),
+  fillStyle: shapeFill.optional(),
+  dash: z.array(z.number()).optional(),
+  lineCap: z.string().optional(),
+  lineJoin: z.string().optional(),
+  trimStart: z.number().optional(),
+  trimEnd: z.number().optional()
 });
 export type ClipShapeStyle = z.infer<typeof clipShapeStyle>;
+
+/**
+ * Shape mask on one clip, in the layer's own normalized 0..1 space. `kind` is
+ * a plain string for forward compat: an unknown kind parses and is skipped at
+ * render time rather than failing the document.
+ */
+export const clipMask = z.object({
+  kind: z.string(),
+  x: z.number().optional(),
+  y: z.number().optional(),
+  width: z.number().optional(),
+  height: z.number().optional(),
+  d: z.string().optional(),
+  featherPx: z.number().optional(),
+  invert: z.boolean().optional()
+});
+export type ClipMask = z.infer<typeof clipMask>;
+
+/** Track matte: another clip's alpha or luma drives this layer's alpha. */
+export const clipMatte = z.object({
+  sourceClipId: z.string(),
+  mode: z.string(),
+  invert: z.boolean().optional()
+});
+export type ClipMatte = z.infer<typeof clipMatte>;
+
+/**
+ * Retimes a clip's source. `t` is normalized 0..1 over the clip's window and
+ * must ascend; `sourceMs` may descend, which is reverse playback.
+ */
+export const clipTimeRemap = z.object({
+  keyframes: z.array(
+    z.object({
+      t: z.number(),
+      sourceMs: z.number(),
+      easing: z.string().optional()
+    })
+  )
+});
+export type ClipTimeRemap = z.infer<typeof clipTimeRemap>;
 
 export const timelineClip = z.object({
   id: z.string(),
@@ -406,7 +671,17 @@ export const timelineClip = z.object({
   durationMs: z.number(),
   inPointMs: z.number().optional(),
   outPointMs: z.number().optional(),
-  mediaType: z.enum(["image", "video", "audio", "overlay", "text", "shape"]),
+  /** `"group"` carries no media: it is a transform parent children name with
+   * `parentId`. Without it here Zod fails a document containing a group. */
+  mediaType: z.enum([
+    "image",
+    "video",
+    "audio",
+    "overlay",
+    "text",
+    "shape",
+    "group"
+  ]),
   sourceType: z.enum(["imported", "generated"]),
   bindingKind: clipBindingKind.optional(),
   workflowId: z.string().optional(),
@@ -480,7 +755,26 @@ export const timelineClip = z.object({
   paragraphId: z.string().optional(),
   /** Motion-design animations. Without this field Zod strips it on every
    * PATCH, so autosave erases animations. */
-  animations: z.array(clipAnimation).optional()
+  animations: z.array(clipAnimation).optional(),
+  /** Group this clip is parented to. Without this field Zod strips it on every
+   * PATCH, so autosave unparents every child of a group. */
+  parentId: z.string().optional(),
+  /** Shape mask. Without this field Zod strips it on every PATCH, so a masked
+   * layer reverts to its full rectangle on the next save. */
+  mask: clipMask.optional(),
+  /** Track matte. Without this field Zod strips it on every PATCH, so the
+   * matted layer reverts to opaque on the next save. */
+  matte: clipMatte.optional(),
+  /** Time remap. Without this field Zod strips it on every PATCH, so a
+   * retimed or reversed clip plays back at its plain rate after one save. */
+  timeRemap: clipTimeRemap.optional(),
+  /** Composition provenance stamped by `insert_composition`. Without these
+   * fields Zod strips them on every PATCH, so an instantiated composition
+   * loses the link to its template and its parameter values. */
+  compositionId: z.string().optional(),
+  compositionParams: z
+    .record(z.string(), z.union([z.number(), z.string(), z.boolean()]))
+    .optional()
 });
 export type TimelineClip = z.infer<typeof timelineClip>;
 

--- a/packages/protocol/tests/timeline-motion-schema.test.ts
+++ b/packages/protocol/tests/timeline-motion-schema.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Contract tests for the motion-graphics fields on the timeline schema
+ * (`docs/plans/motion-graphics.md` § Document model).
+ *
+ * Two halves. The runtime half parses a clip carrying each new field and
+ * asserts the parse hands it back — the Zod object strips what it does not
+ * declare, so a missing field here is data loss on the next autosave, not an
+ * error. The type half pins the shape `z.infer<typeof timelineClip>` produces
+ * against the interface `packages/timeline/src/types.ts` declares, in both
+ * directions, so a field that exists on one side only fails to compile.
+ *
+ * `packages/timeline` depends on this package, not the other way round, so the
+ * mirror below is written out rather than imported; the check against the real
+ * `TimelineClip` runs in `packages/execution/tests/timeline-schema-roundtrip.test.ts`.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  timelineClip,
+  type TimelineClip,
+  type ClipEffect,
+  type ClipTransition,
+  type ShapeFill
+} from "../src/api-schemas/timeline.js";
+
+const baseClip = {
+  id: "c1",
+  trackId: "t1",
+  name: "Clip",
+  startMs: 0,
+  durationMs: 1000,
+  mediaType: "video" as const,
+  sourceType: "imported" as const,
+  status: "generated" as const,
+  locked: false,
+  versions: []
+};
+
+// ── Type mirror ──────────────────────────────────────────────────────────────
+
+type Extends<A, B> = A extends B ? true : false;
+/** `true` only when each side is assignable to the other. */
+type MutuallyAssignable<A, B> = Extends<A, B> & Extends<B, A>;
+
+/** The motion-graphics half of `TimelineClip` as `types.ts` declares it. */
+interface MotionClipFields {
+  mediaType:
+    | "image"
+    | "video"
+    | "audio"
+    | "overlay"
+    | "text"
+    | "shape"
+    | "group";
+  parentId?: string;
+  mask?: {
+    kind: string;
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+    d?: string;
+    featherPx?: number;
+    invert?: boolean;
+  };
+  matte?: { sourceClipId: string; mode: string; invert?: boolean };
+  timeRemap?: {
+    keyframes: { t: number; sourceMs: number; easing?: string }[];
+  };
+  compositionId?: string;
+  compositionParams?: Record<string, number | string | boolean>;
+}
+
+const motionFieldMirror: MutuallyAssignable<
+  Pick<TimelineClip, keyof MotionClipFields>,
+  MotionClipFields
+> = true;
+
+type MotionShapeFill =
+  | { type: "solid"; color: string }
+  | {
+      type: "linear";
+      angle: number;
+      stops: { offset: number; color: string }[];
+    }
+  | { type: "radial"; stops: { offset: number; color: string }[] };
+
+const shapeFillMirror: MutuallyAssignable<ShapeFill, MotionShapeFill> = true;
+
+/** Every transition type the design names, and no other. */
+const transitionTypeMirror: MutuallyAssignable<
+  ClipTransition["type"],
+  "crossfade" | "dipToColor" | "wipe" | "push" | "slide" | "zoom"
+> = true;
+
+/** Every clip effect type the design names, and no other. */
+const effectTypeMirror: MutuallyAssignable<
+  ClipEffect["type"],
+  | "color"
+  | "blur"
+  | "glow"
+  | "dropShadow"
+  | "vignette"
+  | "sharpen"
+  | "chromaKey"
+  | "curves"
+  | "levels"
+  | "liftGammaGain"
+> = true;
+
+describe("timelineClip — motion-graphics field types", () => {
+  it("mirrors the TypeScript declaration in both directions", () => {
+    // Each constant is typed `true & true` only while both directions hold, so
+    // this file stops compiling when the two sides drift. Asserting them keeps
+    // a reader from deleting them as unused.
+    expect([
+      motionFieldMirror,
+      shapeFillMirror,
+      transitionTypeMirror,
+      effectTypeMirror
+    ]).toEqual([true, true, true, true]);
+  });
+});
+
+describe("timelineClip — motion-graphics round trips", () => {
+  it("accepts a group clip", () => {
+    const parsed = timelineClip.parse({ ...baseClip, mediaType: "group" });
+    expect(parsed.mediaType).toBe("group");
+  });
+
+  it("preserves parenting, mask, matte, remap and composition provenance", () => {
+    const clip = {
+      ...baseClip,
+      parentId: "group-1",
+      mask: {
+        kind: "ellipse",
+        x: 0.1,
+        y: 0.1,
+        width: 0.8,
+        height: 0.8,
+        d: "M0 0 L1 1 Z",
+        featherPx: 8,
+        invert: true
+      },
+      matte: { sourceClipId: "src-1", mode: "alpha", invert: false },
+      timeRemap: {
+        keyframes: [
+          { t: 0, sourceMs: 0 },
+          { t: 1, sourceMs: 2000, easing: "spring(180,12,1)" }
+        ]
+      },
+      compositionId: "comp-1",
+      compositionParams: { title: "Ada", lines: 2, boxed: true }
+    };
+    expect(timelineClip.parse(clip)).toEqual(clip);
+  });
+
+  it("preserves every transition type", () => {
+    const transitions: ClipTransition[] = [
+      { type: "crossfade", durationMs: 300, easing: "easeInOut" },
+      { type: "dipToColor", durationMs: 300, color: "#000000" },
+      { type: "wipe", durationMs: 300, direction: "left", softness: 0.2 },
+      { type: "push", durationMs: 300, direction: "up" },
+      { type: "slide", durationMs: 300, direction: "right" },
+      { type: "zoom", durationMs: 300, easing: "easeOutBack" }
+    ];
+    for (const transitionIn of transitions) {
+      const parsed = timelineClip.parse({ ...baseClip, transitionIn });
+      expect(parsed.transitionIn).toEqual(transitionIn);
+    }
+  });
+
+  it("preserves every new clip effect", () => {
+    const effects: ClipEffect[] = [
+      { id: "e1", type: "glow", enabled: true, radius: 8, intensity: 0.5, color: "#fff" },
+      {
+        id: "e2",
+        type: "dropShadow",
+        enabled: true,
+        offsetX: 4,
+        offsetY: 4,
+        blur: 6,
+        color: "#000",
+        opacity: 0.5
+      },
+      { id: "e3", type: "vignette", enabled: true, amount: 0.3, softness: 0.5 },
+      { id: "e4", type: "sharpen", enabled: true, amount: 0.4, radius: 2 },
+      {
+        id: "e5",
+        type: "chromaKey",
+        enabled: true,
+        color: "#00ff00",
+        tolerance: 0.2,
+        softness: 0.1,
+        spill: 0.4
+      },
+      {
+        id: "e6",
+        type: "curves",
+        enabled: true,
+        master: [
+          { x: 0, y: 0 },
+          { x: 1, y: 1 }
+        ],
+        r: [{ x: 0.5, y: 0.6 }]
+      },
+      {
+        id: "e7",
+        type: "levels",
+        enabled: true,
+        inBlack: 0.05,
+        inWhite: 0.95,
+        gamma: 1.1,
+        outBlack: 0,
+        outWhite: 1
+      },
+      {
+        id: "e8",
+        type: "liftGammaGain",
+        enabled: true,
+        lift: [0, 0, 0],
+        gamma: [1, 1, 1],
+        gain: [1, 1, 1]
+      }
+    ];
+    const parsed = timelineClip.parse({ ...baseClip, effects });
+    expect(parsed.effects).toEqual(effects);
+  });
+
+  it("preserves the text style additions", () => {
+    const textStyle = {
+      text: "Title",
+      fontSizePx: 96,
+      color: "#ffffff",
+      fontStyle: "italic",
+      letterSpacingPx: 2,
+      lineHeight: 1.3,
+      verticalAlign: "bottom",
+      stroke: { color: "#000000", widthPx: 3 },
+      shadow: { color: "#000000", blurPx: 6, offsetX: 2, offsetY: 2 },
+      background: { color: "#000000", paddingPx: 12, radiusPx: 4 },
+      fill: {
+        type: "linear" as const,
+        angle: 90,
+        stops: [
+          { offset: 0, color: "#fff" },
+          { offset: 1, color: "#000" }
+        ]
+      }
+    };
+    const parsed = timelineClip.parse({
+      ...baseClip,
+      mediaType: "text" as const,
+      textStyle
+    });
+    expect(parsed.textStyle).toEqual(textStyle);
+  });
+
+  it("preserves the shape style additions", () => {
+    const shapeStyle = {
+      kind: "star" as const,
+      d: "M0 0 L1 1 Z",
+      sides: 5,
+      innerRadius: 0.5,
+      cornerRadius: 0.02,
+      fillStyle: {
+        type: "radial" as const,
+        stops: [
+          { offset: 0, color: "#fff" },
+          { offset: 1, color: "#000" }
+        ]
+      },
+      dash: [0.02, 0.01],
+      lineCap: "round",
+      lineJoin: "miter",
+      trimStart: 0.2,
+      trimEnd: 0.9
+    };
+    const parsed = timelineClip.parse({
+      ...baseClip,
+      mediaType: "shape" as const,
+      shapeStyle
+    });
+    expect(parsed.shapeStyle).toEqual(shapeStyle);
+  });
+
+  it("preserves caption word classification and caption style (F16)", () => {
+    const caption = {
+      words: [
+        { word: "um", startMs: 0, endMs: 120, kind: "filler" as const, confidence: 0.3 },
+        { word: "go", startMs: 120, endMs: 400, kind: "word" as const, confidence: 0.99 }
+      ],
+      style: {
+        fontFamily: "Inter",
+        fontSizeFrac: 0.06,
+        color: "#ffffff",
+        activeColor: "#ffd60a",
+        outline: { color: "#000000", widthPx: 2 },
+        bottomMarginFrac: 0.05,
+        background: { color: "#000000", paddingPx: 10, radiusPx: 4 }
+      }
+    };
+    const parsed = timelineClip.parse({ ...baseClip, caption });
+    expect(parsed.caption).toEqual(caption);
+  });
+});

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -1627,9 +1627,19 @@ export class ProcessingContext {
    * its context. Six hosts assembled these by hand and three of them forgot
    * `createAsset`, so the same workflow saved an image under `workflows run`
    * and died under `debug` with "model interface is not configured".
+   *
+   * The two compose key by key, the context's own winning, so wiring one
+   * interface does not uninstall the rest of the floor.
    */
   private modelInterfaces(): ProcessingContextModelInterfaces | null {
-    return this._modelInterfaces ?? getDefaultModelInterfaces();
+    const own = this._modelInterfaces;
+    const floor = getDefaultModelInterfaces();
+    if (!own) return floor;
+    if (!floor) return own;
+    // Per key, not per object: a host that wires two interfaces of its own
+    // keeps the other twelve. Replacing wholesale is how the HTTP run route
+    // lost `getTimelineSequence` while setting only the asset pair.
+    return { ...floor, ...own };
   }
 
   /**

--- a/packages/runtime/tests/default-model-interfaces.test.ts
+++ b/packages/runtime/tests/default-model-interfaces.test.ts
@@ -51,6 +51,37 @@ describe("setDefaultModelInterfaces", () => {
     ).resolves.toEqual({ id: "own" });
   });
 
+  it("keeps the interfaces a context did not wire itself", async () => {
+    const getTimelineSequence = vi.fn(async () => null);
+    setDefaultModelInterfaces({
+      createAsset: async () => ({ id: "default" }),
+      getTimelineSequence
+    });
+
+    // The HTTP run route wires the asset pair and nothing else. Replacing the
+    // floor wholesale uninstalled `getTimelineSequence`, so RenderTimeline
+    // threw "model interface is not configured" over HTTP while running fine
+    // from the editor.
+    const context = new ProcessingContext({ jobId: "j4", userId: "u1" });
+    context.setModelInterfaces({ createAsset: async () => ({ id: "own" }) });
+
+    expect(context.hasModelInterface("getTimelineSequence")).toBe(true);
+    await expect(
+      context.getTimelineSequence("t1")
+    ).resolves.toBeNull();
+    expect(getTimelineSequence).toHaveBeenCalledWith({
+      userId: "u1",
+      id: "t1"
+    });
+    await expect(
+      context.createAsset({
+        name: "out.png",
+        contentType: "image/png",
+        content: bytes
+      })
+    ).resolves.toEqual({ id: "own" });
+  });
+
   it("leaves a host that installed nothing exactly as it was", async () => {
     const context = new ProcessingContext({ jobId: "j3", userId: "u1" });
     expect(context.hasModelInterface("createAsset")).toBe(false);

--- a/packages/timeline/src/animation/types.ts
+++ b/packages/timeline/src/animation/types.ts
@@ -146,17 +146,77 @@ export type AnimationPresetId =
  * - `blur` — added to the layer's blur radius, in source px (identity 0)
  * - `brightness` — added to the grade shader's brightness term, -1..1 (identity 0)
  * - `saturation` — multiplies the grade shader's saturation, 0..4 (identity 1)
+ * - `contrast` — multiplies the grade shader's contrast, 0..4 (identity 1)
+ * - `hue` — added to the grade shader's hue rotation, degrees (identity 0)
+ * - `temperature` — added to the grade's cool→warm term, -1..1 (identity 0)
+ * - `tint` — added to the grade's green→magenta term, -1..1 (identity 0)
+ *
+ * Four channels set an absolute value rather than composing with the clip's:
+ *
+ * - `positionX` / `positionY` — replace `transform.position`, canvas px
+ * - `anchorX` / `anchorY` — replace `transform.anchor`, normalized 0..1
+ * - `trimStart` / `trimEnd` — replace the shape's stroked sub-range, 0..1
  */
 export const ANIMATED_PROPERTIES = [
   "offsetX",
   "offsetY",
   "scale",
+  "scaleX",
+  "scaleY",
   "rotation",
   "opacity",
   "wipeProgress",
   "blur",
   "brightness",
-  "saturation"
+  "saturation",
+  "contrast",
+  "hue",
+  "temperature",
+  "tint",
+  "positionX",
+  "positionY",
+  "anchorX",
+  "anchorY",
+  "trimStart",
+  "trimEnd"
 ] as const;
 
 export type AnimatedProperty = (typeof ANIMATED_PROPERTIES)[number];
+
+/**
+ * How several animations driving one channel combine. The sampler folds by
+ * this table rather than by a switch, so a new channel declares its fold here
+ * and nowhere else (I3).
+ *
+ * - `add` — offsets and additive grade terms sum
+ * - `multiply` — scale, opacity and multiplicative grade terms multiply
+ * - `min` — overlapping wipes keep the smaller progress: more hidden wins
+ * - `replace` — the last enabled animation in document order wins; the
+ *   validator warns when two replace curves overlap in time
+ */
+export const ANIMATED_PROPERTY_FOLD: Record<
+  AnimatedProperty,
+  "add" | "multiply" | "replace" | "min"
+> = {
+  offsetX: "add",
+  offsetY: "add",
+  scale: "multiply",
+  scaleX: "multiply",
+  scaleY: "multiply",
+  rotation: "add",
+  opacity: "multiply",
+  wipeProgress: "min",
+  blur: "add",
+  brightness: "add",
+  saturation: "multiply",
+  contrast: "multiply",
+  hue: "add",
+  temperature: "add",
+  tint: "add",
+  positionX: "replace",
+  positionY: "replace",
+  anchorX: "replace",
+  anchorY: "replace",
+  trimStart: "replace",
+  trimEnd: "replace"
+};

--- a/packages/timeline/src/render/sceneModel.ts
+++ b/packages/timeline/src/render/sceneModel.ts
@@ -224,12 +224,28 @@ export interface ComputeActiveLayersOptions {
   maxVideoLayers?: number;
 }
 
+/** Why a clip that was active at the query time contributed no layer. */
+export type DroppedLayerReason = "video_layer_cap";
+
+/** A clip the scene model resolved and then left out of the composite. */
+export interface DroppedLayer {
+  clipId: string;
+  reason: DroppedLayerReason;
+}
+
 /**
  * Result of {@link computeActiveLayersWithHorizon}: the resolved layers plus
  * the change horizon (see that function for what the horizon means).
  */
 export interface ActiveLayersResult {
   layers: ActiveLayer[];
+  /**
+   * Clips active at the query time that the scene model refused to draw. The
+   * layer cap used to discard them with a bare `continue`, so a frame quietly
+   * lost a layer and no host could say which one. Every caller that reports
+   * what it drew reports these beside it.
+   */
+  droppedLayers: DroppedLayer[];
   /**
    * The minimum time (ms), strictly greater than the query `currentTimeMs`,
    * at which the resolved layer set OR any layer's active caption word could
@@ -260,7 +276,9 @@ export interface ActiveLayersResult {
  *
  * Video layers are capped to keep parity with the live preview's video pool;
  * the cap is applied in composite order (top tracks win, matching the preview
- * which fills slots while iterating top-to-bottom).
+ * which fills slots while iterating top-to-bottom). Each clip the cap turns
+ * away is named in `droppedLayers` so a host can say what is missing from the
+ * frame instead of showing a picture that quietly lost a layer.
  */
 export function computeActiveLayersWithHorizon(
   tracks: TimelineTrack[],
@@ -280,6 +298,7 @@ export function computeActiveLayersWithHorizon(
 
   const mediaLayers: ActiveLayer[] = [];
   const captionLayers: ActiveLayer[] = [];
+  const droppedLayers: DroppedLayer[] = [];
   let videoCount = 0;
 
   // Change horizon: the smallest upcoming time at which `isClipActive`,
@@ -411,7 +430,13 @@ export function computeActiveLayersWithHorizon(
       } else {
         // video | overlay
         if (common.assetId) {
-          if (videoCount >= maxVideoLayers) continue;
+          if (videoCount >= maxVideoLayers) {
+            droppedLayers.push({
+              clipId: clip.id,
+              reason: "video_layer_cap"
+            });
+            continue;
+          }
           videoCount += 1;
         }
         mediaLayers.push({ kind: "video", ...common });
@@ -419,7 +444,11 @@ export function computeActiveLayersWithHorizon(
     }
   }
 
-  return { layers: [...mediaLayers, ...captionLayers], nextChangeMs };
+  return {
+    layers: [...mediaLayers, ...captionLayers],
+    droppedLayers,
+    nextChangeMs
+  };
 }
 
 /**

--- a/packages/timeline/src/types.ts
+++ b/packages/timeline/src/types.ts
@@ -85,6 +85,27 @@ export interface CaptionWord {
  */
 export interface ClipCaption {
   words: CaptionWord[];
+  /** Look of the caption layer. Absent means the built-in default style. */
+  style?: CaptionStyle;
+}
+
+/**
+ * Authored look of a caption layer. Every field is optional: an absent one
+ * keeps the drawing default, so a caption written before styling existed
+ * renders exactly as it did.
+ */
+export interface CaptionStyle {
+  fontFamily?: string;
+  /** Font size as a fraction of frame height. */
+  fontSizeFrac?: number;
+  /** Colour of inactive words. */
+  color?: string;
+  /** Colour of the word being spoken. */
+  activeColor?: string;
+  outline?: { color: string; widthPx: number };
+  /** Distance from the frame bottom as a fraction of frame height. */
+  bottomMarginFrac?: number;
+  background?: { color: string; paddingPx: number; radiusPx?: number };
 }
 
 /**
@@ -99,11 +120,53 @@ export interface ClipTextStyle {
   color: string;
   align?: "left" | "center" | "right";
   maxWidthFrac?: number;
+  /** `"normal"` (default) or `"italic"`. A plain string for forward compat. */
+  fontStyle?: string;
+  /** Extra advance between glyphs, in sequence px. Default 0. */
+  letterSpacingPx?: number;
+  /** Line advance as a multiple of the font size. Default 1.2. */
+  lineHeight?: number;
+  /** `"top" | "middle" | "bottom"`. Default `"middle"`. */
+  verticalAlign?: string;
+  /** Outline drawn under the fill. */
+  stroke?: { color: string; widthPx: number };
+  shadow?: { color: string; blurPx: number; offsetX: number; offsetY: number };
+  /** Scrim drawn behind the wrapped block. */
+  background?: { color: string; paddingPx: number; radiusPx?: number };
+  /** Gradient fill. Wins over `color` when set. */
+  fill?: ShapeFill;
 }
+
+/**
+ * How a shape or a text run is filled. `solid` is the same thing a plain
+ * colour string says; the gradients carry their stops in normalized 0..1
+ * offsets so a fill is independent of the shape's size.
+ */
+export type ShapeFill =
+  | { type: "solid"; color: string }
+  | {
+      type: "linear";
+      /** Gradient axis in degrees, 0 = left→right. */
+      angle: number;
+      stops: { offset: number; color: string }[];
+    }
+  | { type: "radial"; stops: { offset: number; color: string }[] };
+
+/**
+ * Every geometry a shape clip can draw. `rect`, `ellipse` and `line` are
+ * rasterized today; the rest are drawn by the path renderer.
+ */
+export type ClipShapeKind =
+  | "rect"
+  | "ellipse"
+  | "line"
+  | "path"
+  | "polygon"
+  | "star";
 
 /** Authored vector-like geometry drawn by a rasterized shape clip. */
 export interface ClipShapeStyle {
-  kind: "rect" | "ellipse" | "line";
+  kind: ClipShapeKind;
   fill?: string;
   stroke?: string;
   strokeWidthPx?: number;
@@ -114,6 +177,25 @@ export interface ClipShapeStyle {
   height?: number;
   x2?: number;
   y2?: number;
+  /** SVG path data in normalized 0..1 space. `kind: "path"` only. */
+  d?: string;
+  /** Point count for `polygon` and `star`. */
+  sides?: number;
+  /** Inner radius as a fraction of the outer radius. `star` only. */
+  innerRadius?: number;
+  /** Corner rounding in normalized units. */
+  cornerRadius?: number;
+  /** Gradient or solid fill. Wins over `fill` when set. */
+  fillStyle?: ShapeFill;
+  /** Dash pattern in normalized units, as `ctx.setLineDash` takes it. */
+  dash?: number[];
+  /** `"butt" | "round" | "square"`. */
+  lineCap?: string;
+  /** `"miter" | "round" | "bevel"`. */
+  lineJoin?: string;
+  /** Stroke the sub-range `[trimStart, trimEnd]` of the path, 0..1. Animatable. */
+  trimStart?: number;
+  trimEnd?: number;
 }
 
 /**
@@ -323,6 +405,19 @@ export type ClipBindingKind =
   | "text-to-video"
   | "text-to-audio";
 
+/**
+ * What a clip draws. `"group"` carries no media: it is a transform parent its
+ * children name with `parentId` (see {@link TimelineClip.parentId}).
+ */
+export type ClipMediaType =
+  | "image"
+  | "video"
+  | "audio"
+  | "overlay"
+  | "text"
+  | "shape"
+  | "group";
+
 export interface TimelineClip {
   id: string;
   trackId: string;
@@ -331,7 +426,7 @@ export interface TimelineClip {
   durationMs: number;
   inPointMs?: number;
   outPointMs?: number;
-  mediaType: "image" | "video" | "audio" | "overlay" | "text" | "shape";
+  mediaType: ClipMediaType;
   sourceType: "imported" | "generated";
   /** Defaults to "workflow" when absent on legacy persisted data. */
   bindingKind?: ClipBindingKind;
@@ -446,19 +541,125 @@ export interface TimelineClip {
    * only. Must also exist on the protocol zod schema or PATCH would strip it.
    */
   animations?: ClipAnimation[];
+  /**
+   * Group this clip belongs to. The parent's transform composes with this
+   * clip's, its opacity multiplies, and its window clips this one. Must name a
+   * clip with `mediaType: "group"`; a missing or cyclic parent is a validator
+   * error and renders unparented.
+   */
+  parentId?: string;
+  /** Shape mask applied to this layer before it is blended. */
+  mask?: ClipMask;
+  /** Track matte: another clip's alpha or luma drives this layer's alpha. */
+  matte?: ClipMatte;
+  /** Retime the clip's source. Replaces `speedMultiplier` when set. */
+  timeRemap?: ClipTimeRemap;
+  /** Composition provenance, stamped by `insert_composition`. */
+  compositionId?: string;
+  /** Parameter values the composition was instantiated with. */
+  compositionParams?: Record<string, number | string | boolean>;
 }
 
 /**
- * Per-clip incoming transition. Only `crossfade` is implemented today; the
- * union is open for future types (`fade`, `wipe`, etc.) without a schema
- * break.
+ * A shape mask on one clip, in the layer's own normalized 0..1 space so it
+ * rotates and scales with the layer. `kind` is a plain string for the same
+ * forward compat `preset` has: an unknown kind parses and is skipped.
  */
-export type ClipTransition = ClipCrossfadeTransition;
+export interface ClipMask {
+  /** `"rect" | "ellipse" | "path"`. */
+  kind: string;
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  /** SVG path data in normalized 0..1 space. `kind: "path"` only. */
+  d?: string;
+  /** Feathered edge width in source px. 0 = hard edge. */
+  featherPx?: number;
+  /** Keep what the mask excludes instead of what it covers. */
+  invert?: boolean;
+}
+
+/**
+ * Track matte: `sourceClipId` names the clip whose pixels drive this layer's
+ * alpha. A matte source never draws itself.
+ */
+export interface ClipMatte {
+  sourceClipId: string;
+  /** `"alpha" | "luma"`. */
+  mode: string;
+  invert?: boolean;
+}
+
+/**
+ * Retimes a clip's source. `t` is normalized 0..1 over the clip's own window
+ * and must ascend; `sourceMs` may descend, which is reverse playback. A clip
+ * carrying a remap cannot be split or trimmed until it is baked.
+ */
+export interface ClipTimeRemap {
+  keyframes: { t: number; sourceMs: number; easing?: string }[];
+}
+
+/**
+ * Per-clip incoming transition, resolved for both the incoming clip and the
+ * outgoing clip it overlaps on the same track. `easing` takes the same string
+ * grammar animations take; an unparseable one falls back to linear.
+ */
+export type ClipTransition =
+  | ClipCrossfadeTransition
+  | ClipDipToColorTransition
+  | ClipWipeTransition
+  | ClipPushTransition
+  | ClipSlideTransition
+  | ClipZoomTransition;
 
 export interface ClipCrossfadeTransition {
   type: "crossfade";
   /** Length of the cross-fade in milliseconds. */
   durationMs: number;
+  easing?: string;
+}
+
+/** Both clips fade through a solid colour that peaks at the midpoint. */
+export interface ClipDipToColorTransition {
+  type: "dipToColor";
+  durationMs: number;
+  color: string;
+  easing?: string;
+}
+
+/** The incoming clip is revealed behind a feathered edge. */
+export interface ClipWipeTransition {
+  type: "wipe";
+  durationMs: number;
+  /** Edge the reveal starts from: `"left" | "right" | "up" | "down"`. */
+  direction: string;
+  /** Feathered edge width as a fraction of the wipe axis. 0 = hard edge. */
+  softness?: number;
+  easing?: string;
+}
+
+/** The incoming clip pushes the outgoing one off the frame. */
+export interface ClipPushTransition {
+  type: "push";
+  durationMs: number;
+  direction: string;
+  easing?: string;
+}
+
+/** The incoming clip slides in over a stationary outgoing one. */
+export interface ClipSlideTransition {
+  type: "slide";
+  durationMs: number;
+  direction: string;
+  easing?: string;
+}
+
+/** The outgoing clip scales up while the incoming one scales in. */
+export interface ClipZoomTransition {
+  type: "zoom";
+  durationMs: number;
+  easing?: string;
 }
 
 /**
@@ -475,7 +676,28 @@ export interface ClipTransform {
   anchor: { x: number; y: number };
 }
 
-export type ClipEffect = ClipColorEffect | ClipBlurEffect;
+/**
+ * Effects a clip applies in order. Every member carries `id` and `enabled`:
+ * the compositor filters the chain on `enabled` and pools intermediates per
+ * effect, so both are part of the union's shared shape.
+ */
+export type ClipEffect =
+  | ClipColorEffect
+  | ClipBlurEffect
+  | ClipGlowEffect
+  | ClipDropShadowEffect
+  | ClipVignetteEffect
+  | ClipSharpenEffect
+  | ClipChromaKeyEffect
+  | ClipCurvesEffect
+  | ClipLevelsEffect
+  | ClipLiftGammaGainEffect;
+
+/** One control point of a tone curve. Both axes are normalized 0..1. */
+export interface CurvePoint {
+  x: number;
+  y: number;
+}
 
 export interface ClipColorEffect {
   id: string;
@@ -507,6 +729,101 @@ export interface ClipBlurEffect {
   radius: number;
   /** Optional Gaussian sigma. Defaults to radius / 3. */
   sigma?: number;
+}
+
+export interface ClipGlowEffect {
+  id: string;
+  type: "glow";
+  enabled: boolean;
+  /** Bloom radius in source pixels. */
+  radius: number;
+  /** Bloom strength, 0..2 typical. */
+  intensity: number;
+  /** Tint of the bloom. Defaults to the source colour. */
+  color?: string;
+}
+
+export interface ClipDropShadowEffect {
+  id: string;
+  type: "dropShadow";
+  enabled: boolean;
+  /** Offset in source pixels. */
+  offsetX: number;
+  offsetY: number;
+  /** Shadow blur radius in source pixels. */
+  blur: number;
+  color: string;
+  /** 0..1, default 1. */
+  opacity?: number;
+}
+
+export interface ClipVignetteEffect {
+  id: string;
+  type: "vignette";
+  enabled: boolean;
+  /** 0..1. */
+  amount: number;
+  /** Falloff width, 0..1. */
+  softness: number;
+}
+
+export interface ClipSharpenEffect {
+  id: string;
+  type: "sharpen";
+  enabled: boolean;
+  /** 0..2 typical. */
+  amount: number;
+  /** Unsharp-mask radius in source pixels. */
+  radius?: number;
+}
+
+export interface ClipChromaKeyEffect {
+  id: string;
+  type: "chromaKey";
+  enabled: boolean;
+  /** Key colour as `#rrggbb`. */
+  color: string;
+  /** Match tolerance 0..1. */
+  tolerance: number;
+  /** Edge softness 0..1. */
+  softness: number;
+  /** Spill suppression 0..1. */
+  spill?: number;
+}
+
+export interface ClipCurvesEffect {
+  id: string;
+  type: "curves";
+  enabled: boolean;
+  /** Luminance curve applied to every channel. */
+  master: CurvePoint[];
+  r?: CurvePoint[];
+  g?: CurvePoint[];
+  b?: CurvePoint[];
+}
+
+export interface ClipLevelsEffect {
+  id: string;
+  type: "levels";
+  enabled: boolean;
+  /** Input black/white points, 0..1. */
+  inBlack: number;
+  inWhite: number;
+  /** Midtone gamma. 1 = unchanged. */
+  gamma: number;
+  /** Output black/white points, 0..1. */
+  outBlack: number;
+  outWhite: number;
+}
+
+export interface ClipLiftGammaGainEffect {
+  id: string;
+  type: "liftGammaGain";
+  enabled: boolean;
+  /** Per-channel RGB triples. */
+  lift: [number, number, number];
+  gamma: [number, number, number];
+  gain: [number, number, number];
 }
 
 export interface ClipVersion {

--- a/packages/timeline/tests/render.sceneModel.test.ts
+++ b/packages/timeline/tests/render.sceneModel.test.ts
@@ -5,12 +5,14 @@ import type { TimelineClip, TimelineTrack } from "../src/index.js";
 import {
   clipSourceTimeSec,
   computeActiveLayers,
+  computeActiveLayersWithHorizon,
   crossfadeOpacity,
   effectiveAssetId,
   isClipActive,
   resolveCaptionAtTime,
   trackZ,
-  LAYER_Z_BASE
+  LAYER_Z_BASE,
+  MAX_VIDEO_LAYERS
 } from "../src/render/sceneModel.js";
 
 const clip = (overrides: Partial<TimelineClip>): TimelineClip =>
@@ -181,6 +183,54 @@ describe("computeActiveLayers", () => {
       clip({ id: `c-${t.id}`, trackId: t.id, startMs: 0, durationMs: 1000 })
     );
     expect(computeActiveLayers(tracks, clips, 100, { maxVideoLayers: 8 })).toHaveLength(8);
+  });
+
+  it("names every clip the cap turned away (F17)", () => {
+    // Nine video clips, one per track, all live at 100ms. The default cap
+    // draws eight, so exactly one is dropped — the one on the bottom track,
+    // since the cap fills slots top-down.
+    const tracks = Array.from({ length: 9 }, (_, i) =>
+      track({ id: `t${i}`, index: i })
+    );
+    const clips = tracks.map((t) =>
+      clip({ id: `c-${t.id}`, trackId: t.id, startMs: 0, durationMs: 1000 })
+    );
+    const result = computeActiveLayersWithHorizon(tracks, clips, 100);
+    expect(result.layers).toHaveLength(MAX_VIDEO_LAYERS);
+    expect(result.droppedLayers).toEqual([
+      { clipId: "c-t8", reason: "video_layer_cap" }
+    ]);
+  });
+
+  it("reports nothing dropped when the layer set fits", () => {
+    const tracks = Array.from({ length: 8 }, (_, i) =>
+      track({ id: `t${i}`, index: i })
+    );
+    const clips = tracks.map((t) =>
+      clip({ id: `c-${t.id}`, trackId: t.id, startMs: 0, durationMs: 1000 })
+    );
+    expect(
+      computeActiveLayersWithHorizon(tracks, clips, 100).droppedLayers
+    ).toEqual([]);
+  });
+
+  it("does not report an over-cap clip that had no asset to draw anyway", () => {
+    // A draft clip resolves no assetId, so it never consumed a video slot and
+    // the cap is not what kept it off the screen.
+    const tracks = Array.from({ length: 10 }, (_, i) =>
+      track({ id: `t${i}`, index: i })
+    );
+    const clips = tracks.map((t, i) =>
+      clip({
+        id: `c-${t.id}`,
+        trackId: t.id,
+        startMs: 0,
+        durationMs: 1000,
+        status: i === 9 ? "draft" : "generated"
+      })
+    );
+    const { droppedLayers } = computeActiveLayersWithHorizon(tracks, clips, 100);
+    expect(droppedLayers.map((d) => d.clipId)).toEqual(["c-t8"]);
   });
 
   it("does not cap image layers", () => {

--- a/packages/video-nodes/src/nodes/timeline.ts
+++ b/packages/video-nodes/src/nodes/timeline.ts
@@ -10,10 +10,13 @@
  * visual track. ffmpeg decodes clip media into RGBA and encodes the result.
  *
  * Compositing needs a WebGPU device, which means the optional `webgpu` (Dawn)
- * package and a working driver — the desktop app ships both; the headless
- * server image today ships neither. Without one the node falls back to the
- * older ffmpeg rough cut — video/image clips normalized and concatenated in
- * start order — which ignores everything above and says so in the log.
+ * package and a working driver. Both profiles ship Dawn (D9,
+ * docs/plans/motion-graphics.md), and the Docker image installs lavapipe as its
+ * Vulkan driver, so a server render is composited too. A host that still has no
+ * adapter falls back to the older ffmpeg rough cut — video/image clips
+ * normalized and concatenated in start order — which ignores everything above.
+ * The fallback is a `warning` on the job and `metadata.render_mode` on the
+ * output says which path ran: "composited" or "rough_cut".
  */
 
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
@@ -551,6 +554,9 @@ async function mixAudioInto(opts: {
   return outPath;
 }
 
+/** Shortest gap between two `node_progress` posts — four a second. */
+const PROGRESS_INTERVAL_MS = 250;
+
 /** Output handles RenderTimelineNode.process() emits. */
 type RenderTimelineNodeOutputs = {
   output: VideoRef;
@@ -613,6 +619,7 @@ export class RenderTimelineNode extends BaseNode {
       let basePath: string;
       let baseHasAudio: boolean;
       let audioToMix: TimelineClip[];
+      let renderMode: "composited" | "rough_cut";
 
       try {
         basePath = path.join(workDir, "composited.mp4");
@@ -623,13 +630,18 @@ export class RenderTimelineNode extends BaseNode {
           fps,
           durationMs,
           resolveAssetPath: (assetId) => assets.path(assetId),
-          outPath: basePath
+          outPath: basePath,
+          onProgress: this.progressReporter(ctx),
+          signal: ctx.signal
         });
         for (const name of skippedClips) {
-          console.warn(
-            `RenderTimeline: clip "${name}" was skipped — its media could not be decoded`
+          this.log(
+            ctx,
+            `Clip "${name}" was skipped — its media could not be decoded`,
+            "warning"
           );
         }
+        renderMode = "composited";
         // A composite carries no sound: every audible clip is mixed in below,
         // including the audio muxed into video clips.
         baseHasAudio = false;
@@ -638,10 +650,11 @@ export class RenderTimelineNode extends BaseNode {
           : [];
       } catch (error) {
         if (!(error instanceof CompositorUnavailableError)) throw error;
-        console.warn(
-          `RenderTimeline: ${error.message} Falling back to a rough cut — ` +
-            "clip transforms, effects, transitions, captions and overlay " +
-            "tracks are not applied."
+        this.log(
+          ctx,
+          `${error.message} Falling back to a rough cut — clip transforms, ` +
+            "effects, transitions, captions and overlay tracks are not applied.",
+          "warning"
         );
         basePath = await renderRoughCut({
           seq,
@@ -653,6 +666,7 @@ export class RenderTimelineNode extends BaseNode {
           height,
           fps
         });
+        renderMode = "rough_cut";
         baseHasAudio = true;
         audioToMix = audioClips;
       }
@@ -673,12 +687,60 @@ export class RenderTimelineNode extends BaseNode {
       return {
         output: videoRef(rendered, {
           format: "mp4",
-          duration: duration > 0 ? duration : null
+          duration: duration > 0 ? duration : null,
+          // Which of the two paths produced these bytes. The docker smoke test
+          // asserts "composited": it is what proves the image renders the
+          // picture the editor previews rather than a concatenation.
+          metadata: { render_mode: renderMode }
         })
       };
     } finally {
       await fs.rm(workDir, { recursive: true, force: true });
     }
+  }
+
+  /** Post on the node's log channel, where the run has one. */
+  private log(
+    context: ProcessingContext,
+    content: string,
+    severity: "info" | "warning" | "error"
+  ): void {
+    if (!this.__node_id) return;
+    context.postMessage({
+      type: "log_update",
+      node_id: this.__node_id,
+      node_name: RenderTimelineNode.title,
+      content,
+      severity,
+      workflow_id: context.workflowId
+    });
+  }
+
+  /**
+   * A `node_progress` reporter for the frame loop, rate-limited to four posts a
+   * second. A minute of 1080p is thousands of frames and every post crosses the
+   * websocket; the final frame always posts, so the bar reaches its end.
+   */
+  private progressReporter(
+    context: ProcessingContext
+  ): (frame: number, totalFrames: number) => void {
+    const nodeId = this.__node_id;
+    let lastPostMs = 0;
+    return (frame, totalFrames) => {
+      if (!nodeId) return;
+      const now = Date.now();
+      if (frame < totalFrames && now - lastPostMs < PROGRESS_INTERVAL_MS) {
+        return;
+      }
+      lastPostMs = now;
+      context.postMessage({
+        type: "node_progress",
+        node_id: nodeId,
+        progress: frame,
+        total: totalFrames,
+        workflow_id: context.workflowId
+      });
+    };
   }
 }
 

--- a/packages/video-nodes/src/nodes/timeline/compositeRender.ts
+++ b/packages/video-nodes/src/nodes/timeline/compositeRender.ts
@@ -46,6 +46,11 @@ interface CompositeRenderOptions {
   /** Destination video file. */
   outPath: string;
   onProgress?: (frame: number, totalFrames: number) => void;
+  /**
+   * Run cancellation. Checked once per frame, so a cancelled render stops
+   * within one frame's work instead of encoding the whole timeline first.
+   */
+  signal?: AbortSignal;
 }
 
 interface CompositeRenderResult {
@@ -64,6 +69,11 @@ export class CompositorUnavailableError extends Error {
     this.name = "CompositorUnavailableError";
     this.cause = cause;
   }
+}
+
+/** The rejection a cancelled render throws, named the way callers test for. */
+function abortError(): Error {
+  return new DOMException("Timeline render cancelled", "AbortError");
 }
 
 async function acquireDevice(): Promise<GPUDevice> {
@@ -85,13 +95,14 @@ interface ClipVideoSource {
 export async function renderTimelineComposited(
   opts: CompositeRenderOptions
 ): Promise<CompositeRenderResult> {
-  const { sequence, fps, durationMs, resolveAssetPath, outPath } = opts;
+  const { sequence, fps, durationMs, resolveAssetPath, outPath, signal } = opts;
   // H.264 requires even dimensions.
   const width = Math.max(2, Math.floor(opts.width / 2) * 2);
   const height = Math.max(2, Math.floor(opts.height / 2) * 2);
   const totalFrames = Math.max(1, Math.round((durationMs / 1000) * fps));
   const canvas = { width, height };
 
+  if (signal?.aborted) throw abortError();
   const device = await acquireDevice();
   const compositor = new HeadlessFrameCompositor(device, width, height);
   const rasterizer = new NodeRasterizer(width, height);
@@ -153,6 +164,7 @@ export async function renderTimelineComposited(
 
   try {
     for (let frame = 0; frame < totalFrames; frame++) {
+      if (signal?.aborted) throw abortError();
       const timeMs = (frame * 1000) / fps;
 
       for (const [clipId, source] of videoSources) {

--- a/packages/video-nodes/tests/timeline-composite.test.ts
+++ b/packages/video-nodes/tests/timeline-composite.test.ts
@@ -117,19 +117,36 @@ function audioClip(overrides: Record<string, unknown> = {}) {
   };
 }
 
+let posted: Array<Record<string, unknown>> = [];
+
 function contextFor(seq: unknown) {
   return {
     getTimelineSequence: vi.fn().mockResolvedValue(seq),
     resolveAssetBytes: vi
       .fn()
-      .mockResolvedValue({ bytes: new Uint8Array([1, 2, 3]) })
+      .mockResolvedValue({ bytes: new Uint8Array([1, 2, 3]) }),
+    postMessage: (msg: Record<string, unknown>) => posted.push(msg),
+    workflowId: "wf-1",
+    signal: new AbortController().signal
   };
 }
 
 async function render(seq: unknown, props: Record<string, unknown> = {}) {
   const node = new RenderTimelineNode();
-  Object.assign(node, { timeline: { type: "timeline", id: "seq-1" }, ...props });
+  Object.assign(node, {
+    timeline: { type: "timeline", id: "seq-1" },
+    __node_id: "node-1",
+    ...props
+  });
   return node.process(contextFor(seq) as never);
+}
+
+/** Log lines the node posted, joined for substring assertions. */
+function logs(severity: string): string {
+  return posted
+    .filter((m) => m.type === "log_update" && m.severity === severity)
+    .map((m) => String(m.content))
+    .join(" ");
 }
 
 function ffmpegArgs(): string[] {
@@ -140,6 +157,7 @@ function ffmpegArgs(): string[] {
 
 beforeEach(() => {
   execFileCalls = [];
+  posted = [];
   renderComposited.mockReset();
   renderComposited.mockResolvedValue({ totalFrames: 120, skippedClips: [] });
 });
@@ -158,6 +176,47 @@ describe("RenderTimeline — composited path", () => {
     });
     // No segment-per-clip encode: the rough cut is not involved.
     expect(ffmpegArgs().some((a) => a.includes("-f concat"))).toBe(false);
+  });
+
+  it("reports which path produced the bytes", async () => {
+    const out = await render(sequence({ clips: [videoClip()] }));
+    expect(out.output.metadata).toEqual({ render_mode: "composited" });
+  });
+
+  it("passes the run's abort signal down to the frame loop", async () => {
+    await render(sequence({ clips: [videoClip()] }));
+    expect(renderComposited.mock.calls[0][0].signal).toBeInstanceOf(
+      AbortSignal
+    );
+  });
+
+  it("posts node_progress at most four times a second, last frame included", () => {
+    const node = new RenderTimelineNode();
+    Object.assign(node, { __node_id: "node-1" });
+    const context = contextFor(null);
+    const report = (
+      node as unknown as {
+        progressReporter: (
+          c: unknown
+        ) => (frame: number, total: number) => void;
+      }
+    ).progressReporter(context);
+
+    const now = vi.spyOn(Date, "now");
+    now.mockReturnValue(1_000);
+    report(1, 4);
+    now.mockReturnValue(1_100);
+    report(2, 4);
+    now.mockReturnValue(1_150);
+    report(3, 4);
+    now.mockReturnValue(1_160);
+    report(4, 4);
+    now.mockRestore();
+
+    const progress = posted.filter((m) => m.type === "node_progress");
+    // Frames 2 and 3 fall inside the 250 ms window; the final frame always posts.
+    expect(progress.map((m) => m.progress)).toEqual([1, 4]);
+    expect(progress[1]).toMatchObject({ node_id: "node-1", total: 4 });
   });
 
   it("renders a text-only timeline, which has no clip media at all", async () => {
@@ -221,22 +280,20 @@ describe("RenderTimeline — fallback when no GPU is available", () => {
     );
   });
 
-  it("falls back to the rough cut", async () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    await render(sequence({ clips: [videoClip()] }));
+  it("falls back to the rough cut and says so on the job log", async () => {
+    const out = await render(sequence({ clips: [videoClip()] }));
 
     expect(ffmpegArgs().some((a) => a.includes("-f concat"))).toBe(true);
-    expect(warn.mock.calls.flat().join(" ")).toMatch(/rough cut/);
-    warn.mockRestore();
+    expect(logs("warning")).toMatch(/rough cut/);
+    expect(logs("warning")).toMatch(/no adapter/);
+    expect(out.output.metadata).toEqual({ render_mode: "rough_cut" });
   });
 
   it("keeps the rough cut's own soundtrack in the mix", async () => {
-    vi.spyOn(console, "warn").mockImplementation(() => {});
     await render(sequence({ clips: [videoClip(), audioClip()] }));
 
     const mix = ffmpegArgs().find((a) => a.includes("amix"));
     expect(mix).toContain("[0:a]");
-    vi.restoreAllMocks();
   });
 
   it("surfaces a non-GPU failure instead of silently degrading", async () => {

--- a/packages/video-nodes/tests/timeline-render.test.ts
+++ b/packages/video-nodes/tests/timeline-render.test.ts
@@ -1,0 +1,171 @@
+/**
+ * `renderTimelineComposited` driving the real GPU compositor.
+ *
+ * `timeline-composite.test.ts` mocks this function to test the node around it;
+ * this one runs it. The fixture is a text clip over a solid shape, so nothing
+ * has to be decoded — the frames come from the rasterizer and the compositor,
+ * which is what needs a WebGPU device. The encoder is the one seam that is
+ * faked: it counts frames instead of spawning ffmpeg, because what is under
+ * test is the frame loop's progress reporting and cancellation, not muxing.
+ *
+ * A missing WebGPU adapter skips the suite and says why. On headless Linux that
+ * means no Vulkan ICD — see AGENTS.md § WebGPU on a headless machine, which
+ * installs lavapipe (CI does exactly that on the test-packages leg).
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { TimelineSequence } from "@nodetool-ai/timeline";
+
+/** Frames the fake encoder accepted, per render. */
+let framesWritten = 0;
+
+vi.mock("../src/nodes/timeline/rawFrames.js", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    openFrameEncoder: () => ({
+      write: async () => {
+        framesWritten++;
+      },
+      finish: async () => {},
+      abort: () => {}
+    })
+  };
+});
+
+const { renderTimelineComposited } = await import(
+  "../src/nodes/timeline/compositeRender.js"
+);
+
+/**
+ * Probed at module load, not in `beforeAll` — vitest decides `describe.runIf`
+ * while collecting, which is before any hook has run.
+ */
+const noAdapterReason = await (async (): Promise<string | null> => {
+  try {
+    const { getNodeGPUDevice } = await import("@nodetool-ai/gpu/node");
+    await getNodeGPUDevice();
+    return null;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    // Straight to stderr: this runs while vitest is collecting, where a
+    // console.* call is swallowed rather than reported.
+    process.stderr.write(
+      `timeline-render: skipping every case — no WebGPU device. ${reason}\n`
+    );
+    return reason;
+  }
+})();
+
+const FPS = 10;
+const DURATION_MS = 2000;
+/** 20 frames: enough that a mid-render abort lands well short of the end. */
+const TOTAL_FRAMES = (DURATION_MS / 1000) * FPS;
+
+/** A text clip over a solid shape — two layers, no media to decode. */
+function fixture(): TimelineSequence {
+  return {
+    id: "seq-render",
+    name: "Render fixture",
+    width: 320,
+    height: 180,
+    fps: FPS,
+    durationMs: DURATION_MS,
+    tracks: [
+      { id: "t-text", type: "overlay", index: 0, visible: true },
+      { id: "t-shape", type: "video", index: 1, visible: true }
+    ],
+    clips: [
+      {
+        id: "clip-text",
+        trackId: "t-text",
+        name: "Title",
+        startMs: 0,
+        durationMs: DURATION_MS,
+        mediaType: "text",
+        sourceType: "generated",
+        textStyle: { text: "Hello", fontSizePx: 32, color: "#ffffff" }
+      },
+      {
+        id: "clip-shape",
+        trackId: "t-shape",
+        name: "Card",
+        startMs: 0,
+        durationMs: DURATION_MS,
+        mediaType: "shape",
+        sourceType: "generated",
+        shapeStyle: {
+          kind: "rect",
+          fill: "#1e3a8a",
+          x: 0.1,
+          y: 0.1,
+          width: 0.8,
+          height: 0.8
+        }
+      }
+    ]
+  } as TimelineSequence;
+}
+
+function render(overrides: {
+  onProgress?: (frame: number, totalFrames: number) => void;
+  signal?: AbortSignal;
+}) {
+  return renderTimelineComposited({
+    sequence: fixture(),
+    width: 320,
+    height: 180,
+    fps: FPS,
+    durationMs: DURATION_MS,
+    resolveAssetPath: async () => null,
+    // Never opened: the encoder above is a counter, not ffmpeg.
+    outPath: "unused.mp4",
+    ...overrides
+  });
+}
+
+describe.runIf(!noAdapterReason)("renderTimelineComposited", () => {
+  it("reports every frame in order, ending at the total", async () => {
+    framesWritten = 0;
+    const progress: Array<[number, number]> = [];
+    const result = await render({
+      onProgress: (frame, total) => progress.push([frame, total])
+    });
+
+    expect(result.totalFrames).toBe(TOTAL_FRAMES);
+    expect(framesWritten).toBe(TOTAL_FRAMES);
+    expect(progress.map(([frame]) => frame)).toEqual(
+      Array.from({ length: TOTAL_FRAMES }, (_, i) => i + 1)
+    );
+    expect(progress.every(([, total]) => total === TOTAL_FRAMES)).toBe(true);
+  }, 120_000);
+
+  it("stops on an already-aborted signal before compositing a frame", async () => {
+    framesWritten = 0;
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(render({ signal: controller.signal })).rejects.toMatchObject({
+      name: "AbortError"
+    });
+    expect(framesWritten).toBe(0);
+  }, 120_000);
+
+  it("stops mid-render when the signal aborts, short of totalFrames", async () => {
+    framesWritten = 0;
+    const controller = new AbortController();
+    const progress: number[] = [];
+
+    await expect(
+      render({
+        signal: controller.signal,
+        onProgress: (frame) => {
+          progress.push(frame);
+          if (frame === 3) controller.abort();
+        }
+      })
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    expect(progress).toEqual([1, 2, 3]);
+    expect(framesWritten).toBeLessThan(TOTAL_FRAMES);
+  }, 120_000);
+});

--- a/scripts/bundle-backend.mjs
+++ b/scripts/bundle-backend.mjs
@@ -97,25 +97,18 @@ const PROFILE = OPTIONS.profile;
 // ---------------------------------------------------------------------------
 
 // Packages that MUST be found and copied — build fails if any are missing.
-const COMMON_REQUIRED_EXTERNAL_PACKAGES = [
+// webgpu (Dawn) is on this list for every profile: the server renders
+// timelines through the same GPU compositor the editor previews with, on
+// lavapipe in the container (D9, docs/plans/motion-graphics.md).
+const REQUIRED_EXTERNAL_PACKAGES = [
   "sharp",
   "better-sqlite3",
   "@jitl/quickjs-ng-wasmfile-release-sync",
   "mediabunny",
   "@mediabunny/server",
   "node-av",
+  "webgpu",
 ];
-// webgpu is required on desktop only: the GPU compositor needs the dawn.node
-// binary there, while the server profile does no local GPU compute (the gpu
-// package lazy-imports webgpu behind an install-hint error).
-const DESKTOP_REQUIRED_EXTERNAL_PACKAGES = ["webgpu"];
-const REQUIRED_EXTERNAL_PACKAGES =
-  PROFILE === "desktop"
-    ? [
-        ...COMMON_REQUIRED_EXTERNAL_PACKAGES,
-        ...DESKTOP_REQUIRED_EXTERNAL_PACKAGES,
-      ]
-    : COMMON_REQUIRED_EXTERNAL_PACKAGES;
 
 // Staged into _modules/ on every profile.
 const COMMON_EXTERNAL_PACKAGES = [
@@ -123,6 +116,10 @@ const COMMON_EXTERNAL_PACKAGES = [
   "better-sqlite3",
   "sqlite-vec",
   "sharp",
+  // Dawn. The GPU compositor behind nodetool.image.* and RenderTimeline needs
+  // it on the server as well as on desktop; the Docker image installs lavapipe
+  // so the container has a Vulkan ICD for it to reach.
+  "webgpu",
   // @img/sharp-* is deliberately NOT seeded here. Other packages in the tree
   // depend on older sharp majors, so npm hoists their @img/sharp-<platform>
   // prebuilds to the root node_modules while sharp's own (matching) copies sit
@@ -198,8 +195,6 @@ const COMMON_EXTERNAL_PACKAGES = [
 // module-init side effects would break server.mjs); the server profile just
 // doesn't ship them, matching today's Docker image.
 const DESKTOP_ONLY_EXTERNAL_PACKAGES = [
-  // Server: no local GPU compute; gpu lazy-imports with an install-hint error.
-  "webgpu",
   // Server: both call sites (packages/security/src/master-key.ts,
   // packages/runtime/src/providers/oauth/secure-credential-store.ts) are lazy
   // try/catch imports, and headless deployments run without a keychain.
@@ -1303,9 +1298,7 @@ async function main() {
   // regression fails the build here instead of silently shipping an app with
   // empty model lists.
   console.log("\nVerifying staged bundle layout...");
-  for (const line of verifyBackendBundle(BUNDLE_DIR, {
-    requireWebgpu: PROFILE === "desktop",
-  })) {
+  for (const line of verifyBackendBundle(BUNDLE_DIR)) {
     console.log(`  ${line}`);
   }
 

--- a/scripts/docker-smoke.mjs
+++ b/scripts/docker-smoke.mjs
@@ -42,6 +42,169 @@ const get = async (path) => {
   }
 };
 
+const postJson = async (path, body) => {
+  const res = await fetch(new URL(path, baseUrl), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const detail = summarize(await res.text());
+    throw new Error(`POST ${path} -> ${res.status} ${detail}`);
+  }
+  return res.json();
+};
+
+/** One tRPC mutation, unwrapped to the procedure's own result. */
+const trpc = async (procedure, input) =>
+  (await postJson(`/trpc/${procedure}`, input)).result.data;
+
+/**
+ * Render a two-clip timeline — a text clip over a solid shape — through
+ * `nodetool.timeline.RenderTimeline` and assert the job composited it.
+ *
+ * This is the check that proves the image renders the picture the editor
+ * previews. The node falls back to an ffmpeg concatenation when it cannot
+ * acquire a WebGPU device, and that fallback is silent apart from a job log:
+ * the run still succeeds and still returns an mp4. `render_mode` is what
+ * separates the two, so an image that shipped without Dawn — or without the
+ * lavapipe Vulkan driver it reaches the CPU through — fails here instead of
+ * quietly serving flat cuts in production.
+ */
+async function checkTimelineRender() {
+  const stamp = Date.now();
+  try {
+    const project = await trpc("projects.create", {
+      name: `docker-smoke-${stamp}`,
+      kind: "",
+    });
+    const timeline = await trpc("timeline.create", {
+      name: `docker-smoke-${stamp}`,
+      projectId: project.id,
+      fps: 10,
+      width: 320,
+      height: 180,
+    });
+    await trpc("timeline.update", {
+      id: timeline.id,
+      document: {
+        tracks: [
+          {
+            id: "t-text",
+            name: "Text",
+            type: "overlay",
+            index: 0,
+            visible: true,
+            locked: false,
+          },
+          {
+            id: "t-shape",
+            name: "Shape",
+            type: "video",
+            index: 1,
+            visible: true,
+            locked: false,
+          },
+        ],
+        clips: [
+          {
+            id: "clip-text",
+            trackId: "t-text",
+            name: "Title",
+            startMs: 0,
+            durationMs: 500,
+            mediaType: "text",
+            sourceType: "generated",
+            status: "generated",
+            locked: false,
+            versions: [],
+            textStyle: { text: "Smoke", fontSizePx: 32, color: "#ffffff" },
+          },
+          {
+            id: "clip-shape",
+            trackId: "t-shape",
+            name: "Card",
+            startMs: 0,
+            durationMs: 500,
+            mediaType: "shape",
+            sourceType: "generated",
+            status: "generated",
+            locked: false,
+            versions: [],
+            shapeStyle: {
+              kind: "rect",
+              fill: "#1e3a8a",
+              x: 0.1,
+              y: 0.1,
+              width: 0.8,
+              height: 0.8,
+            },
+          },
+        ],
+        markers: [],
+      },
+    });
+
+    const workflow = await trpc("workflows.create", {
+      name: `docker-smoke-render-${stamp}`,
+      description: "RenderTimeline smoke",
+      access: "private",
+      graph: {
+        nodes: [
+          {
+            id: "render",
+            type: "nodetool.timeline.RenderTimeline",
+            data: {
+              timeline: { type: "timeline", id: timeline.id, data: null },
+              include_audio: false,
+            },
+          },
+          {
+            id: "out",
+            type: "nodetool.output.Output",
+            data: { name: "video" },
+          },
+        ],
+        edges: [
+          {
+            id: "e1",
+            source: "render",
+            sourceHandle: "output",
+            target: "out",
+            targetHandle: "value",
+            ui_properties: null,
+          },
+        ],
+      },
+    });
+
+    const run = await postJson(`/api/workflows/${workflow.id}/run`, {});
+    if (run.status !== "completed") {
+      failures.push(
+        `RenderTimeline run -> ${run.status} (${run.error ?? "no error"}). ` +
+          "A text-and-shape timeline gives the rough-cut fallback nothing to " +
+          "concatenate, so a failure here usually means the same thing a " +
+          '"rough_cut" verdict does: no WebGPU device in the container.'
+      );
+      return;
+    }
+    // An output slot collects every value the node emitted, so it arrives as
+    // an array even for a single-shot node.
+    const video = [run.outputs?.video].flat()[0];
+    const mode = video?.metadata?.render_mode;
+    if (mode !== "composited") {
+      failures.push(
+        `RenderTimeline rendered in "${mode ?? "unknown"}" mode, expected ` +
+          `"composited" — the container has no WebGPU device, so the node fell ` +
+          `back to an ffmpeg concatenation. Check that bundle-backend.mjs ` +
+          `staged webgpu and that mesa-vulkan-drivers is installed.`
+      );
+    }
+  } catch (cause) {
+    failures.push(`RenderTimeline smoke — ${cause.message}`);
+  }
+}
+
 const config = await get("/api/config");
 if (config && !config.ok) {
   failures.push(`GET /api/config -> ${config.status}`);
@@ -61,6 +224,8 @@ if (workflows && !workflows.ok) {
 if (failures.length > 0) {
   report();
 }
+
+await checkTimelineRender();
 
 const browser = await chromium.launch();
 const page = await browser.newPage();

--- a/scripts/verify-backend-bundle.mjs
+++ b/scripts/verify-backend-bundle.mjs
@@ -16,7 +16,9 @@
  *
  * Standalone usage: node scripts/verify-backend-bundle.mjs [bundleDir]
  *                   [--profile desktop|server]
- *                   Defaults: electron/backend-bundle, desktop profile.
+ *                   Defaults: electron/backend-bundle, desktop profile. The
+ *                   profile names the artifact in the log; every check below
+ *                   applies to both, webgpu included (D9).
  *                   Exits 1 with diagnostics if any check fails.
  */
 
@@ -134,11 +136,11 @@ function listShippedSandboxPackNames() {
 
 /**
  * Verify the staged bundle layout. Returns human-readable summary lines on
- * success; throws an Error listing every failed check otherwise.
- * `requireWebgpu` is true for the desktop profile; the server profile does no
- * local GPU compute and deliberately ships without webgpu.
+ * success; throws an Error listing every failed check otherwise. Every check
+ * applies to both profiles — the server renders timelines on the same GPU
+ * compositor the desktop app does, so webgpu is required there too (D9).
  */
-export function verifyBackendBundle(bundleDir, { requireWebgpu = true } = {}) {
+export function verifyBackendBundle(bundleDir) {
   const errors = [];
   const summary = [];
 
@@ -275,24 +277,23 @@ export function verifyBackendBundle(bundleDir, { requireWebgpu = true } = {}) {
     summary.push("sandbox worker entry staged");
   }
 
-  // 3. webgpu dawn binaries (desktop profile only). The GPU compositor loads
+  // 3. webgpu dawn binaries, on every profile. The GPU compositor loads
   //    `webgpu` through a variable-specifier dynamic import esbuild can't see,
   //    so nothing else fails the build when it's missing from _modules/.
-  if (requireWebgpu) {
-    const dawnFiles = (
-      listFiles(path.join(bundleDir, "_modules", "webgpu", "dist")) ?? []
-    ).filter((f) => f.endsWith(".dawn.node"));
-    if (dawnFiles.length === 0) {
-      errors.push(
-        "no *.dawn.node binary under _modules/webgpu/dist — the packaged GPU " +
-          'compositor would fail with "requires the optional \'webgpu\' package". ' +
-          "Keep webgpu in DESKTOP_ONLY_EXTERNAL_PACKAGES in bundle-backend.mjs."
-      );
-    } else {
-      summary.push(
-        `webgpu staged with ${dawnFiles.length} dawn.node binary(ies)`
-      );
-    }
+  const dawnFiles = (
+    listFiles(path.join(bundleDir, "_modules", "webgpu", "dist")) ?? []
+  ).filter((f) => f.endsWith(".dawn.node"));
+  if (dawnFiles.length === 0) {
+    errors.push(
+      "no *.dawn.node binary under _modules/webgpu/dist — the packaged GPU " +
+        'compositor would fail with "requires the optional \'webgpu\' package", ' +
+        "so image nodes and RenderTimeline would drop to their fallbacks. " +
+        "Keep webgpu in COMMON_EXTERNAL_PACKAGES in bundle-backend.mjs."
+    );
+  } else {
+    summary.push(
+      `webgpu staged with ${dawnFiles.length} dawn.node binary(ies)`
+    );
   }
 
   // 3b. Sandbox packs staged under _sandbox/ must be complete: the pack
@@ -489,12 +490,10 @@ if (isCli) {
       )
   );
   try {
-    for (const line of verifyBackendBundle(bundleDir, {
-      requireWebgpu: profile === "desktop",
-    })) {
+    for (const line of verifyBackendBundle(bundleDir)) {
       console.log(`verify-backend-bundle: ${line}`);
     }
-    console.log(`verify-backend-bundle: ${bundleDir} OK`);
+    console.log(`verify-backend-bundle: ${bundleDir} OK (${profile} profile)`);
   } catch (e) {
     console.error(`verify-backend-bundle: ${e.message}`);
     process.exit(1);

--- a/web/src/components/timeline/Tracks/Clip.tsx
+++ b/web/src/components/timeline/Tracks/Clip.tsx
@@ -84,7 +84,8 @@ function isClipCompatibleWithTrack(
   if (
     clipMediaType === "overlay" ||
     clipMediaType === "text" ||
-    clipMediaType === "shape"
+    clipMediaType === "shape" ||
+    clipMediaType === "group"
   ) {
     return trackType === "video" || trackType === "overlay";
   }

--- a/web/src/components/timeline/timelineAgentBridge.ts
+++ b/web/src/components/timeline/timelineAgentBridge.ts
@@ -36,7 +36,14 @@ export interface TimelineClipNode {
   trackId: string;
   /** Name of the clip's track, or null when the track is gone. */
   trackName: string | null;
-  mediaType: "image" | "video" | "audio" | "overlay" | "text" | "shape";
+  mediaType:
+    | "image"
+    | "video"
+    | "audio"
+    | "overlay"
+    | "text"
+    | "shape"
+    | "group";
   sourceType: "imported" | "generated";
   bindingKind?: string;
   /** Absolute start on the sequence timeline (ms). */
@@ -83,7 +90,7 @@ interface TimelineTextStyle {
 }
 
 interface TimelineShapeStyle {
-  kind: "rect" | "ellipse" | "line";
+  kind: "rect" | "ellipse" | "line" | "path" | "polygon" | "star";
   fill?: string;
   stroke?: string;
   strokeWidthPx?: number;

--- a/web/src/stores/timeline/__tests__/transcriptOps.test.ts
+++ b/web/src/stores/timeline/__tests__/transcriptOps.test.ts
@@ -1,5 +1,11 @@
 import { makeClip } from "@nodetool-ai/timeline";
-import type { CaptionWord, TimelineClip, TranscriptLine } from "@nodetool-ai/timeline";
+import type {
+  CaptionWord,
+  CaptionWordKind,
+  TimelineClip,
+  TranscriptLine
+} from "@nodetool-ai/timeline";
+import { timelineDocument } from "@nodetool-ai/protocol/api-schemas/timeline.js";
 
 import {
   PLACEHOLDER_BEAT_MS,
@@ -478,6 +484,62 @@ describe("filler words", () => {
       )
     });
     const out = removeFillers([c]);
+    const texts = buildTranscriptDoc(out.clips)
+      .segments.flatMap((s) => s.tokens)
+      .map((t) => t.text);
+    expect(texts).toEqual(["okay", "sure"]);
+    expect(out.durationMs).toBe(800);
+  });
+
+  // F16: `kind` was missing from the Zod `captionWord`, so a save stripped it
+  // and a filler the lexicon does not know — "like", "basically" — came back as
+  // ordinary speech. The words below carry no lexicon fillers on purpose, so
+  // removal finds them only if `kind` survived the round trip.
+  it("still cuts tagged fillers after a save round trip", () => {
+    const tagged = (
+      word: string,
+      startMs: number,
+      endMs: number,
+      kind: CaptionWordKind
+    ): CaptionWord => ({ word, startMs, endMs, kind, confidence: 0.5 });
+
+    const c = beat("c", {
+      startMs: 0,
+      durationMs: 1200,
+      words: [
+        tagged("like", 0, 200, "filler"),
+        tagged("okay", 200, 500, "word"),
+        tagged("basically", 500, 700, "filler"),
+        tagged("sure", 700, 1200, "word")
+      ]
+    });
+
+    const saved = timelineDocument.parse({
+      tracks: [
+        {
+          id: "audio",
+          name: "Voiceover",
+          type: "audio",
+          index: 0,
+          visible: true,
+          locked: false
+        }
+      ],
+      clips: [c],
+      markers: []
+    });
+    // The wire clip narrows nothing this test reads; the schema is the thing
+    // under test, so the parse output is what removal must run on.
+    const reloaded = saved.clips as unknown as TimelineClip[];
+
+    expect(reloaded[0].caption?.words.map((w) => w.kind)).toEqual([
+      "filler",
+      "word",
+      "filler",
+      "word"
+    ]);
+
+    const out = removeFillers(reloaded);
     const texts = buildTranscriptDoc(out.clips)
       .segments.flatMap((s) => s.tokens)
       .map((t) => t.text);


### PR DESCRIPTION
## What changed

Milestone 0 of [docs/plans/motion-graphics-tasks.md](https://github.com/nodetool-ai/nodetool/blob/main/docs/plans/motion-graphics-tasks.md) — the unblock-and-correct tasks that everything after it depends on. Landed so far: T5 puts `preview_timeline_frame` in the CodeAct `timelines` namespace so an agent writing sandboxed JavaScript can look at a frame rather than only validate one; T3 ships `webgpu` on the server bundle profile so a hosted render composites instead of silently falling back to the rough cut, and adds progress reporting, abort-signal cancellation, and a `render_mode` on the output ref that the docker smoke test asserts. T1 (schema landing), T2 (caption fields and the dropped-layer report) and T4 (the custom animation op) are still in flight and will land on this branch.

Getting the docker smoke assertion to pass turned up a separate defect: `ProcessingContext.setModelInterfaces` replaced the process-wide floor rather than layering over it, so the HTTP run route — which wires only the asset pair — uninstalled `getTimelineSequence` and every `RenderTimeline` run over `POST /api/workflows/:id/run` threw "model interface is not configured". Fixed in `packages/runtime` where that floor contract is documented, since both partial call sites had the same latent bug.

**Found, not fixed:** `packages/websocket/src/session/chat-prompt.ts` describes the `nodetool.timelines` namespace in prose and now understates it — `preview` belongs in that sentence.

## Verification

- [x] `npm run test --workspace=packages/runtime` — 168 files, 3204 tests pass
- [x] `npm run test --workspace=packages/agents` — 239 files, 3729 tests pass
- [x] `npm run test --workspace=packages/video-nodes` under lavapipe — 21 files, 205 tests pass
- [x] `npm run lint`
- [x] `npm run backend:smoke` — booted, `webgpu staged with 4 dawn.node binary(ies)`
- [x] `npm run capabilities:check` — capability table current, no new capability added
- [ ] `npm run typecheck` / `npm run test:affected` / `harness gate` — run once T1's schema lands, since its union widening has downstream consumers

Checks inverted to prove they can fail:

- Repointed `timelines.preview` at `validate_timeline`: both new routing tests failed (`expected [ 'validate_timeline', …(1) ] to deeply equal [ 'preview_timeline_frame', …(1) ]`). Restored, green.
- Removed the per-frame abort check in `compositeRender`: the cancellation test failed. Restored, green.
- Deleted the staged dawn binaries and re-ran `verify-backend-bundle --profile server`: exit 1 with the new message, so the requirement bites on the server profile and not only on desktop.
- Made `modelInterfaces()` return the context's own set again: `keeps the interfaces a context did not wire itself` failed. Restored, green.

## Agent capabilities

No capability added and no declared contract changed — T5 wires an existing capability into the CodeAct object model. `npm run capabilities:check` passes (252 capabilities).

## New checks

- [x] Each new check above was inverted once and observed failing; the failing commands are in **Verification**
- [x] The docker-smoke render check asserts a positive result (`render_mode === "composited"`), so it cannot pass on an empty match — it was also observed failing against a server with no Vulkan driver

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtYJyRjZTXjXwkkRCAeneA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtYJyRjZTXjXwkkRCAeneA)_