### PR TITLE
feat(timeline): let a caption carry its own look [T15]

### DIFF
--- a/packages/agents/src/capabilities/timelines.specs.ts
+++ b/packages/agents/src/capabilities/timelines.specs.ts
@@ -146,6 +146,10 @@ export const EDIT_TIMELINE_SCHEMA: JsonSchema = {
         'set_matte takes {"target", "matte": {source, mode: "alpha"|"luma", ' +
         "invert?} | null}; the source clip stops drawing itself and its alpha " +
         "or brightness becomes the target's transparency. " +
+        'set_clip_params takes {"target", ...fields}; a caption clip\'s look ' +
+        'is "captionStyle": {fontFamily?, fontSizeFrac?, color?, activeColor?, ' +
+        "outline?, bottomMarginFrac?, background?}, each field optional and " +
+        "each absent one keeping the built-in value. " +
         'set_effects takes {"target", "effects": [{type, ...}]} and replaces ' +
         "the whole chain — types color, blur, glow, dropShadow, vignette, " +
         "sharpen, chromaKey, curves, levels, liftGammaGain, applied in the " +

--- a/packages/agents/src/evals/surfaces/timeline.ts
+++ b/packages/agents/src/evals/surfaces/timeline.ts
@@ -124,6 +124,40 @@ const textStyleParams = z.object({
   maxWidthFrac: z.number().optional()
 });
 
+/**
+ * A caption's look. Every field is optional and an absent one keeps the
+ * built-in value, so a partial patch restyles one thing rather than resetting
+ * the rest.
+ */
+const captionStyleParams = z.object({
+  fontFamily: z.string().optional(),
+  fontSizeFrac: z
+    .number()
+    .optional()
+    .describe("Font size as a fraction of frame height. Default 0.05."),
+  color: z.string().optional().describe("Colour of the words not being spoken."),
+  activeColor: z
+    .string()
+    .optional()
+    .describe("Colour of the word being spoken. Default #FFD60A."),
+  outline: z
+    .object({ color: z.string(), widthPx: z.number() })
+    .optional()
+    .describe("Outline under the glyphs. widthPx 0 draws none."),
+  bottomMarginFrac: z
+    .number()
+    .optional()
+    .describe("Gap from the frame bottom, as a fraction of height. Default 0.12."),
+  background: z
+    .object({
+      color: z.string(),
+      paddingPx: z.number(),
+      radiusPx: z.number().optional()
+    })
+    .optional()
+    .describe("Scrim behind the whole block.")
+});
+
 const shapeStyleParams = z.object({
   kind: z.enum(["rect", "ellipse", "line"]),
   fill: z.string().optional(),
@@ -844,6 +878,7 @@ export function createTimelineToolBridge(
       locked: c.locked,
       textStyle: c.textStyle,
       shapeStyle: c.shapeStyle,
+      captionStyle: c.caption?.style,
       transitionIn: c.transitionIn,
       mask: c.mask,
       matte: c.matte,
@@ -1252,7 +1287,7 @@ export function createTimelineToolBridge(
 
     tool(
       "ui_timeline_set_clip_params",
-      "Change a clip's render/audio params: `name`, `opacity` (0..1), `speedMultiplier` (0.1..8), `volumeDb`, `fadeInMs`, `fadeOutMs`, `blendMode`, `borderRadius`, `hidden`, `muted`, `locked`, a text clip's `textStyle`, or a shape clip's `shapeStyle`. Omit a field to leave it unchanged.",
+      "Change a clip's render/audio params: `name`, `opacity` (0..1), `speedMultiplier` (0.1..8), `volumeDb`, `fadeInMs`, `fadeOutMs`, `blendMode`, `borderRadius`, `hidden`, `muted`, `locked`, a text clip's `textStyle`, a shape clip's `shapeStyle`, or a caption clip's `captionStyle`. Omit a field to leave it unchanged.",
       z.object({
         target: targetParam,
         name: z.string().optional(),
@@ -1267,7 +1302,8 @@ export function createTimelineToolBridge(
         muted: z.boolean().optional(),
         locked: z.boolean().optional(),
         textStyle: fullTextStyleParams.optional(),
-        shapeStyle: shapeStyleParams.optional()
+        shapeStyle: shapeStyleParams.optional(),
+        captionStyle: captionStyleParams.optional()
       }),
       async ({ target, ...patch }) => {
         const clip = resolveClip(target as string);
@@ -1289,6 +1325,20 @@ export function createTimelineToolBridge(
           clip.textStyle = patch.textStyle as TimelineClip["textStyle"];
         if (patch.shapeStyle !== undefined)
           clip.shapeStyle = patch.shapeStyle as TimelineClip["shapeStyle"];
+        if (patch.captionStyle !== undefined) {
+          // The style rides on the clip's caption, so a clip with no words to
+          // draw has nowhere to put it. Say so rather than storing a look
+          // nothing renders.
+          if (!clip.caption) {
+            throw new Error(`Clip "${clip.name}" carries no caption to style.`);
+          }
+          clip.caption = {
+            ...clip.caption,
+            style: patch.captionStyle as NonNullable<
+              TimelineClip["caption"]
+            >["style"]
+          };
+        }
         return { ok: true, clip: serializeClip(clip) };
       }
     ),

--- a/packages/agents/tests/timeline-caption-frames.test.ts
+++ b/packages/agents/tests/timeline-caption-frames.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Caption styling on the Canvas 2D path (T15).
+ *
+ * The load-bearing test is the first one: T15 made a hard-coded look
+ * authorable, so a caption carrying no style of its own must draw the frame it
+ * drew before. `drawCaptionBeforeT15` below is the drawing exactly as it stood,
+ * inlined so the comparison is against the old arithmetic rather than against a
+ * golden PNG whose bytes depend on whichever font the host resolved.
+ *
+ * `packages/timeline/tests/render.captionStyle.test.ts` pins the cache key.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createCanvas } from "@napi-rs/canvas";
+import type { CaptionStyle } from "@nodetool-ai/timeline";
+import {
+  drawCaption,
+  type RasterContext2D,
+  type ResolvedCaption
+} from "@nodetool-ai/timeline/scene";
+
+const W = 640;
+const H = 360;
+
+const CAPTION: ResolvedCaption = {
+  words: [
+    { text: "the", active: false },
+    { text: "quick", active: true },
+    { text: "brown", active: false },
+    { text: "fox", active: false }
+  ]
+};
+
+type Rgba = [number, number, number, number];
+
+/** The whole surface as RGBA bytes, plus the reads the assertions want. */
+function raster(caption: ResolvedCaption): {
+  bytes: Uint8ClampedArray;
+  at(index: number): Rgba;
+} {
+  const canvas = createCanvas(W, H);
+  // SAFETY: `RasterContext2D` is the subset of the 2D canvas API `drawCaption`
+  // uses; the presence test in timeline-shape-frames.test.ts asserts a skia
+  // context provides all of it.
+  drawCaption(
+    canvas.getContext("2d") as unknown as RasterContext2D,
+    caption,
+    W,
+    H
+  );
+  const bytes = canvas.getContext("2d").getImageData(0, 0, W, H).data;
+  return {
+    bytes,
+    at: (index) => [
+      bytes[index]!,
+      bytes[index + 1]!,
+      bytes[index + 2]!,
+      bytes[index + 3]!
+    ]
+  };
+}
+
+/**
+ * `drawCaption` as it stood before `caption.style` existed, byte for byte: the
+ * `#FFD60A` highlight, the `rgba(0,0,0,0.85)` outline at 12% of the font size,
+ * the 5%-of-height font and the 12% bottom margin.
+ */
+function drawCaptionBeforeT15(
+  ctx: RasterContext2D,
+  caption: ResolvedCaption,
+  width: number,
+  height: number
+): void {
+  const fontSize = Math.max(24, Math.round(height * 0.05));
+  ctx.font = `700 ${fontSize}px Inter, Arial, sans-serif`;
+  ctx.textBaseline = "alphabetic";
+  ctx.lineJoin = "round";
+
+  const spaceWidth = ctx.measureText(" ").width;
+  const maxWidth = width * 0.9;
+
+  const measured = caption.words.map((w) => ({
+    text: w.text,
+    active: w.active,
+    width: ctx.measureText(w.text).width
+  }));
+
+  const lines: (typeof measured)[] = [];
+  let current: typeof measured = [];
+  let currentWidth = 0;
+  for (const word of measured) {
+    const advance = (current.length > 0 ? spaceWidth : 0) + word.width;
+    if (current.length > 0 && currentWidth + advance > maxWidth) {
+      lines.push(current);
+      current = [word];
+      currentWidth = word.width;
+    } else {
+      current.push(word);
+      currentWidth += advance;
+    }
+  }
+  if (current.length > 0) lines.push(current);
+
+  const lineHeight = fontSize * 1.25;
+  const totalHeight = lines.length * lineHeight;
+  const bottomMargin = height * 0.12;
+  let y = height - bottomMargin - totalHeight + fontSize;
+
+  ctx.lineWidth = Math.max(2, fontSize * 0.12);
+  ctx.strokeStyle = "rgba(0, 0, 0, 0.85)";
+
+  for (const line of lines) {
+    const lineWidth = line.reduce(
+      (sum, w, i) => sum + w.width + (i > 0 ? spaceWidth : 0),
+      0
+    );
+    let x = (width - lineWidth) / 2;
+    for (let i = 0; i < line.length; i++) {
+      const word = line[i]!;
+      if (i > 0) x += spaceWidth;
+      ctx.fillStyle = word.active ? "#FFD60A" : "#FFFFFF";
+      ctx.strokeText(word.text, x, y);
+      ctx.fillText(word.text, x, y);
+      x += word.width;
+    }
+    y += lineHeight;
+  }
+}
+
+function rasterBefore(caption: ResolvedCaption): Uint8ClampedArray {
+  const canvas = createCanvas(W, H);
+  drawCaptionBeforeT15(
+    canvas.getContext("2d") as unknown as RasterContext2D,
+    caption,
+    W,
+    H
+  );
+  return canvas.getContext("2d").getImageData(0, 0, W, H).data;
+}
+
+/** Pixels where the two surfaces disagree. */
+function differingPixels(a: Uint8ClampedArray, b: Uint8ClampedArray): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < a.length; i += 4) {
+    if (
+      a[i] !== b[i] ||
+      a[i + 1] !== b[i + 1] ||
+      a[i + 2] !== b[i + 2] ||
+      a[i + 3] !== b[i + 3]
+    ) {
+      out.push(i);
+    }
+  }
+  return out;
+}
+
+function countPixels(
+  bytes: Uint8ClampedArray,
+  keep: (rgba: Rgba) => boolean
+): number {
+  let n = 0;
+  for (let i = 0; i < bytes.length; i += 4) {
+    if (keep([bytes[i]!, bytes[i + 1]!, bytes[i + 2]!, bytes[i + 3]!])) n += 1;
+  }
+  return n;
+}
+
+/** On the `#FFD60A` ramp: red leads, blue trails, and there is ink here. */
+const isActiveInk = ([r, g, b, a]: Rgba): boolean =>
+  a > 8 && r > b && r >= g && g > b;
+
+/** On the `#00FF00` ramp. */
+const isGreenInk = ([r, g, b, a]: Rgba): boolean => a > 8 && g > r && g > b;
+
+describe("drawCaption — the default look", () => {
+  it("draws the frame it drew before the style existed", () => {
+    const before = rasterBefore(CAPTION);
+    const after = raster(CAPTION).bytes;
+    expect(differingPixels(before, after)).toEqual([]);
+    // A surface both drew nothing on would pass the comparison above.
+    expect(countPixels(after, ([, , , a]) => a > 8)).toBeGreaterThan(200);
+  });
+
+  it("draws the same frame for an empty style object", () => {
+    const before = rasterBefore(CAPTION);
+    const after = raster({ ...CAPTION, style: {} }).bytes;
+    expect(differingPixels(before, after)).toEqual([]);
+  });
+});
+
+describe("drawCaption — style", () => {
+  it("recolours only the active word", () => {
+    const plain = raster(CAPTION);
+    const styled = raster({ ...CAPTION, style: { activeColor: "#00FF00" } });
+
+    const changed = differingPixels(plain.bytes, styled.bytes);
+    expect(changed.length).toBeGreaterThan(0);
+    // Every pixel that moved carried the highlight; the other three words and
+    // the outline they share are byte-identical.
+    for (const index of changed) {
+      expect(isActiveInk(plain.at(index)), `pixel ${index}`).toBe(true);
+    }
+    expect(countPixels(plain.bytes, isActiveInk)).toBeGreaterThan(20);
+    expect(countPixels(styled.bytes, isGreenInk)).toBeGreaterThan(20);
+  });
+
+  it("recolours the inactive words without touching the active one", () => {
+    const plain = raster(CAPTION);
+    const styled = raster({ ...CAPTION, style: { color: "#FF00FF" } });
+    for (const index of differingPixels(plain.bytes, styled.bytes)) {
+      expect(isActiveInk(plain.at(index)), `pixel ${index}`).toBe(false);
+    }
+  });
+
+  it("sizes the type from fontSizeFrac", () => {
+    const ink = (style?: CaptionStyle): number =>
+      countPixels(raster({ ...CAPTION, style }).bytes, ([, , , a]) => a > 8);
+    expect(ink({ fontSizeFrac: 0.1 })).toBeGreaterThan(ink());
+    // 5% of 360 is 18px, under the 24px floor a caption never drops below, so
+    // asking for less than the floor draws the floor.
+    expect(ink({ fontSizeFrac: 0.01 })).toBe(ink());
+  });
+
+  it("lifts the block off the bottom by bottomMarginFrac", () => {
+    const lowest = (style?: CaptionStyle): number => {
+      const { bytes } = raster({ ...CAPTION, style });
+      for (let y = H - 1; y >= 0; y--) {
+        for (let x = 0; x < W; x++) {
+          if (bytes[(y * W + x) * 4 + 3]! > 8) return y;
+        }
+      }
+      return -1;
+    };
+    expect(lowest({ bottomMarginFrac: 0.4 })).toBeLessThan(lowest() - 50);
+  });
+
+  it("drops the outline when the width is zero", () => {
+    const outlined = raster(CAPTION).bytes;
+    const bare = raster({
+      ...CAPTION,
+      style: { outline: { color: "#000000", widthPx: 0 } }
+    }).bytes;
+    // The outline is the dark ink under the glyphs; without it the drawing is
+    // the fills alone, so it covers strictly fewer pixels.
+    const inked = (bytes: Uint8ClampedArray): number =>
+      countPixels(bytes, ([, , , a]) => a > 8);
+    expect(inked(bare)).toBeLessThan(inked(outlined));
+    expect(countPixels(bare, ([r, g, b, a]) => a > 200 && r + g + b < 90)).toBe(
+      0
+    );
+  });
+
+  it("draws a scrim behind the block", () => {
+    const plain = raster(CAPTION).bytes;
+    const scrimmed = raster({
+      ...CAPTION,
+      style: { background: { color: "#FF0000", paddingPx: 20, radiusPx: 8 } }
+    }).bytes;
+    const red = ([r, g, b, a]: Rgba): boolean =>
+      a > 200 && r > 200 && g < 60 && b < 60;
+    expect(countPixels(plain, red)).toBe(0);
+    expect(countPixels(scrimmed, red)).toBeGreaterThan(1000);
+    // The scrim sits behind: the highlighted word still reads through it.
+    expect(countPixels(scrimmed, isActiveInk)).toBeGreaterThan(20);
+  });
+
+  it("takes the font family the style names", () => {
+    // Read back off the context rather than out of the pixels: a family this
+    // host has no face for falls back to the same glyphs, which would make a
+    // pixel comparison report a missing font as a missing feature.
+    const fontFor = (style?: CaptionStyle): string => {
+      const canvas = createCanvas(W, H);
+      const ctx = canvas.getContext("2d");
+      drawCaption(
+        ctx as unknown as RasterContext2D,
+        { ...CAPTION, style },
+        W,
+        H
+      );
+      return ctx.font;
+    };
+    // 5% of 360 is 18, under the 24px floor.
+    expect(fontFor()).toBe("700 24px Inter, Arial, sans-serif");
+    expect(fontFor({ fontFamily: "Georgia" })).toBe("700 24px Georgia");
+    expect(fontFor({ fontSizeFrac: 0.2 })).toBe(
+      "700 72px Inter, Arial, sans-serif"
+    );
+  });
+});

--- a/packages/timeline/AGENTS.md
+++ b/packages/timeline/AGENTS.md
@@ -87,10 +87,22 @@
   against — the text, not the raster. A draw that computes its own wrap puts a
   staggered title somewhere its un-staggered self is not.
 - **A raster cache key names every field of the style it caches.** A host hands
-  back the bitmap a key hits, so a field `textStyleSignature` does not read
-  renders as the frame drawn before that field changed. The check is the
-  `Object.keys` enumeration in `tests/render.textStyle.test.ts`, which walks the
-  document schema, so a field added under I1 fails there until the key reads it.
+  back the bitmap a key hits, so a field `textStyleSignature` or
+  `captionSignature` does not read renders as the frame drawn before that field
+  changed. The checks are the `Object.keys` enumerations in
+  `tests/render.textStyle.test.ts` and `tests/render.captionStyle.test.ts`,
+  which walk the document schema, so a field added under I1 fails there until
+  the key reads it.
+- **A caption keeps its own layout, and its built-in look is a default rather
+  than a constant.** `drawCaption` anchors an alphabetic baseline to the frame
+  bottom and colours the block word by word, neither of which `layoutTextBlock`
+  expresses; the two share the font shorthand and the scrim, which is where
+  they agree. Every value `caption.style` leaves out is the one the drawing
+  hard-coded before it was authorable, and
+  `packages/agents/tests/timeline-caption-frames.test.ts` compares an unstyled
+  caption against that prior drawing pixel for pixel — so a default nudged
+  while "cleaning up" fails rather than quietly restyling every shipped
+  caption.
 - **A rasterized layer's pixels can depend on its animation sample.** A shape's
   `trimStart`/`trimEnd` change the outline, so every host rasterizes
   `AnimatedLayerProps.shapeStyle`, not the clip's own; a host that reaches for

--- a/packages/timeline/src/render/draw.ts
+++ b/packages/timeline/src/render/draw.ts
@@ -9,6 +9,7 @@
  */
 
 import type {
+  CaptionStyle,
   ClipMask,
   ClipShapeStyle,
   ClipTextStyle,
@@ -155,11 +156,35 @@ export interface RasterContext2D extends MaskContext2D {
   rotate(angle: number): void;
 }
 
+/**
+ * The scrim a block of text sits on. `ClipTextStyle` and {@link CaptionStyle}
+ * declare the same shape, and {@link drawScrim} draws it for both.
+ */
+type BlockScrim = NonNullable<CaptionStyle["background"]>;
+
 // ── Captions ─────────────────────────────────────────────────────────────────
 
+/** The look a caption with no `style` of its own is drawn with. */
 const CAPTION_INACTIVE_COLOR = "#FFFFFF";
 const CAPTION_ACTIVE_COLOR = "#FFD60A";
 const CAPTION_OUTLINE_COLOR = "rgba(0, 0, 0, 0.85)";
+const CAPTION_FONT_WEIGHT = 700;
+/** Font size as a fraction of frame height, and the floor it never goes under. */
+const CAPTION_FONT_SIZE_FRAC = 0.05;
+const CAPTION_MIN_FONT_SIZE_PX = 24;
+/** Outline width as a fraction of the font size, and its own floor. */
+const CAPTION_OUTLINE_WIDTH_FRAC = 0.12;
+const CAPTION_MIN_OUTLINE_WIDTH_PX = 2;
+/** Gap between the last line and the frame bottom, as a fraction of height. */
+const CAPTION_BOTTOM_MARGIN_FRAC = 0.12;
+/**
+ * Line advance as a multiple of the font size, and the share of the frame the
+ * words wrap within. Not on {@link CaptionStyle}: a caption is one or two
+ * lines read at speaking pace, and both numbers are that shape rather than a
+ * look somebody would want to author.
+ */
+const CAPTION_LINE_HEIGHT = 1.25;
+const CAPTION_MAX_WIDTH_FRAC = 0.9;
 
 /** One word of a caption resolved at a point in time. */
 export interface ResolvedCaptionWord {
@@ -169,14 +194,23 @@ export interface ResolvedCaptionWord {
 }
 
 /**
- * A caption's full per-frame state: every word of the line plus which one is
- * currently spoken. Rasterized identically by every render surface.
+ * A caption's full per-frame state: every word of the line, which one is
+ * currently spoken, and the look the clip authored. Rasterized identically by
+ * every render surface.
  */
 export interface ResolvedCaption {
   words: ResolvedCaptionWord[];
+  /** The clip's `caption.style`. Absent means the built-in look. */
+  style?: CaptionStyle;
 }
 
-/** Content signature of a caption raster, for host-side caching. */
+/**
+ * Content signature of a caption raster, for host-side caching.
+ *
+ * The style is in it for the reason {@link textStyleSignature} names every
+ * field of its own: a host hands back the bitmap a key hits, so a field the
+ * key does not read renders as the frame drawn before that field changed.
+ */
 export function captionSignature(
   caption: ResolvedCaption,
   width: number,
@@ -185,7 +219,28 @@ export function captionSignature(
   const words = caption.words
     .map((w) => (w.active ? `*${w.text}` : w.text))
     .join(" ");
-  return `${width}x${height}|${words}`;
+  return `${width}x${height}|${captionStyleSignature(caption.style)}|${words}`;
+}
+
+/** Every field of {@link CaptionStyle}, in a fixed order. */
+function captionStyleSignature(style: CaptionStyle | undefined): string {
+  if (!style) return "-";
+  return [
+    style.fontFamily ?? "-",
+    style.fontSizeFrac ?? "-",
+    style.color ?? "-",
+    style.activeColor ?? "-",
+    style.outline ? `${style.outline.color}@${style.outline.widthPx}` : "-",
+    style.bottomMarginFrac ?? "-",
+    scrimSignature(style.background)
+  ].join(",");
+}
+
+/** A block scrim's own signature, shared by both styles that carry one. */
+function scrimSignature(scrim: BlockScrim | undefined): string {
+  return scrim
+    ? `${scrim.color}@${scrim.paddingPx}/${scrim.radiusPx ?? 0}`
+    : "-";
 }
 
 interface MeasuredWord {
@@ -194,10 +249,110 @@ interface MeasuredWord {
   width: number;
 }
 
+/** A caption's look with every default filled in, in surface pixels. */
+interface ResolvedCaptionStyle {
+  font: string;
+  fontSizePx: number;
+  lineHeightPx: number;
+  color: string;
+  activeColor: string;
+  /** Null when the author asked for no outline. */
+  outline: { color: string; widthPx: number } | null;
+  bottomMarginPx: number;
+  background: BlockScrim | null;
+}
+
+/**
+ * `value` when it is a finite number at or above `min`, `fallback` otherwise.
+ * A hand-written document can carry a NaN or a negative fraction, and a
+ * caption laid out from one is not a look anybody asked for.
+ */
+function fractionOr(
+  value: number | undefined,
+  min: number,
+  fallback: number
+): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= min
+    ? value
+    : fallback;
+}
+
+/**
+ * Fill in what the author left out. Every default is the value this drawing
+ * hard-coded before it was authorable, so a caption carrying no style — which
+ * is every caption written before now — renders the frame it always did.
+ */
+function resolveCaptionStyle(
+  style: CaptionStyle | undefined,
+  height: number
+): ResolvedCaptionStyle {
+  // The size fraction must be positive to mean anything; the bottom margin may
+  // legitimately be zero, which sits the block flush against the frame edge.
+  const sizeFrac = fractionOr(
+    style?.fontSizeFrac,
+    Number.EPSILON,
+    CAPTION_FONT_SIZE_FRAC
+  );
+  const marginFrac = fractionOr(
+    style?.bottomMarginFrac,
+    0,
+    CAPTION_BOTTOM_MARGIN_FRAC
+  );
+  const fontSizePx = Math.max(
+    CAPTION_MIN_FONT_SIZE_PX,
+    Math.round(height * sizeFrac)
+  );
+  return {
+    // A caption is one weight and one size, so the font shorthand is the only
+    // thing it shares with a text clip — through the same builder, which is
+    // where the `Inter, Arial, sans-serif` fallback lives.
+    font: textFontSpec({
+      fontSizePx,
+      fontWeight: CAPTION_FONT_WEIGHT,
+      fontFamily: style?.fontFamily
+    }),
+    fontSizePx,
+    lineHeightPx: fontSizePx * CAPTION_LINE_HEIGHT,
+    color: style?.color ?? CAPTION_INACTIVE_COLOR,
+    activeColor: style?.activeColor ?? CAPTION_ACTIVE_COLOR,
+    outline: resolveCaptionOutline(style?.outline, fontSizePx),
+    bottomMarginPx: height * marginFrac,
+    background: style?.background ?? null
+  };
+}
+
+/**
+ * The outline, or null for none. A width of zero is how an author asks for no
+ * outline, and it has to be read here rather than passed on: `lineWidth = 0`
+ * is ignored by a canvas, which would stroke at whatever width was last set.
+ */
+function resolveCaptionOutline(
+  outline: CaptionStyle["outline"],
+  fontSizePx: number
+): { color: string; widthPx: number } | null {
+  if (!outline) {
+    return {
+      color: CAPTION_OUTLINE_COLOR,
+      widthPx: Math.max(
+        CAPTION_MIN_OUTLINE_WIDTH_PX,
+        fontSizePx * CAPTION_OUTLINE_WIDTH_FRAC
+      )
+    };
+  }
+  if (!Number.isFinite(outline.widthPx) || outline.widthPx <= 0) return null;
+  return { color: outline.color, widthPx: outline.widthPx };
+}
+
 /**
  * Draw a caption as bold, outlined, lower-third text with the currently-spoken
  * word highlighted, at full frame resolution — so it composites with an
- * identity transform.
+ * identity transform. `caption.style` moves any of that; what it leaves out
+ * keeps the built-in look.
+ *
+ * The layout is the caption's own rather than `layoutTextBlock`: a caption is
+ * anchored to the frame bottom on an alphabetic baseline and coloured word by
+ * word, none of which a text block expresses. The two share the font shorthand
+ * and the scrim, which is where they genuinely agree.
  */
 export function drawCaption(
   ctx: RasterContext2D,
@@ -205,13 +360,13 @@ export function drawCaption(
   width: number,
   height: number
 ): void {
-  const fontSize = Math.max(24, Math.round(height * 0.05));
-  ctx.font = `700 ${fontSize}px Inter, Arial, sans-serif`;
+  const style = resolveCaptionStyle(caption.style, height);
+  ctx.font = style.font;
   ctx.textBaseline = "alphabetic";
   ctx.lineJoin = "round";
 
   const spaceWidth = ctx.measureText(" ").width;
-  const maxWidth = width * 0.9;
+  const maxWidth = width * CAPTION_MAX_WIDTH_FRAC;
 
   const measured: MeasuredWord[] = caption.words.map((w) => ({
     text: w.text,
@@ -236,33 +391,41 @@ export function drawCaption(
   }
   if (current.length > 0) lines.push(current);
 
-  const lineHeight = fontSize * 1.25;
-  const totalHeight = lines.length * lineHeight;
-  const bottomMargin = height * 0.12;
+  const lineWidths = lines.map((line) =>
+    line.reduce((sum, w, i) => sum + w.width + (i > 0 ? spaceWidth : 0), 0)
+  );
+  const totalHeight = lines.length * style.lineHeightPx;
+  const blockTop = height - style.bottomMarginPx - totalHeight;
   // Baseline of the first line.
-  let y = height - bottomMargin - totalHeight + fontSize;
+  let y = blockTop + style.fontSizePx;
 
-  ctx.lineWidth = Math.max(2, fontSize * 0.12);
-  ctx.strokeStyle = CAPTION_OUTLINE_COLOR;
+  if (style.background) {
+    const blockWidth = lineWidths.reduce((widest, w) => Math.max(widest, w), 0);
+    drawScrim(ctx, style.background, {
+      x: (width - blockWidth) / 2,
+      y: blockTop,
+      width: blockWidth,
+      height: totalHeight
+    });
+  }
 
-  for (const line of lines) {
-    const lineWidth = line.reduce(
-      (sum, w, i) => sum + w.width + (i > 0 ? spaceWidth : 0),
-      0
-    );
-    let x = (width - lineWidth) / 2;
+  if (style.outline) {
+    ctx.lineWidth = style.outline.widthPx;
+    ctx.strokeStyle = style.outline.color;
+  }
+
+  lines.forEach((line, lineIndex) => {
+    let x = (width - lineWidths[lineIndex]!) / 2;
     for (let i = 0; i < line.length; i++) {
       const word = line[i];
       if (i > 0) x += spaceWidth;
-      ctx.fillStyle = word.active
-        ? CAPTION_ACTIVE_COLOR
-        : CAPTION_INACTIVE_COLOR;
-      ctx.strokeText(word.text, x, y);
+      ctx.fillStyle = word.active ? style.activeColor : style.color;
+      if (style.outline) ctx.strokeText(word.text, x, y);
       ctx.fillText(word.text, x, y);
       x += word.width;
     }
-    y += lineHeight;
-  }
+    y += style.lineHeightPx;
+  });
 }
 
 /**
@@ -311,9 +474,7 @@ export function textStyleSignature(
     style.shadow
       ? `${style.shadow.color}@${style.shadow.blurPx}/${style.shadow.offsetX}/${style.shadow.offsetY}`
       : "-",
-    style.background
-      ? `${style.background.color}@${style.background.paddingPx}/${style.background.radiusPx ?? 0}`
-      : "-",
+    scrimSignature(style.background),
     fillSignature(style.fill)
   ].join("|");
 }
@@ -395,7 +556,7 @@ function prepareText(
 
   ctx.textAlign = "left";
   ctx.textBaseline = "middle";
-  drawTextBackground(ctx, style, layout.box);
+  if (style.background) drawScrim(ctx, style.background, layout.box);
 
   const letterSpacingPx = textLetterSpacingPx(style);
   const nativeSpacing = setLetterSpacing(ctx, letterSpacingPx);
@@ -416,22 +577,24 @@ function prepareText(
   };
 }
 
-/** The scrim behind the wrapped block: a rounded rect grown by the padding. */
-function drawTextBackground(
+/**
+ * The scrim behind a block of text: a rounded rect grown by the padding.
+ * Shared by the text draw and {@link drawCaption}, which measure their own
+ * blocks but sit them on the same thing.
+ */
+function drawScrim(
   ctx: RasterContext2D,
-  style: ClipTextStyle,
+  scrim: BlockScrim,
   box: TextBlockBox
 ): void {
-  const background = style.background;
-  if (!background) return;
   // A scrim backs text. With nothing to back — an empty title, whose block
   // collapses to a point — the padding alone would draw a bare pill.
   if (box.width <= 0) return;
-  const pad = Math.max(0, background.paddingPx);
+  const pad = Math.max(0, scrim.paddingPx);
   const width = box.width + pad * 2;
   const height = box.height + pad * 2;
   if (height <= 0) return;
-  ctx.fillStyle = background.color;
+  ctx.fillStyle = scrim.color;
   ctx.beginPath();
   tracePath(
     ctx,
@@ -440,7 +603,7 @@ function drawTextBackground(
       box.y - pad,
       width,
       height,
-      Math.max(0, background.radiusPx ?? 0)
+      Math.max(0, scrim.radiusPx ?? 0)
     ),
     UNSCALED
   );

--- a/packages/timeline/src/render/sceneModel.ts
+++ b/packages/timeline/src/render/sceneModel.ts
@@ -213,7 +213,8 @@ export function resolveCaptionAtTime(
     words: clip.caption.words.map((w) => ({
       text: w.word,
       active: local >= w.startMs && local < w.endMs
-    }))
+    })),
+    style: clip.caption.style
   };
 }
 

--- a/packages/timeline/src/render/textLayout.ts
+++ b/packages/timeline/src/render/textLayout.ts
@@ -47,8 +47,21 @@ export interface RenderCanvas {
  */
 const FONT_SLANTS = new Set(["italic", "oblique"]);
 
+/**
+ * What the `font` shorthand is built from. Narrower than `ClipTextStyle` so a
+ * caption, which carries no text of its own, resolves its font through the
+ * same builder — and the `Inter, Arial, sans-serif` fallback stays in one
+ * place.
+ */
+export interface FontSpecStyle {
+  fontFamily?: string;
+  fontSizePx: number;
+  fontWeight?: number;
+  fontStyle?: string;
+}
+
 /** The `ctx.font` shorthand a text style renders with. */
-export function textFontSpec(style: ClipTextStyle): string {
+export function textFontSpec(style: FontSpecStyle): string {
   const fontSize = Math.max(1, style.fontSizePx);
   const family = style.fontFamily ?? "Inter, Arial, sans-serif";
   const slant = FONT_SLANTS.has(style.fontStyle ?? "")

--- a/packages/timeline/tests/render.captionStyle.test.ts
+++ b/packages/timeline/tests/render.captionStyle.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The caption raster cache key.
+ *
+ * A host keys a caption bitmap by `captionSignature` and hands the cached
+ * picture back on a hit, so a style field the signature does not read renders
+ * as the frame drawn before that field changed — a restyled caption nobody can
+ * tell from a stuck render. The enumeration below drives every field of the
+ * document schema through the key rather than the ones anybody remembered.
+ *
+ * Pixels are pinned in `packages/agents/tests/timeline-caption-frames.test.ts`,
+ * which draws through a real `@napi-rs/canvas` context.
+ */
+
+import { describe, expect, it } from "vitest";
+import { captionStyle } from "@nodetool-ai/protocol/api-schemas/timeline.js";
+import type { CaptionStyle } from "../src/types.js";
+import type { ResolvedCaption } from "../src/render/draw.js";
+import { captionSignature } from "../src/render/draw.js";
+
+const W = 1920;
+const H = 1080;
+
+const WORDS: ResolvedCaption["words"] = [
+  { text: "the", active: false },
+  { text: "quick", active: true },
+  { text: "fox", active: false }
+];
+
+/**
+ * Every field of `CaptionStyle`, set. `Required` makes TypeScript refuse an
+ * omission and the schema check below refuses a field the document carries and
+ * this object does not.
+ */
+const FULL: Required<CaptionStyle> = {
+  fontFamily: "Georgia",
+  fontSizeFrac: 0.07,
+  color: "#eeeeee",
+  activeColor: "#00ff00",
+  outline: { color: "#101010", widthPx: 5 },
+  bottomMarginFrac: 0.2,
+  background: { color: "#000000", paddingPx: 12, radiusPx: 8 }
+};
+
+/** A different value of the same shape, for every field. */
+const CHANGED: Required<CaptionStyle> = {
+  fontFamily: "Verdana",
+  fontSizeFrac: 0.08,
+  color: "#efefef",
+  activeColor: "#00fe00",
+  outline: { color: "#101010", widthPx: 6 },
+  bottomMarginFrac: 0.21,
+  background: { color: "#000000", paddingPx: 13, radiusPx: 8 }
+};
+
+const sign = (style: CaptionStyle | undefined): string =>
+  captionSignature({ words: WORDS, style }, W, H);
+
+describe("captionSignature", () => {
+  it("names every field the document schema carries", () => {
+    // I1's mirror one rung further: a field added to the schema without a
+    // value here fails before the enumeration below can miss it.
+    expect(Object.keys(FULL).sort()).toEqual(
+      Object.keys(captionStyle.shape).sort()
+    );
+  });
+
+  it("changes when any one style field changes", () => {
+    const base = sign(FULL);
+    for (const field of Object.keys(FULL) as (keyof CaptionStyle)[]) {
+      const mutated: CaptionStyle = { ...FULL, [field]: CHANGED[field] };
+      expect(sign(mutated), field).not.toBe(base);
+    }
+  });
+
+  it("changes when a field is dropped rather than changed", () => {
+    // Every value above is away from its default, so dropping one is a
+    // different picture.
+    const base = sign(FULL);
+    for (const field of Object.keys(FULL) as (keyof CaptionStyle)[]) {
+      const dropped: CaptionStyle = { ...FULL };
+      delete dropped[field];
+      expect(sign(dropped), field).not.toBe(base);
+    }
+  });
+
+  it("separates a styled caption from an unstyled one", () => {
+    expect(sign(FULL)).not.toBe(sign(undefined));
+  });
+
+  it("still keys the words and the raster size", () => {
+    expect(sign(FULL)).not.toBe(
+      captionSignature({ words: [...WORDS].reverse(), style: FULL }, W, H)
+    );
+    expect(sign(FULL)).not.toBe(
+      captionSignature({ words: WORDS, style: FULL }, W, H + 1)
+    );
+  });
+
+  it("keys which word is active", () => {
+    const moved = WORDS.map((w, i) => ({ ...w, active: i === 0 }));
+    expect(captionSignature({ words: moved, style: FULL }, W, H)).not.toBe(
+      sign(FULL)
+    );
+  });
+});

--- a/web/src/components/timeline/Inspector/ClipCaptionStyle.tsx
+++ b/web/src/components/timeline/Inspector/ClipCaptionStyle.tsx
@@ -1,0 +1,276 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * ClipCaptionStyle
+ *
+ * The caption look, on the clip that carries the words: type, the two colours
+ * a word takes depending on whether it is being spoken, how far the block sits
+ * off the frame bottom, the outline under the glyphs and the scrim behind
+ * them. Every field is optional in the document and an empty one here means
+ * the built-in value, so this panel never has to restate a default the
+ * renderer owns.
+ *
+ * The outline colour and the scrim's colour and radius appear once the field
+ * that turns each on carries a value — an outline is a width and a scrim is a
+ * padding, and neither exists without one.
+ */
+
+import React, { memo, useCallback } from "react";
+import { css } from "@emotion/react";
+import { useTheme, type Theme } from "@mui/material/styles";
+import ClosedCaptionOutlinedIcon from "@mui/icons-material/ClosedCaptionOutlined";
+
+import type { CaptionStyle, TimelineClip } from "@nodetool-ai/timeline";
+
+import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { CollapsibleSection, FlexColumn, TextInput } from "../../ui_primitives";
+import { usePersistedFold } from "./usePersistedFold";
+import {
+  InspectorDivider,
+  InspectorPillInput,
+  InspectorRow,
+  InspectorSectionTitle
+} from "./InspectorPrimitives";
+
+const sectionContentStyles = (theme: Theme) =>
+  css({
+    display: "flex",
+    flexDirection: "column",
+    gap: 2,
+    padding: theme.spacing(0.5, 0, 2)
+  });
+
+/** The colours `drawCaption` falls back to, so the swatches show what renders. */
+const DEFAULT_COLOR = "#FFFFFF";
+const DEFAULT_ACTIVE_COLOR = "#FFD60A";
+const DEFAULT_SCRIM_COLOR = "#000000";
+const DEFAULT_OUTLINE_COLOR = "#000000";
+
+/** A fraction of the frame, shown as a percentage. Empty means unset. */
+const asPercent = (value: number | undefined): string =>
+  value === undefined ? "" : String(Number((value * 100).toFixed(2)));
+
+/**
+ * A committed percentage back as a fraction, or `undefined` for a cleared
+ * field — which drops the key and restores the default.
+ */
+const fromPercent = (raw: string): number | undefined | null => {
+  if (raw.trim() === "") return undefined;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed / 100 : null;
+};
+
+interface ClipCaptionStyleProps {
+  clip: TimelineClip;
+}
+
+export const ClipCaptionStyle: React.FC<ClipCaptionStyleProps> = memo(
+  ({ clip }) => {
+    const theme = useTheme();
+    const [open, setOpen] = usePersistedFold("caption");
+    const patchClip = useTimelineStore((s) => s.patchClip);
+    const caption = clip.caption;
+    const style = caption?.style;
+
+    const patchStyle = useCallback(
+      (next: CaptionStyle) => {
+        if (!caption) return;
+        patchClip(clip.id, { caption: { ...caption, style: next } });
+      },
+      [caption, clip.id, patchClip]
+    );
+
+    /** Set one field, dropping the key when the value is cleared. */
+    const setField = useCallback(
+      <K extends keyof CaptionStyle>(
+        key: K,
+        value: CaptionStyle[K] | undefined
+      ) => {
+        const next: CaptionStyle = { ...style };
+        if (value === undefined) delete next[key];
+        else next[key] = value;
+        patchStyle(next);
+      },
+      [patchStyle, style]
+    );
+
+    const handleFraction = useCallback(
+      (key: "fontSizeFrac" | "bottomMarginFrac", raw: string) => {
+        const parsed = fromPercent(raw);
+        if (parsed === null) return;
+        setField(key, parsed);
+      },
+      [setField]
+    );
+
+    const handleOutlineWidth = useCallback(
+      (raw: string) => {
+        if (raw.trim() === "") {
+          setField("outline", undefined);
+          return;
+        }
+        const widthPx = Number(raw);
+        if (!Number.isFinite(widthPx) || widthPx < 0) return;
+        setField("outline", {
+          color: style?.outline?.color ?? DEFAULT_OUTLINE_COLOR,
+          widthPx
+        });
+      },
+      [setField, style?.outline?.color]
+    );
+
+    const handleScrimPadding = useCallback(
+      (raw: string) => {
+        if (raw.trim() === "") {
+          setField("background", undefined);
+          return;
+        }
+        const paddingPx = Number(raw);
+        if (!Number.isFinite(paddingPx) || paddingPx < 0) return;
+        setField("background", {
+          ...style?.background,
+          color: style?.background?.color ?? DEFAULT_SCRIM_COLOR,
+          paddingPx
+        });
+      },
+      [setField, style?.background]
+    );
+
+    if (!caption) return null;
+
+    // Pulled out of `style` so the two blocks below narrow without an
+    // assertion: each renders only when its own field is set.
+    const outline = style?.outline;
+    const scrim = style?.background;
+
+    return (
+      <>
+        <InspectorDivider />
+        <CollapsibleSection
+          title={
+            <InspectorSectionTitle
+              title="Caption"
+              icon={<ClosedCaptionOutlinedIcon />}
+            />
+          }
+          open={open}
+          onToggle={setOpen}
+          unmountOnExit
+        >
+          <FlexColumn css={sectionContentStyles(theme)}>
+            <InspectorRow label="Font">
+              <TextInput
+                value={style?.fontFamily ?? ""}
+                placeholder="Inter"
+                fullWidth
+                onChange={(event) =>
+                  setField("fontFamily", event.target.value || undefined)
+                }
+                inputProps={{ "aria-label": "Caption font family" }}
+              />
+            </InspectorRow>
+            <InspectorRow label="Size">
+              <InspectorPillInput
+                value={asPercent(style?.fontSizeFrac)}
+                unit="%"
+                placeholder="5"
+                onCommit={(raw) => handleFraction("fontSizeFrac", raw)}
+                ariaLabel="Caption size as a percentage of frame height"
+              />
+            </InspectorRow>
+            <InspectorRow label="Color">
+              <TextInput
+                type="color"
+                value={style?.color ?? DEFAULT_COLOR}
+                onChange={(event) => setField("color", event.target.value)}
+                inputProps={{ "aria-label": "Caption color" }}
+              />
+            </InspectorRow>
+            <InspectorRow label="Spoken">
+              <TextInput
+                type="color"
+                value={style?.activeColor ?? DEFAULT_ACTIVE_COLOR}
+                onChange={(event) =>
+                  setField("activeColor", event.target.value)
+                }
+                inputProps={{ "aria-label": "Caption spoken-word color" }}
+              />
+            </InspectorRow>
+            <InspectorRow label="Bottom">
+              <InspectorPillInput
+                value={asPercent(style?.bottomMarginFrac)}
+                unit="%"
+                placeholder="12"
+                onCommit={(raw) => handleFraction("bottomMarginFrac", raw)}
+                ariaLabel="Caption distance from the frame bottom"
+              />
+            </InspectorRow>
+            <InspectorRow label="Outline">
+              <InspectorPillInput
+                value={outline ? String(outline.widthPx) : ""}
+                unit="px"
+                placeholder="auto"
+                onCommit={handleOutlineWidth}
+                ariaLabel="Caption outline width"
+              />
+            </InspectorRow>
+            {outline && (
+              <InspectorRow label="Outline color">
+                <TextInput
+                  type="color"
+                  value={outline.color}
+                  onChange={(event) =>
+                    setField("outline", {
+                      color: event.target.value,
+                      widthPx: outline.widthPx
+                    })
+                  }
+                  inputProps={{ "aria-label": "Caption outline color" }}
+                />
+              </InspectorRow>
+            )}
+            <InspectorRow label="Scrim">
+              <InspectorPillInput
+                value={scrim ? String(scrim.paddingPx) : ""}
+                unit="px"
+                placeholder="none"
+                onCommit={handleScrimPadding}
+                ariaLabel="Caption scrim padding"
+              />
+            </InspectorRow>
+            {scrim && (
+              <>
+                <InspectorRow label="Scrim color">
+                  <TextInput
+                    type="color"
+                    value={scrim.color}
+                    onChange={(event) =>
+                      setField("background", {
+                        ...scrim,
+                        color: event.target.value
+                      })
+                    }
+                    inputProps={{ "aria-label": "Caption scrim color" }}
+                  />
+                </InspectorRow>
+                <InspectorRow label="Scrim radius">
+                  <InspectorPillInput
+                    value={String(scrim.radiusPx ?? 0)}
+                    unit="px"
+                    onCommit={(raw) => {
+                      const radiusPx = Number(raw);
+                      if (!Number.isFinite(radiusPx) || radiusPx < 0) return;
+                      setField("background", { ...scrim, radiusPx });
+                    }}
+                    ariaLabel="Caption scrim corner radius"
+                  />
+                </InspectorRow>
+              </>
+            )}
+          </FlexColumn>
+        </CollapsibleSection>
+      </>
+    );
+  }
+);
+
+ClipCaptionStyle.displayName = "ClipCaptionStyle";

--- a/web/src/components/timeline/Inspector/TimelineInspector.tsx
+++ b/web/src/components/timeline/Inspector/TimelineInspector.tsx
@@ -38,6 +38,7 @@ import {
   parseTimecode
 } from "./InspectorPrimitives.helpers";
 import { ClipAdjustments } from "./ClipAdjustments";
+import { ClipCaptionStyle } from "./ClipCaptionStyle";
 import { ClipStoryboardLink } from "./ClipStoryboardLink";
 import { ClipAnimations } from "./ClipAnimations";
 import { GeneratedClipPanel } from "./GeneratedClipPanel";
@@ -421,6 +422,8 @@ export const TimelineInspector: React.FC = memo(() => {
           />
         </FlexColumn>
       </CollapsibleSection>
+
+      <ClipCaptionStyle clip={clip} />
 
       <ClipAdjustments clip={clip} />
 

--- a/web/src/components/timeline/timelineAgentBridge.ts
+++ b/web/src/components/timeline/timelineAgentBridge.ts
@@ -91,6 +91,20 @@ interface TimelineTextStyle {
   maxWidthFrac?: number;
 }
 
+/**
+ * A caption's look. Every field is optional; an absent one keeps the built-in
+ * value, so a patch restyles one thing rather than resetting the rest.
+ */
+interface TimelineCaptionStyle {
+  fontFamily?: string;
+  fontSizeFrac?: number;
+  color?: string;
+  activeColor?: string;
+  outline?: { color: string; widthPx: number };
+  bottomMarginFrac?: number;
+  background?: { color: string; paddingPx: number; radiusPx?: number };
+}
+
 interface TimelineShapeStyle {
   kind: "rect" | "ellipse" | "line" | "path" | "polygon" | "star";
   fill?: string;
@@ -197,6 +211,7 @@ interface TimelineClipParamsPatch {
   locked?: boolean;
   textStyle?: TimelineTextStyle;
   shapeStyle?: TimelineShapeStyle;
+  captionStyle?: TimelineCaptionStyle;
 }
 
 /** Generation-binding fields the agent can change on a generated clip. */

--- a/web/src/hooks/timeline/useTimelineAgentBridge.ts
+++ b/web/src/hooks/timeline/useTimelineAgentBridge.ts
@@ -567,6 +567,14 @@ export const useTimelineAgentBridge = (sequenceId: string | null): void => {
         if (patch.shapeStyle !== undefined) {
           next.shapeStyle = shapeStyleWithDefaults(patch.shapeStyle);
         }
+        if (patch.captionStyle !== undefined) {
+          // The style rides on the clip's caption, so a clip with no words to
+          // draw has nowhere to put it.
+          if (!clip.caption) {
+            throw new Error(`Clip "${clip.name}" carries no caption to style.`);
+          }
+          next.caption = { ...clip.caption, style: patch.captionStyle };
+        }
         doc.getState().patchClip(clip.id, next);
         return clipNode(reReadClip(clip.id));
       },

--- a/web/src/lib/tools/builtin/timeline.ts
+++ b/web/src/lib/tools/builtin/timeline.ts
@@ -332,7 +332,7 @@ FrontendToolRegistry.register({
 FrontendToolRegistry.register({
   name: "ui_timeline_set_clip_params",
   description:
-    "Change a clip's render/audio params: `name`, `opacity` (0..1), `speedMultiplier` (0.1..8), `volumeDb`, `fadeInMs`, `fadeOutMs`, `blendMode`, `borderRadius`, `hidden`, `muted`, `locked`, a text clip's `textStyle`, or a shape clip's `shapeStyle`. Omit a field to leave it unchanged.",
+    "Change a clip's render/audio params: `name`, `opacity` (0..1), `speedMultiplier` (0.1..8), `volumeDb`, `fadeInMs`, `fadeOutMs`, `blendMode`, `borderRadius`, `hidden`, `muted`, `locked`, a text clip's `textStyle`, a shape clip's `shapeStyle`, or a caption clip's `captionStyle`. Omit a field to leave it unchanged.",
   parameters: z.object({
     timeline_id: timelineIdParam,
     target: targetParam,
@@ -370,6 +370,25 @@ FrontendToolRegistry.register({
         height: z.number().optional(),
         x2: z.number().optional(),
         y2: z.number().optional()
+      })
+      .optional(),
+    captionStyle: z
+      .object({
+        fontFamily: z.string().optional(),
+        fontSizeFrac: z.number().optional(),
+        color: z.string().optional(),
+        activeColor: z.string().optional(),
+        outline: z
+          .object({ color: z.string(), widthPx: z.number() })
+          .optional(),
+        bottomMarginFrac: z.number().optional(),
+        background: z
+          .object({
+            color: z.string(),
+            paddingPx: z.number(),
+            radiusPx: z.number().optional()
+          })
+          .optional()
       })
       .optional()
   }),


### PR DESCRIPTION
## What changed

`docs/plans/motion-graphics-tasks.md` T15, continuing after [#5491](https://github.com/nodetool-ai/nodetool/pull/5491) (M1+M2), [#5493](https://github.com/nodetool-ai/nodetool/pull/5493) (T16) and [#5495](https://github.com/nodetool-ai/nodetool/pull/5495) (T14).

`drawCaption` hard-coded everything: the font, the white and `#FFD60A` word colours, the outline, the 5% type size and the 12% bottom margin. `CaptionStyle` had been in the schema since T1 with nothing reading it. All seven fields already existed in both `types.ts` and Zod, so **no schema change was needed** and I1 holds untouched.

Each constant is now that field's default. `outline.widthPx: 0` is read at resolve time rather than passed through — a canvas ignores `lineWidth = 0` and would stroke at whatever width was set last. `resolveCaptionAtTime` passes the style through `ResolvedCaption`, so all four hosts (web preview, browser export, server render, agent frame preview) get it with no call-site change.

### A deliberate divergence worth reviewing

The caption keeps its own layout rather than moving onto T14's shared `layoutTextBlock`. That helper places on `textBaseline: "middle"` line centres, while a caption anchors an alphabetic baseline to the frame bottom and colours word by word; and it wraps by summing measured word widths where the shared wrap measures the joined candidate. Either change moves pixels, which is the one thing this task must not do. What genuinely agrees — the font shorthand builder and the scrim — **is** shared (`drawScrim` is now used by both text and caption, and `textStyleSignature` reuses the same `scrimSignature`). The reason the rest is separate is recorded in `packages/timeline/AGENTS.md` so it does not get "unified" later.

### How pixel identity is proved

Not with a golden PNG — its bytes depend on which font the host resolved. The pre-T15 drawing is inlined verbatim in the test as `drawCaptionBeforeT15`, rendered to a second surface, and compared byte for byte across all 640×360 pixels, with a separate assertion that the surface has ink so an all-blank pair cannot pass.

`activeColor` isolation is asserted the same way: every pixel that differs between the plain and restyled renders must have carried highlight ink in the plain one, which proves the outline and the other three words byte-identical rather than assuming it.

## Agent surface and inspector

`set_clip_params` / `ui_timeline_set_clip_params` accept `captionStyle`, through the single bridge implementation I11 requires. A clip with no caption is refused by name rather than storing a look nothing renders.

New `ClipCaptionStyle.tsx` inspector section, primitives only (`CollapsibleSection`, `FlexColumn`, `TextInput`, `InspectorRow`, `InspectorPillInput`, `InspectorSectionTitle`, `InspectorDivider`, `usePersistedFold`) with no raw MUI and no literal radius, transition, font size or off-grid spacing. Outline colour and scrim colour/radius appear only once the field that turns each on has a value, so no default is restated in the UI.

## SRT/VTT export — verified, not assumed

`packages/timeline/src/subtitles.ts` is untouched (0 lines in `git diff --stat`) and contains no occurrence of `style`. Its input is `SubtitleWord {word, startMs, endMs}`, and all three callers build entries from script lines, never from a `ClipCaption` — there is no path from `caption.style` to a cue. The `subtitles` suite passes 11/11.

## Verification

Every exit code captured directly, not through a pipeline. `npm run build:packages` run first (exit 0, 59/59) so no stale `dist/` could produce phantom failures.

- [x] `npm run test --workspace=packages/timeline` (lavapipe) — 542 passed
- [x] `npm run test --workspace=packages/protocol` — 1007 passed
- [x] `npm run test --workspace=packages/execution` — 366 passed
- [x] `npm run test --workspace=packages/agents` — 3784 passed, 5 skipped
- [x] `npm run test --workspace=packages/video-nodes` — 202 passed, 6 skipped
- [x] `cd web && npm test -- --testPathPattern=timeline` — 849 passed, 95 suites
- [x] `npm run lint` — exit 0, names none of the changed files
- [ ] `npm run typecheck` — web and electron legs exit 0 run alone. The **mobile** leg fails on a clean tree: `mobile/node_modules` is absent, so `expo/tsconfig.base` cannot resolve and ~448 `TS2307`s cascade. None is in a file this PR touches.

Re-verified after rebasing onto current `main`: timeline 542 passed.

## New checks

- [x] `CAPTION_BOTTOM_MARGIN_FRAC` was moved 0.12 → 0.13 and the package rebuilt; both identity tests went red (`expected [ 735580, 735584, … (3726) ] to deeply equal []`), then restored and re-verified 9/9.
- [x] The caption cache key follows T14's pattern: `Object.keys` of a fully populated style is asserted against the **live Zod schema**, so a field added under I1 fails before it can render a stale bitmap.

## Found, not fixed

- **The `textStyle` and `shapeStyle` tool schemas are stale.** `ui_timeline_set_clip_params` and the bridge's `fullTextStyleParams` / `shapeStyleParams` still list only pre-T14/T16 fields — no `fontStyle`, `letterSpacingPx`, `lineHeight`, `verticalAlign`, `stroke`, `shadow`, `background`, `fill`; `shapeStyle.kind` is still `rect | ellipse | line` with no `d`, `sides`, `fillStyle`, `dash` or trim. The renderer honours all of them, so an agent can build a document the tools cannot express. T14 and T16 each left this; all three style bags should be reconciled at once.
- `web/src/components/timeline/timelineAgentBridge.ts`'s `TimelineShapeStyle` already lists `path | polygon | star` while the Zod schema in `web/src/lib/tools/builtin/timeline.ts` does not — the two disagree on the same field.
- `npm run dev:nodetool -- harness gate --base main` was not run (it needs a `main` base this branch has moved from); worth running in the PR pipeline.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdzG3a3jN3Dzx6QV8xh4Bo

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdzG3a3jN3Dzx6QV8xh4Bo)_