### PR TITLE
fix(agents): harden generation and timeline surfaces against trailer-build failure modes

### DIFF
--- a/packages/agents/src/capabilities/media.ts
+++ b/packages/agents/src/capabilities/media.ts
@@ -59,6 +59,7 @@ import {
   mimeForRef
 } from "../sandbox-media-ref.js";
 import { inferImageMime, persistOutput } from "../tools/asset-persist.js";
+import type { SavedOutput } from "../tools/asset-persist.js";
 import { persistBinaryOutput } from "../tools/binary-output.js";
 import { extractJSON } from "../utils/json-parser.js";
 import { isYtDlpEnabled } from "../yt-dlp-gate.js";
@@ -243,6 +244,37 @@ async function readWorkspaceOrAssetFile(
   return bytes;
 }
 
+/**
+ * A generation that produced no handle is a failure, not a success.
+ *
+ * A run whose bytes never became an asset (no asset interface, `createAsset`
+ * threw, no workspace to fall back to) used to return `{type, provider, model,
+ * bytes, mime_type}` — success-shaped, with `asset_uri` undefined, which an
+ * agent printed as "OK undefined" and carried on from. Report what was missing
+ * instead.
+ */
+function outputError(
+  capability: string,
+  m: MediaModelArgs,
+  missing: string
+): { error: string } {
+  return {
+    error: `${capability} for ${m.provider}:${m.model} returned no usable output — ${missing}.`
+  };
+}
+
+/** The provider's bytes, or null when it produced none. */
+function generatedBytes(result: unknown): Uint8Array | null {
+  return result instanceof Uint8Array && result.length > 0 ? result : null;
+}
+
+/** Whether a persisted output carries a handle the caller can read back. */
+function hasOutputHandle(persisted: SavedOutput): boolean {
+  return (
+    isNonEmptyString(persisted.asset_uri) || isNonEmptyString(persisted.path)
+  );
+}
+
 const generateImage: CapabilityExport = {
   spec: generateImageSpec,
   impl: async (run, params) => {
@@ -265,14 +297,29 @@ const generateImage: CapabilityExport = {
           height: params["height"],
           quality: params["quality"]
         }
-      })) as Uint8Array;
-      const persisted = await persistOutput(context, result, {
+      })) as unknown;
+      const bytes = generatedBytes(result);
+      if (!bytes) {
+        return outputError(
+          "text_to_image",
+          m,
+          "the provider returned no image data"
+        );
+      }
+      const persisted = await persistOutput(context, bytes, {
         namePrefix: "generated-image",
-        mime: inferImageMime(result),
+        mime: inferImageMime(bytes),
         outputFile: isString(params["output_file"])
           ? params["output_file"]
           : undefined
       });
+      if (!hasOutputHandle(persisted)) {
+        return outputError(
+          "text_to_image",
+          m,
+          `the ${persisted.bytes}-byte result could not be stored (no asset was created and no workspace file was written)`
+        );
+      }
       return {
         type: "image",
         provider: m.provider,
@@ -312,14 +359,29 @@ const editImage: CapabilityExport = {
           target_height: params["target_height"],
           strength: params["strength"]
         }
-      })) as Uint8Array;
-      const persisted = await persistOutput(context, result, {
+      })) as unknown;
+      const bytes = generatedBytes(result);
+      if (!bytes) {
+        return outputError(
+          "image_to_image",
+          m,
+          "the provider returned no image data"
+        );
+      }
+      const persisted = await persistOutput(context, bytes, {
         namePrefix: "edited-image",
-        mime: inferImageMime(result),
+        mime: inferImageMime(bytes),
         outputFile: isString(params["output_file"])
           ? params["output_file"]
           : undefined
       });
+      if (!hasOutputHandle(persisted)) {
+        return outputError(
+          "image_to_image",
+          m,
+          `the ${persisted.bytes}-byte result could not be stored (no asset was created and no workspace file was written)`
+        );
+      }
       return {
         type: "image",
         provider: m.provider,
@@ -438,14 +500,29 @@ const generateVideo: CapabilityExport = {
           aspect_ratio: params["aspect_ratio"],
           resolution: params["resolution"]
         }
-      })) as Uint8Array;
-      const persisted = await persistOutput(context, result, {
+      })) as unknown;
+      const bytes = generatedBytes(result);
+      if (!bytes) {
+        return outputError(
+          "text_to_video",
+          m,
+          "the provider returned no video data"
+        );
+      }
+      const persisted = await persistOutput(context, bytes, {
         namePrefix: "generated-video",
         mime: "video/mp4",
         outputFile: isString(params["output_file"])
           ? params["output_file"]
           : undefined
       });
+      if (!hasOutputHandle(persisted)) {
+        return outputError(
+          "text_to_video",
+          m,
+          `the ${persisted.bytes}-byte result could not be stored (no asset was created and no workspace file was written)`
+        );
+      }
       return {
         type: "video",
         provider: m.provider,
@@ -481,14 +558,29 @@ const animateImage: CapabilityExport = {
           aspect_ratio: params["aspect_ratio"],
           resolution: params["resolution"]
         }
-      })) as Uint8Array;
-      const persisted = await persistOutput(context, result, {
+      })) as unknown;
+      const bytes = generatedBytes(result);
+      if (!bytes) {
+        return outputError(
+          "image_to_video",
+          m,
+          "the provider returned no video data"
+        );
+      }
+      const persisted = await persistOutput(context, bytes, {
         namePrefix: "animated-video",
         mime: "video/mp4",
         outputFile: isString(params["output_file"])
           ? params["output_file"]
           : undefined
       });
+      if (!hasOutputHandle(persisted)) {
+        return outputError(
+          "image_to_video",
+          m,
+          `the ${persisted.bytes}-byte result could not be stored (no asset was created and no workspace file was written)`
+        );
+      }
       return {
         type: "video",
         provider: m.provider,

--- a/packages/agents/src/capabilities/timelines.specs.ts
+++ b/packages/agents/src/capabilities/timelines.specs.ts
@@ -138,6 +138,7 @@ export const EDIT_TIMELINE_SCHEMA: JsonSchema = {
         '([{property, keyframes: [{t, value, easing?}]}], `t` running 0..1 ' +
         "over the animation's window) or `code` (a JS body baked into curves " +
         "once, host-side); add `mask` when a curve drives wipeProgress. " +
+        "Either may sit under a nested `custom: {curves|code|mask}` instead. " +
         "list_animation_presets reports the animatable properties. " +
         'set_transition takes {"target", "transition": {type, durationMs, ' +
         "easing?, color?, direction?, softness?} | null} — the cut plays over " +
@@ -161,10 +162,20 @@ export const EDIT_TIMELINE_SCHEMA: JsonSchema = {
         "tracks, so what covers what is unchanged. " +
         'set_parent takes {"target", "parentId": <group> | null}; the parent ' +
         "must be a clip made with add_group, and a cycle is refused. " +
+        'add_shape_clip takes the geometry in "shape" (or "shapeStyle"): ' +
+        '{kind: "rect"|"ellipse"|"line"|"polygon"|"star"|"path", x, y, ' +
+        "width, height, fill?, stroke?, strokeWidthPx?}, where x/y/width/" +
+        "height are 0..1 fractions of the frame; those keys are also read " +
+        "from the op itself, and with no geometry at all the shape is a " +
+        "full-frame rect. " +
         'set_clip_params takes {"target", ...fields}; a caption clip\'s look ' +
         'is "captionStyle": {fontFamily?, fontSizeFrac?, color?, activeColor?, ' +
         "outline?, bottomMarginFrac?, background?}, each field optional and " +
-        "each absent one keeping the built-in value. " +
+        "each absent one keeping the built-in value. It also takes " +
+        '"fontSizePx" (merged into textStyle) and the timing move_clip and ' +
+        'trim_clip apply — "startMs", "trackId", "durationMs", "inPointMs", ' +
+        '"outPointMs" — and refuses a key it does not know by name rather ' +
+        "than ignoring it. " +
         'set_effects takes {"target", "effects": [{type, ...}]} and replaces ' +
         "the whole chain — types color, blur, glow, dropShadow, vignette, " +
         "sharpen, chromaKey, curves, levels, liftGammaGain, applied in the " +

--- a/packages/agents/src/capabilities/timelines.ts
+++ b/packages/agents/src/capabilities/timelines.ts
@@ -75,6 +75,10 @@ import {
   SET_TIMELINE_DOCUMENT_SCHEMA,
   deleteTimelineSpec
 } from "./timelines.specs.js";
+import {
+  normalizeAuthoredDocument,
+  type AuthoredRenderSettings
+} from "@nodetool-ai/timeline";
 import { isFiniteNumber, isRecord, isString } from "../utils/type-guards.js";
 
 export {
@@ -954,14 +958,19 @@ const validateTimeline: CapabilityExport = {
 /**
  * A document the caller sent, ready to validate.
  *
- * `markers` is the one field an agent authoring a cut has no reason to think
- * about, and the Zod schema requires it — so an omitted one becomes an empty
- * list rather than a `schema_invalid` refusal about a field nobody meant to
- * leave out. Everything else is stored as given: the whole point of this
- * capability is that what the caller sends is what the sequence becomes.
+ * A hand-authored cut leaves out the bookkeeping the schema requires — track
+ * `index`/`visible`/`locked`, clip `sourceType`/`status`/`locked`/`versions`,
+ * animation ids, `markers` — and refusing it with two dozen schema errors
+ * teaches the caller nothing. `normalizeAuthoredDocument` fills exactly what is
+ * missing and lifts document-level `fps`/`width`/`height` out as sequence
+ * settings; a value the caller sent is never replaced, because the point of a
+ * whole-document write is that what was sent is what the sequence becomes.
  */
-function documentToStore(raw: Record<string, unknown>): Record<string, unknown> {
-  return raw["markers"] === undefined ? { ...raw, markers: [] } : raw;
+function documentToStore(raw: Record<string, unknown>): {
+  document: Record<string, unknown>;
+  settings: AuthoredRenderSettings;
+} {
+  return normalizeAuthoredDocument(raw);
 }
 
 /** The end of the last clip — what the sequence's stored duration means. */
@@ -1031,14 +1040,30 @@ const setTimelineDocument: CapabilityExport = {
       }
     }
 
-    const fps = sequenceSetting(params["fps"], sequence.fps, "fps");
+    const { document, settings } = documentToStore(raw);
+
+    // Document-level fps/width/height are sequence settings, so opts win and a
+    // document that carries them configures the sequence instead of having
+    // them stripped with a `field_stripped` warning.
+    const fps = sequenceSetting(
+      params["fps"] ?? settings.fps,
+      sequence.fps,
+      "fps"
+    );
     if (isError(fps)) return fps;
-    const width = sequenceSetting(params["width"], sequence.width, "width");
+    const width = sequenceSetting(
+      params["width"] ?? settings.width,
+      sequence.width,
+      "width"
+    );
     if (isError(width)) return width;
-    const height = sequenceSetting(params["height"], sequence.height, "height");
+    const height = sequenceSetting(
+      params["height"] ?? settings.height,
+      sequence.height,
+      "height"
+    );
     if (isError(height)) return height;
 
-    const document = documentToStore(raw);
     const { validateTimelineSequence } =
       await import("@nodetool-ai/execution/timeline-debug");
     const before: TimelineValidation = validateTimelineSequence(document, {

--- a/packages/agents/src/codeact/action-diagnostics.ts
+++ b/packages/agents/src/codeact/action-diagnostics.ts
@@ -15,6 +15,10 @@
 
 import { parseCodeBody } from "@nodetool-ai/node-sdk";
 import { entryBodyLineOffset } from "../js-sandbox-worker/interpreter.js";
+import {
+  RESERVED_ACTION_BINDINGS,
+  RESERVED_BINDINGS_SENTENCE
+} from "./tool-api.js";
 
 /**
  * A stack frame pointing into the guest's `user-code` module. Both shapes
@@ -99,6 +103,8 @@ export function annotateFailure(
   prelude: string,
   code: string
 ): { readonly error?: string; readonly stack?: string } {
+  const collision = reservedRedeclaration(error);
+  if (collision !== undefined) return { error: collision };
   const reparsed = reparseSyntaxError(error, code);
   if (reparsed !== undefined) return reparsed;
   if (!stack) return { error };
@@ -136,4 +142,31 @@ function reparseSyntaxError(
       ? `    at action:${line}`
       : `    at action:${line}\n    >> your code, line ${line}: ${excerpt}`;
   return { error: message, stack };
+}
+
+/**
+ * QuickJS names a redeclared binding but not where it came from, so
+ * "SyntaxError: lexical redefinition of 'tools'" points a model at a
+ * declaration that looks fine — the clashing one is in the prelude it never
+ * sees. Say which prelude binding it hit and what to do about it.
+ *
+ * Only a name the prelude actually reserves is rewritten; a redeclaration
+ * inside the action's own code is the model's to find, and the position it
+ * already carries is enough.
+ */
+function reservedRedeclaration(error: string | undefined): string | undefined {
+  if (error === undefined || !error.includes("SyntaxError")) return undefined;
+  const match = /(?:redefinition|redeclaration) of (?:lexical identifier )?['"`]?([A-Za-z_$][\w$]*)/.exec(
+    error
+  );
+  const name = match?.[1];
+  if (name === undefined || !RESERVED_ACTION_BINDINGS.includes(name)) {
+    return undefined;
+  }
+  return (
+    `${error.trim()} — \`${name}\` is a binding the action prelude declares ` +
+    `before your code runs, not one of yours. Rename your variable (e.g. ` +
+    `\`my${name.charAt(0).toUpperCase()}${name.slice(1)}\`). ` +
+    RESERVED_BINDINGS_SENTENCE
+  );
 }

--- a/packages/agents/src/codeact/capability-modules.ts
+++ b/packages/agents/src/codeact/capability-modules.ts
@@ -33,7 +33,48 @@ import {
 } from "../capabilities/dispatcher.js";
 import { listCapabilityModules } from "../capabilities/registry.js";
 import type { CapabilityRun } from "../capabilities/types.js";
+import {
+  extractInjectableImages,
+  IMAGE_CONTENT_FIELD,
+  IMAGE_CONTENTS_FIELD
+} from "../tools/image-injection.js";
+import { isRecord, isString } from "../utils/type-guards.js";
 import type { SandboxCapabilityMount } from "../js-sandbox.js";
+
+/**
+ * What a capability answering with pixels is told inside an action.
+ *
+ * `view_image` answers with an `image_content` payload the tool loop injects
+ * into the model's next turn as a real image block. A capability imported into
+ * a code action has no such channel: its result is a JavaScript value that
+ * reaches the model only as the action's JSON observation, so the pixels went
+ * nowhere and the model read back its own question. Say where the pixels are
+ * instead of pretending they arrived.
+ */
+export const SANDBOX_IMAGE_NOTE =
+  "No pixels were delivered: an image cannot cross into a code action, only " +
+  "its reference. To look at it, call view_image as a direct tool call " +
+  "(outside execute_code) with this image_id, or ask a vision model about it " +
+  "with critique_image / score_image_adherence, which answer in text.";
+
+/**
+ * Replace an injectable-image payload with the note above. Every other result
+ * passes through untouched.
+ */
+function withoutPixels(result: unknown): unknown {
+  if (extractInjectableImages(result) === null || !isRecord(result)) {
+    return result;
+  }
+  const stripped: Record<string, unknown> = { ...result };
+  delete stripped[IMAGE_CONTENT_FIELD];
+  delete stripped[IMAGE_CONTENTS_FIELD];
+  const note = stripped["note"];
+  stripped["note"] =
+    isString(note) && note.length > 0
+      ? `${note} ${SANDBOX_IMAGE_NOTE}`
+      : SANDBOX_IMAGE_NOTE;
+  return stripped;
+}
 
 export type CapabilityModuleMount =
   | { ok: true; mount?: SandboxCapabilityMount }
@@ -179,14 +220,16 @@ export async function mountCapabilityModules(
       if (graft === undefined) {
         throw new Error(`no session module serves "${moduleKey}"`);
       }
-      return graft.call(exportName, args[0] === undefined ? {} : args[0]);
+      return withoutPixels(
+        await graft.call(exportName, args[0] === undefined ? {} : args[0])
+      );
     }
     if (dispatcher === undefined) {
       throw new Error(
         `"${exportName}" is not available in this run — it needs a capability run.`
       );
     }
-    return dispatcher.call(moduleKey, exportName, args);
+    return withoutPixels(await dispatcher.call(moduleKey, exportName, args));
   };
   return { ok: true, mount: { facades, call } };
 }

--- a/packages/agents/src/codeact/mcp-guest-contract.ts
+++ b/packages/agents/src/codeact/mcp-guest-contract.ts
@@ -12,6 +12,7 @@ import {
   type SandboxManifest
 } from "../code-gen/sandbox-manifest.js";
 import { chatUnavailableBridges } from "./prompt.js";
+import { RESERVED_BINDINGS_SENTENCE } from "./tool-api.js";
 
 /** Structured guest surface for MCP clients that read resources. */
 export const MCP_SANDBOX_RESOURCE_URI = "nodetool://sandbox";
@@ -61,6 +62,7 @@ Rules:
 - Static \`import\` only for allowed packs. This session lists them below; anything else fails.
 - \`return\` a small summary. Nothing carries over between actions except what a tool saved — generation results are already assets (\`asset://\`). Record anything a later action needs with \`nodetool.memory.save\`; the next action must reuse it, not generate again.
 - A failed tool throws. Use \`try/catch\`.
+- ${RESERVED_BINDINGS_SENTENCE}
 - This is a chat turn: there is no \`finish()\`. A plain assistant message ends the turn.
 - \`fetch\`, \`workspace\`, \`media\`, and \`getSecret\` are not available here. Files and assets go through \`nodetool.*\`: feed a generation result into \`image.*\`, save with \`nodetool.media.toImage(handle)\`. The guest holds handles, never encoded bytes. \`nodetool.assets.read/save\` the library, \`nodetool.web.fetch\` the network.
 - Full guest surface: resource \`${MCP_SANDBOX_RESOURCE_URI}\`. Tool catalog: \`nodetool://capabilities\`.`;

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -1135,7 +1135,11 @@ const nodetool = (() => {
         __need("list_timeline_versions")(__merge(opts, { timeline_id: id })),
       getVersion: (id, version) =>
         __need("get_timeline_version")({ timeline_id: id, version: version }),
+      /** Save the current state as a version. Options: {name}. */
       snapshot: (id, opts) =>
+        __need("create_timeline_version")(__merge(opts, { timeline_id: id })),
+      /** Alias of snapshot(), named after the create_timeline_version tool. */
+      createVersion: (id, opts) =>
         __need("create_timeline_version")(__merge(opts, { timeline_id: id })),
       restore: (id, version) =>
         __need("restore_timeline_version")({
@@ -1180,6 +1184,14 @@ const nodetool = (() => {
        * is written and snapshotted first, so a bad document is refused and a
        * good one is undoable. Options: {fps, width, height,
        * expected_updated_at, snapshot_name}.
+       *
+       * Bookkeeping you leave out is filled in rather than refused: a track's
+       * index (its position in the array), visible: true and locked: false; a
+       * clip's sourceType (generated when it names a prompt, workflow or
+       * binding, else imported), status "generated", locked: false and
+       * versions: []; an animation's id (anim_1, anim_2, …); and markers: [].
+       * Anything you do send is kept as sent. fps/width/height on the document
+       * itself are read as the sequence's settings when the options omit them.
        */
       setDocument: (id, document, opts) =>
         __need("set_timeline_document")(
@@ -1660,11 +1672,16 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   timelines or two versions — per-frame pixel difference and a side-by-side
   sheet),
   \`versions(id)\`,
-  \`getVersion(id, n)\`, \`snapshot(id, {name})\`, \`restore(id, n)\`,
+  \`getVersion(id, n)\`, \`snapshot(id, {name})\` (also \`createVersion\`,
+  the same call under the tool's own name), \`restore(id, n)\`,
   \`deleteVersion(id, n)\`,
   \`setDocument(id, document, {fps, width, height, expected_updated_at,
   snapshot_name})\` — the whole document in one call, validated before it is
-  written and snapshotted first, for authoring a cut from scratch —
+  written and snapshotted first, for authoring a cut from scratch. Missing
+  bookkeeping is filled in: track \`index\`/\`visible\`/\`locked\`, clip
+  \`sourceType\`/\`status\`/\`locked\`/\`versions\`, animation ids and
+  \`markers\`; document-level \`fps\`/\`width\`/\`height\` are read as
+  the sequence's settings —
   \`render(id, {wait, preview_scale, format, alpha, timeout_ms})\` — the cut
   as a video, run as a job; render and look before you call a cut done, and
   draft at a \`preview_scale\` below 1 while you are still iterating — and

--- a/packages/agents/src/codeact/prompt.ts
+++ b/packages/agents/src/codeact/prompt.ts
@@ -11,7 +11,11 @@ import {
 } from "../code-gen/sandbox-manifest.js";
 import { extractApiReferences } from "../code-gen/sandbox-prompt.js";
 import { NODETOOL_API_SECTION_HEADER } from "./nodetool-api.js";
-import { renderToolCatalog, type ToolSignatureSource } from "./tool-api.js";
+import {
+  renderToolCatalog,
+  RESERVED_BINDINGS_SENTENCE,
+  type ToolSignatureSource
+} from "./tool-api.js";
 
 /**
  * The bounded fan-out primitive the concurrency bullet advertises. One per
@@ -71,6 +75,7 @@ Rules:
   sits behind a fold — so a description that restates the title, or describes
   the code instead of its effect, is a user clicking Allow on something they
   could not read. Write \`""\` for a \`"low"\` risk call; nobody is asked.
+- ${RESERVED_BINDINGS_SENTENCE}
 - Chain the WHOLE pipeline into one action: call several tools, loop over
   items, branch on intermediate results, retry inside try/catch, and
   post-process in the same program. Hold intermediates in local variables.

--- a/packages/agents/src/codeact/tool-api.ts
+++ b/packages/agents/src/codeact/tool-api.ts
@@ -317,6 +317,25 @@ export const CODEACT_INJECTED_GLOBALS = [
   ...NODETOOL_API_GLOBALS
 ] as const;
 
+/**
+ * The injected names a model's own code can collide with: the bindings above
+ * minus the `__`-prefixed host bridges, which nobody writes by accident.
+ *
+ * The prelude declares them with `const`, so `const tools = [...]` in an action
+ * is a SyntaxError before a line runs ("lexical redefinition of 'tools'") — a
+ * failure whose cause is invisible from the action's own source. They are named
+ * in the `execute_code` contract, and {@link annotateFailure} names the one
+ * that collided.
+ */
+export const RESERVED_ACTION_BINDINGS: readonly string[] =
+  CODEACT_INJECTED_GLOBALS.filter((name) => !name.startsWith("__"));
+
+/** One sentence naming the reserved bindings, for the action contract. */
+export const RESERVED_BINDINGS_SENTENCE =
+  `The prelude already declares ${RESERVED_ACTION_BINDINGS.map((n) => `\`${n}\``).join(", ")}. ` +
+  "Declaring one of them again is a SyntaxError before your code runs, so " +
+  "name your own variables something else.";
+
 // ---------------------------------------------------------------------------
 // Signature rendering (JSON schema → compact TS-ish signature)
 // ---------------------------------------------------------------------------

--- a/packages/agents/src/evals/surfaces/timeline.ts
+++ b/packages/agents/src/evals/surfaces/timeline.ts
@@ -424,6 +424,119 @@ function tool<TResult>(
   };
 }
 
+/**
+ * The shape geometry for `add_shape_clip`, from whichever of the three forms
+ * the caller used: `shape`, `shapeStyle` (the name `set_clip_params` takes),
+ * or the geometry keys spread at the top level. With none of them the shape is
+ * a full-frame rect — a caller that asked for a shape and named no box wants
+ * something it can see, not a schema error about a field it did not know
+ * existed.
+ */
+function resolveShapeArg(
+  shape: unknown,
+  shapeStyle: unknown,
+  loose: Record<string, unknown>
+): z.infer<typeof shapeStyleParams> {
+  const given = (shape ?? shapeStyle) as
+    | z.infer<typeof shapeStyleParams>
+    | undefined;
+  if (given) return given;
+  const bare = Object.fromEntries(
+    Object.entries(loose).filter(([, value]) => value !== undefined)
+  );
+  const parsed = shapeStyleParams.safeParse({
+    kind: "rect",
+    x: 0,
+    y: 0,
+    width: 1,
+    height: 1,
+    ...bare
+  });
+  if (!parsed.success) {
+    throw new Error(
+      'add_shape_clip takes the geometry in `shape` (or `shapeStyle`): {kind: "rect"|"ellipse"|"line"|"polygon"|"star"|"path", x, y, width, height, fill?, stroke?, strokeWidthPx?}, with x/y/width/height as 0..1 fractions of the frame. ' +
+        parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ")
+    );
+  }
+  return parsed.data;
+}
+
+/**
+ * Timing and geometry are their own ops, and a key this tool does not read
+ * used to be stripped by the schema — a call that reported success and changed
+ * nothing. Name the op that does the job instead.
+ */
+const CLIP_PARAM_ELSEWHERE: Record<string, string> = {
+  animations: "animate_clip",
+  transition: "set_transition",
+  parentId: "set_parent",
+  mask: "set_mask",
+  effects: "set_effects",
+  timeRemap: "set_time_remap"
+};
+
+const CLIP_PARAM_KEYS = [
+  "name",
+  "startMs",
+  "trackId",
+  "durationMs",
+  "inPointMs",
+  "outPointMs",
+  "opacity",
+  "speedMultiplier",
+  "volumeDb",
+  "fadeInMs",
+  "fadeOutMs",
+  "blendMode",
+  "borderRadius",
+  "hidden",
+  "muted",
+  "locked",
+  "fontSizePx",
+  "textStyle",
+  "shapeStyle",
+  "captionStyle"
+];
+
+function rejectUnknownClipParams(patch: Record<string, unknown>): void {
+  for (const key of Object.keys(patch)) {
+    if (CLIP_PARAM_KEYS.includes(key)) continue;
+    const elsewhere = CLIP_PARAM_ELSEWHERE[key];
+    if (elsewhere) {
+      throw new Error(
+        `set_clip_params does not change \`${key}\`; use ${elsewhere}.`
+      );
+    }
+    throw new Error(
+      `set_clip_params has no \`${key}\` param. It takes: ${CLIP_PARAM_KEYS.join(", ")}.`
+    );
+  }
+}
+
+/**
+ * Lift a nested `custom: {curves|code|mask}` onto the animation itself. The
+ * flat form is the contract, but the nested one is the obvious guess from
+ * `preset: "custom"`, and it used to be stripped by the schema and then
+ * rejected as an animation with neither curves nor code.
+ */
+function liftCustom<
+  T extends {
+    curves?: unknown;
+    code?: string;
+    mask?: unknown;
+    custom?: { curves?: unknown; code?: string; mask?: unknown };
+  }
+>(input: T): T {
+  if (!input.custom) return input;
+  const { custom, ...rest } = input;
+  return {
+    ...rest,
+    curves: input.curves ?? custom.curves,
+    code: input.code ?? custom.code,
+    mask: input.mask ?? custom.mask
+  } as T;
+}
+
 function capitalize(s: string): string {
   return s.length > 0 ? s[0].toUpperCase() + s.slice(1) : s;
 }
@@ -564,6 +677,50 @@ export function createTimelineToolBridge(
     );
   }
 
+  /**
+   * The body of `trim_clip`, shared with `set_clip_params`: a caller that sends
+   * `durationMs` alongside a style change means the same edit either way, and
+   * two copies of the group-trim rule would drift.
+   */
+  function applyTrim(
+    clip: TimelineClip,
+    patch: { durationMs?: number; inPointMs?: number; outPointMs?: number }
+  ): TimelineClip {
+    // A group carries what it holds (D4): shortening one pulls its children
+    // inside the window that leaves, rather than leaving them hanging past an
+    // edge nothing draws.
+    if (isGroupClip(clip) && patch.durationMs !== undefined) {
+      clips = trimGroup(clips, clip.id, "end", patch.durationMs - clip.durationMs);
+      return clips.find((c) => c.id === clip.id)!;
+    }
+    if (patch.durationMs !== undefined) clip.durationMs = patch.durationMs;
+    if (patch.inPointMs !== undefined) clip.inPointMs = patch.inPointMs;
+    if (patch.outPointMs !== undefined) clip.outPointMs = patch.outPointMs;
+    return clip;
+  }
+
+  /** The body of `move_clip`, shared with `set_clip_params`. */
+  function applyMove(
+    clip: TimelineClip,
+    patch: { startMs?: number; trackId?: string }
+  ): TimelineClip {
+    // Moving a group moves what it holds by the same delta (D4). Children keep
+    // their own tracks, so their z-order is untouched (I9) — only the group
+    // itself takes a new `trackId`.
+    let moved = clip;
+    if (isGroupClip(clip) && patch.startMs !== undefined) {
+      const nextStartMs = Math.max(0, patch.startMs);
+      clips = moveGroup(clips, clip.id, nextStartMs - clip.startMs);
+      moved = clips.find((c) => c.id === clip.id)!;
+    } else if (patch.startMs !== undefined) {
+      clip.startMs = Math.max(0, patch.startMs);
+    }
+    if (patch.trackId !== undefined) {
+      moved.trackId = resolveTrack(patch.trackId).id;
+    }
+    return moved;
+  }
+
   /** Resolve a marker by id, or by case-insensitive label. */
   function resolveMarker(target: string): TimelineMarker {
     const byId = markers.find((m) => m.id === target);
@@ -653,7 +810,9 @@ export function createTimelineToolBridge(
     }
     if (!hasCurves && !hasCode) {
       throw new Error(
-        'A "custom" animation needs `curves` (keyframes: [{property, keyframes:[{t, value}]}]) or `code` (a JS body baked into curves).'
+        'A "custom" animation needs `curves` or `code`. Accepted shape: ' +
+          '{role: "in", preset: "custom", curves: [{property: "offsetY", keyframes: [{t: 0, value: 160}, {t: 1, value: 0}]}]}' +
+          ' — `t` runs 0..1 over the window. `code` is a JS body baked into curves instead. Either may also be nested under `custom`.'
       );
     }
 
@@ -942,18 +1101,27 @@ export function createTimelineToolBridge(
 
     tool(
       "ui_timeline_add_shape_clip",
-      "Add a rectangle, ellipse, or line on an overlay track of the specified timeline sequence. Omitted colors use a visible white fill for rectangles/ellipses or a visible white stroke for lines. Shapes are rasterized for preview/export and can use the standard motion presets.",
+      'Add a rectangle, ellipse, or line on an overlay track of the specified timeline sequence. The geometry goes in `shape` (or `shapeStyle`, the name `set_clip_params` uses): {kind: "rect"|"ellipse"|"line"|"polygon"|"star"|"path", x, y, width, height, fill, stroke, ...}, with x/y/width/height as 0..1 fractions of the frame. Those keys are also accepted at the top level. With no geometry at all the shape is a full-frame rect. Omitted colors use a visible white fill for rectangles/ellipses or a visible white stroke for lines. Shapes are rasterized for preview/export and can use the standard motion presets.',
       z.object({
-        shape: shapeStyleParams,
+        shape: shapeStyleParams.optional(),
+        shapeStyle: shapeStyleParams.optional(),
+        kind: shapeStyleParams.shape.kind.optional(),
+        x: z.number().optional(),
+        y: z.number().optional(),
+        width: z.number().optional(),
+        height: z.number().optional(),
+        fill: z.string().optional(),
+        stroke: z.string().optional(),
+        strokeWidthPx: z.number().optional(),
         trackId: z.string().optional(),
         startMs: z.number().optional(),
         durationMs: z.number().optional()
       }),
-      async ({ shape, trackId, startMs, durationMs }) => {
+      async ({ shape, shapeStyle, trackId, startMs, durationMs, ...loose }) => {
         const track = trackId
           ? resolveTrack(trackId as string)
           : findOrCreateTrack("overlay");
-        const shapeArg = shape as z.infer<typeof shapeStyleParams>;
+        const shapeArg = resolveShapeArg(shape, shapeStyle, loose);
         const isLine = shapeArg.kind === "line";
         const clip = makeClip({
           id: nextClipId(),
@@ -1100,25 +1268,12 @@ export function createTimelineToolBridge(
         outPointMs: z.number().optional()
       }),
       async ({ target, durationMs, inPointMs, outPointMs }) => {
-        const clip = resolveClip(target as string);
-        // A group carries what it holds (D4): shortening one pulls its
-        // children inside the window that leaves, rather than leaving them
-        // hanging past an edge nothing draws.
-        if (isGroupClip(clip) && durationMs !== undefined) {
-          const next = trimGroup(
-            clips,
-            clip.id,
-            "end",
-            (durationMs as number) - clip.durationMs
-          );
-          clips = next;
-          const trimmed = clips.find((c) => c.id === clip.id)!;
-          return { ok: true, clip: serializeClip(trimmed) };
-        }
-        if (durationMs !== undefined) clip.durationMs = durationMs as number;
-        if (inPointMs !== undefined) clip.inPointMs = inPointMs as number;
-        if (outPointMs !== undefined) clip.outPointMs = outPointMs as number;
-        return { ok: true, clip: serializeClip(clip) };
+        const trimmed = applyTrim(resolveClip(target as string), {
+          durationMs: durationMs as number | undefined,
+          inPointMs: inPointMs as number | undefined,
+          outPointMs: outPointMs as number | undefined
+        });
+        return { ok: true, clip: serializeClip(trimmed) };
       }
     ),
 
@@ -1131,24 +1286,11 @@ export function createTimelineToolBridge(
         trackId: z.string().optional()
       }),
       async ({ target, startMs, trackId }) => {
-        const clip = resolveClip(target as string);
-        // Moving a group moves what it holds by the same delta (D4). Children
-        // keep their own tracks, so their z-order is untouched (I9) — only the
-        // group itself takes a new `trackId`.
-        if (isGroupClip(clip) && startMs !== undefined) {
-          const nextStartMs = Math.max(0, startMs as number);
-          clips = moveGroup(clips, clip.id, nextStartMs - clip.startMs);
-          const moved = clips.find((c) => c.id === clip.id)!;
-          if (trackId !== undefined) {
-            moved.trackId = resolveTrack(trackId as string).id;
-          }
-          return { ok: true, clip: serializeClip(moved) };
-        }
-        if (startMs !== undefined) clip.startMs = Math.max(0, startMs as number);
-        if (trackId !== undefined) {
-          clip.trackId = resolveTrack(trackId as string).id;
-        }
-        return { ok: true, clip: serializeClip(clip) };
+        const moved = applyMove(resolveClip(target as string), {
+          startMs: startMs as number | undefined,
+          trackId: trackId as string | undefined
+        });
+        return { ok: true, clip: serializeClip(moved) };
       }
     ),
 
@@ -1193,9 +1335,15 @@ export function createTimelineToolBridge(
 
     tool(
       "ui_timeline_set_clip_params",
-      "Change a clip's render/audio params: `name`, `opacity` (0..1), `speedMultiplier` (0.1..8), `volumeDb`, `fadeInMs`, `fadeOutMs`, `blendMode`, `borderRadius`, `hidden`, `muted`, `locked`, a text clip's `textStyle`, a shape clip's `shapeStyle`, or a caption clip's `captionStyle`. Omit a field to leave it unchanged.",
+      "Change a clip's render/audio params: `name`, `opacity` (0..1), `speedMultiplier` (0.1..8), `volumeDb`, `fadeInMs`, `fadeOutMs`, `blendMode`, `borderRadius`, `hidden`, `muted`, `locked`, a text clip's `textStyle`, a shape clip's `shapeStyle`, or a caption clip's `captionStyle`. `fontSizePx` is shorthand for `textStyle.fontSizePx`. Timing is accepted too and applied as trim_clip/move_clip would: `durationMs`, `inPointMs`, `outPointMs`, `startMs`, `trackId`. A key this tool does not know is refused by name rather than ignored. Omit a field to leave it unchanged.",
       z.object({
         target: targetParam,
+        startMs: z.number().optional(),
+        trackId: z.string().optional(),
+        durationMs: z.number().optional(),
+        inPointMs: z.number().optional(),
+        outPointMs: z.number().optional(),
+        fontSizePx: z.number().optional(),
         name: z.string().optional(),
         opacity: z.number().optional(),
         speedMultiplier: z.number().optional(),
@@ -1210,9 +1358,38 @@ export function createTimelineToolBridge(
         textStyle: textStyleParams.optional(),
         shapeStyle: shapeStyleParams.optional(),
         captionStyle: captionStyleParams.optional()
-      }),
+        // A key the schema does not list is kept rather than stripped, so it
+        // can be refused by name below: silently dropping `startMs` looked
+        // like a successful call that changed nothing.
+      }).catchall(z.unknown()),
       async ({ target, ...patch }) => {
-        const clip = resolveClip(target as string);
+        let clip = resolveClip(target as string);
+        rejectUnknownClipParams(patch);
+        // Timing belongs to move_clip and trim_clip, but a caller sending it
+        // here means one edit either way — so apply it through the same code
+        // rather than dropping it or making them call twice.
+        clip = applyTrim(clip, {
+          durationMs: patch.durationMs as number | undefined,
+          inPointMs: patch.inPointMs as number | undefined,
+          outPointMs: patch.outPointMs as number | undefined
+        });
+        clip = applyMove(clip, {
+          startMs: patch.startMs as number | undefined,
+          trackId: patch.trackId as string | undefined
+        });
+        if (patch.fontSizePx !== undefined) {
+          // Shorthand for the one text field callers reach for by name.
+          const size = patch.fontSizePx as number;
+          const style = (patch.textStyle ?? clip.textStyle) as
+            | TimelineClip["textStyle"]
+            | undefined;
+          if (!style) {
+            throw new Error(
+              `Clip "${clip.name}" carries no text to size; fontSizePx applies to a text clip's textStyle.`
+            );
+          }
+          patch.textStyle = { ...style, fontSizePx: size };
+        }
         if (patch.name !== undefined) clip.name = patch.name as string;
         if (patch.opacity !== undefined) clip.opacity = patch.opacity as number;
         if (patch.speedMultiplier !== undefined)
@@ -1499,6 +1676,16 @@ export function createTimelineToolBridge(
               curves: customCurvesParam,
               code: customCodeParam,
               mask: customMaskParam,
+              custom: z
+                .object({
+                  curves: customCurvesParam,
+                  code: customCodeParam,
+                  mask: customMaskParam
+                })
+                .optional()
+                .describe(
+                  'Same as `curves`/`code`/`mask` one level down: {preset: "custom", custom: {curves: [...]}} is accepted and lifted.'
+                ),
               stagger: z
                 .object({
                   unit: z.enum(STAGGER_UNITS),
@@ -1528,12 +1715,15 @@ export function createTimelineToolBridge(
           curves?: unknown;
           code?: string;
           mask?: unknown;
+          custom?: { curves?: unknown; code?: string; mask?: unknown };
           stagger?: ClipAnimation["stagger"];
         }>;
         const built: ClipAnimation[] = [];
         for (const input of inputs) {
           if (input.preset === CUSTOM_ANIMATION_PRESET_ID) {
-            built.push(await buildCustomAnimation(clip, input));
+            // `{preset: "custom", custom: {curves}}` reads as naturally as the
+            // flat form, so lift it rather than refusing it.
+            built.push(await buildCustomAnimation(clip, liftCustom(input)));
             continue;
           }
           const preset = ANIMATION_PRESETS.find((p) => p.id === input.preset);

--- a/packages/agents/tests/action-diagnostics.test.ts
+++ b/packages/agents/tests/action-diagnostics.test.ts
@@ -150,3 +150,26 @@ describe("annotateFailure re-diagnoses a syntax error", () => {
     expect(result.error).toBe("Error: boom");
   });
 });
+
+describe("annotateFailure — redeclaring a prelude binding", () => {
+  it("names the reserved binding and suggests a rename", () => {
+    const result = annotateFailure(
+      "SyntaxError: lexical redefinition of 'tools'",
+      undefined,
+      "const tools = {};",
+      "const tools = [1, 2];\nreturn tools.length;"
+    );
+    expect(result.error).toContain("lexical redefinition of 'tools'");
+    expect(result.error).toContain("the action prelude declares");
+    expect(result.error).toContain("myTools");
+    expect(result.error).toContain("`nodetool`");
+  });
+
+  it("leaves a collision between two of the action's own names alone", () => {
+    const error = "SyntaxError: lexical redefinition of 'shots'";
+    expect(
+      annotateFailure(error, undefined, "const tools = {};", "const shots = 1;")
+        .error
+    ).toBe(error);
+  });
+});

--- a/packages/agents/tests/capabilities-media.test.ts
+++ b/packages/agents/tests/capabilities-media.test.ts
@@ -166,6 +166,49 @@ describe("generate_image through the adapter", () => {
     expect(call["model"]).toBe("gpt-image-1");
   });
 
+  it("errors when the bytes reach no asset and no workspace", async () => {
+    // The failure this pins: createAsset throws and there is no workspace to
+    // fall back to, so the result used to be success-shaped with asset_uri
+    // undefined — the agent printed "OK undefined" and carried on.
+    const context = {
+      userId: "user-1",
+      runProviderPrediction: vi.fn(async () => new Uint8Array([1, 2, 3])),
+      hasModelInterface: () => true,
+      createAsset: vi.fn(async () => {
+        throw new Error("asset store unavailable");
+      })
+    } as unknown as ProcessingContext;
+
+    const result = (await asTool(generateImage).process(context, {
+      provider: "atlascloud",
+      model: "black-forest-labs/flux-schnell",
+      prompt: "a red fox"
+    })) as Record<string, unknown>;
+
+    expect(result["asset_uri"]).toBeUndefined();
+    expect(result["error"]).toMatch(
+      /text_to_image for atlascloud:black-forest-labs\/flux-schnell.*could not be stored/
+    );
+  });
+
+  it("errors when the provider returns no image data", async () => {
+    const context = {
+      userId: "user-1",
+      runProviderPrediction: vi.fn(async () => new Uint8Array()),
+      hasModelInterface: () => false
+    } as unknown as ProcessingContext;
+
+    const result = (await asTool(generateImage).process(context, {
+      provider: "atlascloud",
+      model: "black-forest-labs/flux-schnell",
+      prompt: "a red fox"
+    })) as Record<string, unknown>;
+
+    expect(result["error"]).toMatch(
+      /text_to_image for atlascloud:black-forest-labs\/flux-schnell.*no image data/
+    );
+  });
+
   it("rejects a missing model before calling the provider", async () => {
     const predict = vi.fn();
     const result = await asTool(generateImage).process(makeContext(predict), {

--- a/packages/agents/tests/capabilities-timelines.test.ts
+++ b/packages/agents/tests/capabilities-timelines.test.ts
@@ -567,6 +567,65 @@ describe("set_timeline_document", () => {
     expect(stored?.fps).toBe(24);
   });
 
+  it("fills the bookkeeping a hand-authored document leaves out", async () => {
+    const row = await makeTimeline();
+    const result = (await run().invoke("set_timeline_document", {
+      timeline_id: row.id,
+      document: {
+        tracks: [{ id: "track-1", name: "Video 1", type: "video" }],
+        clips: [
+          {
+            id: "clip-a",
+            trackId: "track-1",
+            name: "Title",
+            startMs: 0,
+            durationMs: 2000,
+            mediaType: "text",
+            textStyle: { text: "Hello", fontSizePx: 96, color: "#FFFFFF" },
+            animations: [{ role: "in", preset: "fade", durationMs: 400 }]
+          }
+        ]
+      }
+    })) as { ok: boolean; written: boolean; validation: { ok: boolean } };
+
+    expect(result).toMatchObject({ ok: true, written: true });
+    const stored = (await TimelineSequence.findById(row.id))!.toDocument();
+    expect(stored.tracks[0]).toMatchObject({
+      index: 0,
+      visible: true,
+      locked: false
+    });
+    expect(stored.clips[0]).toMatchObject({
+      sourceType: "imported",
+      status: "generated",
+      locked: false,
+      versions: []
+    });
+    expect(stored.clips[0].animations?.[0].id).toBe("anim_1");
+    expect(stored.markers).toEqual([]);
+  });
+
+  it("reads fps/width/height off the document when the options omit them", async () => {
+    const row = await makeTimeline();
+    const result = (await run().invoke("set_timeline_document", {
+      timeline_id: row.id,
+      document: { ...replacement(), fps: 24, width: 1080, height: 1920 }
+    })) as {
+      ok: boolean;
+      fps: number;
+      width: number;
+      height: number;
+      validation: { ok: boolean; warnings: Array<{ code: string }> };
+    };
+
+    expect(result).toMatchObject({ ok: true, fps: 24, width: 1080, height: 1920 });
+    expect(
+      result.validation.warnings.map((w) => w.code)
+    ).not.toContain("field_stripped");
+    const stored = await TimelineSequence.findById(row.id);
+    expect([stored?.fps, stored?.width, stored?.height]).toEqual([24, 1080, 1920]);
+  });
+
   it("refuses an invalid document and writes nothing at all", async () => {
     const row = await makeTimeline();
     const before = await TimelineSequence.findById(row.id);

--- a/packages/agents/tests/capability-module-image-payload.test.ts
+++ b/packages/agents/tests/capability-module-image-payload.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Pixels cannot cross into a code action: a capability imported into an action
+ * answers as a JavaScript value, and the injectable-image channel the tool loop
+ * uses does not exist there. A `view_image` call written inside `execute_code`
+ * therefore returned an `image_content` reference nothing ever dereferenced,
+ * and the model read back only the question it had asked. These pin the note
+ * that replaces the payload.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  mountCapabilityModules,
+  SESSION_CAPABILITY_MODULE
+} from "../src/codeact/capability-modules.js";
+
+const SPECIFIER = `@nodetool-ai/sandbox-nodetool/${SESSION_CAPABILITY_MODULE}`;
+
+const session = [
+  {
+    module: SESSION_CAPABILITY_MODULE,
+    exports: ["look", "count"],
+    call: async (name: string) =>
+      name === "look"
+        ? {
+            ok: true,
+            image_id: "abc",
+            note: "is the title centered?",
+            image_content: { uri: "asset://abc", mimeType: "image/png" }
+          }
+        : { ok: true, total: 3 }
+  }
+];
+
+const mountFor = async (code: string) => {
+  const result = await mountCapabilityModules(code, undefined, { session });
+  if (!result.ok || !result.mount) throw new Error("expected a mount");
+  return result.mount;
+};
+
+describe("capability results carrying pixels, inside an action", () => {
+  it("drops the image payload and says how to look at the image", async () => {
+    const mount = await mountFor(`import { look } from "${SPECIFIER}";`);
+    const value = (await mount.call(SPECIFIER, "look", [{}])) as Record<
+      string,
+      unknown
+    >;
+
+    expect(value["image_content"]).toBeUndefined();
+    expect(value["image_id"]).toBe("abc");
+    const note = String(value["note"]);
+    expect(note).toContain("is the title centered?");
+    expect(note).toContain("view_image");
+    expect(note).toMatch(/outside execute_code/);
+  });
+
+  it("leaves an ordinary result untouched", async () => {
+    const mount = await mountFor(`import { count } from "${SPECIFIER}";`);
+    expect(await mount.call(SPECIFIER, "count", [{}])).toEqual({
+      ok: true,
+      total: 3
+    });
+  });
+});

--- a/packages/agents/tests/nodetool-api.test.ts
+++ b/packages/agents/tests/nodetool-api.test.ts
@@ -47,6 +47,7 @@ const TIMELINE_TOOLS = [
   "preview_timeline_frame",
   "compare_timeline_frames",
   "set_timeline_document",
+  "create_timeline_version",
   "list_compositions",
   "get_composition",
   "save_composition",
@@ -153,6 +154,8 @@ function createFakeRouter() {
         });
       case "list_timelines":
         return JSON.stringify({ timelines: [] });
+      case "create_timeline_version":
+        return JSON.stringify({ version: 1 });
       case "validate_timeline":
         return JSON.stringify({ ok: true, target: args });
       case "preview_timeline_frame":
@@ -511,6 +514,23 @@ describe("nodetool object model", () => {
       expected_updated_at: "2026-01-01T00:00:00.000Z",
       snapshot_name: "before the recut"
     });
+  });
+
+  it("routes timelines.createVersion to create_timeline_version, like snapshot", async () => {
+    const { executeTool, calls } = createFakeRouter();
+    const session = makeSession(TIMELINE_TOOLS, executeTool);
+    const obs = await runAction(
+      session,
+      `await nodetool.timelines.snapshot("tl1", { name: "one" });
+       await nodetool.timelines.createVersion("tl1", { name: "two" });
+       return "done";`
+    );
+    expect(obs.ok).toBe(true);
+    expect(calls.map((c) => c.name)).toEqual([
+      "create_timeline_version",
+      "create_timeline_version"
+    ]);
+    expect(calls[1].args).toEqual({ timeline_id: "tl1", name: "two" });
   });
 
   it("names preview_timeline_frame when the belt lacks it", async () => {

--- a/packages/agents/tests/timeline-op-ergonomics.test.ts
+++ b/packages/agents/tests/timeline-op-ergonomics.test.ts
@@ -1,0 +1,167 @@
+/**
+ * The shapes an agent authoring a cut actually sends.
+ *
+ * Each case here is a call a real run made and the surface refused or silently
+ * dropped: a shape clip with no `shape` object, timing sent to
+ * `set_clip_params`, a custom animation nested under `custom`.
+ */
+import { describe, expect, it } from "vitest";
+import { createTimelineToolBridge } from "../src/evals/surfaces/timeline.js";
+import type { HeadlessTool } from "../src/evals/tool-loop-bridge.js";
+
+function bridge() {
+  const b = createTimelineToolBridge({
+    tracks: [{ type: "video" }],
+    clips: [
+      {
+        name: "shot",
+        trackIndex: 0,
+        mediaType: "video",
+        startMs: 0,
+        durationMs: 4000
+      }
+    ]
+  });
+  const byName: Record<string, HeadlessTool> = Object.fromEntries(
+    b.tools.map((t) => [t.name, t])
+  );
+  return { b, byName };
+}
+
+const clipOf = (result: unknown): Record<string, unknown> =>
+  (result as { clip: Record<string, unknown> }).clip;
+
+describe("ui_timeline_add_shape_clip", () => {
+  it("takes the geometry under shapeStyle", async () => {
+    const { byName } = bridge();
+    const result = await byName["ui_timeline_add_shape_clip"].execute({
+      shapeStyle: {
+        kind: "rect",
+        fill: "#000000",
+        stroke: "#FFFFFF",
+        x: 0,
+        y: 0.8,
+        width: 1,
+        height: 0.2
+      }
+    });
+    expect(clipOf(result).shapeStyle).toMatchObject({
+      kind: "rect",
+      fill: "#000000",
+      height: 0.2
+    });
+  });
+
+  it("reads the geometry keys off the op itself", async () => {
+    const { byName } = bridge();
+    const result = await byName["ui_timeline_add_shape_clip"].execute({
+      kind: "ellipse",
+      x: 0.25,
+      y: 0.25,
+      width: 0.5,
+      height: 0.5
+    });
+    expect(clipOf(result).shapeStyle).toMatchObject({
+      kind: "ellipse",
+      x: 0.25,
+      width: 0.5
+    });
+  });
+
+  it("defaults to a full-frame rect when nothing names a shape", async () => {
+    const { byName } = bridge();
+    const result = await byName["ui_timeline_add_shape_clip"].execute({});
+    expect(clipOf(result).shapeStyle).toMatchObject({
+      kind: "rect",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1
+    });
+  });
+});
+
+describe("ui_timeline_set_clip_params", () => {
+  it("applies startMs and durationMs instead of dropping them", async () => {
+    const { b, byName } = bridge();
+    await byName["ui_timeline_set_clip_params"].execute({
+      target: "shot",
+      startMs: 1500,
+      durationMs: 2500,
+      opacity: 0.5
+    });
+    expect(b.finalState().documentClips[0]).toMatchObject({
+      startMs: 1500,
+      durationMs: 2500,
+      opacity: 0.5
+    });
+  });
+
+  it("merges fontSizePx into the clip's textStyle", async () => {
+    const { byName } = bridge();
+    await byName["ui_timeline_add_text_clip"].execute({ text: "Title" });
+    const result = await byName["ui_timeline_set_clip_params"].execute({
+      target: "selected",
+      fontSizePx: 140
+    });
+    expect(
+      (clipOf(result).textStyle as Record<string, unknown>).fontSizePx
+    ).toBe(140);
+  });
+
+  it("refuses a key it does not know, naming the op that does the job", async () => {
+    const { byName } = bridge();
+    await expect(
+      byName["ui_timeline_set_clip_params"].execute({
+        target: "shot",
+        animations: []
+      })
+    ).rejects.toThrow(/animate_clip/);
+    await expect(
+      byName["ui_timeline_set_clip_params"].execute({
+        target: "shot",
+        wobble: 3
+      })
+    ).rejects.toThrow(/no `wobble` param/);
+  });
+});
+
+describe("ui_timeline_animate_clip", () => {
+  it("lifts a custom animation nested under `custom`", async () => {
+    const { b, byName } = bridge();
+    await byName["ui_timeline_animate_clip"].execute({
+      target: "shot",
+      animations: [
+        {
+          role: "in",
+          preset: "custom",
+          custom: {
+            curves: [
+              {
+                property: "offsetY",
+                keyframes: [
+                  { t: 0, value: 160 },
+                  { t: 1, value: 0 }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    });
+    const animations = b.finalState().documentClips[0].animations ?? [];
+    expect(animations).toHaveLength(1);
+    expect(animations[0].preset).toBe("custom");
+    expect(animations[0].custom?.curves?.[0].property).toBe("offsetY");
+  });
+
+  it("prints the accepted shape when a custom animation carries neither", async () => {
+    const { byName } = bridge();
+    await expect(
+      byName["ui_timeline_animate_clip"].execute({
+        target: "shot",
+        animations: [{ role: "in", preset: "custom" }]
+      })
+    ).rejects.toThrow(/keyframes: \[\{t: 0, value: 160\}/);
+  });
+});

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -1794,7 +1794,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "edit_timeline",
     module: "timelines",
     impl: "packages/agents/src/capabilities/timelines.ts",
-    contract: "3de996ce0ff2",
+    contract: "c3e650396a79",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-timelines.test.ts",

--- a/packages/cli/tests/agent-command.test.ts
+++ b/packages/cli/tests/agent-command.test.ts
@@ -31,6 +31,9 @@ vi.mock("@nodetool-ai/runtime", async () => {
   return {
     ...stub,
     ACTIVE_MODEL_CONTEXT_KEY: "active_agent_model",
+    // The stub context resolves no media; the real one returns undefined
+    // for a context without resolveMessageMediaUris, same as here.
+    mediaResolverFor: () => undefined,
     isProviderSessionUpdate: types.isProviderSessionUpdate,
     isProviderMessageEvent: types.isProviderMessageEvent,
     isProviderStop: types.isProviderStop,

--- a/packages/runtime/src/providers/atlascloud-provider.ts
+++ b/packages/runtime/src/providers/atlascloud-provider.ts
@@ -207,6 +207,24 @@ function runJobOptions(params: {
   return opts;
 }
 
+/**
+ * A one-line summary of a submit body for an error message: scalar values
+ * verbatim, long strings and data URIs reduced to a length, so a rejection can
+ * name the parameter that was sent without echoing a prompt or an image.
+ */
+function describeInput(input: Record<string, unknown>): string {
+  const parts = Object.entries(input).map(([key, value]) => {
+    if (isString(value)) {
+      return value.length > 40 || value.startsWith("data:")
+        ? `${key}=<${value.length} chars>`
+        : `${key}=${value}`;
+    }
+    if (isNumber(value) || isBoolean(value)) return `${key}=${value}`;
+    return `${key}=<${Array.isArray(value) ? "array" : typeof value}>`;
+  });
+  return parts.length > 0 ? parts.join(", ") : "no fields";
+}
+
 async function atlasSubmit(
   apiKey: string,
   modality: "image" | "video",
@@ -233,7 +251,13 @@ async function atlasSubmit(
     data = null;
   }
   if (!res.ok) {
-    throw new Error(`AtlasCloud submit ${res.status}: ${text.slice(0, 500)}`);
+    // AtlasCloud answers a bad field with a bare "Invalid request parameters",
+    // which names nothing. Append the request shape so the caller can see which
+    // parameter it sent — prompts and data URIs are summarized, not echoed.
+    throw new Error(
+      `AtlasCloud submit ${res.status} for ${modelId}: ${text.slice(0, 500)} ` +
+        `(sent ${describeInput(input)})`
+    );
   }
   const id = data?.data?.id;
   if (!id) {
@@ -401,6 +425,14 @@ function setIfDeclared(
   });
 }
 
+/** Pixel granularity every AtlasCloud diffusion model accepts. */
+const SIZE_MULTIPLE = 16;
+
+/** Round a dimension to the nearest multiple of `step`, never below `step`. */
+function snapToMultiple(value: number, step: number): number {
+  return Math.max(step, Math.round(value / step) * step);
+}
+
 /** Parse a `1024x768` / `1024*768` size string into pixel dimensions. */
 function parseSize(value: string): { w: number; h: number } | null {
   const m = /^(\d+)\s*[x*]\s*(\d+)$/i.exec(value);
@@ -426,7 +458,19 @@ function renderSize(field: FieldInfo, w: number, h: number): string | null {
   const allowed = field.values;
   if (!allowed || allowed.length === 0) {
     const sep = String(field.default ?? "").includes("x") ? "x" : "*";
-    return `${w}${sep}${h}`;
+    // Latent-diffusion models on AtlasCloud take dimensions in multiples of 16
+    // (8× VAE downsample, 2× patch). A caller-supplied 1920×1080 is rejected at
+    // submit with a bare "Invalid request parameters", so snap each side to the
+    // nearest legal multiple rather than sending a size that cannot render.
+    const sw = snapToMultiple(w, SIZE_MULTIPLE);
+    const sh = snapToMultiple(h, SIZE_MULTIPLE);
+    if (sw !== w || sh !== h) {
+      log.debug("AtlasCloud: snapped size to a legal multiple", {
+        requested: `${w}${sep}${h}`,
+        sent: `${sw}${sep}${sh}`
+      });
+    }
+    return `${sw}${sep}${sh}`;
   }
   const exact = allowed.find(
     (v) => String(v) === `${w}x${h}` || String(v) === `${w}*${h}`

--- a/packages/runtime/tests/providers/atlascloud-provider.test.ts
+++ b/packages/runtime/tests/providers/atlascloud-provider.test.ts
@@ -274,6 +274,44 @@ describe("AtlasCloudProvider — textToImage", () => {
     expect(capture.submitBody!.size).toBe("1280*720");
   });
 
+  it("snaps a free-string `size` to a legal 16-pixel multiple", async () => {
+    const capture: { submitBody?: Record<string, unknown> } = {};
+    mockAtlasFetch({ capture });
+    const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
+    // FLUX Schnell takes a free-string `size`, but 1080 is not a multiple of
+    // 16 and AtlasCloud rejects the submit with a bare "Invalid request
+    // parameters". 1088 is the nearest size the model can actually render.
+    await p.textToImage({
+      model: imageModel("black-forest-labs/flux-schnell"),
+      prompt: "a cat",
+      width: 1920,
+      height: 1080
+    });
+    expect(capture.submitBody!.size).toBe("1920*1088");
+  });
+
+  it("names the rejected parameters when a submit 400s", async () => {
+    global.fetch = vi.fn(async (url: string | URL) => {
+      if (String(url).endsWith("/generateImage")) {
+        return {
+          ok: false,
+          status: 400,
+          text: async () => JSON.stringify({ message: "Invalid request parameters" })
+        } as Response;
+      }
+      throw new Error(`unexpected fetch: ${String(url)}`);
+    }) as unknown as typeof fetch;
+    const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
+    await expect(
+      p.textToImage({
+        model: imageModel("black-forest-labs/flux-schnell"),
+        prompt: "a cat",
+        width: 1920,
+        height: 1080
+      })
+    ).rejects.toThrow(/black-forest-labs\/flux-schnell.*Invalid request parameters.*size=1920\*1088/s);
+  });
+
   it("snaps `size` to the nearest declared option on enum models", async () => {
     const capture: { submitBody?: Record<string, unknown> } = {};
     mockAtlasFetch({ capture });

--- a/packages/timeline/src/authoring.ts
+++ b/packages/timeline/src/authoring.ts
@@ -1,0 +1,161 @@
+/**
+ * Normalizing a hand-authored timeline document.
+ *
+ * An agent writing a cut from scratch sends the fields it cares about —
+ * tracks, clips, the words on screen — and leaves out the bookkeeping the
+ * document schema requires (`index`, `visible`, `locked`, `sourceType`,
+ * `status`, `versions`, animation ids, `markers`). Refusing that document with
+ * two dozen schema errors teaches the caller nothing it could not have been
+ * given, so the missing fields are filled here before validation.
+ *
+ * Only absent fields are filled. A value the caller sent is never replaced —
+ * the point of a whole-document write is that what was sent is what is stored.
+ */
+
+import type { TimelineClip } from "./types.js";
+
+/** Render settings that belong on the sequence row, not in the document. */
+export interface AuthoredRenderSettings {
+  fps?: number;
+  width?: number;
+  height?: number;
+}
+
+export interface NormalizedAuthoredDocument {
+  /** The document with the schema's required fields filled in. */
+  document: Record<string, unknown>;
+  /**
+   * `fps`/`width`/`height` found at the top level of the document. They are
+   * sequence settings rather than document fields, so a schema round trip
+   * strips them; lifted here they configure the sequence instead of being
+   * silently dropped with a `field_stripped` warning.
+   */
+  settings: AuthoredRenderSettings;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function positiveNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}
+
+/**
+ * Whether a clip describes media it will produce or media it already has.
+ *
+ * A clip naming a prompt, a workflow, or a generation binding is a clip the
+ * renderer will generate; everything else — a placed asset, a title, a shape,
+ * a group — is authored or imported. Matches what the `ui_timeline_*` bridge
+ * stamps when it creates each kind of clip.
+ */
+export function sourceTypeForClip(
+  clip: Pick<
+    Partial<TimelineClip>,
+    "prompt" | "workflowId" | "bindingKind" | "provider" | "model"
+  >
+): TimelineClip["sourceType"] {
+  const generated =
+    (typeof clip.prompt === "string" && clip.prompt.trim() !== "") ||
+    typeof clip.workflowId === "string" ||
+    typeof clip.bindingKind === "string" ||
+    (typeof clip.provider === "string" && typeof clip.model === "string");
+  return generated ? "generated" : "imported";
+}
+
+function normalizeTrack(
+  track: Record<string, unknown>,
+  index: number
+): Record<string, unknown> {
+  const next = { ...track };
+  if (next["index"] === undefined) next["index"] = index;
+  if (next["visible"] === undefined) next["visible"] = true;
+  if (next["locked"] === undefined) next["locked"] = false;
+  return next;
+}
+
+function normalizeClip(
+  clip: Record<string, unknown>,
+  nextAnimationId: () => string
+): Record<string, unknown> {
+  const next = { ...clip };
+  if (next["sourceType"] === undefined) {
+    next["sourceType"] = sourceTypeForClip(next as Partial<TimelineClip>);
+  }
+  // "generated" is the ready state for a clip that already has its media —
+  // the schema has no "ready", and it is what the bridge stamps on the text,
+  // shape and asset clips it creates.
+  if (next["status"] === undefined) next["status"] = "generated";
+  if (next["locked"] === undefined) next["locked"] = false;
+  if (next["versions"] === undefined) next["versions"] = [];
+  const animations = next["animations"];
+  if (Array.isArray(animations)) {
+    next["animations"] = animations.map((animation) => {
+      if (!isRecord(animation) || animation["id"] !== undefined) {
+        return animation;
+      }
+      return { ...animation, id: nextAnimationId() };
+    });
+  }
+  return next;
+}
+
+/** Collect the animation ids already in use, so a filled one cannot collide. */
+function usedAnimationIds(clips: unknown[]): Set<string> {
+  const used = new Set<string>();
+  for (const clip of clips) {
+    if (!isRecord(clip)) continue;
+    const animations = clip["animations"];
+    if (!Array.isArray(animations)) continue;
+    for (const animation of animations) {
+      if (isRecord(animation) && typeof animation["id"] === "string") {
+        used.add(animation["id"]);
+      }
+    }
+  }
+  return used;
+}
+
+/**
+ * Fill the required fields a hand-authored document leaves out and lift its
+ * render settings. See {@link NormalizedAuthoredDocument}.
+ */
+export function normalizeAuthoredDocument(
+  raw: Record<string, unknown>
+): NormalizedAuthoredDocument {
+  const document: Record<string, unknown> = { ...raw };
+
+  const settings: AuthoredRenderSettings = {};
+  for (const key of ["fps", "width", "height"] as const) {
+    const lifted = positiveNumber(document[key]);
+    if (lifted !== undefined) settings[key] = lifted;
+    if (document[key] !== undefined) delete document[key];
+  }
+
+  if (Array.isArray(document["tracks"])) {
+    document["tracks"] = document["tracks"].map((track, index) =>
+      isRecord(track) ? normalizeTrack(track, index) : track
+    );
+  }
+
+  if (Array.isArray(document["clips"])) {
+    const clips = document["clips"];
+    const used = usedAnimationIds(clips);
+    let counter = 0;
+    const nextAnimationId = (): string => {
+      let id = `anim_${++counter}`;
+      while (used.has(id)) id = `anim_${++counter}`;
+      used.add(id);
+      return id;
+    };
+    document["clips"] = clips.map((clip) =>
+      isRecord(clip) ? normalizeClip(clip, nextAnimationId) : clip
+    );
+  }
+
+  if (document["markers"] === undefined) document["markers"] = [];
+
+  return { document, settings };
+}

--- a/packages/timeline/src/index.ts
+++ b/packages/timeline/src/index.ts
@@ -4,6 +4,7 @@
 
 export * from "./types.js";
 export * from "./defaults.js";
+export * from "./authoring.js";
 // `dependencyHash` is intentionally NOT re-exported: it depends on
 // `node:crypto`, which breaks browser bundles. Server consumers should
 // import it directly from "@nodetool-ai/timeline/dependencyHash".

--- a/packages/timeline/tests/authoring.test.ts
+++ b/packages/timeline/tests/authoring.test.ts
@@ -1,0 +1,98 @@
+/**
+ * A hand-authored document arrives without the schema's bookkeeping; these pin
+ * what is filled in, what is left alone, and what is lifted out.
+ */
+import { describe, expect, it } from "vitest";
+import { normalizeAuthoredDocument, sourceTypeForClip } from "../src/authoring.js";
+
+describe("normalizeAuthoredDocument", () => {
+  it("fills the fields the schema requires and the caller omitted", () => {
+    const { document } = normalizeAuthoredDocument({
+      tracks: [{ id: "T1", name: "Video", type: "video" }],
+      clips: [
+        {
+          id: "C1",
+          trackId: "T1",
+          name: "Title",
+          mediaType: "text",
+          startMs: 0,
+          durationMs: 2000,
+          animations: [{ role: "in", preset: "fade" }]
+        }
+      ]
+    });
+    expect(document.tracks).toEqual([
+      { id: "T1", name: "Video", type: "video", index: 0, visible: true, locked: false }
+    ]);
+    const clip = (document.clips as Record<string, unknown>[])[0];
+    expect(clip).toMatchObject({
+      sourceType: "imported",
+      status: "generated",
+      locked: false,
+      versions: []
+    });
+    expect((clip.animations as Record<string, unknown>[])[0].id).toBe("anim_1");
+    expect(document.markers).toEqual([]);
+  });
+
+  it("never overwrites a value the caller sent", () => {
+    const { document } = normalizeAuthoredDocument({
+      tracks: [{ id: "T1", index: 4, visible: false, locked: true }],
+      clips: [
+        {
+          id: "C1",
+          status: "draft",
+          locked: true,
+          sourceType: "generated",
+          versions: [{ id: "V1" }],
+          animations: [{ id: "keep", role: "in", preset: "fade" }]
+        }
+      ],
+      markers: [{ id: "M1", timeMs: 10, label: "beat" }]
+    });
+    expect(document.tracks).toEqual([
+      { id: "T1", index: 4, visible: false, locked: true }
+    ]);
+    const clip = (document.clips as Record<string, unknown>[])[0];
+    expect(clip).toMatchObject({ status: "draft", locked: true, sourceType: "generated" });
+    expect((clip.animations as Record<string, unknown>[])[0].id).toBe("keep");
+    expect(document.markers).toHaveLength(1);
+  });
+
+  it("numbers filled animation ids uniquely across the document", () => {
+    const { document } = normalizeAuthoredDocument({
+      clips: [
+        { id: "C1", animations: [{ role: "in" }, { id: "anim_2", role: "out" }] },
+        { id: "C2", animations: [{ role: "in" }] }
+      ]
+    });
+    const ids = (document.clips as Record<string, unknown>[]).flatMap((c) =>
+      (c.animations as Record<string, unknown>[]).map((a) => a.id)
+    );
+    expect(ids).toEqual(["anim_1", "anim_2", "anim_3"]);
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it("lifts document-level fps/width/height out as sequence settings", () => {
+    const { document, settings } = normalizeAuthoredDocument({
+      fps: 24,
+      width: 1080,
+      height: 1920,
+      tracks: [],
+      clips: []
+    });
+    expect(settings).toEqual({ fps: 24, width: 1080, height: 1920 });
+    expect(document.fps).toBeUndefined();
+    expect(document.width).toBeUndefined();
+    expect(document.height).toBeUndefined();
+  });
+});
+
+describe("sourceTypeForClip", () => {
+  it("calls a clip generated only when it names what generates it", () => {
+    expect(sourceTypeForClip({})).toBe("imported");
+    expect(sourceTypeForClip({ prompt: "a fox" })).toBe("generated");
+    expect(sourceTypeForClip({ workflowId: "wf" })).toBe("generated");
+    expect(sourceTypeForClip({ prompt: "   " })).toBe("imported");
+  });
+});


### PR DESCRIPTION
## What changed

Fixes the failure modes an agent hit while building a trailer through the codeact `nodetool.*` API and the agent capabilities.

Generation: AtlasCloud free-string sizes snap to the multiple of 16 the models accept (1920×1080 → 1920×1088) and a submit 400 names the model and the fields sent. A generation whose bytes never became an asset is an error naming provider, model and what was missing, instead of a success with no `asset_uri`.

Timelines: `nodetool.timelines.createVersion` is an alias of `snapshot`. `add_shape_clip` accepts `shape`, `shapeStyle` or bare geometry and defaults to a full-frame rect. `setDocument` fills the bookkeeping a hand-authored document leaves out (track index/visible/locked, clip sourceType/status/locked/versions, animation ids, markers) and lifts document-level fps/width/height into the sequence settings instead of stripping them. `set_clip_params` applies startMs/trackId/durationMs/fontSizePx through the shared move/trim/textStyle paths and refuses any other unknown key by name. `animate_clip` accepts the nested `custom:{curves|code}` form and the error prints the accepted shape.

Codeact: a capability that answers with pixels (view_image) called from inside an action now strips the payload and says how to actually see the image. The prelude's reserved bindings (`tools`, `finish`, `openWorkflow`, `nodetool`) are listed in the execute_code contract, and a redeclaration error names the clash.

Also fixes the cli `agent-command` suite, red on main since the runtime grew `mediaResolverFor` without the test mock following, and refreshes the capability table fingerprint for the changed `edit_timeline` description.

## Verification

- [x] `npm run test:affected` — green apart from environment gaps this diff does not touch (image-nodes needs a Vulkan ICD, video-nodes/runtime suites need ffmpeg)
- [x] `npm run typecheck` — web/electron/packages clean; mobile fails only on uninstalled Expo modules here
- [x] `npm run lint`
- [x] `npm run dev:nodetool -- harness gate --base main` — 6/6 selfchecks passed

Each new test was run once against the pre-fix source and observed failing (e.g. `expected '1920*1080' to be '1920*1088'`, `expected [] to include 'execute_code'`, 11 timeline op cases, 4 codeact cases).

## Agent capabilities

- [x] `npm run capabilities:check` passes
- [x] No capability was added; the `edit_timeline` description changed and its fingerprint was refreshed with `capabilities:sync`. Coverage mappings are unchanged.

## New checks

No new checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014abWxpD4t4YqeqfkNJ39DJ