### PR TITLE
feat(timeline): motion graphics M3–M4 — text, shapes, fonts, agent surface

### DIFF
--- a/packages/agents/src/timeline-preview/frames.ts
+++ b/packages/agents/src/timeline-preview/frames.ts
@@ -334,7 +334,8 @@ export async function renderTimelineFrames(
       | { skipped: string };
 
     const sourceForLayer = async (
-      layer: ActiveLayer
+      layer: ActiveLayer,
+      anim: AnimatedLayerProps
     ): Promise<LayerSource> => {
       if (layer.kind === "caption" && layer.caption) {
         const raster = rasterizer.caption(layer.caption);
@@ -357,8 +358,12 @@ export async function renderTimelineFrames(
         if (!raster) return { skipped: "nothing to draw" };
         return { source: raster, width: raster.width, height: raster.height };
       }
-      if (layer.kind === "shape" && layer.shapeStyle) {
-        const raster = rasterizer.shape(layer.shapeStyle);
+      if (layer.kind === "shape") {
+        // The animated style carries a driven trim range; without it a trim
+        // animation would rasterize its first frame and hold.
+        const shapeStyle = anim.shapeStyle ?? layer.shapeStyle;
+        if (!shapeStyle) return { skipped: "nothing to draw" };
+        const raster = rasterizer.shape(shapeStyle);
         if (!raster) return { skipped: "nothing to draw" };
         return { source: raster, width: raster.width, height: raster.height };
       }
@@ -413,11 +418,11 @@ export async function renderTimelineFrames(
       layer: ActiveLayer,
       sampled?: AnimatedLayerProps
     ): Promise<Canvas2DLayer<PreviewSource> | string> => {
-      const resolved = await sourceForLayer(layer);
-      if ("skipped" in resolved) return resolved.skipped;
       const anim =
         sampled ??
         resolveAnimatedLayerProps(layer, timeMs, animationCanvas, animCache);
+      const resolved = await sourceForLayer(layer, anim);
+      if ("skipped" in resolved) return resolved.skipped;
       const drawn: Canvas2DLayer<PreviewSource> = {
         source: resolved.source,
         sourceWidth: resolved.width,

--- a/packages/agents/tests/timeline-shape-frames.test.ts
+++ b/packages/agents/tests/timeline-shape-frames.test.ts
@@ -1,0 +1,521 @@
+/**
+ * Shape clips on the Canvas 2D path (F8, T16): paths, polygons, stars,
+ * gradients, dashes and trim.
+ *
+ * `packages/timeline/tests/render.shapeGeometry.test.ts` pins what the geometry
+ * functions decide. This reads the pixels `@napi-rs/canvas` actually produced,
+ * because a shape that resolves to the right segments and then draws nothing —
+ * a gradient assigned to the wrong property, a dash list a context ignores — is
+ * exactly the failure a pure test cannot see.
+ *
+ * It also stands as the runtime half of I6: every member of `RasterContext2D`
+ * is asserted present on a real skia context, so a member added for the browser
+ * cannot silently be missing on the server.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createCanvas, loadImage } from "@napi-rs/canvas";
+import type {
+  ClipAnimation,
+  ClipShapeStyle,
+  TimelineClip,
+  TimelineSequence,
+  TimelineTrack
+} from "@nodetool-ai/timeline";
+import {
+  drawShape,
+  resolveShapeFill,
+  type RasterContext2D
+} from "@nodetool-ai/timeline/scene";
+
+import { renderTimelineFrames } from "../src/timeline-preview/frames.js";
+
+const W = 240;
+const H = 240;
+
+/** Draw one style on a fresh surface and hand back its pixels. */
+function raster(style: ClipShapeStyle, width = W, height = H) {
+  const canvas = createCanvas(width, height);
+  // SAFETY: `RasterContext2D` is the subset of the 2D canvas API `drawShape`
+  // uses; the presence test below asserts a skia context provides all of it.
+  const ctx = canvas.getContext("2d") as unknown as RasterContext2D;
+  drawShape(ctx, style, width, height);
+  const data = canvas.getContext("2d").getImageData(0, 0, width, height).data;
+  return {
+    /** RGBA at a pixel. */
+    at(x: number, y: number): [number, number, number, number] {
+      const i = (Math.round(y) * width + Math.round(x)) * 4;
+      return [data[i]!, data[i + 1]!, data[i + 2]!, data[i + 3]!];
+    },
+    /** True where anything was drawn. */
+    on(x: number, y: number): boolean {
+      return this.at(x, y)[3] > 24;
+    }
+  };
+}
+
+describe("drawShape — polygons and stars", () => {
+  it("puts a star's points where a sample around a circle finds them", () => {
+    // A five-pointed star filling the surface. Sampling a circle just inside
+    // the outer radius crosses the shape once per point and nowhere else, so
+    // the run count is the point count.
+    const pixels = raster({
+      kind: "star",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+      sides: 5,
+      innerRadius: 0.45,
+      fill: "#ffffff"
+    });
+    expect(countRuns(pixels, 0.9)).toBe(5);
+  });
+
+  it("counts a seven-sided polygon's sides the same way", () => {
+    // A convex polygon's own vertices are the only places its outline reaches
+    // the circumscribed circle, so the same sample counts sides.
+    const pixels = raster({
+      kind: "polygon",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+      sides: 7,
+      fill: "#ffffff"
+    });
+    expect(countRuns(pixels, 0.985)).toBe(7);
+  });
+
+  it("cuts a rect's corners off when a corner radius is set", () => {
+    const square = { kind: "rect", x: 0, y: 0, width: 1, height: 1 } as const;
+    expect(raster({ ...square, fill: "#ffffff" }).on(1, 1)).toBe(true);
+    expect(
+      raster({ ...square, fill: "#ffffff", cornerRadius: 0.25 }).on(1, 1)
+    ).toBe(false);
+  });
+});
+
+describe("drawShape — paths", () => {
+  it("fills authored path data in the clip's normalized space", () => {
+    // The lower-left triangle of the surface.
+    const pixels = raster({
+      kind: "path",
+      d: "M 0 0 L 0 1 L 1 1 Z",
+      fill: "#ffffff"
+    });
+    expect(pixels.on(W * 0.2, H * 0.8)).toBe(true);
+    expect(pixels.on(W * 0.8, H * 0.2)).toBe(false);
+  });
+
+  it("draws nothing at all when the path data does not parse", () => {
+    const pixels = raster({ kind: "path", d: "A 4 4 0", fill: "#ffffff" });
+    expect(pixels.on(W / 2, H / 2)).toBe(false);
+  });
+});
+
+describe("drawShape — gradients", () => {
+  it("runs a linear fill from its first stop to its last across the box", () => {
+    const pixels = raster({
+      kind: "rect",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+      fillStyle: {
+        type: "linear",
+        angle: 0,
+        stops: [
+          { offset: 0, color: "#ff0000" },
+          { offset: 1, color: "#0000ff" }
+        ]
+      }
+    });
+    const [lr, , lb] = pixels.at(2, H / 2);
+    const [rr, , rb] = pixels.at(W - 3, H / 2);
+    expect(lr).toBeGreaterThan(240);
+    expect(lb).toBeLessThan(16);
+    expect(rb).toBeGreaterThan(240);
+    expect(rr).toBeLessThan(16);
+  });
+
+  it("turns the axis with the angle", () => {
+    const vertical = raster({
+      kind: "rect",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+      fillStyle: {
+        type: "linear",
+        angle: 90,
+        stops: [
+          { offset: 0, color: "#ff0000" },
+          { offset: 1, color: "#0000ff" }
+        ]
+      }
+    });
+    expect(vertical.at(W / 2, 2)[0]).toBeGreaterThan(240);
+    expect(vertical.at(W / 2, H - 3)[2]).toBeGreaterThan(240);
+  });
+
+  it("runs a radial fill from the centre out to the corners", () => {
+    const pixels = raster({
+      kind: "rect",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+      fillStyle: {
+        type: "radial",
+        stops: [
+          { offset: 0, color: "#ffffff" },
+          { offset: 1, color: "#000000" }
+        ]
+      }
+    });
+    expect(pixels.at(W / 2, H / 2)[0]).toBeGreaterThan(240);
+    expect(pixels.at(1, 1)[0]).toBeLessThan(24);
+  });
+
+  it("beats the plain colour when both are set", () => {
+    const pixels = raster({
+      kind: "rect",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+      fill: "#00ff00",
+      fillStyle: { type: "solid", color: "#ff0000" }
+    });
+    expect(pixels.at(W / 2, H / 2)).toEqual([255, 0, 0, 255]);
+  });
+
+  it("places a gradient against the box it is handed, not the surface", () => {
+    // The seam T14 uses for gradient text: the box is the text block, not the
+    // raster, so the same fill spans whatever it is measured against.
+    const canvas = createCanvas(W, H);
+    const ctx = canvas.getContext("2d") as unknown as RasterContext2D;
+    const paint = resolveShapeFill(
+      ctx,
+      {
+        type: "linear",
+        angle: 0,
+        stops: [
+          { offset: 0, color: "#ff0000" },
+          { offset: 1, color: "#0000ff" }
+        ]
+      },
+      { x: 100, y: 0, width: 40, height: 10 }
+    );
+    ctx.fillStyle = paint;
+    ctx.fillRect(0, 0, W, H);
+    const pixels = canvas.getContext("2d").getImageData(0, 0, W, H).data;
+    const red = (x: number): number => pixels[(120 * W + x) * 4]!;
+    // Outside the box the gradient clamps to its end stops, so the transition
+    // happens across the box and nowhere else.
+    expect(red(90)).toBeGreaterThan(240);
+    expect(red(150)).toBeLessThan(16);
+  });
+});
+
+describe("drawShape — dashes, caps and trim", () => {
+  const line = (over: Partial<ClipShapeStyle> = {}): ClipShapeStyle => ({
+    kind: "line",
+    x: 0,
+    y: 0.5,
+    x2: 1,
+    y2: 0.5,
+    stroke: "#ffffff",
+    strokeWidthPx: 6,
+    ...over
+  });
+
+  it("leaves a gap between dashes", () => {
+    // 0.1 of the width on, 0.1 off: 24px each on a 240px surface.
+    const pixels = raster(line({ dash: [0.1, 0.1] }));
+    expect(pixels.on(12, H / 2)).toBe(true);
+    expect(pixels.on(36, H / 2)).toBe(false);
+    expect(pixels.on(60, H / 2)).toBe(true);
+    expect(pixels.on(84, H / 2)).toBe(false);
+  });
+
+  it("draws one unbroken run without a dash pattern", () => {
+    const pixels = raster(line());
+    expect(pixels.on(36, H / 2)).toBe(true);
+    expect(pixels.on(84, H / 2)).toBe(true);
+  });
+
+  it("strokes half the path's length at trimEnd 0.5", () => {
+    const pixels = raster(line({ trimEnd: 0.5 }));
+    // Measured as arc length: the lit run ends at half the line's length, and
+    // a bounding-box reading could not tell that from a half-height stroke.
+    expect(litRunLength(pixels, H / 2)).toBeCloseTo(W / 2, -1);
+    expect(pixels.on(W * 0.45, H / 2)).toBe(true);
+    expect(pixels.on(W * 0.55, H / 2)).toBe(false);
+  });
+
+  it("strokes the middle when both trim ends move in", () => {
+    const pixels = raster(line({ trimStart: 0.25, trimEnd: 0.75 }));
+    expect(pixels.on(W * 0.15, H / 2)).toBe(false);
+    expect(pixels.on(W * 0.5, H / 2)).toBe(true);
+    expect(pixels.on(W * 0.85, H / 2)).toBe(false);
+    expect(litRunLength(pixels, H / 2)).toBeCloseTo(W / 2, -1);
+  });
+
+  it("trims a curve by its arc length, not by its box", () => {
+    // A quarter circle of radius W centred on the surface's bottom-right
+    // corner, drawn from due west round to due north.
+    const arc = (fraction: number): [number, number] => {
+      const angle = Math.PI * (1 + fraction / 2);
+      return [W + W * Math.cos(angle), H + H * Math.sin(angle)];
+    };
+    const curve: ClipShapeStyle = {
+      kind: "path",
+      d: "M 0 1 C 0 0.4477 0.4477 0 1 0",
+      stroke: "#ffffff",
+      strokeWidthPx: 6
+    };
+    const half = raster({ ...curve, trimEnd: 0.5 });
+    expect(half.on(...arc(0.4))).toBe(true);
+    expect(half.on(...arc(0.6))).toBe(false);
+    // Two thirds along the arc sits at 60% of the box's width, so a
+    // box-based trim would have kept it. The whole path proves the probe
+    // itself lands on the curve.
+    expect(raster(curve).on(...arc(0.6))).toBe(true);
+  });
+
+  it("leaves the fill whole while the stroke is trimmed", () => {
+    const pixels = raster({
+      kind: "rect",
+      x: 0.1,
+      y: 0.1,
+      width: 0.8,
+      height: 0.8,
+      fill: "#ffffff",
+      stroke: "#ff0000",
+      strokeWidthPx: 6,
+      trimEnd: 0.1
+    });
+    expect(pixels.on(W / 2, H / 2)).toBe(true);
+  });
+
+  it("rounds a stroke's ends when lineCap says to", () => {
+    // A round cap extends the stroke by half its width past the end point; a
+    // butt cap stops on it.
+    const end = Math.round(W * 0.5) + 2;
+    expect(
+      raster(line({ trimEnd: 0.5, lineCap: "round" })).on(end, H / 2)
+    ).toBe(true);
+    expect(raster(line({ trimEnd: 0.5, lineCap: "butt" })).on(end, H / 2)).toBe(
+      false
+    );
+  });
+
+  it("draws no stroke at all when the trim range is empty", () => {
+    const pixels = raster(line({ trimStart: 0.5, trimEnd: 0.5 }));
+    expect(pixels.on(W / 2, H / 2)).toBe(false);
+  });
+});
+
+describe("RasterContext2D on @napi-rs/canvas (I6)", () => {
+  it("provides every member the drawing rules call", () => {
+    const ctx = createCanvas(4, 4).getContext("2d") as unknown as Record<
+      string,
+      unknown
+    >;
+    const methods = [
+      "save",
+      "restore",
+      "translate",
+      "scale",
+      "rotate",
+      "beginPath",
+      "closePath",
+      "moveTo",
+      "lineTo",
+      "bezierCurveTo",
+      "quadraticCurveTo",
+      "rect",
+      "ellipse",
+      "fill",
+      "stroke",
+      "clip",
+      "clearRect",
+      "fillRect",
+      "setLineDash",
+      "measureText",
+      "fillText",
+      "strokeText",
+      "createLinearGradient",
+      "createRadialGradient"
+    ];
+    for (const name of methods) {
+      expect(typeof ctx[name], name).toBe("function");
+    }
+    for (const name of [
+      "font",
+      "fillStyle",
+      "strokeStyle",
+      "filter",
+      "globalCompositeOperation",
+      "globalAlpha",
+      "lineWidth",
+      "lineJoin",
+      "lineCap",
+      "textAlign",
+      "textBaseline"
+    ]) {
+      expect(ctx[name], name).toBeDefined();
+    }
+  });
+});
+
+describe("an animated trim on a shape clip", () => {
+  const tracks: TimelineTrack[] = [
+    {
+      id: "track-0",
+      name: "V1",
+      type: "video",
+      index: 0,
+      visible: true,
+      locked: false
+    }
+  ];
+
+  /** `trimEnd` sweeping 0 → 1 across the clip. */
+  const sweep: ClipAnimation = {
+    id: "draw-on",
+    role: "in",
+    preset: "custom",
+    durationMs: 1000,
+    custom: {
+      curves: [
+        {
+          property: "trimEnd",
+          keyframes: [
+            { t: 0, value: 0 },
+            { t: 1, value: 1 }
+          ]
+        }
+      ]
+    }
+  };
+
+  const clip = (animations?: ClipAnimation[]): TimelineClip => ({
+    id: "stroke",
+    trackId: "track-0",
+    name: "Stroke",
+    startMs: 0,
+    durationMs: 1000,
+    mediaType: "shape",
+    sourceType: "generated",
+    status: "generated",
+    shapeStyle: {
+      kind: "line",
+      x: 0,
+      y: 0.5,
+      x2: 1,
+      y2: 0.5,
+      stroke: "#ffffff",
+      strokeWidthPx: 8
+    },
+    animations
+  });
+
+  async function framesAt(
+    timesMs: number[],
+    animations?: ClipAnimation[]
+  ): Promise<((x: number, y: number) => boolean)[]> {
+    const sequence: TimelineSequence = {
+      id: "seq-1",
+      projectId: "proj-1",
+      name: "Trim sequence",
+      fps: 30,
+      width: 320,
+      height: 180,
+      durationMs: 1000,
+      tracks,
+      clips: [clip(animations)],
+      markers: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+    const { frames } = await renderTimelineFrames({
+      sequence,
+      timesMs,
+      width: 320,
+      loadAsset: async () => null
+    });
+    return Promise.all(frames.map((frame) => litProbe(frame.png)));
+  }
+
+  it("draws a different length at two timecodes", async () => {
+    const [early, late] = await framesAt([100, 900], [sweep]);
+    // A tenth of the way in, the stroke has not reached the middle; nine
+    // tenths in, it has passed it. Without the animated style reaching the
+    // rasterizer both frames would be the clip's static (whole) outline.
+    expect(early!(160, 90)).toBe(false);
+    expect(late!(160, 90)).toBe(true);
+  });
+
+  it("holds the whole outline when nothing drives the trim", async () => {
+    const [early, late] = await framesAt([100, 900]);
+    expect(early!(160, 90)).toBe(true);
+    expect(late!(160, 90)).toBe(true);
+  });
+});
+
+/**
+ * How many separate lit runs a circle of `radius` (as a fraction of the
+ * inscribed radius) crosses — the point count of a star, the side count of a
+ * polygon.
+ */
+function countRuns(
+  pixels: { on(x: number, y: number): boolean },
+  radius: number
+): number {
+  const samples = 720;
+  const rx = (W / 2) * radius;
+  const ry = (H / 2) * radius;
+  const lit: boolean[] = [];
+  for (let i = 0; i < samples; i++) {
+    const angle = (i * 2 * Math.PI) / samples;
+    lit.push(
+      pixels.on(W / 2 + rx * Math.cos(angle), H / 2 + ry * Math.sin(angle))
+    );
+  }
+  let runs = 0;
+  for (let i = 0; i < samples; i++) {
+    if (lit[i] && !lit[(i - 1 + samples) % samples]) runs++;
+  }
+  return runs;
+}
+
+/** The total lit width along one row, in pixels. */
+function litRunLength(
+  pixels: { on(x: number, y: number): boolean },
+  y: number
+): number {
+  let count = 0;
+  for (let x = 0; x < W; x++) {
+    if (pixels.on(x, y)) count++;
+  }
+  return count;
+}
+
+/** A lit-pixel probe over a rendered PNG frame. */
+async function litProbe(
+  png: Uint8Array
+): Promise<(x: number, y: number) => boolean> {
+  const image = await loadImage(Buffer.from(png));
+  const canvas = createCanvas(image.width, image.height);
+  const ctx = canvas.getContext("2d");
+  ctx.drawImage(image, 0, 0);
+  const data = ctx.getImageData(0, 0, image.width, image.height).data;
+  return (x, y) => {
+    const i = (Math.round(y) * image.width + Math.round(x)) * 4;
+    // The frame is composited on black, so a lit pixel is a bright one.
+    return data[i]! > 128;
+  };
+}

--- a/packages/timeline/AGENTS.md
+++ b/packages/timeline/AGENTS.md
@@ -76,3 +76,11 @@
 - **Draw code takes a `RasterContext2D`, not a concrete canvas.** The browser
   passes an `OffscreenCanvas` context and the server `@napi-rs/canvas`; a type
   that only one of them satisfies breaks the other silently at build time.
+- **Every shape resolves to one `PathSegment[]`** (`render/shapeGeometry.ts`),
+  in surface pixels, arcs included as cubics. Trim, dashes and gradients then
+  apply to a rect, an ellipse, a star and an authored `d` the same way — and a
+  trimmed ellipse has an arc length to walk, which `ctx.ellipse` would not.
+- **A rasterized layer's pixels can depend on its animation sample.** A shape's
+  `trimStart`/`trimEnd` change the outline, so every host rasterizes
+  `AnimatedLayerProps.shapeStyle`, not the clip's own; a host that reaches for
+  `layer.shapeStyle` renders a trim animation as a held first frame.

--- a/packages/timeline/src/render/draw.ts
+++ b/packages/timeline/src/render/draw.ts
@@ -8,7 +8,12 @@
  * host's bitmap type stay with the caller — everything here just draws.
  */
 
-import type { ClipMask, ClipShapeStyle, ClipTextStyle } from "../types.js";
+import type {
+  ClipMask,
+  ClipShapeStyle,
+  ClipTextStyle,
+  ShapeFill
+} from "../types.js";
 import type {
   AnimationSample,
   CompiledAnimation,
@@ -19,7 +24,14 @@ import {
   sampleStaggeredAnimations
 } from "../animation/index.js";
 import type { MeasureTextWidth } from "./textLayout.js";
-import { parseSvgPath, tracePath } from "./svgPath.js";
+import { parseSvgPath, tracePath, type PathSegment } from "./svgPath.js";
+import {
+  buildShapeSegments,
+  flattenSegments,
+  shapeBox,
+  shapeUnitScale,
+  trimFlatPath
+} from "./shapeGeometry.js";
 import {
   layoutStaggerUnits,
   textFontSpec,
@@ -40,6 +52,28 @@ export interface CanvasGradient2D {
 }
 
 /**
+ * The gradient factories a fill resolves through. Its own interface, and the
+ * narrowest one in this file, so {@link resolveShapeFill} can be handed a mask
+ * surface, a raster surface or a compositing scratch surface alike.
+ */
+export interface GradientContext2D {
+  createLinearGradient(
+    x0: number,
+    y0: number,
+    x1: number,
+    y1: number
+  ): CanvasGradient2D;
+  createRadialGradient(
+    x0: number,
+    y0: number,
+    r0: number,
+    x1: number,
+    y1: number,
+    r1: number
+  ): CanvasGradient2D;
+}
+
+/**
  * The Canvas 2D surface a mask rasterizes through: paths, gradients, composite
  * ops and a filter.
  *
@@ -50,7 +84,7 @@ export interface CanvasGradient2D {
  * (I6). Every member is satisfied by `OffscreenCanvasRenderingContext2D`, a DOM
  * canvas context and `@napi-rs/canvas`.
  */
-export interface MaskContext2D {
+export interface MaskContext2D extends GradientContext2D {
   fillStyle: CanvasPaint;
   filter: string;
   globalCompositeOperation: string;
@@ -85,20 +119,6 @@ export interface MaskContext2D {
   clip(fillRule?: string): void;
   clearRect(x: number, y: number, w: number, h: number): void;
   fillRect(x: number, y: number, w: number, h: number): void;
-  createLinearGradient(
-    x0: number,
-    y0: number,
-    x1: number,
-    y1: number
-  ): CanvasGradient2D;
-  createRadialGradient(
-    x0: number,
-    y0: number,
-    r0: number,
-    x1: number,
-    y1: number,
-    r1: number
-  ): CanvasGradient2D;
 }
 
 /** The Canvas 2D surface the rasterizers draw through. */
@@ -107,6 +127,8 @@ export interface RasterContext2D extends MaskContext2D {
   strokeStyle: CanvasPaint;
   lineWidth: number;
   lineJoin: string;
+  lineCap: string;
+  setLineDash(pattern: number[]): void;
   textAlign: string;
   textBaseline: string;
   globalAlpha: number;
@@ -423,6 +445,69 @@ export function createStaggerScratch(): AnimationSample {
   return createAnimationSample();
 }
 
+// ── Fills ───────────────────────────────────────────────────────────────────
+
+/** The box a gradient fill is measured against, in surface pixels. */
+export interface FillBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * A {@link ShapeFill} as something assignable to `fillStyle`: the colour itself
+ * for a solid, a canvas gradient placed against `box` for the other two.
+ *
+ * Stops are normalized 0..1 offsets, so the same fill reads the same on a
+ * title, a rounded rect and a traced path — which is why text takes this too
+ * rather than growing a gradient of its own.
+ *
+ * A linear fill's `angle` is degrees clockwise from left→right, and its axis is
+ * scaled so the gradient spans the box's projection onto that angle exactly: at
+ * 0° it runs the full width, at 90° the full height, and in between it still
+ * reaches both ends. A radial fill runs from the box's centre to its corners,
+ * matching CSS `radial-gradient`'s farthest-corner default.
+ */
+export function resolveShapeFill(
+  ctx: GradientContext2D,
+  fill: ShapeFill,
+  box: FillBox
+): CanvasPaint {
+  if (fill.type === "solid") return fill.color;
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+  if (fill.type === "linear") {
+    const radians = (fill.angle * Math.PI) / 180;
+    const half =
+      (Math.abs(Math.cos(radians)) * box.width +
+        Math.abs(Math.sin(radians)) * box.height) /
+      2;
+    const dx = Math.cos(radians) * half;
+    const dy = Math.sin(radians) * half;
+    return withStops(
+      ctx.createLinearGradient(cx - dx, cy - dy, cx + dx, cy + dy),
+      fill.stops
+    );
+  }
+  const radius = Math.hypot(box.width, box.height) / 2;
+  return withStops(
+    ctx.createRadialGradient(cx, cy, 0, cx, cy, radius),
+    fill.stops
+  );
+}
+
+/** Apply stops in authored order, clamped — a canvas throws outside 0..1. */
+function withStops(
+  gradient: CanvasGradient2D,
+  stops: readonly { offset: number; color: string }[]
+): CanvasGradient2D {
+  for (const stop of stops) {
+    gradient.addColorStop(Math.max(0, Math.min(1, stop.offset)), stop.color);
+  }
+  return gradient;
+}
+
 // ── Shapes ───────────────────────────────────────────────────────────────────
 
 /** Content signature of a shape raster, for host-side caching. */
@@ -434,42 +519,86 @@ export function shapeStyleSignature(
   return `${width}x${height}|${JSON.stringify(style)}`;
 }
 
-function number(value: number | undefined, fallback: number): number {
-  return value ?? fallback;
+/** The segments are already in surface pixels, so tracing them is a replay. */
+const UNSCALED = { scaleX: 1, scaleY: 1 };
+
+/** The whole outline, when neither trim channel is driven away from its end. */
+function trimIsWhole(style: ClipShapeStyle): boolean {
+  return (style.trimStart ?? 0) <= 0 && (style.trimEnd ?? 1) >= 1;
 }
 
+/** The dash pattern in surface pixels, or an empty list for a solid stroke. */
+function dashPattern(style: ClipShapeStyle, width: number): number[] {
+  const scale = shapeUnitScale(width);
+  const pattern = (style.dash ?? [])
+    .filter((n) => Number.isFinite(n) && n >= 0)
+    .map((n) => n * scale);
+  return pattern.some((n) => n > 0) ? pattern : [];
+}
+
+/**
+ * Draw a shape clip's geometry: fill, then stroke.
+ *
+ * The fill always covers the whole outline. `trimStart`/`trimEnd` cut the
+ * **stroke** to a sub-range of the outline's arc length — the channel exists so
+ * a line can draw itself on, and a partly-filled shape is not that.
+ */
 export function drawShape(
   ctx: RasterContext2D,
   style: ClipShapeStyle,
   width: number,
   height: number
 ): void {
-  const x = number(style.x, 0.25) * width;
-  const y = number(style.y, 0.25) * height;
-  const shapeWidth = number(style.width, 0.5) * width;
-  const shapeHeight = number(style.height, 0.5) * height;
-  ctx.fillStyle = style.fill ?? "transparent";
-  ctx.strokeStyle = style.stroke ?? "transparent";
-  ctx.lineWidth = number(style.strokeWidthPx, 0);
-  ctx.beginPath();
-  if (style.kind === "rect") ctx.rect(x, y, shapeWidth, shapeHeight);
-  if (style.kind === "ellipse") {
-    ctx.ellipse(
-      x + shapeWidth / 2,
-      y + shapeHeight / 2,
-      shapeWidth / 2,
-      shapeHeight / 2,
-      0,
-      0,
-      Math.PI * 2
-    );
+  const segments = buildShapeSegments(style, width, height);
+  if (!segments || segments.length === 0) return;
+  const box = shapeBox(style, width, height);
+  const lineWidth = style.strokeWidthPx ?? 0;
+
+  ctx.save();
+  if (style.fill || style.fillStyle) {
+    ctx.fillStyle = style.fillStyle
+      ? resolveShapeFill(ctx, style.fillStyle, box)
+      : (style.fill ?? "transparent");
+    ctx.beginPath();
+    tracePath(ctx, segments, UNSCALED);
+    ctx.fill();
   }
-  if (style.kind === "line") {
-    ctx.moveTo(x, y);
-    ctx.lineTo(number(style.x2, 0.75) * width, number(style.y2, 0.75) * height);
+  if (style.stroke && lineWidth > 0) {
+    ctx.strokeStyle = style.stroke;
+    ctx.lineWidth = lineWidth;
+    ctx.lineJoin = style.lineJoin ?? "miter";
+    ctx.lineCap = style.lineCap ?? "butt";
+    ctx.setLineDash(dashPattern(style, width));
+    ctx.beginPath();
+    if (trimIsWhole(style)) {
+      tracePath(ctx, segments, UNSCALED);
+    } else {
+      traceTrimmed(ctx, segments, style);
+    }
+    ctx.stroke();
   }
-  if (style.fill) ctx.fill();
-  if (style.stroke && ctx.lineWidth > 0) ctx.stroke();
+  ctx.restore();
+}
+
+
+/** Issue only the trimmed sub-range of the outline, as open polylines. */
+function traceTrimmed(
+  ctx: RasterContext2D,
+  segments: readonly PathSegment[],
+  style: ClipShapeStyle
+): void {
+  const runs = trimFlatPath(
+    flattenSegments(segments),
+    style.trimStart ?? 0,
+    style.trimEnd ?? 1
+  );
+  for (const run of runs) {
+    if (run.length < 2) continue;
+    ctx.moveTo(run[0]!.x, run[0]!.y);
+    for (let i = 1; i < run.length; i++) {
+      ctx.lineTo(run[i]!.x, run[i]!.y);
+    }
+  }
 }
 
 // ── Masks ────────────────────────────────────────────────────────────────────

--- a/packages/timeline/src/render/index.ts
+++ b/packages/timeline/src/render/index.ts
@@ -14,6 +14,7 @@ export * from "./transform.js";
 export * from "./transition.js";
 export * from "./draw.js";
 export * from "./svgPath.js";
+export * from "./shapeGeometry.js";
 export * from "./textLayout.js";
 export * from "./canvas2d.js";
 export * from "./effects.js";

--- a/packages/timeline/src/render/shapeGeometry.ts
+++ b/packages/timeline/src/render/shapeGeometry.ts
@@ -1,0 +1,554 @@
+/**
+ * shapeGeometry — a shape clip's outline as absolute path segments, and the
+ * arc-length walk that trims it.
+ *
+ * Every geometry a shape clip can draw — rect, ellipse, line, polygon, star and
+ * an authored SVG `d` — resolves to one {@link PathSegment}[] in the surface's
+ * own pixels. One representation is what lets trim, dashes and gradients apply
+ * to all six the same way: the alternative is `ctx.rect` here and `ctx.ellipse`
+ * there, and then a trimmed ellipse has no length to walk.
+ *
+ * Circular arcs (a rounded corner, an ellipse) are emitted as cubics rather
+ * than as `ctx.arc` calls for the same reason, plus one more: a shape's box is
+ * normalized against a non-square canvas, so its "circle" is an ellipse, and
+ * `arc` cannot draw one.
+ */
+
+import type { ClipShapeStyle } from "../types.js";
+import { parseSvgPath, type PathSegment } from "./svgPath.js";
+
+/** The shape's bounds in surface pixels. */
+export interface ShapeBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** A point on a flattened outline, in surface pixels. */
+export interface FlatPoint {
+  x: number;
+  y: number;
+}
+
+/** One flattened subpath: consecutive points, plus whether it closes. */
+export interface FlatSubpath {
+  points: FlatPoint[];
+  closed: boolean;
+}
+
+/**
+ * The cubic control-point offset that approximates a quarter circle, as a
+ * fraction of the radius: `(4/3)·tan(π/8)`. Four of them draw a circle to
+ * within 0.02% of its radius, which no rasterizer resolves.
+ */
+const QUARTER_ARC_K = 0.5522847498307936;
+
+/** Default vertex count for `polygon` and `star` when none is authored. */
+const DEFAULT_SIDES = 5;
+
+/** Default inner radius of a star, as a fraction of the outer one. */
+const DEFAULT_INNER_RADIUS = 0.5;
+
+/**
+ * Target chord length, in pixels, when flattening a curve. Small enough that
+ * the polyline's length is within a fraction of a percent of the curve's — trim
+ * is measured off it — and bounded below so a hairline curve is not subdivided
+ * into hundreds of segments.
+ */
+const FLATTEN_CHORD_PX = 3;
+const FLATTEN_MIN_STEPS = 8;
+const FLATTEN_MAX_STEPS = 96;
+
+function number(value: number | undefined, fallback: number): number {
+  return value ?? fallback;
+}
+
+/** The shape's bounds in surface pixels, with today's defaults. */
+export function shapeBox(
+  style: ClipShapeStyle,
+  width: number,
+  height: number
+): ShapeBox {
+  return {
+    x: number(style.x, 0.25) * width,
+    y: number(style.y, 0.25) * height,
+    width: number(style.width, 0.5) * width,
+    height: number(style.height, 0.5) * height
+  };
+}
+
+/**
+ * Scalar lengths a shape authors in normalized units — `cornerRadius`, a dash
+ * pattern — measured against the surface's width.
+ *
+ * They are lengths along an outline, so they have no axis of their own to
+ * normalize against, and the two axes disagree on any non-square canvas. Width
+ * is the reference because a shape's own box is authored against the frame and
+ * the frame's width is the dimension that stays put when only the aspect
+ * changes.
+ */
+export function shapeUnitScale(width: number): number {
+  return width;
+}
+
+/**
+ * The shape's outline as absolute segments in surface pixels, or null when it
+ * names a kind this build does not draw or path data that does not parse. A
+ * caller draws nothing in that case; the validator reports the shape.
+ */
+export function buildShapeSegments(
+  style: ClipShapeStyle,
+  width: number,
+  height: number
+): PathSegment[] | null {
+  const box = shapeBox(style, width, height);
+  const radius = Math.max(0, number(style.cornerRadius, 0)) *
+    shapeUnitScale(width);
+
+  if (style.kind === "rect") {
+    return polygonSegments(
+      [
+        { x: box.x, y: box.y },
+        { x: box.x + box.width, y: box.y },
+        { x: box.x + box.width, y: box.y + box.height },
+        { x: box.x, y: box.y + box.height }
+      ],
+      radius
+    );
+  }
+  if (style.kind === "ellipse") {
+    return ellipseSegments(box);
+  }
+  if (style.kind === "line") {
+    return [
+      { kind: "move", x: box.x, y: box.y },
+      {
+        kind: "line",
+        x: number(style.x2, 0.75) * width,
+        y: number(style.y2, 0.75) * height
+      }
+    ];
+  }
+  if (style.kind === "polygon" || style.kind === "star") {
+    const sides = Math.max(3, Math.round(number(style.sides, DEFAULT_SIDES)));
+    const points =
+      style.kind === "polygon"
+        ? regularPoints(box, sides)
+        : starPoints(
+            box,
+            sides,
+            Math.max(0, number(style.innerRadius, DEFAULT_INNER_RADIUS))
+          );
+    return polygonSegments(points, radius);
+  }
+  if (style.kind === "path") {
+    const parsed = parseSvgPath(style.d ?? "");
+    if (!parsed.ok) return null;
+    // Path data is authored in the clip's normalized 0..1 space, the same space
+    // the box coordinates live in.
+    return parsed.segments.map((segment) => scaleSegment(segment, width, height));
+  }
+  return null;
+}
+
+function scaleSegment(
+  segment: PathSegment,
+  width: number,
+  height: number
+): PathSegment {
+  switch (segment.kind) {
+    case "move":
+    case "line":
+      return { kind: segment.kind, x: segment.x * width, y: segment.y * height };
+    case "cubic":
+      return {
+        kind: "cubic",
+        x1: segment.x1 * width,
+        y1: segment.y1 * height,
+        x2: segment.x2 * width,
+        y2: segment.y2 * height,
+        x: segment.x * width,
+        y: segment.y * height
+      };
+    case "quad":
+      return {
+        kind: "quad",
+        x1: segment.x1 * width,
+        y1: segment.y1 * height,
+        x: segment.x * width,
+        y: segment.y * height
+      };
+    case "close":
+      return segment;
+  }
+}
+
+/** An ellipse inscribed in `box`, as four cubics from its rightmost point. */
+function ellipseSegments(box: ShapeBox): PathSegment[] {
+  const rx = box.width / 2;
+  const ry = box.height / 2;
+  const cx = box.x + rx;
+  const cy = box.y + ry;
+  const kx = rx * QUARTER_ARC_K;
+  const ky = ry * QUARTER_ARC_K;
+  const quadrant = (
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    x: number,
+    y: number
+  ): PathSegment => ({ kind: "cubic", x1, y1, x2, y2, x, y });
+  return [
+    { kind: "move", x: cx + rx, y: cy },
+    quadrant(cx + rx, cy + ky, cx + kx, cy + ry, cx, cy + ry),
+    quadrant(cx - kx, cy + ry, cx - rx, cy + ky, cx - rx, cy),
+    quadrant(cx - rx, cy - ky, cx - kx, cy - ry, cx, cy - ry),
+    quadrant(cx + kx, cy - ry, cx + rx, cy - ky, cx + rx, cy),
+    { kind: "close" }
+  ];
+}
+
+/**
+ * `sides` points spread evenly around the ellipse inscribed in `box`, starting
+ * at the top so an odd-sided polygon or star stands upright.
+ */
+function regularPoints(box: ShapeBox, sides: number): FlatPoint[] {
+  const rx = box.width / 2;
+  const ry = box.height / 2;
+  const cx = box.x + rx;
+  const cy = box.y + ry;
+  const points: FlatPoint[] = [];
+  for (let i = 0; i < sides; i++) {
+    const angle = -Math.PI / 2 + (i * 2 * Math.PI) / sides;
+    points.push({ x: cx + rx * Math.cos(angle), y: cy + ry * Math.sin(angle) });
+  }
+  return points;
+}
+
+/**
+ * A star of `points` points: the outer vertices of the same polygon, with an
+ * inner vertex between each pair at `innerRadius` of the outer radius. So the
+ * outline has `2 × points` vertices and the point count is what a caller
+ * counts when it samples a circle around the centre.
+ */
+function starPoints(
+  box: ShapeBox,
+  points: number,
+  innerRadius: number
+): FlatPoint[] {
+  const rx = box.width / 2;
+  const ry = box.height / 2;
+  const cx = box.x + rx;
+  const cy = box.y + ry;
+  const out: FlatPoint[] = [];
+  for (let i = 0; i < points * 2; i++) {
+    const angle = -Math.PI / 2 + (i * Math.PI) / points;
+    const scale = i % 2 === 0 ? 1 : innerRadius;
+    out.push({
+      x: cx + rx * scale * Math.cos(angle),
+      y: cy + ry * scale * Math.sin(angle)
+    });
+  }
+  return out;
+}
+
+/**
+ * A closed polygon through `points`, with each corner rounded to `radius`.
+ *
+ * A corner is the circular arc tangent to both edges, emitted as one cubic. The
+ * tangent points sit `radius / tan(interior/2)` back from the vertex, which is
+ * `radius` itself at a right angle (a rect) and further back as the corner
+ * sharpens — so a star's spikes round visibly before its shallow inner corners
+ * do, which is what makes the rounding read as one radius everywhere.
+ */
+function polygonSegments(points: FlatPoint[], radius: number): PathSegment[] {
+  if (points.length < 2) return [];
+  if (radius <= 0) {
+    const segments: PathSegment[] = [
+      { kind: "move", x: points[0]!.x, y: points[0]!.y }
+    ];
+    for (let i = 1; i < points.length; i++) {
+      segments.push({ kind: "line", x: points[i]!.x, y: points[i]!.y });
+    }
+    segments.push({ kind: "close" });
+    return segments;
+  }
+
+  const segments: PathSegment[] = [];
+  for (let i = 0; i < points.length; i++) {
+    const v = points[i]!;
+    const prev = points[(i - 1 + points.length) % points.length]!;
+    const next = points[(i + 1) % points.length]!;
+    const corner = roundCorner(prev, v, next, radius);
+    if (!corner) {
+      // A degenerate corner (zero-length edge, or a vertex doubled back on
+      // itself) has no arc; the vertex stays sharp.
+      segments.push(
+        i === 0
+          ? { kind: "move", x: v.x, y: v.y }
+          : { kind: "line", x: v.x, y: v.y }
+      );
+      continue;
+    }
+    segments.push(
+      i === 0
+        ? { kind: "move", x: corner.enter.x, y: corner.enter.y }
+        : { kind: "line", x: corner.enter.x, y: corner.enter.y }
+    );
+    segments.push({
+      kind: "cubic",
+      x1: corner.c1.x,
+      y1: corner.c1.y,
+      x2: corner.c2.x,
+      y2: corner.c2.y,
+      x: corner.exit.x,
+      y: corner.exit.y
+    });
+  }
+  segments.push({ kind: "close" });
+  return segments;
+}
+
+interface RoundedCorner {
+  enter: FlatPoint;
+  exit: FlatPoint;
+  c1: FlatPoint;
+  c2: FlatPoint;
+}
+
+function roundCorner(
+  prev: FlatPoint,
+  v: FlatPoint,
+  next: FlatPoint,
+  radius: number
+): RoundedCorner | null {
+  const inLen = Math.hypot(v.x - prev.x, v.y - prev.y);
+  const outLen = Math.hypot(next.x - v.x, next.y - v.y);
+  if (inLen <= 1e-6 || outLen <= 1e-6) return null;
+  const ux = (prev.x - v.x) / inLen;
+  const uy = (prev.y - v.y) / inLen;
+  const wx = (next.x - v.x) / outLen;
+  const wy = (next.y - v.y) / outLen;
+  const cos = Math.max(-1, Math.min(1, ux * wx + uy * wy));
+  const sin = Math.abs(ux * wy - uy * wx);
+  // Straight through, or folded back on itself: no arc to draw.
+  if (sin <= 1e-6) return null;
+  const interior = Math.acos(cos);
+  const tangent = Math.min(
+    radius / Math.tan(interior / 2),
+    inLen / 2,
+    outLen / 2
+  );
+  if (!Number.isFinite(tangent) || tangent <= 1e-6) return null;
+  const arcRadius = tangent * Math.tan(interior / 2);
+  const sweep = Math.PI - interior;
+  const handle = (4 / 3) * Math.tan(sweep / 4) * arcRadius;
+  const enter = { x: v.x + ux * tangent, y: v.y + uy * tangent };
+  const exit = { x: v.x + wx * tangent, y: v.y + wy * tangent };
+  return {
+    enter,
+    exit,
+    c1: { x: enter.x - ux * handle, y: enter.y - uy * handle },
+    c2: { x: exit.x - wx * handle, y: exit.y - wy * handle }
+  };
+}
+
+/**
+ * Flatten absolute segments into polylines. Curves are subdivided so each chord
+ * is roughly {@link FLATTEN_CHORD_PX} long, which is what makes the polyline's
+ * length a usable stand-in for the curve's.
+ */
+export function flattenSegments(
+  segments: readonly PathSegment[]
+): FlatSubpath[] {
+  const subpaths: FlatSubpath[] = [];
+  let cx = 0;
+  let cy = 0;
+  // The subpath being built is addressed by index rather than held in a local,
+  // so the reads below stay narrowed after the closures that append to it.
+  let at = -1;
+
+  const open = (x: number, y: number): void => {
+    at = subpaths.push({ points: [{ x, y }], closed: false }) - 1;
+    cx = x;
+    cy = y;
+  };
+  const push = (x: number, y: number): void => {
+    const current = subpaths[at];
+    if (!current) open(x, y);
+    else {
+      current.points.push({ x, y });
+      cx = x;
+      cy = y;
+    }
+  };
+
+  for (const segment of segments) {
+    switch (segment.kind) {
+      case "move":
+        open(segment.x, segment.y);
+        break;
+      case "line":
+        push(segment.x, segment.y);
+        break;
+      case "cubic": {
+        // The curve's start is the point before this segment, and `push` moves
+        // it, so both are read into locals before the walk begins.
+        const sx = cx;
+        const sy = cy;
+        const steps = curveSteps(sx, sy, [
+          segment.x1,
+          segment.y1,
+          segment.x2,
+          segment.y2,
+          segment.x,
+          segment.y
+        ]);
+        for (let i = 1; i <= steps; i++) {
+          const t = i / steps;
+          push(
+            cubicAt(t, sx, segment.x1, segment.x2, segment.x),
+            cubicAt(t, sy, segment.y1, segment.y2, segment.y)
+          );
+        }
+        break;
+      }
+      case "quad": {
+        const sx = cx;
+        const sy = cy;
+        const steps = curveSteps(sx, sy, [
+          segment.x1,
+          segment.y1,
+          segment.x,
+          segment.y
+        ]);
+        for (let i = 1; i <= steps; i++) {
+          const t = i / steps;
+          push(
+            quadAt(t, sx, segment.x1, segment.x),
+            quadAt(t, sy, segment.y1, segment.y)
+          );
+        }
+        break;
+      }
+      case "close": {
+        const current = subpaths[at];
+        if (current && current.points.length > 0) {
+          const start = current.points[0]!;
+          current.closed = true;
+          if (Math.hypot(cx - start.x, cy - start.y) > 1e-6) {
+            current.points.push({ x: start.x, y: start.y });
+          }
+          cx = start.x;
+          cy = start.y;
+        }
+        break;
+      }
+    }
+  }
+  return subpaths.filter((subpath) => subpath.points.length > 1);
+}
+
+/** Subdivision count for a curve, from the length of its control polygon. */
+function curveSteps(x0: number, y0: number, control: number[]): number {
+  let length = 0;
+  let px = x0;
+  let py = y0;
+  for (let i = 0; i < control.length; i += 2) {
+    const x = control[i]!;
+    const y = control[i + 1]!;
+    length += Math.hypot(x - px, y - py);
+    px = x;
+    py = y;
+  }
+  return Math.max(
+    FLATTEN_MIN_STEPS,
+    Math.min(FLATTEN_MAX_STEPS, Math.ceil(length / FLATTEN_CHORD_PX))
+  );
+}
+
+function cubicAt(t: number, a: number, b: number, c: number, d: number): number {
+  const s = 1 - t;
+  return s * s * s * a + 3 * s * s * t * b + 3 * s * t * t * c + t * t * t * d;
+}
+
+function quadAt(t: number, a: number, b: number, c: number): number {
+  const s = 1 - t;
+  return s * s * a + 2 * s * t * b + t * t * c;
+}
+
+/** Total length of every subpath, in surface pixels. */
+export function flatPathLength(subpaths: readonly FlatSubpath[]): number {
+  let total = 0;
+  for (const subpath of subpaths) {
+    for (let i = 1; i < subpath.points.length; i++) {
+      total += Math.hypot(
+        subpath.points[i]!.x - subpath.points[i - 1]!.x,
+        subpath.points[i]!.y - subpath.points[i - 1]!.y
+      );
+    }
+  }
+  return total;
+}
+
+/**
+ * The sub-range `[startFrac, endFrac]` of a flattened outline, as open
+ * polylines.
+ *
+ * Length is measured over every subpath **concatenated in order**, so a figure
+ * drawn as several subpaths trims through them one after another: a range
+ * straddling a boundary comes back as two polylines, the tail of one and the
+ * head of the next, and a range wholly inside one subpath leaves the others
+ * undrawn. That is the same rule After Effects applies with its per-path trim
+ * switched off, and it is what makes a trim animation on a multi-part logo
+ * read as one stroke being drawn rather than as every part growing at once.
+ */
+export function trimFlatPath(
+  subpaths: readonly FlatSubpath[],
+  startFrac: number,
+  endFrac: number
+): FlatPoint[][] {
+  const total = flatPathLength(subpaths);
+  if (total <= 0) return [];
+  const from = Math.max(0, Math.min(1, startFrac)) * total;
+  const to = Math.max(0, Math.min(1, endFrac)) * total;
+  if (to - from <= 1e-6) return [];
+
+  const out: FlatPoint[][] = [];
+  let walked = 0;
+  let run: FlatPoint[] | null = null;
+
+  for (const subpath of subpaths) {
+    for (let i = 1; i < subpath.points.length; i++) {
+      const a = subpath.points[i - 1]!;
+      const b = subpath.points[i]!;
+      const length = Math.hypot(b.x - a.x, b.y - a.y);
+      const segStart = walked;
+      const segEnd = walked + length;
+      walked = segEnd;
+      if (length <= 0 || segEnd <= from || segStart >= to) continue;
+      const t0 = Math.max(0, (from - segStart) / length);
+      const t1 = Math.min(1, (to - segStart) / length);
+      const p0 = lerpPoint(a, b, t0);
+      const p1 = lerpPoint(a, b, t1);
+      if (!run) {
+        run = [p0];
+        out.push(run);
+      }
+      run.push(p1);
+      // The kept range stops inside this segment, so anything after it belongs
+      // to a later run — there is none, but ending the run here keeps the
+      // invariant that a run is contiguous.
+      if (t1 < 1) run = null;
+    }
+    // Subpaths are separate strokes even when the range spans both.
+    run = null;
+  }
+  return out;
+}
+
+function lerpPoint(a: FlatPoint, b: FlatPoint, t: number): FlatPoint {
+  return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t };
+}

--- a/packages/timeline/src/scene.ts
+++ b/packages/timeline/src/scene.ts
@@ -17,5 +17,6 @@ export * from "./render/transform.js";
 export * from "./render/transition.js";
 export * from "./render/draw.js";
 export * from "./render/svgPath.js";
+export * from "./render/shapeGeometry.js";
 export * from "./render/textLayout.js";
 export * from "./render/canvas2d.js";

--- a/packages/timeline/tests/render.shapeGeometry.test.ts
+++ b/packages/timeline/tests/render.shapeGeometry.test.ts
@@ -1,0 +1,171 @@
+/**
+ * A shape clip's outline and the arc-length walk that trims it (F8, T16).
+ *
+ * Everything a shape can draw resolves to one segment list, so the claims worth
+ * pinning are the ones that would otherwise only show up as a wrong picture:
+ * the vertex count of a star, the length of a curve the flattener measured, and
+ * where a trim range lands when the figure is made of several subpaths.
+ *
+ * `packages/agents/tests/timeline-shape-frames.test.ts` reads the pixels the
+ * same styles produce on a real canvas; what a pure function decides is here.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { ClipShapeStyle } from "../src/index.js";
+import {
+  buildShapeSegments,
+  flatPathLength,
+  flattenSegments,
+  trimFlatPath
+} from "../src/render/shapeGeometry.js";
+
+const W = 400;
+const H = 400;
+
+/** A shape filling the whole surface, so its box is the surface. */
+function shape(over: Partial<ClipShapeStyle> & Pick<ClipShapeStyle, "kind">) {
+  return { x: 0, y: 0, width: 1, height: 1, ...over } as ClipShapeStyle;
+}
+
+function segments(style: ClipShapeStyle) {
+  const built = buildShapeSegments(style, W, H);
+  expect(built).not.toBeNull();
+  return built!;
+}
+
+function lengthOf(style: ClipShapeStyle): number {
+  return flatPathLength(flattenSegments(segments(style)));
+}
+
+describe("buildShapeSegments", () => {
+  it("draws a rect as four straight sides", () => {
+    const built = segments(shape({ kind: "rect" }));
+    expect(built.map((s) => s.kind)).toEqual([
+      "move",
+      "line",
+      "line",
+      "line",
+      "close"
+    ]);
+    expect(lengthOf(shape({ kind: "rect" }))).toBeCloseTo(4 * W, 6);
+  });
+
+  it("rounds a rect's corners to a circular arc of the authored radius", () => {
+    // Perimeter of a rounded rect: the straight runs plus one whole circle.
+    const radius = 0.1 * W;
+    const expected = 4 * (W - 2 * radius) + 2 * Math.PI * radius;
+    expect(lengthOf(shape({ kind: "rect", cornerRadius: 0.1 }))).toBeCloseTo(
+      expected,
+      0
+    );
+  });
+
+  it("draws an ellipse whose flattened length is its circumference", () => {
+    // A circle of radius W/2, so the exact answer is known.
+    expect(lengthOf(shape({ kind: "ellipse" }))).toBeCloseTo(Math.PI * W, 0);
+  });
+
+  it("gives a star two vertices per point, alternating radius", () => {
+    const built = segments(shape({ kind: "star", sides: 6 }));
+    // move + 11 lines + close: twelve vertices for a six-pointed star.
+    expect(built.filter((s) => s.kind === "line")).toHaveLength(11);
+    expect(built.map((s) => s.kind).filter((k) => k === "move")).toHaveLength(1);
+
+    const outer = built.filter(
+      (s): s is { kind: "move" | "line"; x: number; y: number } =>
+        s.kind === "move" || s.kind === "line"
+    );
+    const radii = outer.map((p) => Math.hypot(p.x - W / 2, p.y - H / 2));
+    // Alternating: every even vertex is on the outer circle, every odd one on
+    // the inner one at the default half radius.
+    radii.forEach((r, i) => expect(r).toBeCloseTo((i % 2 === 0 ? 1 : 0.5) * (W / 2), 4));
+  });
+
+  it("gives a polygon one vertex per side, all on the circumscribed circle", () => {
+    const built = segments(shape({ kind: "polygon", sides: 7 }));
+    expect(built.filter((s) => s.kind === "line")).toHaveLength(6);
+    for (const segment of built) {
+      if (segment.kind !== "move" && segment.kind !== "line") continue;
+      expect(
+        Math.hypot(segment.x - W / 2, segment.y - H / 2)
+      ).toBeCloseTo(W / 2, 4);
+    }
+  });
+
+  it("scales authored path data out of its normalized space", () => {
+    const built = segments(shape({ kind: "path", d: "M 0 0 L 1 0.5" }));
+    expect(built[1]).toEqual({ kind: "line", x: W, y: H / 2 });
+  });
+
+  it("refuses path data that does not parse, and a kind it cannot draw", () => {
+    expect(buildShapeSegments(shape({ kind: "path", d: "A 1 1" }), W, H)).toBeNull();
+    expect(buildShapeSegments(shape({ kind: "path" }), W, H)).toBeNull();
+    expect(
+      buildShapeSegments(
+        { kind: "hexahedron" } as unknown as ClipShapeStyle,
+        W,
+        H
+      )
+    ).toBeNull();
+  });
+});
+
+describe("trimFlatPath", () => {
+  /** A single straight run of known length, so a fraction reads exactly. */
+  const line = () =>
+    flattenSegments(
+      segments(shape({ kind: "line", x: 0, y: 0, x2: 1, y2: 0 }))
+    );
+
+  it("keeps the first half of the outline at trimEnd 0.5", () => {
+    const runs = trimFlatPath(line(), 0, 0.5);
+    expect(runs).toHaveLength(1);
+    expect(runLength(runs[0]!)).toBeCloseTo(W / 2, 6);
+    expect(runs[0]![0]).toEqual({ x: 0, y: 0 });
+  });
+
+  it("keeps the middle of the outline when both ends move in", () => {
+    const runs = trimFlatPath(line(), 0.25, 0.75);
+    expect(runLength(runs[0]!)).toBeCloseTo(W / 2, 6);
+    expect(runs[0]![0]!.x).toBeCloseTo(W * 0.25, 6);
+  });
+
+  it("keeps half of a curve's arc length, not half its bounding box", () => {
+    // A quarter circle of radius W: the arc is π·W/2 long while its box is W
+    // square, so a length-based trim and a box-based one differ by 57%.
+    const flat = flattenSegments(
+      segments(shape({ kind: "path", d: "M 0 1 C 0 0.4477 0.4477 0 1 0" }))
+    );
+    const whole = flatPathLength(flat);
+    expect(whole).toBeCloseTo((Math.PI * W) / 2, 0);
+    const runs = trimFlatPath(flat, 0, 0.5);
+    expect(runLength(runs[0]!)).toBeCloseTo(whole / 2, 1);
+  });
+
+  it("walks several subpaths in order, so a range can straddle two", () => {
+    // Two separate unit-width strokes: the second half of the first and the
+    // first half of the second come back as two runs, not one.
+    const flat = flattenSegments(
+      segments(shape({ kind: "path", d: "M 0 0 L 1 0 M 0 1 L 1 1" }))
+    );
+    const runs = trimFlatPath(flat, 0.25, 0.75);
+    expect(runs).toHaveLength(2);
+    expect(runs[0]![0]!.y).toBe(0);
+    expect(runs[1]![0]!.y).toBe(H);
+    // Half of both strokes together: the range is measured over their total.
+    expect(runLength(runs[0]!) + runLength(runs[1]!)).toBeCloseTo(W, 6);
+  });
+
+  it("draws nothing when the range is empty or inverted", () => {
+    expect(trimFlatPath(line(), 0.5, 0.5)).toEqual([]);
+    expect(trimFlatPath(line(), 0.8, 0.2)).toEqual([]);
+  });
+});
+
+function runLength(run: readonly { x: number; y: number }[]): number {
+  let total = 0;
+  for (let i = 1; i < run.length; i++) {
+    total += Math.hypot(run[i]!.x - run[i - 1]!.x, run[i]!.y - run[i - 1]!.y);
+  }
+  return total;
+}

--- a/packages/video-nodes/src/nodes/timeline/compositeRender.ts
+++ b/packages/video-nodes/src/nodes/timeline/compositeRender.ts
@@ -273,8 +273,12 @@ export async function renderTimelineComposited(
           return finish({ ...common, id: id("t"), source: raster });
         }
 
-        if (layer.kind === "shape" && layer.shapeStyle) {
-          const raster = rasterizer.shape(layer.shapeStyle);
+        if (layer.kind === "shape") {
+          // The animated style carries a driven trim range; without it a trim
+          // animation would rasterize its first frame and hold.
+          const shapeStyle = anim.shapeStyle ?? layer.shapeStyle;
+          if (!shapeStyle) return null;
+          const raster = rasterizer.shape(shapeStyle);
           if (!raster) return null;
           return finish({ ...common, id: id("s"), source: raster });
         }

--- a/web/src/components/timeline/preview/PreviewCompositor.tsx
+++ b/web/src/components/timeline/preview/PreviewCompositor.tsx
@@ -45,7 +45,10 @@ import {
   PREVIEW_OVERLAY_Z,
   MAX_VIDEO_LAYERS
 } from "@nodetool-ai/timeline/render";
-import type { ActiveLayer } from "@nodetool-ai/timeline/render";
+import type {
+  ActiveLayer,
+  AnimatedLayerProps
+} from "@nodetool-ai/timeline/render";
 import {
   buildCompositeLayers,
   buildCompositePrecomposites,
@@ -794,7 +797,8 @@ export const PreviewCompositor: React.FC = memo(() => {
         : sceneLayers;
 
       const resolveSource = (
-        layer: ActiveLayer
+        layer: ActiveLayer,
+        anim: AnimatedLayerProps
       ): ResolvedCompositeSource | null => {
         if (layer.kind === "caption") {
           if (!layer.caption) return null;
@@ -824,9 +828,12 @@ export const PreviewCompositor: React.FC = memo(() => {
           return bitmap ? { source: bitmap } : null;
         }
         if (layer.kind === "shape") {
-          if (!layer.shapeStyle) return null;
+          // The animated style carries a driven trim range; without it a trim
+          // animation would rasterize its first frame and hold.
+          const shapeStyle = anim.shapeStyle ?? layer.shapeStyle;
+          if (!shapeStyle) return null;
           const bitmap = shapeRasterizerRef.current.rasterize(
-            layer.shapeStyle,
+            shapeStyle,
             sequenceWidth,
             sequenceHeight
           );

--- a/web/src/components/timeline/preview/__tests__/shapeTrim.test.ts
+++ b/web/src/components/timeline/preview/__tests__/shapeTrim.test.ts
@@ -1,0 +1,114 @@
+/**
+ * A shape clip's animated trim reaching the rasterizer (F8, T16).
+ *
+ * `trimStart`/`trimEnd` are the only animated channels the compositor cannot
+ * apply — they change the outline itself, so they have to be in hand *before*
+ * the layer is rasterized. Both browser hosts get them the same way, through
+ * the sampled props `buildCompositeLayer` now hands to `resolveSource`; before
+ * that they rasterized `layer.shapeStyle` and a trim animation held its first
+ * frame in the preview and the export while animating in the server render.
+ *
+ * jsdom has no 2D canvas, so this pins the style the host would draw rather
+ * than the pixels. The pixels are checked in
+ * `packages/agents/tests/timeline-shape-frames.test.ts`.
+ */
+
+import { makeClip, makeTrack } from "@nodetool-ai/timeline";
+import type {
+  ClipAnimation,
+  ClipShapeStyle,
+  TimelineClip
+} from "@nodetool-ai/timeline";
+import {
+  computeActiveLayersWithHorizon,
+  type ActiveLayer,
+  type AnimatedLayerProps
+} from "@nodetool-ai/timeline/render";
+
+import { buildCompositeLayers } from "../compositeLayers";
+import type { CompositeSource } from "../gpu/types";
+
+const FRAME = { width: 200, height: 100 };
+
+const track = makeTrack({
+  id: "video",
+  type: "video",
+  index: 0,
+  visible: true
+});
+
+const stroke: ClipShapeStyle = {
+  kind: "line",
+  x: 0,
+  y: 0.5,
+  x2: 1,
+  y2: 0.5,
+  stroke: "#ffffff",
+  strokeWidthPx: 4
+};
+
+/** `trimEnd` sweeping 0 → 1 across the clip. */
+const drawOn: ClipAnimation = {
+  id: "draw-on",
+  role: "in",
+  preset: "custom",
+  durationMs: 1000,
+  custom: {
+    curves: [
+      {
+        property: "trimEnd",
+        keyframes: [
+          { t: 0, value: 0 },
+          { t: 1, value: 1 }
+        ]
+      }
+    ]
+  }
+};
+
+function shapeClip(animations?: ClipAnimation[]): TimelineClip {
+  return makeClip({
+    id: "stroke",
+    trackId: track.id,
+    mediaType: "shape",
+    startMs: 0,
+    durationMs: 1000,
+    status: "generated",
+    shapeStyle: stroke,
+    animations
+  });
+}
+
+/** The style the host would rasterize at `atMs`. */
+function rasterizedStyleAt(
+  clip: TimelineClip,
+  atMs: number
+): ClipShapeStyle | undefined {
+  const scene = computeActiveLayersWithHorizon([track], [clip], atMs, {
+    canvas: FRAME
+  });
+  let seen: ClipShapeStyle | undefined;
+  buildCompositeLayers(scene.layers, {
+    atMs,
+    canvas: FRAME,
+    resolveSource: (layer: ActiveLayer, anim: AnimatedLayerProps) => {
+      seen = anim.shapeStyle ?? layer.shapeStyle;
+      return { source: {} as CompositeSource };
+    }
+  });
+  return seen;
+}
+
+describe("an animated trim on a shape clip", () => {
+  it("hands the rasterizer a different range at two timecodes", () => {
+    const clip = shapeClip([drawOn]);
+    expect(rasterizedStyleAt(clip, 250)?.trimEnd).toBeCloseTo(0.25, 3);
+    expect(rasterizedStyleAt(clip, 750)?.trimEnd).toBeCloseTo(0.75, 3);
+  });
+
+  it("leaves the clip's own style alone when nothing drives the trim", () => {
+    const style = rasterizedStyleAt(shapeClip(), 500);
+    expect(style).toBe(stroke);
+    expect(style?.trimEnd).toBeUndefined();
+  });
+});

--- a/web/src/components/timeline/preview/compositeLayers.ts
+++ b/web/src/components/timeline/preview/compositeLayers.ts
@@ -17,6 +17,7 @@
 
 import type {
   ActiveLayer,
+  AnimatedLayerProps,
   Canvas2DLayer,
   Canvas2DMatte,
   PrecompositeLayer
@@ -50,9 +51,14 @@ export interface ResolvedCompositeSource {
  * How a host gets one layer's pixels. Null means it has none this frame — a
  * video still seeking, an image still decoding, a raster with nothing on it —
  * and the layer is left out of the frame.
+ *
+ * The layer's sampled props come with it because a rasterized layer's pixels
+ * depend on them: a shape clip with an animated trim draws a different outline
+ * at every timecode, and `anim.shapeStyle` is the one carrying it.
  */
 export type CompositeSourceResolver = (
-  layer: ActiveLayer
+  layer: ActiveLayer,
+  anim: AnimatedLayerProps
 ) => ResolvedCompositeSource | null;
 
 export interface BuildCompositeLayersOptions {
@@ -91,15 +97,15 @@ export function buildCompositeLayer(
   options: BuildCompositeLayersOptions,
   idPrefix = ""
 ): CompositeLayer | null {
-  const resolved = options.resolveSource(layer);
-  if (!resolved) return null;
-
   const anim = resolveAnimatedLayerProps(
     layer,
     options.atMs,
     options.canvas,
     options.animationCache
   );
+  const resolved = options.resolveSource(layer, anim);
+  if (!resolved) return null;
+
   const built: CompositeLayer = {
     id: compositeLayerId(layer, idPrefix),
     source: resolved.source,

--- a/web/src/components/timeline/preview/rasterClipFrames.ts
+++ b/web/src/components/timeline/preview/rasterClipFrames.ts
@@ -86,6 +86,16 @@ export async function renderRasterClipFrames(
       // A staggered text clip re-rasterizes per requested time so the agent
       // sees the per-word motion mid-window, same draw path as preview/export.
       let frameSource = source;
+      // A shape with a driven trim range redraws per requested time for the
+      // same reason: its outline is different at every timecode.
+      if (clip.mediaType === "shape" && animated.shapeStyle) {
+        frameSource =
+          shapeRasterizer.rasterize(
+            animated.shapeStyle,
+            sequenceWidth,
+            sequenceHeight
+          ) ?? source;
+      }
       if (clip.mediaType === "text" && clip.textStyle) {
         const stagger = resolveTextStaggerContext(
           clip,

--- a/web/src/components/timeline/render/TimelineRenderer.ts
+++ b/web/src/components/timeline/render/TimelineRenderer.ts
@@ -28,9 +28,13 @@ import {
   clipSourceTimeSec,
   computeActiveLayersWithHorizon,
   createAnimationCompileCache,
+  resolveAnimatedLayerProps,
   resolveTextStaggerContext
 } from "@nodetool-ai/timeline/render";
-import type { ActiveLayer } from "@nodetool-ai/timeline/render";
+import type {
+  ActiveLayer,
+  AnimatedLayerProps
+} from "@nodetool-ai/timeline/render";
 import {
   buildCompositeLayer,
   buildCompositePrecomposites,
@@ -275,7 +279,8 @@ export async function renderTimeline(
        * concurrently and the mapping runs after, in scene order.
        */
       const sourceFor = async (
-        layer: ActiveLayer
+        layer: ActiveLayer,
+        anim: AnimatedLayerProps
       ): Promise<ResolvedCompositeSource | null> => {
         if (layer.kind === "caption" && layer.caption) {
           const bitmap = captionRasterizer.rasterize(
@@ -302,12 +307,12 @@ export async function renderTimeline(
           );
           return bitmap ? { source: bitmap } : null;
         }
-        if (layer.kind === "shape" && layer.shapeStyle) {
-          const bitmap = shapeRasterizer.rasterize(
-            layer.shapeStyle,
-            width,
-            height
-          );
+        if (layer.kind === "shape") {
+          // The animated style carries a driven trim range; without it a trim
+          // animation would rasterize its first frame and hold.
+          const shapeStyle = anim.shapeStyle ?? layer.shapeStyle;
+          if (!shapeStyle) return null;
+          const bitmap = shapeRasterizer.rasterize(shapeStyle, width, height);
           return bitmap ? { source: bitmap } : null;
         }
 
@@ -336,7 +341,14 @@ export async function renderTimeline(
       const sources = new Map<ActiveLayer, ResolvedCompositeSource>();
       await Promise.all(
         needed.map(async (layer) => {
-          const source = await sourceFor(layer);
+          // Rasterizing a layer can depend on its sampled props (a shape's trim
+          // range), and this prefetch runs before `buildCompositeLayer` samples
+          // them, so it samples them itself. The compile cache makes the second
+          // call a lookup.
+          const source = await sourceFor(
+            layer,
+            resolveAnimatedLayerProps(layer, timeMs, animCanvas, animCache)
+          );
           if (source) sources.set(layer, source);
         })
       );


### PR DESCRIPTION
## What changed

Continues `docs/plans/motion-graphics-tasks.md` where [#5491](https://github.com/nodetool-ai/nodetool/pull/5491) left off. That PR merged M1 and M2 (T6–T13 plus two corrective tasks); a merged PR cannot carry new commits, so this branch was restarted from `main` and the remaining work lands here. The description is updated as each task lands, and the verification block is re-run against the finished branch before this is ready to merge.

**Landed so far**

- **T16 — shapes: paths, polygons, gradients, dashes, trim (F8).** Shapes were rect, ellipse and line, rasterized directly, with no paths, no gradients, no dashes, and a `trimStart`/`trimEnd` range the schema carried and nothing drew. Every kind now resolves to one absolute `PathSegment[]` in surface pixels — including an authored `d`, with arcs emitted as cubics. That single representation is what lets trim, dashes and gradients apply uniformly: a trimmed ellipse has an arc length to walk, which `ctx.ellipse` would not. Trim measures cumulative length across subpaths in document order, so a range straddling a boundary returns two runs and a multi-part figure reads as one stroke being drawn rather than every part growing at once; it cuts the stroke only, since a line drawing itself on is what the channel is for.

**In flight:** T14 (text style), T15 (caption style), T17 (font pipeline), then M4 — T18, T20, T22, T19, T21, T23, T26, T24, T25.

### Decisions worth review

- **`arc` was deliberately left off `RasterContext2D`**, against the task's literal wording. A shape's box is normalized against a non-square canvas, so its "circle" is an ellipse and `arc` cannot draw one; and an `arc` call has no arc length to walk, which is exactly what trim needs. Every circular arc — rounded corners, ellipses — is emitted as a cubic instead, so one representation serves fill, stroke, dash and trim. Adding an unused interface member would have been dead surface.
- **T7 landed animated `trimStart`/`trimEnd` on the sampled `shapeStyle` and no host read it**, so a trim animation held its first frame on every surface. All four rasterizing hosts now read the sampled style rather than the clip's own, and the two rules that makes load-bearing are written into `packages/timeline/AGENTS.md` so the next task does not rediscover them.

### Found, not fixed

- `ShapeFill.type` is a closed discriminated union in Zod, so a fill type from a newer build fails the whole clip rather than just the fill — the same shape T11b widened for `clipTransition`/`clipEffect`, but `fillStyle` is not in I2's named list and was outside T16's scope.
- `cornerRadius` and `dash` are normalized against surface width; they are lengths along an outline with no axis of their own, and the two axes disagree on any non-square canvas. If T31 exposes them, the control should say "fraction of frame width".
- A trim animation defeats the shape raster cache: the style signature stringifies the whole style, so a driven trim mints a new key every frame. Correct, but it thrashes a 64-entry LRU — worth noting if T28's motion blur multiplies the frame count.
- `shapeStyleWithDefaults` in `web/src/hooks/timeline/authoredClipStyles.ts` has no notion of the new geometry fields, so the authoring path gives a `path`/`polygon`/`star` clip no sensible defaults. T19 territory.

## Verification

Re-run against the finished branch before merge. As of T16, on the current `main` base:

- [x] `npm run build:packages` — 59 packages, exit 0
- [x] `npm run test --workspace=packages/timeline` (lavapipe) — 518 passed
- [x] `npm run test --workspace=packages/agents` — 3750 passed, 5 skipped (239 files; main's baseline is 238/3729)
- [ ] `npm run typecheck` — web and electron legs clean. The **mobile** leg fails on a clean tree in this container: `mobile/node_modules` is absent (mobile is deliberately not a root workspace), so `expo/tsconfig.base` cannot resolve and cascading `TS2307`s follow. None is in a file this branch touches.
- [ ] `npm run test:affected`
- [ ] `npm run dev:nodetool -- harness gate --base main`

**A stale-artifact trap worth recording.** After rebasing onto the new `main`, `packages/agents` reported 1190 failures across 112 files — on `main` itself, with no changes applied. The cause was `dist/`: `main` had moved under a tree built for the old base, and the decorator packages load from `dist/`. `npm run build:packages` returns `main` to 3729 passed. Separately, `npm run test … | tail -6` reported `exit 0` for a run that had actually failed, because the pipeline's status comes from `tail`. Both are the measurement traps `AGENTS.md` § Claims, Checks, and Measurements names; acting on either would have meant chasing a fix for something that was not broken.

## New checks

- [x] T16's animated-trim wiring was inverted (`frames.ts` reverted to `layer.shapeStyle`, the pre-T16 read) and observed failing — `draws a different length at two timecodes`, 1 failed | 20 passed — then restored.
- [x] Every `RasterContext2D` member is asserted present on a real `@napi-rs/canvas` context at runtime; the `OffscreenCanvas` side is pinned at compile time by the web rasterizer passing its context with no cast (I6).
- [x] A flattener bug the tests caught rather than review: reading the current point after advancing it made every curve ~5% long (an ellipse measured 1319.7px against a true circumference of 1256.6).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdzG3a3jN3Dzx6QV8xh4Bo

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdzG3a3jN3Dzx6QV8xh4Bo)_