### PR TITLE
feat(timeline): mark the beats and cut to them [T20]

### DIFF
--- a/packages/agents/src/capabilities/timelines.specs.ts
+++ b/packages/agents/src/capabilities/timelines.specs.ts
@@ -126,7 +126,8 @@ export const EDIT_TIMELINE_SCHEMA: JsonSchema = {
         "split_clip, trim_clip, move_clip, duplicate_clip, delete_clip, " +
         "set_clip_params, set_clip_binding, set_transition, set_mask, " +
         "set_matte, set_effects, animate_clip, " +
-        "clear_animations, list_animation_presets, select_clip, seek. " +
+        "clear_animations, list_animation_presets, select_clip, seek, " +
+        "add_marker, delete_marker, set_markers_from_beats, snap_to_beats. " +
         "Start with get_state to " +
         "read track and clip ids. To lay existing videos end to end, call " +
         'add_media_clip once per asset ({"op": "add_media_clip", "asset": ' +
@@ -153,7 +154,17 @@ export const EDIT_TIMELINE_SCHEMA: JsonSchema = {
         'set_effects takes {"target", "effects": [{type, ...}]} and replaces ' +
         "the whole chain — types color, blur, glow, dropShadow, vignette, " +
         "sharpen, chromaKey, curves, levels, liftGammaGain, applied in the " +
-        "order given. An empty list clears it.",
+        "order given. An empty list clears it. " +
+        'add_marker takes {"timeMs", "label"?, "color"?, "note"?} and ' +
+        'delete_marker {"target"} (marker id or label). ' +
+        "set_markers_from_beats and snap_to_beats both take a grid — " +
+        '"onsets_ms" (detect_audio_events reports `onsets.times` in SECONDS, ' +
+        'so multiply by 1000) or "bpm" with "offset_ms"?; ' +
+        'set_markers_from_beats also needs "count". snap_to_beats takes ' +
+        '"targets" (clip ids or names, or "all"), "tolerance_ms"? (default ' +
+        '60), "mode"? ("start" | "end" | "both") and "action"? ("move" slides ' +
+        'the clip, "trim" changes its length), and reports every target — ' +
+        "including the ones no beat was in reach of, with the reason.",
       items: { type: "object" }
     }
   },

--- a/packages/agents/src/capabilities/timelines.ts
+++ b/packages/agents/src/capabilities/timelines.ts
@@ -629,7 +629,8 @@ async function applyOps(
       width: sequence.width,
       height: sequence.height,
       tracks: document.tracks,
-      clips: document.clips
+      clips: document.clips,
+      markers: document.markers
     },
     resolveAsset: (ref) => resolveTimelineAsset(run, ref),
     bakeAnimation: (request) => bakeTimelineAnimation(run, request)
@@ -691,9 +692,10 @@ function resolveNamedUnit(
 /**
  * The unit ids one op's result names.
  *
- * The bridge answers `{ok, clip}`, `{ok, track}`, `{ok, clips}` (a split),
- * `{ok, deleted}` (a delete) or `{ok, selected}` — never a bare `id`, which
- * is why reading `result.id` alone left every `"selected"` target unresolved.
+ * The bridge answers `{ok, clip}`, `{ok, track}`, `{ok, marker}`, `{ok, clips}`
+ * (a split), `{ok, deleted}` (a delete) or `{ok, selected}` — never a bare
+ * `id`, which is why reading `result.id` alone left every `"selected"` target
+ * unresolved.
  */
 export function resultUnitIds(result: unknown): string[] {
   if (!isRecord(result)) return [];
@@ -701,7 +703,7 @@ export function resultUnitIds(result: unknown): string[] {
   const push = (value: unknown): void => {
     if (isRecord(value) && isString(value["id"])) ids.push(value["id"]);
   };
-  for (const key of ["clip", "track", "deleted", "selected"]) {
+  for (const key of ["clip", "track", "marker", "deleted", "selected"]) {
     push(result[key]);
   }
   const clips = result["clips"];
@@ -775,12 +777,14 @@ const editTimeline: CapabilityExport = {
       const document = sequence.toDocument();
       const { records, state } = await applyOps(run, sequence, document, ops);
 
-      // Markers and the transcript ride along untouched: no timeline operation
-      // edits them, so the stored copies stay authoritative.
+      // The transcript rides along untouched — no timeline operation edits it,
+      // so the stored copy stays authoritative. Markers come back from the
+      // bridge, which seeded them and which the marker ops write to.
       const next: TimelineDocument = {
         ...document,
         tracks: state.documentTracks,
-        clips: state.documentClips
+        clips: state.documentClips,
+        markers: state.markers
       };
       const saved = await TimelineSequence.updateDocumentIfUnchanged(
         timelineId,

--- a/packages/agents/src/evals/surfaces/creative-pipeline.ts
+++ b/packages/agents/src/evals/surfaces/creative-pipeline.ts
@@ -649,10 +649,10 @@ export function createCreativePipelineBridge(
     "Check the assembled sequence without rendering it: tracks and clips a render would refuse, timings that cannot lay out, animation presets that do not exist. Returns errors and warnings. Call it on the delivered cut — a sequence that assembled is not necessarily a sequence that validates.",
     z.object({}),
     async () => {
-      const { fps, width, height, documentTracks, documentClips } =
+      const { fps, width, height, documentTracks, documentClips, markers } =
         timeline.finalState();
       timelineValidation = validateTimelineSequence(
-        { tracks: documentTracks, clips: documentClips, markers: [] },
+        { tracks: documentTracks, clips: documentClips, markers },
         { fps, width, height }
       );
       // `ok` here is the validator's verdict, not "the call succeeded" — a cut

--- a/packages/agents/src/evals/surfaces/timeline.ts
+++ b/packages/agents/src/evals/surfaces/timeline.ts
@@ -45,12 +45,19 @@ import {
   mediaTypeForContentType,
   trackTypeForMediaType,
   STAGGER_UNITS,
+  DEFAULT_BEAT_TOLERANCE_MS,
+  buildBeatGrid,
+  beatCountToCover,
+  snapClipsToGrid,
   type AnimationRole,
   type CustomClipAnimation,
   type PropertyCurve,
   type ClipEffect,
   type ClipMask,
+  type SnapBoundaryMode,
+  type SnapAction,
   type TimelineClip,
+  type TimelineMarker,
   type TimelineTrack,
   type ClipAnimation
 } from "@nodetool-ai/timeline";
@@ -518,6 +525,8 @@ export interface TimelineBridgeSequenceSeed {
   height?: number;
   tracks: TimelineTrack[];
   clips: TimelineClip[];
+  /** The document's markers. Absent reads as a sequence with none. */
+  markers?: TimelineMarker[];
 }
 
 /**
@@ -610,6 +619,11 @@ export interface TimelineBridgeFinalState {
    */
   documentTracks: TimelineTrack[];
   documentClips: TimelineClip[];
+  /**
+   * The document's markers. There is no reduced twin: a marker is four fields
+   * wide, so a predicate and a document reader want the same shape.
+   */
+  markers: TimelineMarker[];
 }
 
 function tool<TResult>(
@@ -671,8 +685,10 @@ export function createTimelineToolBridge(
   let trackSeq = 0;
   let clipSeq = 0;
   let animSeq = 0;
+  let markerSeq = 0;
   const tracks: TimelineTrack[] = [];
   let clips: TimelineClip[] = [];
+  let markers: TimelineMarker[] = [];
 
   // Ids the sequence already uses. A seeded document brings its own, which the
   // `track_1`/`clip_1` counters would otherwise collide with on the first edit.
@@ -686,6 +702,7 @@ export function createTimelineToolBridge(
   const nextTrackId = () => mint("track", () => ++trackSeq);
   const nextClipId = () => mint("clip", () => ++clipSeq);
   const nextAnimId = () => mint("anim", () => ++animSeq);
+  const nextMarkerId = () => mint("marker", () => ++markerSeq);
 
   function addTrackInternal(
     type: TimelineTrack["type"],
@@ -740,6 +757,51 @@ export function createTimelineToolBridge(
     const byName = clips.find((c) => c.name.toLowerCase() === lower);
     if (byName) return byName;
     throw new Error(`No clip found matching "${target}".`);
+  }
+
+  /** Resolve a marker by id, or by case-insensitive label. */
+  function resolveMarker(target: string): TimelineMarker {
+    const byId = markers.find((m) => m.id === target);
+    if (byId) return byId;
+    const lower = target.toLowerCase();
+    const byLabel = markers.find((m) => m.label.toLowerCase() === lower);
+    if (byLabel) return byLabel;
+    const known = markers
+      .map((m) => `${m.id} ("${m.label}") at ${m.timeMs}ms`)
+      .join(", ");
+    throw new Error(
+      `No marker matches "${target}". Use a marker id or its label. ` +
+        (known.length > 0
+          ? `Markers: ${known}.`
+          : "This sequence has no markers yet.")
+    );
+  }
+
+  /**
+   * Resolve the clips one beat op addresses: the named ones, or every clip.
+   *
+   * A target that matches nothing comes back as a miss rather than throwing —
+   * a batch op that dies on one bad name hides what the other targets did.
+   */
+  function resolveSnapTargets(targets: string[] | undefined): {
+    clips: TimelineClip[];
+    missing: string[];
+  } {
+    if (!targets || targets.length === 0) {
+      return { clips: [...clips], missing: [] };
+    }
+    const resolved: TimelineClip[] = [];
+    const missing: string[] = [];
+    for (const target of targets) {
+      try {
+        const clip = resolveClip(target);
+        if (!resolved.includes(clip)) resolved.push(clip);
+      } catch {
+        // Recorded as a skip in the op's own report, with the reason.
+        missing.push(target);
+      }
+    }
+    return { clips: resolved, missing };
   }
 
   function serializeTrack(t: TimelineTrack) {
@@ -900,6 +962,11 @@ export function createTimelineToolBridge(
       for (const animation of copy.animations ?? []) usedIds.add(animation.id);
       clips.push(copy);
     }
+    for (const marker of seed.markers ?? []) {
+      const copy = structuredClone(marker);
+      usedIds.add(copy.id);
+      markers.push(copy);
+    }
   }
 
   // Seed initial tracks and clips.
@@ -947,7 +1014,8 @@ export function createTimelineToolBridge(
           playheadMs,
           selectedClipIds: [...selectedClipIds],
           tracks: tracks.map(serializeTrack),
-          clips: clips.map(serializeClip)
+          clips: clips.map(serializeClip),
+          markers: markers.map((m) => ({ ...m }))
         };
       }
     ),
@@ -1633,6 +1701,231 @@ export function createTimelineToolBridge(
         playheadMs = Math.max(0, timeMs as number);
         return { ok: true, playheadMs };
       }
+    ),
+
+    tool(
+      "ui_timeline_add_marker",
+      "Drop a marker at an absolute time on the timeline, to flag a moment — a beat, a scene boundary, a note for the user. Markers do not render; they are annotations on the ruler.",
+      z.object({
+        timeMs: z
+          .number()
+          .describe("Absolute position on the timeline in ms. Must be >= 0."),
+        label: z.string().optional().describe("Short label shown on the ruler."),
+        color: z.string().optional().describe("CSS colour for the marker dot."),
+        note: z.string().optional().describe("Longer note attached to the marker.")
+      }),
+      async ({ timeMs, label, color, note }) => {
+        const at = timeMs as number;
+        if (at < 0) {
+          throw new Error(`A marker cannot sit before zero; got ${at}ms.`);
+        }
+        const marker: TimelineMarker = {
+          id: nextMarkerId(),
+          timeMs: Math.round(at),
+          label: (label as string | undefined) ?? ""
+        };
+        if (color !== undefined) marker.color = color as string;
+        if (note !== undefined) marker.note = note as string;
+        markers.push(marker);
+        return { ok: true, marker: { ...marker } };
+      }
+    ),
+
+    tool(
+      "ui_timeline_delete_marker",
+      "Remove a marker by id or by its label (case-insensitive). Call ui_timeline_get_state to see the markers a sequence carries.",
+      z.object({
+        target: z.string().describe("Marker id or label (case-insensitive).")
+      }),
+      async ({ target }) => {
+        const marker = resolveMarker(target as string);
+        markers = markers.filter((m) => m.id !== marker.id);
+        return { ok: true, deleted: { ...marker } };
+      }
+    ),
+
+    tool(
+      "ui_timeline_set_markers_from_beats",
+      "Lay a marker on every beat of a grid, so the cut has something to work against. The grid is either `onsets_ms` — detect_audio_events reports `onsets.times` in SECONDS, so multiply by 1000 — or `bpm` with `count` and an optional `offset_ms` for where beat one sits. Markers already on the sequence are kept, and a beat that already carries one is skipped, so re-running the same grid changes nothing.",
+      z.object({
+        onsets_ms: z
+          .array(z.number())
+          .optional()
+          .describe("Absolute beat times in ms. Exactly one of this and `bpm`."),
+        bpm: z.number().optional().describe("Tempo. Needs `count`."),
+        offset_ms: z
+          .number()
+          .optional()
+          .describe("Where beat one sits, in ms. Default 0."),
+        count: z.number().optional().describe("Beats to lay down, with `bpm`."),
+        label: z
+          .string()
+          .optional()
+          .describe(
+            'Label stem; each marker is numbered from 1 ("Beat 1", "Beat 2", …). Default "Beat".'
+          )
+      }),
+      async ({ onsets_ms, bpm, offset_ms, count, label }) => {
+        const grid = buildBeatGrid({
+          onsetsMs: onsets_ms as number[] | undefined,
+          bpm: bpm as number | undefined,
+          offsetMs: offset_ms as number | undefined,
+          count: count as number | undefined
+        });
+        const stem = ((label as string | undefined) ?? "Beat").trim() || "Beat";
+        const taken = new Set(markers.map((m) => m.timeMs));
+        const added: TimelineMarker[] = [];
+        const skipped: number[] = [];
+        for (const [index, timeMs] of grid.entries()) {
+          if (taken.has(timeMs)) {
+            skipped.push(timeMs);
+            continue;
+          }
+          const marker: TimelineMarker = {
+            id: nextMarkerId(),
+            timeMs,
+            label: `${stem} ${index + 1}`
+          };
+          markers.push(marker);
+          taken.add(timeMs);
+          added.push(marker);
+        }
+        return {
+          ok: true,
+          grid: { count: grid.length, firstMs: grid[0], lastMs: grid[grid.length - 1] },
+          added: added.map((m) => ({ ...m })),
+          skipped_times_ms: skipped,
+          markers: markers.length
+        };
+      }
+    ),
+
+    tool(
+      "ui_timeline_snap_to_beats",
+      "Put clip boundaries on a beat grid. The grid is either `onsets_ms` — detect_audio_events reports `onsets.times` in SECONDS, so multiply by 1000 — or `bpm` with an optional `offset_ms`. `mode` picks the boundary, `action` picks how it gets there: `move` slides the whole clip and keeps its length, `trim` holds the opposite boundary and changes the length. A boundary further than `tolerance_ms` from every beat is left where it is and reported with the reason, so read the per-clip result rather than assuming everything moved.",
+      z.object({
+        targets: z
+          .union([z.array(z.string()), z.literal("all")])
+          .optional()
+          .describe(
+            'Clip ids or names, or "all". Default: every clip on the sequence.'
+          ),
+        onsets_ms: z
+          .array(z.number())
+          .optional()
+          .describe("Absolute beat times in ms. Exactly one of this and `bpm`."),
+        bpm: z.number().optional().describe("Tempo. The grid is generated far enough to reach every target."),
+        offset_ms: z
+          .number()
+          .optional()
+          .describe("Where beat one sits, in ms. Default 0."),
+        tolerance_ms: z
+          .number()
+          .optional()
+          .describe(
+            `How far a boundary may travel to reach a beat. Default ${DEFAULT_BEAT_TOLERANCE_MS}ms.`
+          ),
+        mode: z
+          .enum(["start", "end", "both"])
+          .optional()
+          .describe('Which boundary lands on a beat. Default "start".'),
+        action: z
+          .enum(["move", "trim"])
+          .optional()
+          .describe('"move" slides the clip, "trim" changes its length. Default "move".')
+      }),
+      async ({
+        targets,
+        onsets_ms,
+        bpm,
+        offset_ms,
+        tolerance_ms,
+        mode,
+        action
+      }) => {
+        const named =
+          targets === undefined || targets === "all"
+            ? undefined
+            : (targets as string[]);
+        const { clips: targeted, missing } = resolveSnapTargets(named);
+
+        const offsetMs = (offset_ms as number | undefined) ?? 0;
+        // A tempo grid has to reach the last boundary being snapped, so its
+        // length comes from the targets rather than from the caller.
+        const reachMs = targeted.reduce(
+          (end, clip) => Math.max(end, clip.startMs + clip.durationMs),
+          0
+        );
+        const grid = buildBeatGrid({
+          onsetsMs: onsets_ms as number[] | undefined,
+          bpm: bpm as number | undefined,
+          offsetMs: offset_ms as number | undefined,
+          count:
+            bpm === undefined
+              ? undefined
+              : beatCountToCover(bpm as number, offsetMs, reachMs)
+        });
+
+        const options: {
+          toleranceMs?: number;
+          mode?: SnapBoundaryMode;
+          action?: SnapAction;
+        } = {};
+        if (tolerance_ms !== undefined) {
+          options.toleranceMs = tolerance_ms as number;
+        }
+        if (mode !== undefined) options.mode = mode as SnapBoundaryMode;
+        if (action !== undefined) options.action = action as SnapAction;
+
+        const result = snapClipsToGrid(
+          targeted.map((clip) => ({
+            id: clip.id,
+            startMs: clip.startMs,
+            durationMs: clip.durationMs
+          })),
+          grid,
+          options
+        );
+
+        const byId = new Map(targeted.map((clip) => [clip.id, clip]));
+        const reported = result.clips.map((entry) => {
+          const clip = byId.get(entry.clipId);
+          if (entry.snapped && clip) {
+            clip.startMs = entry.after.startMs;
+            clip.durationMs = entry.after.durationMs;
+          }
+          return { ...entry, clipName: clip?.name ?? null };
+        });
+
+        // A name nothing matched is a skip like any other: the caller has to
+        // see it in the same list, not infer it from a shorter one.
+        for (const target of missing) {
+          reported.push({
+            clipId: target,
+            clipName: null,
+            snapped: false,
+            before: { startMs: 0, endMs: 0, durationMs: 0 },
+            after: { startMs: 0, endMs: 0, durationMs: 0 },
+            delta: { startMs: 0, endMs: 0 },
+            reason: `no clip matches "${target}"`
+          });
+        }
+
+        return {
+          ok: true,
+          grid: {
+            count: grid.length,
+            firstMs: grid[0],
+            lastMs: grid[grid.length - 1]
+          },
+          toleranceMs: result.toleranceMs,
+          mode: result.mode,
+          action: result.action,
+          snapped: result.snapped,
+          skipped: result.skipped + missing.length,
+          clips: reported
+        };
+      }
     )
   ];
 
@@ -1667,7 +1960,8 @@ export function createTimelineToolBridge(
         }))
       })),
       documentTracks: tracks.map((t) => structuredClone(t)),
-      documentClips: clips.map((c) => structuredClone(c))
+      documentClips: clips.map((c) => structuredClone(c)),
+      markers: markers.map((m) => structuredClone(m))
     })
   };
 }
@@ -1681,6 +1975,7 @@ Use the ui_timeline_* tools to inspect and modify the sequence:
 - Before animating a clip, call ui_timeline_list_animation_presets to discover the exact preset ids, allowed roles, and params.
 - For motion no preset covers, animate with preset "custom" and pass curves — [{property, keyframes: [{t, value}]}], where t runs 0..1 over the animation window. list_animation_presets reports which properties a curve may drive.
 - ui_timeline_seek moves the playhead (useful before a playhead-relative split).
+- Flag moments with ui_timeline_add_marker / ui_timeline_delete_marker. To cut to music, lay the grid down with ui_timeline_set_markers_from_beats and put clip boundaries on it with ui_timeline_snap_to_beats, then read its per-clip report — a clip further than the tolerance from every beat is left alone and says so.
 
 Call one tool at a time and use the result before the next call. When the objective is fully satisfied, STOP calling tools and give a one-line summary.`;
 

--- a/packages/agents/tests/capabilities-timelines.test.ts
+++ b/packages/agents/tests/capabilities-timelines.test.ts
@@ -286,6 +286,59 @@ describe("timelines capability behaviour", () => {
     expect(result.tracks.map((t) => t.name)).toContain("Music");
   });
 
+  it("writes markers back to the stored document, and snaps a clip to them", async () => {
+    // Markers used to ride along untouched because no op edited them; the beat
+    // ops do, so the bridge's copy has to reach the row.
+    const row = await makeTimeline();
+    const result = (await run().invoke("edit_timeline", {
+      timeline_id: row.id,
+      ops: [
+        { op: "set_markers_from_beats", bpm: 120, count: 3, label: "Beat" },
+        { op: "move_clip", target: "Shot 1", startMs: 530 },
+        { op: "snap_to_beats", targets: ["Shot 1"], bpm: 120 }
+      ]
+    })) as { applied: number; failed: number; ops: { result?: unknown }[] };
+    expect(result).toMatchObject({ applied: 3, failed: 0 });
+
+    const stored = (await run().invoke("get_timeline", {
+      timeline_id: row.id
+    })) as {
+      timeline: {
+        markers: { timeMs: number; label: string }[];
+        clips: { start_ms?: number; startMs?: number }[];
+      };
+    };
+    expect(stored.timeline.markers.map((m) => m.timeMs)).toEqual([0, 500, 1000]);
+
+    const snap = result.ops[2].result as {
+      snapped: number;
+      clips: { before: { startMs: number }; after: { startMs: number } }[];
+    };
+    expect(snap.snapped).toBe(1);
+    expect(snap.clips[0].before.startMs).toBe(530);
+    expect(snap.clips[0].after.startMs).toBe(500);
+  });
+
+  it("keeps the markers a document already carried through an unrelated edit", async () => {
+    const row = await makeTimeline({
+      document: JSON.stringify({
+        ...JSON.parse(document()),
+        markers: [{ id: "m1", timeMs: 750, label: "Intro" }]
+      })
+    });
+    await run().invoke("edit_timeline", {
+      timeline_id: row.id,
+      ops: [{ op: "add_track", type: "audio", name: "Music" }]
+    });
+
+    const stored = (await run().invoke("get_timeline", {
+      timeline_id: row.id
+    })) as { timeline: { markers: { id: string }[] } };
+    expect(stored.timeline.markers).toEqual([
+      { id: "m1", timeMs: 750, label: "Intro" }
+    ]);
+  });
+
   it("lays two library videos end to end with add_media_clip", async () => {
     const row = await makeTimeline();
     const first = (await Asset.create({

--- a/packages/agents/tests/timelines-op-input.test.ts
+++ b/packages/agents/tests/timelines-op-input.test.ts
@@ -648,3 +648,311 @@ describe("set_effects", () => {
     ).toThrow(/liftGammaGain/);
   });
 });
+
+describe("marker ops", () => {
+  function bridgeWithNoMarkers() {
+    const bridge = createTimelineToolBridge({ tracks: [{ type: "video" }] });
+    const byName = Object.fromEntries(bridge.tools.map((t) => [t.name, t]));
+    return { bridge, byName };
+  }
+
+  it("adds a marker and reports it in the final state", async () => {
+    const { bridge, byName } = bridgeWithNoMarkers();
+    const added = await byName["ui_timeline_add_marker"].execute({
+      timeMs: 4500,
+      label: "Chorus",
+      color: "#ff0055"
+    });
+
+    expect(added).toEqual({
+      ok: true,
+      marker: {
+        id: "marker_1",
+        timeMs: 4500,
+        label: "Chorus",
+        color: "#ff0055"
+      }
+    });
+    expect(bridge.finalState().markers).toEqual([
+      { id: "marker_1", timeMs: 4500, label: "Chorus", color: "#ff0055" }
+    ]);
+  });
+
+  it("refuses a marker before zero", async () => {
+    const { byName } = bridgeWithNoMarkers();
+    await expect(
+      byName["ui_timeline_add_marker"].execute({ timeMs: -1 })
+    ).rejects.toThrow(/before zero/);
+  });
+
+  it("deletes a marker by label, case-insensitively", async () => {
+    const { bridge, byName } = bridgeWithNoMarkers();
+    await byName["ui_timeline_add_marker"].execute({
+      timeMs: 1000,
+      label: "Cut"
+    });
+    const deleted = await byName["ui_timeline_delete_marker"].execute({
+      target: "cut"
+    });
+
+    expect(deleted).toEqual({
+      ok: true,
+      deleted: { id: "marker_1", timeMs: 1000, label: "Cut" }
+    });
+    expect(bridge.finalState().markers).toEqual([]);
+  });
+
+  it("lists the markers it knows when the target matches none", async () => {
+    const { byName } = bridgeWithNoMarkers();
+    await byName["ui_timeline_add_marker"].execute({
+      timeMs: 1000,
+      label: "Cut"
+    });
+    await expect(
+      byName["ui_timeline_delete_marker"].execute({ target: "nope" })
+    ).rejects.toThrow(/marker_1 \("Cut"\) at 1000ms/);
+  });
+
+  it("reports the markers on get_state, so delete_marker has a target", async () => {
+    const { byName } = bridgeWithNoMarkers();
+    await byName["ui_timeline_add_marker"].execute({ timeMs: 500, label: "A" });
+    const state = (await byName["ui_timeline_get_state"].execute({})) as {
+      markers: { id: string; timeMs: number }[];
+    };
+
+    expect(state.markers).toEqual([
+      { id: "marker_1", timeMs: 500, label: "A" }
+    ]);
+  });
+
+  it("seeds the markers a document already carries", () => {
+    const bridge = createTimelineToolBridge({
+      sequence: {
+        tracks: [],
+        clips: [],
+        markers: [{ id: "m_seeded", timeMs: 250, label: "Intro" }]
+      }
+    });
+
+    expect(bridge.finalState().markers).toEqual([
+      { id: "m_seeded", timeMs: 250, label: "Intro" }
+    ]);
+  });
+});
+
+describe("set_markers_from_beats", () => {
+  function bareBridge() {
+    const bridge = createTimelineToolBridge();
+    const byName = Object.fromEntries(bridge.tools.map((t) => [t.name, t]));
+    return { bridge, byName };
+  }
+
+  it("lays one numbered marker per beat of a tempo grid", async () => {
+    const { bridge, byName } = bareBridge();
+    await byName["ui_timeline_set_markers_from_beats"].execute({
+      bpm: 120,
+      count: 3
+    });
+
+    expect(
+      bridge.finalState().markers.map((m) => [m.timeMs, m.label])
+    ).toEqual([
+      [0, "Beat 1"],
+      [500, "Beat 2"],
+      [1000, "Beat 3"]
+    ]);
+  });
+
+  it("takes onset times and a label stem", async () => {
+    const { bridge, byName } = bareBridge();
+    await byName["ui_timeline_set_markers_from_beats"].execute({
+      onsets_ms: [1200, 400],
+      label: "Hit"
+    });
+
+    expect(
+      bridge.finalState().markers.map((m) => [m.timeMs, m.label])
+    ).toEqual([
+      [400, "Hit 1"],
+      [1200, "Hit 2"]
+    ]);
+  });
+
+  it("keeps existing markers and skips a beat one already sits on", async () => {
+    const { bridge, byName } = bareBridge();
+    await byName["ui_timeline_add_marker"].execute({
+      timeMs: 500,
+      label: "Hand-placed"
+    });
+    const result = (await byName[
+      "ui_timeline_set_markers_from_beats"
+    ].execute({ bpm: 120, count: 3 })) as { skipped_times_ms: number[] };
+
+    expect(result.skipped_times_ms).toEqual([500]);
+    expect(bridge.finalState().markers.map((m) => m.label)).toEqual([
+      "Hand-placed",
+      "Beat 1",
+      "Beat 3"
+    ]);
+  });
+
+  it("is a no-op on a re-run of the same grid", async () => {
+    const { bridge, byName } = bareBridge();
+    const set = byName["ui_timeline_set_markers_from_beats"];
+    await set.execute({ bpm: 120, count: 4 });
+    await set.execute({ bpm: 120, count: 4 });
+
+    expect(bridge.finalState().markers).toHaveLength(4);
+  });
+
+  it("refuses a grid with no source, and one with both", async () => {
+    const { byName } = bareBridge();
+    await expect(
+      byName["ui_timeline_set_markers_from_beats"].execute({})
+    ).rejects.toThrow(/onsets_ms/);
+    await expect(
+      byName["ui_timeline_set_markers_from_beats"].execute({
+        bpm: 120,
+        count: 2,
+        onsets_ms: [0]
+      })
+    ).rejects.toThrow(/exactly one/);
+  });
+});
+
+describe("snap_to_beats", () => {
+  /** Two clips: one 30 ms off a 120 BPM beat, one 90 ms off. */
+  function bridgeWithTwoClips() {
+    const bridge = createTimelineToolBridge({
+      tracks: [{ type: "video" }],
+      clips: [
+        {
+          name: "near",
+          trackIndex: 0,
+          mediaType: "video",
+          startMs: 530,
+          durationMs: 1000
+        },
+        {
+          name: "far",
+          trackIndex: 0,
+          mediaType: "video",
+          startMs: 2090,
+          durationMs: 1000
+        }
+      ]
+    });
+    const byName = Object.fromEntries(bridge.tools.map((t) => [t.name, t]));
+    return { bridge, byName };
+  }
+
+  const clipNamed = (
+    bridge: { finalState: () => TimelineBridgeFinalState },
+    name: string
+  ) => bridge.finalState().documentClips.find((c) => c.name === name);
+
+  it("moves the clip inside tolerance and leaves the one outside it", async () => {
+    const { bridge, byName } = bridgeWithTwoClips();
+    const result = (await byName["ui_timeline_snap_to_beats"].execute({
+      bpm: 120
+    })) as {
+      snapped: number;
+      skipped: number;
+      clips: { clipId: string; clipName: string | null; snapped: boolean; reason?: string }[];
+    };
+
+    expect([result.snapped, result.skipped]).toEqual([1, 1]);
+    expect(clipNamed(bridge, "near")?.startMs).toBe(500);
+    expect(clipNamed(bridge, "far")?.startMs).toBe(2090);
+
+    const far = result.clips.find((entry) => entry.clipName === "far");
+    expect(far?.snapped).toBe(false);
+    expect(far?.reason).toContain("90ms from the nearest beat (2000ms)");
+  });
+
+  it("reports before, after and delta per clip", async () => {
+    const { byName } = bridgeWithTwoClips();
+    const result = (await byName["ui_timeline_snap_to_beats"].execute({
+      targets: ["near"],
+      bpm: 120
+    })) as {
+      clips: {
+        clipId: string;
+        before: { startMs: number };
+        after: { startMs: number };
+        delta: { startMs: number; endMs: number };
+      }[];
+    };
+
+    expect(result.clips[0].before.startMs).toBe(530);
+    expect(result.clips[0].after.startMs).toBe(500);
+    expect(result.clips[0].delta).toEqual({ startMs: -30, endMs: -30 });
+  });
+
+  it("widens the tolerance on request", async () => {
+    const { bridge, byName } = bridgeWithTwoClips();
+    await byName["ui_timeline_snap_to_beats"].execute({
+      bpm: 120,
+      tolerance_ms: 100
+    });
+
+    expect(clipNamed(bridge, "far")?.startMs).toBe(2000);
+  });
+
+  it("trims the end onto the beat without moving the start", async () => {
+    const { bridge, byName } = bridgeWithTwoClips();
+    await byName["ui_timeline_snap_to_beats"].execute({
+      targets: ["near"],
+      onsets_ms: [530, 1500],
+      mode: "end",
+      action: "trim"
+    });
+
+    expect(clipNamed(bridge, "near")).toMatchObject({
+      startMs: 530,
+      durationMs: 970
+    });
+  });
+
+  it("resolves targets by name and by id, and reports a name it cannot", async () => {
+    const { bridge, byName } = bridgeWithTwoClips();
+    const nearId = bridge.finalState().documentClips[0].id;
+    const result = (await byName["ui_timeline_snap_to_beats"].execute({
+      targets: [nearId, "ghost"],
+      bpm: 120
+    })) as { clips: { clipId: string; reason?: string }[] };
+
+    expect(result.clips.map((entry) => entry.clipId)).toEqual([
+      nearId,
+      "ghost"
+    ]);
+    expect(result.clips[1].reason).toBe('no clip matches "ghost"');
+  });
+
+  it('takes "all" as the whole sequence', async () => {
+    const { byName } = bridgeWithTwoClips();
+    const result = (await byName["ui_timeline_snap_to_beats"].execute({
+      targets: "all",
+      bpm: 120
+    })) as { clips: unknown[] };
+
+    expect(result.clips).toHaveLength(2);
+  });
+
+  it("generates a tempo grid long enough to reach the last clip", async () => {
+    const { byName } = bridgeWithTwoClips();
+    const result = (await byName["ui_timeline_snap_to_beats"].execute({
+      bpm: 120
+    })) as { grid: { lastMs: number } };
+
+    // The far clip ends at 3090 ms, so the grid has to run past it.
+    expect(result.grid.lastMs).toBeGreaterThanOrEqual(3090);
+  });
+
+  it("refuses a mode this build does not implement", () => {
+    const { byName } = bridgeWithTwoClips();
+    expect(() =>
+      byName["ui_timeline_snap_to_beats"].execute({ bpm: 120, mode: "middle" })
+    ).toThrow(/start/);
+  });
+});

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -1793,7 +1793,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "edit_timeline",
     module: "timelines",
     impl: "packages/agents/src/capabilities/timelines.ts",
-    contract: "5dde045840c1",
+    contract: "27ca8c848268",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-timelines.test.ts",

--- a/packages/cli/src/timeline-debug/harness.ts
+++ b/packages/cli/src/timeline-debug/harness.ts
@@ -60,6 +60,7 @@ export interface TimelineBridgeTool {
 export interface TimelineBridgeSnapshot {
   documentTracks?: TimelineDocument["tracks"];
   documentClips?: TimelineDocument["clips"];
+  markers?: TimelineDocument["markers"];
 }
 
 export interface TimelineBridge {
@@ -71,6 +72,7 @@ export type CreateTimelineBridge = (initial: {
   sequence: TimelineSequenceSettings & {
     tracks: TimelineDocument["tracks"];
     clips: TimelineDocument["clips"];
+    markers?: TimelineDocument["markers"];
   };
 }) => TimelineBridge;
 
@@ -169,7 +171,8 @@ export async function runTimelineDebug(
       sequence: {
         ...resolved.meta,
         tracks: resolved.document.tracks,
-        clips: resolved.document.clips
+        clips: resolved.document.clips,
+        markers: resolved.document.markers
       }
     });
     const byName = new Map(bridge.tools.map((t) => [t.name, t]));
@@ -210,15 +213,15 @@ export async function runTimelineDebug(
     snapshot = bridge.finalState();
   }
 
-  // The bridge hands back its full tracks and clips, so the document the
-  // session ended with is a real document — markers ride along untouched,
-  // since no timeline tool edits them.
+  // The bridge hands back its full tracks, clips and markers, so the document
+  // the session ended with is a real document. Markers fall back to the ones
+  // the target carried, for a bridge that does not report them.
   const finalDocument: TimelineDocument | undefined =
     snapshot?.documentTracks && snapshot.documentClips
       ? {
           tracks: snapshot.documentTracks,
           clips: snapshot.documentClips,
-          markers: resolved.document.markers
+          markers: snapshot.markers ?? resolved.document.markers
         }
       : undefined;
 

--- a/packages/cli/tests/timeline-harness.test.ts
+++ b/packages/cli/tests/timeline-harness.test.ts
@@ -196,7 +196,8 @@ describe("runTimelineDebug", () => {
         width: 1280,
         height: 720,
         tracks: [track],
-        clips: [clip]
+        clips: [clip],
+        markers: []
       }
     });
     expect(report.interactions).toEqual([
@@ -252,6 +253,38 @@ describe("runTimelineDebug", () => {
     expect(built.finalDocument?.clips).toEqual([clip]);
     expect(built.finalDocument?.markers).toEqual([]);
     expect(built.finalState).toBeDefined();
+  });
+
+  it("takes the markers the bridge reports over the target's own", async () => {
+    // The marker ops edit them, so a session that added one has to reach the
+    // report — the fallback to the target's markers is for a bridge with none.
+    const core = fakeCore();
+    const marker = { id: "m1", timeMs: 500, label: "Beat 1" };
+    await runTimelineDebug(
+      timelineFile(),
+      {
+        interact: parseInteractionScript(
+          JSON.stringify([{ tool: "add_track", input: { type: "audio" } }])
+        ),
+        outDir: outDir()
+      },
+      {
+        loadSequence: async () => null,
+        core,
+        createBridge: () => {
+          const bridge = fakeBridge();
+          return {
+            ...bridge,
+            finalState: () => ({ ...bridge.finalState(), markers: [marker] })
+          };
+        }
+      }
+    );
+
+    const built = core.calls.build[0] as {
+      finalDocument?: { markers: unknown[] };
+    };
+    expect(built.finalDocument?.markers).toEqual([marker]);
   });
 
   it("runs no bridge at all without an interact script", async () => {

--- a/packages/timeline/src/beats.ts
+++ b/packages/timeline/src/beats.ts
@@ -1,0 +1,351 @@
+/**
+ * Beat grids and clip snapping.
+ *
+ * `detect_audio_events` reports onset times and a tempo; this turns either of
+ * those into a grid of absolute times and moves or trims clips onto it. Every
+ * function here is pure arithmetic over plain numbers, so the capability op,
+ * the browser twin and the tests all read the same rules.
+ */
+
+/** Times a grid may hold, so a runaway `count` cannot fill a document. */
+export const MAX_BEAT_GRID_POINTS = 2048;
+
+/** Distance a boundary may travel to reach a beat, when the caller names none. */
+export const DEFAULT_BEAT_TOLERANCE_MS = 60;
+
+/**
+ * Where a grid comes from: onset times measured off the audio, or a tempo.
+ * Exactly one of `onsetsMs` and `bpm`.
+ */
+export interface BeatGridSpec {
+  /** Absolute times in ms. Order and duplicates do not matter. */
+  onsetsMs?: readonly number[];
+  /** Beats per minute. */
+  bpm?: number;
+  /** Where beat one sits, in ms. Defaults to 0. */
+  offsetMs?: number;
+  /** Beats to generate from `bpm`. Required with `bpm`. */
+  count?: number;
+}
+
+/**
+ * Build the absolute grid times, ascending and deduplicated.
+ *
+ * Throws rather than returning an error value: every caller has to stop
+ * anyway, and the message is what the agent needs to read.
+ */
+export function buildBeatGrid(spec: BeatGridSpec): number[] {
+  const hasOnsets = spec.onsetsMs !== undefined;
+  const hasBpm = spec.bpm !== undefined;
+  if (hasOnsets && hasBpm) {
+    throw new Error(
+      "A beat grid takes exactly one of `onsets_ms` and `bpm`; both were given."
+    );
+  }
+  if (!hasOnsets && !hasBpm) {
+    throw new Error(
+      "A beat grid needs `onsets_ms` (times in ms, e.g. detect_audio_events' " +
+        "`onsets.times` multiplied by 1000) or `bpm` with `count`."
+    );
+  }
+
+  if (hasOnsets) {
+    const onsets = spec.onsetsMs ?? [];
+    const times: number[] = [];
+    for (const onset of onsets) {
+      if (!Number.isFinite(onset) || onset < 0) {
+        throw new Error(
+          `onsets_ms holds ${String(onset)}; every onset must be a time in ms at or after zero.`
+        );
+      }
+      times.push(Math.round(onset));
+    }
+    if (times.length === 0) {
+      throw new Error("onsets_ms is empty; there is nothing to snap to.");
+    }
+    if (times.length > MAX_BEAT_GRID_POINTS) {
+      throw new Error(
+        `onsets_ms holds ${times.length} times; at most ${MAX_BEAT_GRID_POINTS}.`
+      );
+    }
+    return dedupeSorted(times);
+  }
+
+  const bpm = spec.bpm ?? 0;
+  if (!Number.isFinite(bpm) || bpm <= 0) {
+    throw new Error(`bpm must be a positive number; got ${String(spec.bpm)}.`);
+  }
+  const offsetMs = spec.offsetMs ?? 0;
+  if (!Number.isFinite(offsetMs) || offsetMs < 0) {
+    throw new Error(
+      `offset_ms must be a time in ms at or after zero; got ${String(spec.offsetMs)}.`
+    );
+  }
+  const count = spec.count ?? 0;
+  if (!Number.isInteger(count) || count < 1) {
+    throw new Error(
+      `count must be a positive whole number of beats; got ${String(spec.count)}.`
+    );
+  }
+  if (count > MAX_BEAT_GRID_POINTS) {
+    throw new Error(
+      `count is ${count}; at most ${MAX_BEAT_GRID_POINTS} beats per grid.`
+    );
+  }
+
+  const intervalMs = 60000 / bpm;
+  const times: number[] = [];
+  // Each beat is `offset + i * interval` rather than an accumulated sum, so a
+  // fractional interval (140 BPM is 428.571… ms) does not drift over a long
+  // grid — the same rule `buildSnapPoints` follows for its ticks.
+  for (let i = 0; i < count; i++) {
+    times.push(Math.round(offsetMs + i * intervalMs));
+  }
+  return dedupeSorted(times);
+}
+
+function dedupeSorted(times: number[]): number[] {
+  return Array.from(new Set(times)).sort((a, b) => a - b);
+}
+
+/**
+ * Beats needed to cover `untilMs` at `bpm` starting at `offsetMs`, capped.
+ *
+ * `snap_to_beats` takes a tempo with no count, because the count that matters
+ * is whatever reaches the last clip.
+ */
+export function beatCountToCover(
+  bpm: number,
+  offsetMs: number,
+  untilMs: number
+): number {
+  if (!Number.isFinite(bpm) || bpm <= 0) return 0;
+  const intervalMs = 60000 / bpm;
+  const beyond = Math.max(0, untilMs - offsetMs);
+  // One past the beat that reaches `untilMs`, so a boundary sitting just after
+  // the last whole beat still has a later beat to snap forward to.
+  return Math.min(MAX_BEAT_GRID_POINTS, Math.floor(beyond / intervalMs) + 2);
+}
+
+/** The clip fields snapping reads and writes. */
+export interface SnapClipInput {
+  id: string;
+  startMs: number;
+  durationMs: number;
+}
+
+/** Which boundary of a clip is put on the grid. */
+export type SnapBoundaryMode = "start" | "end" | "both";
+
+/**
+ * How a boundary reaches the grid. `move` slides the whole clip and keeps its
+ * length; `trim` holds the opposite boundary and changes the length — so
+ * trimming the end keeps `startMs`, and trimming the start keeps the end.
+ */
+export type SnapAction = "move" | "trim";
+
+export interface SnapClipBounds {
+  startMs: number;
+  endMs: number;
+  durationMs: number;
+}
+
+/** What one clip did, whether or not it moved. */
+export interface ClipSnapResult {
+  clipId: string;
+  snapped: boolean;
+  before: SnapClipBounds;
+  after: SnapClipBounds;
+  /** Signed shift of each boundary in ms; zero where it did not move. */
+  delta: { startMs: number; endMs: number };
+  /** Why nothing moved. Set only when `snapped` is false. */
+  reason?: string;
+}
+
+export interface SnapClipsToGridOptions {
+  toleranceMs?: number;
+  mode?: SnapBoundaryMode;
+  action?: SnapAction;
+}
+
+export interface SnapClipsToGridResult {
+  toleranceMs: number;
+  mode: SnapBoundaryMode;
+  action: SnapAction;
+  snapped: number;
+  skipped: number;
+  /** One entry per input clip, in input order. */
+  clips: ClipSnapResult[];
+}
+
+/**
+ * The grid time nearest `timeMs` within `toleranceMs`, or null.
+ *
+ * Ties go to the earlier time, matching `snap()` — an editor that resolved a
+ * tie differently per call would place two identical cuts in two places.
+ */
+export function nearestGridTime(
+  timeMs: number,
+  grid: readonly number[],
+  toleranceMs: number
+): number | null {
+  let best: number | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const candidate of grid) {
+    const distance = Math.abs(candidate - timeMs);
+    if (distance > toleranceMs) continue;
+    if (distance < bestDistance) {
+      best = candidate;
+      bestDistance = distance;
+      continue;
+    }
+    if (distance === bestDistance && best !== null && candidate < best) {
+      best = candidate;
+    }
+  }
+  return best;
+}
+
+function bounds(startMs: number, durationMs: number): SnapClipBounds {
+  return { startMs, endMs: startMs + durationMs, durationMs };
+}
+
+/** `"90ms from the nearest beat"`, or that there is no beat in reach at all. */
+function distanceNote(
+  label: string,
+  timeMs: number,
+  grid: readonly number[]
+): string {
+  let nearest: number | null = null;
+  let nearestDistance = Number.POSITIVE_INFINITY;
+  for (const candidate of grid) {
+    const distance = Math.abs(candidate - timeMs);
+    if (distance < nearestDistance) {
+      nearest = candidate;
+      nearestDistance = distance;
+    }
+  }
+  if (nearest === null) return `${label} ${timeMs}ms has no beat to reach`;
+  return `${label} ${timeMs}ms is ${Math.round(nearestDistance)}ms from the nearest beat (${nearest}ms)`;
+}
+
+/**
+ * Put each clip's chosen boundary on the nearest grid time within tolerance.
+ *
+ * A clip whose boundary is out of tolerance is reported with `snapped: false`
+ * and a reason rather than dropped from the result: the caller has to be able
+ * to see which clips did not move and why, and a silent skip reads as success.
+ */
+export function snapClipsToGrid(
+  clips: readonly SnapClipInput[],
+  grid: readonly number[],
+  options: SnapClipsToGridOptions = {}
+): SnapClipsToGridResult {
+  const toleranceMs = Math.max(0, options.toleranceMs ?? DEFAULT_BEAT_TOLERANCE_MS);
+  const mode = options.mode ?? "start";
+  const action = options.action ?? "move";
+
+  const results: ClipSnapResult[] = [];
+  for (const clip of clips) {
+    results.push(snapOneClip(clip, grid, toleranceMs, mode, action));
+  }
+
+  const snapped = results.filter((result) => result.snapped).length;
+  return {
+    toleranceMs,
+    mode,
+    action,
+    snapped,
+    skipped: results.length - snapped,
+    clips: results
+  };
+}
+
+function snapOneClip(
+  clip: SnapClipInput,
+  grid: readonly number[],
+  toleranceMs: number,
+  mode: SnapBoundaryMode,
+  action: SnapAction
+): ClipSnapResult {
+  const before = bounds(clip.startMs, clip.durationMs);
+  const unchanged = (reason: string): ClipSnapResult => ({
+    clipId: clip.id,
+    snapped: false,
+    before,
+    after: before,
+    delta: { startMs: 0, endMs: 0 },
+    reason
+  });
+
+  if (grid.length === 0) {
+    return unchanged("the beat grid is empty");
+  }
+
+  const wantsStart = mode === "start" || mode === "both";
+  const wantsEnd = mode === "end" || mode === "both";
+  const startTarget = wantsStart
+    ? nearestGridTime(before.startMs, grid, toleranceMs)
+    : null;
+  const endTarget = wantsEnd
+    ? nearestGridTime(before.endMs, grid, toleranceMs)
+    : null;
+
+  if (startTarget === null && endTarget === null) {
+    const notes: string[] = [];
+    if (wantsStart) notes.push(distanceNote("start", before.startMs, grid));
+    if (wantsEnd) notes.push(distanceNote("end", before.endMs, grid));
+    return unchanged(`${notes.join("; ")}; tolerance is ${toleranceMs}ms`);
+  }
+
+  let after: SnapClipBounds;
+  if (action === "move") {
+    // One boundary decides the shift and the length rides along. With `both`
+    // the start wins: a move cannot satisfy two boundaries at once, and the
+    // start is where a cut is read from.
+    const shift =
+      startTarget !== null
+        ? startTarget - before.startMs
+        : (endTarget ?? before.endMs) - before.endMs;
+    after = bounds(before.startMs + shift, before.durationMs);
+  } else {
+    const startMs = startTarget ?? before.startMs;
+    const endMs = endTarget ?? before.endMs;
+    after = bounds(startMs, endMs - startMs);
+  }
+
+  if (after.startMs < 0) {
+    return unchanged(
+      `snapping would start the clip at ${after.startMs}ms, before zero`
+    );
+  }
+  if (after.durationMs <= 0) {
+    return unchanged(
+      `snapping would leave the clip ${after.durationMs}ms long`
+    );
+  }
+  if (
+    after.startMs === before.startMs &&
+    after.durationMs === before.durationMs
+  ) {
+    return {
+      clipId: clip.id,
+      snapped: false,
+      before,
+      after,
+      delta: { startMs: 0, endMs: 0 },
+      reason: "already on the grid"
+    };
+  }
+
+  return {
+    clipId: clip.id,
+    snapped: true,
+    before,
+    after,
+    delta: {
+      startMs: after.startMs - before.startMs,
+      endMs: after.endMs - before.endMs
+    }
+  };
+}

--- a/packages/timeline/src/index.ts
+++ b/packages/timeline/src/index.ts
@@ -17,6 +17,7 @@ export * from "./splitClip.js";
 export * from "./trimClip.js";
 export * from "./sourceRate.js";
 export * from "./snap.js";
+export * from "./beats.js";
 export * from "./staleSet.js";
 export * from "./subtitles.js";
 export * from "./placement/index.js";

--- a/packages/timeline/tests/beats.test.ts
+++ b/packages/timeline/tests/beats.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Beat grids and clip snapping (T20, F23).
+ *
+ * The cases are analytic: a 120 BPM grid is a beat every 500 ms, so a clip
+ * 30 ms off a beat is inside the default 60 ms tolerance and a clip 90 ms off
+ * is not, whatever the implementation does internally.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_BEAT_TOLERANCE_MS,
+  MAX_BEAT_GRID_POINTS,
+  beatCountToCover,
+  buildBeatGrid,
+  nearestGridTime,
+  snapClipsToGrid,
+  type SnapClipInput
+} from "../src/beats.js";
+
+/** A beat every 500 ms: 0, 500, 1000, 1500, 2000, 2500. */
+const GRID_120_BPM = buildBeatGrid({ bpm: 120, count: 6 });
+
+const clip = (
+  id: string,
+  startMs: number,
+  durationMs: number
+): SnapClipInput => ({ id, startMs, durationMs });
+
+describe("buildBeatGrid", () => {
+  it("lays a 120 BPM grid every 500 ms", () => {
+    expect(GRID_120_BPM).toEqual([0, 500, 1000, 1500, 2000, 2500]);
+  });
+
+  it("offsets beat one without moving the interval", () => {
+    expect(buildBeatGrid({ bpm: 120, offsetMs: 120, count: 3 })).toEqual([
+      120, 620, 1120
+    ]);
+  });
+
+  it("does not drift on a fractional interval", () => {
+    // 140 BPM is 428.571… ms. Beat 100 is 42857.14 ms; accumulating the
+    // interval instead would land tens of ms away by then.
+    const grid = buildBeatGrid({ bpm: 140, count: 101 });
+    expect(grid[100]).toBe(42857);
+  });
+
+  it("sorts and deduplicates onsets", () => {
+    expect(buildBeatGrid({ onsetsMs: [900, 100, 900, 500] })).toEqual([
+      100, 500, 900
+    ]);
+  });
+
+  it("rounds onsets to whole milliseconds", () => {
+    // `detect_audio_events` reports seconds to 3 decimals, so ×1000 arrives
+    // with a fractional tail.
+    expect(buildBeatGrid({ onsetsMs: [1234.4, 2000.6] })).toEqual([1234, 2001]);
+  });
+
+  it("refuses both sources, and neither", () => {
+    expect(() => buildBeatGrid({ onsetsMs: [0], bpm: 120, count: 2 })).toThrow(
+      /exactly one/
+    );
+    expect(() => buildBeatGrid({})).toThrow(/onsets_ms/);
+  });
+
+  it("refuses a tempo with no count, a bad tempo, and an empty onset list", () => {
+    expect(() => buildBeatGrid({ bpm: 120 })).toThrow(/count/);
+    expect(() => buildBeatGrid({ bpm: 0, count: 4 })).toThrow(/positive/);
+    expect(() => buildBeatGrid({ onsetsMs: [] })).toThrow(/empty/);
+  });
+
+  it("caps the grid so a runaway count cannot fill a document", () => {
+    expect(() =>
+      buildBeatGrid({ bpm: 120, count: MAX_BEAT_GRID_POINTS + 1 })
+    ).toThrow(new RegExp(String(MAX_BEAT_GRID_POINTS)));
+  });
+});
+
+describe("beatCountToCover", () => {
+  it("reaches past the last boundary so a late clip can snap forward", () => {
+    // 4000 ms at 120 BPM is beat index 8, and the count runs one past it.
+    expect(beatCountToCover(120, 0, 4000)).toBe(10);
+  });
+
+  it("is at least one beat for a zero-length span", () => {
+    expect(beatCountToCover(120, 0, 0)).toBe(2);
+  });
+});
+
+describe("nearestGridTime", () => {
+  it("takes the nearest candidate inside the tolerance", () => {
+    expect(nearestGridTime(530, GRID_120_BPM, 60)).toBe(500);
+    expect(nearestGridTime(960, GRID_120_BPM, 60)).toBe(1000);
+  });
+
+  it("answers null when nothing is in reach", () => {
+    expect(nearestGridTime(590, GRID_120_BPM, 60)).toBeNull();
+  });
+
+  it("breaks a tie toward the earlier time", () => {
+    expect(nearestGridTime(750, GRID_120_BPM, 300)).toBe(500);
+  });
+});
+
+describe("snapClipsToGrid", () => {
+  it("moves a clip 30 ms off the beat onto it, keeping its length", () => {
+    const result = snapClipsToGrid([clip("c1", 530, 1000)], GRID_120_BPM);
+
+    expect(result.toleranceMs).toBe(DEFAULT_BEAT_TOLERANCE_MS);
+    expect(result.snapped).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.clips[0]).toEqual({
+      clipId: "c1",
+      snapped: true,
+      before: { startMs: 530, endMs: 1530, durationMs: 1000 },
+      after: { startMs: 500, endMs: 1500, durationMs: 1000 },
+      delta: { startMs: -30, endMs: -30 }
+    });
+  });
+
+  it("leaves a clip 90 ms off the beat where it is, and says why", () => {
+    const result = snapClipsToGrid([clip("c1", 590, 1000)], GRID_120_BPM);
+
+    expect(result.snapped).toBe(0);
+    expect(result.skipped).toBe(1);
+    const [only] = result.clips;
+    expect(only.snapped).toBe(false);
+    expect(only.after).toEqual(only.before);
+    expect(only.delta).toEqual({ startMs: 0, endMs: 0 });
+    expect(only.reason).toContain("90ms from the nearest beat (500ms)");
+    expect(only.reason).toContain("tolerance is 60ms");
+  });
+
+  it("reports the clips that did not move alongside the ones that did", () => {
+    const result = snapClipsToGrid(
+      [clip("near", 530, 400), clip("far", 590, 400)],
+      GRID_120_BPM
+    );
+
+    expect(result.clips.map((entry) => entry.clipId)).toEqual(["near", "far"]);
+    expect(result.clips.map((entry) => entry.snapped)).toEqual([true, false]);
+  });
+
+  it("trims the end onto the beat and keeps startMs", () => {
+    const result = snapClipsToGrid([clip("c1", 500, 970)], GRID_120_BPM, {
+      mode: "end",
+      action: "trim"
+    });
+
+    expect(result.clips[0]).toEqual({
+      clipId: "c1",
+      snapped: true,
+      before: { startMs: 500, endMs: 1470, durationMs: 970 },
+      after: { startMs: 500, endMs: 1500, durationMs: 1000 },
+      delta: { startMs: 0, endMs: 30 }
+    });
+  });
+
+  it("trims the start onto the beat and keeps the end", () => {
+    const result = snapClipsToGrid([clip("c1", 530, 970)], GRID_120_BPM, {
+      mode: "start",
+      action: "trim"
+    });
+
+    expect(result.clips[0].after).toEqual({
+      startMs: 500,
+      endMs: 1500,
+      durationMs: 1000
+    });
+  });
+
+  it("moves on the end boundary by sliding the whole clip", () => {
+    const result = snapClipsToGrid([clip("c1", 500, 970)], GRID_120_BPM, {
+      mode: "end",
+      action: "move"
+    });
+
+    expect(result.clips[0].after).toEqual({
+      startMs: 530,
+      endMs: 1500,
+      durationMs: 970
+    });
+  });
+
+  it("snaps both boundaries under `both` + trim", () => {
+    const result = snapClipsToGrid([clip("c1", 470, 1060)], GRID_120_BPM, {
+      mode: "both",
+      action: "trim"
+    });
+
+    expect(result.clips[0].after).toEqual({
+      startMs: 500,
+      endMs: 1500,
+      durationMs: 1000
+    });
+    expect(result.clips[0].delta).toEqual({ startMs: 30, endMs: -30 });
+  });
+
+  it("takes the start when `both` + move can only satisfy one boundary", () => {
+    const result = snapClipsToGrid([clip("c1", 470, 1060)], GRID_120_BPM, {
+      mode: "both",
+      action: "move"
+    });
+
+    expect(result.clips[0].after).toEqual({
+      startMs: 500,
+      endMs: 1560,
+      durationMs: 1060
+    });
+  });
+
+  it("skips a clip already sitting on the grid rather than reporting a move", () => {
+    const result = snapClipsToGrid([clip("c1", 500, 1000)], GRID_120_BPM);
+
+    expect(result.snapped).toBe(0);
+    expect(result.clips[0].reason).toBe("already on the grid");
+  });
+
+  it("refuses a trim that would leave nothing of the clip", () => {
+    // The end is dragged back onto beat 500, at or before the clip's start.
+    const result = snapClipsToGrid([clip("c1", 500, 30)], GRID_120_BPM, {
+      mode: "end",
+      action: "trim"
+    });
+
+    expect(result.clips[0].snapped).toBe(false);
+    expect(result.clips[0].reason).toContain("long");
+    expect(result.clips[0].after).toEqual(result.clips[0].before);
+  });
+
+  it("refuses a move that would start the clip before zero", () => {
+    const result = snapClipsToGrid([clip("c1", 20, 500)], [-40], {
+      toleranceMs: 100
+    });
+
+    expect(result.clips[0].snapped).toBe(false);
+    expect(result.clips[0].reason).toContain("before zero");
+  });
+
+  it("skips every clip when the grid is empty", () => {
+    const result = snapClipsToGrid([clip("c1", 530, 400)], []);
+
+    expect(result.clips[0].reason).toBe("the beat grid is empty");
+  });
+
+  it("snaps to onsets the same way it snaps to a tempo", () => {
+    const result = snapClipsToGrid(
+      [clip("c1", 1234, 500)],
+      buildBeatGrid({ onsetsMs: [1200, 4000] }),
+      { toleranceMs: 60 }
+    );
+
+    expect(result.clips[0].after.startMs).toBe(1200);
+  });
+});

--- a/web/src/components/timeline/Tracks/__tests__/TimeRuler.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/TimeRuler.test.tsx
@@ -28,7 +28,7 @@ describe("TimeRuler markers", () => {
   it("renders a flag and seeks the playhead on click", () => {
     renderRuler();
     act(() => {
-      useTimelineStore.getState().addMarker(2000, "Scene 1");
+      useTimelineStore.getState().addMarker({ timeMs: 2000, label: "Scene 1" });
     });
 
     const flag = screen.getByTestId("timeline-marker");
@@ -43,7 +43,7 @@ describe("TimeRuler markers", () => {
   it("deletes a marker via its × button", () => {
     renderRuler();
     act(() => {
-      useTimelineStore.getState().addMarker(2000, "Scene 1");
+      useTimelineStore.getState().addMarker({ timeMs: 2000, label: "Scene 1" });
     });
     expect(screen.getByTestId("timeline-marker")).toBeInTheDocument();
 

--- a/web/src/components/timeline/__tests__/TranscriptPanel.test.tsx
+++ b/web/src/components/timeline/__tests__/TranscriptPanel.test.tsx
@@ -173,7 +173,7 @@ describe("TranscriptPanel", () => {
     seed([voicedBeat([{ word: "hi", startMs: 0, endMs: 300 }])], 300);
 
     act(() => {
-      useTimelineStore.getState().addMarker(0, "Scene 1");
+      useTimelineStore.getState().addMarker({ timeMs: 0, label: "Scene 1" });
     });
     const br = await screen.findByTestId("scene-break");
     expect(br).toHaveTextContent("Scene 1");

--- a/web/src/components/timeline/__tests__/timelineAgentBridge.test.ts
+++ b/web/src/components/timeline/__tests__/timelineAgentBridge.test.ts
@@ -24,7 +24,9 @@ const makeMockHandler = (): TimelineAgentHandler => ({
   clearClipAnimations: jest.fn(),
   getClipFrames: jest.fn(),
   selectClip: jest.fn(),
-  seek: jest.fn()
+  seek: jest.fn(),
+  addMarker: jest.fn(),
+  deleteMarker: jest.fn()
 });
 
 describe("timelineAgentBridge", () => {

--- a/web/src/components/timeline/timelineAgentBridge.ts
+++ b/web/src/components/timeline/timelineAgentBridge.ts
@@ -130,6 +130,23 @@ export interface TimelineAnimationNode {
   params?: Record<string, number | string | boolean>;
 }
 
+/** Serializable view of a marker on the ruler. */
+export interface TimelineMarkerNode {
+  id: string;
+  timeMs: number;
+  label: string;
+  color?: string;
+  note?: string;
+}
+
+/** What `addMarker` places. */
+export interface TimelineAddMarkerOptions {
+  timeMs: number;
+  label?: string;
+  color?: string;
+  note?: string;
+}
+
 /** Full snapshot of the open sequence the agent reads to plan edits. */
 export interface TimelineSnapshot {
   sequenceId: string | null;
@@ -144,6 +161,7 @@ export interface TimelineSnapshot {
   selectedClipIds: string[];
   tracks: TimelineTrackNode[];
   clips: TimelineClipNode[];
+  markers: TimelineMarkerNode[];
 }
 
 /** Direct-generation kinds the agent can spawn. */
@@ -380,6 +398,10 @@ export interface TimelineAgentHandler {
   selectClip: (target: string | null) => TimelineClipNode | null;
   /** Move the playhead and return the resulting position (ms). */
   seek: (timeMs: number) => number;
+  /** Flag a moment on the ruler. Markers annotate; they do not render. */
+  addMarker: (opts: TimelineAddMarkerOptions) => TimelineMarkerNode;
+  /** Remove a marker by id or by case-insensitive label. */
+  deleteMarker: (target: string) => TimelineMarkerNode;
 }
 
 const handlers = new Map<string, TimelineAgentHandler>();

--- a/web/src/hooks/timeline/useTimelineAgentBridge.ts
+++ b/web/src/hooks/timeline/useTimelineAgentBridge.ts
@@ -16,6 +16,7 @@ import { makeClip, trackTypeForMediaType } from "@nodetool-ai/timeline";
 import type {
   ClipAnimation,
   TimelineClip,
+  TimelineMarker,
   TimelineTrack
 } from "@nodetool-ai/timeline";
 import { buildClipAnimation } from "./buildClipAnimation";
@@ -47,6 +48,7 @@ import {
   type TimelineAnimationNode,
   type TimelineClipNode,
   type TimelineClipFrameNode,
+  type TimelineMarkerNode,
   type TimelineAddMediaClipOptions,
   type TimelineAddTextClipOptions,
   type TimelineAddShapeClipOptions,
@@ -160,6 +162,17 @@ function toAnimationNode(anim: ClipAnimation): TimelineAnimationNode {
   };
 }
 
+function toMarkerNode(marker: TimelineMarker): TimelineMarkerNode {
+  const node: TimelineMarkerNode = {
+    id: marker.id,
+    timeMs: marker.timeMs,
+    label: marker.label
+  };
+  if (marker.color !== undefined) node.color = marker.color;
+  if (marker.note !== undefined) node.note = marker.note;
+  return node;
+}
+
 function toTrackNode(
   track: TimelineTrack,
   clipCount: number
@@ -207,6 +220,25 @@ export const useTimelineAgentBridge = (sequenceId: string | null): void => {
       const byName = clips.find((c) => c.name.toLowerCase() === lower);
       if (byName) return byName;
       throw new Error(`Clip not found on the timeline: ${target}`);
+    };
+
+    /** Resolve a marker by id, or by case-insensitive label. */
+    const requireMarker = (target: string): TimelineMarker => {
+      const { markers } = doc.getState();
+      const byId = markers.find((m) => m.id === target);
+      if (byId) return byId;
+      const lower = target.toLowerCase();
+      const byLabel = markers.find((m) => m.label.toLowerCase() === lower);
+      if (byLabel) return byLabel;
+      const known = markers
+        .map((m) => `${m.id} ("${m.label}") at ${m.timeMs}ms`)
+        .join(", ");
+      throw new Error(
+        `No marker matches "${target}". Use a marker id or its label. ` +
+          (known.length > 0
+            ? `Markers: ${known}.`
+            : "This sequence has no markers yet.")
+      );
     };
 
     const requireTrack = (target: string): TimelineTrack => {
@@ -258,7 +290,8 @@ export const useTimelineAgentBridge = (sequenceId: string | null): void => {
           tracks: tracks.map((t) =>
             toTrackNode(t, clipCountByTrack.get(t.id) ?? 0)
           ),
-          clips: state.clips.map((c) => toClipNode(c, map))
+          clips: state.clips.map((c) => toClipNode(c, map)),
+          markers: state.markers.map(toMarkerNode)
         };
       },
 
@@ -742,6 +775,21 @@ export const useTimelineAgentBridge = (sequenceId: string | null): void => {
       seek(timeMs) {
         playback.getState().seek(Math.max(0, timeMs));
         return Math.round(playback.getState().getTimeMs());
+      },
+
+      addMarker(opts) {
+        if (opts.timeMs < 0) {
+          throw new Error(
+            `A marker cannot sit before zero; got ${opts.timeMs}ms.`
+          );
+        }
+        return toMarkerNode(doc.getState().addMarker(opts));
+      },
+
+      deleteMarker(target) {
+        const marker = requireMarker(target);
+        doc.getState().deleteMarker(marker.id);
+        return toMarkerNode(marker);
       }
     };
   }, [doc, ui, playback, startDirectGen]);

--- a/web/src/lib/tools/__tests__/openDocument.test.ts
+++ b/web/src/lib/tools/__tests__/openDocument.test.ts
@@ -22,7 +22,8 @@ const snapshot = (sequenceId: string | null): TimelineSnapshot => ({
   playheadMs: 0,
   selectedClipIds: [],
   tracks: [],
-  clips: []
+  clips: [],
+  markers: []
 });
 
 const timelineHandler = (sequenceId: string | null): TimelineAgentHandler =>

--- a/web/src/lib/tools/__tests__/timelineTools.test.ts
+++ b/web/src/lib/tools/__tests__/timelineTools.test.ts
@@ -59,7 +59,8 @@ const snapshot = (): TimelineSnapshot => ({
   playheadMs: 0,
   selectedClipIds: [],
   tracks: [trackNode()],
-  clips: [clipNode()]
+  clips: [clipNode()],
+  markers: []
 });
 
 const createMockHandler = (): jest.Mocked<TimelineAgentHandler> => ({
@@ -80,7 +81,9 @@ const createMockHandler = (): jest.Mocked<TimelineAgentHandler> => ({
   clearClipAnimations: jest.fn(),
   getClipFrames: jest.fn(),
   selectClip: jest.fn(),
-  seek: jest.fn()
+  seek: jest.fn(),
+  addMarker: jest.fn(),
+  deleteMarker: jest.fn()
 });
 
 // The timeline tools never touch the workflow state, so a bare stub satisfies ctx.
@@ -117,7 +120,9 @@ describe("ui_timeline_* tools", () => {
         "ui_timeline_list_animation_presets",
         "ui_timeline_get_clip_frames",
         "ui_timeline_select_clip",
-        "ui_timeline_seek"
+        "ui_timeline_seek",
+        "ui_timeline_add_marker",
+        "ui_timeline_delete_marker"
       ])
     );
   });
@@ -534,5 +539,65 @@ describe("ui_timeline_* tools", () => {
     );
     const kenBurns = result.presets.find((p) => p.id === "kenBurns");
     expect(kenBurns?.roles).toContain("loop");
+  });
+});
+
+describe("marker tools", () => {
+  const marker = {
+    id: "marker-1",
+    timeMs: 4500,
+    label: "Chorus",
+    color: "#ff0055"
+  };
+
+  it("adds a marker, passing every field through to the handler", async () => {
+    const handler = createMockHandler();
+    handler.addMarker.mockReturnValue(marker);
+    setTimelineAgentHandler(SEQ_ID, handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_timeline_add_marker",
+      {
+        timeline_id: SEQ_ID,
+        timeMs: 4500,
+        label: "Chorus",
+        color: "#ff0055"
+      },
+      "tc-marker-add",
+      ctx
+    )) as { ok: boolean; marker: typeof marker };
+
+    expect(handler.addMarker).toHaveBeenCalledWith({
+      timeMs: 4500,
+      label: "Chorus",
+      color: "#ff0055"
+    });
+    expect(result).toMatchObject({ ok: true, marker });
+  });
+
+  it("deletes a marker by label", async () => {
+    const handler = createMockHandler();
+    handler.deleteMarker.mockReturnValue(marker);
+    setTimelineAgentHandler(SEQ_ID, handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_timeline_delete_marker",
+      { timeline_id: SEQ_ID, target: "Chorus" },
+      "tc-marker-del",
+      ctx
+    )) as { ok: boolean; deleted: typeof marker };
+
+    expect(handler.deleteMarker).toHaveBeenCalledWith("Chorus");
+    expect(result.deleted).toEqual(marker);
+  });
+
+  it("requires timeMs, so a marker cannot land at an unstated time", () => {
+    const tool = FrontendToolRegistry.getManifest().find(
+      (t) => t.name === "ui_timeline_add_marker"
+    );
+    const schema = tool?.parameters as { required?: string[] };
+    expect(schema.required).toEqual(
+      expect.arrayContaining(["timeline_id", "timeMs"])
+    );
   });
 });

--- a/web/src/lib/tools/builtin/timeline.ts
+++ b/web/src/lib/tools/builtin/timeline.ts
@@ -611,3 +611,36 @@ FrontendToolRegistry.register({
     return { ok: true, playheadMs };
   }
 });
+
+FrontendToolRegistry.register({
+  name: "ui_timeline_add_marker",
+  description:
+    "Drop a marker at an absolute time on the specified timeline sequence, to flag a moment — a beat, a scene boundary, a note for the user. Markers do not render; they are annotations on the ruler.",
+  parameters: z.object({
+    timeline_id: timelineIdParam,
+    timeMs: z
+      .number()
+      .describe("Absolute position on the timeline in ms. Must be >= 0."),
+    label: z.string().optional().describe("Short label shown on the ruler."),
+    color: z.string().optional().describe("CSS colour for the marker dot."),
+    note: z.string().optional().describe("Longer note attached to the marker.")
+  }),
+  async execute({ timeline_id, ...opts }) {
+    const marker = getTimelineAgentHandler(timeline_id).addMarker(opts);
+    return { ok: true, marker, url: docUrl("timeline", timeline_id) };
+  }
+});
+
+FrontendToolRegistry.register({
+  name: "ui_timeline_delete_marker",
+  description:
+    "Remove a marker from the specified timeline sequence by id or by its label (case-insensitive). Call ui_timeline_get_state to see the markers it carries.",
+  parameters: z.object({
+    timeline_id: timelineIdParam,
+    target: z.string().describe("Marker id or label (case-insensitive).")
+  }),
+  async execute({ timeline_id, target }) {
+    const deleted = getTimelineAgentHandler(timeline_id).deleteMarker(target);
+    return { ok: true, deleted, url: docUrl("timeline", timeline_id) };
+  }
+});

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -68,6 +68,14 @@ const SNAP_THRESHOLD_PX = 8;
 
 // ── State interface ────────────────────────────────────────────────────────
 
+/** What {@link TimelineStoreState.addMarker} places. */
+export interface TimelineMarkerInput {
+  timeMs: number;
+  label?: string;
+  color?: string;
+  note?: string;
+}
+
 export interface TimelineStoreState {
   // ── Document ─────────────────────────────────────────────────────────────
   sequenceId: string | null;
@@ -446,8 +454,14 @@ export interface TimelineStoreState {
     durationMs?: number;
   }) => void;
 
-  /** Append a timeline marker (e.g. a scene boundary) at the given time. */
-  addMarker: (timeMs: number, label?: string) => void;
+  /**
+   * Append a timeline marker (e.g. a scene boundary) and return it, so a
+   * caller that has to report what it placed does not have to go looking.
+   */
+  addMarker: (input: TimelineMarkerInput) => TimelineMarker;
+
+  /** Remove one marker by id. Unknown ids are a no-op. */
+  deleteMarker: (markerId: string) => void;
 
   /**
    * Merge clip halves that were split at `timeMs` back into single clips — the
@@ -1931,16 +1945,22 @@ export const createTimelineStore = (
             return { transcript, clips, durationMs };
           }),
 
-        addMarker: (timeMs, label) =>
-          set((state) => ({
-            markers: [
-              ...state.markers,
-              makeMarker({
-                timeMs: Math.max(0, Math.round(timeMs)),
-                label: label ?? ""
-              })
-            ]
-          })),
+        addMarker: (input) => {
+          const marker = makeMarker({
+            timeMs: Math.max(0, Math.round(input.timeMs)),
+            label: input.label ?? ""
+          });
+          if (input.color !== undefined) marker.color = input.color;
+          if (input.note !== undefined) marker.note = input.note;
+          set((state) => ({ markers: [...state.markers, marker] }));
+          return marker;
+        },
+
+        deleteMarker: (markerId) =>
+          set((state) => {
+            const markers = state.markers.filter((m) => m.id !== markerId);
+            return markers.length === state.markers.length ? {} : { markers };
+          }),
 
         mergeClipsAt: (timeMs) =>
           set((state) => {


### PR DESCRIPTION
## What changed

`docs/plans/motion-graphics-tasks.md` T20, following [#5491](https://github.com/nodetool-ai/nodetool/pull/5491) (M1+M2), [#5493](https://github.com/nodetool-ai/nodetool/pull/5493) (T16), [#5495](https://github.com/nodetool-ai/nodetool/pull/5495) (T14), [#5496](https://github.com/nodetool-ai/nodetool/pull/5496) (T15) and [#5498](https://github.com/nodetool-ai/nodetool/pull/5498) (T17+T18).

An agent could already hear a track — `detect_audio_events` returns onsets — and had no way to act on them. Markers could only be added from the mobile tool, and nothing could move a clip onto a beat.

Four ops: `add_marker`, `delete_marker`, `set_markers_from_beats`, `snap_to_beats`, with browser twins for the marker pair.

### The reporting contract is the point

A clip that does not snap is **reported, never dropped**. It comes back in the same `clips` array with `snapped: false`, `after` equal to `before`, a zeroed delta, and a reason naming the distance and the beat it missed:

```
start 590ms is 90ms from the nearest beat (500ms); tolerance is 60ms
```

Five skip reasons in all — out of tolerance, already on the grid, empty grid, a trim that would leave a non-positive duration, a move that would start the clip before zero — plus `no clip matches "ghost"` for a target name nothing resolves to, appended to the *same* list. One list, so a caller never infers a skip from a shorter result.

### Other decisions

- **`snapClipsToGrid` is pure**, in `packages/timeline/src/beats.ts`; the op calls it and holds no arithmetic.
- `move` slides a clip and keeps its length; `trim` holds the opposite boundary and changes it. Under `mode: "both"` a move takes the start, since one move cannot satisfy two boundaries.
- **A tempo grid computes each beat from its index** rather than accumulating an interval, so a fractional beat length does not drift over a long timeline — pinned at 140 BPM, beat 100 = 42857 ms.

## Verification

Exit codes captured directly, never through a pipeline. `npm run build:packages` run first (59/59).

- [x] `packages/timeline` — 566 passed, 24 skipped
- [x] `packages/agents` — 3819 passed, 5 skipped
- [x] `packages/execution` — 373 passed · `packages/cli` — 695 passed
- [x] `web` (jest, timeline-related) — 781 passed, 87 suites
- [x] `npm run capabilities:sync` / `capabilities:check` — table current, 253 capabilities
- [x] `npm run lint` — 0 errors
- [ ] `npm run typecheck` — web and electron legs exit 0 run alone; the **mobile** leg fails on a clean tree because `mobile/node_modules` is absent. No mobile file changed (mobile already shipped both marker tools).

Re-verified after rebasing onto current `main`: timeline 566 passed.

## New checks

- [x] `nearestGridTime`'s tolerance comparison was widened tenfold (`distance > toleranceMs * 10`) and observed failing: `answers null when nothing is in reach`, `leaves a clip 90 ms off the beat where it is, and says why`, `reports the clips that did not move alongside the ones that did` — 3 failed | 23 passed. Restored and re-verified 26/26.
- The edit was **grepped in the file before and after** to confirm it applied, after an earlier task on this branch had an inversion silently no-op and produce a green run that proved nothing.

## Found, not fixed

- **`snap_to_beats` contests every unit kind in the `resource_change` merge.** `opUnitKind` in `web/src/stores/timeline/merge.ts` reads the kind from a substring of the verb, and `snap_to_beats` contains none of `clip`/`track`/`marker`, so it falls back to `ALL_UNIT_KINDS` with no unit id. That is conservative and safe — a concurrent editor just prefers the server for anything that drifted — and stamping the clip ids would be wrong under the current mapping, since a null `ownKind` would pair those ids with the marker and track kinds too. Making the mapping op-aware is a merge-layer change.
- **`edit_timeline`'s CAS retry re-applies beat ops against a newer document.** Correct for the marker ops, but a `snap_to_beats` retried after a concurrent write snaps against whatever the clips now are, which may differ from what the first attempt reported. Every other op already has this property; it is noted because the per-clip `before` values make it visible for the first time.
- **`MAX_OPS = 60` bounds the op list, not the work** — one `set_markers_from_beats` can add 2048 markers. The grid cap is the only bound; there is no document-level marker cap.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdzG3a3jN3Dzx6QV8xh4Bo

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdzG3a3jN3Dzx6QV8xh4Bo)_