### PR TITLE
feat(oauth): bring the Claude sign-in to parity with the Codex login

### DIFF
--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -1149,7 +1149,13 @@ export const CLAUDE_CODE_OAUTH_TOKEN_URL =
  */
 export const CLAUDE_CODE_OAUTH_MANUAL_REDIRECT_URL =
   "https://platform.claude.com/oauth/code/callback";
-/** Path the loopback listener serves; the port is ephemeral. */
+/**
+ * The loopback redirect the `claude` CLI registers: a fixed port, like the
+ * Codex client's 1455, so the browser lands on the same address whichever
+ * tool started the login. A `claude login` already holding the port is the
+ * one expected collision.
+ */
+export const CLAUDE_CODE_CALLBACK_PORT = 54545;
 export const CLAUDE_CODE_CALLBACK_PATH = "/callback";
 /** Scopes requested at login. */
 export const CLAUDE_CODE_OAUTH_SCOPES = [

--- a/packages/runtime/src/providers/oauth/README.md
+++ b/packages/runtime/src/providers/oauth/README.md
@@ -293,11 +293,15 @@ Refresh also narrows the scope set: `org:create_api_key` is requested at login
 
 `begin()` mints one PKCE pair and state, then hands back both URLs:
 
-- **Loopback** (`authUrl`) — the browser is redirected to an ephemeral
-  `127.0.0.1` listener; the registered redirect uses the `localhost` spelling,
-  matching the CLI. Only works when the browser runs on this machine.
+- **Loopback** (`authUrl`) — the browser is redirected to a `127.0.0.1`
+  listener on the CLI's own port, `CLAUDE_CODE_CALLBACK_PORT` (54545); the
+  registered redirect uses the `localhost` spelling, matching the CLI. Only
+  works when the browser runs on this machine, and fails naming the port when
+  a `claude login` already holds it.
 - **Manual** (`manualAuthUrl`) — the console shows `<code>#<state>` to paste
-  back. The only option on a headless or remote host.
+  back. The only option on a headless or remote host, and what the server's
+  `start` offers on a shared deployment (`isAuthEnforced()`, or `?manual=true`),
+  the same way the Codex route does.
 
 They differ only in `redirect_uri`, which must match between the authorization
 request and the exchange — hence `waitForRedirect()` and

--- a/packages/runtime/src/providers/oauth/claude-code-login.ts
+++ b/packages/runtime/src/providers/oauth/claude-code-login.ts
@@ -20,6 +20,7 @@
 import { createLogger, type Logger } from "@nodetool-ai/config";
 import {
   CLAUDE_CODE_CALLBACK_PATH,
+  CLAUDE_CODE_CALLBACK_PORT,
   CLAUDE_CODE_OAUTH_MANUAL_REDIRECT_URL
 } from "@nodetool-ai/protocol";
 import {
@@ -72,6 +73,8 @@ export interface ClaudeCodeAuthStatus {
 export interface PendingClaudeCodeLogin {
   /** Authorization URL for the loopback flow. Null when `manualOnly`. */
   readonly authUrl: string | null;
+  /** Where the loopback flow sends the browser. Null when `manualOnly`. */
+  readonly redirectUri: string | null;
   /** Authorization URL whose redirect shows a paste-able `code#state`. */
   readonly manualAuthUrl: string;
   /** CSRF state; the caller may key the pending login on it. */
@@ -122,6 +125,7 @@ export class ClaudeCodeLogin {
       (() =>
         new LocalCallbackServer({
           host: "127.0.0.1",
+          port: CLAUDE_CODE_CALLBACK_PORT,
           path: CLAUDE_CODE_CALLBACK_PATH,
           logger: this.logger
         }));
@@ -149,7 +153,16 @@ export class ClaudeCodeLogin {
     let loopbackRedirectUri: string | null = null;
     if (!options.manualOnly) {
       server = this.callbackServerFactory();
-      const { port } = await server.listen();
+      let port: number;
+      try {
+        ({ port } = await server.listen());
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new OAuthError(
+          "token_exchange_failed",
+          `Could not bind the loopback listener on port ${CLAUDE_CODE_CALLBACK_PORT} (is a \`claude login\` already waiting?): ${message}`
+        );
+      }
       // The listener binds 127.0.0.1, but the registered redirect uses the
       // `localhost` spelling the authorization server expects from the CLI.
       loopbackRedirectUri = `http://localhost:${port}${CLAUDE_CODE_CALLBACK_PATH}`;
@@ -178,6 +191,7 @@ export class ClaudeCodeLogin {
 
     return {
       authUrl,
+      redirectUri: loopbackRedirectUri,
       manualAuthUrl,
       state,
       waitForRedirect: async (signal?: AbortSignal) => {

--- a/packages/runtime/tests/providers/oauth/claude-code-oauth.test.ts
+++ b/packages/runtime/tests/providers/oauth/claude-code-oauth.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  CLAUDE_CODE_CALLBACK_PORT,
   CLAUDE_CODE_OAUTH_CLIENT_ID,
   CLAUDE_CODE_OAUTH_MANUAL_REDIRECT_URL,
   CLAUDE_CODE_OAUTH_TOKEN_URL
@@ -24,6 +25,7 @@ import {
   StateMismatchError,
   TokenExchangeError
 } from "../../../src/providers/oauth/errors.js";
+import { LocalCallbackServer } from "../../../src/providers/oauth/local-callback-server.js";
 
 interface RecordedRequest {
   url: string;
@@ -365,17 +367,66 @@ describe("ClaudeCodeLogin", () => {
   });
 
   function login(
-    responses: Array<{ ok: boolean; status: number; body: unknown }>
+    responses: Array<{ ok: boolean; status: number; body: unknown }>,
+    options: { callbackServerFactory?: () => LocalCallbackServer } = {}
   ): { login: ClaudeCodeLogin; fetchFn: ReturnType<typeof fakeFetch> } {
     const fetchFn = fakeFetch(responses);
     return {
       fetchFn,
       login: new ClaudeCodeLogin({
         client: new ClaudeCodeOAuthClient({ fetchFn }),
-        credentials: new ClaudeCodeCredentialsStore({ configDir: dir })
+        credentials: new ClaudeCodeCredentialsStore({ configDir: dir }),
+        // Tests share a machine; an ephemeral port keeps them from colliding
+        // on the fixed one the default factory binds.
+        callbackServerFactory:
+          options.callbackServerFactory ??
+          (() =>
+            new LocalCallbackServer({ host: "127.0.0.1", path: "/callback" }))
       })
     };
   }
+
+  it("binds the claude CLI's own callback port by default", async () => {
+    const flow = new ClaudeCodeLogin({
+      client: new ClaudeCodeOAuthClient({ fetchFn: fakeFetch([]) }),
+      credentials: new ClaudeCodeCredentialsStore({ configDir: dir })
+    });
+    const pending = await flow.begin();
+    try {
+      expect(pending.redirectUri).toBe(
+        `http://localhost:${CLAUDE_CODE_CALLBACK_PORT}/callback`
+      );
+      expect(new URL(pending.authUrl!).searchParams.get("redirect_uri")).toBe(
+        pending.redirectUri
+      );
+    } finally {
+      await pending.cancel();
+    }
+  });
+
+  it("names the port when the listener cannot bind", async () => {
+    const { login: flow } = login([], {
+      callbackServerFactory: () =>
+        new LocalCallbackServer({
+          host: "127.0.0.1",
+          port: CLAUDE_CODE_CALLBACK_PORT,
+          path: "/callback"
+        })
+    });
+    const holder = new LocalCallbackServer({
+      host: "127.0.0.1",
+      port: CLAUDE_CODE_CALLBACK_PORT,
+      path: "/callback"
+    });
+    await holder.listen();
+    try {
+      await expect(flow.begin()).rejects.toThrow(
+        `port ${CLAUDE_CODE_CALLBACK_PORT}`
+      );
+    } finally {
+      await holder.close();
+    }
+  });
 
   it("reports a disconnected status when nothing is stored", async () => {
     const { login: flow } = login([]);
@@ -417,7 +468,7 @@ describe("ClaudeCodeLogin", () => {
     expect(status.subscriptionType).toBe("pro");
   });
 
-  it("completes a loopback login against the bound ephemeral port", async () => {
+  it("completes a loopback login against the bound port", async () => {
     const { login: flow, fetchFn } = login([
       { ok: true, status: 200, body: tokenResponse },
       { ok: false, status: 404, body: {} }

--- a/packages/websocket/src/oauth-api.ts
+++ b/packages/websocket/src/oauth-api.ts
@@ -1200,10 +1200,17 @@ async function handleOpenAIDisconnect(
 // store, because the SDK spawns the `claude` binary as this process's user and
 // reads it directly; a per-user DB row would be invisible to it.
 //
-// Two ways to finish, both from the one authorization request `start` creates:
-// the browser redirects to a loopback listener this process binds (same-machine
-// hosts), or the user pastes the `code#state` the console displays (headless and
-// remote hosts). The UI reflects success by polling `/api/oauth/claude/tokens`.
+// Two ways to finish, both from the one authorization request `start` creates,
+// mirroring the Codex flow above:
+//
+//  - **Loopback** — `start` binds the `claude` CLI's own callback port (54545)
+//    and finishes the exchange in the background. Only works when the browser
+//    runs on this machine (desktop, local dev).
+//  - **Manual** — the browser is sent to the console, which displays a
+//    `code#state` the user pastes back to `/complete`. What `start` offers on a
+//    shared server (`isAuthEnforced()`) or when asked with `?manual=true`.
+//
+// The UI reflects success by polling `/api/oauth/claude/tokens`.
 
 /** The single in-flight login, so a re-click supersedes a stale listener. */
 let activeClaudeLogin: {
@@ -1226,16 +1233,17 @@ async function handleClaudeStart(request: Request): Promise<Response> {
   const url = new URL(request.url);
   const loginMethod =
     url.searchParams.get("login_method") === "console" ? "console" : "claude-ai";
-  // A remote browser can't reach this process's loopback listener; the caller
-  // says so and only the paste flow is offered.
-  const manualOnly = url.searchParams.get("manual") === "true";
+  // A shared server's users browse from their own machines, where the loopback
+  // redirect lands — so binding it here would receive nothing. The caller can
+  // also ask for the paste flow outright.
+  const manual = url.searchParams.get("manual") === "true" || isAuthEnforced();
 
   await closeActiveClaudeLogin();
 
   const login = new ClaudeCodeLogin();
   let pending: PendingClaudeCodeLogin;
   try {
-    pending = await login.begin({ loginMethod, manualOnly });
+    pending = await login.begin({ loginMethod, manualOnly: manual });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return errorResponse(500, `Could not start the Claude login: ${message}`);
@@ -1262,6 +1270,8 @@ async function handleClaudeStart(request: Request): Promise<Response> {
   return jsonResponse({
     auth_url: pending.authUrl ?? pending.manualAuthUrl,
     manual_auth_url: pending.manualAuthUrl,
+    manual,
+    redirect_uri: pending.redirectUri,
     state: pending.state
   });
 }

--- a/packages/websocket/tests/oauth-api.test.ts
+++ b/packages/websocket/tests/oauth-api.test.ts
@@ -777,6 +777,8 @@ describe("OAuth API: Claude subscription endpoints", () => {
     const body = (await jsonBody(response!)) as {
       auth_url: string;
       manual_auth_url: string;
+      manual: boolean;
+      redirect_uri: string | null;
       state: string;
     };
     const authUrl = new URL(body.auth_url);
@@ -785,13 +787,42 @@ describe("OAuth API: Claude subscription endpoints", () => {
     );
     expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
     expect(authUrl.searchParams.get("state")).toBe(body.state);
-    // The loopback listener is bound, so the redirect points back at this process.
-    expect(authUrl.searchParams.get("redirect_uri")).toMatch(
-      /^http:\/\/localhost:\d+\/callback$/
+    // The loopback listener is bound on the `claude` CLI's own port, so the
+    // redirect points back at this process.
+    expect(authUrl.searchParams.get("redirect_uri")).toBe(
+      "http://localhost:54545/callback"
     );
+    expect(body.manual).toBe(false);
+    expect(body.redirect_uri).toBe("http://localhost:54545/callback");
     expect(body.manual_auth_url).toContain(
       encodeURIComponent("https://platform.claude.com/oauth/code/callback")
     );
+  });
+
+  it("offers only the paste flow on a shared server", async () => {
+    // A shared server's users browse from elsewhere, so localhost:54545 is
+    // theirs, not ours — binding it here would only swallow the port.
+    vi.stubEnv("SUPABASE_URL", "https://project.supabase.co");
+    vi.stubEnv("SUPABASE_KEY", "service-key");
+
+    const response = await claudeRequest("/api/oauth/claude/start");
+    const body = (await jsonBody(response!)) as {
+      auth_url: string;
+      manual_auth_url: string;
+      manual: boolean;
+      redirect_uri: string | null;
+    };
+    expect(body.manual).toBe(true);
+    expect(body.redirect_uri).toBeNull();
+    expect(body.auth_url).toBe(body.manual_auth_url);
+
+    // Nothing is listening, so the port is free to bind.
+    const probe = createServer();
+    await new Promise<void>((resolve, reject) => {
+      probe.once("error", reject);
+      probe.listen(54545, "127.0.0.1", resolve);
+    });
+    await new Promise<void>((resolve) => probe.close(() => resolve()));
   });
 
   it("offers only the paste flow when the browser can't reach this process", async () => {

--- a/web/src/components/oauth/OAuthManualCompletionDialog.tsx
+++ b/web/src/components/oauth/OAuthManualCompletionDialog.tsx
@@ -7,6 +7,10 @@
  * localhost with nothing listening and the authorization code sitting in the
  * address bar. This dialog takes that address and hands it back to the server,
  * which does the code exchange.
+ *
+ * Claude's console has a page for exactly this case: it displays a
+ * `code#state` string instead of redirecting, so the dialog asks for that
+ * string rather than an address.
  */
 
 import { useCallback, useState } from "react";
@@ -68,16 +72,28 @@ export const OAuthManualCompletionDialog = ({
       minWidth="520px"
     >
       <FlexColumn gap={2}>
-        <Text size="small">
-          {label} sends the browser to{" "}
-          <code>{prompt.redirectUri ?? "a local address"}</code>, which only
-          exists on your own machine — so this server never sees it. Approve the
-          sign-in, then copy the whole address the browser ends up on (an error
-          page is expected) and paste it below.
-        </Text>
+        {prompt.input === "code" ? (
+          <Text size="small">
+            This server cannot receive the sign-in callback, so {label} shows
+            you a code instead. Approve the sign-in, then copy the code the page
+            displays and paste it below.
+          </Text>
+        ) : (
+          <Text size="small">
+            {label} sends the browser to{" "}
+            <code>{prompt.redirectUri ?? "a local address"}</code>, which only
+            exists on your own machine — so this server never sees it. Approve
+            the sign-in, then copy the whole address the browser ends up on (an
+            error page is expected) and paste it below.
+          </Text>
+        )}
         <TextInput
-          label="Redirect address"
-          placeholder="http://localhost:1455/auth/callback?code=…&state=…"
+          label={prompt.input === "code" ? "Authorization code" : "Redirect address"}
+          placeholder={
+            prompt.input === "code"
+              ? "code#state"
+              : "http://localhost:1455/auth/callback?code=…&state=…"
+          }
           value={value}
           onChange={(event) => setValue(event.target.value)}
           multiline

--- a/web/src/components/oauth/__tests__/OAuthManualCompletionDialog.test.tsx
+++ b/web/src/components/oauth/__tests__/OAuthManualCompletionDialog.test.tsx
@@ -8,7 +8,8 @@ import { OAuthManualCompletionDialog } from "../OAuthManualCompletionDialog";
 
 const prompt = {
   authUrl: "https://auth.openai.com/oauth/authorize?x=1",
-  redirectUri: "http://localhost:1455/auth/callback"
+  redirectUri: "http://localhost:1455/auth/callback",
+  input: "address" as const
 };
 
 const renderDialog = (
@@ -65,5 +66,23 @@ describe("OAuthManualCompletionDialog", () => {
 
     await user.type(screen.getByLabelText("Redirect address"), "x");
     expect(connect).toBeEnabled();
+  });
+
+  it("asks for the displayed code instead of an address for Claude", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderDialog({
+      label: "Claude",
+      prompt: {
+        authUrl: "https://claude.com/cai/oauth/authorize?x=1",
+        redirectUri: null,
+        input: "code"
+      }
+    });
+
+    expect(screen.queryByLabelText("Redirect address")).not.toBeInTheDocument();
+    await user.type(screen.getByLabelText("Authorization code"), "ac_abc#st");
+    await user.click(screen.getByRole("button", { name: "Connect" }));
+
+    expect(onSubmit).toHaveBeenCalledWith("ac_abc#st");
   });
 });

--- a/web/src/hooks/__tests__/useOAuthConnection.test.tsx
+++ b/web/src/hooks/__tests__/useOAuthConnection.test.tsx
@@ -158,7 +158,36 @@ describe("useOAuthConnection", () => {
 
     expect(result.current.manualPrompt).toEqual({
       authUrl: "https://example.com/auth",
-      redirectUri: "http://localhost:1455/auth/callback"
+      redirectUri: "http://localhost:1455/auth/callback",
+      input: "address"
+    });
+  });
+
+  it("asks Claude users for the displayed code when /start answers manual", async () => {
+    mockRestFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/tokens")) return jsonResponse({ tokens: [] });
+      if (url.endsWith("/start"))
+        return jsonResponse({
+          auth_url: "https://claude.com/cai/oauth/authorize",
+          manual: true,
+          redirect_uri: null
+        });
+      return jsonResponse({});
+    });
+
+    const { result } = renderHook(() => useOAuthConnection("claude"), {
+      wrapper: createWrapper()
+    });
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(result.current.manualPrompt).toEqual({
+      authUrl: "https://claude.com/cai/oauth/authorize",
+      redirectUri: null,
+      input: "code"
     });
   });
 

--- a/web/src/hooks/useOAuthConnection.ts
+++ b/web/src/hooks/useOAuthConnection.ts
@@ -14,15 +14,38 @@ interface OAuthProviderConfig {
   /**
    * Whether `/start` may answer `manual: true`, meaning the provider redirects
    * somewhere this server cannot receive and the user finishes the login by
-   * pasting the address back to `/complete`.
+   * pasting something back to `/complete`.
    */
   canCompleteManually: boolean;
+  /**
+   * What the user pastes back: the whole redirect address the browser lands
+   * on (Codex), or the `code#state` the provider's own page displays (Claude).
+   */
+  manualInput: OAuthManualInput;
 }
 
+/** What a manual completion asks the user to paste. */
+export type OAuthManualInput = "address" | "code";
+
 const PROVIDER_CONFIG = {
-  openai: { label: "OpenAI", canDisconnect: true, canCompleteManually: true },
-  hf: { label: "HuggingFace", canDisconnect: false, canCompleteManually: false },
-  claude: { label: "Claude", canDisconnect: true, canCompleteManually: false }
+  openai: {
+    label: "OpenAI",
+    canDisconnect: true,
+    canCompleteManually: true,
+    manualInput: "address"
+  },
+  hf: {
+    label: "HuggingFace",
+    canDisconnect: false,
+    canCompleteManually: false,
+    manualInput: "address"
+  },
+  claude: {
+    label: "Claude",
+    canDisconnect: true,
+    canCompleteManually: true,
+    manualInput: "code"
+  }
 } satisfies Record<OAuthProvider, OAuthProviderConfig>;
 
 interface TokensResponse {
@@ -44,6 +67,8 @@ export interface OAuthManualPrompt {
   authUrl: string;
   /** The redirect address to look for in the browser's address bar. */
   redirectUri: string | null;
+  /** Whether to paste that address, or a code the provider's page shows. */
+  input: OAuthManualInput;
 }
 
 /**
@@ -190,7 +215,11 @@ export const useOAuthConnection = (
       // the address the browser lands on instead of waiting for a callback
       // that cannot arrive.
       if (body.manual && config.canCompleteManually) {
-        setManualPrompt({ authUrl, redirectUri: body.redirect_uri ?? null });
+        setManualPrompt({
+          authUrl,
+          redirectUri: body.redirect_uri ?? null,
+          input: config.manualInput
+        });
       }
       if (useNativeBrowser) {
         await window.api?.shell?.openExternal(authUrl);


### PR DESCRIPTION
## What changed

The Claude subscription sign-in existed but lagged the Codex one in three ways: it bound a random loopback port, the server never switched to the paste flow on a shared install, and the web card had no way to finish a login by hand. The loopback listener now binds the `claude` CLI's own callback port (54545), so the browser returns to the same `http://localhost:54545/callback` whichever tool started the login, and a port already held by a `claude login` fails naming it. `/api/oauth/claude/start` answers `manual` and `redirect_uri` the way the Codex route does and offers only the paste flow when auth is enforced. The web hook accepts a manual completion for Claude and the completion dialog asks for the `code#state` the console displays rather than a redirect address. Tokens still land in the Claude Agent SDK's credential file, and the card stays `localOnly`, so hosted deployments keep hiding it.

## Verification

- [x] Targeted suites instead of `npm run test:affected`: `vitest run tests/providers/oauth/claude-code-oauth.test.ts` in `packages/runtime` (24 passed), `vitest run tests/oauth-api.test.ts` in `packages/websocket` (44 passed), `jest src/hooks/__tests__/useOAuthConnection.test.tsx src/components/oauth/__tests__/OAuthManualCompletionDialog.test.tsx` in `web` (17 passed)
- [x] `npm run typecheck`: web and electron pass; mobile fails only on its uninstalled dependency tree in this sandbox (`Cannot find module 'react-native'`), unrelated to the diff
- [x] `npm run lint`: exit 0, only pre-existing warnings in untouched files
- [ ] `npm run dev:nodetool -- harness gate --base main` not run

New tests: the runtime suite pins the default port and the busy-port error, the websocket suite pins `manual: true` with the port left unbound when auth is enforced, and the web suites cover the Claude prompt and the code-mode dialog.

## Agent capabilities

Skipped: no capability added or changed.

## New checks

Skipped: no check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KEMk8gP5EEvTUQ2AfVLXrw

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEMk8gP5EEvTUQ2AfVLXrw)_