### PR TITLE
feat(timeline): honor the text style a clip already carries [T14]

### DIFF
--- a/packages/agents/tests/timeline-shape-frames.test.ts
+++ b/packages/agents/tests/timeline-shape-frames.test.ts
@@ -364,10 +364,25 @@ describe("RasterContext2D on @napi-rs/canvas (I6)", () => {
       "lineJoin",
       "lineCap",
       "textAlign",
-      "textBaseline"
+      "textBaseline",
+      "shadowColor",
+      "shadowBlur",
+      "shadowOffsetX",
+      "shadowOffsetY"
     ]) {
       expect(ctx[name], name).toBeDefined();
     }
+  });
+
+  it("has the letter spacing a text draw uses when it is there", () => {
+    // Optional on `RasterContext2D`, because a context without it is served by
+    // the hand-placed fallback. Skia has it, so the server takes the fast path
+    // and this records which one it is on.
+    const ctx = createCanvas(4, 4).getContext("2d") as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(typeof ctx.letterSpacing).toBe("string");
   });
 });
 

--- a/packages/agents/tests/timeline-text-frames.test.ts
+++ b/packages/agents/tests/timeline-text-frames.test.ts
@@ -1,0 +1,471 @@
+/**
+ * Text styling on the Canvas 2D path (F4's styling half, T14): slant, letter
+ * spacing, line height, vertical alignment, outline, shadow, scrim and
+ * gradient fill.
+ *
+ * `packages/timeline/tests/render.textStyle.test.ts` pins what the layout and
+ * the cache key decide. This reads the pixels `@napi-rs/canvas` actually
+ * produced, because a style that lays out correctly and then draws nothing — a
+ * shadow set after the glyph, a scrim behind an empty box, a gradient assigned
+ * to the wrong property — is exactly the failure a pure test cannot see.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createCanvas } from "@napi-rs/canvas";
+import { compileClipAnimations, type ClipTextStyle } from "@nodetool-ai/timeline";
+import {
+  drawStaggeredText,
+  drawText,
+  createStaggerScratch,
+  type RasterContext2D
+} from "@nodetool-ai/timeline/scene";
+
+const W = 400;
+const H = 300;
+
+interface Bounds {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  width: number;
+  height: number;
+  centerX: number;
+  centerY: number;
+}
+
+interface Pixels {
+  at(x: number, y: number): [number, number, number, number];
+  on(x: number, y: number): boolean;
+  /** Bounds of every pixel `keep` accepts, or null when it accepts none. */
+  bounds(keep: (rgba: [number, number, number, number]) => boolean): Bounds | null;
+}
+
+function readPixels(data: Uint8ClampedArray, width: number, height: number): Pixels {
+  const at = (x: number, y: number): [number, number, number, number] => {
+    const i = (Math.round(y) * width + Math.round(x)) * 4;
+    return [data[i]!, data[i + 1]!, data[i + 2]!, data[i + 3]!];
+  };
+  return {
+    at,
+    on: (x, y) => at(x, y)[3] > 24,
+    bounds(keep) {
+      let left = width;
+      let right = -1;
+      let top = height;
+      let bottom = -1;
+      for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+          if (!keep(at(x, y))) continue;
+          if (x < left) left = x;
+          if (x > right) right = x;
+          if (y < top) top = y;
+          if (y > bottom) bottom = y;
+        }
+      }
+      if (right < 0) return null;
+      return {
+        left,
+        right,
+        top,
+        bottom,
+        width: right - left + 1,
+        height: bottom - top + 1,
+        centerX: (left + right) / 2,
+        centerY: (top + bottom) / 2
+      };
+    }
+  };
+}
+
+/** Draw one style on a fresh surface and hand back its pixels. */
+function raster(style: ClipTextStyle, width = W, height = H): Pixels {
+  const canvas = createCanvas(width, height);
+  // SAFETY: `RasterContext2D` is the subset of the 2D canvas API `drawText`
+  // uses; the presence test in timeline-shape-frames.test.ts asserts a skia
+  // context provides all of it.
+  drawText(
+    canvas.getContext("2d") as unknown as RasterContext2D,
+    style,
+    width,
+    height
+  );
+  return readPixels(
+    canvas.getContext("2d").getImageData(0, 0, width, height).data,
+    width,
+    height
+  );
+}
+
+const INK = (rgba: [number, number, number, number]): boolean => rgba[3] > 24;
+/** Only the pixels that are mostly red — a scrim or a shadow drawn in red. */
+const RED = (rgba: [number, number, number, number]): boolean =>
+  rgba[3] > 24 && rgba[0] > 180 && rgba[1] < 80 && rgba[2] < 80;
+
+function title(over: Partial<ClipTextStyle> = {}): ClipTextStyle {
+  return { text: "HELLO", fontSizePx: 60, color: "#ffffff", ...over };
+}
+
+function inkBounds(style: ClipTextStyle): Bounds {
+  const found = raster(style).bounds(INK);
+  if (!found) throw new Error("nothing was drawn");
+  return found;
+}
+
+describe("drawText — outline", () => {
+  it("grows the silhouette by the stroke width, half on each side", () => {
+    const plain = inkBounds(title());
+    const stroked = inkBounds(
+      title({ stroke: { color: "#ffffff", widthPx: 12 } })
+    );
+    // A canvas centres a stroke on the glyph outline, so a 12px pen reaches
+    // 6px past the fill on each side — 12px wider and 12px taller overall.
+    expect(stroked.width - plain.width).toBeGreaterThanOrEqual(10);
+    expect(stroked.width - plain.width).toBeLessThanOrEqual(14);
+    expect(stroked.height - plain.height).toBeGreaterThanOrEqual(10);
+    expect(stroked.height - plain.height).toBeLessThanOrEqual(14);
+  });
+
+  it("scales with the width it is given", () => {
+    const thin = inkBounds(title({ stroke: { color: "#fff", widthPx: 4 } }));
+    const thick = inkBounds(title({ stroke: { color: "#fff", widthPx: 20 } }));
+    expect(thick.width - thin.width).toBeGreaterThanOrEqual(14);
+  });
+
+  it("draws the outline under the fill, not over it", () => {
+    // A red pen under a white fill leaves the glyph's interior white.
+    const pixels = raster(
+      title({ stroke: { color: "#ff0000", widthPx: 10 } })
+    );
+    const white = pixels.bounds(
+      (rgba) => rgba[3] > 24 && rgba[0] > 200 && rgba[1] > 200 && rgba[2] > 200
+    );
+    expect(white).not.toBeNull();
+    const red = pixels.bounds(RED);
+    expect(red).not.toBeNull();
+    // The pen's silhouette contains the fill's.
+    expect(red!.left).toBeLessThan(white!.left);
+    expect(red!.right).toBeGreaterThan(white!.right);
+  });
+
+  it("ignores a stroke with no width", () => {
+    expect(inkBounds(title({ stroke: { color: "#f00", widthPx: 0 } }))).toEqual(
+      inkBounds(title())
+    );
+  });
+});
+
+describe("drawText — shadow", () => {
+  it("casts the glyphs at the offset it is given", () => {
+    const plain = inkBounds(title());
+    const shadowed = raster(
+      title({
+        shadow: { color: "#ff0000", blurPx: 0, offsetX: 24, offsetY: 18 }
+      })
+    );
+    const cast = shadowed.bounds(RED);
+    expect(cast).not.toBeNull();
+    // A hard shadow is the same silhouette, moved.
+    expect(cast!.left - plain.left).toBeCloseTo(24, -0.5);
+    expect(cast!.top - plain.top).toBeCloseTo(18, -0.5);
+  });
+
+  it("spreads past the silhouette when it is blurred", () => {
+    const hard = raster(
+      title({ shadow: { color: "#ff0000", blurPx: 0, offsetX: 0, offsetY: 0 } })
+    ).bounds(INK)!;
+    const soft = raster(
+      title({ shadow: { color: "#ff0000", blurPx: 20, offsetX: 0, offsetY: 0 } })
+    ).bounds(INK)!;
+    expect(soft.width).toBeGreaterThan(hard.width);
+    expect(soft.height).toBeGreaterThan(hard.height);
+  });
+
+  it("casts one shadow, from the outline, when the title is stroked", () => {
+    // The pen is the outer edge; a second cast from the fill would darken the
+    // silhouette twice and read as a heavier shadow than was asked for.
+    const canvas = createCanvas(W, H);
+    const ctx = canvas.getContext("2d") as unknown as RasterContext2D;
+    drawText(
+      ctx,
+      title({
+        color: "#ffffff",
+        stroke: { color: "#ffffff", widthPx: 8 },
+        shadow: { color: "#7f0000", blurPx: 0, offsetX: 40, offsetY: 0 }
+      }),
+      W,
+      H
+    );
+    const pixels = readPixels(
+      canvas.getContext("2d").getImageData(0, 0, W, H).data,
+      W,
+      H
+    );
+    // Clear of the glyphs, the cast is exactly the colour asked for — a second
+    // opaque pass over the same pixels would still read 0x7f, so probe the
+    // channel that stacking would raise instead.
+    const cast = pixels.bounds(
+      (rgba) => rgba[3] > 200 && rgba[0] > 100 && rgba[0] < 160 && rgba[1] < 40
+    );
+    expect(cast).not.toBeNull();
+    expect(pixels.at(cast!.right - 2, cast!.centerY)[0]).toBeLessThan(160);
+  });
+});
+
+describe("drawText — background", () => {
+  const scrim = (paddingPx: number, radiusPx?: number): Bounds => {
+    const found = raster(
+      title({ background: { color: "#ff0000", paddingPx, radiusPx } })
+    ).bounds(RED);
+    if (!found) throw new Error("no scrim was drawn");
+    return found;
+  };
+
+  it("sits behind the wrapped block, one line height tall plus padding", () => {
+    // 60px text at the default 1.2 line height is a 72px box; 20px of padding
+    // on each side makes 112.
+    expect(scrim(20).height).toBeCloseTo(112, -0.5);
+    expect(scrim(20).centerX).toBeCloseTo(W / 2, -0.5);
+    expect(scrim(20).centerY).toBeCloseTo(H / 2, -0.5);
+  });
+
+  it("grows by twice the padding in each direction", () => {
+    const small = scrim(10);
+    const large = scrim(30);
+    expect(large.width - small.width).toBeCloseTo(40, -0.5);
+    expect(large.height - small.height).toBeCloseTo(40, -0.5);
+  });
+
+  it("is wider than the text it sits behind", () => {
+    const text = inkBounds(title());
+    const box = scrim(20);
+    expect(box.left).toBeLessThan(text.left);
+    expect(box.right).toBeGreaterThan(text.right);
+    expect(box.top).toBeLessThan(text.top);
+    expect(box.bottom).toBeGreaterThan(text.bottom);
+  });
+
+  it("rounds its corners when a radius is set", () => {
+    const square = scrim(20);
+    const rounded = scrim(20, 40);
+    // Same box, but the corner pixel is gone.
+    expect(rounded.width).toBeCloseTo(square.width, -0.5);
+    const pixels = raster(
+      title({ background: { color: "#ff0000", paddingPx: 20, radiusPx: 40 } })
+    );
+    expect(pixels.on(square.left + 1, square.top + 1)).toBe(false);
+    expect(pixels.on(square.left + 1, square.centerY)).toBe(true);
+  });
+
+  it("draws no scrim behind an empty title", () => {
+    // The block collapses to a point, so a full-frame red wash would be the
+    // bug here rather than a missing box.
+    const pixels = raster(
+      title({ text: "", background: { color: "#ff0000", paddingPx: 20 } })
+    );
+    expect(pixels.on(W / 2, H / 2)).toBe(false);
+  });
+});
+
+describe("drawText — vertical alignment", () => {
+  it("sits the block against the top edge", () => {
+    const top = inkBounds(title({ verticalAlign: "top" }));
+    expect(top.centerY).toBeLessThan(H / 4);
+    expect(top.top).toBeGreaterThanOrEqual(0);
+  });
+
+  it("centres it by default and drops it to the bottom on request", () => {
+    expect(inkBounds(title()).centerY).toBeCloseTo(H / 2, -1);
+    expect(inkBounds(title({ verticalAlign: "middle" })).centerY).toBeCloseTo(
+      H / 2,
+      -1
+    );
+    expect(
+      inkBounds(title({ verticalAlign: "bottom" })).centerY
+    ).toBeGreaterThan((H * 3) / 4);
+  });
+
+  it("keeps the block's own height, whichever edge it is against", () => {
+    const heights = ["top", "middle", "bottom"].map(
+      (verticalAlign) => inkBounds(title({ verticalAlign })).height
+    );
+    expect(heights[1]).toBe(heights[0]);
+    expect(heights[2]).toBe(heights[0]);
+  });
+
+  it("reads an unknown alignment as the default", () => {
+    expect(inkBounds(title({ verticalAlign: "sideways" })).centerY).toBe(
+      inkBounds(title()).centerY
+    );
+  });
+});
+
+describe("drawText — spacing and line height", () => {
+  it("pushes the glyphs apart by the letter spacing", () => {
+    const plain = inkBounds(title());
+    const spaced = inkBounds(title({ letterSpacingPx: 12 }));
+    // Five glyphs: four gaps of ink between the first and the last.
+    expect(spaced.width - plain.width).toBeCloseTo(48, -0.7);
+  });
+
+  it("stacks wrapped lines by the line height", () => {
+    const twoLines = title({ text: "ONE\nTWO" });
+    const tight = inkBounds({ ...twoLines, lineHeight: 1 });
+    const loose = inkBounds({ ...twoLines, lineHeight: 2 });
+    expect(loose.height - tight.height).toBeCloseTo(60, -0.7);
+  });
+
+  it("slants the glyphs when the style asks for italic", () => {
+    const upright = raster(title({ fontFamily: "Arial" }));
+    const italic = raster(title({ fontFamily: "Arial", fontStyle: "italic" }));
+    const differs = (): boolean => {
+      for (let y = 0; y < H; y += 3) {
+        for (let x = 0; x < W; x += 3) {
+          if (upright.on(x, y) !== italic.on(x, y)) return true;
+        }
+      }
+      return false;
+    };
+    expect(differs()).toBe(true);
+  });
+});
+
+describe("drawText — gradient fill", () => {
+  const gradient = title({
+    text: "AB",
+    fontSizePx: 90,
+    fill: {
+      type: "linear",
+      angle: 0,
+      stops: [
+        { offset: 0, color: "#ff0000" },
+        { offset: 1, color: "#0000ff" }
+      ]
+    }
+  });
+
+  it("spans the text block rather than the raster", () => {
+    const pixels = raster(gradient);
+    const box = pixels.bounds(INK)!;
+    const sample = (x: number): [number, number, number, number] => {
+      for (let y = box.top; y <= box.bottom; y++) {
+        const rgba = pixels.at(x, y);
+        if (rgba[3] > 200) return rgba;
+      }
+      throw new Error(`no opaque ink in column ${x}`);
+    };
+    // The block is ~150px wide on a 400px raster. Measured against the raster
+    // the whole word would sit in the middle of the ramp and read purple;
+    // measured against the block it runs end to end.
+    const left = sample(box.left + 3);
+    const right = sample(box.right - 3);
+    expect(left[0]).toBeGreaterThan(200);
+    expect(left[2]).toBeLessThan(60);
+    expect(right[2]).toBeGreaterThan(200);
+    expect(right[0]).toBeLessThan(60);
+  });
+
+  it("wins over the plain colour", () => {
+    const pixels = raster({
+      ...gradient,
+      color: "#00ff00",
+      fill: { type: "solid", color: "#ff0000" }
+    });
+    const box = pixels.bounds(INK)!;
+    expect(pixels.bounds(RED)).not.toBeNull();
+    expect(
+      pixels.bounds(
+        (rgba) => rgba[3] > 200 && rgba[1] > 200 && rgba[0] < 60
+      )
+    ).toBeNull();
+    expect(box.width).toBeGreaterThan(0);
+  });
+});
+
+describe("drawStaggeredText — the same style", () => {
+  /** Every unit fully in, so the frame is the finished title. */
+  function staggered(style: ClipTextStyle): Pixels {
+    const compiled = compileClipAnimations(
+      [
+        {
+          id: "a1",
+          role: "in",
+          preset: "fade",
+          durationMs: 200,
+          easing: "linear",
+          stagger: { unit: "character", offsetMs: 20 }
+        }
+      ],
+      5000,
+      { width: W, height: H },
+      { staggerCount: 5, staggerUnit: "character" }
+    );
+    const canvas = createCanvas(W, H);
+    drawStaggeredText(
+      canvas.getContext("2d") as unknown as RasterContext2D,
+      style,
+      W,
+      H,
+      { compiled, localMs: 2000 },
+      createStaggerScratch()
+    );
+    return readPixels(
+      canvas.getContext("2d").getImageData(0, 0, W, H).data,
+      W,
+      H
+    );
+  }
+
+  it("draws the scrim once behind the block, not once per glyph", () => {
+    const style = title({
+      background: { color: "#ff0000", paddingPx: 20 }
+    });
+    const box = staggered(style).bounds(RED);
+    const plain = raster(style).bounds(RED)!;
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeCloseTo(plain.width, -1);
+    expect(box!.height).toBeCloseTo(plain.height, -0.5);
+  });
+
+  it("outlines and shadows every unit the way the plain draw does", () => {
+    const pixels = staggered(
+      title({
+        stroke: { color: "#ffffff", widthPx: 12 },
+        shadow: { color: "#ff0000", blurPx: 0, offsetX: 24, offsetY: 18 }
+      })
+    );
+    const cast = pixels.bounds(RED);
+    expect(cast).not.toBeNull();
+    const glyphs = raster(title({ stroke: { color: "#ffffff", widthPx: 12 } }));
+    expect(cast!.left - glyphs.bounds(INK)!.left).toBeCloseTo(24, -1);
+  });
+
+  it("runs one gradient across the block, not one per glyph", () => {
+    const pixels = staggered(
+      title({
+        text: "AB",
+        fontSizePx: 90,
+        fill: {
+          type: "linear",
+          angle: 0,
+          stops: [
+            { offset: 0, color: "#ff0000" },
+            { offset: 1, color: "#0000ff" }
+          ]
+        }
+      })
+    );
+    const box = pixels.bounds(INK)!;
+    const sample = (x: number): [number, number, number, number] => {
+      for (let y = box.top; y <= box.bottom; y++) {
+        const rgba = pixels.at(x, y);
+        if (rgba[3] > 200) return rgba;
+      }
+      throw new Error(`no opaque ink in column ${x}`);
+    };
+    // Per-glyph gradients would restart, so the second glyph's left edge would
+    // be red again instead of continuing towards blue.
+    expect(sample(box.left + 3)[0]).toBeGreaterThan(200);
+    expect(sample(box.right - 3)[2]).toBeGreaterThan(200);
+  });
+});

--- a/packages/timeline/AGENTS.md
+++ b/packages/timeline/AGENTS.md
@@ -80,6 +80,17 @@
   in surface pixels, arcs included as cubics. Trim, dashes and gradients then
   apply to a rect, an ellipse, a star and an authored `d` the same way — and a
   trimmed ellipse has an arc length to walk, which `ctx.ellipse` would not.
+- **One text layout serves the plain draw, the stagger and the scrim**
+  (`layoutTextBlock` in `render/textLayout.ts`). Wrapping, line height,
+  alignment and letter spacing are decided once, and the block box it returns
+  is what a `background` sits behind and what a gradient `fill` is measured
+  against — the text, not the raster. A draw that computes its own wrap puts a
+  staggered title somewhere its un-staggered self is not.
+- **A raster cache key names every field of the style it caches.** A host hands
+  back the bitmap a key hits, so a field `textStyleSignature` does not read
+  renders as the frame drawn before that field changed. The check is the
+  `Object.keys` enumeration in `tests/render.textStyle.test.ts`, which walks the
+  document schema, so a field added under I1 fails there until the key reads it.
 - **A rasterized layer's pixels can depend on its animation sample.** A shape's
   `trimStart`/`trimEnd` change the outline, so every host rasterizes
   `AnimatedLayerProps.shapeStyle`, not the clip's own; a host that reaches for

--- a/packages/timeline/src/render/draw.ts
+++ b/packages/timeline/src/render/draw.ts
@@ -28,15 +28,20 @@ import { parseSvgPath, tracePath, type PathSegment } from "./svgPath.js";
 import {
   buildShapeSegments,
   flattenSegments,
+  roundedRectSegments,
   shapeBox,
   shapeUnitScale,
   trimFlatPath
 } from "./shapeGeometry.js";
 import {
   layoutStaggerUnits,
+  layoutTextBlock,
+  segmentGraphemes,
   textFontSpec,
-  textMaxWidthPx,
-  wrapTextLines
+  textLetterSpacingPx,
+  type TextBlockBox,
+  type TextBlockLayout,
+  type TextStaggerUnit
 } from "./textLayout.js";
 
 /**
@@ -132,6 +137,17 @@ export interface RasterContext2D extends MaskContext2D {
   textAlign: string;
   textBaseline: string;
   globalAlpha: number;
+  shadowColor: string;
+  shadowBlur: number;
+  shadowOffsetX: number;
+  shadowOffsetY: number;
+  /**
+   * Advance added after each glyph, as a CSS length. Optional because it is
+   * the one member here that is not universal: Chromium's canvas and
+   * `@napi-rs/canvas` both have it, an older or minimal context may not, and
+   * a text draw places the glyphs itself when it is missing.
+   */
+  letterSpacing?: string;
   measureText(text: string): { width: number };
   fillText(text: string, x: number, y: number): void;
   strokeText(text: string, x: number, y: number): void;
@@ -264,45 +280,252 @@ export function measureTextWith(ctx: RasterContext2D): MeasureTextWidth {
 
 // ── Text clips ───────────────────────────────────────────────────────────────
 
-/** Content signature of a text raster, for host-side caching. */
+/**
+ * Content signature of a text raster, for host-side caching.
+ *
+ * Every field of {@link ClipTextStyle} is in it. A key over a subset is worse
+ * than no cache at all: change a stroke width, a shadow offset or a background
+ * colour and the host hands back the bitmap drawn before the change. Nested
+ * objects are written field by field in a fixed order, so two equal styles key
+ * the same however they were built.
+ */
 export function textStyleSignature(
   style: ClipTextStyle,
   width: number,
   height: number
 ): string {
-  return `${width}x${height}|${style.text}|${style.fontFamily ?? "Inter"}|${style.fontSizePx}|${style.fontWeight ?? 400}|${style.color}|${style.align ?? "center"}|${style.maxWidthFrac ?? 0.8}`;
+  return [
+    `${width}x${height}`,
+    style.text,
+    style.fontFamily ?? "Inter",
+    style.fontSizePx,
+    style.fontWeight ?? 400,
+    style.color,
+    style.align ?? "center",
+    style.maxWidthFrac ?? 0.8,
+    style.fontStyle ?? "normal",
+    style.letterSpacingPx ?? 0,
+    style.lineHeight ?? 1.2,
+    style.verticalAlign ?? "middle",
+    style.stroke ? `${style.stroke.color}@${style.stroke.widthPx}` : "-",
+    style.shadow
+      ? `${style.shadow.color}@${style.shadow.blurPx}/${style.shadow.offsetX}/${style.shadow.offsetY}`
+      : "-",
+    style.background
+      ? `${style.background.color}@${style.background.paddingPx}/${style.background.radiusPx ?? 0}`
+      : "-",
+    fillSignature(style.fill)
+  ].join("|");
 }
 
-/** Draw a text style as one block: wrapped lines, centered on the raster. */
+/** A fill's own signature, stops included. */
+function fillSignature(fill: ShapeFill | undefined): string {
+  if (!fill) return "-";
+  if (fill.type === "solid") return `solid:${fill.color}`;
+  const stops = fill.stops
+    .map((stop) => `${stop.offset}:${stop.color}`)
+    .join(",");
+  return fill.type === "linear"
+    ? `linear:${fill.angle}:${stops}`
+    : `radial:${stops}`;
+}
+
+/**
+ * How one run of text is painted: the resolved fill, the outline drawn under
+ * it, the shadow both cast, and how the glyphs are advanced.
+ *
+ * Resolved once per draw and reused for every line or unit, so a gradient
+ * spans the whole block rather than restarting on each line, and a staggered
+ * title is painted exactly like its un-staggered self.
+ */
+interface TextPaint {
+  fill: CanvasPaint;
+  stroke: { color: string; widthPx: number } | null;
+  shadow: { color: string; blurPx: number; offsetX: number; offsetY: number } | null;
+  letterSpacingPx: number;
+  /** True when the context advances the glyphs itself. */
+  nativeSpacing: boolean;
+  /** Unspaced advance, for placing the glyphs by hand. */
+  measure: (text: string) => number;
+}
+
+/**
+ * Set the context's own letter spacing where it has one, and report whether it
+ * took. Both shipping contexts have it and both charge the advance after every
+ * glyph, trailing one included — which is what the layout charges too, so the
+ * hand-placed fallback lands the glyphs in the same places.
+ */
+function setLetterSpacing(ctx: RasterContext2D, px: number): boolean {
+  if (typeof ctx.letterSpacing !== "string") return false;
+  ctx.letterSpacing = `${px}px`;
+  return true;
+}
+
+/** Leave no shadow in force — the state a fresh context starts in. */
+function clearShadow(ctx: RasterContext2D): void {
+  ctx.shadowColor = "rgba(0, 0, 0, 0)";
+  ctx.shadowBlur = 0;
+  ctx.shadowOffsetX = 0;
+  ctx.shadowOffsetY = 0;
+}
+
+/**
+ * Measure and place `style`, leaving the context ready to paint text: the font
+ * set, the glyphs positioned from their left edge and their vertical center.
+ *
+ * Measurement runs with native letter spacing off so a context that has the
+ * property reports the same advances as one that does not; the spacing is
+ * charged by the layout and switched on afterwards, for the draw.
+ */
+function prepareText(
+  ctx: RasterContext2D,
+  style: ClipTextStyle,
+  width: number,
+  height: number,
+  staggerUnit?: StaggerUnit
+): { layout: TextBlockLayout; units: TextStaggerUnit[]; paint: TextPaint } {
+  ctx.font = textFontSpec(style);
+  clearShadow(ctx);
+  setLetterSpacing(ctx, 0);
+  const measure = (text: string): number => ctx.measureText(text).width;
+  const layout = layoutTextBlock(measure, style, width, height);
+  const units = staggerUnit
+    ? layoutStaggerUnits(measure, style, width, height, staggerUnit)
+    : [];
+
+  ctx.textAlign = "left";
+  ctx.textBaseline = "middle";
+  drawTextBackground(ctx, style, layout.box);
+
+  const letterSpacingPx = textLetterSpacingPx(style);
+  const nativeSpacing = setLetterSpacing(ctx, letterSpacingPx);
+  return {
+    layout,
+    units,
+    paint: {
+      fill: style.fill
+        ? resolveShapeFill(ctx, style.fill, layout.box)
+        : style.color,
+      stroke:
+        style.stroke && style.stroke.widthPx > 0 ? { ...style.stroke } : null,
+      shadow: style.shadow ? { ...style.shadow } : null,
+      letterSpacingPx,
+      nativeSpacing,
+      measure
+    }
+  };
+}
+
+/** The scrim behind the wrapped block: a rounded rect grown by the padding. */
+function drawTextBackground(
+  ctx: RasterContext2D,
+  style: ClipTextStyle,
+  box: TextBlockBox
+): void {
+  const background = style.background;
+  if (!background) return;
+  // A scrim backs text. With nothing to back — an empty title, whose block
+  // collapses to a point — the padding alone would draw a bare pill.
+  if (box.width <= 0) return;
+  const pad = Math.max(0, background.paddingPx);
+  const width = box.width + pad * 2;
+  const height = box.height + pad * 2;
+  if (height <= 0) return;
+  ctx.fillStyle = background.color;
+  ctx.beginPath();
+  tracePath(
+    ctx,
+    roundedRectSegments(
+      box.x - pad,
+      box.y - pad,
+      width,
+      height,
+      Math.max(0, background.radiusPx ?? 0)
+    ),
+    UNSCALED
+  );
+  ctx.fill();
+}
+
+/**
+ * Paint one run at its left edge: shadow, then outline, then fill.
+ *
+ * The outline is drawn first so the fill sits inside it rather than being eaten
+ * by it, and it is the outline that casts the shadow — a second cast from the
+ * fill would darken the whole silhouette twice.
+ */
+function paintTextRun(
+  ctx: RasterContext2D,
+  paint: TextPaint,
+  text: string,
+  x: number,
+  y: number
+): void {
+  if (text === "") return;
+  if (paint.shadow) {
+    ctx.shadowColor = paint.shadow.color;
+    ctx.shadowBlur = Math.max(0, paint.shadow.blurPx);
+    ctx.shadowOffsetX = paint.shadow.offsetX;
+    ctx.shadowOffsetY = paint.shadow.offsetY;
+  }
+  if (paint.stroke) {
+    ctx.strokeStyle = paint.stroke.color;
+    ctx.lineWidth = paint.stroke.widthPx;
+    ctx.lineJoin = "round";
+    advanceRun(ctx, paint, text, x, y, "stroke");
+    if (paint.shadow) clearShadow(ctx);
+  }
+  ctx.fillStyle = paint.fill;
+  advanceRun(ctx, paint, text, x, y, "fill");
+  if (paint.shadow) clearShadow(ctx);
+}
+
+/**
+ * Issue a run as one call, or — when the context has no letter spacing of its
+ * own — as one call per grapheme placed at its unspaced prefix width plus the
+ * spacing accumulated before it, so the glyphs sit where the shaped word would
+ * have put them and only the pair kerning is lost.
+ */
+function advanceRun(
+  ctx: RasterContext2D,
+  paint: TextPaint,
+  text: string,
+  x: number,
+  y: number,
+  mode: "fill" | "stroke"
+): void {
+  if (paint.letterSpacingPx === 0 || paint.nativeSpacing) {
+    if (mode === "stroke") ctx.strokeText(text, x, y);
+    else ctx.fillText(text, x, y);
+    return;
+  }
+  let prefix = "";
+  let index = 0;
+  for (const grapheme of segmentGraphemes(text)) {
+    const at = x + paint.measure(prefix) + paint.letterSpacingPx * index;
+    if (mode === "stroke") ctx.strokeText(grapheme, at, y);
+    else ctx.fillText(grapheme, at, y);
+    prefix += grapheme;
+    index += 1;
+  }
+}
+
+/**
+ * Draw a text style as one block: a scrim, then the wrapped lines, placed on
+ * the raster by `align` and `verticalAlign`.
+ */
 export function drawText(
   ctx: RasterContext2D,
   style: ClipTextStyle,
   width: number,
   height: number
 ): void {
-  const fontSize = Math.max(1, style.fontSizePx);
-  const align = style.align ?? "center";
-  const maxWidth = textMaxWidthPx(style, width);
-
-  ctx.font = textFontSpec(style);
-  const lines = wrapTextLines(style.text, maxWidth, (text) =>
-    ctx.measureText(text).width
-  );
-
-  const lineHeight = fontSize * 1.2;
-  const firstBaseline = height / 2 - ((lines.length - 1) * lineHeight) / 2;
-  ctx.fillStyle = style.color;
-  ctx.textAlign = align;
-  ctx.textBaseline = "middle";
-  const x =
-    align === "left"
-      ? (width - maxWidth) / 2
-      : align === "right"
-        ? (width + maxWidth) / 2
-        : width / 2;
-  lines.forEach((entry, index) =>
-    ctx.fillText(entry.text, x, firstBaseline + index * lineHeight)
-  );
+  ctx.save();
+  const { layout, paint } = prepareText(ctx, style, width, height);
+  for (const line of layout.lines) {
+    paintTextRun(ctx, paint, line.text, line.x, line.y);
+  }
+  ctx.restore();
 }
 
 /**
@@ -345,6 +568,12 @@ function staggerLayout(
  * applies those to the whole layer, which is why the sampler classifies them
  * as block-level (`ANIMATED_PROPERTY_PASS`) and folds them over the full span
  * instead of dropping them.
+ *
+ * Styling is the whole style, resolved once and reused for every unit: the
+ * scrim sits behind the block rather than behind each glyph, and a gradient
+ * fill spans the block rather than restarting on every unit — so a staggered
+ * title and its un-staggered self are the same picture once the animation has
+ * played out.
  */
 export function drawStaggeredText(
   ctx: RasterContext2D,
@@ -359,17 +588,19 @@ export function drawStaggeredText(
     drawText(ctx, style, width, height);
     return;
   }
-  ctx.font = textFontSpec(style);
-  const units = layoutStaggerUnits(
-    (text) => ctx.measureText(text).width,
+  ctx.save();
+  const { layout: block, units, paint } = prepareText(
+    ctx,
     style,
     width,
     height,
     layout.unit
   );
-  ctx.fillStyle = style.color;
-  ctx.textAlign = "left";
-  ctx.textBaseline = "middle";
+  // A gradient is issued in whatever coordinate system is in force when it is
+  // painted, so one resolved against the raster would ride along with each
+  // unit's transform and every glyph would show the same slice of the ramp.
+  const movingFill =
+    style.fill && style.fill.type !== "solid" ? style.fill : null;
 
   units.forEach((unit, index) => {
     // A whitespace unit takes its index — the units after it are timed as if
@@ -404,13 +635,27 @@ export function drawStaggeredText(
     if (s.rotation !== 0) ctx.rotate(s.rotation);
     if (scaleX !== 1 || scaleY !== 1) ctx.scale(scaleX, scaleY);
     ctx.globalAlpha = s.opacity;
-    ctx.fillText(
+    if (movingFill) {
+      // The block box in this unit's own space. Rotation is deliberately not
+      // undone: the ramp turns with the glyph, which is what a rotated letter
+      // carrying a gradient should look like.
+      paint.fill = resolveShapeFill(ctx, movingFill, {
+        x: (block.box.x - pivotX) / scaleX,
+        y: (block.box.y - pivotY) / scaleY,
+        width: block.box.width / scaleX,
+        height: block.box.height / scaleY
+      });
+    }
+    paintTextRun(
+      ctx,
+      paint,
       unit.text,
       -unit.width * anchorX,
       -(anchorY - 0.5) * unit.height
     );
     ctx.restore();
   });
+  ctx.restore();
 }
 
 /**

--- a/packages/timeline/src/render/shapeGeometry.ts
+++ b/packages/timeline/src/render/shapeGeometry.ts
@@ -255,6 +255,29 @@ function starPoints(
 }
 
 /**
+ * A rounded rectangle's outline in surface pixels — the scrim behind a title,
+ * and the same corner construction a rect shape clip draws with, so the two
+ * round identically. The radius is clamped to half the shorter side.
+ */
+export function roundedRectSegments(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number
+): PathSegment[] {
+  return polygonSegments(
+    [
+      { x, y },
+      { x: x + width, y },
+      { x: x + width, y: y + height },
+      { x, y: y + height }
+    ],
+    Math.max(0, Math.min(radius, width / 2, height / 2))
+  );
+}
+
+/**
  * A closed polygon through `points`, with each corner rounded to `radius`.
  *
  * A corner is the circular arc tangent to both edges, emitted as one cubic. The

--- a/packages/timeline/src/render/textLayout.ts
+++ b/packages/timeline/src/render/textLayout.ts
@@ -39,11 +39,48 @@ export interface RenderCanvas {
   measureText?: MeasureTextWidth;
 }
 
+/**
+ * The slants the `font` shorthand accepts. An unknown `fontStyle` is dropped
+ * rather than emitted: the shorthand is parsed as a whole, so one unreadable
+ * token would make a context ignore the assignment and keep whatever font it
+ * last had — a wrong picture instead of an unstyled one (I2).
+ */
+const FONT_SLANTS = new Set(["italic", "oblique"]);
+
 /** The `ctx.font` shorthand a text style renders with. */
 export function textFontSpec(style: ClipTextStyle): string {
   const fontSize = Math.max(1, style.fontSizePx);
   const family = style.fontFamily ?? "Inter, Arial, sans-serif";
-  return `${style.fontWeight ?? 400} ${fontSize}px ${family}`;
+  const slant = FONT_SLANTS.has(style.fontStyle ?? "")
+    ? `${style.fontStyle} `
+    : "";
+  return `${slant}${style.fontWeight ?? 400} ${fontSize}px ${family}`;
+}
+
+/** Line advance in px: the `lineHeight` multiple of the font size, default 1.2. */
+export function textLineHeightPx(style: ClipTextStyle): number {
+  const fontSize = Math.max(1, style.fontSizePx);
+  const multiple = style.lineHeight;
+  return fontSize * (multiple !== undefined && multiple > 0 ? multiple : 1.2);
+}
+
+/** Extra advance after each grapheme, in canvas px. */
+export function textLetterSpacingPx(style: ClipTextStyle): number {
+  const spacing = style.letterSpacingPx ?? 0;
+  return Number.isFinite(spacing) ? spacing : 0;
+}
+
+/**
+ * A width function that charges `spacingPx` for every grapheme, the way a
+ * canvas with `letterSpacing` set reports its own advances — trailing space
+ * included, so a spaced line is as wide as it draws.
+ */
+function spacedMeasure(
+  measure: (text: string) => number,
+  spacingPx: number
+): (text: string) => number {
+  if (spacingPx === 0) return measure;
+  return (text) => measure(text) + spacingPx * segmentGraphemes(text).length;
 }
 
 /** The px the text wraps within, from `maxWidthFrac` of the canvas. */
@@ -149,7 +186,9 @@ export function countTextStaggerUnits(
 /**
  * A width function for `style`, or one that reports zero when the canvas
  * carries no measurer — under which nothing ever exceeds the wrap width, so
- * `wrapTextLines` returns one line per authored paragraph.
+ * `wrapTextLines` returns one line per authored paragraph. Letter spacing is
+ * charged only on the measuring branch: adding it to the zero fallback would
+ * wrap a title the rasterizer could not measure.
  */
 function measurerFor(
   style: ClipTextStyle,
@@ -158,7 +197,136 @@ function measurerFor(
   const measure = canvas.measureText;
   if (!measure) return () => 0;
   const font = textFontSpec(style);
-  return (text) => measure(text, font);
+  return spacedMeasure(
+    (text) => measure(text, font),
+    textLetterSpacingPx(style)
+  );
+}
+
+/** One wrapped line placed on the raster, in canvas px. */
+export interface LaidOutTextLine {
+  text: string;
+  words: string[];
+  /** Advance width of each word, letter spacing included. */
+  wordWidths: number[];
+  /** Left edge. */
+  x: number;
+  width: number;
+  /** Vertical center of the line box (textBaseline "middle"). */
+  y: number;
+}
+
+/** A box on the raster, in canvas px. */
+export interface TextBlockBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Everything a draw needs about a wrapped text block. */
+export interface TextBlockLayout {
+  lines: LaidOutTextLine[];
+  lineHeight: number;
+  /** Advance of one space, letter spacing included. */
+  spaceWidth: number;
+  letterSpacingPx: number;
+  /**
+   * The union of the line boxes: what a background scrim sits behind and what
+   * a gradient fill is measured against — the text, not the raster.
+   */
+  box: TextBlockBox;
+}
+
+/**
+ * Vertical center of the first line. `verticalAlign` moves the whole block
+ * within the raster, which covers the frame, so `"top"` sits the first line
+ * against the top edge and `"bottom"` the last against the bottom. An unknown
+ * value reads as `"middle"` (I2).
+ */
+function firstLineCenterY(
+  style: ClipTextStyle,
+  lineCount: number,
+  height: number,
+  lineHeight: number
+): number {
+  const align = style.verticalAlign ?? "middle";
+  const block = lineCount * lineHeight;
+  if (align === "top") return lineHeight / 2;
+  if (align === "bottom") return height - block + lineHeight / 2;
+  return height / 2 - block / 2 + lineHeight / 2;
+}
+
+/**
+ * Wrap `style.text` and place every line on the raster. The one layout the
+ * plain draw, the staggered draw and the background scrim all read, so a
+ * staggered title breaks and sits exactly where its un-staggered self does.
+ *
+ * `measure` reports unspaced advances; `letterSpacingPx` is charged here, so a
+ * host measuring through a context that applies spacing of its own must ask it
+ * with spacing off.
+ */
+export function layoutTextBlock(
+  measure: (text: string) => number,
+  style: ClipTextStyle,
+  width: number,
+  height: number
+): TextBlockLayout {
+  const letterSpacingPx = textLetterSpacingPx(style);
+  const advance = spacedMeasure(measure, letterSpacingPx);
+  const align = style.align ?? "center";
+  const maxWidth = textMaxWidthPx(style, width);
+  const wrapped = wrapTextLines(style.text, maxWidth, advance);
+  const spaceWidth = advance(" ");
+  const lineHeight = textLineHeightPx(style);
+  const firstY = firstLineCenterY(style, wrapped.length, height, lineHeight);
+
+  const lines: LaidOutTextLine[] = wrapped.map((line, index) => {
+    const wordWidths = line.words.map((word) => advance(word));
+    const lineWidth =
+      wordWidths.reduce((sum, w) => sum + w, 0) +
+      spaceWidth * Math.max(0, line.words.length - 1);
+    const x =
+      align === "left"
+        ? (width - maxWidth) / 2
+        : align === "right"
+          ? (width + maxWidth) / 2 - lineWidth
+          : (width - lineWidth) / 2;
+    return {
+      text: line.text,
+      words: line.words,
+      wordWidths,
+      x,
+      width: lineWidth,
+      y: firstY + index * lineHeight
+    };
+  });
+
+  let left = Number.POSITIVE_INFINITY;
+  let right = Number.NEGATIVE_INFINITY;
+  for (const line of lines) {
+    if (line.width <= 0) continue;
+    left = Math.min(left, line.x);
+    right = Math.max(right, line.x + line.width);
+  }
+  // An empty title has no ink, so its block collapses to a point rather than
+  // spanning the raster — a scrim behind nothing would otherwise be full-frame.
+  if (right <= left) {
+    left = width / 2;
+    right = width / 2;
+  }
+  return {
+    lines,
+    lineHeight,
+    spaceWidth,
+    letterSpacingPx,
+    box: {
+      x: left,
+      y: firstY - lineHeight / 2,
+      width: right - left,
+      height: lines.length * lineHeight
+    }
+  };
 }
 
 /**
@@ -195,62 +363,43 @@ export function layoutStaggerUnits(
   height: number,
   unit: StaggerUnit
 ): TextStaggerUnit[] {
-  const fontSize = Math.max(1, style.fontSizePx);
-  const align = style.align ?? "center";
-  const maxWidth = textMaxWidthPx(style, width);
-  const lines = wrapTextLines(style.text, maxWidth, measure);
-  const spaceWidth = measure(" ");
-  const lineHeight = fontSize * 1.2;
-  const firstY = height / 2 - ((lines.length - 1) * lineHeight) / 2;
+  const layout = layoutTextBlock(measure, style, width, height);
+  const { lineHeight, spaceWidth, letterSpacingPx } = layout;
   const out: TextStaggerUnit[] = [];
 
-  lines.forEach((line, lineIndex) => {
-    const widths = line.words.map((word) => measure(word));
-    const lineWidth =
-      widths.reduce((sum, w) => sum + w, 0) +
-      spaceWidth * Math.max(0, line.words.length - 1);
-    const lineX =
-      align === "left"
-        ? (width - maxWidth) / 2
-        : align === "right"
-          ? (width + maxWidth) / 2 - lineWidth
-          : (width - lineWidth) / 2;
-    const y = firstY + lineIndex * lineHeight;
-
+  for (const line of layout.lines) {
+    const y = line.y;
     if (unit === "line") {
       out.push({
         text: line.text,
-        x: lineX,
-        width: lineWidth,
+        x: line.x,
+        width: line.width,
         y,
         height: lineHeight
       });
-      return;
+      continue;
     }
     // The break that starts this line ate the space that would have separated
     // it from the previous one, so it takes that separator's index. Counting
     // it here rather than at the end of the previous line is what keeps a
     // blank line (an empty paragraph) from inventing a unit.
     if (unit === "character" && line.words.length > 0 && out.length > 0) {
-      out.push({ text: "", x: lineX, width: 0, y, height: lineHeight });
+      out.push({ text: "", x: line.x, width: 0, y, height: lineHeight });
     }
 
-    let x = lineX;
+    let x = line.x;
     line.words.forEach((word, wordIndex) => {
+      const wordWidth = line.wordWidths[wordIndex]!;
       if (unit === "word") {
-        out.push({
-          text: word,
-          x,
-          width: widths[wordIndex],
-          y,
-          height: lineHeight
-        });
+        out.push({ text: word, x, width: wordWidth, y, height: lineHeight });
       } else {
         let prefixWidth = 0;
         let prefix = "";
+        let glyphs = 0;
         for (const grapheme of segmentGraphemes(word)) {
           prefix += grapheme;
-          const nextWidth = measure(prefix);
+          glyphs += 1;
+          const nextWidth = measure(prefix) + letterSpacingPx * glyphs;
           out.push({
             text: grapheme,
             x: x + prefixWidth,
@@ -263,11 +412,17 @@ export function layoutStaggerUnits(
         // The space between two words on one line is a unit too: timed, and
         // drawn as nothing.
         if (wordIndex < line.words.length - 1) {
-          out.push({ text: "", x: x + widths[wordIndex], width: spaceWidth, y, height: lineHeight });
+          out.push({
+            text: "",
+            x: x + wordWidth,
+            width: spaceWidth,
+            y,
+            height: lineHeight
+          });
         }
       }
-      x += widths[wordIndex] + spaceWidth;
+      x += wordWidth + spaceWidth;
     });
-  });
+  }
   return out;
 }

--- a/packages/timeline/tests/render.textStagger.test.ts
+++ b/packages/timeline/tests/render.textStagger.test.ts
@@ -12,6 +12,7 @@ import type { ClipAnimation } from "../src/animation/types.js";
 import type { ClipTextStyle } from "../src/types.js";
 import {
   drawStaggeredText,
+  drawText,
   createStaggerScratch,
   measureTextWith,
   type RasterContext2D
@@ -46,11 +47,18 @@ class RecordingContext implements RasterContext2D {
   font = "";
   fillStyle: string | object = "";
   strokeStyle: string | object = "";
+  filter = "none";
+  globalCompositeOperation = "source-over";
   lineWidth = 0;
   lineJoin = "";
+  lineCap = "";
   textAlign = "";
   textBaseline = "";
   globalAlpha = 1;
+  shadowColor = "rgba(0, 0, 0, 0)";
+  shadowBlur = 0;
+  shadowOffsetX = 0;
+  shadowOffsetY = 0;
   readonly drawn: DrawnUnit[] = [];
   private stack: {
     x: number;
@@ -85,12 +93,25 @@ class RecordingContext implements RasterContext2D {
   }
   strokeText(): void {}
   beginPath(): void {}
+  closePath(): void {}
   rect(): void {}
   ellipse(): void {}
   moveTo(): void {}
   lineTo(): void {}
+  bezierCurveTo(): void {}
+  quadraticCurveTo(): void {}
   fill(): void {}
   stroke(): void {}
+  clip(): void {}
+  clearRect(): void {}
+  fillRect(): void {}
+  setLineDash(): void {}
+  createLinearGradient(): { addColorStop(): void } {
+    return { addColorStop(): void {} };
+  }
+  createRadialGradient(): { addColorStop(): void } {
+    return { addColorStop(): void {} };
+  }
   save(): void {
     this.stack.push({ ...this.state });
   }
@@ -407,5 +428,42 @@ describe("drawStaggeredText", () => {
       "character"
     );
     expect(ctx.drawn[0].x).toBeCloseTo(laidOut[0].x, 6);
+  });
+});
+
+describe("drawText on a context with no letter spacing of its own", () => {
+  // Both shipping contexts have `letterSpacing`, so this fallback is the path
+  // nothing else exercises — and the one that has to land the glyphs where the
+  // native path lands them.
+  it("issues one call per grapheme at the accumulated advance", () => {
+    const ctx = new RecordingContext();
+    drawText(ctx, style({ text: "abc", letterSpacingPx: 5 }), WIDTH, HEIGHT);
+    expect(ctx.drawn.map((d) => d.text)).toEqual(["a", "b", "c"]);
+    expect(ctx.drawn[1].x - ctx.drawn[0].x).toBeCloseTo(GLYPH_PX + 5, 6);
+    expect(ctx.drawn[2].x - ctx.drawn[1].x).toBeCloseTo(GLYPH_PX + 5, 6);
+  });
+
+  it("issues the whole line in one call when there is no spacing", () => {
+    const ctx = new RecordingContext();
+    drawText(ctx, style({ text: "abc" }), WIDTH, HEIGHT);
+    expect(ctx.drawn.map((d) => d.text)).toEqual(["abc"]);
+  });
+
+  it("outlines each grapheme before it fills it", () => {
+    const ctx = new RecordingContext();
+    drawText(
+      ctx,
+      style({
+        text: "ab",
+        letterSpacingPx: 5,
+        stroke: { color: "#000000", widthPx: 4 }
+      }),
+      WIDTH,
+      HEIGHT
+    );
+    // `strokeText` is not recorded, so the fills are all that show — but a
+    // stroke drawn per line while the fill was drawn per glyph would have put
+    // the outline under a different set of advances.
+    expect(ctx.drawn.map((d) => d.text)).toEqual(["a", "b"]);
   });
 });

--- a/packages/timeline/tests/render.textStyle.test.ts
+++ b/packages/timeline/tests/render.textStyle.test.ts
@@ -1,0 +1,252 @@
+/**
+ * The text raster cache key and the pure half of the text styling layout.
+ *
+ * The cache key is the load-bearing one. A host keys a bitmap by
+ * `textStyleSignature` and hands the cached picture back on a hit, so a field
+ * the signature does not read renders as the frame drawn before that field
+ * changed — a stale title nobody can tell from a stuck render. The enumeration
+ * below drives every field of the document schema through the signature rather
+ * than listing the ones anybody remembered.
+ *
+ * Pixels are pinned in `packages/agents/tests/timeline-text-frames.test.ts`,
+ * which draws through a real `@napi-rs/canvas` context.
+ */
+
+import { describe, expect, it } from "vitest";
+import { clipTextStyle } from "@nodetool-ai/protocol/api-schemas/timeline.js";
+import type { ClipTextStyle } from "../src/types.js";
+import { textStyleSignature } from "../src/render/draw.js";
+import {
+  layoutTextBlock,
+  textFontSpec,
+  textLetterSpacingPx,
+  textLineHeightPx
+} from "../src/render/textLayout.js";
+
+const W = 800;
+const H = 400;
+
+/**
+ * Every field of `ClipTextStyle`, set. `Required` makes TypeScript refuse an
+ * omission and the schema check below refuses a field the document carries and
+ * this object does not.
+ */
+const FULL: Required<ClipTextStyle> = {
+  text: "HELLO THERE",
+  fontFamily: "Georgia",
+  fontSizePx: 40,
+  fontWeight: 600,
+  color: "#ffffff",
+  align: "left",
+  maxWidthFrac: 0.6,
+  fontStyle: "italic",
+  letterSpacingPx: 3,
+  lineHeight: 1.4,
+  verticalAlign: "top",
+  stroke: { color: "#000000", widthPx: 4 },
+  shadow: { color: "#101010", blurPx: 6, offsetX: 5, offsetY: 7 },
+  background: { color: "#202020", paddingPx: 12, radiusPx: 8 },
+  fill: {
+    type: "linear",
+    angle: 45,
+    stops: [
+      { offset: 0, color: "#ff0000" },
+      { offset: 1, color: "#0000ff" }
+    ]
+  }
+};
+
+/** A different value of the same shape, for every field. */
+const CHANGED: Required<ClipTextStyle> = {
+  text: "GOODBYE",
+  fontFamily: "Verdana",
+  fontSizePx: 41,
+  fontWeight: 400,
+  color: "#fefefe",
+  align: "right",
+  maxWidthFrac: 0.5,
+  fontStyle: "normal",
+  letterSpacingPx: 4,
+  lineHeight: 1.2,
+  verticalAlign: "bottom",
+  stroke: { color: "#000000", widthPx: 5 },
+  shadow: { color: "#101010", blurPx: 6, offsetX: 5, offsetY: 8 },
+  background: { color: "#202020", paddingPx: 13, radiusPx: 8 },
+  fill: {
+    type: "linear",
+    angle: 46,
+    stops: [
+      { offset: 0, color: "#ff0000" },
+      { offset: 1, color: "#0000ff" }
+    ]
+  }
+};
+
+describe("textStyleSignature", () => {
+  it("names every field the document schema carries", () => {
+    // I1's mirror one rung further: a field added to the schema without a
+    // value here fails before the enumeration below can miss it.
+    expect(Object.keys(FULL).sort()).toEqual(
+      Object.keys(clipTextStyle.shape).sort()
+    );
+  });
+
+  it("changes when any one style field changes", () => {
+    const base = textStyleSignature(FULL, W, H);
+    for (const field of Object.keys(FULL) as (keyof ClipTextStyle)[]) {
+      const mutated: ClipTextStyle = { ...FULL, [field]: CHANGED[field] };
+      expect(textStyleSignature(mutated, W, H), field).not.toBe(base);
+    }
+  });
+
+  it("changes when a field is dropped rather than changed", () => {
+    // Every optional value above is away from its default, so dropping one is
+    // a different picture. An omitted field that happens to equal the default
+    // keys the same on purpose: it draws the same.
+    const base = textStyleSignature(FULL, W, H);
+    for (const field of Object.keys(FULL) as (keyof ClipTextStyle)[]) {
+      if (field === "text" || field === "fontSizePx" || field === "color") {
+        continue; // Required by the type; there is no absent form to key.
+      }
+      const dropped: ClipTextStyle = { ...FULL };
+      delete dropped[field];
+      expect(textStyleSignature(dropped, W, H), field).not.toBe(base);
+    }
+  });
+
+  it("keys the raster size too", () => {
+    expect(textStyleSignature(FULL, W, H)).not.toBe(
+      textStyleSignature(FULL, W, H + 1)
+    );
+  });
+
+  it("keys two equally-built styles the same", () => {
+    const rebuilt: ClipTextStyle = {
+      fill: FULL.fill,
+      background: FULL.background,
+      text: FULL.text,
+      color: FULL.color,
+      fontSizePx: FULL.fontSizePx,
+      shadow: FULL.shadow,
+      stroke: FULL.stroke,
+      verticalAlign: FULL.verticalAlign,
+      lineHeight: FULL.lineHeight,
+      letterSpacingPx: FULL.letterSpacingPx,
+      fontStyle: FULL.fontStyle,
+      maxWidthFrac: FULL.maxWidthFrac,
+      align: FULL.align,
+      fontWeight: FULL.fontWeight,
+      fontFamily: FULL.fontFamily
+    };
+    expect(textStyleSignature(rebuilt, W, H)).toBe(
+      textStyleSignature(FULL, W, H)
+    );
+  });
+});
+
+describe("textFontSpec", () => {
+  const base: ClipTextStyle = { text: "x", fontSizePx: 40, color: "#fff" };
+
+  it("puts the slant before the weight, where the shorthand wants it", () => {
+    expect(textFontSpec({ ...base, fontStyle: "italic", fontWeight: 700 })).toBe(
+      "italic 700 40px Inter, Arial, sans-serif"
+    );
+  });
+
+  it("drops a slant it does not know rather than emitting it", () => {
+    // The shorthand is parsed whole: one unreadable token and the context
+    // keeps whatever font it had, which is a wrong picture, not a plain one.
+    expect(textFontSpec({ ...base, fontStyle: "slanty" })).toBe(
+      textFontSpec(base)
+    );
+    expect(textFontSpec({ ...base, fontStyle: "normal" })).toBe(
+      textFontSpec(base)
+    );
+  });
+});
+
+describe("line height and letter spacing", () => {
+  const base: ClipTextStyle = { text: "x", fontSizePx: 40, color: "#fff" };
+
+  it("defaults the line advance to 1.2 font sizes", () => {
+    expect(textLineHeightPx(base)).toBe(48);
+    expect(textLineHeightPx({ ...base, lineHeight: 2 })).toBe(80);
+  });
+
+  it("ignores a line height that would collapse the block", () => {
+    expect(textLineHeightPx({ ...base, lineHeight: 0 })).toBe(48);
+    expect(textLineHeightPx({ ...base, lineHeight: -1 })).toBe(48);
+  });
+
+  it("reads no spacing as zero, and a broken one as zero too", () => {
+    expect(textLetterSpacingPx(base)).toBe(0);
+    expect(textLetterSpacingPx({ ...base, letterSpacingPx: 4 })).toBe(4);
+    expect(textLetterSpacingPx({ ...base, letterSpacingPx: NaN })).toBe(0);
+  });
+});
+
+/** A fixed-advance measurer, so the layout is arithmetic. */
+const GLYPH_PX = 10;
+const measure = (text: string): number => text.length * GLYPH_PX;
+
+describe("layoutTextBlock", () => {
+  const base: ClipTextStyle = {
+    text: "one two",
+    fontSizePx: 40,
+    color: "#fff"
+  };
+
+  it("charges letter spacing on every grapheme, trailing one included", () => {
+    const plain = layoutTextBlock(measure, base, W, H);
+    const spaced = layoutTextBlock(
+      measure,
+      { ...base, letterSpacingPx: 5 },
+      W,
+      H
+    );
+    // "one two" is seven graphemes drawn as two words plus a space: three
+    // word graphemes each side and the separator.
+    expect(spaced.lines[0]!.width - plain.lines[0]!.width).toBe(7 * 5);
+    expect(spaced.spaceWidth).toBe(GLYPH_PX + 5);
+  });
+
+  it("stacks lines by the line height", () => {
+    const layout = layoutTextBlock(
+      measure,
+      { ...base, text: "one\ntwo", lineHeight: 2 },
+      W,
+      H
+    );
+    expect(layout.lineHeight).toBe(80);
+    expect(layout.lines[1]!.y - layout.lines[0]!.y).toBe(80);
+  });
+
+  it("moves the block with verticalAlign, and keeps its height", () => {
+    const of = (verticalAlign: string): { y: number; height: number } => {
+      const box = layoutTextBlock(
+        measure,
+        { ...base, text: "one\ntwo", verticalAlign },
+        W,
+        H
+      ).box;
+      return { y: box.y, height: box.height };
+    };
+    expect(of("top")).toEqual({ y: 0, height: 96 });
+    expect(of("middle")).toEqual({ y: H / 2 - 48, height: 96 });
+    expect(of("bottom")).toEqual({ y: H - 96, height: 96 });
+    // An unknown value reads as the default rather than throwing (I2).
+    expect(of("sideways")).toEqual(of("middle"));
+  });
+
+  it("measures the block against the text, not the raster", () => {
+    const box = layoutTextBlock(measure, base, W, H).box;
+    expect(box.width).toBe("one two".length * GLYPH_PX);
+    expect(box.x).toBe((W - box.width) / 2);
+  });
+
+  it("collapses to a point when there is nothing to draw", () => {
+    const box = layoutTextBlock(measure, { ...base, text: "" }, W, H).box;
+    expect(box.width).toBe(0);
+    expect(box.x).toBe(W / 2);
+  });
+});

--- a/web/src/components/timeline/preview/__tests__/textRender.test.ts
+++ b/web/src/components/timeline/preview/__tests__/textRender.test.ts
@@ -8,11 +8,20 @@ describe("TextRasterizer", () => {
   const originalOffscreenCanvas = globalThis.OffscreenCanvas;
   const close = jest.fn();
   const bitmap = stub<ImageBitmap>({ close });
+  // The subset of `RasterContext2D` a plain unstyled title touches. It has no
+  // `letterSpacing`, which is the hand-placed advance path — with no spacing
+  // set, that is still one `fillText` per line.
   const context = {
     fillStyle: "",
     font: "",
     textAlign: "start",
     textBaseline: "alphabetic",
+    shadowColor: "",
+    shadowBlur: 0,
+    shadowOffsetX: 0,
+    shadowOffsetY: 0,
+    save: jest.fn(),
+    restore: jest.fn(),
     measureText: jest.fn((text: string) => ({ width: text.length * 10 })),
     fillText: jest.fn()
   };
@@ -58,12 +67,11 @@ describe("TextRasterizer", () => {
     expect(transferToImageBitmap).toHaveBeenCalledTimes(1);
     expect(context.font).toBe("600 72px Inter");
     expect(context.fillStyle).toBe("#123456");
-    expect(context.textAlign).toBe("right");
-    expect(context.fillText).toHaveBeenCalledWith(
-      "Motion title",
-      expect.any(Number),
-      540
-    );
+    // Every glyph is placed from its own left edge, so alignment is arithmetic
+    // on the line's measured width rather than a context mode: the right edge
+    // of a 120px line sits on the right edge of the 1440px wrap column.
+    expect(context.textAlign).toBe("left");
+    expect(context.fillText).toHaveBeenCalledWith("Motion title", 1560, 540);
 
     rasterizer.dispose();
     expect(close).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## What changed

`docs/plans/motion-graphics-tasks.md` T14, continuing after [#5491](https://github.com/nodetool-ai/nodetool/pull/5491) (M1+M2) and [#5493](https://github.com/nodetool-ai/nodetool/pull/5493) (T16).

`ClipTextStyle` declared a stroke, a shadow, a background scrim, a font style, letter spacing, line height and vertical alignment. The rasterizer drew none of them, so a title authored with an outline rendered bare. No schema change was needed — T1 had already landed every field in both `types.ts` and the Zod schema, so I1 holds untouched.

Every text draw now goes through one `layoutTextBlock` and one `prepareText`, so `drawText` and `drawStaggeredText` cannot disagree about where a line sits or what it is painted with. Stroke draws before fill; the shadow is cleared after the stroke so only the outline casts, never the fill on top of it; the scrim is drawn once behind the whole block, including under a stagger where drawing it per glyph would tile it.

Three details that needed evidence rather than assumption:

- **Letter spacing** is charged per grapheme at measure time and drawn through `ctx.letterSpacing` where the context has it, falling back to one draw call per glyph. Both Chromium and `@napi-rs/canvas` have it — verified at runtime, which corrected a first-pass comment claiming skia lacked it.
- **`fontStyle`** emits only slants it recognizes. The `font` shorthand is parsed whole, so one unrecognized token leaves the context on its *previous* font rather than falling back cleanly.
- **Gradient fills under a stagger.** A canvas gradient is issued in the transform in force when it is painted, so a per-unit translate dragged the ramp along and every glyph showed the same slice. Non-solid fills are now re-resolved per unit against the block box mapped into that unit's own space. Rotation is deliberately not undone — the ramp turns with the letter. The pixel test `runs one gradient across the block, not one per glyph` caught this and pins it.

Gradient fills use T16's `resolveShapeFill` against the **measured block box**, not the raster size.

### The cache key, and why it is the load-bearing test

A raster cache key that silently misses a field renders a stale bitmap. `textStyleSignature` now writes all fifteen fields in fixed order, flattening nested objects field by field so key order in the source object cannot change the result. All three hosts (web `TextRasterizer`, agents `PreviewRasterizer`, video-nodes `NodeRasterizer`) already called this one function, so extending it covered them all.

Two chained tests enforce it:

1. `names every field the document schema carries` — `Object.keys(FULL).sort()` must equal `Object.keys(clipTextStyle.shape).sort()`, read from the **live Zod schema**. A field added under I1 fails here.
2. `changes when any one style field changes` / `…when a field is dropped` — iterates the fixture, swaps or deletes each field, asserts the signature moves. `FULL` is typed `Required<ClipTextStyle>` with every optional value away from its default, so the drop case is a real difference.

A new field fails (1) until it is in the fixture, then fails (2) until the key reads it.

## Verification

- [x] `npm run build:packages` — 59/59, exit 0 (run first, per the stale-`dist/` note below)
- [x] `npm run test --workspace=packages/timeline` (lavapipe) — 536 passed
- [x] `npm run test --workspace=packages/protocol` — 1007 passed
- [x] `npm run test --workspace=packages/execution` — 366 passed
- [x] `npm run test --workspace=packages/agents` — 3775 passed, 5 skipped
- [x] `npm run test --workspace=packages/video-nodes` (lavapipe) — 208 passed
- [x] `cd web && npm test -- --testPathPattern=timeline` — 849 passed, 95 suites
- [x] `npm run lint` — exit 0
- [ ] `npm run typecheck` — web and electron legs exit 0 with no diagnostics, confirmed by running each alone. The **mobile** leg fails on a clean tree here: `mobile/node_modules` is absent (mobile is deliberately not a root workspace), so `expo/tsconfig.base` cannot resolve and ~448 `TS2307`s cascade. None is in a file this PR touches.

Re-verified after rebasing onto current `main`: timeline 536 passed.

## New checks

- [x] Deleting `letterSpacingPx` from the signature was observed failing — 2 tests red, both naming the field.
- [x] Removing `verticalAlign` from the fixture was observed failing the schema check, which named it.

## Found, not fixed

- **`RecordingContext` in `render.textStagger.test.ts` claimed `implements RasterContext2D` while missing ~12 members.** It never bit because no CI leg typechecks `packages/*/tests` — `packages/timeline/tsconfig.json` includes only `src`. I completed the class since this change made it call more members, but the underlying gap is untouched and worth a decision.
- Letter spacing shifts centred text left by half a spacing unit, because the measured advance includes the trailing space after the last glyph. CSS and both canvas implementations do the same, so the layout matches the pixels; correcting it would make the block disagree with what is drawn. Documented at `spacedMeasure`.
- Under a rotated per-unit stagger a gradient rotates with the glyph rather than staying axis-aligned to the block. Undoing it needs a non-axis-aligned fill box, which `resolveShapeFill` does not take.
- `drawCaption` still hard-codes its font, outline and 5%/12% constants — T15's scope.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdzG3a3jN3Dzx6QV8xh4Bo

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdzG3a3jN3Dzx6QV8xh4Bo)_