### PR TITLE
docs(readme): reposition around the closed studio and the repeat job

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,17 @@
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE.txt)
 [![Powered by Atlas Cloud](https://www.atlascloud.ai/oss-program/powered-by-atlas-cloud.svg)](https://www.atlascloud.ai/?ref=PW9AD2)
 
-![NodeTool node editor](marketing/public/screen_canvas.webp)
+![NodeTool: one sentence becomes a storyboard, rendered stills and clips, a cut on the timeline, and a finished film](marketing/public/hero-project-poster.webp)
 
-NodeTool is an open-source, agent-first AI production studio that runs on your local machine. Describe your concept, and an autonomous agent writes the script, storyboards the scenes, generates the footage, and cuts the timeline. Instead of a flattened video file, it hands you a fully editable multi-track project.
+**You are the director. The agent is your crew.**
 
-Every interface—the node canvas, timeline, sketch pad, and script editor—is exposed to the agent. 
+NodeTool is an open-source AI film studio. Describe your idea. The agent writes the script, storyboards every scene, generates the footage, and cuts the timeline. What comes back is a project, not a render: re-roll one shot, re-voice one line, re-cut the ending.
 
-* **01 / Pitch** — tell the agent your concept, style, and tone. It drafts the script, casts the voices, and sets the visual direction.
-* **02 / Automate** — it storyboards scenes, generates footage, syncs audio, and cuts it together on a multi-track timeline.
-* **03 / Direct** — jump in at any moment. Swap a voice take, re-roll a clip, or trim frames. The agent builds the foundation; you make the final cut.
+Runway, LTX Studio, Figma Weave and the rest will generate your trailer too. On their model list, priced in their credits, saved in a project only their app opens. When they raise the price or drop the model, the film goes with it. NodeTool hands the project back, on your keys.
+
+* **01 / Pitch.** Tell the agent your concept, style, and tone. It drafts the script, casts the voices, and sets the visual direction. Prefer to wire it yourself? It is the same canvas.
+* **02 / Automate.** The agent storyboards scenes, generates the footage, syncs the audio, and cuts it together on a multi-track timeline, running on your own accounts at provider list prices.
+* **03 / Direct.** Jump in at any moment. Swap a voice take, re-roll a clip, or trim frames. The agent builds the foundation. You make the final cut.
 
 ## Get NodeTool
 
@@ -25,36 +27,117 @@ Every interface—the node canvas, timeline, sketch pad, and script editor—is 
 | **Windows** | [Download Studio](https://nodetool.ai/studio) | Windows 10+, 8GB+ RAM, 20GB space |
 | **Linux** | [Download Studio](https://nodetool.ai/studio) | Ubuntu 22+, 8GB+ RAM |
 
-**NodeTool** is a free desktop app. Workflows, keys, and files stay local. Run inference on your own hardware, or plug in a provider key to use cloud models without a GPU.
+**Studio** is the full product, and it is free. It keeps your project files, your model library, and your keys on disk, and it runs offline. Language and image models run on your own machine through MLX, Ollama, and llama.cpp. Every major provider runs on your own keys.
+
+**[Cloud](https://nodetool.ai/cloud)** is the same studio in a browser, in alpha, with nothing to install.
 
 [Flatpak CI builds](https://github.com/nodetool-ai/nodetool/actions/workflows/flatpak-ci.yml) are available for Linux. Developers can skip the installer and [run from source](#development-setup).
 
-## What you can build
+## Four jobs a team runs every week
 
-* **[Movie trailer](https://nodetool.ai/use-cases/movie-trailer)** — Pitch a logline. The agent boards the shots, generates key art, and cuts the trailer.
-* **[Documentary teaser](https://nodetool.ai/use-cases/documentary-teaser)** — One sentence becomes a six-shot board, stills, and a 26-second cut.
-* **[Product video](https://nodetool.ai/use-cases/product-video)** — A campaign brief and a single product photo become a 16:9 spot, directed by an agent and rendered by a video model.
-* **[Poster concepts](https://nodetool.ai/use-cases/movie-poster)** — A title, genre, and audience become a creative strategy and a batch of poster concepts, complete with tagline and billing block.
+Each recipe is a real run against live models: what you end up holding, who it is for, the models the shipped chain calls, and every workflow in it as one `.nodetool` bundle you open in the studio. Each runs on your keys, at provider list prices.
 
-More in the [showcase](https://nodetool.ai/showcase) and the [template gallery](https://nodetool.ai/templates).
+| Recipe | What you end up holding | Who it is for | Models the shipped chain calls |
+| :--- | :--- | :--- | :--- |
+| **[Viral Video Ad Engine](https://nodetool.ai/recipes/viral-video-ad-engine)** | A vertical product ad, plus the hook lines and thumbnails to test it against. | Performance and social teams shipping several ad variants a week. | GPT-5 mini, FLUX.1 Schnell, Kling 2.6 |
+| **[Multilingual Video Dubber](https://nodetool.ai/recipes/multilingual-video-dubber)** | One presenter clip, spoken in a second language, with a lip-synced cut, subtitles, and a back-translation to check it. | Anyone re-releasing a recorded talk, demo, or ad into another market. | GPT-4o mini Transcribe, GPT-5 mini, OpenAI TTS, Inworld TTS, Sync Lipsync |
+| **[E-commerce SKU Visual Factory](https://nodetool.ai/recipes/ecommerce-sku-visual-factory)** | One packshot per SKU becomes the whole channel set: cutout, studio scene, seasonal relight, turntable clip, print master, and the listing copy. | Catalogue and marketplace teams with more SKUs than shoot days. | Bria background removal, Nano Banana, image relighting, LTX 2.3, Clarity upscaler, GPT-5 mini |
+| **[Storyboard to Trailer](https://nodetool.ai/recipes/storyboard-to-trailer)** | A logline becomes a beat sheet, a numbered shot list, a cut teaser, and a score under it. | Directors, agencies, and anyone pitching a film that does not exist yet. | GPT-5 mini, Gemini 3.1 Pro, GPT Image 2, Veo 3.1, Stable Audio 2.5 |
 
-## Local. Open. Yours.
+The bundles are at [nodetool.ai/recipes](https://nodetool.ai/recipes), with a contact sheet from each run. The [showcase](https://nodetool.ai/showcase) and the [template gallery](https://nodetool.ai/templates) hold the single workflows the recipes chain.
 
-No locked project formats, no token markups, zero subscription traps.
+## One canvas, pitch through final cut
 
-* **Bring your own keys.** Pay provider prices directly—or run open weights on your own hardware for free.
-* **Your files stay yours.** Projects, API keys, and footage never leave your machine.
-* **Open source.** AGPL-3.0, end to end. Read it, fork it, host it.
+Five surfaces share one studio, so a piece never leaves it to be finished. An agent drives every one of them through the same actions you have.
 
-If a provider deprecates a model or raises prices, swap the node. The rest of the workflow stays intact.
+### Storyboard
 
-## Agents
+![NodeTool storyboard](marketing/public/surface-storyboard-poster.webp)
 
-Most tools bolt a chat panel onto an editor. NodeTool built the editors around the agent. The entire app is the toolbelt. Every surface hands the agent the same actions you have: wire a graph, paint a layer, cut a clip, revise a shot, or voice a line.
+Board the film shot by shot. Generate cheap stills first to lock the look, then pay to animate only the shots you approved.
+
+Pitch a concept and a visual style, pick a shot count, and press **Direct**: the Director node returns a typed screenplay, one structured shot per card with action, camera, motion, and duration, plus the logline, style bible, narration, and music direction.
+
+* **Cheap stages first.** A still costs cents, a clip costs dollars. Generate stills until one looks right, pick it, and only then generate the clip.
+* **Revise one shot, not the reel.** "Make it darker, add rain" runs video-to-video on the existing clip and swaps the result in place. Fixing shot 3 never re-rolls shots 1 to 5.
+* **Entities keep the cast steady.** Characters, locations, styles, and props are named objects whose canonical descriptor is pasted verbatim into every prompt that names them.
+* **Assemble the cut.** One click lays the rendered shots onto a timeline with narration and music tracks. Every clip stays linked to its shot, so a later revision replaces the clip in the saved cut.
+
+Agents drive the same board through the `ui_storyboard_*` tools, or headlessly with `render_storyboard_stills`, `render_storyboard_clips`, and `assemble_storyboard_timeline`.
+
+[Creative agent guide →](https://docs.nodetool.ai/creative-agent)
+
+### Script and voice
+
+![NodeTool script editor: the transcript panel beside the sequence it assembles into](marketing/public/surface-script-poster.webp)
+
+Draft the dialogue, cast a voice per character, and audition alternate line readings. Change the words and the take flags itself stale, so you see exactly what still needs voicing.
+
+* **Cast a voice per character.** Each speaker carries a provider, model, and voice. Every line inherits it unless you override the line.
+* **Takes, not overwrites.** Voicing a line saves a take with its own word timings. Audition several, keep the one you want.
+* **Send it to a timeline.** The current takes assemble into a sequence end to end, word timings riding along as captions.
+
+An agent does the same without the editor open: `voice_script_lines` voices every draft or stale line with its cast voice, and `assemble_script_timeline` cuts the result into a saved sequence that `validate_timeline` then checks.
+
+### Timeline
+
+![NodeTool timeline](marketing/public/surface-timeline-poster.webp)
+
+Arrange, trim, and layer generated video and audio across multiple tracks, down to the frame and the stem. The agent edits the same document when you ask it to tighten the opening.
+
+Drop in your own footage or bind a workflow to a clip (text-to-image, image-to-video, or text-to-speech) and generate it in place. Change a parameter and the clip regenerates. Tweak the bound workflow and the clip flags itself stale. Export the sequence to MP4.
+
+[Video editor guide →](https://docs.nodetool.ai/video-editor)
+
+### Sketch
+
+![NodeTool sketch editor](marketing/public/screen_sketch_editor.webp)
+
+Sketch, paint with brushes, and blend hand-drawn elements with AI-generated layers. Bind a layer to a prompt and regenerate that layer alone.
+
+Build a composition in layers with blend modes and masks, then bind a layer to a model or one of your own workflows and generate where you are painting. Change a prompt or an upstream input and the layer flags itself stale. The node hands the rest of the workflow a flattened image, a mask, and per-layer outputs, so it pairs with the editing nodes (mask, inpaint, outpaint, compositing) for sketch-then-generate pipelines.
+
+[Sketch editor guide →](https://docs.nodetool.ai/sketch-editor)
+
+### 3D
+
+![NodeTool 3D scene editor](marketing/public/surface-3d-poster.webp)
+
+Place primitives and lights in a glTF scene by hand or by tool call. The same operations run headlessly, so a scene is reproducible. Capture a view as a depth or composition reference for an image or video model.
+
+Agents get `create_model3d`, `get_model3d`, `edit_model3d`, and `validate_model3d` with no editor open.
+
+## Your keys, your project file, your models
+
+* **Bring your own keys.** Connect directly to OpenAI, Anthropic, Gemini, FAL, KIE, Replicate, and the specialized video models. Your keys stay on your disk in Studio, encrypted in Cloud.
+* **No markups.** If an image costs $0.03 at the provider, you pay $0.03 to the provider. NodeTool takes no cut.
+* **Open source, end to end.** AGPL-3.0. Read it, fork it, host it.
+* **A project file that opens anywhere.** The board, the script with its takes, and the multi-track cut are ordinary files on your disk. Export a `.nodetool` bundle and open it on another machine, or in a fork.
+
+When a better model ships, add it the day it ships. No roster has to catch up first.
+
+## How NodeTool compares
+
+The comparison is against the closed AI studios (Runway, LTX Studio, Figma Weave), because that is what a production team is choosing between.
+
+| | NodeTool | Closed AI studios |
+| :--- | :--- | :--- |
+| **Models** | Every major provider, switched in one click | The list they picked |
+| **When a better model ships** | Add it the day it ships | Wait for them to add it |
+| **What you pay** | Provider list prices, on your own keys | Their credits |
+| **What you keep** | The board, the takes, and the multi-track cut as an editable project | An exported video. The project stays in their app. |
+| **Source** | Open, AGPL-3.0 | Closed |
+| **Where it runs** | Desktop app and browser, self-host any time | Their servers only |
+
+Choosing against a node tool instead? See [ComfyUI](https://nodetool.ai/alternatives/comfyui) and [Figma Weave](https://nodetool.ai/alternatives/figma-weave).
+
+## The agent
+
+Most tools bolt a chat panel onto an editor. NodeTool built the editors around the agent. The entire studio is the toolbelt. Every surface hands the agent the same actions you have: wire a graph, paint a layer, cut a clip, revise a shot, or voice a line.
 
 * **Build workflows.** Describe the pipeline. The agent picks the nodes, wires the edges, and validates the graph. What it leaves behind is a workflow you own and control.
 * **Build apps.** Ask for a custom UI. The agent plans the workflow, places widgets, and replays interactions. A separate judge model grades the result. No passing verdict, no app.
-* **Repair on the fly.** Put an agent on the failure path. It decides whether to retry, repair, skip, or stop—strictly within the cost budget you set.
+* **Repair on the fly.** Put an agent on the failure path. It decides whether to retry, repair, skip, or stop, strictly within the cost budget you set.
 * **Bring your own agent.** The toolbelt is exposed over MCP. Point Claude Desktop, Claude Code, or Codex at the local server to drive the studio.
 
 ```bash
@@ -64,128 +147,58 @@ npm run build:mcpb                    # → dist/nodetool.mcpb for Claude Deskto
 
 Under the hood: a planner turns an objective into a DAG of steps, executors walk it in parallel, and every LLM call emits an OpenTelemetry span with tokens and cost. See the [agent guide](https://docs.nodetool.ai/agents/) and [docs/AGENTS.md](docs/AGENTS.md).
 
-## What's in the box
+## What is underneath
 
-**Create**
+The film surfaces sit on a node canvas, and everything on it is reachable without the film.
 
 | | |
 | :--- | :--- |
 | **Node canvas** | Drag-and-drop nodes with type-safe connections. Live output at every step. |
-| **Video editor** | Sequence, composite, and generate clips on a true multi-track timeline. Export direct to MP4. |
-| **Sketch editor** | Paint on layers with blend modes and masks. Bind a layer to a model and generate straight onto the canvas. |
-| **Storyboard** | Pitch a concept, get a screenplay, pick stills, render clips, assemble the cut. |
-| **Script editor** | Draft the script, cast a voice per character, audition takes, send the result to a timeline. |
-| **Mini apps** | Wire widgets to workflow inputs and outputs. Publish a version. |
+| **Mini apps** | Give a workflow a screen: inputs, a Run button, a place for the result. Hand it to a teammate who never sees the canvas. |
 | **Editing tools as nodes** | Mask, inpaint, outpaint, relight, upscale, layer, and composite. |
-
-**Run and extend**
-
-| | |
-| :--- | :--- |
 | **Every modality** | Image, video, audio, and text in one workflow. |
-| **BYOK everywhere** | OpenAI, Anthropic, Gemini, FAL, KIE, Replicate, ElevenLabs, HuggingFace. No markups. |
-| **Local inference** | Run Ollama, MLX (Apple Silicon), and GGUF on your own hardware. |
+| **Every major provider** | OpenAI, Anthropic, Gemini, FAL, KIE, Replicate, ElevenLabs, HuggingFace, plus one node for every model on Replicate, fal.ai, and KIE. |
+| **Open weights** | Ollama, MLX (Apple Silicon), and GGUF on your own hardware. |
 | **Document search** | Index and query your files with the built-in vector store. |
-| **JS scripts** | Write versioned JavaScript documents with ports, tests, and a sandbox. |
+| **JS scripts** | Versioned JavaScript documents with ports, tests, and a sandbox. |
 | **MCP server** | Point Claude Desktop, Claude Code, Codex, or any MCP agent at the toolbelt. |
 | **Custom nodes** | Extend in TypeScript or Python. |
-| **Deploy & scale** | Self-host with Docker. Rent GPU workers on RunPod or Vast. |
-| **Cross-platform** | Ship to macOS, Windows, and Linux. |
+| **Deploy and scale** | Self-host with Docker. Rent GPU workers on RunPod or Vast. |
+| **Cross-platform** | macOS, Windows, and Linux. |
 
-## The editors
+### Node canvas
 
-These surfaces share one workspace, and an agent can drive every one of them.
-Full tours live at [docs.nodetool.ai](https://docs.nodetool.ai).
+![NodeTool node canvas](marketing/public/screen_workflow.webp)
 
-### Script editor — scripting and casting, with the words as the source of truth
-
-![NodeTool script editor — the transcript panel beside the sequence it assembles into](marketing/public/surface-script-poster.webp)
-
-The text is the source of truth. Draft the script, cast a voice per character, and audition alternative takes with automatic word-level sync.
-
-* **Cast a voice per character.** Each speaker carries a provider, model, and voice; every line inherits it unless you override the line.
-* **Takes, not overwrites.** Voicing a line saves a take with its own word timings. Audition several, keep the one you want.
-* **Staleness is visible.** Change a line's text or its voice and the line flags itself against the take that no longer matches — re-voice just that line.
-* **Send it to a timeline.** The current takes assemble into a sequence end to end, word timings riding along as captions.
-
-An agent does the same without the editor open: `voice_script_lines` voices every draft or stale line with its cast voice, and `assemble_script_timeline` cuts the result into a saved sequence that `validate_timeline` then checks.
-
-### Storyboard — board the film shot by shot before you pay for video
-
-![NodeTool storyboard](marketing/public/surface-storyboard-poster.webp)
-
-Board the film before you pay for video. Render cheap stills, pick the best shots, and then generate the clips. Revise a single shot without re-rolling the entire reel.
-
-Pitch a concept and a visual style, pick a shot count, and press **Direct**: the Director node returns a typed screenplay — logline, style bible, narration, music direction, and one structured shot per card with action, camera, motion, and duration.
-
-* **Cheap stages first.** A still costs cents, a clip costs dollars. Generate stills until one looks right, pick it, and only then generate the clip.
-* **Revise one shot, not the reel.** "Make it darker, add rain" runs video-to-video on the existing clip and swaps the result in place. Fixing shot 3 never re-rolls shots 1–5.
-* **Entities keep the cast steady.** Characters, locations, styles, and props are named objects whose canonical descriptor is pasted verbatim into every prompt that names them.
-* **Assemble the cut.** One click lays the rendered shots onto a timeline with narration and music tracks. Every clip stays linked to its shot, so a later revision replaces the clip in the saved cut.
-
-Agents drive the same board through the `ui_storyboard_*` tools, or headlessly with `render_storyboard_stills`, `render_storyboard_clips`, and `assemble_storyboard_timeline` — no browser involved.
-
-[Creative agent guide →](https://docs.nodetool.ai/creative-agent)
-
-### Video editor — a real multi-track timeline, not a black box
-
-![NodeTool video editor](screen_video_editor.png)
-
-A real multi-track timeline, not a black box. Regenerate an AI clip in place without losing your edit. Fine-tune every frame, layer, and audio stem.
-
-Instead of a single unfixable video file, you get a fully editable project. Drop in your own footage or bind a workflow to a clip — text-to-image, image-to-video, or text-to-speech — and generate it in place. Change a parameter and the clip regenerates; tweak the bound workflow and the clip flags itself stale. Fine-tune every frame, layer, and audio stem across video, audio, and overlay tracks, then export the sequence to MP4.
-
-[Video editor guide →](https://docs.nodetool.ai/video-editor)
-
-### Node editor — build a pipeline by chaining steps
-
-![NodeTool node editor](marketing/public/screen_workflow.webp)
-
-Chain steps and wire the graph. Connector handles are color-coded and type-safe. Live output renders at every node as the workflow runs.
-
-Double-click to search and add a node, or drag a connection into empty space to see compatible next steps. The editor refuses a mismatch, so an image can't land in a text field. Tweak properties on a node, group them, or bypass one to test a variation. Pan, zoom, minimap, and search by name for large graphs.
+Chain steps and wire the graph. Connector handles are color-coded and type-safe, and live output renders at every node as the workflow runs. Double-click to search and add a node, or drag a connection into empty space to see compatible next steps. The editor refuses a mismatch, so an image cannot land in a text field. Tweak properties on a node, group them, or bypass one to test a variation.
 
 [Getting started guide →](https://docs.nodetool.ai/getting-started)
 
-### Sketch editor — paint and generate on the same layers
-
-![NodeTool sketch editor](marketing/public/screen_sketch_editor.webp)
-
-Paint, mask, and generate on the same layers. Feed the flattened output directly into the workflow—no export/import round-trips.
-
-Draw and paint with real brushes, build a composition in layers with blend modes and masks, then bind a layer to a model or one of your own workflows and generate image content where you're painting. Change a prompt or an upstream input and the layer flags itself stale; regenerate in place and keep working on top. The node hands the rest of the workflow a flattened image, a mask, and per-layer outputs. It pairs with the editing nodes (mask, inpaint, outpaint, compositing) for sketch-then-generate pipelines.
-
-[Sketch editor guide →](https://docs.nodetool.ai/sketch-editor)
-
-### Mini apps & app builder — put an interface in front of a workflow
+### Mini apps and app builder
 
 ![NodeTool app builder](marketing/public/screen_app_builder.png)
 
-Wrap a complex graph in a clean UI. Drag fields and buttons onto a screen, bind them to workflow inputs, and publish. The agent can build and test these end-to-end.
+A workflow is a graph. A mini app is the interface on top of it. Drag fields, buttons, and result displays onto a screen, wire each one to an input or output, declare which operations a click starts, and publish a version that pins the workflows behind it. Results stream into the widgets as the run happens, and the graph stays underneath, editable. An operation can run a [JS script](docs/js-script-document-design.md) instead of a workflow, for the ten lines of glue that do not deserve a graph.
 
-A workflow is a graph; a mini app is the interface on top of it. Drag fields, buttons, and result displays onto a screen, wire each one to an input or output, declare which operations a click starts, and publish a version that pins the workflows behind it. Results stream into the widgets as the run happens, and the graph stays underneath, editable. An operation can run a [JS script](docs/js-script-document-design.md) instead of a workflow, for the ten lines of glue that don't deserve a graph.
-
-Agents build them end to end. `nodetool app build` runs six stages — spec, plan, author, check, run, judge — and hands back a bundle only when the app's interactions do what the prompt asked. The judge is a second model, configured apart from the builder, because a model grading its own work is the weakest reviewer available:
+Agents build them end to end. `nodetool app build` runs six stages (spec, plan, author, check, run, judge) and hands back a bundle only when the app's interactions do what the prompt asked. The judge is a second model, configured apart from the builder, because a model grading its own work is the weakest reviewer available:
 
 ```bash
 nodetool app build "an app that drafts a note from a prompt" -p anthropic -m claude-sonnet-5
 nodetool app debug <application_id>    # headless: validate bindings, replay interactions
 ```
 
-Export an app as one `.json` bundle — the document plus the full graph of every workflow it binds — and import it anywhere.
+Export an app as one `.json` bundle, the document plus the full graph of every workflow it binds, and import it anywhere.
 
 [App builder guide →](https://docs.nodetool.ai/app-builder) ·
 [Mini apps guide →](https://docs.nodetool.ai/mini-apps)
 
-### JS scripts — ten lines of JavaScript instead of a node graph
+### JS scripts
 
-Ten lines of JavaScript instead of a node graph. Versioned, sandbox-tested logic for fast data transformations.
+Ten lines of JavaScript instead of a node graph. Reshape an API response, merge two lists, format a date. A JS script is a named, versioned document for exactly that: a body with declared input and output ports, the secrets it may read, a timeout, and saved test cases. It opens in its own tab with a code editor and an assistant panel beside it.
 
-Reshape an API response, merge two lists, format a date. A JS script is a named, versioned document for exactly that — a body with declared input and output ports, the secrets it may read, a timeout, and saved test cases. It opens in its own tab with a code editor and an assistant panel beside it.
-
-* **Runs in the sandbox.** A QuickJS guest that starts with nothing: `fetch` and the workspace are capabilities the host grants, under a per-run cap and an SSRF guard. Every installed sandbox pack — date-fns, papaparse, cheerio, exceljs, pdf-lib, and thirty more — resolves by import.
+* **Runs in the sandbox.** A QuickJS guest that starts with nothing. `fetch` and the workspace are capabilities the host grants, under a per-run cap and an SSRF guard. Every installed sandbox pack (date-fns, papaparse, cheerio, exceljs, pdf-lib, and thirty more) resolves by import.
 * **Reusable.** Call it from a mini app as an operation, link it as a Code node's body, invoke it from an agent, or compose it from another script.
-* **Tested like code.** Save cases with inputs and expected outputs; `nodetool jsscript test` grades them and exits non-zero on a failure. Version history is per script, with restore.
+* **Tested like code.** Save cases with inputs and expected outputs. `nodetool jsscript test` grades them and exits non-zero on a failure. Version history is per script, with restore.
 
 ```bash
 nodetool jsscript validate my-script.json
@@ -194,22 +207,6 @@ nodetool jsscript test <id>
 ```
 
 Agents get the same surface through `list_js_scripts`, `save_js_script`, `run_js_script`, and `test_js_script`. See [docs/js-script-document-design.md](docs/js-script-document-design.md) and the [JavaScript sandbox](docs/javascript-sandbox.md).
-
-## How NodeTool compares
-
-| | NodeTool | ComfyUI | Weavy | n8n |
-| :--- | :--- | :--- | :--- | :--- |
-| **Built for** | Filmmakers and creators working with AI | Stable Diffusion power users | Creative teams (now part of Figma) | Business workflows |
-| **Modalities** | Image, video, audio, text | Image, video | Image, video | Text |
-| **Agents** | Every editor is a toolbelt; agents build, run, and repair | Community extensions | Assistant features | AI nodes in a workflow |
-| **Models** | Every major provider, BYOK | Stable Diffusion | Curated marketplace | API integrations |
-| **Source & pricing** | AGPL-3.0, provider prices | Open source, free | Closed, credits | Fair-code, subscription |
-
-**vs ComfyUI.** ComfyUI exposes every parameter for engineers who want them. NodeTool keeps the node graph, gives it an interface that doesn't fight you, and covers the rest of the stack: video, audio, text, document search.
-
-**vs Weavy.** Weavy was the closed-source canvas for creative AI. After the Figma acquisition, the roadmap belongs to someone else. NodeTool is the open alternative: same node-based canvas, your keys, your files, no acquisition risk.
-
-**vs n8n.** n8n is for business workflows and API plumbing. NodeTool is built for creative work: models, masks, layers, video, audio, RAG.
 
 ## Documentation
 
@@ -281,10 +278,10 @@ NodeTool is a monorepo: TypeScript backend, React frontend, Electron desktop she
 
 ```
 nodetool/
-├── packages/          # Backend monorepo (58 packages)
+├── packages/          # Backend monorepo (TypeScript)
 │   ├── kernel/        #   Workflow graph & runner
 │   ├── node-sdk/      #   BaseNode class & node registry
-│   ├── base-nodes/    #   100+ built-in node types
+│   ├── base-nodes/    #   Built-in node types
 │   ├── agents/        #   Planning agents, the editor toolbelt, app build harness
 │   ├── runtime/       #   Processing context & model providers
 │   ├── websocket/     #   HTTP + WebSocket server (entry point)
@@ -348,7 +345,7 @@ server starts with no node types registered.
 
 The repo ships a starter kit in [`.claude/`](.claude/README.md): a SessionStart
 hook that installs dependencies in web sessions, slash commands (`/serve`,
-`/verify`, `/onboard`), and 9 NodeTool skills covering workflow building,
+`/verify`, `/onboard`), and NodeTool skills covering workflow building,
 custom nodes, the API, deployment, and troubleshooting.
 
 ### Python Nodes (optional)


### PR DESCRIPTION
## What changed

Brings the README in line with the narrative `marketing/NARRATIVE.md` pins and the landing page now runs. The hero carries the director line and the project-not-render claim. The enemy (the closed AI studio: their models, their credits, their locked project) is named once and early. The four use-case demos give way to the four recipes, each with its audience, the models the shipped chain calls, and a link to its `.nodetool` bundle. The five surfaces (storyboard, script, timeline, sketch, 3D) sit under "one canvas, pitch through final cut", and the node canvas, mini apps, and JS scripts move under "what is underneath". The comparison is against Runway, LTX Studio, and Figma Weave, with ComfyUI pointed at `/alternatives`. Cost is stated as fact in three places instead of six, Cloud is labelled alpha, local inference is claimed for language and image models only, and the stale package, node, and skill counts are dropped. The developer half is unchanged apart from those counts.

## Verification

Markdown-only diff, so no suite, typecheck, or lint target reads it.

- [x] `npm run test:affected -- --dry-run` → `nothing — no workspace owns the changed files.`
- [x] `npm run typecheck` (not applicable: no TypeScript changed)
- [x] `npm run lint` (not applicable: README is not on any lint path)
- [x] `npm run dev:nodetool -- harness gate --base main` (not applicable: README maps to no surface)
- [x] Every local image and file the README links resolves on disk (scripted check over the `](path)` links)
- [x] Scanned for the forbidden-expressions list and the BRAND.md avoid table; the remaining `credits` hits describe the closed studios' billing, not NodeTool's

## Agent capabilities

Skipped: no capability added or changed.

## New checks

Skipped: no check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tT3hK3qqbiQDCBHVjmTHZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015tT3hK3qqbiQDCBHVjmTHZ)_