### PR TITLE
fix(mobile): mock the trpc export TimelineViewerScreen reads

### DIFF
--- a/mobile/src/screens/__tests__/TimelineViewerScreen.test.tsx
+++ b/mobile/src/screens/__tests__/TimelineViewerScreen.test.tsx
@@ -12,6 +12,7 @@ const isNumber = (value: unknown): value is number =>
   typeof value === 'number';
 import type {
   TimelineAgentHandler,
+  TimelineClipNode,
   TimelineDocument,
 } from '../../documents/timelineTypes';
 
@@ -29,6 +30,14 @@ jest.mock('@react-navigation/native', () => ({
 
 const mockRead = jest.fn();
 const mockUpdate = jest.fn();
+const mockAssetGet = jest.fn();
+
+// `useUtils()` returns one stable object per app in tRPC; the screen keeps it in
+// a callback dependency list, so a fresh object per render would re-register the
+// agent handler on every render.
+const mockTrpcUtils = {
+  assets: { get: { fetch: (input: unknown) => mockAssetGet(input) } },
+};
 
 jest.mock('../../trpc/client', () => ({
   createMobileTRPCClient: () => ({
@@ -37,6 +46,7 @@ jest.mock('../../trpc/client', () => ({
       update: { mutate: (input: unknown) => mockUpdate(input) },
     },
   }),
+  trpc: { useUtils: () => mockTrpcUtils },
 }));
 
 const SEQ_ID = 'seq-1';
@@ -403,6 +413,41 @@ describe('TimelineViewerScreen', () => {
       [0, 2500],
       [2500, 1500],
     ]);
+  });
+
+  it('places a media clip from an asset:// URI, resolved through assets.get', async () => {
+    mockAssetGet.mockResolvedValue({
+      id: 'asset-9',
+      name: 'Drone pass',
+      content_type: 'video/mp4',
+      duration: 6.4,
+    });
+    renderScreen();
+    await screen.findByLabelText(/^Clip Opening shot/);
+
+    const handler = getDocumentHandler<TimelineAgentHandler>('timeline', SEQ_ID);
+    let clip: TimelineClipNode | undefined;
+    await act(async () => {
+      clip = await handler.addMediaClip({ asset: 'asset://asset-9.mp4', trackId: 't1' });
+    });
+
+    expect(mockAssetGet).toHaveBeenCalledWith({ id: 'asset-9' });
+    expect(clip).toMatchObject({ name: 'Drone pass', durationMs: 6400 });
+    expect(screen.getByLabelText(/^Clip Drone pass, video/)).toBeTruthy();
+  });
+
+  it('says which asset was not found when assets.get resolves to nothing', async () => {
+    mockAssetGet.mockResolvedValue(null);
+    renderScreen();
+    await screen.findByLabelText(/^Clip Opening shot/);
+
+    const handler = getDocumentHandler<TimelineAgentHandler>('timeline', SEQ_ID);
+    await act(async () => {
+      await expect(handler.addMediaClip({ asset: 'asset-missing' })).rejects.toThrow(
+        /No asset found for "asset-missing"/
+      );
+    });
+    expect(handler.getSnapshot().dirty).toBe(false);
   });
 
   it('renames the document', async () => {


### PR DESCRIPTION
## What changed

`TimelineViewerScreen` resolves an asset through `trpc.useUtils().assets.get.fetch` before it can place a media clip, but the test's `../../trpc/client` mock exported only `createMobileTRPCClient`. `trpc` came back `undefined` and all 15 cases in the suite died on `useUtils` during render — which is what turns the Quality Gate's `test-app` leg (`npm run test`) red. The mock now supplies `trpc.useUtils()`, returning one stable object, because the screen keeps it in a callback dependency list and a fresh object per render would re-register the agent handler every time. Two cases cover the path that needed the export, since nothing did: placing a clip from an `asset://` URI (the id is parsed out and looked up, and the asset's name and duration reach the clip), and the error naming the asset when the lookup resolves to nothing.

## Verification

- [x] `npm run test:affected -- --base origin/main` — `All affected suites passed` (17/17 in the touched suite).
- [x] `npm run typecheck` — web and electron clean. See the note on mobile below.
- [x] `npm run lint` — no findings on the changed file.
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — 0 selfchecks to run (`mobile` is a documented gap surface).

Full app suites, all green after the fix:

```
web       Test Suites: 1262 passed   Tests: 14213 passed, 3 skipped, 1 todo
electron  Test Suites:   63 passed   Tests:   690 passed
mobile    Test Suites:   79 passed   Tests:  1108 passed   (3 consecutive runs)
```

The two added cases were each inverted against the screen to prove they bite:

```
# trpcUtils.assets.get.fetch({ id: ref })  — the asset:// prefix left unstripped
✕ places a media clip from an asset:// URI, resolved through assets.get (71 ms)

# the "No asset found for …" message replaced
✕ says which asset was not found when assets.get resolves to nothing (69 ms)
```

## Pre-existing, not touched here

Two things found while reproducing this, both unrelated to the diff and left alone rather than folded in.

**1. `typecheck:mobile` is red after a cold `npm ci` in `mobile/`, though CI is green today.** `mobile/package-lock.json` pins `@nodetool-ai/protocol` to the published `0.7.0-rc.11` from the registry, and neither `mobile/tsconfig.json` nor `metro.config.js` maps the bare specifier to source (only `/triggers` and `/blend-modes` are mapped). A fresh `cd mobile && npm ci` therefore materializes `mobile/node_modules/@nodetool-ai/protocol`, which shadows the root workspace symlink, and `tsc` reports 36 errors against a protocol that predates `TRPC_MAX_BATCH_SIZE`, `ShotStatus`, `processingMessageSchemas`, and `Node.sync_mode`. Deleting just that directory drops it to 0 errors, since resolution then falls through to the repo's source. Jest maps the specifier to source regardless, which is why the tests pass either way.

The `typecheck` leg on this PR passed, so CI is running against a tree without that directory — its `mobile/node_modules` cache is keyed on `hashFiles('mobile/package-lock.json')` and is being restored, not rebuilt. That makes this latent rather than broken: the next change to `mobile/package-lock.json` invalidates the cache, CI takes the `npm ci` path, and the leg goes red. Resolving it is a wiring decision (drop the dependency in favour of the root workspace, publish a newer protocol, or add the path mapping and accept divergence from what metro bundles) — not a test fix, so it is written up here rather than folded in.

**2. `captureInputs.test.tsx` flaked once** (`AudioRecorder › records with the microphone`) in the same loaded run that carried the 15 failures above, with the suite taking 18.4s against 1.7s alone. It has not reproduced in four subsequent full-suite runs, so there is no failure here to diagnose — recording it in case it returns.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added. (The two new test cases were inverted; the failing output is in **Verification**.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ALoCEfW88r9JgM1JdH3Q12