### PR TITLE
feat(agents): one RunBudget per run, shared downward (A1)

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -87,8 +87,15 @@ You can skip planning entirely by passing a pre-built `task` object to the Agent
 2. Stream the LLM response
 3. Run the action's JavaScript in the QuickJS sandbox, where the toolbelt is imported from `@nodetool-ai/sandbox-nodetool/<namespace>`
 4. Feed the observation (return value, logs, error) back as the tool result
-5. Repeat until the program calls `finish(result)` or max iterations are reached
+5. Repeat until the program calls `finish(result)`, the run's budget stops it, or max iterations are reached
 6. Validate the result against the step's output schema — host-side, in `finish`
+
+A run's bounds — a USD cap, a wall clock, a limit on open provider
+conversations, and a cumulative turn count — are one `RunBudget` the host
+creates and every loop below it shares, so a sub-agent reserves against its
+parent instead of opening a fresh allowance. A step that a cap or deadline
+stops fails naming that reason. See
+[packages/agents/AGENTS.md § One budget per run](../packages/agents/AGENTS.md).
 
 See [codeact-design.md](codeact-design.md) for the action protocol and
 the sandbox limits that apply per action, and [javascript-sandbox.md](javascript-sandbox.md)

--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -1122,9 +1122,69 @@ const agent = new Agent({
 defaults in `DEFAULT_AGENT_POLICY`) and hands the same object to every mode —
 single task, multi-task plan, graph. A knob therefore means the same thing
 everywhere: `maxTokens` reaches the graph runner, `maxSteps` bounds multi-task
-runs, and task/fan-out dispatch is capped by one semaphore
+runs, and task/fan-out dispatch is bounded by `mergeAsyncGenerators`
 (`utils/merge-generators.ts`). The plan-approval gate is likewise a property of
 the run, not of the planning mode: a planned graph goes through it too.
+
+`maxConcurrentAgents` alone bounds one `mergeAsyncGenerators` call, not the
+run — tasks, steps and sub-agents each apply it separately, so the three
+multiply. The run-level bound is the budget's semaphore below.
+
+### One budget per run (`@nodetool-ai/runtime` → `RunBudget`)
+
+A run's bounds are one object, created by the host and shared downward, never
+re-created by a child. `RunBudget` carries four:
+
+| Bound | What refuses | Setting |
+|---|---|---|
+| `turns` | a turn whose worst case would cross the USD cap | `NODETOOL_AGENT_TURN_COST_CAP_USD` |
+| `deadline` | any turn or tool call after the wall clock runs out | `NODETOOL_AGENT_TURN_DEADLINE_MS` |
+| `concurrency` | a branch beyond the run's open-conversation limit | `NODETOOL_AGENT_MAX_CONCURRENCY` |
+| `turnCount` | a turn past the run's cumulative total | `NODETOOL_AGENT_MAX_TURNS` |
+
+Spend admission is reserve-then-commit, because the next call's cost is only
+known afterwards: $0.49 spent under a $0.50 cap still admits a $0.30 call.
+`turns.reserve` is the single admission point and records the first reason it
+refuses; `exhausted` is set once, so a run that ran out of money and then ran
+out of time stopped for the money.
+
+**An unpriced model is not a free one.** A model the price catalog does not
+cover has no worst case to reserve, so it is admitted only while its prompt
+fits `NODETOOL_AGENT_UNPRICED_TOKEN_CEILING`, counted in `unpricedTurns`, and
+leaves `spentUsd` a declared lower bound — the `unpriced` convention `nodetool
+costs` already follows. With no USD cap configured there is nothing for the
+ceiling to protect and it does not apply; the run stays bounded by its deadline
+and turn count.
+
+**How a child reserves against its parent.** The budget rides
+`CapabilityRun.budget` and `SubAgentToolRuntime.budget`, and `subAgentRuntime()`
+(`capabilities/agents.ts`) is the one seam where it joins the runtime, so every
+delegation capability inherits it from a single place. `runSubAgent` hands that
+object — never a new one — to its `CodeActExecutor`; `execute_plan` carries it
+into `ParallelTaskExecutor`, which forwards it to every `TaskExecutor` and on to
+every CodeAct step. It also rides `RUN_BUDGET_CONTEXT_KEY` on the context, which
+is how a loop the host never constructs finds it: an `AgentNode` started through
+`run_node`, or a JS script. `ProcessingContext.copy()` shallow-copies the
+variable bag, so a child context shares the same budget object rather than a
+clone — that sharing is what makes a cap a run total.
+
+**Permits are taken once per branch.** A run-total semaphore deadlocks if a
+holder queues for a second permit, which nested merges do by construction:
+`ParallelTaskExecutor` holds permits for tasks whose `TaskExecutor`s then queue
+for step permits. `acquireRunSlot` is therefore re-entrant on a context flag,
+and each DAG executor holds one slot for the length of its run.
+
+**A budget stop is visible, never silent.** `generateLoop` used to `return`, so
+a consumer could not tell a refused turn from the model ending its turn. It
+yields one `ProviderStop` as its final item — `budget`, `deadline`,
+`iterations`, or `aborted` — and a turn the model ends on its own yields none.
+Every consumer surfaces it: a CodeAct step fails naming the reason the budget
+recorded, and `AgentNode` raises a node error. `classifyProviderStream`
+(`llm-nodes/agent-utils.ts`) yields a `stop` event for it; before that branch
+existed the item fell through its chunk/tool-call/message chain and vanished.
+
+Absent means unbudgeted, not exhausted: a kernel workflow run with no host
+budget behaves exactly as it did before.
 
 ### Step failure is terminal, not completion
 
@@ -2207,7 +2267,8 @@ Steps can enforce structured output via JSON schema:
 - Schema'd steps finalize ONLY through the finishing tool — `finish_step` in tool mode, `finish()` in a CodeAct action. There is no JSON-from-text extraction path, so a step that never calls it fails and emits an explicit error result.
 - Unstructured steps (no schema) finalize when the model emits a no-tool-call assistant message; that text becomes the result.
 - Two things make that contract visible to a model that believes `return graph` finished the step, because the observation for the losing move used to be indistinguishable from success. A CodeAct observation for a schema'd step that returned a value without finishing carries `finished: false` and a `note` — which says so explicitly when the returned value already matched the schema. And a schema'd step whose turn ended in prose is re-prompted with the contract, at most `MAX_FINISH_NUDGES` (2) times, before it fails.
-- The failure message names the terminal state it actually hit: the provider's error, `exceeded N iterations` only when the loop really used its budget, else "ended after N action(s) / model turn(s) without calling finish", quoting the model's last message.
+- The failure message names the terminal state it actually hit: the provider's error, the run budget's own reason when a cost cap or deadline stopped the step, `exceeded N iterations` only when the loop really used its budget, else "ended after N action(s) / model turn(s) without calling finish", quoting the model's last message. A budget stop reported as "without calling finish" blamed the model for something it never got to do.
+- `maxIterations` bounds the **step**, not each finish-nudge round. Each round is given what is left of the allowance and a round with nothing left is not run, so `MAX_FINISH_NUDGES` no longer multiplies the ceiling — a step configured for 4 model turns used to be able to make 12.
 
 ### Skills System
 

--- a/packages/agents/src/author-graph.ts
+++ b/packages/agents/src/author-graph.ts
@@ -20,10 +20,13 @@
 import type {
   BaseProvider,
   ProcessingContext,
+  RunBudget,
   SandboxModuleCatalog,
   TurnBudget
 } from "@nodetool-ai/runtime";
 import {
+  budgetFromContext,
+  isRunBudget,
   getProcessSandboxModuleCatalog,
   withAgentSpanGen
 } from "@nodetool-ai/runtime";
@@ -112,8 +115,12 @@ export interface AuthorGraphOptions {
   providers?: Record<string, BaseProvider>;
   /** External cancellation. Stops the authoring loop mid-flight. */
   signal?: AbortSignal;
-  /** Spend admission, consulted before every provider turn. */
-  turnBudget?: TurnBudget;
+  /**
+   * Spend admission, consulted before every provider turn. Pass the run's
+   * {@link RunBudget} so authoring spends the caller's remaining headroom;
+   * omitted, the budget on {@link context} is used.
+   */
+  turnBudget?: TurnBudget | RunBudget;
   threadId?: string;
   /** Provider rounds. Defaults to {@link AUTHOR_GRAPH_MAX_ITERATIONS}. */
   maxIterations?: number;
@@ -255,6 +262,16 @@ function resolveCatalog(
 }
 
 /**
+ * The run budget behind an authoring run: the caller's when it passed one, the
+ * context's otherwise. A bare {@link TurnBudget} carries no run-level bounds,
+ * so it is not one.
+ */
+function resolveAuthoringBudget(opts: AuthorGraphOptions): RunBudget | undefined {
+  if (isRunBudget(opts.turnBudget)) return opts.turnBudget;
+  return budgetFromContext(opts.context);
+}
+
+/**
  * Discovery, graph validation, and the Code-body harness — plus `find_model`
  * when providers are configured. Everything else the agent needs is the pack.
  */
@@ -262,6 +279,9 @@ export function buildAuthoringBelt(opts: AuthorGraphOptions): Tool[] {
   const runOptions: CreateCapabilityRunOptions = {
     context: opts.context,
     gate: UNGATED,
+    // The belt's capabilities run inside the authoring run, so they share its
+    // budget rather than starting one.
+    budget: resolveAuthoringBudget(opts),
     // The belt carries `validate_workflow`, so a graph the child authors
     // against a provider this install has no key for comes back saying so.
     // A hermetic caller's context resolves no secrets and gets no callback.

--- a/packages/agents/src/capabilities/agents.ts
+++ b/packages/agents/src/capabilities/agents.ts
@@ -29,6 +29,7 @@
  */
 
 import type { JsonSchema } from "@nodetool-ai/runtime";
+import { budgetFromContext } from "@nodetool-ai/runtime";
 import { Tool } from "../tools/base-tool.js";
 import { TOOL_CALL_ID_FIELD } from "../tools/subtask-fields.js";
 import { READ_ONLY_SEARCH_DESCRIPTION } from "../prompts/read-only-search-prompt.js";
@@ -65,6 +66,11 @@ export {
  * The sub-agent runtime this run carries, or an error naming what is missing.
  * A headless run (an eval, an MCP mount, a CLI invocation with no forwarder)
  * has no runtime, and no child loop can be spawned without one.
+ *
+ * Every delegation capability goes through here, so this is also where the
+ * run's budget joins the runtime: a host that put one on the `CapabilityRun`
+ * (or on the context) has it reach `run_subtask`, `run_search`,
+ * `start_subtask` and `execute_plan` without naming it six times.
  */
 function subAgentRuntime(
   run: CapabilityRun,
@@ -78,7 +84,9 @@ function subAgentRuntime(
         "that builds the CapabilityRun must supply it."
     );
   }
-  return runtime;
+  if (runtime.budget) return runtime;
+  const budget = run.budget ?? budgetFromContext(run.context);
+  return budget ? { ...runtime, budget } : runtime;
 }
 
 /**
@@ -313,6 +321,11 @@ const executePlan: CapabilityExport = {
             t.name !== executePlanSpec.name && t.name !== createPlanSpec.name
         ),
       taskPlan: plan,
+      // The run's budget and the parent's per-step iteration cap: every step
+      // this plan runs is a loop of the same run, so it reserves against the
+      // same cap and gets the same bound as a `run_subtask` child would.
+      budget: runtime.budget,
+      maxStepIterations: runtime.maxIterations,
       // The thread's own signal: cancelling the turn cancels every task.
       signal: run.context.signal
     });

--- a/packages/agents/src/capabilities/invoke.ts
+++ b/packages/agents/src/capabilities/invoke.ts
@@ -12,7 +12,12 @@
  * lives".
  */
 
-import type { BaseProvider, ProcessingContext } from "@nodetool-ai/runtime";
+import type {
+  BaseProvider,
+  ProcessingContext,
+  RunBudget
+} from "@nodetool-ai/runtime";
+import { budgetFromContext } from "@nodetool-ai/runtime";
 import type { NodeRegistry } from "@nodetool-ai/node-sdk";
 import type { VectorCollection } from "@nodetool-ai/vectorstore";
 import { Tool } from "../tools/base-tool.js";
@@ -99,6 +104,8 @@ export interface CreateCapabilityRunOptions {
   /** Opens the bespoke secret dialog; see {@link CapabilityRun.secretPrompt}. */
   secretPrompt?: SecretPrompt;
   subAgent?: SubAgentRuntime;
+  /** The run's budget; see {@link CapabilityRun.budget}. */
+  budget?: RunBudget;
   /**
    * Which declared credentials this install holds; see
    * {@link CapabilityRun.availableSecrets}. Build it with
@@ -142,6 +149,7 @@ export function createCapabilityRun(
     projectId: options.projectId,
     secretPrompt: options.secretPrompt,
     subAgent: options.subAgent,
+    budget: options.budget ?? budgetFromContext(options.context),
     availableSecrets: options.availableSecrets,
     nodeRegistry: options.nodeRegistry,
     providers: options.providers,

--- a/packages/agents/src/capabilities/types.ts
+++ b/packages/agents/src/capabilities/types.ts
@@ -13,7 +13,8 @@
 import type {
   BaseProvider,
   JsonSchema,
-  ProcessingContext
+  ProcessingContext,
+  RunBudget
 } from "@nodetool-ai/runtime";
 import type { ZodType } from "zod";
 import type { NodeRegistry } from "@nodetool-ai/node-sdk";
@@ -169,6 +170,13 @@ export interface CapabilityRun {
   readonly secretPrompt?: SecretPrompt;
   /** What `run_subtask` / `run_search` need. */
   readonly subAgent?: SubAgentRuntime;
+  /**
+   * The one budget this run shares downward: every loop it spawns reserves
+   * against the same cap, deadline, permit pool and turn count instead of
+   * getting an allowance of its own (invariant I-2). Absent means unbudgeted,
+   * not exhausted — a kernel workflow run with no host budget is unchanged.
+   */
+  readonly budget?: RunBudget;
   /**
    * Answers which declared credentials this install holds, so
    * `validate_workflow` can report a graph whose nodes need a key nobody has

--- a/packages/agents/src/codeact/codeact-executor.ts
+++ b/packages/agents/src/codeact/codeact-executor.ts
@@ -19,12 +19,16 @@ import type {
   ProcessingContext,
   Message,
   MessageContent,
+  ProviderStop,
   ProviderStreamItem,
+  RunBudget,
   ToolCall,
   TurnBudget
 } from "@nodetool-ai/runtime";
 import {
   ACTIVE_MODEL_CONTEXT_KEY,
+  isProviderStop,
+  isRunBudget,
   memoryKeys,
   withAgentSpanGen,
   type ActiveModelSelection
@@ -269,8 +273,12 @@ export interface CodeActExecutorOptions {
   /**
    * Spend admission, consulted before every provider turn. A refusal ends the
    * loop, so a caller's cost cap bounds the step rather than being overrun.
+   *
+   * A {@link RunBudget} carries the run's other bounds too, and the step then
+   * also checks the deadline before every action and every bridged tool call.
+   * A bare {@link TurnBudget} keeps its existing meaning — spend only.
    */
-  turnBudget?: TurnBudget;
+  turnBudget?: TurnBudget | RunBudget;
   useFinishTask?: boolean;
   threadId?: string;
   upstreamMemoryKeys?: string[];
@@ -375,7 +383,9 @@ export class CodeActExecutor {
   private readonly systemPrompt: string;
   private readonly maxIterations: number;
   private readonly maxTokens?: number;
-  private readonly turnBudget?: TurnBudget;
+  private readonly turnBudget?: TurnBudget | RunBudget;
+  /** The same budget when it carries the run's deadline; otherwise absent. */
+  private readonly runBudget?: RunBudget;
   private readonly useFinishTask: boolean;
   private readonly threadId?: string;
   private readonly upstreamMemoryKeys: string[];
@@ -419,6 +429,7 @@ export class CodeActExecutor {
     this.maxIterations = opts.maxIterations ?? DEFAULT_CODEACT_MAX_ITERATIONS;
     this.maxTokens = opts.maxTokens;
     this.turnBudget = opts.turnBudget;
+    if (isRunBudget(opts.turnBudget)) this.runBudget = opts.turnBudget;
     this.useFinishTask = opts.useFinishTask ?? false;
     this.threadId = opts.threadId;
     this.upstreamMemoryKeys = opts.upstreamMemoryKeys ?? [];
@@ -654,12 +665,47 @@ export class CodeActExecutor {
       maxToolCallsPerAction: this.maxToolCallsPerAction
     });
 
+    // The run's wall clock, when the host gave this step one. A step that has
+    // run out of time must stop where it is: an expired deadline aborts the
+    // controller the provider loop and the action's sandbox both run on, and
+    // the stop is remembered here so the step fails naming the deadline rather
+    // than the abort it caused (invariant I-3).
+    let deadlineStop: ProviderStop | null = null;
+    const stopIfPastDeadline = (): ProviderStop | null => {
+      const budget = this.runBudget;
+      if (!budget || !budget.deadline.expired()) return null;
+      if (!deadlineStop) {
+        const exhausted = budget.exhausted;
+        deadlineStop = {
+          type: "stop",
+          reason: "deadline",
+          detail:
+            exhausted?.kind === "deadline"
+              ? exhausted.detail
+              : "the run deadline passed"
+        };
+      }
+      abort.abort();
+      return deadlineStop;
+    };
+
     // `__callTool` serves the graft as well as the belt, so gating is
     // unchanged on either path.
-    const callBeltTool = bridge.globals["__callTool"] as (
+    const bridgedCall = bridge.globals["__callTool"] as (
       name: unknown,
       argsJson: unknown
     ) => Promise<{ ok: true; result: unknown } | { ok: false; error: string }>;
+    const callBeltTool = async (
+      name: unknown,
+      argsJson: unknown
+    ): Promise<{ ok: true; result: unknown } | { ok: false; error: string }> => {
+      const expired = stopIfPastDeadline();
+      if (expired) return { ok: false, error: expired.detail };
+      return bridgedCall(name, argsJson);
+    };
+    // The guest reaches tools through this global, so the check covers every
+    // bridged call an action makes, not just the ones the host initiates.
+    bridge.globals["__callTool"] = callBeltTool;
 
     const finishBridge = async (
       resultJson: unknown
@@ -751,6 +797,14 @@ export class CodeActExecutor {
     const executeAction = async (
       args: Record<string, unknown>
     ): Promise<string | MessageContent[]> => {
+      const expired = stopIfPastDeadline();
+      if (expired) {
+        return JSON.stringify({
+          ok: false,
+          error: expired.detail,
+          toolCalls: 0
+        } satisfies ActionObservation);
+      }
       const code = isString(args?.["code"]) ? args["code"] : "";
       if (!code.trim()) {
         return JSON.stringify({
@@ -803,7 +857,10 @@ export class CodeActExecutor {
         code: `${this.prelude}\n${code}`,
         context: this.context,
         timeoutMs: this.actionTimeoutMs ?? DEFAULT_CODEACT_ACTION_TIMEOUT_MS,
-        signal: this.signal,
+        // The linked controller, not the caller's raw signal: it fires for the
+        // caller's cancellation *and* for a deadline that expires mid-action,
+        // which is the only way an in-flight program is stopped.
+        signal: abort.signal,
         clock: this.clock,
         modules: mount.modules,
         capabilities: platform.mount,
@@ -889,15 +946,29 @@ export class CodeActExecutor {
     // "exceeded N iterations"; the loop below distinguishes them.
     let exhaustedIterations = false;
     let nudges = 0;
+    // Model turns across every nudge round. `maxIterations` bounds the *step*,
+    // so each round is given what is left of it — handing every round the full
+    // allowance let MAX_FINISH_NUDGES multiply the ceiling by three.
+    let turnsTotal = 0;
+    // Why the provider loop stopped, when it was not the model ending its turn.
+    let providerStop: ProviderStop | null = null;
 
     try {
       for (;;) {
+        const remainingIterations = this.maxIterations - turnsTotal;
+        if (remainingIterations <= 0) {
+          // Nothing left to spend on another round, so there is no round to
+          // run: `generateLoop` with a non-positive budget makes no turn and
+          // would report an iteration stop nobody asked for.
+          exhaustedIterations = true;
+          break;
+        }
         const loopArgs: Parameters<BaseProvider["generateLoop"]>[0] = {
           messages: history,
           model: this.model,
           tools: providerTools,
           threadId: this.threadId,
-          maxIterations: this.maxIterations,
+          maxIterations: remainingIterations,
           maxTokens: this.maxTokens,
           sequentialTools: true,
           workspaceDir: this.context.workspaceDir ?? undefined,
@@ -911,6 +982,13 @@ export class CodeActExecutor {
         let turnsThisRound = 0;
 
         for await (const item of stream) {
+          if (isProviderStop(item)) {
+            // The loop ran out of something. Recorded rather than yielded: it
+            // is what the step's failure message names.
+            providerStop = item;
+            yield* drainUi();
+            continue;
+          }
           if (isToolCall(item)) {
             const coreTool =
               item.name === EXECUTE_CODE_TOOL_NAME
@@ -953,7 +1031,8 @@ export class CodeActExecutor {
           }
           yield* drainUi();
         }
-        exhaustedIterations = turnsThisRound >= this.maxIterations;
+        turnsTotal += turnsThisRound;
+        exhaustedIterations = turnsTotal >= this.maxIterations;
 
         if (!this.shouldNudgeToFinish(lastAssistant, nudges, abort.signal)) {
           break;
@@ -1002,15 +1081,24 @@ export class CodeActExecutor {
 
     if (!this.step.completed) {
       this.step.endTime = Date.now();
+      // A deadline this executor tripped outranks the abort it caused; an
+      // `iterations` stop keeps the wording it always had.
+      const budgetStop =
+        deadlineStop ??
+        (providerStop && providerStop.reason !== "iterations"
+          ? providerStop
+          : null);
       const message = generationError
         ? `Step failed: ${generationError.message}`
-        : exhaustedIterations
-          ? `Step failed: exceeded ${this.maxIterations} iterations without completion`
-          : this.resultSchema !== null
-            ? `Step failed: ended after ${this.actionCount} action(s) without ` +
-              `calling finish().${lastProseHint(lastAssistant)}`
-            : `Step failed: ended after ${this.actionCount} action(s) with no ` +
-              `final message to use as the result.`;
+        : budgetStop
+          ? `Step failed: ${this.stopDetail(budgetStop)}`
+          : exhaustedIterations
+            ? `Step failed: exceeded ${this.maxIterations} iterations without completion`
+            : this.resultSchema !== null
+              ? `Step failed: ended after ${this.actionCount} action(s) without ` +
+                `calling finish().${lastProseHint(lastAssistant)}`
+              : `Step failed: ended after ${this.actionCount} action(s) with no ` +
+                `final message to use as the result.`;
       this.step.failed = true;
       this.step.error = message;
       const errorResult = { error: message };
@@ -1031,6 +1119,19 @@ export class CodeActExecutor {
         is_task_result: this.useFinishTask
       } satisfies StepResult;
     }
+  }
+
+  /**
+   * What to say about a stop the step ended on. A {@link RunBudget} knows which
+   * ceiling it was and says so ("turn budget of $5 reached"); a bare
+   * {@link TurnBudget} only knows that one refused, and the stop item's own
+   * text is all there is.
+   */
+  private stopDetail(stop: ProviderStop): string {
+    if (stop.reason === "budget" || stop.reason === "deadline") {
+      return this.runBudget?.exhausted?.detail ?? stop.detail;
+    }
+    return stop.detail;
   }
 
   /**

--- a/packages/agents/src/parallel-task-executor.ts
+++ b/packages/agents/src/parallel-task-executor.ts
@@ -13,9 +13,13 @@
  *     → repeats until all tasks complete
  */
 
-import type { BaseProvider } from "@nodetool-ai/runtime";
-import type { ProcessingContext } from "@nodetool-ai/runtime";
-import { memoryKeys } from "@nodetool-ai/runtime";
+import type {
+  BaseProvider,
+  ProcessingContext,
+  RunBudget,
+  Semaphore
+} from "@nodetool-ai/runtime";
+import { budgetFromContext, memoryKeys } from "@nodetool-ai/runtime";
 import { createLogger } from "@nodetool-ai/config";
 import type {
   ProcessingMessage,
@@ -24,6 +28,7 @@ import type {
 } from "@nodetool-ai/protocol";
 import { TaskUpdateEvent } from "@nodetool-ai/protocol";
 import { TaskExecutor } from "./task-executor.js";
+import { holdsRunSlot, markRunSlotHeld } from "./subagent.js";
 import { mergeAsyncGenerators } from "./utils/merge-generators.js";
 import { DEFAULT_AGENT_POLICY } from "./agent-policy.js";
 import type { Tool } from "./tools/base-tool.js";
@@ -71,6 +76,12 @@ export interface ParallelTaskExecutorOptions {
    * lines up with the plan cache key.
    */
   planTools?: string[];
+  /**
+   * The run's budget, forwarded to every task (and through it to every step),
+   * and used as the concurrency bound the task fan-out shares with them.
+   * Omitted, the budget on {@link context} is used.
+   */
+  budget?: RunBudget;
   /** External cancellation, forwarded to every task and step executor. */
   signal?: AbortSignal;
   /** Sandbox package specifiers the session consents to, forwarded per task. */
@@ -93,6 +104,12 @@ export class ParallelTaskExecutor {
   private readonly checkpointStore?: CheckpointStore;
   private readonly runId?: string;
   private readonly planTools?: string[];
+  private readonly budget?: RunBudget;
+  /**
+   * The run's permit pool, when this executor is the layer drawing from it —
+   * see {@link TaskExecutor}'s own field for why only one layer per branch may.
+   */
+  private mergeSemaphore?: Semaphore;
   private readonly signal?: AbortSignal;
   private readonly sandboxPackages: readonly string[];
   /**
@@ -122,6 +139,7 @@ export class ParallelTaskExecutor {
     this.checkpointStore = opts.checkpointStore;
     this.runId = opts.runId;
     this.planTools = opts.planTools;
+    this.budget = opts.budget ?? budgetFromContext(opts.context);
     this.signal = opts.signal;
     this.sandboxPackages = opts.sandboxPackages ?? [];
   }
@@ -159,6 +177,30 @@ export class ParallelTaskExecutor {
    * Independent tasks run concurrently as separate sub-agents.
    */
   async *execute(): AsyncGenerator<ProcessingMessage> {
+    const leaveRunSlot = this.enterRunSlot();
+    try {
+      yield* this.runPlan();
+    } finally {
+      leaveRunSlot();
+    }
+  }
+
+  /**
+   * Claim this branch's run slot for the task fan-out, and hand back the undo.
+   * The `TaskExecutor`s built below then see the branch holding it and bound
+   * their own step fan-outs numerically, instead of queueing for permits this
+   * executor is already holding on their behalf — which would deadlock.
+   */
+  private enterRunSlot(): () => void {
+    if (!this.budget || holdsRunSlot(this.context)) {
+      this.mergeSemaphore = undefined;
+      return () => {};
+    }
+    this.mergeSemaphore = this.budget.concurrency;
+    return markRunSlotHeld(this.context);
+  }
+
+  private async *runPlan(): AsyncGenerator<ProcessingMessage> {
     // Seed inputs into shared agent memory so every task and step sees them.
     for (const [key, value] of Object.entries(this.inputs)) {
       this.context.memory.set({
@@ -261,7 +303,8 @@ export class ParallelTaskExecutor {
 
       if (taskGenerators.length > 1) {
         yield* mergeAsyncGenerators(taskGenerators, {
-          concurrency: this.maxConcurrentAgents
+          concurrency: this.maxConcurrentAgents,
+          semaphore: this.mergeSemaphore
         });
       } else {
         // Single task — no need for merge overhead
@@ -334,6 +377,7 @@ export class ParallelTaskExecutor {
       maxStepIterations: this.maxStepIterations,
       maxTokens: this.maxTokens,
       maxConcurrentAgents: this.maxConcurrentAgents,
+      budget: this.budget,
       parallelExecution: true, // Enable parallel step execution within each task
       upstreamMemoryKeys,
       signal: this.signal,

--- a/packages/agents/src/subagent.ts
+++ b/packages/agents/src/subagent.ts
@@ -38,8 +38,11 @@ import { randomUUID } from "node:crypto";
 import type {
   BaseProvider,
   ProcessingContext,
+  Release,
+  RunBudget,
   TurnBudget
 } from "@nodetool-ai/runtime";
+import { budgetFromContext, isRunBudget } from "@nodetool-ai/runtime";
 import type { ProcessingMessage, StepResult } from "@nodetool-ai/protocol";
 import type { BackgroundSubtaskRegistry } from "./background-subtasks.js";
 import { CodeActExecutor } from "./codeact/codeact-executor.js";
@@ -50,6 +53,65 @@ import {
 } from "./tools/subtask-fields.js";
 import type { Step, Task } from "./types.js";
 import { isString } from "./utils/type-guards.js";
+
+/**
+ * Context flag marking that this branch already holds one of the run's
+ * concurrency permits.
+ *
+ * The pool is a run total, so a holder that blocks waiting for a *second*
+ * permit deadlocks the run: a parent holding the last one while its child
+ * queues for another stops both until the deadline. A permit is therefore
+ * taken once per branch. `ProcessingContext.copy()` gives every spawn its own
+ * variable bag over the same budget object, so siblings each take one and
+ * everything below a holder inherits the flag and takes none.
+ */
+const RUN_SLOT_KEY = "nodetool_run_slot_held";
+
+/** Release for a branch that took no permit because it already holds one. */
+const NO_PERMIT: Release = () => {};
+
+/** Whether this branch already holds one of the run's concurrency permits. */
+export function holdsRunSlot(context: ProcessingContext): boolean {
+  return context.get<boolean>(RUN_SLOT_KEY) === true;
+}
+
+/**
+ * Mark this branch as holding a run permit for the fan-outs beneath it, and
+ * hand back the undo. Used by a layer that draws permits itself (the DAG
+ * executors, which acquire per merged generator) so nothing below it draws a
+ * second one.
+ */
+export function markRunSlotHeld(context: ProcessingContext): () => void {
+  const previous = context.get<boolean>(RUN_SLOT_KEY);
+  context.set(RUN_SLOT_KEY, true);
+  let undone = false;
+  return () => {
+    if (undone) return;
+    undone = true;
+    context.set(RUN_SLOT_KEY, previous);
+  };
+}
+
+/**
+ * Take one of the run's concurrency permits for this branch, or nothing when
+ * the branch already holds one. Returns the release either way, so the caller
+ * has one `finally`.
+ */
+export async function acquireRunSlot(
+  budget: RunBudget | undefined,
+  context: ProcessingContext
+): Promise<Release> {
+  if (!budget || holdsRunSlot(context)) return NO_PERMIT;
+  const release = await budget.concurrency.acquire();
+  const undo = markRunSlotHeld(context);
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    undo();
+    release();
+  };
+}
 
 /** Forwards child agent events upward (typically to the websocket sender). */
 export type ForwardMessage = (msg: ProcessingMessage) => Promise<void> | void;
@@ -82,8 +144,14 @@ export interface SubAgentRunOptions {
   systemPrompt?: string;
   maxIterations?: number;
   maxTokens?: number;
-  /** Spend admission, consulted before every provider turn of the child. */
-  turnBudget?: TurnBudget;
+  /**
+   * Spend admission, consulted before every provider turn of the child. A
+   * {@link RunBudget} is the run's own — passed down rather than re-created, so
+   * the child spends the parent's remaining headroom instead of a fresh
+   * allowance (invariant I-2). Omitted, the budget on {@link context} is used;
+   * absent there too, the child is unbudgeted.
+   */
+  turnBudget?: TurnBudget | RunBudget;
   threadId?: string;
   /**
    * Sandbox package specifiers the child's actions may import. Defaults to
@@ -145,6 +213,12 @@ export async function* runSubAgent(
     steps: [step]
   };
 
+  // The run's budget, never a fresh one: a caller that passes none still gets
+  // the one the host put on the context, so a child spawned three levels down
+  // spends the same allowance as the turn that started it.
+  const turnBudget = opts.turnBudget ?? budgetFromContext(opts.context);
+  const runBudget = isRunBudget(turnBudget) ? turnBudget : undefined;
+
   const executor = new CodeActExecutor({
     task,
     step,
@@ -155,7 +229,7 @@ export async function* runSubAgent(
     systemPrompt: opts.systemPrompt,
     maxIterations: opts.maxIterations,
     maxTokens: opts.maxTokens,
-    turnBudget: opts.turnBudget,
+    turnBudget,
     threadId: opts.threadId,
     sandboxPackages: opts.sandboxPackages,
     // Without the run's signal a cancelled parent leaves its children driving
@@ -164,6 +238,11 @@ export async function* runSubAgent(
   });
 
   let outcome: SubAgentOutcome | null = null;
+  // One of the run's permits for the whole child loop. `start_subtask` detaches
+  // its children, so nothing else bounds a fan-out of twenty of them: the
+  // permit is what keeps the twenty-first from opening a provider conversation
+  // before one of the first two finishes.
+  const release = await acquireRunSlot(runBudget, opts.context);
   try {
     for await (const msg of executor.execute()) {
       yield msg;
@@ -176,6 +255,8 @@ export async function* runSubAgent(
     }
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  } finally {
+    release();
   }
 
   // A child that settled without a value is not a failure — callers decide
@@ -378,6 +459,13 @@ export interface SubAgentToolRuntime {
   /** Max LLM iterations per child loop. */
   maxIterations?: number;
   /**
+   * The run's budget, shared with the parent loop rather than re-created for
+   * the child — the cap is a run total, so a spawn that starts a fresh one
+   * makes it an allowance per loop (invariant I-2). A host that carries none
+   * leaves this off and the child falls back to the budget on its context.
+   */
+  budget?: RunBudget;
+  /**
    * Per-turn registry behind `start_subtask` / `wait_subtasks`. A host that
    * does not build one (an MCP mount, a headless harness) leaves the field
    * off, and background delegation refuses by name instead of half-working.
@@ -425,6 +513,8 @@ export abstract class SubAgentTool extends Tool {
   protected readonly forward: ForwardMessage;
   protected readonly maxDepth: number;
   protected readonly maxIterations?: number;
+  /** The run's budget, held once here for every subclass. */
+  protected readonly budget?: RunBudget;
 
   protected constructor(runtime: SubAgentToolRuntime) {
     super();
@@ -434,6 +524,7 @@ export abstract class SubAgentTool extends Tool {
     this.forward = runtime.forwardMessage;
     this.maxDepth = runtime.maxDepth ?? DEFAULT_SUBAGENT_MAX_DEPTH;
     this.maxIterations = runtime.maxIterations;
+    this.budget = runtime.budget;
   }
 
   /**
@@ -472,6 +563,9 @@ export abstract class SubAgentTool extends Tool {
       outputSchema: run.outputSchema,
       systemPrompt: run.systemPrompt,
       maxIterations: run.maxIterations ?? this.maxIterations,
+      // The parent's budget, not a new one. Dropping it here was the hole:
+      // every child of a capped turn ran unbudgeted.
+      turnBudget: this.budget ?? budgetFromContext(context),
       signal: context.signal
     });
 

--- a/packages/agents/src/task-executor.ts
+++ b/packages/agents/src/task-executor.ts
@@ -14,9 +14,13 @@
  */
 
 import { createHash } from "node:crypto";
-import type { BaseProvider } from "@nodetool-ai/runtime";
-import type { ProcessingContext } from "@nodetool-ai/runtime";
-import { memoryKeys } from "@nodetool-ai/runtime";
+import type {
+  BaseProvider,
+  ProcessingContext,
+  RunBudget,
+  Semaphore
+} from "@nodetool-ai/runtime";
+import { budgetFromContext, memoryKeys } from "@nodetool-ai/runtime";
 import { createLogger } from "@nodetool-ai/config";
 import {
   TaskUpdateEvent,
@@ -27,6 +31,7 @@ import {
 
 const log = createLogger("nodetool.agents.task-executor");
 import { CodeActExecutor } from "./codeact/codeact-executor.js";
+import { holdsRunSlot, markRunSlotHeld } from "./subagent.js";
 import { mergeAsyncGenerators } from "./utils/merge-generators.js";
 import type { Tool } from "./tools/base-tool.js";
 import type { Step, Task } from "./types.js";
@@ -64,6 +69,13 @@ export interface TaskExecutorOptions {
    * upstream context. Forwarded to {@link CodeActExecutor.upstreamMemoryKeys}.
    */
   upstreamMemoryKeys?: string[];
+  /**
+   * The run's budget, forwarded to every step executor so the whole task
+   * reserves against one cap, and used as the concurrency bound its fan-outs
+   * share. Omitted, the budget on {@link context} is used; absent there too,
+   * the task is unbudgeted.
+   */
+  budget?: RunBudget;
   /** External cancellation, forwarded to every step executor. */
   signal?: AbortSignal;
   /**
@@ -88,6 +100,15 @@ export class TaskExecutor {
   private parallelExecution: boolean;
   private maxConcurrentAgents: number;
   private upstreamMemoryKeys: string[];
+  private readonly budget?: RunBudget;
+  /**
+   * The run's permit pool, when this executor is the layer drawing from it.
+   * Set for the length of a run by {@link enterRunSlot}: a nested executor, or
+   * a sub-agent under one of these steps, sees the branch already holding a
+   * permit and takes none, because a holder that queues for a second permit
+   * deadlocks the run.
+   */
+  private mergeSemaphore?: Semaphore;
   private signal?: AbortSignal;
   private readonly sandboxPackages: readonly string[];
   private _finishStepId: string | undefined;
@@ -110,7 +131,21 @@ export class TaskExecutor {
     this.maxConcurrentAgents =
       opts.maxConcurrentAgents ?? DEFAULT_AGENT_POLICY.maxConcurrentAgents;
     this.upstreamMemoryKeys = opts.upstreamMemoryKeys ?? [];
+    this.budget = opts.budget ?? budgetFromContext(opts.context);
     this.signal = opts.signal;
+  }
+
+  /**
+   * Claim this branch's run slot for the fan-outs below, and hand back the
+   * undo. A branch already holding one keeps its numeric bound only.
+   */
+  private enterRunSlot(): () => void {
+    if (!this.budget || holdsRunSlot(this.context)) {
+      this.mergeSemaphore = undefined;
+      return () => {};
+    }
+    this.mergeSemaphore = this.budget.concurrency;
+    return markRunSlotHeld(this.context);
   }
 
   /**
@@ -118,6 +153,15 @@ export class TaskExecutor {
    * Supports both sequential and parallel execution modes.
    */
   async *executeTasks(): AsyncGenerator<ProcessingMessage> {
+    const leaveRunSlot = this.enterRunSlot();
+    try {
+      yield* this.runSteps();
+    } finally {
+      leaveRunSlot();
+    }
+  }
+
+  private async *runSteps(): AsyncGenerator<ProcessingMessage> {
     // Seed inputs into shared memory so every step sees them. Skip keys that
     // were already seeded by an upstream caller (e.g. ParallelTaskExecutor) to
     // avoid redundant writes and extra subscriber notifications.
@@ -183,6 +227,7 @@ export class TaskExecutor {
           systemPrompt: this.systemPrompt,
           maxIterations: this.maxStepIterations,
           maxTokens: this.maxTokens,
+          turnBudget: this.budget,
           useFinishTask: this.isFinishStep(step),
           upstreamMemoryKeys: this.upstreamMemoryKeys,
           signal: this.signal,
@@ -193,7 +238,8 @@ export class TaskExecutor {
 
       if (this.parallelExecution && stepGenerators.length > 1) {
         yield* mergeAsyncGenerators(stepGenerators, {
-          concurrency: this.maxConcurrentAgents
+          concurrency: this.maxConcurrentAgents,
+          semaphore: this.mergeSemaphore
         });
       } else {
         for (const generator of stepGenerators) {
@@ -463,6 +509,7 @@ export class TaskExecutor {
         systemPrompt: this.systemPrompt,
         maxIterations: this.maxStepIterations,
         maxTokens: this.maxTokens,
+        turnBudget: this.budget,
         useFinishTask: false,
         upstreamMemoryKeys: this.upstreamMemoryKeys,
         signal: this.signal,
@@ -489,7 +536,8 @@ export class TaskExecutor {
 
     if (this.parallelExecution && generators.length > 1) {
       for await (const msg of mergeAsyncGenerators(generators, {
-        concurrency: this.maxConcurrentAgents
+        concurrency: this.maxConcurrentAgents,
+        semaphore: this.mergeSemaphore
       })) {
         collect(msg);
         yield msg;

--- a/packages/agents/src/tools/start-subtask-tool.ts
+++ b/packages/agents/src/tools/start-subtask-tool.ts
@@ -13,7 +13,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { budgetFromContext, type ProcessingContext } from "@nodetool-ai/runtime";
 import type { ProcessingMessage } from "@nodetool-ai/protocol";
 import {
   enterSubAgentDepth,
@@ -99,6 +99,7 @@ export class StartSubtaskTool extends SubAgentTool {
       forwardMessage: this.forward,
       maxDepth: this.maxDepth,
       maxIterations: this.maxIterations,
+      budget: this.budget,
       background: this.registry
     };
   }
@@ -147,6 +148,9 @@ export class StartSubtaskTool extends SubAgentTool {
       outputSchema: run.outputSchema,
       systemPrompt: run.systemPrompt,
       maxIterations: run.maxIterations ?? this.maxIterations,
+      // A detached child still spends the parent's allowance, and still draws
+      // one of the run's concurrency permits before it opens a conversation.
+      turnBudget: this.budget ?? budgetFromContext(context),
       signal: context.signal
     });
 

--- a/packages/agents/src/utils/merge-generators.ts
+++ b/packages/agents/src/utils/merge-generators.ts
@@ -7,13 +7,28 @@
  * conversations simultaneously. Script mode has had a semaphore since it
  * shipped; this is the same bound for the task-plan modes.
  *
+ * A number bounds *this* merge and nothing else, so nested fan-outs multiply:
+ * eight tasks, each dispatching eight steps, each fanning out over eight items
+ * is 512 provider conversations under a `concurrency` of 8. A {@link Semaphore}
+ * is the run's own permit pool, so passing one bounds every merge that shares
+ * it together. Both may be given: the number caps this merge, the pool caps the
+ * run.
+ *
  * Generators are lazy: one that has not been started yet has issued no provider
  * call, so holding it back costs nothing.
  */
 
-interface MergeOptions {
+import type { Release, Semaphore } from "@nodetool-ai/runtime";
+
+export interface MergeOptions {
   /** Maximum generators consumed at once. Defaults to unbounded. */
   concurrency?: number;
+  /**
+   * Run-level permit pool. A generator holds one permit for as long as it is
+   * consumed, so several merges sharing a pool share one bound rather than
+   * each getting `concurrency` of their own.
+   */
+  semaphore?: Semaphore;
 }
 
 export async function* mergeAsyncGenerators<T>(
@@ -50,7 +65,13 @@ export async function* mergeAsyncGenerators<T>(
       activeCount++;
       tasks.push(
         (async () => {
+          // A generator waiting for a permit still occupies its numeric slot:
+          // admitting another in its place would let `concurrency` generators
+          // run *and* a queue of them wait, which is not the bound the caller
+          // asked for.
+          let release: Release | null = null;
           try {
+            if (options.semaphore) release = await options.semaphore.acquire();
             for await (const item of gen) {
               queue.push(item);
               notify();
@@ -61,6 +82,7 @@ export async function* mergeAsyncGenerators<T>(
               firstError = e;
             }
           } finally {
+            release?.();
             activeCount--;
             // A finished slot admits the next generator.
             pump();

--- a/packages/agents/tests/_helpers/looping-mock-provider.ts
+++ b/packages/agents/tests/_helpers/looping-mock-provider.ts
@@ -1,0 +1,116 @@
+/**
+ * A mock provider whose *loop* is the real one.
+ *
+ * `generateMessages` replays a scripted turn, but `generateLoop` delegates to
+ * `BaseProvider.prototype.generateLoop`, so everything the loop owns is
+ * genuinely exercised: tool-call rounds, the terminal chunk, and — what the
+ * budget work needs — the reserve-before-a-turn / commit-after admission.
+ *
+ * `costPerTurn` is what makes a budget assertion mean something. The loop
+ * reconciles a reservation against `getTotalCost()`'s delta, so a provider that
+ * never moves that number books every turn as free and no USD cap ever binds.
+ *
+ * Three test files carried a copy of this each; this is the one they share.
+ */
+
+import { vi } from "vitest";
+import { BaseProvider } from "@nodetool-ai/runtime";
+
+export type MockStreamItem =
+  | { type: "chunk"; content: string; done?: boolean }
+  | { id: string; name: string; args: Record<string, unknown> };
+
+export interface LoopingMockProviderOptions {
+  /** Provider id. Pricing is looked up against it, so "openai" prices. */
+  provider?: string;
+  /** USD the provider reports as billed for every turn it completes. */
+  costPerTurn?: number;
+  /**
+   * Replay the last scripted turn once the script runs out, instead of
+   * answering with nothing. For a fan-out where every child runs one turn.
+   */
+  repeatLast?: boolean;
+  /** Awaited before a turn produces anything — holds a loop open. */
+  gate?: (call: number) => Promise<void> | void;
+  /** Notified as a turn's stream opens and as it closes. */
+  onTurnStart?: (call: number) => void;
+  onTurnEnd?: (call: number) => void;
+}
+
+/** Turns actually made, for a test that counts them. */
+export interface LoopingMockProvider extends BaseProvider {
+  readonly turnsStarted: number;
+}
+
+export function createLoopingMockProvider(
+  responseSequence: MockStreamItem[][],
+  options: LoopingMockProviderOptions = {}
+): LoopingMockProvider {
+  const costPerTurn = options.costPerTurn ?? 0;
+  let callIndex = 0;
+  let totalCost = 0;
+  let turnsStarted = 0;
+
+  return {
+    provider: options.provider ?? "mock",
+    hasToolSupport: async () => true,
+    getTotalCost: () => totalCost,
+    get turnsStarted() {
+      return turnsStarted;
+    },
+    generateMessages: async function* () {
+      const call = callIndex++;
+      turnsStarted++;
+      options.onTurnStart?.(call);
+      try {
+        await options.gate?.(call);
+        const items =
+          responseSequence[call] ??
+          (options.repeatLast
+            ? responseSequence[responseSequence.length - 1]
+            : undefined) ??
+          [];
+        for (const item of items) {
+          yield item;
+        }
+        totalCost += costPerTurn;
+      } finally {
+        options.onTurnEnd?.(call);
+      }
+    },
+    async *generateMessagesTraced(...args: any[]) {
+      yield* (this as any).generateMessages(...args);
+    },
+    generateLoop(args: unknown) {
+      return (
+        BaseProvider.prototype as { generateLoop: (a: unknown) => unknown }
+      ).generateLoop.call(this, args);
+    },
+    // The loop's admission point. Borrowed from the base class for the same
+    // reason `generateLoop` is: a hand-written stand-in would estimate prompt
+    // tokens differently and the reservation under test would not be the one
+    // production makes.
+    _admitTurn(...args: any[]) {
+      return (BaseProvider.prototype as any)._admitTurn.apply(this, args);
+    },
+    async generateMessageTraced(...args: any[]) {
+      return (this as any).generateMessage(...args);
+    },
+    generateMessage: vi.fn(),
+    getAvailableLanguageModels: vi.fn().mockResolvedValue([]),
+    getAvailableImageModels: vi.fn().mockResolvedValue([]),
+    getAvailableVideoModels: vi.fn().mockResolvedValue([]),
+    getAvailableTTSModels: vi.fn().mockResolvedValue([]),
+    getAvailableASRModels: vi.fn().mockResolvedValue([]),
+    getAvailableEmbeddingModels: vi.fn().mockResolvedValue([]),
+    getContainerEnv: () => ({}),
+    textToImage: vi.fn(),
+    imageToImage: vi.fn(),
+    textToSpeech: vi.fn(),
+    automaticSpeechRecognition: vi.fn(),
+    textToVideo: vi.fn(),
+    imageToVideo: vi.fn(),
+    generateEmbedding: vi.fn(),
+    isContextLengthError: () => false
+  } as any;
+}

--- a/packages/agents/tests/background-subtasks.test.ts
+++ b/packages/agents/tests/background-subtasks.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
-import { ProcessingContext, BaseProvider } from "@nodetool-ai/runtime";
+import { ProcessingContext, createRunBudget } from "@nodetool-ai/runtime";
 import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import { createLoopingMockProvider } from "./_helpers/looping-mock-provider.js";
 import {
   BackgroundSubtaskRegistry,
   StartSubtaskTool,
@@ -13,58 +14,15 @@ function makeCtx(): ProcessingContext {
   return new ProcessingContext({ jobId: "test-job", userId: "test" });
 }
 
-type StreamItem =
-  | { type: "chunk"; content: string; done?: boolean }
-  | { id: string; name: string; args: Record<string, unknown> };
-
 /**
- * Minimal mock BaseProvider — the same shape run-subtask-tool.test.ts uses.
- * `gates` holds one promise per generateMessages call, resolved by the test
- * to hold the child loop open before its scripted response plays.
+ * The shared looping mock, holding each turn behind its gate: `gates[i]` is
+ * resolved by the test to let child *i* past its scripted response.
  */
 function createMockProvider(gates: Array<Promise<void>> = []) {
-  let callIndex = 0;
-  const responseSequence: Array<Array<StreamItem>> = [
-    [{ type: "chunk", content: "late answer", done: true }]
-  ];
-  return {
-    provider: "mock",
-    hasToolSupport: async () => true,
-    generateMessages: async function* () {
-      const gate = gates[callIndex];
-      callIndex++;
-      if (gate) await gate;
-      const items = responseSequence[0] ?? [];
-      for (const item of items) yield item;
-    },
-    async *generateMessagesTraced(...args: any[]) {
-      yield* (this as any).generateMessages(...args);
-    },
-    generateLoop(args: unknown) {
-      return (
-        BaseProvider.prototype as { generateLoop: (a: unknown) => unknown }
-      ).generateLoop.call(this, args);
-    },
-    async generateMessageTraced(...args: any[]) {
-      return (this as any).generateMessage(...args);
-    },
-    generateMessage: vi.fn(),
-    getAvailableLanguageModels: vi.fn().mockResolvedValue([]),
-    getAvailableImageModels: vi.fn().mockResolvedValue([]),
-    getAvailableVideoModels: vi.fn().mockResolvedValue([]),
-    getAvailableTTSModels: vi.fn().mockResolvedValue([]),
-    getAvailableASRModels: vi.fn().mockResolvedValue([]),
-    getAvailableEmbeddingModels: vi.fn().mockResolvedValue([]),
-    getContainerEnv: () => ({}),
-    textToImage: vi.fn(),
-    imageToImage: vi.fn(),
-    textToSpeech: vi.fn(),
-    automaticSpeechRecognition: vi.fn(),
-    textToVideo: vi.fn(),
-    imageToVideo: vi.fn(),
-    generateEmbedding: vi.fn(),
-    isContextLengthError: () => false
-  } as any;
+  return createLoopingMockProvider(
+    [[{ type: "chunk", content: "late answer", done: true }]],
+    { repeatLast: true, gate: (call) => gates[call] }
+  );
 }
 
 describe("BackgroundSubtaskRegistry", () => {
@@ -173,6 +131,44 @@ describe("StartSubtaskTool", () => {
       prompt: "p"
     })) as Record<string, unknown>;
     expect(result.error).toBe("background_unavailable");
+  });
+
+  it("hands the run's budget to the detached child", async () => {
+    // The child runs after `process()` returned, so nothing but the budget it
+    // was given stops it — a fresh one here would be an uncapped background
+    // loop per spawn.
+    const budget = createRunBudget({
+      capUsd: 0,
+      maxOutputTokens: 1024,
+      unpricedTokenCeiling: 0,
+      deadlineMs: Infinity,
+      maxConcurrency: 4,
+      maxTurns: 10
+    });
+    const provider = createLoopingMockProvider(
+      [[{ type: "chunk", content: "late answer", done: true }]],
+      { provider: "openai", repeatLast: true }
+    );
+    const registry = new BackgroundSubtaskRegistry();
+    const tool = new StartSubtaskTool({
+      provider,
+      model: "gpt-4o-mini",
+      parentTools: () => [],
+      forwardMessage: () => {},
+      background: registry,
+      budget
+    });
+
+    const receipt = (await tool.process(makeCtx(), {
+      description: "capped",
+      prompt: "work"
+    })) as Record<string, unknown>;
+    expect(receipt.status).toBe("running");
+
+    await vi.waitFor(() => expect(registry.runningCount).toBe(0));
+    expect(provider.turnsStarted).toBe(0);
+    expect(registry.snapshot()[0].status).toBe("failed");
+    expect(budget.exhausted?.kind).toBe("cost");
   });
 
   it("still enforces the recursion depth gate", async () => {

--- a/packages/agents/tests/codeact-executor.test.ts
+++ b/packages/agents/tests/codeact-executor.test.ts
@@ -7,10 +7,16 @@ import { CodeActExecutor } from "../src/codeact/codeact-executor.js";
 import { Tool } from "../src/tools/base-tool.js";
 import type { Step, Task } from "../src/types.js";
 import type {
-  BaseProvider,
   ProcessingContext,
   ProviderStreamItem,
+  RunBudget,
   ToolCall
+} from "@nodetool-ai/runtime";
+import {
+  BaseProvider,
+  createCounter,
+  createRunBudget,
+  createSemaphore
 } from "@nodetool-ai/runtime";
 import { createMockContext } from "./_helpers/mock-context.js";
 
@@ -740,5 +746,225 @@ describe("coercionArtifactPaths", () => {
         word: "SHIP IT"
       })
     ).toEqual([]);
+  });
+});
+
+/**
+ * The run's bounds, seen from a step: `maxIterations` is what the whole step
+ * may spend on model turns (nudge rounds included), and a deadline stops the
+ * work in flight. Both failures have to name themselves — a step that ran out
+ * of budget and reports "ended without calling finish()" sends the reader
+ * looking for a prompt bug (invariants I-3, I-5).
+ */
+describe("CodeActExecutor run budget", () => {
+  /**
+   * Drives the real `BaseProvider.generateLoop`, so `maxIterations` and turn
+   * admission behave exactly as they do in production. Every turn calls
+   * `execute_code` except every `proseEvery`-th, which ends in prose — the one
+   * shape that earns a finish-nudge round.
+   */
+  class ScriptedTurnProvider extends BaseProvider {
+    readonly provider = "openai" as const;
+    turns = 0;
+
+    constructor(private readonly proseEvery: number) {
+      super();
+    }
+
+    async *generateMessages(): AsyncGenerator<ProviderStreamItem> {
+      this.turns++;
+      if (this.turns % this.proseEvery === 0) {
+        yield { type: "chunk", content: "I will finish next time.", done: true };
+        return;
+      }
+      yield {
+        id: `call_${this.turns}`,
+        name: "execute_code",
+        args: { code: "return 1;" }
+      };
+    }
+
+    async generateMessage(): Promise<never> {
+      throw new Error("not used");
+    }
+  }
+
+  /** A belt tool that reports each call, so a test can act on the first one. */
+  class TickTool extends Tool {
+    readonly name = "tick";
+    readonly description = "Records a call.";
+    calls = 0;
+    constructor(private readonly onCall: () => void) {
+      super();
+    }
+    async process(): Promise<unknown> {
+      this.calls++;
+      this.onCall();
+      return { ok: true };
+    }
+  }
+
+  const runBudget = (opts: Partial<Parameters<typeof createRunBudget>[0]>) =>
+    createRunBudget({
+      capUsd: null,
+      maxOutputTokens: 2048,
+      unpricedTokenCeiling: 400_000,
+      deadlineMs: 600_000,
+      maxConcurrency: 4,
+      maxTurns: 1000,
+      ...opts
+    });
+
+  it("spends maxIterations across the whole step, not once per nudge round", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    // Round shape: three tool turns then prose, which is what triggers a nudge.
+    const provider = new ScriptedTurnProvider(4);
+
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "gpt-4o-mini",
+      tools: [],
+      maxIterations: 4
+    });
+    const results: Array<{ type: string; error?: string }> = [];
+    for await (const msg of executor.execute()) {
+      results.push(msg as { type: string; error?: string });
+    }
+
+    // Two nudges used to hand each round the full four, for twelve turns.
+    expect(provider.turns).toBe(4);
+    expect(step.completed).toBe(false);
+    expect(results.find((m) => m.type === "step_result")?.error).toContain(
+      "exceeded 4 iterations"
+    );
+  });
+
+  it("fails with the deadline reason when the run is already out of time", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    const provider = new ScriptedTurnProvider(1);
+    const budget = runBudget({ deadlineMs: 0 });
+
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "gpt-4o-mini",
+      tools: [],
+      turnBudget: budget
+    });
+    for await (const msg of executor.execute()) void msg;
+
+    expect(provider.turns).toBe(0);
+    expect(step.failed).toBe(true);
+    expect(budget.exhausted?.kind).toBe("deadline");
+    expect(step.error).toContain("run deadline");
+    expect(step.error).not.toContain("without calling finish()");
+  });
+
+  it("aborts the action through the sandbox signal when the deadline passes mid-action", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    // A deadline the first bridged tool call trips, so expiry lands *inside*
+    // the running action rather than before it starts.
+    let outOfTime = false;
+    const budget: RunBudget = {
+      turns: { reserve: () => true, commit: () => {}, spentUsd: 0 },
+      deadline: {
+        at: Number.POSITIVE_INFINITY,
+        remainingMs: () => (outOfTime ? 0 : 1000),
+        expired: () => outOfTime
+      },
+      concurrency: createSemaphore(1),
+      turnCount: createCounter(10),
+      get exhausted() {
+        return outOfTime
+          ? { kind: "deadline" as const, detail: "run deadline of 1000ms reached" }
+          : null;
+      }
+    };
+    const tick = new TickTool(() => {
+      outOfTime = true;
+    });
+
+    const observations: string[] = [];
+    const provider = {
+      provider: "fake",
+      hasToolSupport: async () => true,
+      async *generateLoop(args: {
+        tools?: Array<{
+          name: string;
+          execute?: (a: Record<string, unknown>) => Promise<string | unknown>;
+        }>;
+      }) {
+        const tool = (args.tools ?? []).find((t) => t.name === "execute_code");
+        const result = await tool?.execute?.({
+          code: `import { tick } from "@nodetool-ai/sandbox-nodetool/session";
+                 await tick({});
+                 await tick({});
+                 await finish({answer: 1});`
+        });
+        observations.push(String(result));
+        yield {
+          type: "message",
+          message: { role: "assistant", content: "ran out of time" }
+        };
+        yield { type: "chunk", content: "", done: true };
+      }
+    } as unknown as BaseProvider;
+
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: [tick],
+      turnBudget: budget
+    });
+    for await (const msg of executor.execute()) void msg;
+
+    // The second call never reached the tool, and the program never finished.
+    expect(tick.calls).toBe(1);
+    expect(step.completed).toBe(false);
+    const observation = JSON.parse(observations[0] ?? "{}") as {
+      ok: boolean;
+      error?: string;
+    };
+    expect(observation.ok).toBe(false);
+    // "Execution cancelled" is what the sandbox reports for an aborted run —
+    // the action stopped on the signal, it did not merely see a failing call.
+    expect(observation.error).toBe("Execution cancelled");
+    expect(step.error).toContain("run deadline of 1000ms reached");
+    expect(step.error).not.toContain("without calling finish()");
+  });
+
+  it("fails naming the cost cap when the budget refuses the first turn", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    const provider = new ScriptedTurnProvider(1);
+    // Below one turn's worst case on a priced model.
+    const budget = runBudget({ capUsd: 0.000001 });
+
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "gpt-4o-mini",
+      tools: [],
+      turnBudget: budget
+    });
+    for await (const msg of executor.execute()) void msg;
+
+    expect(provider.turns).toBe(0);
+    expect(step.failed).toBe(true);
+    expect(step.error).toContain("turn budget of $");
+    expect(step.error).not.toContain("without calling finish()");
   });
 });

--- a/packages/agents/tests/merge-generators.test.ts
+++ b/packages/agents/tests/merge-generators.test.ts
@@ -2,6 +2,7 @@
  * The bounded generator merge that backs task and fan-out dispatch.
  */
 import { describe, it, expect } from "vitest";
+import { createSemaphore } from "@nodetool-ai/runtime";
 import { mergeAsyncGenerators } from "../src/utils/merge-generators.js";
 
 function tracked(id: string, items: number, state: { active: number; peak: number }) {
@@ -69,6 +70,48 @@ describe("mergeAsyncGenerators", () => {
     }
 
     expect(started).toEqual(["g0", "g1"]);
+  });
+
+  it("never runs more than the semaphore's permits at once", async () => {
+    const state = { active: 0, peak: 0 };
+    const generators = Array.from({ length: 8 }, (_, i) =>
+      tracked(`g${i}`, 2, state)
+    );
+
+    const out: string[] = [];
+    for await (const item of mergeAsyncGenerators(generators, {
+      semaphore: createSemaphore(2)
+    })) {
+      out.push(item);
+    }
+
+    expect(out).toHaveLength(16);
+    expect(state.peak).toBeLessThanOrEqual(2);
+  });
+
+  it("bounds two merges together when they share one semaphore", async () => {
+    // The nesting the number cannot bound: two fan-outs of 4 under a
+    // `concurrency` of 4 each run 8 at once, and a run's permit pool is what
+    // makes them 3 between them.
+    const state = { active: 0, peak: 0 };
+    const semaphore = createSemaphore(3);
+    const fanOut = (prefix: string) =>
+      mergeAsyncGenerators(
+        Array.from({ length: 4 }, (_, i) => tracked(`${prefix}${i}`, 2, state)),
+        { concurrency: 4, semaphore }
+      );
+
+    const out: string[] = [];
+    await Promise.all(
+      [fanOut("a"), fanOut("b")].map(async (merged) => {
+        for await (const item of merged) {
+          out.push(item);
+        }
+      })
+    );
+
+    expect(out).toHaveLength(16);
+    expect(state.peak).toBeLessThanOrEqual(3);
   });
 
   it("rethrows the first error after draining", async () => {

--- a/packages/agents/tests/run-budget-propagation.test.ts
+++ b/packages/agents/tests/run-budget-propagation.test.ts
@@ -1,0 +1,212 @@
+/**
+ * One budget per run, shared downward (invariant I-2).
+ *
+ * A cap that a child re-creates is not a cap: three children under a $1.25
+ * turn each get $1.25 of their own and the run spends $5. So the assertions
+ * here are about the *total* across every loop a turn opens, and about the
+ * permit pool that keeps a fan-out from opening twenty provider conversations
+ * at once.
+ *
+ * The provider is scripted but its loop is real (`BaseProvider.generateLoop`),
+ * so admission is exercised where it actually lives: reserve before a turn,
+ * commit the provider's own reported cost after it.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { ProcessingContext, createRunBudget } from "@nodetool-ai/runtime";
+import type { RunBudget } from "@nodetool-ai/runtime";
+import {
+  BackgroundSubtaskRegistry,
+  ParallelTaskExecutor,
+  RunSubtaskTool,
+  StartSubtaskTool
+} from "../src/index.js";
+import { createLoopingMockProvider } from "./_helpers/looping-mock-provider.js";
+
+/** A model the price catalog covers, so a turn has a knowable worst case. */
+const PRICED_MODEL = "gpt-4o-mini";
+
+/**
+ * $0.60 of output at gpt-4o-mini's rate: the worst case every reservation is
+ * measured against, and above the $0.50 each turn actually reports, so the cap
+ * holds rather than being crossed by an under-reserved turn.
+ */
+const MAX_OUTPUT_TOKENS = 1_000_000;
+const TURN_COST_USD = 0.5;
+/** Room for two turns' worst case, not three. */
+const CAP_USD = 1.25;
+
+function makeCtx(): ProcessingContext {
+  return new ProcessingContext({ jobId: "budget-test", userId: "test" });
+}
+
+function makeBudget(overrides: Partial<Parameters<typeof createRunBudget>[0]> = {}): RunBudget {
+  return createRunBudget({
+    capUsd: CAP_USD,
+    maxOutputTokens: MAX_OUTPUT_TOKENS,
+    unpricedTokenCeiling: 0,
+    deadlineMs: Infinity,
+    maxConcurrency: 8,
+    maxTurns: 50,
+    ...overrides
+  });
+}
+
+function answersOnce() {
+  return createLoopingMockProvider(
+    [[{ type: "chunk", content: "child answer", done: true }]],
+    { provider: "openai", costPerTurn: TURN_COST_USD, repeatLast: true }
+  );
+}
+
+describe("run budget propagation", () => {
+  it("spends at most the parent's cap across the parent and three children", async () => {
+    const budget = makeBudget();
+
+    // The parent turn — what a chat turn does with the budget it created.
+    const parent = createLoopingMockProvider(
+      [[{ type: "chunk", content: "parent turn", done: true }]],
+      { provider: "openai", costPerTurn: TURN_COST_USD }
+    );
+    for await (const _ of parent.generateLoop({
+      model: PRICED_MODEL,
+      messages: [{ role: "user", content: "go" }],
+      turnBudget: budget,
+      maxIterations: 1
+    } as never)) {
+      // drained; the assertions are on the budget, not the stream
+    }
+
+    const ctx = makeCtx();
+    const children = [answersOnce(), answersOnce(), answersOnce()];
+    const results: Array<unknown> = [];
+    for (const provider of children) {
+      const tool = new RunSubtaskTool({
+        provider,
+        model: PRICED_MODEL,
+        parentTools: () => [],
+        forwardMessage: () => {},
+        // The parent's budget, not one of the child's own.
+        budget
+      });
+      results.push(
+        await tool.process(ctx, { description: "d", prompt: "do a thing" })
+      );
+    }
+
+    // Measured off the providers themselves, not off the budget's own books:
+    // a child spending outside the budget would leave `spentUsd` looking fine.
+    const billed =
+      parent.getTotalCost() +
+      children.reduce((sum, c) => sum + c.getTotalCost(), 0);
+    expect(billed).toBeLessThanOrEqual(CAP_USD);
+    expect(budget.turns.spentUsd).toBeLessThanOrEqual(CAP_USD);
+    // The parent's turn plus one child's fits; the other two are refused
+    // before they open a conversation.
+    expect(parent.turnsStarted).toBe(1);
+    expect(children.filter((c) => c.turnsStarted > 0)).toHaveLength(1);
+    expect(budget.exhausted?.kind).toBe("cost");
+
+    const refused = results.filter(
+      (r) => (r as { error?: string }).error === "subtask_failed"
+    );
+    expect(refused).toHaveLength(2);
+    expect(String((refused[0] as { message: string }).message)).toContain(
+      "turn budget"
+    );
+  });
+
+  it("reaches every step of a plan the DAG executors run", async () => {
+    // `execute_plan` hands the plan to `ParallelTaskExecutor`, which builds a
+    // `TaskExecutor` per task and a `CodeActExecutor` per step. A budget that
+    // stops at any of those layers is a plan that spends without a cap.
+    const budget = makeBudget({ capUsd: 0 });
+    const provider = createLoopingMockProvider(
+      [[{ type: "chunk", content: "step answer", done: true }]],
+      { provider: "openai", repeatLast: true }
+    );
+    const executor = new ParallelTaskExecutor({
+      provider,
+      model: PRICED_MODEL,
+      context: makeCtx(),
+      tools: [],
+      taskPlan: {
+        title: "plan",
+        tasks: [
+          {
+            id: "t1",
+            title: "T1",
+            steps: [
+              {
+                id: "s1",
+                instructions: "do a thing",
+                completed: false,
+                dependsOn: [],
+                logs: []
+              }
+            ]
+          }
+        ]
+      },
+      budget
+    });
+
+    for await (const _ of executor.execute()) {
+      // drained
+    }
+
+    expect(provider.turnsStarted).toBe(0);
+    expect(executor.getFailedTaskIds()).toContain("t1");
+    expect(budget.exhausted?.kind).toBe("cost");
+  });
+
+  it("keeps a fan-out of twenty background children inside the run's permit pool", async () => {
+    const budget = makeBudget({ capUsd: null, maxConcurrency: 2, maxTurns: 100 });
+    const registry = new BackgroundSubtaskRegistry();
+
+    let active = 0;
+    let peak = 0;
+    const provider = createLoopingMockProvider(
+      [[{ type: "chunk", content: "child answer", done: true }]],
+      {
+        provider: "openai",
+        repeatLast: true,
+        onTurnStart: () => {
+          active++;
+          peak = Math.max(peak, active);
+        },
+        onTurnEnd: () => {
+          active--;
+        },
+        // Hold every turn open long enough for the others to pile up behind
+        // the permit pool if nothing were bounding them.
+        gate: () => new Promise((r) => setTimeout(r, 5))
+      }
+    );
+
+    const tool = new StartSubtaskTool({
+      provider,
+      model: PRICED_MODEL,
+      parentTools: () => [],
+      forwardMessage: () => {},
+      background: registry,
+      budget
+    });
+
+    const ctx = makeCtx();
+    for (let i = 0; i < 20; i++) {
+      const receipt = (await tool.process(ctx, {
+        description: `job ${i}`,
+        prompt: "work"
+      })) as Record<string, unknown>;
+      expect(receipt.status).toBe("running");
+    }
+
+    await vi.waitFor(() => expect(registry.runningCount).toBe(0), {
+      timeout: 10_000
+    });
+
+    expect(provider.turnsStarted).toBe(20);
+    expect(peak).toBeLessThanOrEqual(2);
+  }, 20_000);
+});

--- a/packages/agents/tests/run-search-tool.test.ts
+++ b/packages/agents/tests/run-search-tool.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
-import { ProcessingContext, BaseProvider } from "@nodetool-ai/runtime";
+import { describe, it, expect } from "vitest";
+import { ProcessingContext } from "@nodetool-ai/runtime";
 import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import {
+  createLoopingMockProvider,
+  type MockStreamItem
+} from "./_helpers/looping-mock-provider.js";
 import { RunSearchTool } from "../src/tools/run-search-tool.js";
 import {
   SUBTASK_DEPTH_KEY,
@@ -13,58 +17,13 @@ function makeCtx(): ProcessingContext {
 }
 
 /**
- * Minimal mock BaseProvider — just enough surface for the search's
- * StepExecutor. The provider replays a queued sequence of stream events per
- * `generateMessages` call. (Reused verbatim from run-subtask-tool.test.ts.)
+ * The looping mock every sub-agent suite shares — a scripted turn under the
+ * real `BaseProvider.generateLoop`.
  */
-function createMockProvider(
-  responseSequence: Array<
-    Array<
-      | { type: "chunk"; content: string; done?: boolean }
-      | { id: string; name: string; args: Record<string, unknown> }
-    >
-  >
-) {
-  let callIndex = 0;
-  return {
-    provider: "mock",
-    hasToolSupport: async () => true,
-    generateMessages: async function* () {
-      const items = responseSequence[callIndex] ?? [];
-      callIndex++;
-      for (const item of items) {
-        yield item;
-      }
-    },
-    async *generateMessagesTraced(...args: any[]) {
-      yield* (this as any).generateMessages(...args);
-    },
-    generateLoop(args: unknown) {
-      return (
-        BaseProvider.prototype as { generateLoop: (a: unknown) => unknown }
-      ).generateLoop.call(this, args);
-    },
-    async generateMessageTraced(...args: any[]) {
-      return (this as any).generateMessage(...args);
-    },
-    generateMessage: vi.fn(),
-    getAvailableLanguageModels: vi.fn().mockResolvedValue([]),
-    getAvailableImageModels: vi.fn().mockResolvedValue([]),
-    getAvailableVideoModels: vi.fn().mockResolvedValue([]),
-    getAvailableTTSModels: vi.fn().mockResolvedValue([]),
-    getAvailableASRModels: vi.fn().mockResolvedValue([]),
-    getAvailableEmbeddingModels: vi.fn().mockResolvedValue([]),
-    getContainerEnv: () => ({}),
-    textToImage: vi.fn(),
-    imageToImage: vi.fn(),
-    textToSpeech: vi.fn(),
-    automaticSpeechRecognition: vi.fn(),
-    textToVideo: vi.fn(),
-    imageToVideo: vi.fn(),
-    generateEmbedding: vi.fn(),
-    isContextLengthError: () => false
-  } as any;
-}
+const createMockProvider = (
+  responseSequence: MockStreamItem[][]
+): ReturnType<typeof createLoopingMockProvider> =>
+  createLoopingMockProvider(responseSequence);
 
 const makeTool = (name: string): any => ({
   name,

--- a/packages/agents/tests/run-subtask-tool.test.ts
+++ b/packages/agents/tests/run-subtask-tool.test.ts
@@ -1,6 +1,14 @@
-import { describe, it, expect, vi } from "vitest";
-import { ProcessingContext, BaseProvider } from "@nodetool-ai/runtime";
+import { describe, it, expect } from "vitest";
+import {
+  ProcessingContext,
+  RUN_BUDGET_CONTEXT_KEY,
+  createRunBudget
+} from "@nodetool-ai/runtime";
 import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import {
+  createLoopingMockProvider,
+  type MockStreamItem
+} from "./_helpers/looping-mock-provider.js";
 import {
   RunSubtaskTool,
   SUBTASK_DEPTH_KEY,
@@ -12,58 +20,13 @@ function makeCtx(): ProcessingContext {
 }
 
 /**
- * Minimal mock BaseProvider — just enough surface for the subtask's
- * StepExecutor. The provider replays a queued sequence of stream events
- * per `generateMessages` call.
+ * The looping mock every sub-agent suite shares — a scripted turn under the
+ * real `BaseProvider.generateLoop`.
  */
-function createMockProvider(
-  responseSequence: Array<
-    Array<
-      | { type: "chunk"; content: string; done?: boolean }
-      | { id: string; name: string; args: Record<string, unknown> }
-    >
-  >
-) {
-  let callIndex = 0;
-  return {
-    provider: "mock",
-    hasToolSupport: async () => true,
-    generateMessages: async function* () {
-      const items = responseSequence[callIndex] ?? [];
-      callIndex++;
-      for (const item of items) {
-        yield item;
-      }
-    },
-    async *generateMessagesTraced(...args: any[]) {
-      yield* (this as any).generateMessages(...args);
-    },
-    generateLoop(args: unknown) {
-      return (
-        BaseProvider.prototype as { generateLoop: (a: unknown) => unknown }
-      ).generateLoop.call(this, args);
-    },
-    async generateMessageTraced(...args: any[]) {
-      return (this as any).generateMessage(...args);
-    },
-    generateMessage: vi.fn(),
-    getAvailableLanguageModels: vi.fn().mockResolvedValue([]),
-    getAvailableImageModels: vi.fn().mockResolvedValue([]),
-    getAvailableVideoModels: vi.fn().mockResolvedValue([]),
-    getAvailableTTSModels: vi.fn().mockResolvedValue([]),
-    getAvailableASRModels: vi.fn().mockResolvedValue([]),
-    getAvailableEmbeddingModels: vi.fn().mockResolvedValue([]),
-    getContainerEnv: () => ({}),
-    textToImage: vi.fn(),
-    imageToImage: vi.fn(),
-    textToSpeech: vi.fn(),
-    automaticSpeechRecognition: vi.fn(),
-    textToVideo: vi.fn(),
-    imageToVideo: vi.fn(),
-    generateEmbedding: vi.fn(),
-    isContextLengthError: () => false
-  } as any;
-}
+const createMockProvider = (
+  responseSequence: MockStreamItem[][]
+): ReturnType<typeof createLoopingMockProvider> =>
+  createLoopingMockProvider(responseSequence);
 
 describe("RunSubtaskTool", () => {
   describe("name + schema", () => {
@@ -169,6 +132,94 @@ describe("RunSubtaskTool", () => {
       ) as { subtask_depth?: number; parent_tool_call_id?: string } | undefined;
       expect(sample).toBeDefined();
       expect(sample?.subtask_depth).toBe(1);
+    });
+  });
+
+  describe("run budget", () => {
+    /** A cap no turn can fit under, so a refusal is unambiguous. */
+    function exhaustedBudget() {
+      return createRunBudget({
+        capUsd: 0,
+        maxOutputTokens: 1024,
+        unpricedTokenCeiling: 0,
+        deadlineMs: Infinity,
+        maxConcurrency: 4,
+        maxTurns: 10
+      });
+    }
+
+    it("reserves against the budget the runtime carries", async () => {
+      const budget = exhaustedBudget();
+      const provider = createLoopingMockProvider(
+        [[{ type: "chunk", content: "answer", done: true }]],
+        { provider: "openai" }
+      );
+      const tool = new RunSubtaskTool({
+        provider,
+        model: "gpt-4o-mini",
+        parentTools: () => [],
+        forwardMessage: () => {},
+        budget
+      });
+
+      const result = (await tool.process(makeCtx(), {
+        description: "d",
+        prompt: "do a thing"
+      })) as Record<string, unknown>;
+
+      expect(provider.turnsStarted).toBe(0);
+      expect(result.error).toBe("subtask_failed");
+      expect(String(result.message)).toContain("budget");
+      expect(budget.exhausted?.kind).toBe("cost");
+    });
+
+    it("falls back to the budget the host left on the context", async () => {
+      // The host that put a budget on the context never sees the sub-agent
+      // runtime this tool is built from — the fallback is what makes a child
+      // three levels down share the turn's cap.
+      const budget = exhaustedBudget();
+      const provider = createLoopingMockProvider(
+        [[{ type: "chunk", content: "answer", done: true }]],
+        { provider: "openai" }
+      );
+      const tool = new RunSubtaskTool({
+        provider,
+        model: "gpt-4o-mini",
+        parentTools: () => [],
+        forwardMessage: () => {}
+      });
+      const ctx = makeCtx();
+      ctx.set(RUN_BUDGET_CONTEXT_KEY, budget);
+
+      const result = (await tool.process(ctx, {
+        description: "d",
+        prompt: "do a thing"
+      })) as Record<string, unknown>;
+
+      expect(provider.turnsStarted).toBe(0);
+      expect(result.error).toBe("subtask_failed");
+      expect(budget.exhausted?.kind).toBe("cost");
+    });
+
+    it("leaves an unbudgeted run unbounded rather than exhausted", async () => {
+      const provider = createLoopingMockProvider(
+        [[{ type: "chunk", content: "answer", done: true }]],
+        { provider: "openai" }
+      );
+      const tool = new RunSubtaskTool({
+        provider,
+        model: "gpt-4o-mini",
+        parentTools: () => [],
+        forwardMessage: () => {}
+      });
+
+      const result = await tool.process(makeCtx(), {
+        description: "d",
+        prompt: "do a thing"
+      });
+
+      expect(provider.turnsStarted).toBe(1);
+      expect(String(result)).toContain("answer");
     });
   });
 

--- a/packages/base-nodes/tests/coverage-100pct-remaining.test.ts
+++ b/packages/base-nodes/tests/coverage-100pct-remaining.test.ts
@@ -23,7 +23,15 @@ function asLoopProvider(p: any): any {
       return (
         BaseProvider.prototype as { generateLoop: (a: unknown) => unknown }
       ).generateLoop.call(this, loopArgs);
-    }
+    },
+    // AgentNode now always hands generateLoop a run budget, and the base loop
+    // reserves against it through these BaseProvider members. A mock that only
+    // implements generateMessages has none of them.
+    provider: p.provider ?? "mock",
+    _admitTurn(this: any, ...args: any[]) {
+      return (BaseProvider.prototype as any)._admitTurn.call(this, ...args);
+    },
+    getTotalCost: p.getTotalCost ?? (() => 0)
   };
 }
 

--- a/packages/base-nodes/tests/nodes.test.ts
+++ b/packages/base-nodes/tests/nodes.test.ts
@@ -383,7 +383,14 @@ describe("input/output nodes", () => {
           return (
             BaseProvider.prototype as { generateLoop: (a: unknown) => unknown }
           ).generateLoop.call(this, loopArgs);
-        }
+        },
+        // AgentNode always budgets its loop now, and the base loop reserves
+        // through these BaseProvider members.
+        provider: "openai",
+        _admitTurn(this: any, ...args: any[]) {
+          return (BaseProvider.prototype as any)._admitTurn.call(this, ...args);
+        },
+        getTotalCost: () => 0
       })
     } as unknown as ProcessingContext;
     agent.assign({

--- a/packages/config/src/setting-catalog.ts
+++ b/packages/config/src/setting-catalog.ts
@@ -137,7 +137,7 @@ s(
 s(
   "NODETOOL_AGENT_TURN_COST_CAP_USD",
   "Agents",
-  "Ceiling on provider spend for one agent run, in US dollars (default: 5.00). The whole run shares it: sub-agents, background subtasks, and agent nodes reserve against the same cap rather than opening their own. A turn whose worst case would cross it is refused before the call, and the run stops with a message naming the cap. Set to an empty value for no cap, which is what a local-only install wants."
+  "Ceiling on provider spend for one agent run, in US dollars (default: 5.00). The whole run shares it: sub-agents, background subtasks, and agent nodes reserve against the same cap rather than opening their own. A turn whose worst case would cross it is refused before the call, and the run stops with a message naming the cap. Set it to 0 for no cap at all, which is what a local-only install wants — clearing the value restores the default instead, because an empty setting is indistinguishable from an unset one."
 );
 s(
   "NODETOOL_AGENT_TURN_DEADLINE_MS",

--- a/packages/config/src/setting-catalog.ts
+++ b/packages/config/src/setting-catalog.ts
@@ -131,6 +131,34 @@ s(
   "Execution",
   "Maximum number of concurrent runs of the same workflow before additional runs queue (default: 4). Only applies to runs that opt into concurrency (e.g. timeline/sketch generation); canvas runs always stay sequential per workflow. Also bounded by MAX_CONCURRENT_JOBS."
 );
+// Agent budgets — the bounds one agent run shares across every loop it starts
+// (a chat turn, its sub-agents, an AgentNode it spawns). See A1 in
+// docs/plans/agent-system-improvements.md.
+s(
+  "NODETOOL_AGENT_TURN_COST_CAP_USD",
+  "Agents",
+  "Ceiling on provider spend for one agent run, in US dollars (default: 5.00). The whole run shares it: sub-agents, background subtasks, and agent nodes reserve against the same cap rather than opening their own. A turn whose worst case would cross it is refused before the call, and the run stops with a message naming the cap. Set to an empty value for no cap, which is what a local-only install wants."
+);
+s(
+  "NODETOOL_AGENT_TURN_DEADLINE_MS",
+  "Agents",
+  "Wall-clock bound on one agent run, in milliseconds (default: 1800000, i.e. 30 minutes). Checked before every model turn and every tool call, so a run that stalls on a slow provider ends instead of hanging."
+);
+s(
+  "NODETOOL_AGENT_MAX_CONCURRENCY",
+  "Agents",
+  "Maximum provider conversations an agent run may have open at once (default: 8). Shared by the whole run, so a fan-out of sub-agents inside a fan-out of steps cannot multiply into hundreds of simultaneous calls."
+);
+s(
+  "NODETOOL_AGENT_MAX_TURNS",
+  "Agents",
+  "Maximum model turns an agent run may make in total (default: 200), counted across every loop it starts. This is the bound that still holds for a local model with no price, where the dollar cap cannot apply."
+);
+s(
+  "NODETOOL_AGENT_UNPRICED_TOKEN_CEILING",
+  "Agents",
+  "Prompt-token ceiling for a turn on a model the price catalog does not cover (default: 400000). An unpriced model has no worst-case cost to reserve, so admitting it freely would make the dollar cap advisory; this bounds it by size instead. Such turns are counted as unpriced rather than as free spend."
+);
 // Provider endpoints
 s(
   "VLLM_BASE_URL",

--- a/packages/dsl/src/flow/generated/nodetool.agents.ts
+++ b/packages/dsl/src/flow/generated/nodetool.agents.ts
@@ -111,6 +111,8 @@ export type AgentInputs = {
   thread_id?: string;
   max_tokens?: number;
   max_turns?: number;
+  cost_cap_usd?: number;
+  timeout_s?: number;
 };
 
 export interface AgentOutputs {

--- a/packages/dsl/src/generated/nodetool.agents.ts
+++ b/packages/dsl/src/generated/nodetool.agents.ts
@@ -101,6 +101,8 @@ export type AgentInputs = {
   thread_id?: Connectable<string>;
   max_tokens?: Connectable<number>;
   max_turns?: Connectable<number>;
+  cost_cap_usd?: Connectable<number>;
+  timeout_s?: Connectable<number>;
 };
 
 export interface AgentOutputs {

--- a/packages/llm-nodes/src/nodes/agent-utils.ts
+++ b/packages/llm-nodes/src/nodes/agent-utils.ts
@@ -6,13 +6,15 @@ import type {
   MessageContent,
   MessageImageContent,
   ProcessingContext,
+  ProviderStop,
   ProviderStreamItem,
   ToolCall
 } from "@nodetool-ai/runtime";
 import {
   expandAssetReferences,
   extractJson,
-  generateStructured
+  generateStructured,
+  isProviderStop
 } from "@nodetool-ai/runtime";
 import type { Chunk } from "@nodetool-ai/protocol";
 import { hydrateBuiltinAgentTool } from "./agent-tool-hydration.js";
@@ -441,21 +443,33 @@ export type ProviderStreamEvent =
   | { kind: "audio"; chunk: Chunk }
   | { kind: "text"; chunk: Chunk; delta: string }
   | { kind: "assistant_message"; message: Message }
-  | { kind: "tool_message"; message: Message };
+  | { kind: "tool_message"; message: Message }
+  /**
+   * The loop ended for a reason other than the model ending its turn — a
+   * budget, the deadline, the iteration cap, or an abort. Dropping it would
+   * make a refused run read exactly like a finished one (invariant I-3), so
+   * every consumer sees it and decides what to do.
+   */
+  | { kind: "stop"; stop: ProviderStop };
 
 /**
  * Normalize and classify a provider stream into {@link ProviderStreamEvent}s.
  * Mirrors the branch structure both consumers previously inlined: tool-call
  * announcements, thinking chunks, audio chunks, any other content chunk (as
  * `text`, carrying the original chunk so a consumer can inspect content_type),
- * and finalized `{ type: "message" }` events split by role. The `text` event's
- * `delta` is the chunk's string content ("" for non-string payloads).
+ * finalized `{ type: "message" }` events split by role, and the loop's `stop`
+ * item. The `text` event's `delta` is the chunk's string content ("" for
+ * non-string payloads).
  */
 export async function* classifyProviderStream(
   stream: AsyncIterable<ProviderStreamItem>
 ): AsyncGenerator<ProviderStreamEvent> {
   for await (const raw of stream) {
     const item = normalizeProviderStreamItem(raw);
+    if (isProviderStop(item)) {
+      yield { kind: "stop", stop: item };
+      continue;
+    }
     if (isToolCallItem(item)) {
       yield { kind: "tool_call", toolCall: item };
       continue;

--- a/packages/llm-nodes/src/nodes/agents.ts
+++ b/packages/llm-nodes/src/nodes/agents.ts
@@ -1,12 +1,15 @@
-import { createLogger } from "@nodetool-ai/config";
+import { createLogger, getEnv } from "@nodetool-ai/config";
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { ImageRef, AudioRef } from "@nodetool-ai/node-sdk";
 import type {
   Message,
   MessageContent,
   ProcessingContext,
-  ProviderTool
+  ProviderStop,
+  ProviderTool,
+  RunBudget
 } from "@nodetool-ai/runtime";
+import { budgetFromContext, createRunBudget } from "@nodetool-ai/runtime";
 import type {
   LanguageModel,
   OutputCorrelation
@@ -80,6 +83,18 @@ export { runAgentLoop } from "./agent-loop.js";
 export type { AgentLoopOptions, AgentLoopResult } from "./agent-loop.js";
 
 const log = createLogger("nodetool.base-nodes.agents");
+
+/**
+ * An install-wide agent bound read from the environment, or its documented
+ * default. These two have no node prop of their own: an unpriced model's
+ * prompt ceiling and the run's concurrency bound are install policy, not
+ * per-node authoring decisions. Names and defaults come from
+ * `settingCatalog()` in `@nodetool-ai/config`.
+ */
+function agentEnvInt(key: string, fallback: number): number {
+  const parsed = Number(getEnv(key));
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 const DEFAULT_SYSTEM_PROMPT = "You are a friendly assistant";
 const AGENT_DEFAULT_MAX_TOKENS = 16_384;
@@ -906,6 +921,28 @@ export class AgentNode extends BaseNode {
   })
   declare max_turns: number;
 
+  @prop({
+    type: "float",
+    default: 5.0,
+    title: "Cost Cap (USD)",
+    description:
+      "Ceiling on provider spend for this run, in US dollars. A turn whose worst case (this prompt plus Max Tokens of output) would cross it is refused before the call is made, and the node fails with an error naming the cap — so the ceiling holds instead of being noticed after the money is gone. Zero or less means no cap, which is what a local-only install wants. Matches the install-wide default in NODETOOL_AGENT_TURN_COST_CAP_USD. Ignored when the node runs inside an agent run that already has a budget (a chat turn calling run_node): it reserves against that run's cap instead of opening a second allowance.",
+    min: 0,
+    max: 1000
+  })
+  declare cost_cap_usd: number;
+
+  @prop({
+    type: "int",
+    default: 1200,
+    title: "Timeout (s)",
+    description:
+      "Wall-clock bound on this run, in seconds (default 1200, i.e. 20 minutes). Checked before every model turn, so a run stalled on a slow provider or a tool loop ends with an error naming the timeout instead of hanging until the workflow is cancelled. Ignored when the node runs inside an agent run that already has a budget — that run's deadline applies.",
+    min: 1,
+    max: 86400
+  })
+  declare timeout_s: number;
+
   /**
    * Build the tool list for this run. Override in subclasses to inject
    * additional tools (e.g. sandbox shell/file/browser tools) alongside the
@@ -963,6 +1000,32 @@ export class AgentNode extends BaseNode {
     const threadId = String(this.thread_id ?? "").trim();
     const maxTokens = Number(this.max_tokens ?? AGENT_DEFAULT_MAX_TOKENS);
     const maxTurns = Math.max(1, Number(this.max_turns ?? 100));
+    // A prop that is not a number must not read as "no cap" — that is the one
+    // direction of this coercion that silently removes a ceiling.
+    const capProp = Number(this.cost_cap_usd);
+    const costCapUsd = Number.isFinite(capProp) ? capProp : 5;
+    const timeoutS = Math.max(1, Number(this.timeout_s) || 1200);
+    const inheritedBudget = budgetFromContext(context);
+    // Invariant I-2: one budget per run, shared downward. A node a chat turn
+    // started through `run_node` inherits that turn's budget and reserves
+    // against the same cap; only a node whose context carries none opens an
+    // allowance of its own. Creating one unconditionally would give every
+    // nested node a fresh $5 of headroom, which is no cap at all.
+    const budget: RunBudget =
+      inheritedBudget ??
+      createRunBudget({
+        // A cap of zero would refuse every turn rather than lift the ceiling,
+        // so non-positive means "no USD cap".
+        capUsd: costCapUsd > 0 ? costCapUsd : null,
+        maxOutputTokens: maxTokens,
+        unpricedTokenCeiling: agentEnvInt(
+          "NODETOOL_AGENT_UNPRICED_TOKEN_CEILING",
+          400000
+        ),
+        deadlineMs: timeoutS * 1000,
+        maxConcurrency: agentEnvInt("NODETOOL_AGENT_MAX_CONCURRENCY", 8),
+        maxTurns
+      });
     const tools: ToolLike[] = await this.buildTools(context);
 
     // Build control tools from _control_context (injected by the kernel
@@ -1197,11 +1260,20 @@ export class AgentNode extends BaseNode {
         maxIterations: maxTurns,
         sequentialTools: true,
         threadId: threadId || undefined,
+        turnBudget: budget,
         // Without this a cancelled workflow leaves
         // the provider loop (and any tool calls it makes) running.
         signal: context?.signal
       });
+      // The loop's own reason for ending, when it was not the model ending its
+      // turn. Read after the stream drains so any text the run did produce is
+      // emitted before the node decides whether to fail.
+      let stop: ProviderStop | null = null;
       for await (const event of classifyProviderStream(stream)) {
+        if (event.kind === "stop") {
+          stop = event.stop;
+          continue;
+        }
         if (event.kind === "tool_call") {
           const toolCall = event.toolCall;
           log.info("AgentNode received tool call", {
@@ -1295,6 +1367,22 @@ export class AgentNode extends BaseNode {
       // Flush any trailing turn for providers that stream final text without a
       // closing assistant message event (no-op once a turn has been finalized).
       yield* finalizeAssistantTurn();
+
+      // A budget or deadline stop is a failure: the node did not finish the
+      // job it was given, and returning its partial text as if it had would
+      // hide the cap from the user who set it (decision D2, invariant I-3).
+      // `iterations` keeps its long-standing behavior — reaching Max Turns has
+      // always just ended the node — and `aborted` is a cancelled workflow,
+      // which must stay a clean stop.
+      if (stop && (stop.reason === "budget" || stop.reason === "deadline")) {
+        log.warn("AgentNode stopped by the run budget", {
+          nodeId: this.__node_id ?? null,
+          reason: stop.reason,
+          detail: stop.detail,
+          spentUsd: budget.turns.spentUsd
+        });
+        throw new Error(`Agent stopped: ${stop.detail}`);
+      }
     }
 
     if (structuredSchema && structuredResult) {

--- a/packages/llm-nodes/tests/agent-budget.test.ts
+++ b/packages/llm-nodes/tests/agent-budget.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+// Import from source (not the package's stale dist) so the test exercises the
+// AgentNode in this working tree.
+import { AgentNode } from "../src/nodes/agents.js";
+import { BaseProvider, createRunBudget } from "@nodetool-ai/runtime";
+import { RUN_BUDGET_CONTEXT_KEY } from "@nodetool-ai/runtime";
+import type { ProcessingContext, RunBudget } from "@nodetool-ai/runtime";
+
+/** A model the price catalog covers, so a USD cap has a worst case to reserve. */
+const PRICED_MODEL = "gpt-4o-mini";
+const MAX_TOKENS = 4096;
+
+interface ScriptedProvider {
+  provider: string;
+  /** Model calls the loop actually made. */
+  calls: number;
+  /** What the provider reports having spent so far, in USD. */
+  totalCost: number;
+}
+
+/**
+ * A provider that answers one turn with a single final chunk and books
+ * `costPerCall` for it. Delegates the tool-calling loop to `BaseProvider`, so
+ * the admission point under test is the real one.
+ */
+function makeScriptedProvider(costPerCall = 0): () => ScriptedProvider {
+  return () => {
+    const self = {
+      provider: "openai",
+      calls: 0,
+      totalCost: 0,
+      getTotalCost() {
+        return self.totalCost;
+      },
+      async *generateMessages() {
+        self.calls += 1;
+        yield {
+          type: "chunk",
+          content: "answer",
+          content_type: "text",
+          done: true
+        };
+        self.totalCost += costPerCall;
+      },
+      async *generateMessagesTraced(...args: unknown[]) {
+        yield* (self as any).generateMessages(...args);
+      },
+      generateLoop(loopArgs: unknown) {
+        return (
+          BaseProvider.prototype as { generateLoop: (a: unknown) => unknown }
+        ).generateLoop.call(self, loopArgs);
+      },
+      // The admission point under test lives on BaseProvider; borrow it so
+      // this mock reserves exactly the way a real provider does.
+      _admitTurn(...args: unknown[]) {
+        return (
+          BaseProvider.prototype as unknown as {
+            _admitTurn: (...a: unknown[]) => boolean;
+          }
+        )._admitTurn.call(self, ...args);
+      }
+    };
+    return self as unknown as ScriptedProvider;
+  };
+}
+
+/** A provider whose loop ends with the given stop item after one chunk. */
+function makeStoppingProvider(reason: "aborted" | "iterations") {
+  return () => ({
+    provider: "openai",
+    getTotalCost: () => 0,
+    async *generateLoop() {
+      yield {
+        type: "chunk",
+        content: "partial",
+        content_type: "text",
+        done: true
+      };
+      yield {
+        type: "message",
+        message: { role: "assistant", content: "partial" }
+      };
+      yield { type: "stop", reason, detail: `stopped: ${reason}` };
+    }
+  });
+}
+
+function createContext(
+  provider: () => unknown,
+  variables: Record<string, unknown> = {}
+): ProcessingContext {
+  return {
+    getProvider: async () => provider(),
+    get: <T,>(key: string, defaultValue?: T) =>
+      (key in variables ? variables[key] : defaultValue) as T
+  } as unknown as ProcessingContext;
+}
+
+function makeAgent(props: Record<string, unknown>): AgentNode {
+  const agent = new AgentNode();
+  agent.assign({
+    system: "You are helpful",
+    prompt: "Say hello",
+    model: { provider: "openai", id: PRICED_MODEL },
+    max_tokens: MAX_TOKENS,
+    ...props
+  });
+  return agent;
+}
+
+async function drain(agent: AgentNode, context: ProcessingContext) {
+  const items: Record<string, unknown>[] = [];
+  for await (const item of agent.genProcess(context)) items.push(item);
+  return items;
+}
+
+describe("AgentNode run budget", () => {
+  it("fails naming the cap, and makes no model call, when one turn cannot fit", async () => {
+    // gpt-4o-mini bills $0.60 per 1M output tokens, so 4096 output tokens is a
+    // worst case of ~$0.0025 — well over this cap.
+    const factory = makeScriptedProvider();
+    let created: ScriptedProvider | undefined;
+    const context = createContext(() => (created = factory()));
+    const agent = makeAgent({ cost_cap_usd: 0.0001 });
+
+    await expect(drain(agent, context)).rejects.toThrow(
+      /turn budget of \$0\.0001 reached/
+    );
+    expect(created?.calls).toBe(0);
+  });
+
+  it("reserves against the budget already on the context, not a fresh one", async () => {
+    // The parent's cap is what has to hold. The node asks for $999 of its own,
+    // which it must not get.
+    const parent: RunBudget = createRunBudget({
+      capUsd: 1,
+      maxOutputTokens: MAX_TOKENS,
+      unpricedTokenCeiling: 400000,
+      deadlineMs: 60_000,
+      maxConcurrency: 8,
+      maxTurns: 10
+    });
+    const context = createContext(makeScriptedProvider(0.25), {
+      [RUN_BUDGET_CONTEXT_KEY]: parent
+    });
+    const agent = makeAgent({ cost_cap_usd: 999 });
+
+    await drain(agent, context);
+
+    // A node that opened its own budget would leave the parent's spend at 0.
+    expect(parent.turns.spentUsd).toBeCloseTo(0.25, 6);
+    expect(parent.turnCount.current).toBe(1);
+  });
+
+  it("stops cleanly on an aborted run instead of raising", async () => {
+    const context = createContext(makeStoppingProvider("aborted"));
+    const agent = makeAgent({});
+
+    const items = await drain(agent, context);
+
+    expect(items.some((item) => item.text === "partial")).toBe(true);
+  });
+
+  it("keeps reaching Max Turns a clean end, not an error", async () => {
+    const context = createContext(makeStoppingProvider("iterations"));
+    const agent = makeAgent({});
+
+    await expect(drain(agent, context)).resolves.toBeDefined();
+  });
+});

--- a/packages/llm-nodes/tests/agent-loop.test.ts
+++ b/packages/llm-nodes/tests/agent-loop.test.ts
@@ -442,4 +442,25 @@ describe("classifyProviderStream", () => {
     expect(events[4].chunk.content_type).toBe("text");
     expect(events[5].message.role).toBe("assistant");
   });
+
+  it("surfaces the loop's stop item instead of dropping it", async () => {
+    async function* raw() {
+      yield { type: "chunk", content: "partial", content_type: "text" };
+      yield {
+        type: "stop",
+        reason: "budget",
+        detail: "turn budget of $5 reached"
+      };
+    }
+    const events: any[] = [];
+    for await (const ev of classifyProviderStream(raw() as any)) {
+      events.push(ev);
+    }
+    expect(events.map((e) => e.kind)).toEqual(["text", "stop"]);
+    expect(events[1].stop).toEqual({
+      type: "stop",
+      reason: "budget",
+      detail: "turn budget of $5 reached"
+    });
+  });
 });

--- a/packages/llm-nodes/tests/coverage-ai-nodes.test.ts
+++ b/packages/llm-nodes/tests/coverage-ai-nodes.test.ts
@@ -42,8 +42,20 @@ function withAgentLoop<T extends Record<string, any>>(provider: T): T {
     };
   return {
     ...provider,
+    // `_admitTurn` prices the turn by provider id; an undefined one reaches the
+    // cost calculator as `undefined.toLowerCase()`.
+    provider: provider.provider ?? "mock",
     generateMessagesTraced: traced,
-    generateLoop: delegateGenerateLoop
+    generateLoop: delegateGenerateLoop,
+    // AgentNode now always hands generateLoop a run budget, and the base loop
+    // reserves against it through these two BaseProvider methods. A mock that
+    // only implements generateMessages has neither, so borrow them.
+    _admitTurn:
+      provider._admitTurn ??
+      function (this: any, ...args: any[]) {
+        return (BaseProvider.prototype as any)._admitTurn.call(this, ...args);
+      },
+    getTotalCost: provider.getTotalCost ?? (() => 0)
   };
 }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -101,9 +101,27 @@ export {
 } from "./invocation-account.js";
 export {
   CostCappedTurnBudget,
+  CompositeTurnBudget,
+  createRunBudget,
+  createDeadline,
+  createSemaphore,
+  createCounter,
+  isRunBudget,
+  BUDGET_EXHAUSTION_KINDS,
+  TURN_REFUSALS,
   type TurnBudget,
   type TurnReservation,
-  type CostCappedTurnBudgetOptions
+  type CostCappedTurnBudgetOptions,
+  type CompositeTurnBudgetOptions,
+  type CreateRunBudgetOptions,
+  type RunBudget,
+  type BudgetExhaustion,
+  type BudgetExhaustionKind,
+  type TurnRefusal,
+  type Deadline,
+  type Semaphore,
+  type Release,
+  type Counter
 } from "./turn-budget.js";
 export { packContext, type PackedContext } from "./context-packer.js";
 export {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -107,6 +107,8 @@ export {
   createSemaphore,
   createCounter,
   isRunBudget,
+  budgetFromContext,
+  RUN_BUDGET_CONTEXT_KEY,
   BUDGET_EXHAUSTION_KINDS,
   TURN_REFUSALS,
   type TurnBudget,

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -14,6 +14,7 @@ import type {
   MusicModel,
   ProviderId,
   ProviderSession,
+  ProviderStop,
   ProviderStreamItem,
   ProviderThinkingConfig,
   ProviderEffort,
@@ -41,7 +42,9 @@ import type {
 import {
   isProviderSessionUpdate,
   isProviderMessageEvent,
-  isProviderToolErrorResult
+  isProviderStop,
+  isProviderToolErrorResult,
+  PROVIDER_STOP_ABORTED
 } from "./types.js";
 import { CostCalculator } from "./cost-calculator.js";
 import type { UsageInfo } from "./cost-calculator.js";
@@ -57,7 +60,8 @@ import {
   createUsageSlot,
   type LlmUsage
 } from "../tracing-helpers.js";
-import type { TurnBudget } from "../turn-budget.js";
+import type { RunBudget, TurnBudget } from "../turn-budget.js";
+import { isRunBudget } from "../turn-budget.js";
 import { countTokens } from "../token-counter.js";
 import {
   isCallable,
@@ -81,6 +85,38 @@ import { SpanStatusCode } from "@opentelemetry/api";
 import { createLogger, getDefaultAssetsPath } from "@nodetool-ai/config";
 
 const log = createLogger("nodetool.runtime.provider");
+
+/**
+ * Split the `turnBudget` argument into the run-level bounds (when the caller
+ * passed a {@link RunBudget}) and the per-turn admission object every loop
+ * reserves against. One argument serves both, so callers holding only a bare
+ * {@link TurnBudget} — the supervisor — keep working unchanged.
+ *
+ * A free function rather than a method: `generateLoop` is called unbound on
+ * duck-typed test providers (`BaseProvider.prototype.generateLoop.call(mock)`),
+ * where `this` has no class methods.
+ */
+export function resolveTurnBudget(
+  budget: TurnBudget | RunBudget | undefined
+): { runBudget: RunBudget | null; turnBudget: TurnBudget | undefined } {
+  if (isRunBudget(budget)) {
+    return { runBudget: budget, turnBudget: budget.turns };
+  }
+  return { runBudget: null, turnBudget: budget };
+}
+
+/**
+ * The stop item for a refused turn. A {@link RunBudget} says which ceiling
+ * refused it; a bare {@link TurnBudget} only knows that one did.
+ */
+export function budgetStopItem(runBudget: RunBudget | null): ProviderStop {
+  const exhausted = runBudget?.exhausted ?? null;
+  return {
+    type: "stop",
+    reason: exhausted?.kind === "deadline" ? "deadline" : "budget",
+    detail: exhausted?.detail ?? "the turn budget refused the next model turn"
+  };
+}
 
 /**
  * Collapse a tool result to plain text. Used by string-only tool channels (the
@@ -1087,7 +1123,13 @@ export abstract class BaseProvider {
        * advisory for every model it serves. Both current overrides honor it
        * (the Claude Agent SDK loop and OpenAI's Responses loop). TypeScript
        * cannot enforce this, so a new override that owns its turns owns this
-       * too.
+       * too — including yielding one {@link ProviderStop} as its final item
+       * when a refusal, rather than the model, ended the loop. Returning
+       * silently reads to every consumer as a finished answer.
+       *
+       * Accepts a {@link RunBudget} as well, and then also honors that run's
+       * deadline and cumulative turn count; the stop item names which ceiling
+       * refused the turn.
        *
        * Reserve against the *evolving* transcript, not the opening prompt: a
        * backend that keeps the conversation server-side still bills for it,
@@ -1099,7 +1141,7 @@ export abstract class BaseProvider {
        * driving concurrently; the supervisor owns its provider for exactly
        * this reason.
        */
-      turnBudget?: TurnBudget;
+      turnBudget?: TurnBudget | RunBudget;
       /**
        * The run's workspace directory. Only providers that drive their own
        * agent loop over host tools read it — the Claude Agent SDK uses it as
@@ -1123,11 +1165,12 @@ export abstract class BaseProvider {
       executeTool,
       maxIterations: _omitMax,
       sequentialTools,
-      turnBudget,
+      turnBudget: budgetArg,
       workspaceDir: _omitWorkspaceDir,
       skills: _omitSkills,
       ...turnArgs
     } = args;
+    const { runBudget, turnBudget } = resolveTurnBudget(budgetArg);
     const messages = [...args.messages];
 
     // Tools may carry their own `execute` (provider-dispatched) and/or a
@@ -1157,8 +1200,16 @@ export abstract class BaseProvider {
       : turnArgs.onToolCall;
 
     for (let iteration = 0; iteration < maxIterations; iteration++) {
-      if (turnArgs.signal?.aborted) return;
+      if (turnArgs.signal?.aborted) {
+        yield PROVIDER_STOP_ABORTED;
+        return;
+      }
+      if (runBudget?.deadline.expired()) {
+        yield budgetStopItem(runBudget);
+        return;
+      }
       if (turnBudget && !this._admitTurn(turnBudget, args.model, messages)) {
+        yield budgetStopItem(runBudget);
         return;
       }
       const costBeforeTurn = turnBudget ? this.getTotalCost() : 0;
@@ -1194,6 +1245,12 @@ export abstract class BaseProvider {
           if ("id" in item && "name" in item && "args" in item) {
             pending.push(item);
             yield item;
+            continue;
+          }
+          if (isProviderStop(item)) {
+            // Only this loop ends a loop. A single turn never yields a stop,
+            // so one arriving from `generateMessages` is not the loop's stop
+            // and must not be forwarded as if it were.
             continue;
           }
           const chunk = item;
@@ -1236,14 +1293,18 @@ export abstract class BaseProvider {
         }
         if (finalizedAssistant) {
           messages.push(finalizedAssistant);
-          return;
+        } else {
+          const assistantMsg: Message = {
+            role: "assistant",
+            content: assistantText || null
+          };
+          messages.push(assistantMsg);
+          yield { type: "message", message: assistantMsg };
         }
-        const assistantMsg: Message = {
-          role: "assistant",
-          content: assistantText || null
-        };
-        messages.push(assistantMsg);
-        yield { type: "message", message: assistantMsg };
+        // An abort mid-stream cut the turn short; the model did not end it.
+        if (turnArgs.signal?.aborted) {
+          yield PROVIDER_STOP_ABORTED;
+        }
         return;
       }
 
@@ -1343,7 +1404,10 @@ export abstract class BaseProvider {
           }
         }
       } else {
-        if (turnArgs.signal?.aborted) return;
+        if (turnArgs.signal?.aborted) {
+          yield PROVIDER_STOP_ABORTED;
+          return;
+        }
         const results = await Promise.all(
           pending.map(async (tc) => ({ tc, content: await runTool(tc) }))
         );
@@ -1355,9 +1419,16 @@ export abstract class BaseProvider {
 
       messages.push(...imageMessages);
 
-      // A terminal tool ran this turn — stop after emitting its results.
+      // A terminal tool ran this turn — stop after emitting its results. That
+      // is the loop doing what it was asked, not a limit being hit, so it
+      // carries no stop item.
       if (terminated) return;
     }
+    yield {
+      type: "stop",
+      reason: "iterations",
+      detail: `stopped after ${maxIterations} tool-calling round(s)`
+    };
   }
 
   /** Internal: wrap generateMessages with OTel span */

--- a/packages/runtime/src/providers/claude-agent-provider.ts
+++ b/packages/runtime/src/providers/claude-agent-provider.ts
@@ -46,16 +46,22 @@ import type {
   SDKUserMessage
 } from "@anthropic-ai/claude-agent-sdk";
 import { z, type ZodTypeAny } from "zod";
-import { BaseProvider } from "./base-provider.js";
+import {
+  BaseProvider,
+  budgetStopItem,
+  resolveTurnBudget
+} from "./base-provider.js";
 import { sdkNativeReplacements } from "./core-tools.js";
 import {
   isProviderMessageEvent,
   isProviderSessionUpdate,
+  isProviderStop,
   type LanguageModel,
   type Message,
   type MessageContent,
   type MessageTextContent,
   type ProviderSession,
+  type ProviderStop,
   type ProviderStreamItem,
   type ProviderSkill,
   type ProviderTool,
@@ -68,7 +74,7 @@ import {
   isObjectLike,
   isString
 } from "../type-predicates.js";
-import type { TurnBudget } from "../turn-budget.js";
+import type { RunBudget, TurnBudget } from "../turn-budget.js";
 
 const log = createLogger("nodetool.runtime.providers.claude-agent");
 
@@ -298,7 +304,7 @@ export class ClaudeAgentProvider extends BaseProvider {
     args: Parameters<ClaudeAgentProvider["generateMessages"]>[0] & {
       executeTool?: (toolCall: ToolCall) => Promise<string | MessageContent[]>;
       maxIterations?: number;
-      turnBudget?: TurnBudget;
+      turnBudget?: TurnBudget | RunBudget;
       workspaceDir?: string;
       /**
        * The user's DB skills. Materialized into an isolated local plugin so the
@@ -314,8 +320,13 @@ export class ClaudeAgentProvider extends BaseProvider {
     // reserve before the first turn, and again after every assistant turn that
     // requested tools — that is the point where the SDK will make another call.
     // A refusal aborts the session instead of letting it spend past the cap.
-    const turnBudget = args.turnBudget;
+    const { runBudget, turnBudget } = resolveTurnBudget(args.turnBudget);
+    if (runBudget?.deadline.expired()) {
+      yield budgetStopItem(runBudget);
+      return;
+    }
     if (turnBudget && !this._admitTurn(turnBudget, args.model, args.messages)) {
+      yield budgetStopItem(runBudget);
       return;
     }
     // Drop every NodeTool tool the SDK ships a built-in for. Those built-ins
@@ -399,6 +410,10 @@ export class ClaudeAgentProvider extends BaseProvider {
     }
 
     const costBefore = turnBudget ? this.getTotalCost() : 0;
+    // Set when the budget refuses a further turn: the SDK session is aborted
+    // and the stop is yielded once the stream has drained, so it stays the
+    // loop's final item.
+    let budgetStop: ProviderStop | null = null;
     try {
       const stream = this.runWithSession(
         { ...args, signal: abortController.signal },
@@ -431,6 +446,7 @@ export class ClaudeAgentProvider extends BaseProvider {
           isToolCallingTurn &&
           !this._admitTurn(turnBudget, args.model, transcript)
         ) {
+          budgetStop = budgetStopItem(runBudget);
           abortController.abort();
         }
       }
@@ -460,6 +476,9 @@ export class ClaudeAgentProvider extends BaseProvider {
           .rm(skillsPlugin.dir, { recursive: true, force: true })
           .catch(() => {});
       }
+    }
+    if (budgetStop) {
+      yield budgetStop;
     }
   }
 
@@ -873,7 +892,11 @@ export class ClaudeAgentProvider extends BaseProvider {
     let content = "";
     const toolCalls: ToolCall[] = [];
     for await (const item of this.generateMessages(args)) {
-      if (isProviderSessionUpdate(item) || isProviderMessageEvent(item))
+      if (
+        isProviderSessionUpdate(item) ||
+        isProviderMessageEvent(item) ||
+        isProviderStop(item)
+      )
         continue;
       if ("args" in item) {
         toolCalls.push(item);

--- a/packages/runtime/src/providers/codex-provider.ts
+++ b/packages/runtime/src/providers/codex-provider.ts
@@ -38,7 +38,11 @@ import type {
   TextToImageParams,
   ToolCall
 } from "./types.js";
-import { isProviderSessionUpdate, isProviderMessageEvent } from "./types.js";
+import {
+  isProviderSessionUpdate,
+  isProviderMessageEvent,
+  isProviderStop
+} from "./types.js";
 
 const log = createLogger("nodetool.runtime.codex");
 
@@ -585,7 +589,11 @@ export class CodexProvider extends OpenAIProvider {
     let content = "";
     const toolCalls: ToolCall[] = [];
     for await (const item of this.generateMessages(args)) {
-      if (isProviderSessionUpdate(item) || isProviderMessageEvent(item))
+      if (
+        isProviderSessionUpdate(item) ||
+        isProviderMessageEvent(item) ||
+        isProviderStop(item)
+      )
         continue;
       if ("args" in item) {
         toolCalls.push(item);

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -308,6 +308,7 @@ export type {
   ProviderSession,
   ProviderSessionUpdate,
   ProviderMessageEvent,
+  ProviderStop,
   StreamingAudioChunk,
   EncodedAudioResult,
   AudioChunk,
@@ -320,7 +321,9 @@ export {
 export {
   isProviderSessionUpdate,
   isProviderMessageEvent,
+  isProviderStop,
   isProviderToolErrorResult,
+  PROVIDER_STOP_ABORTED,
   WEB_SEARCH_TOOL_NAME,
   IMAGE_GENERATION_TOOL_NAME
 } from "./types.js";

--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -6,10 +6,15 @@ import OpenAI, { toFile } from "openai";
 import type { Chunk } from "@nodetool-ai/protocol";
 import { PROVIDER_IDS } from "@nodetool-ai/protocol";
 import { createLogger, importHidden } from "@nodetool-ai/config";
-import { BaseProvider, splitToolResultImages } from "./base-provider.js";
+import {
+  BaseProvider,
+  budgetStopItem,
+  resolveTurnBudget,
+  splitToolResultImages
+} from "./base-provider.js";
 import { hashSystemPrompt } from "./provider-session.js";
 import { sniffAudioMime } from "./audio-mime.js";
-import type { TurnBudget } from "../turn-budget.js";
+import type { RunBudget, TurnBudget } from "../turn-budget.js";
 
 /** Extension for each mime `sniffAudioMime` can return; anything else is mp3. */
 const AUDIO_MIME_EXT: Record<string, string> = {
@@ -38,6 +43,7 @@ import {
   isProviderMessageEvent,
   isProviderSessionUpdate,
   IMAGE_GENERATION_TOOL_NAME,
+  PROVIDER_STOP_ABORTED,
   WEB_SEARCH_TOOL_NAME
 } from "./types.js";
 
@@ -1451,7 +1457,7 @@ export class OpenAIProvider extends BaseProvider {
       executeTool?: (toolCall: ToolCall) => Promise<string | MessageContent[]>;
       maxIterations?: number;
       sequentialTools?: boolean;
-      turnBudget?: TurnBudget;
+      turnBudget?: TurnBudget | RunBudget;
     }
   ): AsyncGenerator<ProviderStreamItem> {
     if (!this.usesResponsesApi(args.model)) {
@@ -1463,9 +1469,10 @@ export class OpenAIProvider extends BaseProvider {
       executeTool,
       maxIterations: _omitMaxIterations,
       sequentialTools,
-      turnBudget,
+      turnBudget: budgetArg,
       ...turnArgs
     } = args;
+    const { runBudget, turnBudget } = resolveTurnBudget(budgetArg);
     const systemHash = hashSystemPrompt(responsesSystemPrompt(args.messages));
     const prior = args.providerSession ?? null;
     const canResume =
@@ -1488,7 +1495,8 @@ export class OpenAIProvider extends BaseProvider {
           firstPreviousResponseId: prior.token,
           systemHash,
           firstTurnState,
-          turnBudget
+          turnBudget,
+          runBudget
         });
         return;
       } catch (err) {
@@ -1513,7 +1521,8 @@ export class OpenAIProvider extends BaseProvider {
       firstPreviousResponseId: null,
       systemHash,
       firstTurnState: this.createResponsesTurnState(null),
-      turnBudget
+      turnBudget,
+      runBudget
     });
   }
 
@@ -1600,6 +1609,8 @@ export class OpenAIProvider extends BaseProvider {
     systemHash: string;
     firstTurnState: StreamTurnState;
     turnBudget?: TurnBudget;
+    /** Run-level bounds, when the caller passed a {@link RunBudget}. */
+    runBudget?: RunBudget | null;
   }): AsyncGenerator<ProviderStreamItem> {
     const toolMap = new Map<string, ProviderTool>(
       (config.args.tools ?? []).map((tool) => [tool.name, tool])
@@ -1616,12 +1627,21 @@ export class OpenAIProvider extends BaseProvider {
     // so the reservation grows with the turn it is admitting.
     const transcript: Message[] = [...config.firstMessages];
 
+    const runBudget = config.runBudget ?? null;
     for (let iteration = 0; iteration < config.maxIterations; iteration++) {
-      if (config.args.signal?.aborted) return;
+      if (config.args.signal?.aborted) {
+        yield PROVIDER_STOP_ABORTED;
+        return;
+      }
+      if (runBudget?.deadline.expired()) {
+        yield budgetStopItem(runBudget);
+        return;
+      }
       if (
         config.turnBudget &&
         !this._admitTurn(config.turnBudget, config.args.model, transcript)
       ) {
+        yield budgetStopItem(runBudget);
         return;
       }
       const costBeforeTurn = config.turnBudget ? this.getTotalCost() : 0;
@@ -1751,6 +1771,11 @@ export class OpenAIProvider extends BaseProvider {
     }
 
     yield { type: "chunk", content: "", done: true };
+    yield {
+      type: "stop",
+      reason: "iterations",
+      detail: `stopped after ${config.maxIterations} tool-calling round(s)`
+    };
   }
 
   private async *collectResponsesTurn(

--- a/packages/runtime/src/providers/types.ts
+++ b/packages/runtime/src/providers/types.ts
@@ -656,11 +656,35 @@ export interface ProviderMessageEvent {
   message: Message;
 }
 
+/**
+ * Why an agentic loop ({@link BaseProvider.generateLoop}) stopped, when it was
+ * not the model ending its turn. Yielded as the loop's final item, exactly
+ * once, so a consumer can tell a budget stop from a finished answer — a silent
+ * return reads identically to success and is a bug (invariant I-3).
+ */
+export interface ProviderStop {
+  type: "stop";
+  reason: "budget" | "deadline" | "iterations" | "aborted";
+  /** Human-readable reason, naming the limit that was hit. */
+  detail: string;
+}
+
+/**
+ * The loop ended because the caller aborted it. One shared value so every
+ * abort path — the base loop's and each override's — says the same thing.
+ */
+export const PROVIDER_STOP_ABORTED: ProviderStop = {
+  type: "stop",
+  reason: "aborted",
+  detail: "the run was aborted"
+};
+
 export type ProviderStreamItem =
   | Chunk
   | ToolCall
   | ProviderSessionUpdate
-  | ProviderMessageEvent;
+  | ProviderMessageEvent
+  | ProviderStop;
 
 /**
  * Narrow a stream item to a {@link ProviderSessionUpdate}. `Chunk` carries
@@ -675,6 +699,16 @@ export function isProviderSessionUpdate(
     item !== null &&
     "type" in item &&
     item.type === "session"
+  );
+}
+
+/** Narrow a stream item to a {@link ProviderStop}. */
+export function isProviderStop(item: ProviderStreamItem): item is ProviderStop {
+  return (
+    typeof item === "object" &&
+    item !== null &&
+    "type" in item &&
+    item.type === "stop"
   );
 }
 

--- a/packages/runtime/src/turn-budget.ts
+++ b/packages/runtime/src/turn-budget.ts
@@ -17,7 +17,10 @@
  */
 
 import type { ProviderId } from "@nodetool-ai/protocol";
+import { createLogger } from "@nodetool-ai/config";
 import { CostCalculator } from "./providers/cost-calculator.js";
+
+const log = createLogger("nodetool.runtime.turn-budget");
 
 /** What a provider knows about the turn it is about to make. */
 export interface TurnReservation {
@@ -102,4 +105,396 @@ export class CostCappedTurnBudget implements TurnBudget {
         : Math.max(actualUsd, 0);
     this._reservedUsd = 0;
   }
+}
+
+/* ------------------------------------------------------------------------ *
+ * Run-level bounds: deadline, concurrency, turn count.
+ *
+ * A USD cap alone does not bound a run. A loop on a free local model spends
+ * nothing and still runs forever, and a fan-out of sub-agents multiplies
+ * provider conversations until the process is the limit. These are the other
+ * three ceilings, kept in one object so every loop in a run shares them
+ * instead of each inventing its own.
+ * ------------------------------------------------------------------------ */
+
+/** Wall-clock ceiling for a run. */
+export interface Deadline {
+  /** Epoch milliseconds after which the run must stop. */
+  readonly at: number;
+  remainingMs(): number;
+  expired(): boolean;
+}
+
+/**
+ * A deadline `ms` from now. `Infinity` means no deadline — `at` is `Infinity`,
+ * so `expired()` is false forever without a second "unbounded" code path.
+ */
+export function createDeadline(ms: number): Deadline {
+  const at = Number.isFinite(ms) ? Date.now() + ms : Infinity;
+  return {
+    at,
+    remainingMs: () => (at === Infinity ? Infinity : at - Date.now()),
+    expired: () => Date.now() >= at
+  };
+}
+
+/**
+ * Hand back one permit. Idempotent: a caller that releases twice (a `finally`
+ * plus an explicit release, say) must not inflate the semaphore.
+ *
+ * Not a `Symbol.dispose` object — this package compiles against `lib: ES2022`,
+ * which has no disposable typings. A plain callable works in every consumer.
+ */
+export type Release = () => void;
+
+/** FIFO permit pool bounding concurrent provider conversations for a run. */
+export interface Semaphore {
+  /** Permits the pool was created with. */
+  readonly permits: number;
+  /** Permits not currently held. */
+  readonly available: number;
+  /** Callers waiting for a permit. */
+  readonly waiting: number;
+  acquire(): Promise<Release>;
+}
+
+export function createSemaphore(permits: number): Semaphore {
+  // A non-positive bound would deadlock every acquirer; treat it as "one at a
+  // time", which is the strictest bound that still makes progress.
+  const max = Number.isFinite(permits) && permits > 0 ? Math.floor(permits) : 1;
+  let held = 0;
+  const queue: Array<(release: Release) => void> = [];
+
+  const makeRelease = (): Release => {
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      const next = queue.shift();
+      if (next) {
+        // Hand the permit straight to the head of the queue: `held` stays put,
+        // so a waiter cannot be overtaken by a caller that acquires between
+        // this release and the waiter's continuation.
+        next(makeRelease());
+        return;
+      }
+      held--;
+    };
+  };
+
+  return {
+    permits: max,
+    get available() {
+      return max - held;
+    },
+    get waiting() {
+      return queue.length;
+    },
+    acquire(): Promise<Release> {
+      if (held < max) {
+        held++;
+        return Promise.resolve(makeRelease());
+      }
+      return new Promise<Release>((resolve) => queue.push(resolve));
+    }
+  };
+}
+
+/** Bounded counter. `increment` answers false once `max` has been reached. */
+export interface Counter {
+  readonly max: number;
+  readonly current: number;
+  increment(): boolean;
+}
+
+export function createCounter(max: number): Counter {
+  let current = 0;
+  return {
+    max,
+    get current() {
+      return current;
+    },
+    increment(): boolean {
+      if (current >= max) return false;
+      current++;
+      return true;
+    }
+  };
+}
+
+/** Why a run stopped. An `as const` union, not an enum (AGENTS.md § TypeScript). */
+export const BUDGET_EXHAUSTION_KINDS = ["cost", "deadline", "turns"] as const;
+export type BudgetExhaustionKind = (typeof BUDGET_EXHAUSTION_KINDS)[number];
+
+export interface BudgetExhaustion {
+  kind: BudgetExhaustionKind;
+  detail: string;
+}
+
+/** Which ceiling a {@link CompositeTurnBudget} refusal hit. */
+export const TURN_REFUSALS = ["cost-cap", "unpriced-token-ceiling"] as const;
+export type TurnRefusal = (typeof TURN_REFUSALS)[number];
+
+export interface CompositeTurnBudgetOptions {
+  /**
+   * Ceiling on total spend, in USD, or `null` for no USD cap (a local-only
+   * install).
+   */
+  capUsd: number | null;
+  /** Output-token bound assumed for every turn. See {@link CostCappedTurnBudgetOptions}. */
+  maxOutputTokens: number;
+  /**
+   * Prompt-token ceiling applied to a turn on a model with no catalog price.
+   * Only consulted when a USD cap exists — see {@link CompositeTurnBudget}.
+   */
+  unpricedTokenCeiling: number;
+}
+
+/** Models already logged as unpriced, so the notice fires once per model. */
+const loggedUnpricedModels = new Set<string>();
+
+/**
+ * The budget every run gets. Priced models behave exactly like
+ * {@link CostCappedTurnBudget}; a model with no catalog price is admitted
+ * against a prompt-token ceiling instead and its turns are counted apart from
+ * `spentUsd`.
+ *
+ * Why not just refuse an unpriced model the way `CostCappedTurnBudget` does:
+ * that budget is the supervisor's, where refusing is right — a supervisor that
+ * cannot be priced should not run. A user's chat turn on a model the catalog
+ * has not caught up with is a different case; refusing it would make the
+ * product unusable on any new model. So the run is bounded by the one thing
+ * that is known (prompt size) and the unknown is *reported* rather than
+ * booked: `spentUsd` is a lower bound whenever `unpricedTurns > 0`, never a
+ * claim that those turns were free (assumption A-5, invariant I-4).
+ *
+ * With `capUsd: null` there is no USD cap, and admission is therefore
+ * unbounded by cost — including for unpriced models. The token ceiling exists
+ * to keep a *cap* meaningful when a turn cannot be priced; with no cap there
+ * is nothing to keep meaningful, and enforcing it anyway would impose a prompt
+ * limit nobody configured. Deadline and turn count still bound such a run.
+ */
+export class CompositeTurnBudget implements TurnBudget {
+  private readonly _capUsd: number | null;
+  private readonly _maxOutputTokens: number;
+  private readonly _unpricedTokenCeiling: number;
+  private _spentUsd = 0;
+  private _reservedUsd = 0;
+  private _unpricedTurns = 0;
+  /** Set when the in-flight reservation is for a model with no price. */
+  private _pendingUnpriced = false;
+  private _lastRefusal: TurnRefusal | null = null;
+
+  constructor(opts: CompositeTurnBudgetOptions) {
+    this._capUsd = opts.capUsd;
+    this._maxOutputTokens = opts.maxOutputTokens;
+    this._unpricedTokenCeiling = opts.unpricedTokenCeiling;
+  }
+
+  get spentUsd(): number {
+    return this._spentUsd;
+  }
+
+  /**
+   * Why the most recent `reserve` refused, so a caller can name the ceiling in
+   * the message the user sees rather than guessing which one it was.
+   */
+  get lastRefusal(): TurnRefusal | null {
+    return this._lastRefusal;
+  }
+
+  /** Turns admitted on a model the price catalog does not cover. */
+  get unpricedTurns(): number {
+    return this._unpricedTurns;
+  }
+
+  /** True when `spentUsd` under-reports the run because some turns had no price. */
+  get hasUnpricedTurns(): boolean {
+    return this._unpricedTurns > 0;
+  }
+
+  reserve(turn: TurnReservation): boolean {
+    const worstCase = CostCalculator.estimateTokenCostUsd(
+      turn.model,
+      { inputTokens: turn.inputTokens, outputTokens: this._maxOutputTokens },
+      turn.provider
+    );
+    if (worstCase === null) {
+      return this._reserveUnpriced(turn);
+    }
+    this._pendingUnpriced = false;
+    if (this._capUsd === null) {
+      this._lastRefusal = null;
+      this._reservedUsd += worstCase;
+      return true;
+    }
+    if (this._spentUsd + this._reservedUsd + worstCase > this._capUsd) {
+      this._lastRefusal = "cost-cap";
+      return false;
+    }
+    this._lastRefusal = null;
+    this._reservedUsd += worstCase;
+    return true;
+  }
+
+  commit(actualUsd: number | null): void {
+    if (this._pendingUnpriced) {
+      this._pendingUnpriced = false;
+      this._unpricedTurns++;
+      // No reservation to fall back on: an unpriced model has no worst case.
+      // A number the provider reported anyway is real money and is booked; an
+      // unknown adds nothing to `spentUsd` and is visible as an unpriced turn.
+      if (actualUsd !== null && Number.isFinite(actualUsd)) {
+        this._spentUsd += Math.max(actualUsd, 0);
+      }
+      return;
+    }
+    this._spentUsd +=
+      actualUsd === null || !Number.isFinite(actualUsd)
+        ? this._reservedUsd
+        : Math.max(actualUsd, 0);
+    this._reservedUsd = 0;
+  }
+
+  private _reserveUnpriced(turn: TurnReservation): boolean {
+    if (this._capUsd === null) {
+      this._lastRefusal = null;
+      this._pendingUnpriced = true;
+      return true;
+    }
+    const key = `${turn.provider}/${turn.model}`;
+    if (!loggedUnpricedModels.has(key)) {
+      loggedUnpricedModels.add(key);
+      log.warn("Model has no catalog price; admitting against a token ceiling", {
+        provider: turn.provider,
+        model: turn.model,
+        unpricedTokenCeiling: this._unpricedTokenCeiling
+      });
+    }
+    if (turn.inputTokens > this._unpricedTokenCeiling) {
+      this._lastRefusal = "unpriced-token-ceiling";
+      return false;
+    }
+    this._lastRefusal = null;
+    this._pendingUnpriced = true;
+    return true;
+  }
+}
+
+/** The four bounds one run shares, plus the reason it stopped. */
+export interface RunBudget {
+  /** USD admission; reserve before a turn, commit after. */
+  turns: TurnBudget;
+  /** Absolute deadline; every loop checks it before a turn and before a tool call. */
+  deadline: Deadline;
+  /** Process-wide bound on concurrent provider conversations for this run. */
+  concurrency: Semaphore;
+  /** Cumulative model turns across every loop in the run. */
+  turnCount: Counter;
+  /** Why a stop happened, set once — the first reason wins. */
+  readonly exhausted: BudgetExhaustion | null;
+}
+
+export interface CreateRunBudgetOptions {
+  /** `null` = no USD cap (local-only install). */
+  capUsd: number | null;
+  maxOutputTokens: number;
+  /** Per-turn prompt-token ceiling when the model has no price. */
+  unpricedTokenCeiling: number;
+  deadlineMs: number;
+  maxConcurrency: number;
+  maxTurns: number;
+}
+
+/** Runtime narrower: a {@link RunBudget} carries the other three bounds. */
+export function isRunBudget(
+  value: TurnBudget | RunBudget | undefined | null
+): value is RunBudget {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "turns" in value &&
+    "deadline" in value &&
+    "concurrency" in value &&
+    "turnCount" in value
+  );
+}
+
+/**
+ * Build the one budget a run shares downward (invariant I-2).
+ *
+ * `turns.reserve` is the single admission point: it checks the deadline, then
+ * the cumulative turn count, then the USD cap, and records the first reason it
+ * refuses for. A provider loop therefore only has to call `reserve` to honor
+ * all three, and reads `exhausted` to say which one stopped it.
+ */
+export function createRunBudget(opts: CreateRunBudgetOptions): RunBudget {
+  const cost = new CompositeTurnBudget({
+    capUsd: opts.capUsd,
+    maxOutputTokens: opts.maxOutputTokens,
+    unpricedTokenCeiling: opts.unpricedTokenCeiling
+  });
+  const rawDeadline = createDeadline(opts.deadlineMs);
+  const turnCount = createCounter(opts.maxTurns);
+  let exhausted: BudgetExhaustion | null = null;
+
+  // Set once: a run that ran out of money and then ran out of time stopped for
+  // the money. Overwriting would report the symptom of the first stop.
+  const markExhausted = (kind: BudgetExhaustionKind, detail: string): void => {
+    if (exhausted === null) exhausted = { kind, detail };
+  };
+
+  // Any loop that checks the deadline records the reason by doing so, so a
+  // pre-turn deadline check needs no separate setter on the interface.
+  const deadline: Deadline = {
+    at: rawDeadline.at,
+    remainingMs: () => rawDeadline.remainingMs(),
+    expired: () => {
+      if (!rawDeadline.expired()) return false;
+      markExhausted(
+        "deadline",
+        `run deadline of ${Math.round(opts.deadlineMs)}ms reached`
+      );
+      return true;
+    }
+  };
+
+  const turns: TurnBudget = {
+    reserve(turn: TurnReservation): boolean {
+      if (deadline.expired()) return false;
+      // Read the count before spending it: a turn refused on cost must not
+      // also consume a turn slot, and a reservation cannot be handed back.
+      if (turnCount.current >= turnCount.max) {
+        markExhausted("turns", `turn limit of ${opts.maxTurns} reached`);
+        return false;
+      }
+      if (!cost.reserve(turn)) {
+        markExhausted(
+          "cost",
+          cost.lastRefusal === "unpriced-token-ceiling"
+            ? `${turn.model} has no catalog price and the turn's ${turn.inputTokens} prompt tokens exceed the unpriced ceiling of ${opts.unpricedTokenCeiling}`
+            : `turn budget of $${opts.capUsd} reached`
+        );
+        return false;
+      }
+      turnCount.increment();
+      return true;
+    },
+    commit(actualUsd: number | null): void {
+      cost.commit(actualUsd);
+    },
+    get spentUsd(): number {
+      return cost.spentUsd;
+    }
+  };
+
+  return {
+    turns,
+    deadline,
+    concurrency: createSemaphore(opts.maxConcurrency),
+    turnCount,
+    get exhausted(): BudgetExhaustion | null {
+      return exhausted;
+    }
+  };
 }

--- a/packages/runtime/src/turn-budget.ts
+++ b/packages/runtime/src/turn-budget.ts
@@ -514,9 +514,17 @@ export function createRunBudget(opts: CreateRunBudgetOptions): RunBudget {
  */
 export const RUN_BUDGET_CONTEXT_KEY = "nodetool_run_budget";
 
-/** Minimal reader for the context bag, so this stays free of a context import. */
+/**
+ * Minimal reader for the context bag, so this stays free of a context import.
+ *
+ * `get` is optional because the callers are hosts and nodes that accept a
+ * partial context — a test double, or a node invoked with none at all. A
+ * context that cannot answer has no budget on it, which is the same answer as
+ * a context that answers with nothing; throwing instead would make reading the
+ * budget riskier than not having one.
+ */
 interface RunBudgetContext {
-  get<T = unknown>(key: string, defaultValue?: T): T;
+  get?<T = unknown>(key: string, defaultValue?: T): T;
 }
 
 /**
@@ -528,6 +536,9 @@ interface RunBudgetContext {
 export function budgetFromContext(
   context: RunBudgetContext | undefined | null
 ): RunBudget | undefined {
-  const value = context?.get<unknown>(RUN_BUDGET_CONTEXT_KEY);
-  return isRunBudget(value as RunBudget | undefined) ? (value as RunBudget) : undefined;
+  if (typeof context?.get !== "function") return undefined;
+  const value = context.get<unknown>(RUN_BUDGET_CONTEXT_KEY);
+  return isRunBudget(value as RunBudget | undefined)
+    ? (value as RunBudget)
+    : undefined;
 }

--- a/packages/runtime/src/turn-budget.ts
+++ b/packages/runtime/src/turn-budget.ts
@@ -498,3 +498,36 @@ export function createRunBudget(opts: CreateRunBudgetOptions): RunBudget {
     }
   };
 }
+
+/**
+ * Context variable holding the run's {@link RunBudget}.
+ *
+ * A budget has to reach loops the host never sees: an `AgentNode` a chat turn
+ * started through `run_node`, a JS script, a sub-agent three levels down. The
+ * context bag is the one channel every one of them already carries, and
+ * `ProcessingContext.copy()` shallow-copies it, so a child context shares the
+ * same object rather than a clone of it — which is what makes the cap a run
+ * total instead of a per-loop allowance (invariant I-2).
+ *
+ * It lives here, beside the type it names, so that hosts, `agents`, and
+ * `llm-nodes` agree on the key without any of them importing each other.
+ */
+export const RUN_BUDGET_CONTEXT_KEY = "nodetool_run_budget";
+
+/** Minimal reader for the context bag, so this stays free of a context import. */
+interface RunBudgetContext {
+  get<T = unknown>(key: string, defaultValue?: T): T;
+}
+
+/**
+ * The run budget a host put on the context, or `undefined` when none did.
+ *
+ * Absent means unbudgeted, not exhausted: a workflow run started from the
+ * kernel with no host budget must keep working exactly as it does today.
+ */
+export function budgetFromContext(
+  context: RunBudgetContext | undefined | null
+): RunBudget | undefined {
+  const value = context?.get<unknown>(RUN_BUDGET_CONTEXT_KEY);
+  return isRunBudget(value as RunBudget | undefined) ? (value as RunBudget) : undefined;
+}

--- a/packages/runtime/tests/run-budget.test.ts
+++ b/packages/runtime/tests/run-budget.test.ts
@@ -1,0 +1,436 @@
+/**
+ * The run-level bounds: what admits a turn, what refuses it, and how a loop
+ * says which ceiling stopped it.
+ *
+ * A budget that refuses silently is indistinguishable from a model that
+ * finished answering (invariant I-3), and an unpriced model booked at $0 is
+ * indistinguishable from a free one (assumption A-5, invariant I-4). Both are
+ * pinned here.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  CompositeTurnBudget,
+  createCounter,
+  createDeadline,
+  createRunBudget,
+  createSemaphore,
+  isRunBudget,
+  type Release,
+  type RunBudget
+} from "../src/turn-budget.js";
+import { BaseProvider } from "../src/providers/base-provider.js";
+import {
+  isProviderStop,
+  type ProviderStop,
+  type ProviderStreamItem,
+  type ProviderTool
+} from "../src/providers/types.js";
+
+const PRICED_MODEL = "gpt-4o-mini";
+const UNPRICED_MODEL = "a-model-nobody-prices";
+
+function pricedTurn(inputTokens = 1000) {
+  return { model: PRICED_MODEL, provider: "openai" as const, inputTokens };
+}
+function unpricedTurn(inputTokens = 1000) {
+  return { model: UNPRICED_MODEL, provider: "openai" as const, inputTokens };
+}
+
+describe("CompositeTurnBudget: priced models", () => {
+  it("behaves as the cost-capped budget does", () => {
+    const budget = new CompositeTurnBudget({
+      capUsd: 1,
+      maxOutputTokens: 2048,
+      unpricedTokenCeiling: 100
+    });
+    expect(budget.reserve(pricedTurn())).toBe(true);
+    budget.commit(0.5);
+    expect(budget.spentUsd).toBeCloseTo(0.5);
+    expect(budget.unpricedTurns).toBe(0);
+  });
+
+  it("refuses a turn whose worst case would cross the cap", () => {
+    const budget = new CompositeTurnBudget({
+      capUsd: 0.0001,
+      maxOutputTokens: 2048,
+      unpricedTokenCeiling: 100
+    });
+    expect(budget.reserve(pricedTurn())).toBe(false);
+  });
+});
+
+describe("CompositeTurnBudget: unpriced models", () => {
+  it("admits a turn under the token ceiling and records it as unpriced", () => {
+    const budget = new CompositeTurnBudget({
+      capUsd: 1,
+      maxOutputTokens: 2048,
+      unpricedTokenCeiling: 5000
+    });
+    expect(budget.reserve(unpricedTurn(4999))).toBe(true);
+    budget.commit(null);
+    // Never booked as $0 spend: the turn is counted where a caller can see it,
+    // and `spentUsd` is a lower bound rather than a claim the turn was free.
+    expect(budget.unpricedTurns).toBe(1);
+    expect(budget.hasUnpricedTurns).toBe(true);
+    expect(budget.spentUsd).toBe(0);
+  });
+
+  it("refuses a turn over the token ceiling and says which ceiling", () => {
+    const budget = new CompositeTurnBudget({
+      capUsd: 1,
+      maxOutputTokens: 2048,
+      unpricedTokenCeiling: 5000
+    });
+    expect(budget.reserve(unpricedTurn(5001))).toBe(false);
+    expect(budget.lastRefusal).toBe("unpriced-token-ceiling");
+    expect(budget.reserve(unpricedTurn(10))).toBe(true);
+    expect(budget.lastRefusal).toBeNull();
+  });
+
+  it("books a cost the provider reported anyway", () => {
+    const budget = new CompositeTurnBudget({
+      capUsd: 1,
+      maxOutputTokens: 2048,
+      unpricedTokenCeiling: 5000
+    });
+    expect(budget.reserve(unpricedTurn(10))).toBe(true);
+    budget.commit(0.02);
+    expect(budget.spentUsd).toBeCloseTo(0.02);
+    expect(budget.unpricedTurns).toBe(1);
+  });
+
+  it("ignores the ceiling when there is no USD cap to protect", () => {
+    // Documented choice: the ceiling exists to keep a *cap* meaningful for a
+    // turn that cannot be priced. With no cap, enforcing it would impose a
+    // prompt limit nobody configured.
+    const budget = new CompositeTurnBudget({
+      capUsd: null,
+      maxOutputTokens: 2048,
+      unpricedTokenCeiling: 10
+    });
+    expect(budget.reserve(unpricedTurn(1_000_000))).toBe(true);
+    expect(budget.reserve(pricedTurn(1_000_000))).toBe(true);
+  });
+});
+
+describe("Deadline", () => {
+  it("is expired once its instant has passed", () => {
+    expect(createDeadline(0).expired()).toBe(true);
+    const live = createDeadline(60_000);
+    expect(live.expired()).toBe(false);
+    expect(live.remainingMs()).toBeGreaterThan(0);
+  });
+
+  it("never expires when given no bound", () => {
+    const none = createDeadline(Infinity);
+    expect(none.at).toBe(Infinity);
+    expect(none.expired()).toBe(false);
+    expect(none.remainingMs()).toBe(Infinity);
+  });
+});
+
+describe("Counter", () => {
+  it("stops incrementing at max", () => {
+    const counter = createCounter(2);
+    expect(counter.increment()).toBe(true);
+    expect(counter.increment()).toBe(true);
+    expect(counter.increment()).toBe(false);
+    expect(counter.current).toBe(2);
+    expect(counter.max).toBe(2);
+  });
+});
+
+describe("Semaphore", () => {
+  it("never lets more than `permits` callers hold one at once", async () => {
+    const semaphore = createSemaphore(2);
+    let inFlight = 0;
+    let peak = 0;
+    await Promise.all(
+      Array.from({ length: 8 }, async () => {
+        const release = await semaphore.acquire();
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        inFlight--;
+        release();
+      })
+    );
+    expect(peak).toBe(2);
+    expect(semaphore.available).toBe(2);
+    expect(semaphore.waiting).toBe(0);
+  });
+
+  it("hands permits to waiters in arrival order", async () => {
+    const semaphore = createSemaphore(1);
+    const held = await semaphore.acquire();
+    const order: string[] = [];
+    const first = semaphore.acquire().then((r) => {
+      order.push("first");
+      return r;
+    });
+    const second = semaphore.acquire().then((r) => {
+      order.push("second");
+      return r;
+    });
+    expect(semaphore.waiting).toBe(2);
+    held();
+    (await first)();
+    await second;
+    expect(order).toEqual(["first", "second"]);
+  });
+
+  it("ignores a double release rather than inflating the pool", async () => {
+    const semaphore = createSemaphore(1);
+    const release: Release = await semaphore.acquire();
+    release();
+    release();
+    expect(semaphore.available).toBe(1);
+    // A second permit would exist if the double release had counted: this
+    // acquire must be the only one that resolves without waiting.
+    await semaphore.acquire();
+    expect(semaphore.available).toBe(0);
+    expect(semaphore.waiting).toBe(0);
+  });
+});
+
+describe("RunBudget", () => {
+  const options = {
+    capUsd: 1,
+    maxOutputTokens: 2048,
+    unpricedTokenCeiling: 1000,
+    deadlineMs: 60_000,
+    maxConcurrency: 4,
+    maxTurns: 100
+  };
+
+  it("is recognized by isRunBudget; a bare turn budget is not", () => {
+    const budget = createRunBudget(options);
+    expect(isRunBudget(budget)).toBe(true);
+    expect(isRunBudget(budget.turns)).toBe(false);
+    expect(isRunBudget(undefined)).toBe(false);
+  });
+
+  it("admits a turn and counts it", () => {
+    const budget = createRunBudget(options);
+    expect(budget.turns.reserve(pricedTurn())).toBe(true);
+    expect(budget.turnCount.current).toBe(1);
+    expect(budget.exhausted).toBeNull();
+  });
+
+  it("refuses on an expired deadline and says so", () => {
+    const budget = createRunBudget({ ...options, deadlineMs: 0 });
+    expect(budget.turns.reserve(pricedTurn())).toBe(false);
+    expect(budget.exhausted?.kind).toBe("deadline");
+  });
+
+  it("refuses once the turn count is spent", () => {
+    const budget = createRunBudget({ ...options, maxTurns: 1 });
+    expect(budget.turns.reserve(pricedTurn())).toBe(true);
+    budget.turns.commit(0);
+    expect(budget.turns.reserve(pricedTurn())).toBe(false);
+    expect(budget.exhausted?.kind).toBe("turns");
+  });
+
+  it("names the unpriced ceiling rather than the cap when that is what refused", () => {
+    // Both refusals are `kind: "cost"`, and telling a user their $1 budget ran
+    // out when the real problem is a 100-token ceiling sends them to the wrong
+    // setting.
+    const budget = createRunBudget({ ...options, unpricedTokenCeiling: 5 });
+    expect(budget.turns.reserve(unpricedTurn(500))).toBe(false);
+    expect(budget.exhausted?.kind).toBe("cost");
+    expect(budget.exhausted?.detail).toContain("unpriced ceiling of 5");
+  });
+
+  it("refuses on the USD cap and names it", () => {
+    const budget = createRunBudget({ ...options, capUsd: 0 });
+    expect(budget.turns.reserve(pricedTurn())).toBe(false);
+    expect(budget.exhausted?.kind).toBe("cost");
+    expect(budget.exhausted?.detail).toContain("$0");
+    // A turn that was never made must not consume a turn slot — the count is
+    // of model turns, and a reservation cannot be handed back.
+    expect(budget.turnCount.current).toBe(0);
+  });
+
+  it("keeps the first reason when a second ceiling is hit later", async () => {
+    // Reporting the deadline for a run that had already run out of money would
+    // point whoever reads it at the wrong limit.
+    const budget = createRunBudget({ ...options, capUsd: 0, deadlineMs: 10 });
+    expect(budget.turns.reserve(pricedTurn())).toBe(false);
+    expect(budget.exhausted?.kind).toBe("cost");
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(budget.deadline.expired()).toBe(true);
+    expect(budget.turns.reserve(pricedTurn())).toBe(false);
+    expect(budget.exhausted?.kind).toBe("cost");
+  });
+});
+
+/** Counts model turns and always answers, so the loop ends on its own. */
+class CountingProvider extends BaseProvider {
+  readonly provider = "openai" as const;
+  turns = 0;
+
+  async *generateMessages(): AsyncGenerator<ProviderStreamItem> {
+    this.turns++;
+    yield { type: "chunk", content: "ok", done: true };
+  }
+
+  async generateMessage(): Promise<never> {
+    throw new Error("not used");
+  }
+}
+
+/** Calls the same tool on every turn, so only a limit ends the loop. */
+class LoopingProvider extends BaseProvider {
+  readonly provider = "openai" as const;
+  turns = 0;
+
+  async *generateMessages(): AsyncGenerator<ProviderStreamItem> {
+    this.turns++;
+    yield { id: `call_${this.turns}`, name: "noop", args: {} };
+  }
+
+  async generateMessage(): Promise<never> {
+    throw new Error("not used");
+  }
+}
+
+const NOOP_TOOL: ProviderTool = {
+  name: "noop",
+  description: "",
+  parameters: { type: "object", properties: {} }
+};
+
+async function drain(
+  stream: AsyncGenerator<ProviderStreamItem>
+): Promise<ProviderStreamItem[]> {
+  const items: ProviderStreamItem[] = [];
+  for await (const item of stream) {
+    items.push(item);
+  }
+  return items;
+}
+
+function stopsIn(items: ProviderStreamItem[]): ProviderStop[] {
+  return items.filter(isProviderStop);
+}
+
+function loopArgs(
+  provider: BaseProvider,
+  extra: Record<string, unknown>
+): AsyncGenerator<ProviderStreamItem> {
+  return provider.generateLoop({
+    messages: [{ role: "user", content: "hi" }],
+    model: PRICED_MODEL,
+    ...extra
+  } as Parameters<BaseProvider["generateLoop"]>[0]);
+}
+
+describe("generateLoop stop signal", () => {
+  it("yields exactly one budget stop, last, and makes no model call", async () => {
+    const provider = new CountingProvider();
+    const budget: RunBudget = createRunBudget({
+      // Below the worst case of a single turn on a priced model.
+      capUsd: 0.0000001,
+      maxOutputTokens: 2048,
+      unpricedTokenCeiling: 1000,
+      deadlineMs: 60_000,
+      maxConcurrency: 4,
+      maxTurns: 100
+    });
+
+    const items = await drain(loopArgs(provider, { turnBudget: budget }));
+
+    expect(provider.turns).toBe(0);
+    const stops = stopsIn(items);
+    expect(stops).toHaveLength(1);
+    expect(stops[0]?.reason).toBe("budget");
+    expect(stops[0]?.detail).toContain("$");
+    expect(items[items.length - 1]).toBe(stops[0]);
+  });
+
+  it("reports a deadline stop apart from a cost stop", async () => {
+    const provider = new CountingProvider();
+    const budget = createRunBudget({
+      capUsd: 100,
+      maxOutputTokens: 2048,
+      unpricedTokenCeiling: 1000,
+      deadlineMs: 0,
+      maxConcurrency: 4,
+      maxTurns: 100
+    });
+
+    const items = await drain(loopArgs(provider, { turnBudget: budget }));
+
+    expect(provider.turns).toBe(0);
+    expect(budget.exhausted?.kind).toBe("deadline");
+    const stops = stopsIn(items);
+    expect(stops).toHaveLength(1);
+    expect(stops[0]?.reason).toBe("deadline");
+  });
+
+  it("yields an iterations stop when the rounds run out", async () => {
+    const provider = new LoopingProvider();
+    const items = await drain(
+      loopArgs(provider, {
+        tools: [NOOP_TOOL],
+        maxIterations: 2,
+        executeTool: async () => "done"
+      })
+    );
+
+    expect(provider.turns).toBe(2);
+    const stops = stopsIn(items);
+    expect(stops).toHaveLength(1);
+    expect(stops[0]?.reason).toBe("iterations");
+    expect(items[items.length - 1]).toBe(stops[0]);
+  });
+
+  it("yields an aborted stop when the caller cancels", async () => {
+    const provider = new CountingProvider();
+    const controller = new AbortController();
+    controller.abort();
+
+    const items = await drain(
+      loopArgs(provider, { signal: controller.signal })
+    );
+
+    expect(provider.turns).toBe(0);
+    const stops = stopsIn(items);
+    expect(stops).toHaveLength(1);
+    expect(stops[0]?.reason).toBe("aborted");
+  });
+
+  it("yields no stop at all when the model ends its own turn", async () => {
+    const provider = new CountingProvider();
+    const budget = createRunBudget({
+      capUsd: 10,
+      maxOutputTokens: 2048,
+      unpricedTokenCeiling: 1000,
+      deadlineMs: 60_000,
+      maxConcurrency: 4,
+      maxTurns: 100
+    });
+
+    const items = await drain(loopArgs(provider, { turnBudget: budget }));
+
+    expect(provider.turns).toBe(1);
+    expect(stopsIn(items)).toHaveLength(0);
+  });
+
+  it("still honors a bare TurnBudget, which names no ceiling", async () => {
+    const provider = new CountingProvider();
+    const budget = new CompositeTurnBudget({
+      capUsd: 0,
+      maxOutputTokens: 2048,
+      unpricedTokenCeiling: 1000
+    });
+
+    const items = await drain(loopArgs(provider, { turnBudget: budget }));
+
+    expect(provider.turns).toBe(0);
+    const stops = stopsIn(items);
+    expect(stops).toHaveLength(1);
+    expect(stops[0]?.reason).toBe("budget");
+  });
+});

--- a/packages/runtime/tests/turn-budget.test.ts
+++ b/packages/runtime/tests/turn-budget.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { CostCappedTurnBudget } from "../src/turn-budget.js";
 import { BaseProvider } from "../src/providers/base-provider.js";
 import { OpenAIProvider } from "../src/providers/openai-provider.js";
+import { isProviderStop } from "../src/providers/types.js";
 import type { ProviderStreamItem } from "../src/providers/types.js";
 
 const PRICED_MODEL = "gpt-4o-mini";
@@ -132,14 +133,20 @@ describe("generateLoop turn admission", () => {
       capUsd: 0,
       maxOutputTokens: 2048
     });
-    for await (const _item of provider.generateLoop({
+    const items: ProviderStreamItem[] = [];
+    for await (const item of provider.generateLoop({
       messages: [{ role: "user", content: "hi" }],
       model: PRICED_MODEL,
       turnBudget: budget
     } as Parameters<BaseProvider["generateLoop"]>[0])) {
-      // drain
+      items.push(item);
     }
     expect(provider.turns).toBe(0);
+    // A silent return here reads exactly like a model that finished answering,
+    // which is how a budget stop went unnoticed by every consumer.
+    expect(items.filter(isProviderStop).map((s) => s.reason)).toEqual([
+      "budget"
+    ]);
   });
 });
 
@@ -191,14 +198,18 @@ describe("OpenAI Responses loop honors the budget", () => {
       capUsd: 0,
       maxOutputTokens: 2048
     });
-    for await (const _item of instance.generateLoop({
+    const items: ProviderStreamItem[] = [];
+    for await (const item of instance.generateLoop({
       messages: [{ role: "user", content: "hi" }],
       model: RESPONSES_MODEL,
       turnBudget: budget
     } as Parameters<OpenAIProvider["generateLoop"]>[0])) {
-      // drain
+      items.push(item);
     }
     expect(turnsCollected()).toBe(0);
+    expect(items.filter(isProviderStop).map((s) => s.reason)).toEqual([
+      "budget"
+    ]);
   });
 });
 

--- a/packages/websocket/src/session/chat-turn.ts
+++ b/packages/websocket/src/session/chat-turn.ts
@@ -53,13 +53,17 @@ import type {
 import {
   ACTIVE_MODEL_CONTEXT_KEY,
   DIRECT_TOOL_NAMES,
+  RUN_BUDGET_CONTEXT_KEY,
+  createRunBudget,
   detectImageMime,
   IMAGE_MIME_TO_EXT,
   expandEntitiesForGeneration,
   getProcessSandboxModuleCatalog,
   isProviderSessionUpdate,
   isProviderMessageEvent,
-  type ActiveModelSelection
+  isProviderStop,
+  type ActiveModelSelection,
+  type RunBudget
 } from "@nodetool-ai/runtime";
 import {
   isModelSelection,
@@ -126,6 +130,7 @@ import {
   unroutableToolMessage
 } from "./chat-prompt.js";
 import { createRuntimeContext } from "./model-interfaces.js";
+import { getSetting } from "../settings-registry.js";
 import {
   appendContextToLastUser,
   createWorkflowResponseContent,
@@ -165,6 +170,106 @@ const MEMORY_BLOCK_LIMIT = 100;
  * full thread load.
  */
 const SESSION_PROBE_WINDOW = 50;
+
+/**
+ * Output-token worst case assumed when reserving a chat turn. The chat loop
+ * sends no `maxTokens`, so nothing bounds the answer from this side; the
+ * reservation charges the same ceiling the Agent node defaults to, which is
+ * what makes the dollar cap hold instead of being noticed after the money is
+ * spent.
+ */
+const CHAT_TURN_MAX_OUTPUT_TOKENS = 16_384;
+
+/** Documented defaults for the five `NODETOOL_AGENT_*` budget settings. */
+const AGENT_BUDGET_DEFAULTS = {
+  costCapUsd: 5,
+  deadlineMs: 1_800_000,
+  maxConcurrency: 8,
+  maxTurns: 200,
+  unpricedTokenCeiling: 400_000
+} as const;
+
+/**
+ * Read one budget setting. The store is best-effort — the same rule the rest
+ * of the runner follows for settings: an unreachable database falls back to
+ * the documented default rather than failing the turn.
+ */
+async function readBudgetSetting(key: string): Promise<string | null> {
+  try {
+    return await getSetting(key);
+  } catch {
+    // Settings store unavailable — the caller's default stands.
+    return null;
+  }
+}
+
+async function budgetSettingNumber(
+  key: string,
+  fallback: number
+): Promise<number> {
+  const raw = await readBudgetSetting(key);
+  if (raw === null) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * The run's USD ceiling, or `null` for no ceiling at all.
+ *
+ * `Number("")` is 0 and a cap of 0 refuses every turn rather than lifting the
+ * ceiling, so a blank or non-positive value means *no cap* — which is what a
+ * local-only install wants. An absent setting takes the documented $5 default;
+ * `getSetting` cannot tell an empty stored value from an unset one (it falls
+ * through both), so "no cap" is expressed by storing a non-positive number.
+ */
+async function budgetCostCapUsd(): Promise<number | null> {
+  const raw = await readBudgetSetting("NODETOOL_AGENT_TURN_COST_CAP_USD");
+  // `getSetting` answers null for both an unset and an empty stored value, so
+  // clearing the field restores the default rather than removing the cap.
+  // Removing it is `0`, which is why a non-positive number means "no cap"
+  // instead of a cap nothing could ever pass.
+  if (raw === null) return AGENT_BUDGET_DEFAULTS.costCapUsd;
+  const parsed = Number(raw.trim());
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+/**
+ * The one budget a chat turn shares downward (invariant I-2): the capability
+ * runs, the sub-agent runtime, the provider loop, and — through the context
+ * key — an Agent node started by `run_node` and any JS script the turn runs.
+ * Every one of them reserves against the same cap instead of opening its own.
+ */
+async function createChatTurnBudget(): Promise<RunBudget> {
+  const [capUsd, deadlineMs, maxConcurrency, maxTurns, unpricedTokenCeiling] =
+    await Promise.all([
+      budgetCostCapUsd(),
+      budgetSettingNumber(
+        "NODETOOL_AGENT_TURN_DEADLINE_MS",
+        AGENT_BUDGET_DEFAULTS.deadlineMs
+      ),
+      budgetSettingNumber(
+        "NODETOOL_AGENT_MAX_CONCURRENCY",
+        AGENT_BUDGET_DEFAULTS.maxConcurrency
+      ),
+      budgetSettingNumber(
+        "NODETOOL_AGENT_MAX_TURNS",
+        AGENT_BUDGET_DEFAULTS.maxTurns
+      ),
+      budgetSettingNumber(
+        "NODETOOL_AGENT_UNPRICED_TOKEN_CEILING",
+        AGENT_BUDGET_DEFAULTS.unpricedTokenCeiling
+      )
+    ]);
+  return createRunBudget({
+    capUsd,
+    maxOutputTokens: CHAT_TURN_MAX_OUTPUT_TOKENS,
+    unpricedTokenCeiling,
+    deadlineMs,
+    maxConcurrency,
+    maxTurns
+  });
+}
 
 /**
  * Find the continuation token to resume this thread with: the `provider_session`
@@ -1326,12 +1431,17 @@ export class ChatTurnHandler {
         this.requestToolApproval(threadId, request),
       clock: codeactClock
     };
+    // The bounds this turn runs under, created once and shared by everything
+    // it starts (invariant I-2). A loop that made its own would hand every
+    // nested agent a fresh allowance, which is no ceiling at all.
+    const turnBudget = await createChatTurnBudget();
     const gatedRun = (context: ProcessingContext): CapabilityRun =>
       createCapabilityRun({
         context,
         gate: chatGate,
         projectId: chatProjectId,
-        availableSecrets: contextSecretAvailability(context)
+        availableSecrets: contextSecretAvailability(context),
+        budget: turnBudget
       });
     const rawToolbelt: Tool[] = [
       ...getAgentToolbelt(),
@@ -1397,7 +1507,10 @@ export class ChatTurnHandler {
         model,
         parentTools: () => baseTools,
         forwardMessage: forwardSubtaskMessage,
-        background: new BackgroundSubtaskRegistry()
+        background: new BackgroundSubtaskRegistry(),
+        // Every delegated loop reserves against this turn's cap rather than
+        // opening one of its own.
+        budget: turnBudget
       };
       // All four delegation tools reach the belt as capabilities over this
       // runtime. The class is still what runs — the `agents` module builds one
@@ -1414,7 +1527,8 @@ export class ChatTurnHandler {
           // effect of its own, and the child's tools are the gated `baseTools`.
           gate: UNGATED,
           availableSecrets: contextSecretAvailability(context),
-          subAgent: subAgentRuntime
+          subAgent: subAgentRuntime,
+          budget: turnBudget
         });
       serverTools.unshift(toolForCapabilityName("run_subtask", delegationRun));
       serverTools.unshift(
@@ -1560,6 +1674,10 @@ export class ChatTurnHandler {
       provider: providerId,
       model
     } satisfies ActiveModelSelection);
+    // The channel every nested loop already carries: an Agent node started
+    // through `run_node`, a JS script, a sub-agent three levels down all read
+    // the budget off the context instead of creating one (`budgetFromContext`).
+    ctx.set(RUN_BUDGET_CONTEXT_KEY, turnBudget);
 
     // The capability run for this turn: the same gate the belt is wrapped in,
     // this context, and the singletons the tool constructors take today. Every
@@ -1575,6 +1693,7 @@ export class ChatTurnHandler {
       nodeRegistry: this.session.nodeRegistry,
       providers: chatProviders,
       subAgent: subAgentRuntime,
+      budget: turnBudget,
       secretPrompt: (request) => this.requestSecretEntry(threadId, request),
       ...mcpToolHostDeps(),
       capabilities: [capabilityFromTool(runNodeTool)]
@@ -1980,6 +2099,7 @@ export class ChatTurnHandler {
         loadFullHistory: loadFullHistory ?? undefined,
         executeTool: useTools ? effectiveExecuteTool : undefined,
         maxIterations: MAX_TOOL_ROUNDS,
+        turnBudget,
         sequentialTools: session ? true : undefined,
         workspaceDir: chatWorkspace?.localDir ?? undefined,
         skills: skillsForProvider,
@@ -2015,6 +2135,34 @@ export class ChatTurnHandler {
               openToolCalls: openToolCalls.size
             });
             break;
+          }
+          continue;
+        }
+
+        if (isProviderStop(item)) {
+          // A limit ended the turn, not the model finishing its answer. Said
+          // nowhere, the two are indistinguishable to the user (invariant
+          // I-3), so the reason is persisted as an ordinary assistant message:
+          // it belongs in the transcript the next turn reads, and it is
+          // per-turn text that must never reach the system prompt (I-7).
+          //
+          // `aborted` is the user pressing Stop or a newer message superseding
+          // this one. They already know why it stopped, and a notice there
+          // would scold them for using the control. The other three are limits
+          // nobody asked for in the moment: the dollar cap, the wall clock,
+          // and the tool-round ceiling all leave the turn unfinished mid-work.
+          if (item.reason !== "aborted") {
+            // The budget names the ceiling it hit ("turn budget of $5
+            // reached"); the round cap is not a budget stop, and reading a
+            // budget a sub-agent exhausted earlier would name the wrong limit.
+            const detail =
+              item.reason === "iterations"
+                ? item.detail
+                : (turnBudget.exhausted?.detail ?? item.detail);
+            await persistTurnMessage(
+              { role: "assistant", content: `Stopped: ${detail}` },
+              true
+            );
           }
           continue;
         }
@@ -2067,7 +2215,14 @@ export class ChatTurnHandler {
         thread_id: threadId
       });
 
-      log.debug("Chat complete", { threadId, chars: content.length });
+      log.debug("Chat complete", {
+        threadId,
+        chars: content.length,
+        // What the whole run — this loop plus every sub-agent and node it
+        // started — reserved and committed against the shared budget.
+        spentUsd: turnBudget.turns.spentUsd,
+        stoppedBy: turnBudget.exhausted?.kind ?? null
+      });
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       log.error("Chat processing error", { threadId, error: errMsg });

--- a/packages/websocket/tests/chat-agent-parity.test.ts
+++ b/packages/websocket/tests/chat-agent-parity.test.ts
@@ -19,6 +19,7 @@ import {
   type WebSocketConnection,
   type WebSocketReceiveFrame
 } from "../src/websocket-client-session.js";
+import { borrowedLoopBudgetMembers } from "./chat-turn-test-harness.js";
 
 // ── Mock WebSocket ──────────────────────────────────────────────────
 
@@ -77,7 +78,8 @@ function mockProvider(...items: unknown[]) {
       getAvailableASRModels: async () => [],
       getAvailableEmbeddingModels: async () => [],
       getContainerEnv: () => ({}),
-        generateLoop: BaseProvider.prototype.generateLoop
+        generateLoop: BaseProvider.prototype.generateLoop,
+        ...borrowedLoopBudgetMembers
     }) as any;
 }
 
@@ -120,7 +122,8 @@ describe("handleChatMessage: system prompt", () => {
         getAvailableASRModels: async () => [],
         getAvailableEmbeddingModels: async () => [],
         getContainerEnv: () => ({}),
-        generateLoop: BaseProvider.prototype.generateLoop
+        generateLoop: BaseProvider.prototype.generateLoop,
+        ...borrowedLoopBudgetMembers
       }) as any;
 
     const runner = new WebSocketClientSession({
@@ -247,7 +250,8 @@ describe("handleChatMessage: tool call loop", () => {
         getAvailableASRModels: async () => [],
         getAvailableEmbeddingModels: async () => [],
         getContainerEnv: () => ({}),
-        generateLoop: BaseProvider.prototype.generateLoop
+        generateLoop: BaseProvider.prototype.generateLoop,
+        ...borrowedLoopBudgetMembers
       }) as any;
 
     const runner = new WebSocketClientSession({
@@ -324,7 +328,8 @@ describe("handleChatMessage: error handling", () => {
         getAvailableASRModels: async () => [],
         getAvailableEmbeddingModels: async () => [],
         getContainerEnv: () => ({}),
-        generateLoop: BaseProvider.prototype.generateLoop
+        generateLoop: BaseProvider.prototype.generateLoop,
+        ...borrowedLoopBudgetMembers
       }) as any;
 
     const runner = new WebSocketClientSession({
@@ -414,7 +419,8 @@ describe("permission gate", () => {
         getAvailableASRModels: async () => [],
         getAvailableEmbeddingModels: async () => [],
         getContainerEnv: () => ({}),
-        generateLoop: BaseProvider.prototype.generateLoop
+        generateLoop: BaseProvider.prototype.generateLoop,
+        ...borrowedLoopBudgetMembers
       }) as any;
 
     const runner = new WebSocketClientSession({
@@ -469,7 +475,8 @@ describe("permission gate", () => {
         getAvailableASRModels: async () => [],
         getAvailableEmbeddingModels: async () => [],
         getContainerEnv: () => ({}),
-        generateLoop: BaseProvider.prototype.generateLoop
+        generateLoop: BaseProvider.prototype.generateLoop,
+        ...borrowedLoopBudgetMembers
       }) as any;
 
     const runner = new WebSocketClientSession({
@@ -526,7 +533,8 @@ describe("permission gate", () => {
         getAvailableASRModels: async () => [],
         getAvailableEmbeddingModels: async () => [],
         getContainerEnv: () => ({}),
-        generateLoop: BaseProvider.prototype.generateLoop
+        generateLoop: BaseProvider.prototype.generateLoop,
+        ...borrowedLoopBudgetMembers
       }) as any;
 
     const runner = new WebSocketClientSession({
@@ -609,7 +617,8 @@ describe("permission gate", () => {
         getAvailableASRModels: async () => [],
         getAvailableEmbeddingModels: async () => [],
         getContainerEnv: () => ({}),
-        generateLoop: BaseProvider.prototype.generateLoop
+        generateLoop: BaseProvider.prototype.generateLoop,
+        ...borrowedLoopBudgetMembers
       }) as any;
 
     const runner = new WebSocketClientSession({
@@ -697,7 +706,8 @@ describe("dbMessageToProviderMessage filtering", () => {
         getAvailableASRModels: async () => [],
         getAvailableEmbeddingModels: async () => [],
         getContainerEnv: () => ({}),
-        generateLoop: BaseProvider.prototype.generateLoop
+        generateLoop: BaseProvider.prototype.generateLoop,
+        ...borrowedLoopBudgetMembers
       }) as any;
 
     const runner = new WebSocketClientSession({
@@ -780,7 +790,8 @@ describe("tool-call thought signatures survive the database", () => {
         getAvailableASRModels: async () => [],
         getAvailableEmbeddingModels: async () => [],
         getContainerEnv: () => ({}),
-        generateLoop: BaseProvider.prototype.generateLoop
+        generateLoop: BaseProvider.prototype.generateLoop,
+        ...borrowedLoopBudgetMembers
       }) as any;
 
     const runner = new WebSocketClientSession({
@@ -884,7 +895,8 @@ describe("handleChatMessage: request sequence cancellation", () => {
         getAvailableASRModels: async () => [],
         getAvailableEmbeddingModels: async () => [],
         getContainerEnv: () => ({}),
-        generateLoop: BaseProvider.prototype.generateLoop
+        generateLoop: BaseProvider.prototype.generateLoop,
+        ...borrowedLoopBudgetMembers
       }) as any;
 
     const runner = new WebSocketClientSession({

--- a/packages/websocket/tests/chat-codeact-approval.test.ts
+++ b/packages/websocket/tests/chat-codeact-approval.test.ts
@@ -16,6 +16,7 @@ import {
   type WebSocketConnection,
   type WebSocketReceiveFrame
 } from "../src/websocket-client-session.js";
+import { borrowedLoopBudgetMembers } from "./chat-turn-test-harness.js";
 
 class MockWS implements WebSocketConnection {
   clientState: "connected" | "disconnected" = "connected";
@@ -86,7 +87,8 @@ function codeActProvider(code: string, risk: "low" | "high" = "low") {
       getAvailableASRModels: async () => [],
       getAvailableEmbeddingModels: async () => [],
       getContainerEnv: () => ({}),
-      generateLoop: BaseProvider.prototype.generateLoop
+      generateLoop: BaseProvider.prototype.generateLoop,
+      ...borrowedLoopBudgetMembers
     }) as never;
 }
 

--- a/packages/websocket/tests/chat-project-spend.test.ts
+++ b/packages/websocket/tests/chat-project-spend.test.ts
@@ -11,6 +11,7 @@ import {
   type WebSocketConnection,
   type WebSocketReceiveFrame
 } from "../src/websocket-client-session.js";
+import { borrowedLoopBudgetMembers } from "./chat-turn-test-harness.js";
 
 class MockWS implements WebSocketConnection {
   clientState: "connected" | "disconnected" = "connected";
@@ -64,7 +65,8 @@ function billingProvider() {
       getAvailableASRModels: async () => [],
       getAvailableEmbeddingModels: async () => [],
       getContainerEnv: () => ({}),
-      generateLoop: BaseProvider.prototype.generateLoop
+      generateLoop: BaseProvider.prototype.generateLoop,
+      ...borrowedLoopBudgetMembers
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }) as any;
 }

--- a/packages/websocket/tests/chat-prompt-stability.test.ts
+++ b/packages/websocket/tests/chat-prompt-stability.test.ts
@@ -17,6 +17,7 @@ import {
   type WebSocketConnection,
   type WebSocketReceiveFrame
 } from "../src/websocket-client-session.js";
+import { borrowedLoopBudgetMembers } from "./chat-turn-test-harness.js";
 
 class MockWS implements WebSocketConnection {
   clientState: "connected" | "disconnected" = "connected";
@@ -79,7 +80,8 @@ async function runTurn(
       getAvailableASRModels: async () => [],
       getAvailableEmbeddingModels: async () => [],
       getContainerEnv: () => ({}),
-      generateLoop: BaseProvider.prototype.generateLoop
+      generateLoop: BaseProvider.prototype.generateLoop,
+      ...borrowedLoopBudgetMembers
     }) as never;
 
   const ws = new MockWS();

--- a/packages/websocket/tests/chat-turn-budget.test.ts
+++ b/packages/websocket/tests/chat-turn-budget.test.ts
@@ -1,0 +1,195 @@
+/**
+ * The chat turn's run budget: one object per turn, shared by everything the
+ * turn starts, and a stop the user can see.
+ *
+ * Two failure modes are pinned here. A turn that ends because a ceiling
+ * refused it looks exactly like a model that finished answering unless the
+ * reason is written into the thread (invariant I-3). And a budget the turn
+ * hands out by value — a fresh one per capability run, per sub-agent, per
+ * node — is no ceiling at all, because every nested loop then gets the whole
+ * cap again (invariant I-2).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initTestDb, Message } from "@nodetool-ai/models";
+import { BaseProvider, RUN_BUDGET_CONTEXT_KEY } from "@nodetool-ai/runtime";
+import type {
+  Message as ProviderMessage,
+  ProviderStreamItem,
+  RunBudget
+} from "@nodetool-ai/runtime";
+import { makeChatTurnHarness, type ChatTurnHarness } from "./chat-turn-test-harness.js";
+
+/** Priced by the catalog, so a cap can refuse a turn on it. */
+const PRICED_MODEL = "gpt-4o-mini";
+/** A local model: priced at zero, so no USD cap can ever refuse it. */
+const LOCAL_MODEL = "qwen-3.5:4b";
+
+const BUDGET_ENV_KEYS = [
+  "NODETOOL_AGENT_TURN_COST_CAP_USD",
+  "NODETOOL_AGENT_TURN_DEADLINE_MS",
+  "NODETOOL_AGENT_MAX_CONCURRENCY",
+  "NODETOOL_AGENT_MAX_TURNS",
+  "NODETOOL_AGENT_UNPRICED_TOKEN_CEILING"
+] as const;
+
+/**
+ * A real {@link BaseProvider}, not a `generateLoop` double: the budget is
+ * enforced *inside* the base loop, so a double that replaces the loop would
+ * test nothing. Each turn optionally asks for a tool, which is what keeps the
+ * loop coming back for another turn.
+ */
+class ScriptedProvider extends BaseProvider {
+  readonly provider: "openai" | "ollama";
+  /** Model turns actually made — the number a refused turn must not increase. */
+  turns = 0;
+
+  constructor(
+    providerId: "openai" | "ollama",
+    private readonly callToolEveryTurn: boolean
+  ) {
+    super();
+    this.provider = providerId;
+  }
+
+  async generateMessage(): Promise<ProviderMessage> {
+    return { role: "assistant", content: "unused" };
+  }
+
+  async *generateMessages(): AsyncGenerator<ProviderStreamItem> {
+    this.turns++;
+    if (this.callToolEveryTurn) {
+      yield {
+        id: `call_${this.turns}`,
+        name: "definitely_not_a_tool",
+        args: {}
+      };
+      return;
+    }
+    yield { type: "chunk", content: "done", done: true };
+  }
+}
+
+function chatTurn(
+  threadId: string,
+  providerId: string,
+  model: string
+): Record<string, unknown> {
+  return { thread_id: threadId, content: "hi", provider: providerId, model };
+}
+
+async function assistantTexts(threadId: string): Promise<string[]> {
+  const [rows] = await Message.paginate(threadId, { limit: 100 });
+  return rows
+    .filter((m) => m.role === "assistant")
+    .map((m) => (typeof m.content === "string" ? m.content : ""));
+}
+
+function harnessFor(provider: BaseProvider): ChatTurnHarness {
+  return makeChatTurnHarness({
+    session: { resolveProvider: async () => provider }
+  });
+}
+
+describe("the chat turn's run budget", () => {
+  const saved = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    initTestDb();
+    for (const key of BUDGET_ENV_KEYS) saved.set(key, process.env[key]);
+  });
+
+  afterEach(() => {
+    for (const key of BUDGET_ENV_KEYS) {
+      const value = saved.get(key);
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("ends a turn priced above the cap before any model call, and says why", async () => {
+    // Below one worst-case turn on a priced model (16k output tokens on
+    // gpt-4o-mini is about a cent), so the first reservation is refused and
+    // the call is never made.
+    process.env.NODETOOL_AGENT_TURN_COST_CAP_USD = "0.001";
+    const provider = new ScriptedProvider("openai", false);
+    const harness = harnessFor(provider);
+
+    await harness.handler.handleChatMessage(
+      chatTurn("t-budget-cap", "openai", PRICED_MODEL)
+    );
+
+    expect(provider.turns).toBe(0);
+    const texts = await assistantTexts("t-budget-cap");
+    const notice = texts.find((t) => t.startsWith("Stopped:"));
+    expect(notice).toBeDefined();
+    expect(notice).toContain("turn budget of $0.001 reached");
+    // The same text reaches the client, not just the transcript.
+    expect(
+      harness.session.messages.some(
+        (m) =>
+          m.role === "assistant" &&
+          typeof m.content === "string" &&
+          m.content.includes("turn budget of $")
+      )
+    ).toBe(true);
+  });
+
+  it("reads a non-positive cap as no cap, not as a cap of zero", async () => {
+    // `Number("")` is 0, and a budget of $0 refuses every turn — the coercion
+    // that would silently make a local-only install unable to chat at all.
+    process.env.NODETOOL_AGENT_TURN_COST_CAP_USD = "0";
+    const provider = new ScriptedProvider("openai", false);
+    const harness = harnessFor(provider);
+
+    await harness.handler.handleChatMessage(
+      chatTurn("t-budget-nocap", "openai", PRICED_MODEL)
+    );
+
+    expect(provider.turns).toBe(1);
+    expect(
+      (await assistantTexts("t-budget-nocap")).some((t) =>
+        t.startsWith("Stopped:")
+      )
+    ).toBe(false);
+  });
+
+  it("runs a local model unbounded by dollars and stops it on the turn count", async () => {
+    // A cap far below a single priced turn, which a zero-priced local model
+    // sails past: what ends this run is the turn count, not the money.
+    process.env.NODETOOL_AGENT_TURN_COST_CAP_USD = "0.001";
+    process.env.NODETOOL_AGENT_MAX_TURNS = "2";
+    const provider = new ScriptedProvider("ollama", true);
+    const harness = harnessFor(provider);
+
+    await harness.handler.handleChatMessage(
+      chatTurn("t-budget-local", "ollama", LOCAL_MODEL)
+    );
+
+    expect(provider.turns).toBe(2);
+    const notice = (await assistantTexts("t-budget-local")).find((t) =>
+      t.startsWith("Stopped:")
+    );
+    expect(notice).toContain("turn limit of 2 reached");
+  });
+
+  it("shares one budget object with the capability run, the sub-agent runtime and the context", async () => {
+    process.env.NODETOOL_AGENT_MAX_TURNS = "5";
+    const provider = new ScriptedProvider("ollama", false);
+    const harness = harnessFor(provider);
+
+    await harness.handler.handleChatMessage(
+      chatTurn("t-budget-shared", "ollama", LOCAL_MODEL)
+    );
+
+    const run = harness.handler.getCapabilityRun();
+    expect(run).not.toBeNull();
+    const budget = run?.budget;
+    expect(budget).toBeDefined();
+    // Identity, not equality: a copy would hand every nested loop the whole
+    // cap again (invariant I-2).
+    expect(run?.subAgent?.budget).toBe(budget);
+    expect(run?.context.get(RUN_BUDGET_CONTEXT_KEY)).toBe(budget);
+    // And the provider loop reserved against that same object: one turn ran.
+    expect((budget as RunBudget).turnCount.current).toBe(1);
+  });
+});

--- a/packages/websocket/tests/chat-turn-supersede.test.ts
+++ b/packages/websocket/tests/chat-turn-supersede.test.ts
@@ -20,6 +20,7 @@ import {
   type WebSocketReceiveFrame
 } from "../src/websocket-client-session.js";
 import { SUPERSEDED_TOOL_RESULT } from "../src/chat-tool-call-repair.js";
+import { borrowedLoopBudgetMembers } from "./chat-turn-test-harness.js";
 
 class MockWS implements WebSocketConnection {
   clientState: "connected" | "disconnected" = "connected";
@@ -267,7 +268,8 @@ describe("loading a thread that already carries an orphaned tool call", () => {
           sent = args.messages;
           yield { type: "chunk", content: "hi", done: true };
         },
-        generateLoop: BaseProvider.prototype.generateLoop
+        generateLoop: BaseProvider.prototype.generateLoop,
+        ...borrowedLoopBudgetMembers
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       }) as any;
 

--- a/packages/websocket/tests/chat-turn-test-harness.ts
+++ b/packages/websocket/tests/chat-turn-test-harness.ts
@@ -5,8 +5,8 @@
  * so a suite can assert the register/drop/release accounting a workflow-bound
  * chat run performs.
  */
-import type { HydratedGraphData } from "@nodetool-ai/protocol";
-import type { BaseProvider } from "@nodetool-ai/runtime";
+import type { HydratedGraphData, ProviderId } from "@nodetool-ai/protocol";
+import type { BaseProvider, TurnBudget } from "@nodetool-ai/runtime";
 import {
   ChatTurnHandler,
   type ChatJobAccess,
@@ -184,3 +184,35 @@ export function fakeProvider(shape: FakeProviderShape): BaseProvider {
   // only the ones the double provides, and a missing one fails the test loudly.
   return base as unknown as BaseProvider;
 }
+
+/**
+ * What `BaseProvider.prototype.generateLoop` calls on `this` that a
+ * plain-object double does not inherit. The chat turn hands the loop a run
+ * budget, and the loop then reserves before every model turn — so a double
+ * that borrows the loop without these dies on `this._admitTurn is not a
+ * function` before the first call.
+ *
+ * Spread it beside `generateLoop: BaseProvider.prototype.generateLoop`.
+ */
+export const borrowedLoopBudgetMembers = {
+  _admitTurn(
+    this: { provider: string },
+    budget: TurnBudget,
+    model: string,
+    messages: readonly unknown[]
+  ): boolean {
+    return budget.reserve({
+      model,
+      // SAFETY: the doubles name themselves "mock". The budget reads the pair
+      // only to look up a price, and an unknown provider prices as unknown.
+      provider: this.provider as ProviderId,
+      // The real loop counts prompt tokens; four characters per token is close
+      // enough for a double, and keeps a token ceiling testable.
+      inputTokens: Math.ceil(JSON.stringify(messages ?? []).length / 4)
+    });
+  },
+  /** Nothing was billed, so the turn commits a real zero. */
+  getTotalCost(): number {
+    return 0;
+  }
+};

--- a/packages/websocket/tests/websocket-client-session-chat-resume.test.ts
+++ b/packages/websocket/tests/websocket-client-session-chat-resume.test.ts
@@ -12,6 +12,7 @@ import {
   type WebSocketReceiveFrame
 } from "../src/websocket-client-session.js";
 import { chatTurnRegistry } from "../src/chat-turn-registry.js";
+import { borrowedLoopBudgetMembers } from "./chat-turn-test-harness.js";
 
 class MockWS implements WebSocketConnection {
   clientState: "connected" | "disconnected" = "connected";
@@ -79,7 +80,8 @@ function gatedProvider() {
       getAvailableASRModels: async () => [],
       getAvailableEmbeddingModels: async () => [],
       getContainerEnv: () => ({}),
-      generateLoop: BaseProvider.prototype.generateLoop
+      generateLoop: BaseProvider.prototype.generateLoop,
+      ...borrowedLoopBudgetMembers
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }) as any;
   return { provider, release: () => release() };

--- a/packages/websocket/tests/workflow-message-parity.test.ts
+++ b/packages/websocket/tests/workflow-message-parity.test.ts
@@ -23,6 +23,7 @@ import {
   type WebSocketConnection,
   type WebSocketReceiveFrame
 } from "../src/websocket-client-session.js";
+import { borrowedLoopBudgetMembers } from "./chat-turn-test-harness.js";
 
 // ── Mock WebSocket ──────────────────────────────────────────────────
 
@@ -127,7 +128,8 @@ function mockProvider() {
       getAvailableASRModels: async () => [],
       getAvailableEmbeddingModels: async () => [],
       getContainerEnv: () => ({}),
-        generateLoop: BaseProvider.prototype.generateLoop
+        generateLoop: BaseProvider.prototype.generateLoop,
+        ...borrowedLoopBudgetMembers
     }) as any;
 }
 


### PR DESCRIPTION
## What changed

Work package **A1** from `docs/plans/agent-system-improvements.md`: the only bounds on an agent run were iteration counts, and those nested and reset, so a user on a paid provider could lose an unbounded amount of money to a loop nobody stops. The budget primitive already existed and was tested; it was wired into the supervisor and app-build and nowhere a user can reach. This connects it.

`RunBudget` carries the four bounds one run shares — a reserve-then-commit USD cap, a wall-clock deadline, a semaphore over concurrent provider conversations, and a cumulative turn count — created by the host and shared downward, so a child loop reserves against its parent instead of opening a fresh allowance (invariant I-2).

Five holes it closes, each of them a real one rather than a hardening exercise:

**Child loops opened their own allowance.** `SubAgentTool.process` built the child's executor without the budget at all, and neither DAG executor had one to pass, so a cap bounded one loop rather than the run. Inverting the fix bills **$2.00 against a $1.25 cap** with all three children running.

**Three concurrency caps multiplied.** `maxConcurrentAgents` bounds one `mergeAsyncGenerators` call, and tasks, steps and sub-agents each applied it separately. Inverting the shared semaphore puts **all 20** background children in flight against a limit of 2.

**`maxIterations` reset every finish-nudge round.** `MAX_FINISH_NUDGES` therefore multiplied the ceiling: a step configured for 4 model turns could make **12**.

**A refused turn was silent** (I-3), in two places — `generateLoop` returned rather than yielding, and `classifyProviderStream` had no branch for the stop item, so it vanished before reaching `AgentNode`. `generateLoop` now yields one `ProviderStop` naming `budget`, `deadline`, `iterations` or `aborted`; a turn the model ends on its own yields none. A CodeAct step used to report a budget stop as `ended after N action(s) without calling finish()` — the model's failure, for something it never got to do.

**An unpriced model read as free** (A-5/I-4). It has no worst case to reserve, so it is admitted only while its prompt fits a token ceiling, counted in `unpricedTurns`, and leaves `spentUsd` a declared lower bound.

The last commit is what makes any of it reach users: before it the budget was plumbed through every loop and no chat turn created one, so nothing was capped on the path people actually take. A chat turn now builds one from five `NODETOOL_AGENT_*` settings and shares that object with all three capability runs, the sub-agent runtime, the turn context (so an `AgentNode` reached through `run_node` and a JS script inherit it), and `generateLoop`.

**Deliberately not here.** T-A1.6 (CLI flags): the plan puts it after T-A3.2 rewrites the command it would add flags to, and A3 is not in this change. And `spentUsd` on the wire: this turn has no `log_update` to carry it, so spend goes on the completion log line; a new protocol message belongs in its own change.

## Verification

- [x] `npm run test:affected` — `runtime` 38 budget tests; `agents` 3738 passed; `websocket` 2831 passed; `llm-nodes` 511 passed; `reliability/harness` 27 files / 156 passed.
- [x] `npm run typecheck` — web and electron clean. `mobile` fails on `Cannot find module 'react-native' / 'expo-*'` because `mobile/node_modules` does not exist in this sandbox; mobile is deliberately not a root workspace, so `npm install` never populated it.
- [x] `npm run lint` — exit 0.
- [x] `npm run dev:nodetool -- harness gate --base main` — **10/10 selfchecks passed** (run from `dist`, as the reliability journeys require).
- [x] `npm run capabilities:check` — current, 252 capabilities; no capability added, no declared contract changed.

Three failures were run to ground rather than assumed. `runtime`'s `video-frame-fallback.test.ts` fails to load with `spawn ffmpeg ENOENT` and `base-nodes`' `image-examples-run` suites hit the documented no-Vulkan-ICD WebGPU gap — both reproduce identically on a stashed baseline. And one CI run went red on `client-reconnect-mid-run.test.ts` with `Hook timed out in 10000ms` in a `beforeEach` booting a test server: that journey's graph is `String → Code → Output` with no provider, its `it` carries `{ timeout: 20000 }` while the hook kept vitest's 10s default, and it passes locally 3/3 and in the full suite on this tree. No fix was applied and none was needed — CI is green on the same code.

Adding a budget to every run also broke 48 pre-existing tests across four packages: the duck-typed provider doubles call `BaseProvider.prototype.generateLoop.call(mock)` and lack the `_admitTurn`/`getTotalCost` the budget path now reaches. The doubles were fixed. Making the production loop defensive to satisfy a test double would have been the wrong repair.

Each new check was inverted once and observed failing before it shipped:

| Inverted | Observed |
|---|---|
| Unpriced ceiling replaced with `Infinity` | `× refuses a turn over the token ceiling` — `expected true to be false` |
| Budget-refusal and iterations stop yields deleted | 4 red: `expected [] to have a length of 1` ×3, `expected [] to deeply equal ['budget']` |
| Deadline check in `reserve` forced to `if (false)` | `× refuses on an expired deadline and says so` |
| Set-once dropped from `exhausted` | `× keeps the first reason…` — `expected 'deadline' to be 'cost'` |
| `Release` made non-idempotent, queue made LIFO | `expected 2 to be 1` (permit pool inflated); the FIFO case hung to timeout |
| Turn count incremented before the cost check | `expected 1 to be +0` (a refused turn consumed a slot) |
| Per-round iteration reset restored in CodeAct | `expected 12 to be 4` |
| Both CodeAct deadline checks removed | `expected 2 to be 1` (the second bridged call reached the tool) |
| `isProviderStop` branch removed from the step loop | `expected 'Step failed: ended after 0 action(s) …' to contain 'run deadline'` |
| Budget dropped from `SubAgentTool.process` | `expected 2 to be less than or equal to 1.25`; 3 children ran |
| Fresh budget per `start_subtask` spawn | `expected 20 to be less than or equal to 2` |
| Semaphore ignored in `mergeAsyncGenerators` | `expected 8 to be less than or equal to 2` and `… to 3` |
| `budgetFromContext` lookup dropped from `AgentNode` | `expected +0 to be close to 0.25` (the node opened its own allowance) |
| `isProviderStop` removed from `classifyProviderStream` | `expected [ 'text' ] to deeply equal [ 'text', 'stop' ]` |
| `RUN_BUDGET_CONTEXT_KEY` not set on the chat turn | `expected undefined to be { turns: {…}, … }` |
| Chat notice assertion flipped to `toBeUndefined()` | `expected 'Stopped: turn budget of $0.001 reached' to be undefined` |

The `exhausted` set-once test could not fail on its first draft — a 60s deadline never expired inside the test — and was rewritten with a real 10ms deadline and a sleep before it bit. The propagation test measures spend from the providers' own `getTotalCost()`, not from `budget.turns.spentUsd`: a child spending outside the budget leaves the budget's own books looking fine, so asserting on them could not have failed.

## Notes for review

A run-total semaphore deadlocks if a permit holder queues for a second one, which nested merges do by construction — `ParallelTaskExecutor` holds permits for tasks whose `TaskExecutor`s then queue for step permits. A permit is therefore taken **once per branch**: `acquireRunSlot` is re-entrant on a context flag, and each DAG executor holds one slot for the length of its run.

Clearing the cost-cap setting restores the default rather than removing the cap, because `getSetting` answers `null` for an unset and an empty stored value alike. Removing the cap is `0`. The setting's description originally said the opposite and is corrected here.

## Agent capabilities

No capability is added and no capability's declared contract changes.

## New checks

- [x] Every check added here was inverted once and observed failing; the failing output is in the table above.
- [x] No audit is added, so there is no target-matching claim to make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REowPLbPBf3uYBtnMQJBcM