### PR TITLE
fix(agents,cli): validate the deliverable (A5, T-A5.1)

### DIFF
--- a/docs/plans/agent-system-improvements.md
+++ b/docs/plans/agent-system-improvements.md
@@ -183,6 +183,8 @@ D1 and D2 are recorded with their evidence in [ADR 0002](../adr/0002-codeact-is-
   run budget bound the work.
 - **D7. A5 is a conditional patch.** D1 deletes the code A5 fixes. Ship A5
   only if A3's deletion task cannot land in the same milestone as A1.
+  Resolved: T-A3.3 landed first, so A5 ships against the seams that inherited
+  the defect instead of the compiler (see A5).
 
 ## 3. Work packages
 
@@ -689,31 +691,46 @@ still scroll the full thread.
 
 ---
 
-### A5. Validate the compiler's deliverable (conditional, see D7)
+### A5. Validate the deliverable
 
-**Rationale.** `Agent.getResults()` is the one output a CLI caller reads, and
-it is the only place in the pipeline where a schema is declared and not
-checked.
+**Rationale.** `Agent.getResults()` was the one output a CLI caller read, and
+the only place in the pipeline where a schema was declared and not checked.
 
-**Context.** `compiler-agent.ts:268-312`, `agent.ts:760-771`, the host-side
-validator the step executors use (`codeact-executor.ts:681-707`,
-`step-executor.ts:954-988`; find the shared helper and reuse it, do not write
-a third), `tests/compiler-agent.test.ts`, `tests/agent.test.ts`.
+**Outcome.** T-A3.3 landed first, so D7's condition resolved against the
+original patch: `compiler-agent.ts` and `agent.ts` are deleted and there is no
+compiler `finish_step` closure to validate. The first acceptance criterion is
+met by the code that survived — every deliverable now completes through
+`validateAgainstSchema` (`utils/json-schema-validate.ts`), reached from
+`StepExecutor.validateResultPayload` and the CodeAct `finish()` bridge, and a
+violation round-trips to the model as an error result bounded by
+`maxIterations`, `MAX_FINISH_NUDGES`, and `MAX_REPAIR_ROUNDS`.
 
-**Target design.** In the `finish_step` closure, run the same schema
-validation the step executors run; on failure return the validation errors as
-the tool result so the compiler repairs within its 6 rounds; after the rounds,
-fail. In `Agent`, a null compiler result under an `outputSchema` throws
-`AgentResultError("compiler produced no result")`; without a schema the
-memory fallback stays and is logged as a warning.
+The second criterion did not survive the deletion. A null deliverable stayed
+silent at three seams, each reported as success:
+
+- **The fan-out aggregate.** `task-executor.ts` process mode fills
+  `new Array(n)` from `step_result` messages, so a failed item leaves a hole,
+  and the array is stored and the step marked complete regardless. A step
+  declaring both `perItemSchema` and `outputSchema` has its own `outputSchema`
+  checked by nobody: the per-item executor applied the other one.
+- **`execute_plan`'s results map.** `capabilities/agents.ts` reads each task's
+  deliverable with `if (value !== undefined) results[task.id] = value` and
+  still reports `status: "completed"`. This is the seam that replaced the
+  compiler, and its description tells the model to write the answer from
+  results that may not be there.
+- **`nodetool agent run`'s exit code.** The command's one output is a
+  transcript scrape; when it finds no final assistant text it writes nothing
+  to stdout and exits 0.
 
 **Task.**
 
-- **T-A5.1** Size S. Ship only if T-A3.3 has not merged by the time A1 ships
-  (D7). Acceptance: a compiler `finish_step` with a wrong-typed field is
-  rejected and the second attempt is accepted; a null result under a schema
-  throws. Inversion: bypass the validator and watch the wrong-typed payload
-  pass. Depends: none. Superseded by T-A3.3.
+- **T-A5.1** Size S. Carried to the seams above, since D7's original target is
+  deleted. Acceptance: a fan-out with a failed item fails the step naming the
+  missing indexes, and an aggregate violating a declared `outputSchema` fails
+  with the violations; `execute_plan` marks a task whose `task:<id>` key was
+  never written with `result_missing`; `agent run` exits non-zero and names
+  the reason when it produces no answer. Inversion: each check written and
+  observed failing before the fix. Depends: T-A3.3.
 
 ---
 
@@ -877,7 +894,7 @@ T-A4.2 ┴─► T-A4.3 ──► T-A4.5        T-A4.4 (independent; coordinate 
 T-A3.1 ──► T-A3.2 ──► T-A3.3 ──► T-A3.4
                         │  T-A1.6, T-A2.3 (CLI flags, after the rewrite)
 T-A1.1 ──► T-A7.1 ──► T-A7.2 (after T-A8.2) ──► T-A7.3 (after T-A3.3)
-T-A5.1 only if T-A3.3 slips past A1's milestone
+T-A5.1 after T-A3.3 (retargeted; see A5)
 ```
 
 Parallel lanes for four agents: (1) A8 then A7; (2) A1; (3) A2 then the CLI

--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -1775,7 +1775,8 @@ construction; what it cannot judge is quality, and that is the suite:
 parallel width, decomposition proportional to the objective, real dependencies
 modelled as dependencies, tool routing (`run_python` for arithmetic, not a
 reasoning step), the step-id prefix convention, and the prompt's hard rule that
-final synthesis belongs to the Compiler, not to an "assemble" task. Metrics per
+final synthesis belongs to the loop that ran the plan, not to an "assemble"
+task. Metrics per
 case: tasks, steps, parallel width, critical-path depth, planner tool calls,
 rejected `add_task`/`finish_plan` calls; aggregate adds a **clean rate** — the
 fraction of plans built without a single rejected call.

--- a/packages/agents/src/capabilities/agents.ts
+++ b/packages/agents/src/capabilities/agents.ts
@@ -30,6 +30,7 @@
 
 import type { JsonSchema } from "@nodetool-ai/runtime";
 import { budgetFromContext } from "@nodetool-ai/runtime";
+import { createLogger } from "@nodetool-ai/config";
 import { Tool } from "../tools/base-tool.js";
 import { TOOL_CALL_ID_FIELD } from "../tools/subtask-fields.js";
 import { READ_ONLY_SEARCH_DESCRIPTION } from "../prompts/read-only-search-prompt.js";
@@ -61,6 +62,8 @@ export {
   RUN_SUBTASK_SCHEMA,
   RUN_SEARCH_SCHEMA
 } from "./agents.specs.js";
+
+const log = createLogger("nodetool.agents.capabilities.agents");
 
 /**
  * The sub-agent runtime this run carries, or an error naming what is missing.
@@ -236,6 +239,13 @@ interface ExecutedTask {
   title: string;
   status: "completed" | "failed";
   error?: string;
+  /**
+   * Set when the task ran to completion but wrote nothing under its
+   * `task:<id>` key, so `results` has no entry for it. The description sends
+   * the model to that key for the answer; without this the model is sent to a
+   * key that is not there and told nothing went wrong.
+   */
+  result_missing?: boolean;
 }
 
 /** A rejected plan, shaped so the model can fix the offending task. */
@@ -266,7 +276,9 @@ function invalidPlan(issues: string[]): Record<string, unknown> {
  * are what the thread and the sidebar render, and re-summarizing them into a
  * final blob would leave the user watching nothing until the end. The call
  * returns how each task settled plus its result; the step results also stay in
- * shared memory under `task:<id>`, which the description points at.
+ * shared memory under `task:<id>`, which the description points at. A task
+ * that completed and left nothing under that key comes back with
+ * `result_missing`, so the model is not sent to a key that is not there.
  */
 const executePlan: CapabilityExport = {
   spec: executePlanSpec,
@@ -361,7 +373,20 @@ const executePlan: CapabilityExport = {
         };
       }
       const value = run.context.memory.getValue(memoryKeys.task(task.id));
-      if (value !== undefined) results[task.id] = value;
+      if (value === undefined) {
+        log.warn("Task completed with no result in shared memory", {
+          taskId: task.id,
+          title: task.title,
+          key: memoryKeys.task(task.id)
+        });
+        return {
+          id: task.id,
+          title: task.title,
+          status: "completed",
+          result_missing: true
+        };
+      }
+      results[task.id] = value;
       return { id: task.id, title: task.title, status: "completed" };
     });
 

--- a/packages/agents/src/task-executor.ts
+++ b/packages/agents/src/task-executor.ts
@@ -36,6 +36,10 @@ import { mergeAsyncGenerators } from "./utils/merge-generators.js";
 import type { Tool } from "./tools/base-tool.js";
 import type { Step, Task } from "./types.js";
 import { DEFAULT_AGENT_POLICY } from "./agent-policy.js";
+import {
+  formatViolations,
+  validateAgainstSchema
+} from "./utils/json-schema-validate.js";
 import { isObjectLike, isRecord } from "./utils/type-guards.js";
 
 const DEFAULT_MAX_STEPS = 50;
@@ -522,6 +526,9 @@ export class TaskExecutor {
       ephemeralSteps.map((ephStep, index) => [ephStep.id, index])
     );
     const results: unknown[] = new Array(ephemeralSteps.length);
+    // Which slots a result actually landed in. `results[i] === undefined` is
+    // not the test: an item may legitimately finish with `undefined`.
+    const filled = new Set<number>();
 
     const collect = (msg: unknown): void => {
       const stepResult = msg as StepResult;
@@ -529,9 +536,12 @@ export class TaskExecutor {
       const stepId = stepResult.step?.id;
       if (stepId === undefined) return;
       const index = indexByStepId.get(stepId);
-      if (index !== undefined) {
-        results[index] = stepResult.result;
-      }
+      if (index === undefined) return;
+      // A failed item answers with `{error}`, not with a result. Leaving its
+      // slot empty is what makes the aggregate check below see the hole.
+      if (stepResult.error !== undefined) return;
+      results[index] = stepResult.result;
+      filled.add(index);
     };
 
     if (this.parallelExecution && generators.length > 1) {
@@ -551,6 +561,39 @@ export class TaskExecutor {
       }
     }
 
+    // A fan-out is one deliverable: an item that produced no result makes the
+    // step a failure, never a completion with a hole in it (I-5).
+    const missing = ephemeralSteps
+      .map((_ephStep, index) => index)
+      .filter((index) => !filled.has(index));
+    if (missing.length > 0) {
+      yield* this.failStep(
+        step,
+        `Step failed: fan-out produced no result for ` +
+          `${missing.length} of ${ephemeralSteps.length} item(s) — ` +
+          `index ${missing.join(", ")}`
+      );
+      return;
+    }
+
+    // With a `perItemSchema` the per-item executor validated each item against
+    // that schema, so the step's own `outputSchema` describes the aggregate and
+    // nothing has checked it yet.
+    const aggregateSchema = perItemSchema
+      ? this.parseSchema(step.outputSchema, step.id)
+      : null;
+    if (aggregateSchema) {
+      const violations = validateAgainstSchema(results, aggregateSchema);
+      if (violations.length > 0) {
+        yield* this.failStep(
+          step,
+          `Step failed: fan-out result rejected by outputSchema — ` +
+            formatViolations(violations)
+        );
+        return;
+      }
+    }
+
     this.context.memory.set({
       key: memoryKeys.step(step.id),
       kind: "step_result",
@@ -565,6 +608,21 @@ export class TaskExecutor {
       stepId: step.id,
       resultCount: results.length
     });
+  }
+
+  /** A step's declared schema as an object, or null when absent/unparseable. */
+  private parseSchema(
+    schema: string | undefined,
+    stepId: string
+  ): Record<string, unknown> | null {
+    if (!schema) return null;
+    try {
+      const parsed: unknown = JSON.parse(schema);
+      return isRecord(parsed) ? parsed : null;
+    } catch {
+      log.warn("Ignoring unparseable outputSchema", { stepId });
+      return null;
+    }
   }
 
   /**

--- a/packages/agents/tests/capabilities-agents.test.ts
+++ b/packages/agents/tests/capabilities-agents.test.ts
@@ -14,7 +14,12 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { BaseProvider, ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  AgentMemory,
+  BaseProvider,
+  memoryKeys,
+  ProcessingContext
+} from "@nodetool-ai/runtime";
 import type { ProcessingMessage } from "@nodetool-ai/protocol";
 import {
   AGENT_CAPABILITIES,
@@ -585,6 +590,7 @@ describe("execute_plan", () => {
     opts: {
       failing?: string[];
       parentTools?: () => unknown[];
+      memory?: AgentMemory;
     } = {}
   ) {
     const { provider, seenSteps, offeredTools, promptText } = stepProvider(
@@ -593,7 +599,9 @@ describe("execute_plan", () => {
     const forwarded: ProcessingMessage[] = [];
     const result = (await executePlan.impl(
       createCapabilityRun({
-        context: createMockContext() as never,
+        context: createMockContext(
+          opts.memory ? { memory: opts.memory } : {}
+        ) as never,
         gate: UNGATED,
         subAgent: stubRuntime({
           provider,
@@ -655,6 +663,42 @@ describe("execute_plan", () => {
         (m) => m.type === "task_update" && m.event === "task_failed"
       )
     ).toBe(true);
+  });
+
+  it("says so when a completed task left no result under its `task:<id>` key", async () => {
+    // A task can finish every step and still write nothing under its task
+    // key. The capability's description tells the model to read the result
+    // back from `task:<task id>`, so a task reported as `completed` with no
+    // entry in `results` sends it to a key that is not there. Drop exactly
+    // that one write and the task must say the result is missing.
+    const memory = new AgentMemory();
+    const write = memory.set.bind(memory);
+    memory.set = ((entry: Parameters<AgentMemory["set"]>[0]) => {
+      if (entry.key === memoryKeys.task("draft")) {
+        return { ...entry, createdAt: entry.createdAt ?? Date.now() };
+      }
+      return write(entry);
+    }) as AgentMemory["set"];
+
+    const { result } = await runPlan(twoTaskPlan(), { memory });
+
+    expect(result["completed_count"]).toBe(2);
+    expect(result["failed_count"]).toBe(0);
+    const tasks = result["tasks"] as Array<Record<string, unknown>>;
+    // The task that did leave a result is reported unchanged.
+    expect(tasks[0]).toEqual({
+      id: "gather",
+      title: "Gather the inputs",
+      status: "completed"
+    });
+    // The one that did not is flagged next to the status the model reads.
+    expect(tasks[1]).toEqual({
+      id: "draft",
+      title: "Draft the output",
+      status: "completed",
+      result_missing: true
+    });
+    expect(Object.keys(result["results"] as object)).toEqual(["gather"]);
   });
 
   it("never hands the plan capabilities to the child loops", async () => {

--- a/packages/agents/tests/task-executor-coverage.test.ts
+++ b/packages/agents/tests/task-executor-coverage.test.ts
@@ -404,6 +404,12 @@ describe("TaskExecutor coverage", () => {
       perItemSchema: JSON.stringify({
         type: "object",
         properties: { done: { type: "boolean" } }
+      }),
+      // With a perItemSchema, the step's own outputSchema describes the
+      // aggregate the fan-out produces — a list, not one item's object.
+      outputSchema: JSON.stringify({
+        type: "array",
+        items: { type: "object", properties: { done: { type: "boolean" } } }
       })
     };
     const task: Task = { id: "t1", title: "T", steps: [discover, proc] };

--- a/packages/agents/tests/task-executor.test.ts
+++ b/packages/agents/tests/task-executor.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { TaskExecutor } from "../src/task-executor.js";
 import type { Step, Task } from "../src/types.js";
-import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import {
+  TaskUpdateEvent,
+  type ProcessingMessage
+} from "@nodetool-ai/protocol";
 import { memoryKeys, BaseProvider } from "@nodetool-ai/runtime";
 import { createMockContext } from "./_helpers/mock-context.js";
 import { finishAction } from "./_helpers/codeact-provider.js";
@@ -578,4 +581,196 @@ describe("TaskExecutor", () => {
       { item: "dog" }
     ]);
   });
+
+  it("fails a fan-out whose item produced no result instead of completing it", async () => {
+    // Regression: a failed ephemeral step answers with `{error}`, which the
+    // aggregate stored as if it were a result and the step was marked
+    // completed. A fan-out missing an item is a failed step (I-5).
+    const provider = createFanOutProvider((item) =>
+      item === "beta" ? null : { item }
+    );
+
+    const context = createMockContext();
+    context.memory.set({
+      key: memoryKeys.step("discover"),
+      kind: "step_result",
+      value: ["alpha", "beta", "gamma"],
+      source: "discover",
+      title: "discover"
+    });
+
+    const processStep: Step = {
+      id: "process",
+      instructions: "handle {item}",
+      completed: false,
+      dependsOn: ["discover"],
+      mode: "process",
+      outputSchema: JSON.stringify({
+        type: "object",
+        properties: { item: { type: "string" } }
+      }),
+      logs: []
+    } as Step;
+    const task: Task = {
+      id: "t1",
+      title: "Fan-out",
+      steps: [
+        {
+          id: "discover",
+          instructions: "list",
+          completed: true,
+          dependsOn: [],
+          logs: []
+        },
+        processStep
+      ]
+    };
+
+    const executor = new TaskExecutor({
+      provider,
+      model: "test-model",
+      context,
+      tools: [],
+      task,
+      parallelExecution: true
+    });
+
+    const messages: ProcessingMessage[] = [];
+    for await (const msg of executor.executeTasks()) {
+      messages.push(msg);
+    }
+
+    expect(processStep.completed).toBe(false);
+    expect(processStep.failed).toBe(true);
+    expect(processStep.error).toContain("1");
+    expect(processStep.error).toMatch(/no result/i);
+
+    // The partial aggregate is never stored as the step's result.
+    expect(context.memory.getValue(memoryKeys.step("process"))).toEqual({
+      error: processStep.error
+    });
+
+    const failed = messages.filter(
+      (m) =>
+        m.type === "task_update" &&
+        (m as { node_id?: string }).node_id === "process" &&
+        (m as { event?: string }).event === TaskUpdateEvent.StepFailed
+    );
+    expect(failed).toHaveLength(1);
+  });
+
+  it("validates the aggregate against outputSchema when perItemSchema was used", async () => {
+    // With both schemas declared, `perItemSchema` checks each item and the
+    // step's own `outputSchema` was checked by nobody.
+    const provider = createFanOutProvider((item) => ({ item }));
+
+    const context = createMockContext();
+    context.memory.set({
+      key: memoryKeys.step("discover"),
+      kind: "step_result",
+      value: ["alpha", "beta"],
+      source: "discover",
+      title: "discover"
+    });
+
+    const processStep: Step = {
+      id: "process",
+      instructions: "handle {item}",
+      completed: false,
+      dependsOn: ["discover"],
+      mode: "process",
+      perItemSchema: JSON.stringify({
+        type: "object",
+        properties: { item: { type: "string" } },
+        required: ["item"]
+      }),
+      // The aggregate must be a list of at least three items; the fan-out
+      // produces two.
+      outputSchema: JSON.stringify({ type: "array", minItems: 3 }),
+      logs: []
+    } as Step;
+    const task: Task = {
+      id: "t1",
+      title: "Fan-out",
+      steps: [
+        {
+          id: "discover",
+          instructions: "list",
+          completed: true,
+          dependsOn: [],
+          logs: []
+        },
+        processStep
+      ]
+    };
+
+    const executor = new TaskExecutor({
+      provider,
+      model: "test-model",
+      context,
+      tools: [],
+      task,
+      parallelExecution: true
+    });
+
+    for await (const _msg of executor.executeTasks()) {
+      // consume
+    }
+
+    expect(processStep.completed).toBe(false);
+    expect(processStep.failed).toBe(true);
+    expect(processStep.error).toMatch(/at least 3 items/);
+    expect(context.memory.getValue(memoryKeys.step("process"))).toEqual({
+      error: processStep.error
+    });
+  });
 });
+
+/**
+ * A provider for fan-out tests: `answer` maps the item named in the prompt to
+ * the result its ephemeral step finishes with, or `null` to give up without
+ * calling `finish()` (which is how a step fails).
+ */
+function createFanOutProvider(answer: (item: string) => unknown) {
+  return {
+    provider: "mock",
+    hasToolSupport: async () => true,
+    generateMessages: async function* (args: any) {
+      const text = JSON.stringify(args?.messages ?? "");
+      const item = text.match(/handle (\w+)/)?.[1] ?? "unknown";
+      const result = answer(item);
+      if (result === null) {
+        yield { type: "chunk" as const, content: "Giving up", done: true };
+        return;
+      }
+      yield finishAction(result);
+    },
+    async *generateMessagesTraced(...args: any[]) {
+      yield* (this as any).generateMessages(...args);
+    },
+    generateLoop(args: unknown) {
+      return (
+        BaseProvider.prototype as { generateLoop: (a: unknown) => unknown }
+      ).generateLoop.call(this, args);
+    },
+    async generateMessageTraced(...args: any[]) {
+      return (this as any).generateMessage(...args);
+    },
+    generateMessage: vi.fn(),
+    getAvailableLanguageModels: vi.fn().mockResolvedValue([]),
+    getAvailableImageModels: vi.fn().mockResolvedValue([]),
+    getAvailableVideoModels: vi.fn().mockResolvedValue([]),
+    getAvailableTTSModels: vi.fn().mockResolvedValue([]),
+    getAvailableASRModels: vi.fn().mockResolvedValue([]),
+    getAvailableEmbeddingModels: vi.fn().mockResolvedValue([]),
+    getContainerEnv: () => ({}),
+    textToImage: vi.fn(),
+    imageToImage: vi.fn(),
+    textToSpeech: vi.fn(),
+    automaticSpeechRecognition: vi.fn(),
+    textToVideo: vi.fn(),
+    imageToVideo: vi.fn(),
+    generateEmbedding: vi.fn(),
+    isContextLengthError: () => false
+  } as any;
+}

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -397,6 +397,19 @@ export async function runAgentCommand(opts: RunOptions): Promise<number> {
   if (!opts.json) process.stderr.write(chalk.bold("\n— result —\n"));
   if (finalText) process.stdout.write(finalText + "\n");
 
+  // A run that ended on a tool call or a contentless assistant turn produced
+  // no answer. Writing nothing and exiting 0 is indistinguishable from an
+  // empty-but-successful result, so it fails instead (invariant I-3).
+  if (!errored && !finalText) {
+    const message =
+      "agent produced no answer: the turn ended without a final assistant message";
+    emit({ type: "error", message });
+    if (!opts.json) {
+      process.stderr.write(chalk.red(`\nagent failed: ${message}\n`));
+    }
+    return 1;
+  }
+
   return errored ? 1 : 0;
 }
 

--- a/packages/cli/tests/agent-command.test.ts
+++ b/packages/cli/tests/agent-command.test.ts
@@ -272,6 +272,26 @@ describe("nodetool agent run", () => {
     );
   });
 
+  it("fails the run when the turn produced no final assistant text", async () => {
+    // A turn that ends on a contentless assistant message: `processChat` drops
+    // it, so the transcript carries no answer at all.
+    const provider = new ScriptedProvider([() => []]);
+
+    const { code, stdout, events } = await runWithCapture(provider, {
+      objective: "list my workflows"
+    });
+
+    expect(code).toBe(1);
+    expect(stdout).toBe("");
+    expect(
+      events.some(
+        (e) =>
+          (e as { type?: string }).type === "error" &&
+          String((e as { message?: string }).message).includes("no answer")
+      )
+    ).toBe(true);
+  });
+
   it("reports a provider failure as an error event and exit code 1", async () => {
     const provider = new ScriptedProvider([
       () => {


### PR DESCRIPTION
## What changed

A5 asked for one thing: the deliverable a caller reads must not be declared and then never checked. Its literal target is gone — T-A3.3 deleted `agent.ts` and `compiler-agent.ts` before A5 shipped, which D7 anticipated. The first half of A5's acceptance is already met by the code that survived: every deliverable completes through `validateAgainstSchema`, from `StepExecutor.validateResultPayload` and the CodeAct `finish()` bridge, and a violation round-trips to the model bounded by `maxIterations`/`MAX_FINISH_NUDGES`/`MAX_REPAIR_ROUNDS`. The second half did not survive, so this ships it at the three seams that inherited the defect, each of which reported success for a result nobody produced.

| Seam | Was | Now |
|---|---|---|
| `task-executor.ts` process-mode fan-out | A failed item answers with `{error}` rather than a result, and that error object was stored as the item's output with the step marked completed — a partial fan-out reported as a whole one | An errored item is dropped, leaving an empty slot; an empty slot fails the step naming the indexes |
| same, with both schemas declared | `step.outputSchema` was applied to nothing, since the per-item executor used `perItemSchema` | The aggregate is validated against it through the same shared validator, not a second one |
| `capabilities/agents.ts` (`execute_plan`) | Read each task's answer from the `task:<id>` key and silently dropped it when absent, while still reporting `status: "completed"` — sending the model to an empty key and telling it nothing was wrong | Such a task returns `result_missing`, with a warning |
| `commands/agent.ts` (`nodetool agent run`) | Its single output is a transcript scrape; when the turn ended on a tool call it wrote nothing to stdout and exited 0 — the direct descendant of the `Agent.getResults()` null A5 wanted to throw on | Exits 1 naming the reason |

`agents.specs.ts` is untouched, so no capability contract fingerprint moves. §A5 of the plan, D7, and the sequencing line are rewritten to record the retarget, and the planner-eval section no longer credits final synthesis to the deleted Compiler.

## Verification

- [x] `npm run test:affected` — `All affected suites passed.` (exit 0)
- [x] `npm run typecheck` — 0 errors in `web`, `packages/agents`, `packages/cli`. The 448 remaining are all in `mobile/`, which is deliberately not a root workspace and has no dependency tree installed in this container.
- [x] `npm run lint` — exit 0
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — `Gate: 1/1 selfchecks passed`, `255/255 graphs validate cleanly` (`--base main` fails with `no merge base` on a shallow clone)

Full `packages/agents` suite: 238 files passed, 3732 tests passed.

An earlier `test:affected` run failed 14 tests in `@nodetool-ai/base-nodes` on `No WebGPU adapter available (Node/Dawn)`. That is the documented missing-driver gap, not this diff: after `apt-get install -y mesa-vulkan-drivers` the same two suites pass 14/14, and the re-run above is green.

### Inversions (I-8)

Each check was reverted and observed failing.

Fan-out missing-slot check disabled:

```
 × tests/task-executor.test.ts > fails a fan-out whose item produced no result instead of completing it
 × tests/parallel-task-executor.test.ts > treats an all-error fan-out array as a task failure
      Tests  2 failed | 20 passed (22)
```

Aggregate `outputSchema` check disabled:

```
 × tests/task-executor.test.ts > validates the aggregate against outputSchema when perItemSchema was used
      Tests  1 failed | 39 passed (40)
```

`execute_plan`, before the fix:

```
AssertionError: expected { id: 'draft', …(2) } to deeply equal { id: 'draft', …(3) }
-   "result_missing": true,
    "status": "completed",
 ❯ tests/capabilities-agents.test.ts:695
 Tests  1 failed | 25 passed (26)
```

CLI, before the fix:

```
 × fails the run when the turn produced no final assistant text
AssertionError: expected +0 to be 1
 ❯ tests/agent-command.test.ts:284
 Tests  1 failed | 5 passed (6)
```

A first inversion attempt patched the wrong `missing.length > 0` (an unrelated pre-existing one in `toolsForStep`) and left the suite green; the runs above target the fan-out checks themselves.

## Agent capabilities

No capability is added and no declared contract changes — `packages/agents/src/capabilities/agents.specs.ts` is unmodified, so `execute_plan`'s name, description, input schema and category are untouched. `result_missing` is a field of the returned value, not of the spec.

## New checks

- [x] Each of the four checks was inverted once and observed failing; the failing output is above
- [ ] n/a — none of these is a file-scanning audit that could pass by matching nothing

## One thing deliberately left out

`processChat` (`packages/chat/src/message-processor.ts:227-249`) drops the `ProviderStop` item, so a run cut short by the run budget or the deadline is invisible and exits 0 with whatever prose came last. That is I-3, and it belongs to A1's budget work rather than A5 — flagging it rather than widening this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DE7T9VLWXijpAg5uppDmBq