### PR TITLE
docs(system-skills): point every skill at the motion set

### DIFF
--- a/packages/agents/tests/motion-graphics-skill-names.test.ts
+++ b/packages/agents/tests/motion-graphics-skill-names.test.ts
@@ -36,7 +36,8 @@ const SKILL_NAMES = [
   "color-motion",
   "logo-reveal",
   "motion-background",
-  "motion-curves"
+  "motion-curves",
+  "caption-titles"
 ] as const;
 
 function skillPath(name: string): string {

--- a/packages/system-skills/README.md
+++ b/packages/system-skills/README.md
@@ -32,9 +32,17 @@ directory ships with no other change.
 `motion-graphics` carries the mechanics and the other motion skills carry the
 craft. A craft skill quotes calls rather than teaching them, so
 `packages/agents/tests/motion-graphics-skill-names.test.ts` checks every
-snake_case call in all nine against the capability registry and
+snake_case call in all ten against the capability registry and
 `edit_timeline`'s op list — a renamed tool fails there rather than in a model's
-hands. Add a skill to `SKILL_NAMES` in that test in the same change.
+hands. Add a skill to `SKILL_NAMES` in that test in the same change. The four
+board skills stay out of it: each names `set_entities` in order to say the op
+does not exist, and that check cannot tell such a warning from a typo.
+
+Every skill states where the rest of the set picks up. A craft skill opens by
+pointing back at `motion-graphics` for the op contract and sideways at the
+neighbours that decide its numbers; a board skill points forward at the motion
+skills at the step where a board becomes a cut, so an agent asked to animate a
+finished board loads the craft file instead of improvising against the op list.
 
 ## Credit
 

--- a/packages/system-skills/caption-titles/SKILL.md
+++ b/packages/system-skills/caption-titles/SKILL.md
@@ -7,6 +7,8 @@ description: Add a consistent, timed text layer to an existing picture-locked No
 
 Work directly with timeline capabilities and open-timeline tools. Do not build a workflow, fabricate a cut, or render video.
 
+`motion-graphics` carries the op contract for every call named here. `motion-principles` gives the entry and exit durations and easing behind each tier's presets, `frame-composition` fixes the safe inset and where a tier sits, and `logo-reveal` owns the brand mark at the head or tail.
+
 ## Hard gate
 
 List and read the selected timeline first. It must contain picture clips. If it is missing or empty, stop and ask for a real cut; route users to storyboard or script-to-timeline work instead. Snapshot the timeline before editing with `create_timeline_version`.

--- a/packages/system-skills/color-motion/SKILL.md
+++ b/packages/system-skills/color-motion/SKILL.md
@@ -9,6 +9,10 @@ Two separate jobs: the colours you author into shapes and type, and the grade yo
 apply over picture. They meet in the animated grade channels, which are the only
 colour values on a timeline that move.
 
+`motion-graphics` carries the op contract for the calls named here.
+`motion-direction` decides whether colour is one of the channels this piece
+moves at all.
+
 ## Build a restrained palette
 
 One primary, one accent, two or three neutrals. Get depth from lightness and

--- a/packages/system-skills/commercial-beat-sheet/SKILL.md
+++ b/packages/system-skills/commercial-beat-sheet/SKILL.md
@@ -304,7 +304,7 @@ const timeline = await assemble_storyboard_timeline({
 });
 ```
 
-From here the normal timeline tools take over: audio, music, color, captions.
+From here the normal timeline tools take over, and each has a skill: `motion-graphics` for the op contract, `beat-sync-editing` to put the cuts on the music bed and ramp the hit, `caption-titles` for the supers and the CTA card, `logo-reveal` for the end mark, and `color-motion` for the grade that makes the beats cut together. Load `motion-direction` first if the spot needs one motion language across every beat.
 
 ---
 

--- a/packages/system-skills/explainer-storyboard/SKILL.md
+++ b/packages/system-skills/explainer-storyboard/SKILL.md
@@ -49,3 +49,7 @@ Create the storyboard with `create_storyboard({ name, brief, style, aspect_ratio
 Attach roster ids with `edit_storyboard({ storyboard_id, ops: [{ op: "set_board", entity_ids }] })`. `set_board` is the entity operation; `set_entities` does not exist. Add one shot per beat with `edit_storyboard` and an `add_shot` op. The dense `action` field names the teaching job, visible entity names in brackets, on-screen text, and UI demonstration. Every named entity must exist, and every external generation prompt must apply the ids for every entity visible in that shot.
 
 Stop after the planned board unless the user explicitly requests rendering or a cut. Report the directions, chosen board, and entity roster.
+
+## When the board becomes motion
+
+When a cut is asked for, `motion-graphics` carries the timeline tool contract and routes to the craft skill for the job: `caption-titles` for the on-screen text and callouts this beat sheet already specifies, `frame-composition` for where a UI mock sits and whether it survives 9:16, `motion-direction` to hold one motion language across the mechanism beats, and `beat-sync-editing` when the cut has to sit on a music bed. The half-beat of silence after the aha is a hold, not a gap — keep it in the cut.

--- a/packages/system-skills/launch-commercial/SKILL.md
+++ b/packages/system-skills/launch-commercial/SKILL.md
@@ -209,7 +209,7 @@ Every line must come back `voiced`. A `stale` or `no_voice` line is a defect, no
 
 ```js
 import { assemble_storyboard_timeline } from "@nodetool-ai/sandbox-nodetool/storyboards";
-import { edit_timeline, validate_timeline } from "@nodetool-ai/sandbox-nodetool/timelines";
+import { edit_timeline, preview_timeline_frame, validate_timeline } from "@nodetool-ai/sandbox-nodetool/timelines";
 import { generate_music } from "@nodetool-ai/sandbox-nodetool/media";
 ```
 
@@ -217,8 +217,10 @@ import { generate_music } from "@nodetool-ai/sandbox-nodetool/media";
 2. **Standardize aspect here** — this is where mixed plate ratios get resolved. Pad the black-heavy minimal frames, crop the full-bleed ones. Say which you did to which.
 3. Voice track, aligned to beats.
 4. Music bed at the spot's exact runtime, ducked under VO, with the beat sheet's deliberate pre-CTA silence kept silent.
-5. **Overrun check.** Video models overshoot requested durations. If the cut runs long, trim the **last** clip — trimming an earlier one opens a gap and leaves the runtime unchanged.
-6. `validate_timeline` must come back ok. Fix and re-validate.
+5. **Motion and text.** Supers, the CTA card and the end mark are a text layer over the cut, never a render prompt — no model is asked to letter them. `motion-graphics` carries the op contract; load `caption-titles` for the supers and their tiers, `logo-reveal` for the end mark, `beat-sync-editing` to sit the cuts on the music bed, and `color-motion` for the grade that makes mixed plates cut together. `motion-direction` fixes one easing family and one timing unit for the whole spot before the first animation goes on.
+6. **Overrun check.** Video models overshoot requested durations. If the cut runs long, trim the **last** clip — trimming an earlier one opens a gap and leaves the runtime unchanged.
+7. `validate_timeline` must come back ok. Fix and re-validate.
+8. Look at frames, not at the document: `preview_timeline_frame` at each cut and each text entry. A change nobody looked at is not done.
 
 ---
 

--- a/packages/system-skills/motion-background/SKILL.md
+++ b/packages/system-skills/motion-background/SKILL.md
@@ -8,6 +8,10 @@ description: Build an ambient looping backdrop on a NodeTool timeline — gradie
 A background that draws attention has failed. Slow, low contrast, seamless, and
 cheap enough that the picture in front of it still composites.
 
+`motion-graphics` carries the op contract for the calls named here.
+`color-motion` chooses the palette the bed is built from, and `motion-curves`
+writes the loop when no wrapping preset holds the seam.
+
 ## Pick the cheapest thing that reads
 
 | Look | Build it from | Cost |

--- a/packages/system-skills/motion-curves/SKILL.md
+++ b/packages/system-skills/motion-curves/SKILL.md
@@ -9,6 +9,10 @@ description: Write custom timeline animations — keyframe curves by hand, or a 
 `code` (a JS body baked into curves once, host-side). Add `mask` when a curve
 drives `wipeProgress`.
 
+`motion-graphics` carries the op contract and the preset catalog this file is
+the escape hatch from. `motion-principles` gives the duration and the shape a
+curve should hit before you write its keyframes.
+
 ## When to write one
 
 Write curves as soon as a preset is close but not right. The catalog is seven

--- a/packages/system-skills/music-video-treatment/SKILL.md
+++ b/packages/system-skills/music-video-treatment/SKILL.md
@@ -26,3 +26,7 @@ For each section, provide timecode and bar range, musical and visual jobs, frami
 Create a storyboard with `create_storyboard({ name, brief, style, aspect_ratio })`, using `storyboard_id` from its result. Put the full brief, lyrics, section map, bar grid, and roster in `brief`. Attach entity ids with `edit_storyboard({ storyboard_id, ops: [{ op: "set_board", entity_ids }] })`; `set_entities` does not exist. Add one `add_shot` op per section. Each action names visible entities in brackets, includes its sync point, and uses the section duration rounded to 0.5 seconds.
 
 Stop at the planned board unless asked to render. Report the directions, selected treatment, and entity roster.
+
+## When the treatment becomes a cut
+
+The bar grid computed above is the plan; `beat-sync-editing` derives the real one from the track with `detect_audio_events` and snaps the cuts to it, so the two must agree before anything is trimmed. `motion-graphics` carries the timeline op contract, `color-motion` the per-section grade and any colour that moves on the drop, `frame-composition` the repeated hook framing across choruses, and `caption-titles` any lyric or artist card on screen.


### PR DESCRIPTION
## What changed

The motion skills only pay off when the skill an agent already loaded says they exist, and nine of the fourteen shipped skills never mentioned them. Four craft skills (`caption-titles`, `color-motion`, `motion-background`, `motion-curves`) named no neighbour, so a reader who landed on one had no route to `motion-graphics` for the op contract or to the file holding its numbers; each now opens with that route, the way `beat-sync-editing` and `frame-composition` already did. The four board skills stopped at the board, which is how a finished board gets animated against a guessed op list: `explainer-storyboard` and `music-video-treatment` gain the step where the board becomes a cut, `commercial-beat-sheet` names a skill per timeline job where it used to say "the normal timeline tools take over", and `launch-commercial` — the one that actually assembles — gets motion and text as a numbered step in Phase 7, ahead of the overrun trim and the validate, plus the frame it has to look at afterwards. `caption-titles` also joins `SKILL_NAMES` in the skill-name test: it quotes `insert_composition` and `create_timeline_version` like any craft skill and was the one shipped timeline skill whose calls nothing checked. The board skills stay out of that test, and the README now says why — each names `set_entities` in order to say the op does not exist, which the check reads as a typo.

## Verification

- [x] `npm run test:affected` — packages leg green except `@nodetool-ai/chat` `tests/index.test.ts > exports all public API`, which times out at 60s only when turbo runs workspaces in parallel on this container and passes on its own (`npm run test --workspace=packages/chat` → 4 files, 30 tests passed). The diff is Markdown plus one array entry in an `agents` test, so it cannot reach chat's import time. The web and electron legs were not reached because turbo stopped on that timeout; both are selected only because the `agents` *workspace* changed, and no web or electron file is touched.
- [x] `npm run typecheck`
- [x] `npm run lint` (design-token and media-src rule fixtures pass; the two pre-existing `no-unused-vars` warnings in `web/src/components/node/` are untouched)
- [x] `npm run dev:nodetool -- harness gate --base origin/main` → `Gate: 1/1 selfchecks passed`, 261/261 graphs validate. (`--base main` fails with `no merge base` in this checkout, which has no local `main` ref.)

Also run: `npm run build:packages` clean, after an `npm install --ignore-scripts` — the container's `node_modules` predated `packages/browser`, so `automation-nodes` could not resolve it. The lockfile churn that install produced was reverted; it is not in this diff.

## New checks

- [x] The widened check was inverted once and observed failing. Renaming `insert_composition` to `insert_compositionz` in `caption-titles`:

  ```
  × caption-titles names only capabilities and edit_timeline ops that exist
  AssertionError: named in the skill but registered nowhere:
    expected [ 'insert_compositionz' ] to deeply equal []
  Tests  1 failed | 12 passed (13)
  ```

  Restored afterwards; the skill is unchanged in the diff apart from its two added lines.
- [x] The audit asserts it found its targets: the per-skill case already requires `named.length > 0`, so `caption-titles` passing means calls were read out of it rather than the filter matching nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jfu1D4NeTZEQNgLuJWR8QZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jfu1D4NeTZEQNgLuJWR8QZ)_