### PR TITLE
fix(marketing): stop the background glows animating, and skip compositing the page behind the menu

### DIFF
--- a/marketing/src/app/agents/page.tsx
+++ b/marketing/src/app/agents/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useGridParallax, usePrefersReducedMotion } from "../../lib/useGridParallax";
 import React, { useEffect, useState } from "react";
-import { motion } from "framer-motion";
 import dynamic from "next/dynamic";
 import SiteHeader from "../../components/SiteHeader";
 import SiteFooter from "../../components/SiteFooter";
@@ -61,7 +60,17 @@ export default function AgentsPage() {
       {/* Background */}
       <div className="absolute inset-0 -z-10 overflow-hidden">
         {/* Soft radial glows */}
-        <motion.div
+        {/*
+          Static, not animated. These are 448px and 416px circles under
+          `blur(64px)`; drifting them 10px on an infinite framer-motion loop
+          made Safari re-rasterize both blurred layers every frame and held the
+          whole page at ~4fps for as long as it stayed open, so a tap on the
+          menu waited up to a frame and the panel took over a second to paint.
+          Chrome composited the same animation and stayed at 60fps, which is
+          why it went unnoticed. Measured with
+          `marketing/tests/e2e/idle-animation.spec.ts`.
+        */}
+        <div
           className="pointer-events-none absolute -top-40 left-1/2 h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-teal-500/20 blur-3xl"
           style={{
             WebkitMaskImage:
@@ -69,14 +78,8 @@ export default function AgentsPage() {
             maskImage:
               "radial-gradient(circle at center, black 0%, transparent 65%)",
           }}
-          animate={reducedMotion ? undefined : { y: [0, 10, 0] }}
-          transition={
-            reducedMotion
-              ? undefined
-              : { duration: 18, repeat: Infinity, ease: "easeInOut" }
-          }
         />
-        <motion.div
+        <div
           className="pointer-events-none absolute -bottom-48 right-8 h-[26rem] w-[26rem] rounded-full bg-blue-500/20 blur-3xl"
           style={{
             WebkitMaskImage:
@@ -84,12 +87,6 @@ export default function AgentsPage() {
             maskImage:
               "radial-gradient(circle at center, black 0%, transparent 65%)",
           }}
-          animate={reducedMotion ? undefined : { x: [0, -12, 0], y: [0, 4, 0] }}
-          transition={
-            reducedMotion
-              ? undefined
-              : { duration: 22, repeat: Infinity, ease: "easeInOut" }
-          }
         />
         <div
           aria-hidden="true"

--- a/marketing/src/app/cloud/page.tsx
+++ b/marketing/src/app/cloud/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useGridParallax, usePrefersReducedMotion } from "../../lib/useGridParallax";
 import React, { useEffect, useState } from "react";
-import { motion } from "framer-motion";
 import dynamic from "next/dynamic";
 import {
   Cloud,
@@ -109,7 +108,17 @@ export default function CloudPage() {
     <main className="relative min-h-screen overflow-hidden text-white">
       {/* Background — cool blue/cyan tones to differentiate from Studio */}
       <div className="absolute inset-0 -z-10 overflow-hidden">
-        <motion.div
+        {/*
+          Static, not animated. These are 448px and 416px circles under
+          `blur(64px)`; drifting them 10px on an infinite framer-motion loop
+          made Safari re-rasterize both blurred layers every frame and held the
+          whole page at ~4fps for as long as it stayed open, so a tap on the
+          menu waited up to a frame and the panel took over a second to paint.
+          Chrome composited the same animation and stayed at 60fps, which is
+          why it went unnoticed. Measured with
+          `marketing/tests/e2e/idle-animation.spec.ts`.
+        */}
+        <div
           className="pointer-events-none absolute -top-40 left-1/2 h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-blue-500/20 blur-3xl"
           style={{
             WebkitMaskImage:
@@ -117,14 +126,8 @@ export default function CloudPage() {
             maskImage:
               "radial-gradient(circle at center, black 0%, transparent 65%)",
           }}
-          animate={reducedMotion ? undefined : { y: [0, 10, 0] }}
-          transition={
-            reducedMotion
-              ? undefined
-              : { duration: 18, repeat: Infinity, ease: "easeInOut" }
-          }
         />
-        <motion.div
+        <div
           className="pointer-events-none absolute -bottom-48 right-8 h-[26rem] w-[26rem] rounded-full bg-cyan-500/20 blur-3xl"
           style={{
             WebkitMaskImage:
@@ -132,12 +135,6 @@ export default function CloudPage() {
             maskImage:
               "radial-gradient(circle at center, black 0%, transparent 65%)",
           }}
-          animate={reducedMotion ? undefined : { x: [0, -12, 0], y: [0, 4, 0] }}
-          transition={
-            reducedMotion
-              ? undefined
-              : { duration: 22, repeat: Infinity, ease: "easeInOut" }
-          }
         />
         <div
           aria-hidden="true"

--- a/marketing/src/app/developers/page.tsx
+++ b/marketing/src/app/developers/page.tsx
@@ -1,7 +1,6 @@
 "use client";
-import { useGridParallax, usePrefersReducedMotion } from "../../lib/useGridParallax";
+import { useGridParallax } from "../../lib/useGridParallax";
 import React, { useEffect, useState } from "react";
-import { motion } from "framer-motion";
 import dynamic from "next/dynamic";
 import SiteHeader from "../../components/SiteHeader";
 import SiteFooter from "../../components/SiteFooter";
@@ -53,7 +52,6 @@ const sectionContainer = "mx-auto max-w-7xl px-6 lg:px-8";
 // Prefer reduced motion hook
 export default function DevelopersPage() {
   const [stars, setStars] = useState<number | null>(null);
-  const reducedMotion = usePrefersReducedMotion();
   const parallaxRef = useGridParallax();
 
   // Fetch GitHub stars
@@ -69,7 +67,17 @@ export default function DevelopersPage() {
       {/* Background */}
       <div className="absolute inset-0 -z-10 overflow-hidden">
         {/* Soft radial glows */}
-        <motion.div
+        {/*
+          Static, not animated. These are 448px and 416px circles under
+          `blur(64px)`; drifting them 10px on an infinite framer-motion loop
+          made Safari re-rasterize both blurred layers every frame and held the
+          whole page at ~4fps for as long as it stayed open, so a tap on the
+          menu waited up to a frame and the panel took over a second to paint.
+          Chrome composited the same animation and stayed at 60fps, which is
+          why it went unnoticed. Measured with
+          `marketing/tests/e2e/idle-animation.spec.ts`.
+        */}
+        <div
           className="pointer-events-none absolute -top-40 left-1/2 h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-violet-500/20 blur-3xl"
           style={{
             WebkitMaskImage:
@@ -77,14 +85,8 @@ export default function DevelopersPage() {
             maskImage:
               "radial-gradient(circle at center, black 0%, transparent 65%)",
           }}
-          animate={reducedMotion ? undefined : { y: [0, 10, 0] }}
-          transition={
-            reducedMotion
-              ? undefined
-              : { duration: 18, repeat: Infinity, ease: "easeInOut" }
-          }
         />
-        <motion.div
+        <div
           className="pointer-events-none absolute -bottom-48 right-8 h-[26rem] w-[26rem] rounded-full bg-teal-500/20 blur-3xl"
           style={{
             WebkitMaskImage:
@@ -92,12 +94,6 @@ export default function DevelopersPage() {
             maskImage:
               "radial-gradient(circle at center, black 0%, transparent 65%)",
           }}
-          animate={reducedMotion ? undefined : { x: [0, -12, 0], y: [0, 4, 0] }}
-          transition={
-            reducedMotion
-              ? undefined
-              : { duration: 22, repeat: Infinity, ease: "easeInOut" }
-          }
         />
         <div
           aria-hidden="true"

--- a/marketing/src/app/globals.css
+++ b/marketing/src/app/globals.css
@@ -548,6 +548,21 @@
   html[data-nav-open] .site-nav-overlay {
     display: block;
   }
+
+  /*
+   * The open panel covers the screen, so the page under it does not need to be
+   * composited. Leaving it visible made Safari re-rasterize the landing page's
+   * thirteen blurred glow layers on the frame the menu opened — ~650ms against
+   * ~110ms with this rule, for a pixel-identical result. The header (and the
+   * overlay inside it) is a child of <main>, so the overlay is put back.
+   */
+  html[data-nav-open] main {
+    visibility: hidden;
+  }
+
+  html[data-nav-open] .site-nav-overlay {
+    visibility: visible;
+  }
 }
 
 .mobile-menu-panel {

--- a/marketing/src/app/page.tsx
+++ b/marketing/src/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useGridParallax, usePrefersReducedMotion } from "../lib/useGridParallax";
 import React, { useEffect, useState, useCallback } from "react";
-import { motion } from "framer-motion";
 // Static imports so every section is server-rendered into the HTML (P1).
 // These components are SSR-safe (no window/document at render, no ReactFlow);
 // the hidden duplicate-H1 SEO block has been retired in favour of this.
@@ -133,7 +132,17 @@ export default function Home() {
       {/* Background */}
       <div className="absolute inset-0 -z-10 overflow-hidden">
         {/* Soft radial glows (BackgroundFX) */}
-        <motion.div
+        {/*
+          Static, not animated. These are 448px and 416px circles under
+          `blur(64px)`; drifting them 10px on an infinite framer-motion loop
+          made Safari re-rasterize both blurred layers every frame and held the
+          whole page at ~4fps for as long as it stayed open, so a tap on the
+          menu waited up to a frame and the panel took over a second to paint.
+          Chrome composited the same animation and stayed at 60fps, which is
+          why it went unnoticed. Measured with
+          `marketing/tests/e2e/idle-animation.spec.ts`.
+        */}
+        <div
           className="pointer-events-none absolute -top-40 left-1/2 h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-sky-500/20 blur-3xl"
           style={{
             WebkitMaskImage:
@@ -141,14 +150,8 @@ export default function Home() {
             maskImage:
               "radial-gradient(circle at center, black 0%, transparent 65%)",
           }}
-          animate={reducedMotion ? undefined : { y: [0, 10, 0] }}
-          transition={
-            reducedMotion
-              ? undefined
-              : { duration: 18, repeat: Infinity, ease: "easeInOut" }
-          }
         />
-        <motion.div
+        <div
           className="pointer-events-none absolute -bottom-48 right-8 h-[26rem] w-[26rem] rounded-full bg-teal-500/20 blur-3xl"
           style={{
             WebkitMaskImage:
@@ -156,12 +159,6 @@ export default function Home() {
             maskImage:
               "radial-gradient(circle at center, black 0%, transparent 65%)",
           }}
-          animate={reducedMotion ? undefined : { x: [0, -12, 0], y: [0, 4, 0] }}
-          transition={
-            reducedMotion
-              ? undefined
-              : { duration: 22, repeat: Infinity, ease: "easeInOut" }
-          }
         />
         <div
           aria-hidden="true"

--- a/marketing/src/app/studio/page.tsx
+++ b/marketing/src/app/studio/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useGridParallax, usePrefersReducedMotion } from "../../lib/useGridParallax";
 import React, { useEffect, useState } from "react";
-import { motion } from "framer-motion";
 import dynamic from "next/dynamic";
 import {
   Cpu,
@@ -113,7 +112,17 @@ export default function StudioPage() {
     <main className="relative min-h-screen overflow-hidden text-white">
       {/* Background — warm amber/orange tones to differentiate from Cloud */}
       <div className="absolute inset-0 -z-10 overflow-hidden">
-        <motion.div
+        {/*
+          Static, not animated. These are 448px and 416px circles under
+          `blur(64px)`; drifting them 10px on an infinite framer-motion loop
+          made Safari re-rasterize both blurred layers every frame and held the
+          whole page at ~4fps for as long as it stayed open, so a tap on the
+          menu waited up to a frame and the panel took over a second to paint.
+          Chrome composited the same animation and stayed at 60fps, which is
+          why it went unnoticed. Measured with
+          `marketing/tests/e2e/idle-animation.spec.ts`.
+        */}
+        <div
           className="pointer-events-none absolute -top-40 left-1/2 h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-amber-500/20 blur-3xl"
           style={{
             WebkitMaskImage:
@@ -121,14 +130,8 @@ export default function StudioPage() {
             maskImage:
               "radial-gradient(circle at center, black 0%, transparent 65%)",
           }}
-          animate={reducedMotion ? undefined : { y: [0, 10, 0] }}
-          transition={
-            reducedMotion
-              ? undefined
-              : { duration: 18, repeat: Infinity, ease: "easeInOut" }
-          }
         />
-        <motion.div
+        <div
           className="pointer-events-none absolute -bottom-48 right-8 h-[26rem] w-[26rem] rounded-full bg-orange-500/20 blur-3xl"
           style={{
             WebkitMaskImage:
@@ -136,12 +139,6 @@ export default function StudioPage() {
             maskImage:
               "radial-gradient(circle at center, black 0%, transparent 65%)",
           }}
-          animate={reducedMotion ? undefined : { x: [0, -12, 0], y: [0, 4, 0] }}
-          transition={
-            reducedMotion
-              ? undefined
-              : { duration: 22, repeat: Infinity, ease: "easeInOut" }
-          }
         />
         <div
           aria-hidden="true"

--- a/marketing/tests/e2e/idle-animation.spec.ts
+++ b/marketing/tests/e2e/idle-animation.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * No page animates forever once it has settled.
+ *
+ * Five pages carried two decorative glow blobs — 448px and 416px circles under
+ * `blur(64px)` — drifting 10px on an infinite framer-motion loop. Chrome
+ * composited that and held 60fps, so it looked free. Safari re-rasterized both
+ * blurred layers every frame and sat at ~4fps (median 226ms per frame) for as
+ * long as the tab was open, which is what made a tap on the hamburger take
+ * seconds to produce a panel.
+ *
+ * The assertion is the mechanism, not a frame budget: after the page has
+ * settled, nothing may still be writing inline styles. That is engine
+ * independent — the loop runs in Chromium too, it is merely cheap there — so
+ * this catches a regression without a WebKit runner or a timing threshold.
+ */
+test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
+
+const PAGES = ["/", "/agents", "/developers", "/cloud", "/studio"];
+
+const SETTLE_MS = 6000;
+const WATCH_MS = 2000;
+
+for (const path of PAGES) {
+  test(`${path} stops animating once it has settled`, async ({ page }) => {
+    await page.goto(path, { waitUntil: "load" });
+    await page.waitForTimeout(SETTLE_MS);
+
+    const changed = await page.evaluate(async (watchMs) => {
+      const els = [...document.querySelectorAll("*")];
+      const snapshot = () => els.map((el) => el.getAttribute("style") ?? "");
+      const before = snapshot();
+      await new Promise((resolve) => setTimeout(resolve, watchMs));
+      const after = snapshot();
+
+      return els
+        .map((el, i) =>
+          before[i] === after[i]
+            ? null
+            : {
+                tag: el.tagName,
+                className: String(
+                  (el as HTMLElement).className ?? ""
+                ).slice(0, 80),
+                from: before[i].slice(0, 60),
+                to: after[i].slice(0, 60),
+              }
+        )
+        .filter(Boolean);
+    }, WATCH_MS);
+
+    expect(
+      changed,
+      `still animating after ${SETTLE_MS}ms: ${JSON.stringify(changed, null, 2)}`
+    ).toEqual([]);
+  });
+}

--- a/marketing/tests/e2e/mobile-menu.spec.ts
+++ b/marketing/tests/e2e/mobile-menu.spec.ts
@@ -87,17 +87,46 @@ test.describe("landing page on a phone", () => {
     const panel = page.getByRole("dialog");
     await expect(panel).toBeHidden();
 
-    const open = page.getByRole("button", { name: "Open menu" });
-    await open.click();
+    await page.getByRole("button", { name: "Open menu" }).click();
     await expect(panel).toBeVisible();
-    await expect(open).toHaveAttribute("aria-expanded", "true");
+    // The trigger is inside <main>, which the open panel hides — so read the
+    // attribute off the DOM rather than through a role query, which correctly
+    // no longer resolves it.
+    const expanded = () =>
+      page.evaluate(() =>
+        document.querySelector('[data-nav="open"]')!.getAttribute("aria-expanded")
+      );
+    expect(await expanded()).toBe("true");
     expect(await page.evaluate(() => document.body.style.position)).toBe(
       "fixed"
     );
 
     await page.keyboard.press("Escape");
     await expect(panel).toBeHidden();
-    await expect(open).toHaveAttribute("aria-expanded", "false");
+    expect(await expanded()).toBe("false");
     expect(await page.evaluate(() => document.body.style.position)).toBe("");
+  });
+
+  test("the page under the open panel is not composited", async ({ page }) => {
+    await page.goto("/", { waitUntil: "load" });
+    await page.getByRole("button", { name: "Open menu" }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    // Safari re-rasterized the landing page's thirteen blurred glow layers on
+    // the frame the menu opened (~650ms against ~110ms) while the page under
+    // the full-screen panel stayed visible. The panel itself must still render.
+    expect(
+      await page.evaluate(
+        () => getComputedStyle(document.querySelector("main")!).visibility
+      )
+    ).toBe("hidden");
+    expect(
+      await page.evaluate(
+        () =>
+          getComputedStyle(document.querySelector(".mobile-menu-panel")!)
+            .visibility
+      )
+    ).toBe("visible");
+    await expect(page.getByRole("link", { name: "Pricing" })).toBeVisible();
   });
 });


### PR DESCRIPTION
## What changed

The hamburger still felt slow on mobile Safari after #5529, and the menu was not the cause. Five pages (`/`, `/agents`, `/developers`, `/cloud`, `/studio`) carried two decorative glow blobs — 448px and 416px circles under `blur(64px)` — drifting 10px on an infinite framer-motion loop. Chrome composites that and holds 60fps, so it looked free. Safari re-rasterizes both blurred layers every frame and sat at a **median 226ms per frame, about 4fps, for as long as the tab was open**. Every interaction on those pages waited on that, the menu included. The drift is invisible at 10px over 18s; the pages now paint the glows once.

Opening the panel cost a second, separate frame. The landing page carries thirteen blurred glow layers, and revealing a full-screen overlay made Safari re-rasterize all of them. Since the panel covers the screen, the page under it does not need compositing: while the menu is open `<main>` is `visibility: hidden` and the overlay inside it is put back. The rendered result is pixel-identical — same screenshot hash, byte for byte. As a side effect the page content is now correctly hidden from assistive technology while the modal is open, which is what the panel's `aria-modal` already claimed.

`/agents` is still at 72ms idle from a different cause — the animated agent graph's SVG stroke animation plus Tailwind `spin`/`ping`/`bounce` keyframes. That is a visible, deliberate animation rather than an invisible drift, so it is left alone here.

## Verification

Measured on WebKit (Playwright, iPhone 14 profile) against the production build — the engine that shows the defect. Chromium was at 60fps before and after, which is why this went unnoticed.

| | before | after |
|---|---|---|
| idle frame time, landing page | 226ms (~4fps) | 16ms (~60fps) |
| idle frame time, `/developers`, `/cloud`, `/studio` | 220–270ms | 16–17ms |
| menu open → painted, at top | 1260ms | 95ms |
| menu open → painted, scrolled to 6000px | 2014ms | 74ms |

How the cause was isolated, each step re-measured after the previous conclusion turned out to be wrong:

- Blocking all page JS restored 60fps; disabling `backdrop-filter`, the scroll-driven `scroll-fade` animations, videos and transitions each changed nothing. An earlier round of those overrides appeared to exonerate them for the wrong reason — the CSS is inlined into the document, so a stylesheet route interception never fired. Re-run by rewriting the document, with the computed style asserted to confirm the override applied.
- Sampling inline styles over 2s found exactly two elements still being written to, both the glow blobs.
- Removing them from the DOM at runtime restored 60fps; removing only the blur got part way; freezing the transform did nothing, since framer-motion rewrites it each frame.
- For the open cost, a control that measured the same two frames with no menu action separated the menu's cost from the page's background jank.

Checks (`marketing/` is not a root npm workspace, so the root targets do not reach it):

- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx next lint --dir src` — no new findings (the remaining `no-img-element` warnings are pre-existing and in files this diff does not touch)
- `npx playwright test` against the production build — **366 passed**

- [x] `npm run test:affected` — n/a, no workspace covers `marketing/`; the Playwright suite above is the equivalent
- [x] `npm run typecheck` — n/a for this tree; `npx tsc --noEmit` run in `marketing/`
- [x] `npm run lint` — n/a for this tree; `npx next lint` run in `marketing/`
- [ ] `npm run dev:nodetool -- harness gate --base main` — no harness surface covers `marketing/`

## New checks

`tests/e2e/idle-animation.spec.ts` asserts the mechanism rather than a frame budget: after a page settles, nothing may still be writing inline styles. The loop runs in Chromium too and is merely cheap there, so this catches a regression on the existing Chromium runner — no WebKit in CI, no timing threshold to tune. It covers all five pages.

`tests/e2e/mobile-menu.spec.ts` gains a case pinning that `<main>` is hidden and the panel still renders while the menu is open.

- [x] Inverted and observed failing. The same assertion against the pre-fix code still live on nodetool.ai:

```
https://nodetool.ai/ → 2 elements still animating after settling
    {"cls":"pointer-events-none absolute -top-40 left-1/2 h-[28rem] w-[2","to":"mask-image: radial-gradient(circle, black 0%, tran"}
    {"cls":"pointer-events-none absolute -bottom-48 right-8 h-[26rem] w-","to":"mask-image: radial-gradient(circle, black 0%, tran"}
exit=1

http://localhost:3210/ → 0 elements still animating after settling
exit=0
```

- [x] The check cannot pass by matching nothing: it enumerates every element in the document and fails on a non-empty diff, and the run above shows it finding its targets.

## Agent capabilities

No capability added or re-declared.

## Follow-up, not in this PR

The landing page still carries thirteen `blur(64px)`–`blur(120px)` glow layers, several 800–900px wide. Removing all of them takes the menu-open frame from ~600ms to ~160ms on WebKit, and closing the menu — which repaints the page — still costs ~0.5–1.4s because of them. Replacing those filters with equivalent radial-gradient backgrounds would be a visual change across many section components, so it is a separate decision rather than something to fold in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTwJAaoz9hgDhxTpHkeurg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTwJAaoz9hgDhxTpHkeurg)_