### PR TITLE
feat(timeline): motion graphics M0 — custom animations for agents [T4]

### DIFF
--- a/docs/timeline-custom-animations.md
+++ b/docs/timeline-custom-animations.md
@@ -188,8 +188,9 @@ tool rather than out of this document.
 `nodetool timeline validate` and the `validate_timeline` tool report
 `custom_animation_invalid` for curves the compiler would skip (an unknown
 property, a keyframe with no finite value, a `wipeProgress` curve with no mask)
-and warn `custom_animation_unsourced` when baked curves name neither a script
-nor code, so nothing could re-bake them.
+Curves that are absent or empty are reported by that same code — an animation
+that drives nothing. Inline curves need no script or code behind them: under
+the agent path they are the source, not a bake of one.
 
 ## Code
 

--- a/docs/timeline-custom-animations.md
+++ b/docs/timeline-custom-animations.md
@@ -70,9 +70,18 @@ nobody described.
 
 ### Animatable properties
 
-`offsetX`, `offsetY`, `scale`, `rotation`, `opacity`, `wipeProgress`, `blur`,
-`brightness`, `saturation` — the same set presets drive
-(`ANIMATED_PROPERTIES` in `packages/timeline/src/animation/types.ts`).
+`ANIMATED_PROPERTIES` in `packages/timeline/src/animation/types.ts` is the
+list; `ANIMATED_PROPERTY_DOCS` in `animation/custom.ts` pairs each channel with
+its fold, its identity value and its range, and is what
+`list_animation_presets` prints. Transform: `offsetX`, `offsetY`, `scale`,
+`scaleX`, `scaleY`, `rotation`, `positionX`, `positionY`, `anchorX`, `anchorY`.
+Compositing: `opacity`, `wipeProgress`. Grade and blur: `blur`, `brightness`,
+`saturation`, `contrast`, `hue`, `temperature`, `tint`. Shape stroke:
+`trimStart`, `trimEnd`.
+
+A channel folds one of four ways when several animations drive it: `add`,
+`multiply`, `min` (`wipeProgress` — more hidden wins), or `replace` (the
+absolute channels: position, anchor, trim).
 
 ## Two differences from a preset
 
@@ -126,6 +135,54 @@ The run is **hermetic**: no toolbelt, no secrets, no network, capped at 10s. A
 curve generator is a function of time, and reach would let the same animation
 bake differently depending on where it ran.
 
+## The agent path
+
+An agent writes a custom animation the way it writes any other: one
+`animate_clip` op through `edit_timeline` (or `ui_timeline_animate_clip` in an
+open editor), with `preset: "custom"` and **exactly one** of `curves` and
+`code`.
+
+```jsonc
+{
+  "op": "animate_clip",
+  "target": "Title",
+  "animations": [{
+    "role": "in",
+    "preset": "custom",
+    "durationMs": 800,
+    "curves": [{
+      "property": "offsetY",
+      "keyframes": [{ "t": 0, "value": 120 }, { "t": 1, "value": 0 }]
+    }]
+  }]
+}
+```
+
+`curves` are the keyframes themselves — `t` runs 0..1 over the animation's
+window, and a curve that stops short of either end is extended by holding its
+end value. `code` is the body above: the host bakes it once through
+`bakeCustomAnimation` — the same hermetic run the endpoint uses — and stores
+`code` beside the curves as provenance. Both paths end at
+`normalizeCustomCurves`, so what is stored is what will render.
+
+Four rules the op enforces, each with the message that says how to fix it:
+
+- Both `curves` and `code`, or neither, is refused. One says what the motion
+  is; the other says what computes it.
+- A property outside `ANIMATED_PROPERTIES` is refused, and the message lists
+  the ones a curve may drive.
+- A `wipeProgress` curve needs `mask` (`{direction, softness}`) — the same
+  refusal the compiler and the validator raise.
+- `code` needs a host that can bake it. `edit_timeline` wires one; a surface
+  with none says so and points at `curves` rather than storing an unbaked body.
+
+Without `durationMs` the animation spans the clip, so hand-written curves need
+no arithmetic to line up with a cut.
+
+`list_animation_presets` reports the `custom` contract and every animatable
+property with its fold, identity and range, so the channels can be read off the
+tool rather than out of this document.
+
 ## Checks
 
 `nodetool timeline validate` and the `validate_timeline` tool report
@@ -143,10 +200,11 @@ nor code, so nothing could re-bake them.
 | Wire schema | `packages/protocol/src/api-schemas/timeline.ts` |
 | Bake (the one place the body runs) | `packages/agents/src/custom-animation-bake.ts` |
 | HTTP surface | `packages/websocket/src/routes/timeline-animations.ts` |
+| Agent op (one bridge, both surfaces) | `packages/agents/src/evals/surfaces/timeline.ts` |
 | Validation | `packages/execution/src/timeline-debug/validate.ts` |
 
 ## Not built yet
 
-No editor UI. A custom animation is authored through the bake endpoint and
-written onto the clip by whatever holds the document — the agent tools, the CLI,
-or a client calling the route directly.
+No editor UI. Outside the agent path above, a custom animation is authored
+through the bake endpoint and written onto the clip by whatever holds the
+document — the CLI, or a client calling the route directly.

--- a/packages/agents/src/capabilities/timelines.specs.ts
+++ b/packages/agents/src/capabilities/timelines.specs.ts
@@ -128,7 +128,13 @@ export const EDIT_TIMELINE_SCHEMA: JsonSchema = {
         "list_animation_presets, select_clip, seek. Start with get_state to " +
         "read track and clip ids. To lay existing videos end to end, call " +
         'add_media_clip once per asset ({"op": "add_media_clip", "asset": ' +
-        '"asset://<id>.mp4"}) — each appends after the last.',
+        '"asset://<id>.mp4"}) — each appends after the last. animate_clip ' +
+        'takes catalog presets and, for motion none of them covers, ' +
+        '{"preset": "custom"} with exactly one of `curves` ' +
+        '([{property, keyframes: [{t, value, easing?}]}], `t` running 0..1 ' +
+        "over the animation's window) or `code` (a JS body baked into curves " +
+        "once, host-side); add `mask` when a curve drives wipeProgress. " +
+        "list_animation_presets reports the animatable properties.",
       items: { type: "object" }
     }
   },
@@ -313,7 +319,8 @@ export const editTimelineSpec: CapabilitySpec = {
   description:
     "Edit a saved timeline sequence headlessly: add tracks, add text and " +
     "shape clips, split, trim, move, duplicate and delete clips, set clip " +
-    "params and workflow bindings, and animate clips with presets. Pass a " +
+    "params and workflow bindings, and animate clips with presets or " +
+    "keyframed custom curves. Pass a " +
     "list of operations; they run in order against the stored document and " +
     "the result is saved. An open editor picks the change up live. Call " +
     "list_timelines to find a sequence and validate_timeline afterwards. " +

--- a/packages/agents/src/capabilities/timelines.ts
+++ b/packages/agents/src/capabilities/timelines.ts
@@ -1072,7 +1072,8 @@ const previewTimelineFrame: CapabilityExport = {
           mime_type: saved.mime_type,
           bytes: saved.bytes
         },
-        layers: frame.layers
+        layers: frame.layers,
+        dropped: frame.dropped
       });
     }
 

--- a/packages/agents/src/capabilities/timelines.ts
+++ b/packages/agents/src/capabilities/timelines.ts
@@ -26,9 +26,12 @@ import type {
 } from "@nodetool-ai/models";
 import type { TimelineValidation } from "@nodetool-ai/execution/timeline-debug";
 import type {
+  TimelineAnimationBakeRequest,
+  TimelineAnimationBakeResult,
   TimelineBridgeAsset,
   TimelineBridgeFinalState
 } from "../evals/surfaces/timeline.js";
+import type { BakeCustomAnimationParams } from "../custom-animation-bake.js";
 import type {
   CapabilityExport,
   CapabilityModule,
@@ -571,6 +574,39 @@ async function resolveTimelineAsset(
 }
 
 /**
+ * Run a custom animation's body once and return its curves.
+ *
+ * The bake is the only place that code runs — the curves are stored and every
+ * render site samples them — so it goes through `bakeCustomAnimation`, the
+ * same hermetic path `POST /api/timelines/animations/bake` uses. Imported
+ * lazily: the sandbox is a heavy dependency for a capability most calls never
+ * reach.
+ */
+async function bakeTimelineAnimation(
+  run: CapabilityRun,
+  request: TimelineAnimationBakeRequest
+): Promise<TimelineAnimationBakeResult> {
+  const { bakeCustomAnimation } = await import("../custom-animation-bake.js");
+  const params: BakeCustomAnimationParams = {
+    code: request.code,
+    role: request.role,
+    durationMs: request.durationMs,
+    clipDurationMs: request.clipDurationMs,
+    canvas: request.canvas
+  };
+  if (request.params !== undefined) params.params = request.params;
+  if (request.staggerCount !== undefined) {
+    params.staggerCount = request.staggerCount;
+  }
+  const baked = await bakeCustomAnimation(run.context, params);
+  const result: TimelineAnimationBakeResult = { ok: baked.ok };
+  if (baked.curves !== undefined) result.curves = baked.curves;
+  if (baked.mask !== undefined) result.mask = baked.mask;
+  if (baked.error !== undefined) result.error = baked.error;
+  return result;
+}
+
+/**
  * Run `ops` against a bridge seeded from `document`.
  *
  * A failing op is recorded and the script continues: stopping at the first
@@ -592,7 +628,8 @@ async function applyOps(
       tracks: document.tracks,
       clips: document.clips
     },
-    resolveAsset: (ref) => resolveTimelineAsset(run, ref)
+    resolveAsset: (ref) => resolveTimelineAsset(run, ref),
+    bakeAnimation: (request) => bakeTimelineAnimation(run, request)
   });
   const byName = new Map(
     bridge.tools

--- a/packages/agents/src/evals/surfaces/timeline.ts
+++ b/packages/agents/src/evals/surfaces/timeline.ts
@@ -28,6 +28,11 @@ import { parseWithTypeCoercion } from "@nodetool-ai/runtime";
 import {
   splitClip,
   ANIMATION_PRESETS,
+  ANIMATED_PROPERTIES,
+  CUSTOM_ANIMATION_CONTRACT,
+  CUSTOM_ANIMATION_PRESET_ID,
+  normalizeCustomCurves,
+  resolveCustomMask,
   makeClip,
   makeTrack,
   DEFAULT_TEXT_CLIP_DURATION_MS,
@@ -39,6 +44,9 @@ import {
   DEFAULT_MEDIA_CLIP_DURATION_MS,
   mediaTypeForContentType,
   trackTypeForMediaType,
+  type AnimationRole,
+  type CustomClipAnimation,
+  type PropertyCurve,
   type TimelineClip,
   type TimelineTrack,
   type ClipAnimation
@@ -51,6 +59,51 @@ import type {
 } from "../tool-loop-eval.js";
 
 const animationRole = z.enum(["in", "out", "emphasis", "loop"]);
+
+/**
+ * The `custom` preset's inputs. Values are checked by
+ * `normalizeCustomCurves`/`resolveCustomMask` rather than by Zod: those are the
+ * gates the compiler and the validator already run, and a second, looser copy
+ * of the rules here would refuse or admit different curves than the engine.
+ */
+const customCurvesParam = z
+  .array(
+    z.object({
+      property: z
+        .string()
+        .describe(`One of: ${ANIMATED_PROPERTIES.join(", ")}.`),
+      keyframes: z
+        .array(
+          z.object({
+            t: z.number().describe("0..1 across the animation's window."),
+            value: z.number(),
+            easing: z.string().optional()
+          })
+        )
+        .min(1)
+    })
+  )
+  .optional()
+  .describe(
+    'Keyframes for `preset: "custom"`. Exactly one of `curves` and `code`.'
+  );
+
+const customCodeParam = z
+  .string()
+  .optional()
+  .describe(
+    'JS body for `preset: "custom"`, baked into curves once. It returns ' +
+      "`{curves}` or `{samples}` and reads its clip context off `inputs`. " +
+      "Exactly one of `curves` and `code`."
+  );
+
+const customMaskParam = z
+  .object({
+    direction: z.enum(["left", "right", "up", "down"]),
+    softness: z.number().min(0).max(1)
+  })
+  .optional()
+  .describe("Required when a curve drives wipeProgress, ignored otherwise.");
 
 const targetParam = z
   .string()
@@ -119,6 +172,36 @@ export interface TimelineBridgeSequenceSeed {
   clips: TimelineClip[];
 }
 
+/**
+ * One custom-animation bake: a JS body plus the clip context it is written
+ * against. The bridge never runs the body itself — a sandbox belongs to the
+ * host, so `edit_timeline` hands `bakeCustomAnimation` down and the eval
+ * surface runs without one.
+ */
+export interface TimelineAnimationBakeRequest {
+  code: string;
+  role: AnimationRole;
+  /** The animation's own window, in ms. */
+  durationMs: number;
+  clipDurationMs: number;
+  canvas: { width: number; height: number };
+  params?: Record<string, number | string | boolean>;
+  /** Stagger units the clip splits into (a text clip's word count), else 0. */
+  staggerCount?: number;
+}
+
+/** What a bake returns. Mirrors `BakeCustomAnimationResult` minus the logs. */
+export interface TimelineAnimationBakeResult {
+  ok: boolean;
+  curves?: CustomClipAnimation["curves"];
+  mask?: { direction: string; softness: number };
+  error?: string;
+}
+
+export type TimelineAnimationBaker = (
+  request: TimelineAnimationBakeRequest
+) => Promise<TimelineAnimationBakeResult>;
+
 /** Case-supplied starting point for a run. */
 export interface TimelineBridgeInitialState {
   fps?: number;
@@ -138,6 +221,12 @@ export interface TimelineBridgeInitialState {
    * clip that points at nothing.
    */
   resolveAsset?: TimelineAssetResolver;
+  /**
+   * Bake a `preset: "custom"` animation's `code` into curves. Without one the
+   * op says so and points at `curves`, rather than storing an animation whose
+   * body nothing ever ran.
+   */
+  bakeAnimation?: TimelineAnimationBaker;
   tracks?: { name?: string; type: "video" | "audio" | "overlay" | "subtitle" }[];
   clips?: {
     name: string;
@@ -200,6 +289,21 @@ function capitalize(s: string): string {
 }
 
 /**
+ * Units a staggered animation splits into — a text clip's word count, which is
+ * what a custom body reads off `inputs.staggerCount`. Zero when the clip does
+ * not stagger, matching the un-staggered block case.
+ */
+function staggerUnitCount(
+  clip: TimelineClip,
+  stagger: ClipAnimation["stagger"]
+): number {
+  if (!stagger || clip.mediaType !== "text") return 0;
+  const text = clip.textStyle?.text ?? "";
+  const words = text.trim().split(/\s+/).filter((word) => word.length > 0);
+  return words.length;
+}
+
+/**
  * Build an in-memory timeline bridge whose tools share the `ui_timeline_*`
  * contract but run headlessly against a plain sequence of tracks/clips (no
  * Zustand stores, no rendering).
@@ -209,6 +313,7 @@ export function createTimelineToolBridge(
 ): HeadlessSurfaceBridge<TimelineBridgeFinalState> {
   const seed = initial.sequence;
   const resolveAsset = initial.resolveAsset;
+  const bakeAnimation = initial.bakeAnimation;
   const fps = seed?.fps ?? initial.fps ?? 30;
   const width = seed?.width ?? initial.width ?? 1920;
   const height = seed?.height ?? initial.height ?? 1080;
@@ -300,6 +405,100 @@ export function createTimelineToolBridge(
       muted: t.muted ?? false,
       solo: t.solo ?? false,
       clipCount: clips.filter((c) => c.trackId === t.id).length
+    };
+  }
+
+  /**
+   * Build one `preset: "custom"` animation. `curves` are checked and stored;
+   * `code` is baked into curves first, by the host that supplied a baker. Both
+   * paths end at `normalizeCustomCurves`, the single gate the compiler and the
+   * validator also run, so what is stored is what will render.
+   */
+  async function buildCustomAnimation(
+    clip: TimelineClip,
+    input: {
+      role: ClipAnimation["role"];
+      durationMs?: number;
+      delayMs?: number;
+      easing?: ClipAnimation["easing"];
+      params?: ClipAnimation["params"];
+      curves?: unknown;
+      code?: string;
+      mask?: unknown;
+      stagger?: ClipAnimation["stagger"];
+    }
+  ): Promise<ClipAnimation> {
+    const code = typeof input.code === "string" ? input.code.trim() : "";
+    const hasCurves = input.curves !== undefined;
+    const hasCode = code !== "";
+    if (hasCurves && hasCode) {
+      throw new Error(
+        'A "custom" animation takes exactly one of `curves` and `code`; both were given. Pass the keyframes, or the body that produces them.'
+      );
+    }
+    if (!hasCurves && !hasCode) {
+      throw new Error(
+        'A "custom" animation needs `curves` (keyframes: [{property, keyframes:[{t, value}]}]) or `code` (a JS body baked into curves).'
+      );
+    }
+
+    // Curves are normalized to 0..1 over the window, so a custom animation
+    // with no duration of its own spans the clip and nothing is cropped.
+    const durationMs = input.durationMs ?? clip.durationMs;
+
+    let curves: PropertyCurve[];
+    let maskInput: unknown;
+    if (hasCurves) {
+      const normalized = normalizeCustomCurves(input.curves);
+      if (!normalized.ok) throw new Error(normalized.error);
+      curves = normalized.curves;
+      maskInput = input.mask;
+    } else {
+      if (!bakeAnimation) {
+        throw new Error(
+          'This surface cannot run `code`: no animation baker is wired to it. Pass `curves` instead, or bake the body through POST /api/timelines/animations/bake.'
+        );
+      }
+      const baked = await bakeAnimation({
+        code,
+        role: input.role as AnimationRole,
+        durationMs,
+        clipDurationMs: clip.durationMs,
+        canvas: { width, height },
+        params: input.params,
+        staggerCount: staggerUnitCount(clip, input.stagger)
+      });
+      if (!baked.ok || !baked.curves) {
+        throw new Error(
+          baked.error ?? "The animation body returned no curves."
+        );
+      }
+      const normalized = normalizeCustomCurves(baked.curves);
+      if (!normalized.ok) throw new Error(normalized.error);
+      curves = normalized.curves;
+      maskInput = baked.mask ?? input.mask;
+    }
+
+    const mask = resolveCustomMask(curves, maskInput);
+    if (!mask.ok) throw new Error(mask.error);
+
+    const custom: CustomClipAnimation = {
+      curves,
+      bakedAt: new Date().toISOString()
+    };
+    if (hasCode) custom.code = code;
+    if (mask.mask) custom.mask = mask.mask;
+
+    return {
+      id: nextAnimId(),
+      role: input.role,
+      preset: CUSTOM_ANIMATION_PRESET_ID,
+      durationMs,
+      delayMs: input.delayMs,
+      easing: input.easing,
+      params: input.params,
+      stagger: input.stagger,
+      custom
     };
   }
 
@@ -823,7 +1022,7 @@ export function createTimelineToolBridge(
 
     tool(
       "ui_timeline_animate_clip",
-      'Attach motion-design animations to a clip — no keyframing, just named presets. Roles: `in` (entrance: fade, slide, pop, spin, wipe, blur, colorFade), `out` (exit: fade, slide, pop, spin, wipe, blur, colorFade), `emphasis` (mid-clip: pulse, flash, shake, bounce), `loop` (continuous: kenBurns, float, breathe, rotate). Each animation: `role`, `preset`, optional `durationMs` (defaults per preset), `delayMs`, `easing`, and preset `params`. On text clips, add `stagger` for per-word motion typography: each word runs the animation for `durationMs`, offset `stagger.offsetMs` from the previous word (`from`: start|end|center picks the leading word) — e.g. a pop-in title whose words land one after another. `mode` "replace" (default) swaps the clip\'s animations; "add" appends. Call ui_timeline_list_animation_presets for the full param list.',
+      'Attach motion-design animations to a clip. Roles: `in` (entrance: fade, slide, pop, spin, wipe, blur, colorFade), `out` (exit: fade, slide, pop, spin, wipe, blur, colorFade), `emphasis` (mid-clip: pulse, flash, shake, bounce), `loop` (continuous: kenBurns, float, breathe, rotate). Each animation: `role`, `preset`, optional `durationMs` (defaults per preset), `delayMs`, `easing`, and preset `params`. For motion no preset covers, use `preset: "custom"` with exactly one of `curves` (keyframes you write: [{property, keyframes:[{t, value, easing?}]}], `t` running 0..1 over the window) or `code` (a JS body baked into curves once, host-side); add `mask` when a curve drives wipeProgress. On text clips, add `stagger` for per-word motion typography: each word runs the animation for `durationMs`, offset `stagger.offsetMs` from the previous word (`from`: start|end|center picks the leading word) — e.g. a pop-in title whose words land one after another. `mode` "replace" (default) swaps the clip\'s animations; "add" appends. Call ui_timeline_list_animation_presets for the full param list and the animatable properties.',
       z.object({
         target: targetParam,
         mode: z.enum(["add", "replace"]).optional(),
@@ -834,7 +1033,7 @@ export function createTimelineToolBridge(
               preset: z
                 .string()
                 .describe(
-                  "Preset id, e.g. fade, slide, wipe, pop, kenBurns, float."
+                  'Preset id, e.g. fade, slide, wipe, pop, kenBurns, float — or "custom" with `curves` or `code`.'
                 ),
               durationMs: z.number().positive().optional(),
               delayMs: z.number().nonnegative().optional(),
@@ -842,6 +1041,9 @@ export function createTimelineToolBridge(
               params: z
                 .record(z.string(), z.union([z.number(), z.string(), z.boolean()]))
                 .optional(),
+              curves: customCurvesParam,
+              code: customCodeParam,
+              mask: customMaskParam,
               stagger: z
                 .object({
                   unit: z.literal("word"),
@@ -868,14 +1070,22 @@ export function createTimelineToolBridge(
           delayMs?: number;
           easing?: ClipAnimation["easing"];
           params?: ClipAnimation["params"];
+          curves?: unknown;
+          code?: string;
+          mask?: unknown;
           stagger?: ClipAnimation["stagger"];
         }>;
-        const built: ClipAnimation[] = inputs.map((input) => {
+        const built: ClipAnimation[] = [];
+        for (const input of inputs) {
+          if (input.preset === CUSTOM_ANIMATION_PRESET_ID) {
+            built.push(await buildCustomAnimation(clip, input));
+            continue;
+          }
           const preset = ANIMATION_PRESETS.find((p) => p.id === input.preset);
           if (!preset) {
             const ids = ANIMATION_PRESETS.map((p) => p.id).join(", ");
             throw new Error(
-              `Unknown animation preset "${input.preset}". Valid presets: ${ids}.`
+              `Unknown animation preset "${input.preset}". Valid presets: ${ids}, ${CUSTOM_ANIMATION_PRESET_ID}.`
             );
           }
           if (!preset.roles.includes(input.role)) {
@@ -883,7 +1093,7 @@ export function createTimelineToolBridge(
               `Preset "${input.preset}" does not support role "${input.role}". Valid roles for "${input.preset}": ${preset.roles.join(", ")}.`
             );
           }
-          return {
+          built.push({
             id: nextAnimId(),
             role: input.role,
             preset: input.preset,
@@ -892,8 +1102,8 @@ export function createTimelineToolBridge(
             easing: input.easing,
             params: input.params,
             stagger: input.stagger
-          };
-        });
+          });
+        }
         clip.animations =
           (mode as string | undefined) === "add"
             ? [...(clip.animations ?? []), ...built]
@@ -920,7 +1130,7 @@ export function createTimelineToolBridge(
 
     tool(
       "ui_timeline_list_animation_presets",
-      "List the motion-design animation presets: id, allowed roles, params (with defaults and ranges), default duration/easing, and a one-line description. Use this to discover the exact preset names and params for ui_timeline_animate_clip.",
+      "List the motion-design animation presets: id, allowed roles, params (with defaults and ranges), default duration/easing, and a one-line description. Also returns the `custom` preset's contract and every animatable property with its fold, identity and range, for keyframed motion no preset covers. Use this to discover the exact preset names and params for ui_timeline_animate_clip.",
       z.object({}),
       async () => {
         const presets = ANIMATION_PRESETS.map((p) => ({
@@ -931,7 +1141,12 @@ export function createTimelineToolBridge(
           params: p.params,
           describe: p.describe
         }));
-        return { ok: true, presets };
+        return {
+          ok: true,
+          presets,
+          custom: CUSTOM_ANIMATION_CONTRACT,
+          properties: CUSTOM_ANIMATION_CONTRACT.properties
+        };
       }
     ),
 
@@ -1005,6 +1220,7 @@ Use the ui_timeline_* tools to inspect and modify the sequence:
 - Add content with ui_timeline_add_text_clip, ui_timeline_add_shape_clip, or ui_timeline_generate_clip; add tracks with ui_timeline_add_track when needed.
 - Address existing clips by id, name, or "selected" with ui_timeline_split_clip, ui_timeline_trim_clip, ui_timeline_move_clip, ui_timeline_delete_clip, ui_timeline_duplicate_clip, ui_timeline_set_clip_params, ui_timeline_set_clip_binding, ui_timeline_animate_clip, ui_timeline_clear_animations, ui_timeline_select_clip.
 - Before animating a clip, call ui_timeline_list_animation_presets to discover the exact preset ids, allowed roles, and params.
+- For motion no preset covers, animate with preset "custom" and pass curves — [{property, keyframes: [{t, value}]}], where t runs 0..1 over the animation window. list_animation_presets reports which properties a curve may drive.
 - ui_timeline_seek moves the playhead (useful before a playhead-relative split).
 
 Call one tool at a time and use the result before the next call. When the objective is fully satisfied, STOP calling tools and give a one-line summary.`;
@@ -1094,6 +1310,55 @@ export const TIMELINE_TOOL_LOOP_CASES: readonly ToolLoopEvalCase<TimelineBridgeF
             name: "oneClipLeftAt3000ms",
             detail: "expected exactly 1 clip with durationMs 3000",
             test: (s) => s.clips.length === 1 && s.clips[0].durationMs === 3000
+          }
+        ]
+      }
+    },
+    {
+      id: "keyframed-slide",
+      description:
+        "Keyframe an entrance with a custom animation instead of a preset",
+      objective:
+        "Add a text clip that says 'Launch' and give it a keyframed entrance: over the first 800ms it rises 120 pixels into place, from offsetY 120 down to 0. Use a custom animation with explicit keyframes, not a preset.",
+      createBridge: () => createTimelineToolBridge(),
+      systemPrompt: TIMELINE_SYSTEM_PROMPT,
+      expect: {
+        requiredTools: [
+          "ui_timeline_add_text_clip",
+          "ui_timeline_animate_clip"
+        ],
+        ordering: [["ui_timeline_add_text_clip", "ui_timeline_animate_clip"]],
+        noErrorResults: true,
+        minToolCalls: 2,
+        maxToolCalls: 12,
+        finalState: [
+          {
+            name: "hasCustomOffsetYCurve",
+            detail:
+              "no text clip carrying a custom 'in' animation whose offsetY curve ends at 0",
+            test: (s) =>
+              s.documentClips.some((clip) => {
+                if (clip.mediaType !== "text") return false;
+                const animation = (clip.animations ?? []).find(
+                  (a) => a.role === "in" && a.preset === "custom"
+                );
+                const curve = animation?.custom?.curves.find(
+                  (c) => c.property === "offsetY"
+                );
+                if (!curve) return false;
+                const keyframes = curve.keyframes;
+                const first = keyframes[0];
+                const last = keyframes[keyframes.length - 1];
+                // A rise into place: starts below, lands on the layout
+                // position, and the window is the 800ms that was asked for.
+                return (
+                  first.t === 0 &&
+                  last.t === 1 &&
+                  first.value >= 100 &&
+                  last.value === 0 &&
+                  animation?.durationMs === 800
+                );
+              })
           }
         ]
       }

--- a/packages/agents/tests/capabilities-timeline-preview.test.ts
+++ b/packages/agents/tests/capabilities-timeline-preview.test.ts
@@ -8,7 +8,8 @@
  * only asserted "a PNG came back" would pass on a black frame.
  */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { initTestDb, ModelObserver } from "@nodetool-ai/models";
 import { createCanvas, loadImage } from "@napi-rs/canvas";
 import type {
   TimelineClip,
@@ -246,6 +247,41 @@ describe("renderTimelineFrames", () => {
     expect(frames[0].layers[0].skipped).toContain("draft");
   });
 
+  it("names the layers the video cap kept out of the frame", async () => {
+    // Nine video clips overlap; the compositor holds eight. The ninth used to
+    // vanish with no trace anywhere in the report.
+    const tracks = Array.from({ length: 9 }, (_, i) => track(i));
+    const clips = tracks.map((t, i) => ({
+      ...shapeClip(`shot-${i}`, t.id, "#ff0000"),
+      name: `Shot ${i}`,
+      mediaType: "video" as const,
+      currentAssetId: `asset-${i}`,
+      shapeStyle: undefined
+    }));
+
+    const { frames } = await renderTimelineFrames({
+      sequence: sequence(tracks, clips),
+      timesMs: [1000],
+      width: 160,
+      loadAsset: noAssets
+    });
+
+    expect(frames[0].dropped).toEqual([
+      { clip_id: "shot-8", clip_name: "Shot 8", reason: "video_layer_cap" }
+    ]);
+  });
+
+  it("reports no dropped layer for a frame that fits", async () => {
+    const { frames } = await renderTimelineFrames({
+      sequence: sequence([track(0)], [shapeClip("red", "track-0", "#ff0000")]),
+      timesMs: [1000],
+      width: 160,
+      loadAsset: noAssets
+    });
+
+    expect(frames[0].dropped).toEqual([]);
+  });
+
   it("names the effects Canvas 2D cannot draw", async () => {
     const { effectsNotApplied } = await renderTimelineFrames({
       sequence: sequence(
@@ -332,5 +368,117 @@ describe("preview_timeline_frame", () => {
       document: { tracks: [track(0)], clips: [], markers: [] }
     });
     expect(String(result.error)).toContain("no clips");
+  });
+});
+
+/**
+ * The acceptance for the custom-animation op (T4): keyframes an agent writes
+ * through `edit_timeline` have to reach the picture, not just the document.
+ * The curve here is arithmetic — a white layer over black at opacity 0.5 —
+ * so the pixel is the assertion.
+ */
+describe("edit_timeline custom curves through preview_timeline_frame", () => {
+  beforeEach(() => initTestDb());
+  afterEach(() => ModelObserver.clear());
+
+  /** Context with an asset store, so a previewed frame's bytes are readable. */
+  function contextWithAssets() {
+    const stored = new Map<string, Uint8Array>();
+    const context = {
+      userId: "u1",
+      hasModelInterface: (name: string) => name === "createAsset",
+      createAsset: async ({ content }: { content: Uint8Array }) => {
+        const id = `asset-${stored.size + 1}`;
+        stored.set(id, content);
+        return { id };
+      }
+    } as unknown as ProcessingContext;
+    return { context, stored };
+  }
+
+  it("renders the interpolated opacity at mid-curve", async () => {
+    const { TimelineSequence } = await import("@nodetool-ai/models");
+    const white = shapeClip("plate", "track-0", "#ffffff");
+    const row = await TimelineSequence.create<
+      InstanceType<typeof TimelineSequence>
+    >({
+      user_id: "u1",
+      project_id: "default",
+      name: "Fade plate",
+      fps: 30,
+      width: 640,
+      height: 360,
+      duration_ms: 4000,
+      document: JSON.stringify({
+        tracks: [track(0)],
+        clips: [white],
+        markers: []
+      })
+    });
+
+    const { context, stored } = contextWithAssets();
+    const edit = (await toolForCapabilityName("edit_timeline").process(context, {
+      timeline_id: row.id,
+      ops: [
+        {
+          op: "animate_clip",
+          target: "plate",
+          animations: [
+            {
+              role: "in",
+              preset: "custom",
+              durationMs: 2000,
+              curves: [
+                {
+                  property: "opacity",
+                  keyframes: [
+                    { t: 0, value: 0 },
+                    { t: 1, value: 1 }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    })) as { applied: number; failed: number };
+    expect(edit).toMatchObject({ applied: 1, failed: 0 });
+
+    const saved = await TimelineSequence.findById(row.id);
+    const document = JSON.parse(String(saved?.document)) as {
+      clips: TimelineClip[];
+    };
+    expect(document.clips[0].animations?.[0].custom?.curves[0].property).toBe(
+      "opacity"
+    );
+
+    const preview = (await toolForCapabilityName(
+      "preview_timeline_frame"
+    ).process(context, {
+      document,
+      // Half way through a 2000ms window whose curve runs 0 → 1 linearly.
+      times_ms: [1000],
+      width: 160,
+      width_px: 640,
+      height_px: 360
+    })) as {
+      error?: string;
+      frames: Array<{
+        image: { asset_id: string };
+        layers: Array<{ opacity: number }>;
+      }>;
+    };
+    expect(preview.error).toBeUndefined();
+    expect(preview.frames[0].layers[0].opacity).toBeCloseTo(0.5, 2);
+
+    const png = stored.get(preview.frames[0].image.asset_id);
+    expect(png).toBeDefined();
+    // White at half opacity over the compositor's black ground is mid grey.
+    // Full opacity would read 255 and a dropped curve 0 — both outside this.
+    const [r, g, b] = await pixelAt(png as Uint8Array, 80, 45);
+    expect(r).toBeGreaterThan(110);
+    expect(r).toBeLessThan(145);
+    expect(g).toBe(r);
+    expect(b).toBe(r);
   });
 });

--- a/packages/agents/tests/timeline-tool-loop.test.ts
+++ b/packages/agents/tests/timeline-tool-loop.test.ts
@@ -306,6 +306,68 @@ describe("TIMELINE_TOOL_LOOP_CASES", () => {
     expect(report.cases[0].score).toBe(1);
   });
 
+  it("keyframed-slide: animate_clip with custom curves instead of a preset", async () => {
+    const script: ScriptedCall[] = [
+      { name: "ui_timeline_get_state", args: {} },
+      { name: "ui_timeline_add_text_clip", args: { text: "Launch" } },
+      { name: "ui_timeline_list_animation_presets", args: {} },
+      {
+        name: "ui_timeline_animate_clip",
+        args: {
+          target: "Launch",
+          animations: [
+            {
+              role: "in",
+              preset: "custom",
+              durationMs: 800,
+              curves: [
+                {
+                  property: "offsetY",
+                  keyframes: [
+                    { t: 0, value: 120 },
+                    { t: 1, value: 0 }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ];
+    const provider = createScriptedProvider(script);
+    const report = await runToolLoopEval({
+      provider,
+      model: "test-model",
+      cases: [TIMELINE_TOOL_LOOP_CASES[3]]
+    });
+
+    expect(report.cases[0].success).toBe(true);
+    expect(report.cases[0].score).toBe(1);
+  });
+
+  it("keyframed-slide: a preset entrance does not satisfy the case", async () => {
+    // The predicate reads the stored curves, so an ordinary slide-in — the
+    // shape a model reaches for first — must fail it.
+    const provider = createScriptedProvider([
+      { name: "ui_timeline_add_text_clip", args: { text: "Launch" } },
+      {
+        name: "ui_timeline_animate_clip",
+        args: {
+          target: "Launch",
+          animations: [{ role: "in", preset: "slide", durationMs: 800 }]
+        }
+      }
+    ]);
+    const report = await runToolLoopEval({
+      provider,
+      model: "test-model",
+      cases: [TIMELINE_TOOL_LOOP_CASES[3]]
+    });
+
+    expect(report.cases[0].success).toBe(false);
+    expect(report.cases[0].criticalFailures).toBeGreaterThan(0);
+  });
+
   it("cut-and-trim: split_clip by name then delete_clip the second half", async () => {
     const script: ScriptedCall[] = [
       { name: "ui_timeline_get_state", args: {} },

--- a/packages/agents/tests/timelines-op-input.test.ts
+++ b/packages/agents/tests/timelines-op-input.test.ts
@@ -5,7 +5,13 @@
  */
 import { describe, expect, it } from "vitest";
 import type { TimelineDocument } from "@nodetool-ai/models";
-import type { TimelineBridgeFinalState } from "../src/evals/surfaces/timeline.js";
+import { ANIMATED_PROPERTIES } from "@nodetool-ai/timeline";
+import {
+  createTimelineToolBridge,
+  type TimelineAnimationBakeRequest,
+  type TimelineBridgeFinalState,
+  type TimelineBridgeInitialState
+} from "../src/evals/surfaces/timeline.js";
 import {
   resolveTimelineOpInput,
   resultUnitIds
@@ -103,5 +109,221 @@ describe("resolveTimelineOpInput", () => {
     expect(
       resolveTimelineOpInput({ id: "T9" }, before, state, { ok: true })
     ).toEqual({ id: "T9" });
+  });
+});
+
+/**
+ * `animate_clip` with `preset: "custom"` — the op an agent uses to keyframe
+ * motion the preset catalog does not cover (D2, F19). The bridge is the one
+ * implementation behind both `edit_timeline` and the browser tool (I11), so
+ * these drive it directly.
+ *
+ * Every refusal below ships its own fixture (I12): a call that triggers it.
+ */
+describe("animate_clip custom curves", () => {
+  const fadeCurve = {
+    property: "opacity",
+    keyframes: [
+      { t: 0, value: 0 },
+      { t: 1, value: 1 }
+    ]
+  };
+
+  async function bridgeWithClip(
+    over: Partial<TimelineBridgeInitialState> = {}
+  ) {
+    const bridge = createTimelineToolBridge({
+      tracks: [{ type: "video" }],
+      clips: [
+        {
+          name: "shot",
+          trackIndex: 0,
+          mediaType: "video",
+          startMs: 0,
+          durationMs: 4000
+        }
+      ],
+      ...over
+    });
+    const byName = Object.fromEntries(bridge.tools.map((t) => [t.name, t]));
+    return { bridge, byName };
+  }
+
+  const animate = (
+    byName: Record<string, { execute: (a: Record<string, unknown>) => unknown }>,
+    animation: Record<string, unknown>
+  ) =>
+    byName["ui_timeline_animate_clip"].execute({
+      target: "shot",
+      animations: [{ role: "in", preset: "custom", ...animation }]
+    });
+
+  it("stores inline curves, normalized and stamped with a bake time", async () => {
+    const { bridge, byName } = await bridgeWithClip();
+    await animate(byName, {
+      durationMs: 1000,
+      curves: [
+        {
+          property: "offsetY",
+          keyframes: [
+            { t: 0.25, value: 120 },
+            { t: 0.75, value: 0 }
+          ]
+        }
+      ]
+    });
+
+    const clip = bridge.finalState().documentClips[0];
+    const animation = clip.animations?.[0];
+    expect(animation?.preset).toBe("custom");
+    expect(animation?.durationMs).toBe(1000);
+    expect(animation?.custom?.code).toBeUndefined();
+    expect(animation?.custom?.bakedAt).toBeTruthy();
+    // Ends short of 0..1 are extended by holding, which is what the sampler
+    // assumes — the stored curve is what renders.
+    expect(animation?.custom?.curves).toEqual([
+      {
+        property: "offsetY",
+        keyframes: [
+          { t: 0, value: 120 },
+          { t: 0.25, value: 120 },
+          { t: 0.75, value: 0 },
+          { t: 1, value: 0 }
+        ]
+      }
+    ]);
+  });
+
+  it("spans the clip when the animation states no duration of its own", async () => {
+    const { bridge, byName } = await bridgeWithClip();
+    await animate(byName, { curves: [fadeCurve] });
+    expect(bridge.finalState().documentClips[0].animations?.[0].durationMs).toBe(
+      4000
+    );
+  });
+
+  it("bakes `code` through the host's baker and keeps it as provenance", async () => {
+    const seen: TimelineAnimationBakeRequest[] = [];
+    const { bridge, byName } = await bridgeWithClip({
+      bakeAnimation: async (request) => {
+        seen.push(request);
+        return { ok: true, curves: [fadeCurve] };
+      }
+    });
+
+    await animate(byName, {
+      durationMs: 500,
+      code: 'await output("curves", curves);'
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({
+      role: "in",
+      durationMs: 500,
+      clipDurationMs: 4000,
+      canvas: { width: 1920, height: 1080 }
+    });
+
+    const animation = bridge.finalState().documentClips[0].animations?.[0];
+    expect(animation?.custom?.code).toBe('await output("curves", curves);');
+    expect(animation?.custom?.curves?.[0].property).toBe("opacity");
+  });
+
+  it("reports a failed bake instead of storing an animation that renders nothing", async () => {
+    const { byName } = await bridgeWithClip({
+      bakeAnimation: async () => ({ ok: false, error: "ReferenceError: x" })
+    });
+    await expect(
+      animate(byName, { code: "x;" })
+    ).rejects.toThrow(/ReferenceError: x/);
+  });
+
+  it("refuses `code` on a surface with no baker rather than storing an unbaked body", async () => {
+    const { byName } = await bridgeWithClip();
+    await expect(animate(byName, { code: "x;" })).rejects.toThrow(
+      /cannot run `code`/
+    );
+  });
+
+  it("refuses both `curves` and `code`", async () => {
+    const { byName } = await bridgeWithClip({
+      bakeAnimation: async () => ({ ok: true, curves: [fadeCurve] })
+    });
+    await expect(
+      animate(byName, { curves: [fadeCurve], code: "x;" })
+    ).rejects.toThrow(/exactly one of `curves` and `code`/);
+  });
+
+  it("refuses neither `curves` nor `code`", async () => {
+    const { byName } = await bridgeWithClip();
+    await expect(animate(byName, {})).rejects.toThrow(
+      /needs `curves`.*or `code`/
+    );
+  });
+
+  it("refuses an unknown property, listing the ones a curve may drive", async () => {
+    const { byName } = await bridgeWithClip();
+    const call = animate(byName, {
+      curves: [
+        { property: "wobble", keyframes: [{ t: 0, value: 0 }] }
+      ]
+    });
+    await expect(call).rejects.toThrow(/"wobble"/);
+    // The message has to carry the alternatives, or the agent guesses again.
+    await expect(call).rejects.toThrow(
+      new RegExp(ANIMATED_PROPERTIES.join(", "))
+    );
+  });
+
+  it("refuses a wipeProgress curve with no mask, and takes one when given", async () => {
+    const { byName } = await bridgeWithClip();
+    const wipe = {
+      property: "wipeProgress",
+      keyframes: [
+        { t: 0, value: 0 },
+        { t: 1, value: 1 }
+      ]
+    };
+    await expect(animate(byName, { curves: [wipe] })).rejects.toThrow(
+      /`wipeProgress` curve needs a mask/
+    );
+
+    const { bridge, byName: fresh } = await bridgeWithClip();
+    await animate(fresh, {
+      curves: [wipe],
+      mask: { direction: "left", softness: 0.2 }
+    });
+    expect(
+      bridge.finalState().documentClips[0].animations?.[0].custom?.mask
+    ).toEqual({ direction: "left", softness: 0.2 });
+  });
+
+  it("still refuses a preset that is neither in the catalog nor custom", async () => {
+    const { byName } = await bridgeWithClip();
+    await expect(
+      byName["ui_timeline_animate_clip"].execute({
+        target: "shot",
+        animations: [{ role: "in", preset: "wobble" }]
+      })
+    ).rejects.toThrow(/Unknown animation preset "wobble"/);
+  });
+
+  it("lists the custom contract and every animatable property", async () => {
+    const { byName } = await bridgeWithClip();
+    const listed = (await byName["ui_timeline_list_animation_presets"].execute(
+      {}
+    )) as {
+      custom: { id: string; inputs: Record<string, string> };
+      properties: { property: string; fold: string; range: string }[];
+    };
+    expect(listed.custom.id).toBe("custom");
+    expect(Object.keys(listed.custom.inputs)).toContain("curves");
+    expect(Object.keys(listed.custom.inputs)).toContain("code");
+    expect(listed.properties.map((p) => p.property)).toEqual([
+      ...ANIMATED_PROPERTIES
+    ]);
+    expect(
+      listed.properties.find((p) => p.property === "opacity")
+    ).toMatchObject({ fold: "multiply", range: "0..1" });
   });
 });

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -1793,10 +1793,11 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "edit_timeline",
     module: "timelines",
     impl: "packages/agents/src/capabilities/timelines.ts",
-    contract: "5fbf0507f620",
+    contract: "17cd7f5d2d58",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-timelines.test.ts",
+      "packages/agents/tests/capabilities-timeline-preview.test.ts",
     ],
     evals: [
       {

--- a/packages/execution/src/timeline-debug/validate.ts
+++ b/packages/execution/src/timeline-debug/validate.ts
@@ -285,15 +285,6 @@ function checkClip(
       });
       continue;
     }
-    if (!animation.custom?.scriptId && !animation.custom?.code) {
-      issues.push({
-        severity: "warning",
-        code: "custom_animation_unsourced",
-        message: `Clip "${label}" animation "${animation.id}" carries baked curves but names neither a scriptId nor code, so nothing can re-bake it.`,
-        path: "animations[*].custom",
-        ...at
-      });
-    }
   }
 
   if (clip.sourceType === "generated" && !clip.workflowId && !clip.prompt) {

--- a/packages/execution/tests/timeline-debug.test.ts
+++ b/packages/execution/tests/timeline-debug.test.ts
@@ -377,7 +377,7 @@ describe("validateTimelineSequence — structural checks", () => {
     expect(codes(result.errors)).toContain("custom_animation_invalid");
   });
 
-  it("warns when baked curves name nothing that could re-bake them", () => {
+  it("accepts inline curves that name no script or code", () => {
     const result = validateTimelineSequence(
       doc({
         clips: [
@@ -399,7 +399,10 @@ describe("validateTimelineSequence — structural checks", () => {
         ]
       })
     );
-    expect(codes(result.warnings)).toContain("custom_animation_unsourced");
+    // Inline curves are the source (D2), not an orphaned bake: an agent that
+    // writes keyframes through edit_timeline has nothing to re-bake from, so
+    // the shape must validate clean rather than warn on every animation.
+    expect(codes(result.warnings)).not.toContain("custom_animation_unsourced");
     expect(result.ok).toBe(true);
   });
 
@@ -427,7 +430,7 @@ describe("validateTimelineSequence — structural checks", () => {
       })
     );
     expect(result.ok).toBe(true);
-    expect(codes(result.warnings)).not.toContain("custom_animation_unsourced");
+    expect(result.warnings).toEqual([]);
   });
 
   it("accepts a shipped animation preset", () => {

--- a/packages/timeline/src/animation/custom.ts
+++ b/packages/timeline/src/animation/custom.ts
@@ -23,6 +23,7 @@ import type {
 } from "./compile.js";
 import {
   ANIMATED_PROPERTIES,
+  ANIMATED_PROPERTY_FOLD,
   type AnimatedProperty,
   type AnimationRole,
   type WipeDirection
@@ -55,6 +56,181 @@ const WIPE_DIRECTIONS: readonly WipeDirection[] = [
 ];
 
 const PROPERTY_SET = new Set<string>(ANIMATED_PROPERTIES);
+
+/**
+ * What one animatable channel means to a caller writing curves by hand: the
+ * value that changes nothing, the range values are read in, and how several
+ * animations driving the channel combine.
+ *
+ * `identity` is null for a `replace` channel — those set the clip's value
+ * outright rather than composing with it, so there is nothing to leave alone.
+ */
+export interface AnimatedPropertyDoc {
+  property: AnimatedProperty;
+  fold: (typeof ANIMATED_PROPERTY_FOLD)[AnimatedProperty];
+  identity: number | null;
+  /** Unit and usable span, e.g. "0..1" or "canvas px". */
+  range: string;
+  describe: string;
+}
+
+const PROPERTY_RANGES: Record<
+  AnimatedProperty,
+  { identity: number | null; range: string; describe: string }
+> = {
+  offsetX: {
+    identity: 0,
+    range: "canvas px",
+    describe: "Horizontal offset added to the clip's position."
+  },
+  offsetY: {
+    identity: 0,
+    range: "canvas px",
+    describe: "Vertical offset added to the clip's position."
+  },
+  scale: {
+    identity: 1,
+    range: "0..n",
+    describe: "Uniform multiplier on the clip's scale."
+  },
+  scaleX: {
+    identity: 1,
+    range: "0..n",
+    describe: "Horizontal multiplier on the clip's scale."
+  },
+  scaleY: {
+    identity: 1,
+    range: "0..n",
+    describe: "Vertical multiplier on the clip's scale."
+  },
+  rotation: {
+    identity: 0,
+    range: "radians",
+    describe: "Rotation added to the clip's own rotation."
+  },
+  opacity: {
+    identity: 1,
+    range: "0..1",
+    describe: "Multiplier on the layer's opacity."
+  },
+  wipeProgress: {
+    identity: 1,
+    range: "0..1",
+    describe:
+      "0 hides the layer, 1 reveals it. Needs a mask {direction, softness}."
+  },
+  blur: {
+    identity: 0,
+    range: "source px",
+    describe: "Added to the layer's blur radius."
+  },
+  brightness: {
+    identity: 0,
+    range: "-1..1",
+    describe: "Added to the grade's brightness term."
+  },
+  saturation: {
+    identity: 1,
+    range: "0..4",
+    describe: "Multiplies the grade's saturation."
+  },
+  contrast: {
+    identity: 1,
+    range: "0..4",
+    describe: "Multiplies the grade's contrast."
+  },
+  hue: {
+    identity: 0,
+    range: "degrees",
+    describe: "Added to the grade's hue rotation."
+  },
+  temperature: {
+    identity: 0,
+    range: "-1..1",
+    describe: "Added to the grade's cool-to-warm term."
+  },
+  tint: {
+    identity: 0,
+    range: "-1..1",
+    describe: "Added to the grade's green-to-magenta term."
+  },
+  positionX: {
+    identity: null,
+    range: "canvas px",
+    describe: "Replaces the clip's horizontal position."
+  },
+  positionY: {
+    identity: null,
+    range: "canvas px",
+    describe: "Replaces the clip's vertical position."
+  },
+  anchorX: {
+    identity: null,
+    range: "0..1",
+    describe: "Replaces the clip's horizontal anchor."
+  },
+  anchorY: {
+    identity: null,
+    range: "0..1",
+    describe: "Replaces the clip's vertical anchor."
+  },
+  trimStart: {
+    identity: null,
+    range: "0..1",
+    describe: "Replaces the start of a shape's stroked sub-range."
+  },
+  trimEnd: {
+    identity: null,
+    range: "0..1",
+    describe: "Replaces the end of a shape's stroked sub-range."
+  }
+};
+
+/**
+ * Every animatable channel with its fold, identity and range — what
+ * `list_animation_presets` prints so an agent can write a curve without
+ * reading the engine. Keyed off {@link ANIMATED_PROPERTIES}, so a new channel
+ * cannot reach the document without an entry here.
+ */
+export const ANIMATED_PROPERTY_DOCS: readonly AnimatedPropertyDoc[] =
+  ANIMATED_PROPERTIES.map((property) => ({
+    property,
+    fold: ANIMATED_PROPERTY_FOLD[property],
+    ...PROPERTY_RANGES[property]
+  }));
+
+/**
+ * The `custom` preset as the preset catalog describes a preset: what an author
+ * passes instead of `params`, which roles it takes, and the channels a curve
+ * may drive. `custom` is not in `ANIMATION_PRESETS` — its motion comes from
+ * the document rather than the catalog — so the tools that list presets append
+ * this.
+ */
+export const CUSTOM_ANIMATION_CONTRACT = {
+  id: CUSTOM_ANIMATION_PRESET_ID,
+  roles: ["in", "out", "emphasis", "loop"] as readonly AnimationRole[],
+  describe:
+    "Keyframed motion written out rather than picked: pass `curves` " +
+    "directly, or `code` (a JS body) to bake into curves. Exactly one of " +
+    "the two.",
+  inputs: {
+    curves:
+      "[{property, keyframes: [{t, value, easing?}]}] — `t` runs 0..1 over " +
+      `the animation's window. At most ${MAX_CUSTOM_CURVES} curves, one per ` +
+      `property, ${MAX_CUSTOM_KEYFRAMES} keyframes each.`,
+    code:
+      "A JS body run once, host-side, returning `{curves}` or `{samples}`. " +
+      "It reads role, durationMs, clipDurationMs, canvasWidth, canvasHeight, " +
+      "params, staggerCount and sampleCount off `inputs`.",
+    mask:
+      "{direction: left|right|up|down, softness: 0..1} — required when a " +
+      "curve drives wipeProgress, ignored otherwise.",
+    durationMs:
+      "The animation's window in ms. Defaults to the clip's own duration, " +
+      "so curves span the whole clip."
+  },
+  properties: ANIMATED_PROPERTY_DOCS
+} as const;
 
 /**
  * The bag a custom-animation body reads off `inputs`. Everything the compiler

--- a/web/src/components/timeline/timelineAgentBridge.ts
+++ b/web/src/components/timeline/timelineAgentBridge.ts
@@ -261,6 +261,15 @@ interface TimelineClipFramesResult {
 export interface ClipAnimationInput {
   role: "in" | "out" | "emphasis" | "loop";
   preset: string;
+  /**
+   * Keyframes for `preset: "custom"` — the motion no preset covers. `t` runs
+   * 0..1 over the animation's window. The browser path takes curves only: a
+   * `code` body is baked host-side, and the editor has no client for that
+   * route, so it is refused here rather than silently ignored.
+   */
+  curves?: unknown;
+  code?: string;
+  mask?: unknown;
   durationMs?: number;
   delayMs?: number;
   easing?: string;

--- a/web/src/hooks/timeline/__tests__/buildClipAnimation.test.ts
+++ b/web/src/hooks/timeline/__tests__/buildClipAnimation.test.ts
@@ -67,4 +67,64 @@ describe("buildClipAnimation", () => {
     const b = buildClipAnimation({ role: "loop", preset: "float" });
     expect(a.id).not.toBe(b.id);
   });
+
+  describe("preset custom", () => {
+    const curves = [
+      { property: "opacity", keyframes: [{ t: 0, value: 0 }, { t: 1, value: 1 }] }
+    ];
+
+    it("stores the curves it was handed", () => {
+      const anim = buildClipAnimation({ role: "in", preset: "custom", curves });
+      expect(anim.preset).toBe("custom");
+      expect(anim.custom?.curves).toEqual([
+        { property: "opacity", keyframes: [{ t: 0, value: 0 }, { t: 1, value: 1 }] }
+      ]);
+      expect(anim.custom?.bakedAt).toEqual(expect.any(String));
+    });
+
+    // The tool schema accepts `code`, but baking runs host-side and the editor
+    // has no client for that route. Refusing beats storing an animation whose
+    // curves never arrive.
+    it("refuses a code body", () => {
+      expect(() =>
+        buildClipAnimation({ role: "in", preset: "custom", code: "return {curves: []};" })
+      ).toThrow(/baked host-side/);
+    });
+
+    it("refuses curves that drive nothing", () => {
+      expect(() =>
+        buildClipAnimation({ role: "in", preset: "custom", curves: [] })
+      ).toThrow(/unusable/);
+    });
+
+    it("needs curves at all", () => {
+      expect(() =>
+        buildClipAnimation({ role: "in", preset: "custom" })
+      ).toThrow(/needs `curves`/);
+    });
+
+    it("refuses a wipeProgress curve with no mask", () => {
+      expect(() =>
+        buildClipAnimation({
+          role: "in",
+          preset: "custom",
+          curves: [
+            { property: "wipeProgress", keyframes: [{ t: 0, value: 0 }, { t: 1, value: 1 }] }
+          ]
+        })
+      ).toThrow(/needs a mask/);
+    });
+
+    it("keeps the mask when one is given", () => {
+      const anim = buildClipAnimation({
+        role: "in",
+        preset: "custom",
+        curves: [
+          { property: "wipeProgress", keyframes: [{ t: 0, value: 0 }, { t: 1, value: 1 }] }
+        ],
+        mask: { direction: "left", softness: 0.2 }
+      });
+      expect(anim.custom?.mask).toEqual({ direction: "left", softness: 0.2 });
+    });
+  });
 });

--- a/web/src/hooks/timeline/buildClipAnimation.ts
+++ b/web/src/hooks/timeline/buildClipAnimation.ts
@@ -10,12 +10,18 @@
 
 import {
   ANIMATION_PRESETS,
+  CUSTOM_ANIMATION_PRESET_ID,
   getAnimationPreset,
+  normalizeCustomCurves,
+  resolveCustomMask,
   type ClipAnimation
 } from "@nodetool-ai/timeline";
 import type { ClipAnimationInput } from "../../components/timeline/timelineAgentBridge";
 
 export function buildClipAnimation(input: ClipAnimationInput): ClipAnimation {
+  if (input.preset === CUSTOM_ANIMATION_PRESET_ID) {
+    return buildCustomClipAnimation(input);
+  }
   const preset = getAnimationPreset(input.preset);
   if (!preset) {
     const valid = ANIMATION_PRESETS.map((p) => p.id).join(", ");
@@ -75,5 +81,65 @@ export function buildClipAnimation(input: ClipAnimationInput): ClipAnimation {
     if (input.stagger.from !== undefined) stagger.from = input.stagger.from;
     anim.stagger = stagger;
   }
+  return anim;
+}
+
+/**
+ * `preset: "custom"` — keyframes the caller writes out, rather than a name
+ * from the catalog. The editor bakes nothing: a `code` body is baked host-side
+ * through the agent path, and refusing it here is better than accepting the
+ * field and dropping the motion on the floor.
+ */
+function buildCustomClipAnimation(input: ClipAnimationInput): ClipAnimation {
+  if (input.code !== undefined) {
+    throw new Error(
+      'A "code" body is baked host-side; the editor cannot run one. ' +
+        "Send the keyframes as `curves`, or author the animation through " +
+        "edit_timeline."
+    );
+  }
+  if (input.curves === undefined) {
+    throw new Error(
+      'preset "custom" needs `curves`: ' +
+        "[{property, keyframes: [{t, value, easing?}]}], t running 0..1."
+    );
+  }
+  const baked = normalizeCustomCurves(input.curves);
+  if (!baked.ok) {
+    throw new Error(`Custom animation curves are unusable: ${baked.error}.`);
+  }
+  const mask = resolveCustomMask(baked.curves, input.mask);
+  if (!mask.ok) {
+    throw new Error(mask.error);
+  }
+  const durationMs = input.durationMs;
+  if (
+    durationMs !== undefined &&
+    (!Number.isFinite(durationMs) || durationMs <= 0)
+  ) {
+    throw new Error("Animation durationMs must be a positive finite number.");
+  }
+  const custom: NonNullable<ClipAnimation["custom"]> = {
+    curves: baked.curves,
+    bakedAt: new Date().toISOString()
+  };
+  if (mask.mask !== undefined) custom.mask = mask.mask;
+  const anim: ClipAnimation = {
+    id: crypto.randomUUID(),
+    role: input.role,
+    preset: CUSTOM_ANIMATION_PRESET_ID,
+    durationMs: durationMs ?? 0,
+    custom
+  };
+  if (input.delayMs !== undefined) {
+    if (!Number.isFinite(input.delayMs) || input.delayMs < 0) {
+      throw new Error("Animation delayMs must be a non-negative finite number.");
+    }
+    anim.delayMs = input.delayMs;
+  }
+  if (input.easing !== undefined) {
+    anim.easing = input.easing as ClipAnimation["easing"];
+  }
+  if (input.enabled !== undefined) anim.enabled = input.enabled;
   return anim;
 }

--- a/web/src/lib/tools/builtin/timeline.ts
+++ b/web/src/lib/tools/builtin/timeline.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
-import { ANIMATION_PRESETS } from "@nodetool-ai/timeline";
+import {
+  ANIMATED_PROPERTIES,
+  ANIMATION_PRESETS,
+  CUSTOM_ANIMATION_CONTRACT
+} from "@nodetool-ai/timeline";
 import { FrontendToolRegistry } from "../frontendTools";
 import { getTimelineAgentHandler } from "../../../components/timeline/timelineAgentBridge";
 import { docUrl } from "./resourceLinks";
@@ -36,6 +40,50 @@ const targetParam = z
   .describe(
     'Clip id, clip name (case-insensitive), or the literal "selected" for the currently-selected clip.'
   );
+
+/**
+ * The `custom` preset's inputs: keyframes written out, or a body baked into
+ * them. Values are checked by the engine's own gates
+ * (`normalizeCustomCurves`, `resolveCustomMask`), so Zod only pins the shape.
+ */
+const customCurvesParam = z
+  .array(
+    z.object({
+      property: z
+        .string()
+        .describe(`One of: ${ANIMATED_PROPERTIES.join(", ")}.`),
+      keyframes: z
+        .array(
+          z.object({
+            t: z.number().describe("0..1 across the animation's window."),
+            value: z.number(),
+            easing: z.string().optional()
+          })
+        )
+        .min(1)
+    })
+  )
+  .optional()
+  .describe(
+    'Keyframes for `preset: "custom"`. Exactly one of `curves` and `code`.'
+  );
+
+const customCodeParam = z
+  .string()
+  .optional()
+  .describe(
+    'JS body for `preset: "custom"`, baked into curves once, host-side. ' +
+      "It returns `{curves}` or `{samples}` and reads its clip context off " +
+      "`inputs`. Exactly one of `curves` and `code`."
+  );
+
+const customMaskParam = z
+  .object({
+    direction: z.enum(["left", "right", "up", "down"]),
+    softness: z.number().min(0).max(1)
+  })
+  .optional()
+  .describe("Required when a curve drives wipeProgress, ignored otherwise.");
 
 FrontendToolRegistry.register({
   name: "ui_timeline_get_state",
@@ -373,7 +421,7 @@ FrontendToolRegistry.register({
 FrontendToolRegistry.register({
   name: "ui_timeline_animate_clip",
   description:
-    'Attach motion-design animations to a clip — no keyframing, just named presets. Roles: `in` (entrance: fade, slide, pop, spin, wipe, blur, colorFade), `out` (exit: fade, slide, pop, spin, wipe, blur, colorFade), `emphasis` (mid-clip: pulse, flash, shake, bounce), `loop` (continuous: kenBurns, float, breathe, rotate). Each animation: `role`, `preset`, optional `durationMs` (defaults per preset), `delayMs`, `easing`, and preset `params`. On text clips, add `stagger` for per-word motion typography: each word runs the animation for `durationMs`, offset `stagger.offsetMs` from the previous word (`from`: start|end|center picks the leading word) — e.g. a pop-in title whose words land one after another. `mode` "replace" (default) swaps the clip\'s animations; "add" appends. Call ui_timeline_list_animation_presets for the full param list. Recommended loop: ui_timeline_get_state -> animate -> ui_timeline_get_clip_frames at the window boundaries -> adjust.',
+    'Attach motion-design animations to a clip — no keyframing, just named presets. Roles: `in` (entrance: fade, slide, pop, spin, wipe, blur, colorFade), `out` (exit: fade, slide, pop, spin, wipe, blur, colorFade), `emphasis` (mid-clip: pulse, flash, shake, bounce), `loop` (continuous: kenBurns, float, breathe, rotate). Each animation: `role`, `preset`, optional `durationMs` (defaults per preset), `delayMs`, `easing`, and preset `params`. On text clips, add `stagger` for per-word motion typography: each word runs the animation for `durationMs`, offset `stagger.offsetMs` from the previous word (`from`: start|end|center picks the leading word) — e.g. a pop-in title whose words land one after another. For motion no preset covers, use `preset: "custom"` with exactly one of `curves` (keyframes you write: [{property, keyframes:[{t, value, easing?}]}], `t` running 0..1 over the window) or `code` (a JS body baked into curves once); add `mask` when a curve drives wipeProgress. `mode` "replace" (default) swaps the clip\'s animations; "add" appends. Call ui_timeline_list_animation_presets for the full param list and the animatable properties. Recommended loop: ui_timeline_get_state -> animate -> ui_timeline_get_clip_frames at the window boundaries -> adjust.',
   parameters: z.object({
     timeline_id: timelineIdParam,
     target: targetParam,
@@ -385,7 +433,7 @@ FrontendToolRegistry.register({
           preset: z
             .string()
             .describe(
-              "Preset id, e.g. fade, slide, wipe, pop, kenBurns, float."
+              'Preset id, e.g. fade, slide, wipe, pop, kenBurns, float — or "custom" with `curves` or `code`.'
             ),
           durationMs: z.number().positive().optional(),
           delayMs: z.number().nonnegative().optional(),
@@ -393,6 +441,9 @@ FrontendToolRegistry.register({
           params: z
             .record(z.string(), z.union([z.number(), z.string(), z.boolean()]))
             .optional(),
+          curves: customCurvesParam,
+          code: customCodeParam,
+          mask: customMaskParam,
           stagger: z
             .object({
               unit: z.literal("word"),
@@ -449,7 +500,7 @@ FrontendToolRegistry.register({
 FrontendToolRegistry.register({
   name: "ui_timeline_list_animation_presets",
   description:
-    "List the motion-design animation presets: id, allowed roles, params (with defaults and ranges), default duration/easing, and a one-line description. Use this to discover the exact preset names and params for ui_timeline_animate_clip.",
+    "List the motion-design animation presets: id, allowed roles, params (with defaults and ranges), default duration/easing, and a one-line description. Also returns the `custom` preset's contract and every animatable property with its fold, identity and range, for keyframed motion no preset covers. Use this to discover the exact preset names and params for ui_timeline_animate_clip.",
   parameters: z.object({}),
   async execute() {
     const presets = ANIMATION_PRESETS.map((p) => ({
@@ -460,7 +511,12 @@ FrontendToolRegistry.register({
       params: p.params,
       describe: p.describe
     }));
-    return { ok: true, presets };
+    return {
+      ok: true,
+      presets,
+      custom: CUSTOM_ANIMATION_CONTRACT,
+      properties: CUSTOM_ANIMATION_CONTRACT.properties
+    };
   }
 });
 


### PR DESCRIPTION
## What changed

The last of Milestone 0 in [docs/plans/motion-graphics-tasks.md](https://github.com/nodetool-ai/nodetool/blob/main/docs/plans/motion-graphics-tasks.md). #5488 merged T1, T2, T3 and T5 while T4 was still being written, so this carries T4 plus the three gaps the M0 tasks left between them.

**T4 (F19, decision D2).** `bakeCustomAnimation` and `normalizeCustomCurves` were built end to end and no agent could reach either — `animate_clip` checked the preset catalog, and `custom` is not in it, so the only animations an agent could write were the dozen shipped presets. Keyframing was browser-only. `animate_clip` now takes `preset: "custom"` with exactly one of `curves` (keyframes written out) or `code` (a JS body, baked host-side), on both the browser `ui_timeline_animate_clip` schema and the headless `edit_timeline` op. Neither or both is refused; a curve driving `wipeProgress` still requires a mask, reusing `custom.ts`'s wording rather than inventing a second one; an unknown property is refused with the property list in the message. `list_animation_presets` reports the custom contract and all 21 channels with their fold and range, read off `ANIMATED_PROPERTY_FOLD` so a channel cannot be added without documenting one.

**Three gaps closed.** `preview_timeline_frame` computed `droppedLayers` and dropped them again at the capability boundary — the frame object is built field by field and `dropped` was not one of the fields, so T2's report never reached the agent. The browser tool advertised `curves`/`code` and then threw `Unknown animation preset "custom"` on the shape it had just advertised; `buildClipAnimation` now takes the custom branch, and refuses a `code` body with the reason (baking runs host-side and the editor has no client for that route, which beats storing an animation whose curves never arrive). And `custom_animation_unsourced` warned whenever baked curves named no `scriptId` or `code` — which, once agents can write keyframes directly, is every animation they author; under D2 inline curves are the source, and absent or empty curves already fail as `custom_animation_invalid`, so the warning had no case left to catch.

**Found, not fixed:** `packages/websocket/src/session/chat-prompt.ts` describes the `nodetool.timelines` namespace in prose and understates it — `preview` belongs in that sentence. `ClipAnimation.easing` is `EasingId` in the model but `z.string()` in Zod, so the wire→model mirror only holds one way; T6 (easing grammar, D3) is what widens the model side.

## Verification

- [x] `npm run test:affected --base origin/main` — exit 0 (under lavapipe, see below)
- [x] `npm run typecheck` — web and electron clean; the mobile leg cannot run here (`mobile/node_modules` absent in this container, 448 `Cannot find module` errors on an untouched tree too)
- [x] `npm run lint` — exit 0, zero errors
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — Gate: 5/5 selfchecks passed
- [x] `npm run capabilities:sync` + `capabilities:check` — 252 capabilities, table current
- [x] `npm run test --workspace=packages/agents` — 239 files, 3746 tests
- [x] `npm run test --workspace=packages/execution` — 37 files, 332 tests
- [x] `web`: `npx jest timeline` — 92 suites, 825 tests

`packages/image-nodes` fails 52 tests without a Vulkan ICD and passes 230/230 with `VK_DRIVER_FILES` pointed at lavapipe — the environment gap AGENTS.md § WebGPU on a headless machine documents, not this diff (it touches no image node).

Checks inverted to prove they can fail:

- `if (false && hasCurves && hasCode)` in `buildCustomAnimation`: `refuses both curves and code` failed with `promise resolved "{ ok: true, …(1) }" instead of rejecting`. Restored, 19/19 pass.
- `if (false && input.preset === CUSTOM_ANIMATION_PRESET_ID)` in `buildClipAnimation`: all six new browser cases failed (`6 failed, 7 passed`). Restored, 13/13 pass.

Acceptance criterion for T4, from the task: an `edit_timeline` call writing a two-keyframe `opacity` curve (0→1 over 2000 ms) to a real row, rendered through `preview_timeline_frame` at 1000 ms. **The persisted PNG's pixel reads RGB 128,128,128** — white at half opacity over black; full opacity would be 255 and a dropped curve 0.

## Agent capabilities

`edit_timeline`'s declared contract changed (the `curves`/`code`/`mask` op inputs). `capabilities:sync` moved its fingerprint `5fbf0507f620` → `17cd7f5d2d58` and added `packages/agents/tests/capabilities-timeline-preview.test.ts` to its suites. Note for anyone re-running it: the sync reads `packages/agents/dist`, so `npm run build --workspace=packages/agents` must come first or the fingerprint silently stays stale.

## New checks

- [x] Both new checks were inverted once and observed failing; the failing output is in **Verification**
- [x] The preview assertion reads a rendered pixel rather than asserting the call returned, so it cannot pass on a dropped curve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtYJyRjZTXjXwkkRCAeneA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtYJyRjZTXjXwkkRCAeneA)_