### PR TITLE
fix(marketing): open the mobile menu before the page hydrates

### DIFF
--- a/marketing/src/app/globals.css
+++ b/marketing/src/app/globals.css
@@ -534,6 +534,22 @@
 }
 
 /* A flick past the end of the mobile menu must not chain to the page behind. */
+/*
+ * The mobile menu is CSS state, not React state: the header ships an inline
+ * script that toggles `data-nav-open` on <html> while the page is still
+ * parsing, so a tap works long before hydration. Below `md` only — the panel
+ * duplicates the desktop nav.
+ */
+.site-nav-overlay {
+  display: none;
+}
+
+@media (max-width: 767.98px) {
+  html[data-nav-open] .site-nav-overlay {
+    display: block;
+  }
+}
+
 .mobile-menu-panel {
   overscroll-behavior: contain;
 }

--- a/marketing/src/components/SiteHeader.tsx
+++ b/marketing/src/components/SiteHeader.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline";
@@ -52,50 +52,65 @@ function Wordmark() {
   );
 }
 
+/**
+ * The menu runs on a `data-nav-open` attribute rather than React state, driven
+ * by this script, which the browser executes as it parses the header — seconds
+ * before React hydrates. The landing page is one big `"use client"` tree, so
+ * hydration lands ~2.7s in on a 6x-throttled phone while the hamburger has been
+ * on screen since ~0.3s; every tap in that window used to be swallowed.
+ * Visibility is CSS (`html[data-nav-open]`, see globals.css), so nothing here
+ * waits on a bundle.
+ *
+ * The listener is delegated on `document`, which outlives a soft navigation —
+ * a `next/link` route change re-renders the header but does not re-run an
+ * inline script.
+ *
+ * Opening pins the page rather than only setting `overflow: hidden`, which iOS
+ * Safari ignores — without the pin a flick inside the panel scrolls the
+ * document behind it.
+ */
+const NAV_MENU_SCRIPT = `(function(){
+if(window.__ntNavMenu)return;
+var html=document.documentElement,saved=null;
+function expanded(v){var b=document.querySelector('[data-nav="open"]');if(b)b.setAttribute("aria-expanded",v?"true":"false");}
+function open(){
+  if(html.hasAttribute("data-nav-open"))return;
+  var b=document.body,y=window.scrollY;
+  saved={y:y,position:b.style.position,top:b.style.top,left:b.style.left,right:b.style.right,overflow:b.style.overflow};
+  b.style.position="fixed";b.style.top=-y+"px";b.style.left="0";b.style.right="0";b.style.overflow="hidden";
+  html.setAttribute("data-nav-open","");expanded(true);
+}
+function close(){
+  if(!html.hasAttribute("data-nav-open"))return;
+  html.removeAttribute("data-nav-open");expanded(false);
+  if(!saved)return;
+  var b=document.body,s=saved;saved=null;
+  b.style.position=s.position;b.style.top=s.top;b.style.left=s.left;b.style.right=s.right;b.style.overflow=s.overflow;
+  var behavior=html.style.scrollBehavior;html.style.scrollBehavior="auto";window.scrollTo(0,s.y);html.style.scrollBehavior=behavior;
+}
+document.addEventListener("click",function(e){
+  var t=e.target;
+  if(!t||typeof t.closest!=="function")return;
+  var hit=t.closest("[data-nav]");
+  if(!hit)return;
+  if(hit.getAttribute("data-nav")==="open"){open();}else{close();}
+});
+document.addEventListener("keydown",function(e){if(e.key==="Escape")close();});
+var wide=window.matchMedia("(min-width: 768px)");
+(wide.addEventListener?wide.addEventListener.bind(wide,"change"):wide.addListener.bind(wide))(function(e){if(e.matches)close();});
+window.__ntNavMenu={open:open,close:close};
+})();`;
+
 export default function SiteHeader() {
   const pathname = usePathname();
-  const [mobileOpen, setMobileOpen] = useState(false);
   const stars = useGithubStars();
-
-  // Opening the panel pins the page rather than only setting `overflow:
-  // hidden`, which iOS Safari ignores — without the pin a flick inside the menu
-  // scrolls the document behind it.
-  useEffect(() => {
-    if (!mobileOpen) return;
-    const { body, documentElement: html } = document;
-    const scrollY = window.scrollY;
-    const restore = {
-      position: body.style.position,
-      top: body.style.top,
-      left: body.style.left,
-      right: body.style.right,
-      overflow: body.style.overflow,
-    };
-    body.style.position = "fixed";
-    body.style.top = `-${scrollY}px`;
-    body.style.left = "0";
-    body.style.right = "0";
-    body.style.overflow = "hidden";
-
-    return () => {
-      body.style.position = restore.position;
-      body.style.top = restore.top;
-      body.style.left = restore.left;
-      body.style.right = restore.right;
-      body.style.overflow = restore.overflow;
-      // `html { scroll-behavior: smooth }` would animate this restore.
-      const behavior = html.style.scrollBehavior;
-      html.style.scrollBehavior = "auto";
-      window.scrollTo(0, scrollY);
-      html.style.scrollBehavior = behavior;
-    };
-  }, [mobileOpen]);
 
   const isActive = (item: NavItem) =>
     !item.external && (pathname === item.href);
 
   return (
     <header>
+      <script dangerouslySetInnerHTML={{ __html: NAV_MENU_SCRIPT }} />
       <AnnouncementBar />
       <nav
         className="fixed top-[var(--announce-h)] left-0 right-0 z-50 border-b border-slate-800/60 bg-glass supports-[backdrop-filter]:bg-glass shadow-[0_1px_0_0_rgba(59,130,246,0.08)]"
@@ -140,7 +155,8 @@ export default function SiteHeader() {
               <button
                 type="button"
                 className="md:hidden rounded-md p-1.5 text-slate-300 hover:bg-slate-800/60 transition-colors focus-ring"
-                onClick={() => setMobileOpen(true)}
+                data-nav="open"
+                aria-expanded={false}
                 aria-label="Open menu"
               >
                 <Bars3Icon className="h-5 w-5" aria-hidden="true" />
@@ -172,60 +188,57 @@ export default function SiteHeader() {
         </div>
       </nav>
 
-      {mobileOpen && (
-        <div
-          className="md:hidden fixed inset-0 z-[70]"
-          role="dialog"
-          aria-modal="true"
-        >
-          <button
-            type="button"
-            className="absolute inset-0 bg-slate-950/90"
-            onClick={() => setMobileOpen(false)}
-            aria-label="Close menu"
-          />
-          <div className="mobile-menu-panel absolute inset-y-0 right-0 w-full overflow-y-auto bg-gradient-to-b from-slate-900 to-slate-950 px-6 py-6 sm:max-w-sm border-l border-slate-800/60">
-            <div className="flex items-center justify-between">
-              <Wordmark />
-              <button
-                type="button"
-                className="rounded-md p-2 text-slate-300 hover:bg-slate-800/60 transition-colors focus-ring"
-                onClick={() => setMobileOpen(false)}
-                aria-label="Close menu"
-              >
-                <XMarkIcon className="h-6 w-6" aria-hidden="true" />
-              </button>
-            </div>
-            <div className="mt-6 space-y-2">
-              {NAV.map((item) => (
-                <a
-                  key={item.name}
-                  href={item.href}
-                  {...(item.external
-                    ? { target: "_blank", rel: "noopener noreferrer" }
-                    : {})}
-                  className="block px-3 py-3 text-base font-medium text-slate-200 hover:bg-slate-800/60 hover:text-white rounded-lg transition-colors focus-ring"
-                  onClick={() => setMobileOpen(false)}
-                >
-                  {item.name}
-                </a>
-              ))}
+      <div
+        className="site-nav-overlay fixed inset-0 z-[70]"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Site menu"
+      >
+        <button
+          type="button"
+          className="absolute inset-0 bg-slate-950/90"
+          data-nav="close"
+          aria-label="Close menu"
+        />
+        <div className="mobile-menu-panel absolute inset-y-0 right-0 w-full overflow-y-auto bg-gradient-to-b from-slate-900 to-slate-950 px-6 py-6 sm:max-w-sm border-l border-slate-800/60">
+          <div className="flex items-center justify-between">
+            <Wordmark />
+            <button
+              type="button"
+              className="rounded-md p-2 text-slate-300 hover:bg-slate-800/60 transition-colors focus-ring"
+              data-nav="close"
+              aria-label="Close menu"
+            >
+              <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+            </button>
+          </div>
+          <div className="mt-6 space-y-2">
+            {NAV.map((item) => (
               <a
-                href={GITHUB_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => {
-                  track("Star GitHub");
-                  setMobileOpen(false);
-                }}
+                key={item.name}
+                href={item.href}
+                {...(item.external
+                  ? { target: "_blank", rel: "noopener noreferrer" }
+                  : {})}
                 className="block px-3 py-3 text-base font-medium text-slate-200 hover:bg-slate-800/60 hover:text-white rounded-lg transition-colors focus-ring"
+                data-nav="close"
               >
-                Star on GitHub
+                {item.name}
               </a>
-            </div>
+            ))}
+            <a
+              href={GITHUB_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-nav="close"
+              onClick={() => track("Star GitHub")}
+              className="block px-3 py-3 text-base font-medium text-slate-200 hover:bg-slate-800/60 hover:text-white rounded-lg transition-colors focus-ring"
+            >
+              Star on GitHub
+            </a>
           </div>
         </div>
-      )}
+      </div>
     </header>
   );
 }

--- a/marketing/tests/e2e/mobile-menu.spec.ts
+++ b/marketing/tests/e2e/mobile-menu.spec.ts
@@ -13,6 +13,12 @@ import { test, expect } from "@playwright/test";
  * over ~50 moving cards — 1.2s of the main thread per 3s on a 4x-throttled
  * phone, measured with the section nowhere near the viewport. That is what
  * made every interaction on the page, the menu included, feel stuck.
+ *
+ * And the menu opens without the React bundle at all. The landing page is one
+ * `"use client"` tree, so hydration landed ~2.7s in on a 6x-throttled phone
+ * while the hamburger had been on screen since ~0.3s; every tap in between was
+ * swallowed. Asserted by serving the page with its chunks blocked rather than
+ * by racing a clock.
  */
 test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
 
@@ -71,5 +77,27 @@ test.describe("landing page on a phone", () => {
         track.evaluate((el) => getComputedStyle(el).animationPlayState)
       )
       .toBe("running");
+  });
+
+  test("the menu opens with the page's JavaScript blocked", async ({ page }) => {
+    await page.route("**/_next/static/**/*.js", (route) => route.abort());
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    const panel = page.getByRole("dialog");
+    await expect(panel).toBeHidden();
+
+    const open = page.getByRole("button", { name: "Open menu" });
+    await open.click();
+    await expect(panel).toBeVisible();
+    await expect(open).toHaveAttribute("aria-expanded", "true");
+    expect(await page.evaluate(() => document.body.style.position)).toBe(
+      "fixed"
+    );
+
+    await page.keyboard.press("Escape");
+    await expect(panel).toBeHidden();
+    await expect(open).toHaveAttribute("aria-expanded", "false");
+    expect(await page.evaluate(() => document.body.style.position)).toBe("");
   });
 });


### PR DESCRIPTION
## What changed

The hamburger on the marketing site was painted at ~0.3s and stayed dead until React finished hydrating. `src/app/page.tsx` is one `"use client"` tree, so `SiteHeader`'s interactivity was gated on hydrating the whole landing page: 2.7s on a 6x-throttled phone, 3.7s with a 1.6 Mbps link, measured against the production build. Every tap in that window was swallowed. Server-component pages responded in ~1.1s (`/pricing`) and ~1.2s (`/blog`), which is what pinned the cause to hydration weight rather than to the menu.

The menu no longer runs on React state. `SiteHeader` ships an inline script that toggles `data-nav-open` on `<html>`, and CSS in `globals.css` drives the panel, so the browser wires the button up while it is still parsing the header — nothing waits on a bundle. The click listener is delegated on `document`, which outlives a `next/link` soft navigation (a route change re-renders the header but does not re-run an inline script). The iOS scroll pin and its restore move into that script unchanged, and Escape now closes the panel. Marked-up state is unchanged for a reader: the panel is `display: none` below `md`, so it stays out of the accessibility tree and the tab order until it opens.

Measured after the change, same harness: the hamburger responds the moment it is in the DOM, at 1x, 4x and 6x CPU throttling and on both link profiles.

## Verification

`marketing/` is not a root npm workspace, so the root `test:affected` / `typecheck` / `lint` targets do not reach this diff. The equivalents that do:

- `npx tsc --noEmit -p tsconfig.json` (in `marketing/`) — clean
- `npx next lint --file src/components/SiteHeader.tsx` — no warnings or errors
- `npx playwright test` (in `marketing/`, against the production build) — **360 passed**, including the three `tests/e2e/mobile-menu.spec.ts` cases

Latency, production build, 390x844 viewport, click-to-open measured from a poll that starts at navigation:

| profile | before | after |
|---|---|---|
| 1x CPU | 489ms | responds as soon as it is in the DOM |
| 4x CPU | 1848ms | responds as soon as it is in the DOM |
| 6x CPU | 2729ms | responds as soon as it is in the DOM |
| 6x CPU + 1.6 Mbps | 3736ms | responds as soon as it is in the DOM |

- [x] `npm run test:affected` — n/a, no workspace covers `marketing/`; the Playwright suite above is the equivalent
- [x] `npm run typecheck` — n/a for this tree; `npx tsc --noEmit` run in `marketing/` instead
- [x] `npm run lint` — n/a for this tree; `npx next lint` run in `marketing/` instead
- [ ] `npm run dev:nodetool -- harness gate --base main` — no harness surface covers `marketing/`

## Agent capabilities

No capability added or re-declared.

## New checks

`tests/e2e/mobile-menu.spec.ts` gains "the menu opens with the page's JavaScript blocked" — it aborts every `/_next/static/**/*.js` request and asserts the menu still opens, pins the body and closes on Escape. Mechanism, not a clock.

- [x] Inverted once and observed failing. Serving the same build with the inline script stripped out of the HTML:

```
    Timeout: 3000ms
    Error: element(s) not found

    Call log:
      - Expect "toBeVisible" with timeout 3000ms
      - waiting for getByRole('dialog')

  1 failed
    [chromium] › inversion: menu stays shut when the inline script is removed
```

- [x] The assertion cannot pass by matching nothing: `getByRole("dialog")` does not match the `display: none` panel, so the visible-after-click assertion is the one carrying the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTwJAaoz9hgDhxTpHkeurg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTwJAaoz9hgDhxTpHkeurg)_