### PR TITLE
Track only what needs tracking, and make erasure mechanical

### DIFF
--- a/marketing/src/app/privacy/layout.tsx
+++ b/marketing/src/app/privacy/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Privacy Policy | NodeTool",
   description:
-    "How NodeTool collects, processes, and protects your personal data. GDPR-compliant privacy policy for nodetool.ai and the NodeTool desktop application.",
+    "How NodeTool collects, processes, and protects your personal data. GDPR privacy policy for nodetool.ai, the NodeTool desktop application, and the hosted service at app.nodetool.ai.",
   alternates: {
     canonical: "/privacy",
   },

--- a/marketing/src/app/privacy/page.tsx
+++ b/marketing/src/app/privacy/page.tsx
@@ -1,8 +1,33 @@
 import Link from "next/link";
 
+/*
+  DRAFT — NOT LEGAL ADVICE. This policy must be reviewed by a qualified data
+  protection advisor before it is published.
+
+  Items a human must confirm before this page goes live:
+  1. Signed Art. 28 data processing agreements with Fly.io, Supabase,
+     Cloudflare, Plausible, the email provider, and every AI provider offered
+     in the hosted service. This page states that such agreements are in
+     place; that fact is not verifiable from the repository.
+  2. The transfer mechanism actually relied on per non-EU recipient
+     (adequacy / EU-U.S. Data Privacy Framework certification / SCCs).
+  3. The Supabase project region. `fly.toml` documents the app's primary
+     region as `fra` and notes the database sits in AWS eu-central-1, but the
+     Supabase project settings are the authority.
+  4. The 14-day server-log figure. It is a commitment we make, not a setting
+     read from Fly.io or Cloudflare configuration in this repository.
+  5. Sections 5, 6, 10 and 11 describe the hosted service's activity log,
+     data export and account deletion. Do not publish this page before those
+     ship — at the time of writing they are being implemented in `packages/`.
+  6. That the retention sweep is actually switched on for the hosted
+     deployment (`NODETOOL_STORAGE_AUTO_CLEANUP=1`). Section 11 promises run
+     history and snapshots expire on a schedule; without that flag the sweep
+     only runs when someone triggers it.
+*/
+
 export const dynamic = "force-static";
 
-const LAST_UPDATED = "2 May 2026";
+const LAST_UPDATED = "3 September 2026";
 
 export default function PrivacyPage() {
   return (
@@ -27,9 +52,10 @@ export default function PrivacyPage() {
           <p>
             This Privacy Policy explains how we process personal data when you
             visit <strong>nodetool.ai</strong>, use the <strong>NodeTool</strong>{" "}
-            desktop application, or contact us. We follow the EU General Data
-            Protection Regulation (GDPR) and the German Federal Data Protection
-            Act (BDSG).
+            desktop application, use the hosted service at{" "}
+            <strong>app.nodetool.ai</strong>, or contact us. We follow the EU
+            General Data Protection Regulation (GDPR) and the German Federal
+            Data Protection Act (BDSG).
           </p>
 
           <h2>1. Controller</h2>
@@ -38,31 +64,62 @@ export default function PrivacyPage() {
             Art. 4 (7) GDPR is the NodeTool team. You can reach us at{" "}
             <a href="mailto:hello@nodetool.ai">hello@nodetool.ai</a> for any
             privacy-related question, including requests to exercise your rights
-            described in section 9.
+            described in section 10.
           </p>
 
-          <h2>2. Local-first by design</h2>
+          <h2>2. Two ways to run NodeTool</h2>
           <p>
-            NodeTool is an open-source desktop application that runs on your own
-            machine. Workflows, prompts, model files, generated outputs, API
-            keys and other content you create stay on your device. We do not
-            collect, sync or transmit this data to our servers. If you choose
-            to connect third-party AI providers (OpenAI, Anthropic, Replicate,
-            Hugging Face, etc.), your prompts and inputs are sent directly from
-            your device to those providers under their own terms and privacy
-            policies.
+            NodeTool is open-source software that you can run in two different
+            places. What we process depends entirely on which one you use, so
+            read this section first — the rest of the policy refers back to it.
           </p>
 
-          <h2>3. Data we process when you visit nodetool.ai</h2>
+          <h3>2.1 Desktop and self-hosted installs</h3>
+          <p>
+            The NodeTool desktop application runs on your own machine, and the
+            same server code can be run on infrastructure you control.
+            Workflows, prompts, model files, generated outputs, API keys and
+            other content you create are stored on that machine — in a local
+            database and local files — and stay there. We do not collect, sync
+            or transmit that content to our servers. If you connect third-party
+            AI providers (OpenAI, Anthropic, Replicate, Hugging Face, and
+            others), your prompts and inputs are sent from your machine directly
+            to those providers under their own terms and privacy policies; we
+            are not a party to that exchange.
+          </p>
+          <p>
+            Two things do leave your machine. The desktop application checks
+            GitHub Releases for updates, which tells GitHub your IP address,
+            platform and installed version. And any provider you connect
+            receives whatever you send it. Product analytics are not loaded in
+            the desktop application at all.
+          </p>
+          <p>
+            If you host the NodeTool server yourself, you are the controller for
+            the data it stores. This policy describes our own operation of the
+            hosted service, not yours.
+          </p>
+
+          <h3>2.2 The hosted service (app.nodetool.ai)</h3>
+          <p>
+            The hosted service is a web application we operate. It requires an
+            account, and the local-first description above does not apply to
+            it. Your workflows, chats, generated assets and connected
+            credentials are stored on our servers, and calls to AI providers are
+            made <em>by our servers</em> rather than from your device. Sections
+            5, 6, 7, 8, 9 and 11 describe that processing.
+          </p>
+
+          <h2>3. Data we process when you visit our websites</h2>
           <h3>3.1 Server logs</h3>
           <p>
             When you load a page, our hosting provider temporarily processes
             technical data needed to deliver the site: IP address, user agent,
             referrer, requested URL, response status and timestamp. This data
             is processed on the legal basis of our legitimate interest in
-            operating a secure, stable website (Art. 6 (1) (f) GDPR) and is
-            deleted or anonymised within 14 days unless we need to retain
-            specific entries to investigate a security incident.
+            operating a secure, stable website (Art. 6 (1) (f) GDPR). We keep it
+            no longer than 14 days unless we need specific entries to
+            investigate a security incident.
           </p>
 
           <h3>3.2 Privacy-friendly analytics (Plausible)</h3>
@@ -75,20 +132,28 @@ export default function PrivacyPage() {
             >
               Plausible Analytics
             </a>{" "}
-            to understand aggregate traffic patterns. Plausible is hosted in
-            the EU, does not use cookies and does not collect personal data or
-            cross-site identifiers. IP addresses are processed transiently to
-            generate a daily, salted hash and are never stored. Because no
+            to understand aggregate traffic patterns, on the marketing site
+            (nodetool.ai) and on the hosted application (app.nodetool.ai).
+            Plausible states that its service is hosted in the EU, sets no
+            cookies, and collects no personal data and no cross-site
+            identifiers; IP addresses are processed transiently to generate a
+            daily, salted hash and are not stored. On the marketing site the
+            script additionally counts outbound link clicks, file downloads and
+            a fixed set of named events such as a download or a demo view. These
+            are aggregate counts and are not linked to an account. Because no
             personal data is processed, no consent is required (Art. 6 (1) (f)
-            GDPR — legitimate interest in measuring product reach).
+            GDPR — legitimate interest in measuring product reach). Analytics
+            are not loaded in the desktop application.
           </p>
 
           <h3>3.3 Cookies and local storage</h3>
           <p>
-            The marketing website does not set advertising or tracking cookies.
-            We may use strictly necessary local storage for UI preferences such
-            as theme. Strictly necessary storage does not require consent under
-            § 25 (2) Nr. 2 TDDDG.
+            We do not set advertising or tracking cookies on any of our sites.
+            The marketing site may use strictly necessary local storage for UI
+            preferences such as theme. The hosted application stores your
+            sign-in session in your browser so you stay logged in. Strictly
+            necessary storage does not require consent under § 25 (2) Nr. 2
+            TDDDG.
           </p>
 
           <h2>4. Data we process when you contact us</h2>
@@ -104,35 +169,138 @@ export default function PrivacyPage() {
             with statutory retention periods.
           </p>
 
-          <h2>5. Optional cloud services</h2>
+          <h2>5. Data stored in a hosted account</h2>
           <p>
-            Some parts of the NodeTool ecosystem (for example a hosted runner,
-            account features, or future cloud sync) may be offered as opt-in
-            services. Where such services exist, the data they process is
-            described in service-specific terms presented at sign-up. By
-            default, no account is required to use NodeTool.
-          </p>
-
-          <h2>6. Hosting and data location</h2>
-          <p>
-            We host our infrastructure on EU-based providers. Persistent
-            application data is stored in <strong>Frankfurt, Germany</strong>.
-            Edge requests for static content may be served from a global CDN;
-            in that case only the technical data described in 3.1 is
-            processed at the edge, on the basis of standard contractual
-            clauses where applicable.
-          </p>
-
-          <h2>7. Recipients and processors</h2>
-          <p>
-            We use carefully selected processors who act only on our
-            documented instructions under data processing agreements (Art. 28
-            GDPR), including:
+            This section applies to the hosted service only. Everything below is
+            stored under your account identifier and is separated from other
+            users&apos; data.
           </p>
           <ul>
             <li>
-              <strong>Hosting / CDN</strong> — delivery of nodetool.ai (EU
-              region, Frankfurt for persistent storage).
+              <strong>Account identity</strong> — the account identifier issued
+              by our authentication provider, your email address, and any
+              sign-in or messaging identities you link to the account. Legal
+              basis: Art. 6 (1) (b) GDPR (necessary to provide the service you
+              signed up for).
+            </li>
+            <li>
+              <strong>Content you author</strong> — workflows and their version
+              history, projects, apps and scripts, storyboards, timeline
+              sequences, image documents, workspace files and your settings.
+              Legal basis: Art. 6 (1) (b) GDPR.
+            </li>
+            <li>
+              <strong>Chat and agent memory</strong> — conversation threads and
+              the messages in them, including message text, files you attach,
+              and the tool calls the agent made. Separately, the agent records
+              memories — short notes, facts, preferences and decisions — so it
+              can reuse them in later sessions. You can read and delete these in
+              the product. Legal basis: Art. 6 (1) (b) GDPR.
+            </li>
+            <li>
+              <strong>Generated assets</strong> — images, video, audio and other
+              files produced by your runs, together with their file metadata.
+              Legal basis: Art. 6 (1) (b) GDPR.
+            </li>
+            <li>
+              <strong>Run and spend records</strong> — records of each workflow
+              run (the graph and parameters it ran with, status, timing, errors
+              and logs) and one record per media or model generation, holding
+              the provider and model used, the parameters sent to that provider,
+              token counts and the resulting cost. These records are what your
+              spend view and your plan usage are calculated from. Legal basis:
+              Art. 6 (1) (b) GDPR (service delivery and billing).
+            </li>
+            <li>
+              <strong>Credentials you connect</strong> — provider API keys and
+              OAuth tokens for the services you link, and access tokens you
+              create for API or agent access. Provider keys and OAuth tokens are
+              encrypted before they are stored (see section 12). Legal basis:
+              Art. 6 (1) (b) GDPR.
+            </li>
+            <li>
+              <strong>Plan and usage records</strong> — which plan the account
+              is on, and the record of usage allowances granted and consumed.
+              Legal basis: Art. 6 (1) (b) GDPR.
+            </li>
+            <li>
+              <strong>Security and activity events</strong> — described in
+              section 6. Legal basis: Art. 6 (1) (f) GDPR.
+            </li>
+          </ul>
+
+          <h2>6. Security and activity log</h2>
+          <p>
+            The hosted service keeps a log of security-relevant account activity
+            so that we can investigate suspected account compromise and
+            reconstruct who changed something that other people can see. It
+            records three kinds of events:
+          </p>
+          <ul>
+            <li>
+              authentication and credential events — signing in and out,
+              creating or revoking an access token, linking or unlinking a
+              sign-in identity;
+            </li>
+            <li>
+              actions that cannot be undone or that reach outside your account —
+              deleting a workflow or an asset, storing or revoking a provider
+              credential, sharing or unsharing a workflow, deploying,
+              publishing or unpublishing an app;
+            </li>
+            <li>
+              consent given or withdrawn, acceptance of our terms, and requests
+              you make under section 10 (export, erasure).
+            </li>
+          </ul>
+          <p>
+            What this log does not contain is as important as what it does. It
+            is not behavioural tracking: there are no page views, clicks,
+            feature-usage counters or session recordings tied to your account,
+            and no prompt, message, asset or workflow content is written to it.
+            It records that an action of a given kind happened, by which
+            account, to which item, and when. It holds no IP address, no
+            browser user agent and no free-text field.
+          </p>
+          <p>
+            Legal basis: Art. 6 (1) (f) GDPR — our legitimate interest in
+            keeping accounts secure and in being able to account for changes to
+            shared resources. We consider this interest not to be overridden by
+            your interests because the log is limited to the event categories
+            listed above and excludes content. Records of consent and of
+            data-subject requests are additionally kept as evidence that we met
+            our obligations (Art. 5 (2), Art. 6 (1) (c) GDPR). You can object to
+            processing based on legitimate interests under Art. 21 GDPR; see
+            section 10.
+          </p>
+
+          <h2>7. Hosting and data location</h2>
+          <p>
+            The hosted application server runs on <strong>Fly.io</strong> with
+            its primary region in <strong>Frankfurt, Germany</strong>. The
+            database, authentication and asset storage behind it are provided by{" "}
+            <strong>Supabase</strong>, configured on European infrastructure in
+            the Frankfurt region. The marketing site nodetool.ai is served from{" "}
+            <strong>Cloudflare</strong>&apos;s edge network, which is global; only
+            the technical data described in 3.1 is processed at the edge.
+          </p>
+
+          <h2>8. Recipients and processors</h2>
+          <p>
+            We use selected processors who act on our documented instructions
+            under data processing agreements (Art. 28 GDPR), including:
+          </p>
+          <ul>
+            <li>
+              <strong>Fly.io</strong> — runs the hosted application server
+              (Frankfurt region).
+            </li>
+            <li>
+              <strong>Supabase</strong> — database, authentication and asset
+              storage for the hosted service.
+            </li>
+            <li>
+              <strong>Cloudflare</strong> — delivery and caching of nodetool.ai.
             </li>
             <li>
               <strong>Plausible Analytics</strong> (Plausible Insights OÜ,
@@ -143,23 +311,48 @@ export default function PrivacyPage() {
               messages you send us.
             </li>
             <li>
-              <strong>GitHub</strong> — for our open-source repository,
-              issues, and downloads, when you choose to use those services.
+              <strong>GitHub</strong> — our open-source repository, issues,
+              downloads and desktop application updates.
             </li>
           </ul>
           <p>
-            We do not sell personal data, and we do not use your data to train
-            machine-learning models.
+            <strong>AI and media providers.</strong> In the hosted service, a
+            run that calls a model sends the prompt, the inputs you supplied and
+            the run parameters from our servers to the provider you selected.
+            The categories are: language-model providers (for example OpenAI,
+            Anthropic, Google, Mistral, Groq, Cohere, DeepSeek, xAI), image,
+            video, audio and 3D generation providers (for example Replicate,
+            FAL, kie, ElevenLabs), model hosts and routers (for example Hugging
+            Face, OpenRouter, Together), embedding and reranking services, and
+            web-search services used by agents. Which of them receive anything
+            depends on the models and tools you choose; a provider you never
+            select receives nothing. On the desktop application these calls go
+            from your own machine instead, as described in 2.1.
           </p>
-
-          <h2>8. International transfers</h2>
           <p>
-            Where a processor is located outside the EU/EEA, we rely on an
-            adequacy decision or, where none exists, on EU Standard Contractual
-            Clauses together with appropriate supplementary measures.
+            We do not sell personal data, and we do not use your data to train
+            machine-learning models. Providers process content under their own
+            terms; check those terms before sending confidential material to a
+            provider.
           </p>
 
-          <h2>9. Your rights</h2>
+          <h2>9. International transfers</h2>
+          <p>
+            Several of the recipients named in section 8 are established outside
+            the EU/EEA, principally in the United States. In the hosted service
+            we are the exporter for those transfers, because the call to the
+            provider is made by our servers rather than from your device.
+          </p>
+          <p>
+            Where a recipient is outside the EU/EEA, we rely on an adequacy
+            decision where one covers that recipient, and otherwise on EU
+            Standard Contractual Clauses together with appropriate supplementary
+            measures. For a current list of the recipients relevant to your
+            account and the mechanism relied on for each, write to{" "}
+            <a href="mailto:hello@nodetool.ai">hello@nodetool.ai</a>.
+          </p>
+
+          <h2>10. Your rights</h2>
           <p>Under the GDPR you have the right to:</p>
           <ul>
             <li>access your personal data (Art. 15);</li>
@@ -176,7 +369,15 @@ export default function PrivacyPage() {
             </li>
           </ul>
           <p>
-            To exercise any of these rights, write to{" "}
+            In the hosted service you can act on two of these yourself, without
+            asking us. <strong>Export</strong> produces a machine-readable copy
+            of the data held in your account. <strong>Delete account</strong>{" "}
+            erases your account and the content stored under it, subject to the
+            retention exceptions in section 11. Both are in the account settings
+            of the application.
+          </p>
+          <p>
+            For anything else — or if you would rather we did it — write to{" "}
             <a href="mailto:hello@nodetool.ai">hello@nodetool.ai</a>. You also
             have the right to lodge a complaint with a data protection
             supervisory authority, in particular the authority of your habitual
@@ -184,32 +385,67 @@ export default function PrivacyPage() {
             (Art. 77 GDPR).
           </p>
 
-          <h2>10. Retention</h2>
+          <h2>11. Retention</h2>
           <p>
-            We keep personal data only for as long as necessary for the
-            purposes for which it was collected and to comply with legal
-            obligations. Server logs: ≤ 14 days. Analytics events: aggregated
-            and non-personal. Email correspondence: as long as required to
-            address your matter, plus any statutory retention period.
+            We keep personal data only for as long as necessary for the purposes
+            for which it was collected and to comply with legal obligations.
           </p>
+          <ul>
+            <li>
+              <strong>Server logs</strong> — 14 days or less.
+            </li>
+            <li>
+              <strong>Analytics events</strong> — aggregated and non-personal.
+            </li>
+            <li>
+              <strong>Email correspondence</strong> — as long as required to
+              address your matter, plus any statutory retention period.
+            </li>
+            <li>
+              <strong>Content you author in a hosted account</strong> —
+              workflows, chats, memories, assets and files are kept until you
+              delete them or close the account.
+            </li>
+            <li>
+              <strong>Run history and workflow version snapshots</strong> —
+              removed on the retention schedule configured for your account in
+              Settings, which covers autosaved snapshots, older manual versions
+              and finished run records.
+            </li>
+            <li>
+              <strong>Security and activity events</strong> (section 6) — 180
+              days.
+            </li>
+            <li>
+              <strong>Consent records and records of data-subject requests</strong>{" "}
+              — kept as evidence that we met our legal obligations, beyond the
+              deletion of the account they relate to.
+            </li>
+            <li>
+              <strong>Billing records</strong> — kept for the statutory periods
+              that apply to them, which can outlast an account.
+            </li>
+          </ul>
 
-          <h2>11. Security</h2>
+          <h2>12. Security</h2>
           <p>
             We use TLS for all traffic, restrict administrative access on a
-            need-to-know basis, keep dependencies up to date, and follow
-            current best practices for the technologies we use. No system is
-            perfectly secure; if you believe you have found a vulnerability,
-            please report it to{" "}
+            need-to-know basis, keep dependencies up to date, and follow current
+            best practices for the technologies we use. Provider API keys and
+            OAuth tokens stored in a hosted account are encrypted with AES-256-GCM
+            under a key derived per user, so they are not readable from the
+            database alone. No system is perfectly secure; if you believe you
+            have found a vulnerability, please report it to{" "}
             <a href="mailto:hello@nodetool.ai">hello@nodetool.ai</a>.
           </p>
 
-          <h2>12. Children</h2>
+          <h2>13. Children</h2>
           <p>
             NodeTool is not directed at children under 16 and we do not
             knowingly collect personal data from them.
           </p>
 
-          <h2>13. Changes to this policy</h2>
+          <h2>14. Changes to this policy</h2>
           <p>
             We may update this policy to reflect changes in our services or
             legal obligations. Material changes will be highlighted on this

--- a/marketing/src/data/providerCatalog.generated.ts
+++ b/marketing/src/data/providerCatalog.generated.ts
@@ -31,13 +31,13 @@ export interface ProviderCatalog {
 export const providerCatalog: Record<string, ProviderCatalog> = {
   "fal_ai": {
     "id": "fal_ai",
-    "total": 1560,
+    "total": 1562,
     "counts": {
       "3d": 60,
       "image": 736,
       "audio": 127,
       "text": 18,
-      "video": 619
+      "video": 621
     },
     "topTags": [
       "generation",

--- a/packages/config/src/__tests__/retention.test.ts
+++ b/packages/config/src/__tests__/retention.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { isAutomaticStorageCleanupEnabled } from "../retention.js";
+
+describe("isAutomaticStorageCleanupEnabled", () => {
+  it("is off when the variable is unset", () => {
+    expect(isAutomaticStorageCleanupEnabled({})).toBe(false);
+  });
+
+  it("is on for 1 and true", () => {
+    expect(
+      isAutomaticStorageCleanupEnabled({ NODETOOL_STORAGE_AUTO_CLEANUP: "1" })
+    ).toBe(true);
+    expect(
+      isAutomaticStorageCleanupEnabled({
+        NODETOOL_STORAGE_AUTO_CLEANUP: " TRUE "
+      })
+    ).toBe(true);
+  });
+
+  it("is off for 0, false, and anything else", () => {
+    for (const value of ["0", "false", "", "yes please"]) {
+      expect(
+        isAutomaticStorageCleanupEnabled({
+          NODETOOL_STORAGE_AUTO_CLEANUP: value
+        })
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -21,6 +21,8 @@ export { isAuthEnforced } from "./deployment.js";
 
 export { isGoogleWorkspaceEnabled } from "./google-workspace.js";
 
+export { isAutomaticStorageCleanupEnabled } from "./retention.js";
+
 export {
   registerSetting,
   getSettings,

--- a/packages/config/src/retention.ts
+++ b/packages/config/src/retention.ts
@@ -1,0 +1,21 @@
+/**
+ * Whether this server expires personal data on its own schedule.
+ *
+ * A local install keeps its history until the person using the machine asks for
+ * a cleanup — that machine is theirs, and silently deleting their run history
+ * would surprise them. A hosted deployment is the opposite case: it holds other
+ * people's data under a published retention promise, so the sweep has to run
+ * without anyone pressing a button.
+ *
+ * Set `NODETOOL_STORAGE_AUTO_CLEANUP=1` (or `true`) to run the retention sweep
+ * automatically. Unset, or `0`/`false`, keeps the manual behaviour.
+ */
+import { safeProcessEnv } from "./node-import.js";
+
+/** Whether the storage retention sweep should run without being asked. */
+export function isAutomaticStorageCleanupEnabled(
+  env: Record<string, string | undefined> = safeProcessEnv()
+): boolean {
+  const value = env["NODETOOL_STORAGE_AUTO_CLEANUP"]?.trim().toLowerCase();
+  return value === "1" || value === "true";
+}

--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -678,6 +678,17 @@ const TABLE_COLUMNS = {
     content: "text",
     created_at: "text",
     updated_at: "text"
+  },
+  // Privacy-scoped audit log. No ip_address, no user_agent and no free-text
+  // column, on purpose — see schema/user-events.ts.
+  nodetool_user_events: {
+    id: "text",
+    user_id: "text",
+    event_type: "text",
+    subject_type: "text",
+    subject_id: "text",
+    metadata: "text",
+    created_at: "text"
   }
 } satisfies Record<string, Record<string, string>>;
 
@@ -1469,6 +1480,18 @@ function getCreateSchemaSql(): string {
     );
     CREATE INDEX IF NOT EXISTS "idx_mcp_oauth_token_grant" ON "mcp_oauth_tokens" ("grant_id");
     CREATE UNIQUE INDEX IF NOT EXISTS "idx_mcp_oauth_token_rotated_from" ON "mcp_oauth_tokens" ("rotated_from");
+
+    CREATE TABLE IF NOT EXISTS "nodetool_user_events" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL,
+      "event_type" text NOT NULL,
+      "subject_type" text,
+      "subject_id" text,
+      "metadata" text,
+      "created_at" text NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS "idx_user_event_user_created" ON "nodetool_user_events" ("user_id", "created_at");
+    CREATE INDEX IF NOT EXISTS "idx_user_event_type_created" ON "nodetool_user_events" ("event_type", "created_at");
   `;
 }
 

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -47,7 +47,8 @@ export {
   triggerInputs,
   runInboxMessages,
   triggerRegistrations,
-  externalIdentities
+  externalIdentities,
+  userEvents
 } from "./schema/index.js";
 
 // ── Drizzle Schema (PostgreSQL) ─────────────────────────────────────
@@ -323,6 +324,27 @@ export { AccessToken, isAccessToken, parseAccessToken, ACCESS_TOKEN_PREFIX } fro
 export type { MintedAccessToken, CreateAccessTokenParams } from "./access-token.js";
 export { ExternalIdentity } from "./external-identity.js";
 export type { LinkExternalIdentityParams } from "./external-identity.js";
+export {
+  DEFAULT_USER_EVENT_RETENTION_DAYS,
+  MAX_USER_EVENT_STRING_LENGTH,
+  NEVER_PRUNED_USER_EVENT_TYPES,
+  USER_EVENT_METADATA_ALLOWLIST,
+  UserEventType,
+  deleteUserEventsForUser,
+  isNeverPrunedUserEventType,
+  isUserEventType,
+  listUserEvents,
+  pruneUserEvents,
+  recordUserEvent,
+  sanitizeUserEventMetadata
+} from "./user-event.js";
+export type {
+  ListUserEventsOptions,
+  RecordUserEventInput,
+  UserEventMetadata,
+  UserEventMetadataValue,
+  UserEventRow
+} from "./user-event.js";
 export {
   McpOauthClient,
   McpOauthGrant,

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -86,6 +86,36 @@ export type {
   StorageCleanupResult
 } from "./storage-maintenance.js";
 
+// ── Personal data: Art. 17 erasure and Art. 20 portability ───────────
+export {
+  PERSONAL_DATA_REGISTRY,
+  PERSONAL_DATA_BY_TABLE,
+  WITHHELD_VALUE,
+  isActionable
+} from "./personal-data-registry.js";
+export type {
+  PersonalDataDisposition,
+  PersonalDataEntry,
+  PersonalDataReach
+} from "./personal-data-registry.js";
+export {
+  ERASURE_HANDLED_TABLES,
+  ERASURE_STEPS,
+  EXPORT_HANDLERS,
+  actionableEntries,
+  erasePersonalData,
+  exportPersonalData
+} from "./personal-data.js";
+export type {
+  ErasureObjectStore,
+  ErasureOptions,
+  ErasureReport,
+  PersonalDataExport,
+  PersonalDataExportOptions,
+  PersonalDataExportTable,
+  TableErasureReport
+} from "./personal-data.js";
+
 export { Workflow } from "./workflow.js";
 export type {
   AccessLevel,

--- a/packages/models/src/migrations/versions.ts
+++ b/packages/models/src/migrations/versions.ts
@@ -3251,6 +3251,48 @@ export const migrations: MigrationDef[] = [
       await db.execute("DROP INDEX IF EXISTS idx_prediction_job");
       // Columns stay: dropping them is unsafe across dialects and versions.
     }
+  },
+
+  // ── Create nodetool_user_events ─────────────────────────────────────
+  // A narrow, privacy-scoped audit log keyed by user id: auth and credential
+  // changes, irreversible or outward-facing actions, and consent/policy/DSR
+  // events. Behavioral analytics is deliberately out of scope and stays
+  // aggregate in Plausible. No ip_address, no user_agent, no free-text
+  // column — see schema/user-events.ts for why each is absent.
+  {
+    version: "20260903_000001",
+    name: "create_user_events",
+    createsTables: ["nodetool_user_events"],
+    modifiesTables: [],
+    async up(db) {
+      await db.execute(`
+        CREATE TABLE IF NOT EXISTS nodetool_user_events (
+          id TEXT PRIMARY KEY NOT NULL,
+          user_id TEXT NOT NULL,
+          event_type TEXT NOT NULL,
+          subject_type TEXT,
+          subject_id TEXT,
+          metadata TEXT,
+          created_at TEXT NOT NULL
+        )
+      `);
+      // Serves the erasure and export range scans.
+      await db.execute(`
+        CREATE INDEX IF NOT EXISTS idx_user_event_user_created
+        ON nodetool_user_events (user_id, created_at)
+      `);
+      // Serves the retention sweep, which walks by type because the
+      // consent/policy/DSR types are never pruned.
+      await db.execute(`
+        CREATE INDEX IF NOT EXISTS idx_user_event_type_created
+        ON nodetool_user_events (event_type, created_at)
+      `);
+    },
+    async down(db) {
+      await db.execute("DROP INDEX IF EXISTS idx_user_event_user_created");
+      await db.execute("DROP INDEX IF EXISTS idx_user_event_type_created");
+      await db.execute("DROP TABLE IF EXISTS nodetool_user_events");
+    }
   }
 ];
 

--- a/packages/models/src/personal-data-registry.ts
+++ b/packages/models/src/personal-data-registry.ts
@@ -1,0 +1,540 @@
+/**
+ * The personal-data registry — one row per database table, and what happens to
+ * it when a person exercises Art. 17 (erasure) or Art. 20 (portability).
+ *
+ * This file is the policy document. Someone answering a regulator should be
+ * able to read it top to bottom and explain the whole disposition of the
+ * database without opening another file: which tables hold personal data, how
+ * the person is reached in each, what is deleted, what is kept and under which
+ * lawful basis, and what is deliberately withheld from an export.
+ *
+ * It is a registry rather than a hand-written delete list for the reason
+ * hand-written delete lists always rot: nobody remembers to add the table.
+ * Three things keep it honest, and all three live in
+ * `tests/personal-data-audit.test.ts`:
+ *
+ * 1. Every table exported from `src/schema/index.ts` must appear here exactly
+ *    once. A new table with no entry fails the audit with its name.
+ * 2. A table that has a `user_id` column must be reached directly by it and
+ *    must not be classified `not-personal`. Adding a user-keyed table and
+ *    filing it as infrastructure fails.
+ * 3. Every actionable entry must be wired into `ERASURE_HANDLERS` and, when
+ *    `exported` is true, into `EXPORT_HANDLERS` in `personal-data.ts`. An
+ *    entry added here and never implemented fails.
+ *
+ * The audit asserts it *found* tables before it asserts anything about them,
+ * so a broken schema walk cannot pass by matching nothing.
+ *
+ * Modelled on `PACKAGE_RUNTIME_ASSETS` (`@nodetool-ai/config`) and the URL
+ * egress inventory (`packages/runtime/tests/url-egress-inventory.ts`), which
+ * are the two registries in this repo that already work this way.
+ */
+
+/**
+ * What erasure does to a table. Erasure is not uniformly "delete the row" —
+ * a billing record has to survive its statutory accounting period, and the
+ * consent log is our own proof that consent was given.
+ */
+export type PersonalDataDisposition =
+  /** Remove the rows. The default for content a person authored or generated. */
+  | "delete"
+  /** Keep the row, null the columns that carry personal content. */
+  | "redact"
+  /** Keep the row intact under a lawful basis that outlives the request. */
+  | "retain"
+  /** Keep the row, replace the identifiers so it no longer names a person. */
+  | "anonymize"
+  /** No personal data. Nothing to erase, nothing to export. */
+  | "not-personal";
+
+/**
+ * How the person is reached from the table.
+ *
+ * `direct` names the column carrying the user id — usually `user_id`, but
+ * `nodetool_workflow_shares` calls it `created_by`. `indirect` means the row
+ * is only reachable through a join, which is exactly the case a naive
+ * `WHERE user_id = ?` sweep silently misses.
+ */
+export type PersonalDataReach =
+  | { readonly kind: "direct"; readonly column: string }
+  | {
+      readonly kind: "indirect";
+      /** The column joined on, e.g. "run_id". */
+      readonly column: string;
+      /** The user-keyed table it resolves against, e.g. "nodetool_jobs". */
+      readonly parent: string;
+    }
+  | { readonly kind: "none" };
+
+export interface PersonalDataEntry {
+  /** Physical table name, as `getTableName()` reports it. */
+  readonly table: string;
+  /** The `src/schema/index.ts` export the audit resolves the table through. */
+  readonly schemaExport: string;
+  readonly disposition: PersonalDataDisposition;
+  readonly reach: PersonalDataReach;
+  /**
+   * Columns nulled by a `redact`. Required for that disposition, rejected for
+   * every other one, and each name is checked against the live schema.
+   */
+  readonly redactedColumns?: readonly string[];
+  /**
+   * Columns replaced by a placeholder in an Art. 20 export. Credential
+   * material: a ciphertext, a hash, a bearer token. The column is still
+   * *listed*, so the person can see the record exists — its value never
+   * leaves the process.
+   */
+  readonly withheldColumns?: readonly string[];
+  /** False when the table contributes nothing to an Art. 20 export. */
+  readonly exported: boolean;
+  /** Why this disposition, in a sentence a non-engineer can check. */
+  readonly justification: string;
+}
+
+/**
+ * The placeholder an export writes in place of a withheld column's value.
+ * Distinct from `null`, which would misrepresent an absent value as stored.
+ */
+export const WITHHELD_VALUE = "[withheld: credential material]";
+
+export const PERSONAL_DATA_REGISTRY: readonly PersonalDataEntry[] = [
+  // ── Identity, credentials and consent ──────────────────────────────
+
+  {
+    table: "access_tokens",
+    schemaExport: "accessTokens",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    withheldColumns: ["secret_hash"],
+    exported: true,
+    justification:
+      "API tokens the person minted. Deleted so no credential outlives the account. The hash is a credential verifier, not information about the person, so the export lists the token and withholds the hash."
+  },
+  {
+    table: "external_identities",
+    schemaExport: "externalIdentities",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "The link between this account and a Google/GitHub identity. It identifies the person at a third party, so it goes; the export tells them which providers were linked."
+  },
+  {
+    table: "nodetool_oauth_credentials",
+    schemaExport: "oauthCredentials",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    withheldColumns: ["encrypted_access_token", "encrypted_refresh_token"],
+    exported: true,
+    justification:
+      "Access to the person's third-party accounts. Deleted outright. The export names the provider, account and scope so they can revoke on the other side, but never the tokens — decrypting them into a downloadable file would create a fresh copy of a live credential."
+  },
+  {
+    table: "nodetool_secrets",
+    schemaExport: "secrets",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    withheldColumns: ["encrypted_value"],
+    exported: true,
+    justification:
+      "Provider API keys, encrypted at rest under the master key (see `Secret.getDecryptedValue`). The export lists which keys existed by name and description — that is the portable fact — and withholds the ciphertext."
+  },
+  {
+    table: "mcp_oauth_grants",
+    schemaExport: "mcpOauthGrants",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "One row per MCP client the person consented to. Deleted with the account; exported because the consent record is theirs and shows what each client was allowed to reach."
+  },
+  {
+    table: "mcp_oauth_tokens",
+    schemaExport: "mcpOauthTokens",
+    disposition: "delete",
+    reach: { kind: "indirect", column: "grant_id", parent: "mcp_oauth_grants" },
+    exported: false,
+    justification:
+      "Access and refresh tokens hanging off a grant. No user_id of its own — a sweep keyed on user_id leaves live tokens behind after the grant is gone, so it is deleted by grant id first. Not exported: every column is a hash, an expiry or a rotation pointer, which tells the person nothing and hands an attacker the shape of the credential chain."
+  },
+  {
+    table: "mcp_oauth_clients",
+    schemaExport: "mcpOauthClients",
+    disposition: "not-personal",
+    reach: { kind: "none" },
+    exported: false,
+    justification:
+      "A dynamically registered OAuth client (RFC 7591): name plus redirect URIs, with no owner column. The registration is shared — several people can consent to the same client — so deleting it on one person's request would break other people's grants. Their personal half is `mcp_oauth_grants`, which is deleted."
+  },
+  {
+    table: "nodetool_user_events",
+    schemaExport: "userEvents",
+    disposition: "retain",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "The privacy audit log. Erasure deletes the operational half (sign-ins, token issuance, delete/share audit rows) and keeps the types in `NEVER_PRUNED_USER_EVENT_TYPES` — consent, terms and the data-subject-request rows — for the same reason `pruneUserEvents` refuses to age them out: Art. 7(1) requires being able to demonstrate consent was given, and the DSR rows are our own evidence that the request was received and answered. Deleting them would destroy the proof that this erasure happened. `purgeComplianceEvidence` overrides it for a closed account with legal sign-off."
+  },
+
+  // ── Billing and accounting ─────────────────────────────────────────
+
+  {
+    table: "nodetool_predictions",
+    schemaExport: "predictions",
+    disposition: "redact",
+    reach: { kind: "direct", column: "user_id" },
+    redactedColumns: ["parameters", "metadata", "logs"],
+    exported: true,
+    justification:
+      "The billing ledger for model calls: cost, tokens, provider, model, unit price. Those columns are accounting records kept under Art. 17(3)(b) for the statutory retention period, so the row survives. `parameters`, `metadata` and `logs` carry prompt text and provider payloads and have no accounting purpose, so they are nulled. This is the same redaction the retention sweep performs; erasure reuses `cleanupStorage` rather than re-deriving it."
+  },
+  {
+    table: "nodetool_credit_ledger",
+    schemaExport: "creditLedger",
+    disposition: "retain",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Double-entry balance movements. An accounting record under Art. 17(3)(b); removing entries would leave the balance unreconcilable. Every column is an amount, a kind, a period key or a timestamp — there is no free text to redact, so the row is kept whole."
+  },
+  {
+    table: "nodetool_user_subscriptions",
+    schemaExport: "userSubscriptions",
+    disposition: "retain",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Which plan the account was on and its status. Contract and accounting evidence, retained on the same basis as the ledger it explains. Plan id and status are not content."
+  },
+
+  // ── Workflows and the graph editor ─────────────────────────────────
+
+  {
+    table: "nodetool_workflows",
+    schemaExport: "workflows",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "The person's authored graphs. Their content, deleted on request and exported in full."
+  },
+  {
+    table: "nodetool_workflow_versions",
+    schemaExport: "workflowVersions",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Version history of those graphs. Same content, older revisions — the copy the retention sweep prunes on a timer is deleted outright here."
+  },
+  {
+    table: "nodetool_workflow_collaborators",
+    schemaExport: "workflowCollaborators",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Membership rows, in both directions. Erasure removes the rows where this person is the collaborator, and also the rows on this person's own workflows — those name *other* people and must not be left pointing at a deleted graph. The export is deliberately narrower: only rows whose user_id is the subject, because the other rows are other people's memberships and are not this person's to receive."
+  },
+  {
+    table: "nodetool_workflow_shares",
+    schemaExport: "workflowShares",
+    disposition: "delete",
+    reach: { kind: "direct", column: "created_by" },
+    withheldColumns: ["token"],
+    exported: true,
+    justification:
+      "Public share links. No `user_id` column — the owner is `created_by`, which a user_id sweep misses, leaving live share tokens for deleted workflows. Erasure deletes both by `created_by` and by the workflow ids being deleted. `token` is a live bearer credential and is withheld from the export."
+  },
+
+  // ── Runs, jobs and their exhaust ───────────────────────────────────
+
+  {
+    table: "nodetool_jobs",
+    schemaExport: "jobs",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Run records: the graph as executed, its parameters, logs and errors. The person's own activity, deleted and exported."
+  },
+  {
+    table: "run_events",
+    schemaExport: "runEvents",
+    disposition: "delete",
+    reach: { kind: "indirect", column: "run_id", parent: "nodetool_jobs" },
+    exported: true,
+    justification:
+      "Per-node event payloads — the inputs a person typed and the outputs a model produced, at full fidelity. The heaviest personal-data surface in the database and it has no user_id: it is reached by `run_id` against `nodetool_jobs`. Deleted before the jobs it hangs off, or the join that finds it is gone."
+  },
+  {
+    table: "run_inbox_messages",
+    schemaExport: "runInboxMessages",
+    disposition: "delete",
+    reach: { kind: "indirect", column: "run_id", parent: "nodetool_jobs" },
+    exported: false,
+    justification:
+      "The queue a running graph pulls messages from; `payload_json` can hold user content. Deleted by run id for the same reason as `run_events`. Not exported: it is transport state with claim leases and worker ids, and the content it carried is already in `run_events` in its delivered form."
+  },
+  {
+    table: "trigger_inputs",
+    schemaExport: "triggerInputs",
+    disposition: "delete",
+    reach: { kind: "indirect", column: "run_id", parent: "nodetool_jobs" },
+    exported: true,
+    justification:
+      "The payload that started a run — an inbound webhook body, a polled item. Personal data supplied by or about the person, reached by `run_id`. Exported because it is data they provided."
+  },
+  {
+    table: "trigger_registrations",
+    schemaExport: "triggerRegistrations",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Standing triggers the person configured. Deleted, or a deleted account keeps firing runs. Exported so they can rebuild them elsewhere."
+  },
+
+  // ── Assets, chat and documents ─────────────────────────────────────
+
+  {
+    table: "nodetool_assets",
+    schemaExport: "assets",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Rows describing stored files. The bytes are a second surface: objects live under the `<user_id>/` key prefix and are removed through the injected `ErasureObjectStore`, because deleting the row without the blob leaves the media readable by anyone holding a URL. The export carries the metadata; the bytes are delivered as files, not inlined."
+  },
+  {
+    table: "nodetool_threads",
+    schemaExport: "threads",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Chat threads the person started. Deleted with the messages inside them; a thread row left behind names a conversation that no longer exists."
+  },
+  {
+    table: "nodetool_messages",
+    schemaExport: "messages",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Chat messages, including everything they typed and every model reply. Their content in the most direct sense."
+  },
+  {
+    table: "nodetool_memories",
+    schemaExport: "memories",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Facts the agent retained about the person across sessions. Exactly the profile Art. 17 exists for."
+  },
+  {
+    table: "nodetool_settings",
+    schemaExport: "appSettings",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Per-user preferences. Not sensitive, but keyed to the person and with no reason to outlive them."
+  },
+  {
+    table: "nodetool_workspaces",
+    schemaExport: "workspaces",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Named workspace roots. The row is a pointer; the files under it are removed with the rest of the person's objects."
+  },
+  {
+    table: "projects",
+    schemaExport: "projects",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "The person's project folders — the container the documents, scripts and storyboards below hang off. Deleted after them, so nothing is orphaned."
+  },
+  {
+    table: "skills",
+    schemaExport: "skills",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification: "Skill documents the person wrote, content and all."
+  },
+  {
+    table: "scripts",
+    schemaExport: "scripts",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification: "Screenplay documents the person authored."
+  },
+  {
+    table: "storyboards",
+    schemaExport: "storyboards",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification: "Storyboard documents the person authored."
+  },
+  {
+    table: "js_scripts",
+    schemaExport: "jsScripts",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "JavaScript documents the person wrote. Authored content, deleted on request and exported in full."
+  },
+  {
+    table: "js_script_versions",
+    schemaExport: "jsScriptVersions",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Revision history of those JavaScript documents. Same content, older revisions, deleted with the document rather than left behind by the cascade."
+  },
+  {
+    table: "image_documents",
+    schemaExport: "imageDocuments",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification: "Sketch/image editor documents the person authored."
+  },
+  {
+    table: "image_document_versions",
+    schemaExport: "imageDocumentVersions",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Revision history of those image documents. Deleted explicitly rather than through the declared cascade, which SQLite only enforces when `PRAGMA foreign_keys` is on for that connection."
+  },
+  {
+    table: "timeline_sequences",
+    schemaExport: "timelineSequences",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Video timelines the person edited, including the full timeline document. Authored content."
+  },
+  {
+    table: "timeline_sequence_versions",
+    schemaExport: "timelineSequenceVersions",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Revision history of those timelines. Deleted explicitly for the same reason as the other version tables: the cascade is not guaranteed on a SQLite connection."
+  },
+
+  // ── Published applications ─────────────────────────────────────────
+
+  {
+    table: "applications",
+    schemaExport: "applications",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Mini-apps the person built. Deleted last among the application tables, so a failure part-way leaves the app whole rather than half-erased — the ordering `Application.delete` already uses, because the child rows carry no owner of their own and a leftover child is readable by whoever next claims the id."
+  },
+  {
+    table: "application_versions",
+    schemaExport: "applicationVersions",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Released versions, each holding the app document and its workflow graphs. Deleted explicitly rather than relying on the declared cascade: `PRAGMA foreign_keys` is per-connection and a connection opened without it silently keeps the children."
+  },
+  {
+    table: "application_deployments",
+    schemaExport: "applicationDeployments",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    withheldColumns: ["token"],
+    exported: true,
+    justification:
+      "Deployment records for a published app. The `token` is a live bearer credential for invoking it, so it is withheld from the export and the row is deleted."
+  },
+  {
+    table: "application_invocations",
+    schemaExport: "applicationInvocations",
+    disposition: "delete",
+    reach: { kind: "direct", column: "user_id" },
+    exported: true,
+    justification:
+      "Per-run spend telemetry for the person's own app: estimate, actual, status. Deleted with the app rather than retained, because the money side is already recorded in `nodetool_credit_ledger` and `nodetool_predictions`, which do survive — keeping a third copy would retain more than the accounting basis needs."
+  },
+  {
+    table: "application_budgets",
+    schemaExport: "applicationBudgets",
+    disposition: "delete",
+    reach: {
+      kind: "indirect",
+      column: "application_id",
+      parent: "applications"
+    },
+    exported: true,
+    justification:
+      "The spend ceiling for one app. Keyed only by `application_id`, so a user_id sweep misses it and leaves an orphan budget row; erasure resolves it through the person's applications."
+  },
+
+  // ── Infrastructure: no personal data ───────────────────────────────
+
+  {
+    table: "worker_profiles",
+    schemaExport: "workerProfiles",
+    disposition: "not-personal",
+    reach: { kind: "none" },
+    exported: false,
+    justification:
+      "A reusable preset for provisioning a GPU worker: image, hardware spec, timeouts. Operator configuration shared by the whole install, with no column naming a person."
+  },
+  {
+    table: "worker_instances",
+    schemaExport: "workerInstances",
+    disposition: "not-personal",
+    reach: { kind: "none" },
+    exported: false,
+    justification:
+      "A live handle to a provisioned pod: provider reference, websocket URL, encrypted pod token, status. `attached_to` names the device a pod is bound to, not an account. Instances are ephemeral and torn down by the compute reaper; erasing one on a person's request would kill a running pod that may not be theirs."
+  },
+  {
+    table: "nodetool_team_tasks",
+    schemaExport: "teamTasks",
+    disposition: "not-personal",
+    reach: { kind: "none" },
+    exported: false,
+    justification:
+      "The agent team task board. `created_by` and `claimed_by` name an agent within a team, not an authenticated account, and there is no user_id or team-to-user mapping to reach a person by. No code in this repo writes the table today — the only references are the schema, the migration and the DDL. Revisit the classification in the same change that adds a writer: if tasks become user-attributable, this becomes a `delete` entry."
+  }
+];
+
+/** Registry entries indexed by physical table name. */
+export const PERSONAL_DATA_BY_TABLE: ReadonlyMap<string, PersonalDataEntry> =
+  new Map(PERSONAL_DATA_REGISTRY.map((entry) => [entry.table, entry]));
+
+/** Dispositions that require erasure to do something to the table. */
+const ACTIONABLE: readonly PersonalDataDisposition[] = [
+  "delete",
+  "redact",
+  "retain",
+  "anonymize"
+];
+
+/** True when erasure must handle this table rather than skip it. */
+export function isActionable(entry: PersonalDataEntry): boolean {
+  return ACTIONABLE.includes(entry.disposition);
+}

--- a/packages/models/src/personal-data.ts
+++ b/packages/models/src/personal-data.ts
@@ -1,0 +1,884 @@
+/**
+ * Art. 17 erasure and Art. 20 export, driven by {@link PERSONAL_DATA_REGISTRY}.
+ *
+ * Nothing here decides policy. The registry says what happens to each table
+ * and why; this file is the walk that carries it out. Every step is keyed by
+ * table name, and `tests/personal-data-audit.test.ts` requires those keys to
+ * match the registry — a table registered but never wired up fails there,
+ * which is the point of having a registry at all.
+ *
+ * Four things to know before changing this file:
+ *
+ * - **Ids are collected before the first delete.** `run_events`,
+ *   `run_inbox_messages` and `trigger_inputs` carry no `user_id`; they are
+ *   reached through `nodetool_jobs.user_id`. `collectContext` reads those job
+ *   ids up front, so deleting the jobs cannot leave the rows orphaned and
+ *   unreachable, still holding prompt text. Make that lookup lazy and it can.
+ * - **Children run before parents** so the counts are true. Several child
+ *   tables declare `ON DELETE CASCADE`; deleting `applications` first would
+ *   take `application_versions` with it and the versions step would then
+ *   report zero rows for work it did do. It is also the order
+ *   `Application.delete` uses, and for its reason too: a failure part-way
+ *   leaves the parent whole rather than half-erased.
+ * - **Prediction redaction is not reimplemented.** `cleanupStorage` already
+ *   nulls `parameters`/`metadata`/`logs` while keeping the billing columns.
+ *   Erasure calls it with the retention horizon pushed past every row, which
+ *   is the same operation with the clock moved rather than a second copy of
+ *   the rule.
+ * - **Blobs are a second surface, behind an interface.** `packages/models`
+ *   does not depend on `@nodetool-ai/storage`; the caller injects an
+ *   {@link ErasureObjectStore}. Deleting the asset row without the object
+ *   leaves the media readable to anyone holding a URL.
+ */
+
+import { and, count, eq, inArray, notInArray, type SQL } from "drizzle-orm";
+import type { SQLiteColumn, SQLiteTable } from "drizzle-orm/sqlite-core";
+
+import { getDb } from "./db.js";
+import {
+  PERSONAL_DATA_REGISTRY,
+  WITHHELD_VALUE,
+  isActionable,
+  type PersonalDataDisposition,
+  type PersonalDataEntry,
+  type PersonalDataReach
+} from "./personal-data-registry.js";
+import {
+  cleanupStorage,
+  type StorageRetentionPolicy
+} from "./storage-maintenance.js";
+import {
+  NEVER_PRUNED_USER_EVENT_TYPES,
+  UserEventType,
+  deleteUserEventsForUser,
+  recordUserEvent
+} from "./user-event.js";
+
+import { accessTokens } from "./schema/access-tokens.js";
+import {
+  applicationBudgets,
+  applicationInvocations
+} from "./schema/application-budgets.js";
+import { applicationDeployments } from "./schema/application-deployments.js";
+import { applications, applicationVersions } from "./schema/applications.js";
+import { assets } from "./schema/assets.js";
+import { creditLedger, userSubscriptions } from "./schema/credits.js";
+import { externalIdentities } from "./schema/external-identities.js";
+import { imageDocumentVersions } from "./schema/image-document-versions.js";
+import { imageDocuments } from "./schema/image-documents.js";
+import { jobs } from "./schema/jobs.js";
+import { jsScriptVersions } from "./schema/js-script-versions.js";
+import { jsScripts } from "./schema/js-scripts.js";
+import { mcpOauthGrants, mcpOauthTokens } from "./schema/mcp-oauth.js";
+import { memories } from "./schema/memories.js";
+import { messages } from "./schema/messages.js";
+import { oauthCredentials } from "./schema/oauth-credentials.js";
+import { predictions } from "./schema/predictions.js";
+import { projects } from "./schema/projects.js";
+import { runEvents } from "./schema/run-events.js";
+import { runInboxMessages } from "./schema/run-inbox-messages.js";
+import { scripts } from "./schema/scripts.js";
+import { secrets } from "./schema/secrets.js";
+import { appSettings } from "./schema/settings.js";
+import { skills } from "./schema/skills.js";
+import { storyboards } from "./schema/storyboards.js";
+import { threads } from "./schema/threads.js";
+import { timelineSequenceVersions } from "./schema/timeline-sequence-versions.js";
+import { timelineSequences } from "./schema/timeline-sequences.js";
+import { triggerInputs } from "./schema/trigger-inputs.js";
+import { triggerRegistrations } from "./schema/trigger-registrations.js";
+import { userEvents } from "./schema/user-events.js";
+import { workflowCollaborators, workflowShares } from "./schema/workflow-sharing.js";
+import { workflowVersions } from "./schema/workflow-versions.js";
+import { workflows } from "./schema/workflows.js";
+import { workspaces as workspacesSchema } from "./schema/workspaces.js";
+
+/** Any column on a schema table — what the generic helpers filter on. */
+type TableColumn = SQLiteColumn;
+
+// ── Object storage seam ───────────────────────────────────────────────
+
+/**
+ * The blob half of erasure, injected so `@nodetool-ai/models` keeps no
+ * dependency on `@nodetool-ai/storage`.
+ *
+ * One method, taking the user id rather than a key prefix, because the key
+ * layout belongs to the storage package: objects live at
+ * `<userId>/<assetId>.<ext>` today, and older deployments still hold flat
+ * `<assetId>.<ext>` keys from before the owner prefix existed. Passing a
+ * prefix down here would freeze that layout into the persistence layer.
+ *
+ * A `StorageAdapter` satisfies it in a few lines at the call site:
+ *
+ * ```ts
+ * const store: ErasureObjectStore = {
+ *   async deleteObjectsForUser(userId) {
+ *     const { entries } = await adapter.list(`${userId}/`);
+ *     const gone: string[] = [];
+ *     for (const entry of entries) {
+ *       if (await adapter.delete(entry.uri)) gone.push(entry.key);
+ *     }
+ *     return gone;
+ *   }
+ * };
+ * ```
+ */
+export interface ErasureObjectStore {
+  /** Delete every stored object owned by `userId`; return the keys removed. */
+  deleteObjectsForUser(userId: string): Promise<readonly string[]>;
+}
+
+// ── Reports ───────────────────────────────────────────────────────────
+
+export interface TableErasureReport {
+  readonly table: string;
+  readonly disposition: PersonalDataDisposition;
+  /** Rows removed by this pass. */
+  readonly deleted: number;
+  /** Rows whose personal columns were nulled by this pass. */
+  readonly redacted: number;
+  /** Rows deliberately left in place, and still there when it finished. */
+  readonly retained: number;
+}
+
+export interface ErasureReport {
+  readonly userId: string;
+  readonly completedAt: string;
+  readonly tables: readonly TableErasureReport[];
+  readonly deleted: number;
+  readonly redacted: number;
+  readonly retained: number;
+  /**
+   * Object keys removed from blob storage, or `null` when no
+   * {@link ErasureObjectStore} was injected — which means the DB rows are
+   * gone and the bytes are not, so the caller has to say what it did.
+   */
+  readonly objectKeysDeleted: readonly string[] | null;
+}
+
+export interface ErasureOptions {
+  /** Blob storage to sweep. Omit and the report says the bytes were skipped. */
+  readonly objectStore?: ErasureObjectStore;
+  /**
+   * Also delete the consent, terms and data-subject-request events that
+   * erasure otherwise keeps as evidence. Off by default: those rows are the
+   * proof that consent was given and that this request was answered. Turn it
+   * on only for a closed account with legal sign-off.
+   */
+  readonly purgeComplianceEvidence?: boolean;
+  /**
+   * Ties the `data_erasure_completed` audit event to the request that caused
+   * it. Omit and no completion event is recorded.
+   */
+  readonly requestId?: string;
+}
+
+// ── Small helpers ─────────────────────────────────────────────────────
+
+const CHUNK = 400;
+
+function chunks<T>(items: readonly T[], size = CHUNK): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+async function countRows(
+  table: SQLiteTable,
+  where: SQL | undefined
+): Promise<number> {
+  const [row] = await getDb()
+    .select({ value: count() })
+    .from(table)
+    .where(where);
+  return Number((row as { value: number } | undefined)?.value ?? 0);
+}
+
+/**
+ * Count, then delete. The count is read first because SQLite and PostgreSQL
+ * report affected rows differently — the same reason `deleteUserEventsForUser`
+ * does it this way.
+ */
+async function deleteRows(
+  table: SQLiteTable,
+  where: SQL | undefined
+): Promise<number> {
+  const total = await countRows(table, where);
+  if (total === 0) return 0;
+  await getDb().delete(table).where(where);
+  return total;
+}
+
+/** Delete by a foreign key, in batches, tolerating an empty id list. */
+async function deleteByIds(
+  table: SQLiteTable,
+  column: TableColumn,
+  ids: readonly string[]
+): Promise<number> {
+  let total = 0;
+  for (const batch of chunks(ids)) {
+    total += await deleteRows(table, inArray(column, batch));
+  }
+  return total;
+}
+
+async function selectIds(
+  table: SQLiteTable,
+  column: TableColumn,
+  where: SQL
+): Promise<string[]> {
+  const rows = await getDb().select({ id: column }).from(table).where(where);
+  return (rows as { id: string }[]).map((row) => row.id);
+}
+
+function deleted(
+  table: string,
+  disposition: PersonalDataDisposition,
+  n: number
+): TableErasureReport {
+  return { table, disposition, deleted: n, redacted: 0, retained: 0 };
+}
+
+// ── Erasure steps ─────────────────────────────────────────────────────
+
+interface ErasureContext {
+  readonly userId: string;
+  /** Job ids, which are the run ids `run_events` and friends hang off. */
+  readonly runIds: readonly string[];
+  readonly applicationIds: readonly string[];
+  readonly grantIds: readonly string[];
+  readonly workflowIds: readonly string[];
+  readonly options: ErasureOptions;
+}
+
+interface ErasureStep {
+  readonly table: string;
+  run(ctx: ErasureContext): Promise<TableErasureReport>;
+}
+
+/** Every id the walk needs, read before the first delete makes it unreachable. */
+async function collectContext(
+  userId: string,
+  options: ErasureOptions
+): Promise<ErasureContext> {
+  return {
+    userId,
+    runIds: await selectIds(jobs, jobs.id, eq(jobs.user_id, userId)),
+    applicationIds: await selectIds(
+      applications,
+      applications.id,
+      eq(applications.user_id, userId)
+    ),
+    grantIds: await selectIds(
+      mcpOauthGrants,
+      mcpOauthGrants.id,
+      eq(mcpOauthGrants.user_id, userId)
+    ),
+    workflowIds: await selectIds(
+      workflows,
+      workflows.id,
+      eq(workflows.user_id, userId)
+    ),
+    options
+  };
+}
+
+/** Erasure is the retention sweep with its horizon moved past every row. */
+const ERASURE_HORIZON = new Date("9999-01-01T00:00:00.000Z");
+
+const ERASURE_RETENTION_POLICY: StorageRetentionPolicy = {
+  maxAutosavesPerWorkflow: 0,
+  autosaveRetentionDays: 1,
+  manualVersionRetentionDays: 1,
+  terminalJobRetentionDays: 1,
+  runEventRetentionDays: 1,
+  predictionRetentionDays: 1,
+  automaticCleanup: false
+};
+
+/** A table erased by one `WHERE <column> = <userId>`. */
+function directStep(
+  table: string,
+  sqlTable: SQLiteTable,
+  column: TableColumn
+): ErasureStep {
+  return {
+    table,
+    async run(ctx) {
+      return deleted(
+        table,
+        "delete",
+        await deleteRows(sqlTable, eq(column, ctx.userId))
+      );
+    }
+  };
+}
+
+/** A table erased through a parent's ids. */
+function indirectStep(
+  table: string,
+  sqlTable: SQLiteTable,
+  column: TableColumn,
+  ids: (ctx: ErasureContext) => readonly string[]
+): ErasureStep {
+  return {
+    table,
+    async run(ctx) {
+      return deleted(table, "delete", await deleteByIds(sqlTable, column, ids(ctx)));
+    }
+  };
+}
+
+/**
+ * Ordered: children first, then the parent, then the tables kept on a lawful
+ * basis. See the file header for why the order and the up-front id collection
+ * are separate concerns.
+ */
+export const ERASURE_STEPS: readonly ErasureStep[] = [
+  // Run exhaust, reached through the jobs that are still present.
+  indirectStep("run_events", runEvents, runEvents.run_id, (c) => c.runIds),
+  indirectStep(
+    "run_inbox_messages",
+    runInboxMessages,
+    runInboxMessages.run_id,
+    (c) => c.runIds
+  ),
+  indirectStep(
+    "trigger_inputs",
+    triggerInputs,
+    triggerInputs.run_id,
+    (c) => c.runIds
+  ),
+  directStep("nodetool_jobs", jobs, jobs.user_id),
+  directStep(
+    "trigger_registrations",
+    triggerRegistrations,
+    triggerRegistrations.user_id
+  ),
+
+  // Applications: children first, the app itself last.
+  indirectStep(
+    "application_budgets",
+    applicationBudgets,
+    applicationBudgets.application_id,
+    (c) => c.applicationIds
+  ),
+  directStep(
+    "application_invocations",
+    applicationInvocations,
+    applicationInvocations.user_id
+  ),
+  directStep(
+    "application_versions",
+    applicationVersions,
+    applicationVersions.user_id
+  ),
+  directStep(
+    "application_deployments",
+    applicationDeployments,
+    applicationDeployments.user_id
+  ),
+  directStep("applications", applications, applications.user_id),
+
+  // Credentials and consent.
+  indirectStep(
+    "mcp_oauth_tokens",
+    mcpOauthTokens,
+    mcpOauthTokens.grant_id,
+    (c) => c.grantIds
+  ),
+  directStep("mcp_oauth_grants", mcpOauthGrants, mcpOauthGrants.user_id),
+  directStep("access_tokens", accessTokens, accessTokens.user_id),
+  directStep(
+    "external_identities",
+    externalIdentities,
+    externalIdentities.user_id
+  ),
+  directStep(
+    "nodetool_oauth_credentials",
+    oauthCredentials,
+    oauthCredentials.user_id
+  ),
+  directStep("nodetool_secrets", secrets, secrets.user_id),
+
+  // Sharing, then the workflows the shares point at.
+  {
+    table: "nodetool_workflow_shares",
+    async run(ctx) {
+      // Two sweeps: links this person created, and links on this person's
+      // workflows that someone else created. Leaving the second behind would
+      // keep a live token for a graph that no longer exists.
+      let total = await deleteRows(
+        workflowShares,
+        eq(workflowShares.created_by, ctx.userId)
+      );
+      total += await deleteByIds(
+        workflowShares,
+        workflowShares.workflow_id,
+        ctx.workflowIds
+      );
+      return deleted("nodetool_workflow_shares", "delete", total);
+    }
+  },
+  {
+    table: "nodetool_workflow_collaborators",
+    async run(ctx) {
+      // This person's memberships elsewhere, plus everyone's membership of
+      // this person's graphs — those rows name other people, but they point
+      // at graphs about to be deleted.
+      let total = await deleteRows(
+        workflowCollaborators,
+        eq(workflowCollaborators.user_id, ctx.userId)
+      );
+      total += await deleteByIds(
+        workflowCollaborators,
+        workflowCollaborators.workflow_id,
+        ctx.workflowIds
+      );
+      return deleted("nodetool_workflow_collaborators", "delete", total);
+    }
+  },
+  directStep(
+    "nodetool_workflow_versions",
+    workflowVersions,
+    workflowVersions.user_id
+  ),
+  directStep("nodetool_workflows", workflows, workflows.user_id),
+
+  // Content the person authored.
+  directStep("nodetool_assets", assets, assets.user_id),
+  directStep("nodetool_messages", messages, messages.user_id),
+  directStep("nodetool_threads", threads, threads.user_id),
+  directStep("nodetool_memories", memories, memories.user_id),
+  directStep("nodetool_settings", appSettings, appSettings.user_id),
+  directStep("nodetool_workspaces", workspacesSchema, workspacesSchema.user_id),
+  directStep("projects", projects, projects.user_id),
+  directStep("skills", skills, skills.user_id),
+  directStep("scripts", scripts, scripts.user_id),
+  directStep("storyboards", storyboards, storyboards.user_id),
+  directStep("js_script_versions", jsScriptVersions, jsScriptVersions.user_id),
+  directStep("js_scripts", jsScripts, jsScripts.user_id),
+  directStep(
+    "image_document_versions",
+    imageDocumentVersions,
+    imageDocumentVersions.user_id
+  ),
+  directStep("image_documents", imageDocuments, imageDocuments.user_id),
+  directStep(
+    "timeline_sequence_versions",
+    timelineSequenceVersions,
+    timelineSequenceVersions.user_id
+  ),
+  directStep("timeline_sequences", timelineSequences, timelineSequences.user_id),
+
+  // Kept on a lawful basis that outlives the request.
+  {
+    table: "nodetool_predictions",
+    async run(ctx) {
+      // `cleanupStorage` owns this redaction. Running it at a horizon past
+      // every row redacts all of them; by this point the jobs and versions it
+      // also prunes are already gone, so it reports only the predictions.
+      const result = await cleanupStorage(
+        ctx.userId,
+        ERASURE_RETENTION_POLICY,
+        ERASURE_HORIZON
+      );
+      return {
+        table: "nodetool_predictions",
+        disposition: "redact",
+        deleted: 0,
+        redacted: result.redactedPredictions,
+        retained: await countRows(
+          predictions,
+          eq(predictions.user_id, ctx.userId)
+        )
+      };
+    }
+  },
+  {
+    table: "nodetool_credit_ledger",
+    async run(ctx) {
+      return {
+        table: "nodetool_credit_ledger",
+        disposition: "retain",
+        deleted: 0,
+        redacted: 0,
+        retained: await countRows(
+          creditLedger,
+          eq(creditLedger.user_id, ctx.userId)
+        )
+      };
+    }
+  },
+  {
+    table: "nodetool_user_subscriptions",
+    async run(ctx) {
+      return {
+        table: "nodetool_user_subscriptions",
+        disposition: "retain",
+        deleted: 0,
+        redacted: 0,
+        retained: await countRows(
+          userSubscriptions,
+          eq(userSubscriptions.user_id, ctx.userId)
+        )
+      };
+    }
+  },
+  {
+    table: "nodetool_user_events",
+    async run(ctx) {
+      // Last, so the operational events written by the deletes above are
+      // swept too. The consent/terms/DSR types stay: they are the evidence
+      // that consent was given and that this erasure was performed, and
+      // `pruneUserEvents` refuses to age them out for the same reason.
+      if (ctx.options.purgeComplianceEvidence === true) {
+        const gone = await deleteUserEventsForUser(ctx.userId);
+        return {
+          table: "nodetool_user_events",
+          disposition: "retain",
+          deleted: gone,
+          redacted: 0,
+          retained: 0
+        };
+      }
+      const operational = and(
+        eq(userEvents.user_id, ctx.userId),
+        notInArray(userEvents.event_type, [...NEVER_PRUNED_USER_EVENT_TYPES])
+      );
+      const gone = await deleteRows(userEvents, operational);
+      return {
+        table: "nodetool_user_events",
+        disposition: "retain",
+        deleted: gone,
+        redacted: 0,
+        retained: await countRows(
+          userEvents,
+          eq(userEvents.user_id, ctx.userId)
+        )
+      };
+    }
+  }
+];
+
+// ── The two entry points ──────────────────────────────────────────────
+
+/**
+ * Erase one person's data, everywhere the registry says it lives.
+ *
+ * Idempotent: a second call finds nothing to delete and reports zeros, and
+ * the redaction stops matching once the payload columns are null. Safe to
+ * retry after a partial failure.
+ */
+export async function erasePersonalData(
+  userId: string,
+  options: ErasureOptions = {}
+): Promise<ErasureReport> {
+  if (!userId) throw new Error("erasePersonalData requires a user id");
+
+  const ctx = await collectContext(userId, options);
+  const tables: TableErasureReport[] = [];
+  for (const step of ERASURE_STEPS) {
+    tables.push(await step.run(ctx));
+  }
+
+  const objectKeysDeleted = options.objectStore
+    ? [...(await options.objectStore.deleteObjectsForUser(userId))]
+    : null;
+
+  const totals = tables.reduce(
+    (acc, row) => ({
+      deleted: acc.deleted + row.deleted,
+      redacted: acc.redacted + row.redacted,
+      retained: acc.retained + row.retained
+    }),
+    { deleted: 0, redacted: 0, retained: 0 }
+  );
+
+  if (options.requestId) {
+    // Written after the sweep, so it survives it. This row is the evidence
+    // the erasure happened, which is why the sweep above keeps its type.
+    await recordUserEvent({
+      userId,
+      eventType: UserEventType.DATA_ERASURE_COMPLETED,
+      metadata: {
+        request_id: options.requestId,
+        rows_deleted: totals.deleted
+      }
+    });
+  }
+
+  return {
+    userId,
+    completedAt: new Date().toISOString(),
+    tables,
+    ...totals,
+    objectKeysDeleted
+  };
+}
+
+// ── Export ────────────────────────────────────────────────────────────
+
+export interface PersonalDataExportTable {
+  readonly disposition: PersonalDataDisposition;
+  readonly reach: PersonalDataReach;
+  readonly rowCount: number;
+  /** True when `maxRowsPerTable` cut the list short. */
+  readonly truncated: boolean;
+  /** Columns present in the rows but blanked; empty when nothing is withheld. */
+  readonly withheldColumns: readonly string[];
+  readonly rows: readonly Record<string, unknown>[];
+}
+
+export interface PersonalDataExport {
+  readonly format: "nodetool.personal-data-export/1";
+  readonly subjectUserId: string;
+  readonly generatedAt: string;
+  readonly tables: Readonly<Record<string, PersonalDataExportTable>>;
+  /** Tables holding no portable data for this person, and why. */
+  readonly excluded: readonly { table: string; reason: string }[];
+}
+
+export interface PersonalDataExportOptions {
+  /** Cap per table; `run_events` alone can run to millions of rows. */
+  readonly maxRowsPerTable?: number;
+}
+
+const DEFAULT_MAX_ROWS_PER_TABLE = 50_000;
+
+interface ExportContext {
+  readonly userId: string;
+  readonly runIds: readonly string[];
+  readonly applicationIds: readonly string[];
+  readonly limit: number;
+}
+
+type ExportHandler = (
+  ctx: ExportContext
+) => Promise<readonly Record<string, unknown>[]>;
+
+async function selectRows(
+  table: SQLiteTable,
+  where: SQL | undefined,
+  limit: number
+): Promise<readonly Record<string, unknown>[]> {
+  const rows = await getDb().select().from(table).where(where).limit(limit);
+  return rows as Record<string, unknown>[];
+}
+
+function directExport(
+  sqlTable: SQLiteTable,
+  column: TableColumn
+): ExportHandler {
+  return (ctx) => selectRows(sqlTable, eq(column, ctx.userId), ctx.limit);
+}
+
+function indirectExport(
+  sqlTable: SQLiteTable,
+  column: TableColumn,
+  ids: (ctx: ExportContext) => readonly string[]
+): ExportHandler {
+  return async (ctx) => {
+    const out: Record<string, unknown>[] = [];
+    for (const batch of chunks(ids(ctx))) {
+      if (out.length >= ctx.limit) break;
+      const rows = await selectRows(
+        sqlTable,
+        inArray(column, batch),
+        ctx.limit - out.length
+      );
+      out.push(...rows);
+    }
+    return out;
+  };
+}
+
+/**
+ * One handler per exported table. Keyed by table name so the audit can prove
+ * the set matches the registry's `exported: true` entries.
+ *
+ * The two sharing tables are deliberately narrower here than in erasure.
+ * Erasure removes collaborator and share rows on this person's workflows even
+ * when another person created them; the export must not hand those over,
+ * because they are the other person's data. Both handlers therefore select on
+ * the subject's own id only.
+ */
+export const EXPORT_HANDLERS: Readonly<Record<string, ExportHandler>> = {
+  access_tokens: directExport(accessTokens, accessTokens.user_id),
+  application_budgets: indirectExport(
+    applicationBudgets,
+    applicationBudgets.application_id,
+    (c) => c.applicationIds
+  ),
+  application_deployments: directExport(
+    applicationDeployments,
+    applicationDeployments.user_id
+  ),
+  application_invocations: directExport(
+    applicationInvocations,
+    applicationInvocations.user_id
+  ),
+  application_versions: directExport(
+    applicationVersions,
+    applicationVersions.user_id
+  ),
+  applications: directExport(applications, applications.user_id),
+  external_identities: directExport(
+    externalIdentities,
+    externalIdentities.user_id
+  ),
+  image_document_versions: directExport(
+    imageDocumentVersions,
+    imageDocumentVersions.user_id
+  ),
+  image_documents: directExport(imageDocuments, imageDocuments.user_id),
+  js_script_versions: directExport(jsScriptVersions, jsScriptVersions.user_id),
+  js_scripts: directExport(jsScripts, jsScripts.user_id),
+  mcp_oauth_grants: directExport(mcpOauthGrants, mcpOauthGrants.user_id),
+  nodetool_assets: directExport(assets, assets.user_id),
+  nodetool_credit_ledger: directExport(creditLedger, creditLedger.user_id),
+  nodetool_jobs: directExport(jobs, jobs.user_id),
+  nodetool_memories: directExport(memories, memories.user_id),
+  nodetool_messages: directExport(messages, messages.user_id),
+  nodetool_oauth_credentials: directExport(
+    oauthCredentials,
+    oauthCredentials.user_id
+  ),
+  nodetool_predictions: directExport(predictions, predictions.user_id),
+  nodetool_secrets: directExport(secrets, secrets.user_id),
+  nodetool_settings: directExport(appSettings, appSettings.user_id),
+  nodetool_threads: directExport(threads, threads.user_id),
+  nodetool_user_events: directExport(userEvents, userEvents.user_id),
+  nodetool_user_subscriptions: directExport(
+    userSubscriptions,
+    userSubscriptions.user_id
+  ),
+  nodetool_workflow_collaborators: directExport(
+    workflowCollaborators,
+    workflowCollaborators.user_id
+  ),
+  nodetool_workflow_shares: directExport(
+    workflowShares,
+    workflowShares.created_by
+  ),
+  nodetool_workflow_versions: directExport(
+    workflowVersions,
+    workflowVersions.user_id
+  ),
+  nodetool_workflows: directExport(workflows, workflows.user_id),
+  nodetool_workspaces: directExport(workspacesSchema, workspacesSchema.user_id),
+  projects: directExport(projects, projects.user_id),
+  run_events: indirectExport(runEvents, runEvents.run_id, (c) => c.runIds),
+  scripts: directExport(scripts, scripts.user_id),
+  skills: directExport(skills, skills.user_id),
+  storyboards: directExport(storyboards, storyboards.user_id),
+  timeline_sequence_versions: directExport(
+    timelineSequenceVersions,
+    timelineSequenceVersions.user_id
+  ),
+  timeline_sequences: directExport(timelineSequences, timelineSequences.user_id),
+  trigger_inputs: indirectExport(
+    triggerInputs,
+    triggerInputs.run_id,
+    (c) => c.runIds
+  ),
+  trigger_registrations: directExport(
+    triggerRegistrations,
+    triggerRegistrations.user_id
+  )
+};
+
+/**
+ * Blank the registry's `withheldColumns` on a copy of the row.
+ *
+ * Applied centrally rather than inside each handler so a new table cannot
+ * forget: the registry names the column, and every row for that table goes
+ * through here.
+ */
+function mask(
+  rows: readonly Record<string, unknown>[],
+  entry: PersonalDataEntry
+): readonly Record<string, unknown>[] {
+  const withheld = entry.withheldColumns ?? [];
+  if (withheld.length === 0) return rows;
+  return rows.map((row) => {
+    const copy: Record<string, unknown> = { ...row };
+    for (const column of withheld) {
+      if (column in copy) copy[column] = WITHHELD_VALUE;
+    }
+    return copy;
+  });
+}
+
+/**
+ * Build an Art. 20 portability export for one person.
+ *
+ * Two things it deliberately does not contain. Credential material — secret
+ * ciphertext, OAuth tokens, token hashes, share and deployment tokens — is
+ * replaced by {@link WITHHELD_VALUE}, so the record is visible and the
+ * credential is not. And nobody else's data: the sharing tables are read on
+ * the subject's own id, never on their workflows, so a collaborator's row
+ * stays with the collaborator.
+ */
+export async function exportPersonalData(
+  userId: string,
+  options: PersonalDataExportOptions = {}
+): Promise<PersonalDataExport> {
+  if (!userId) throw new Error("exportPersonalData requires a user id");
+
+  const limit = options.maxRowsPerTable ?? DEFAULT_MAX_ROWS_PER_TABLE;
+  const ctx: ExportContext = {
+    userId,
+    runIds: await selectIds(jobs, jobs.id, eq(jobs.user_id, userId)),
+    applicationIds: await selectIds(
+      applications,
+      applications.id,
+      eq(applications.user_id, userId)
+    ),
+    limit
+  };
+
+  const tables: Record<string, PersonalDataExportTable> = {};
+  const excluded: { table: string; reason: string }[] = [];
+
+  for (const entry of PERSONAL_DATA_REGISTRY) {
+    if (!entry.exported) {
+      excluded.push({ table: entry.table, reason: entry.justification });
+      continue;
+    }
+    const handler = EXPORT_HANDLERS[entry.table];
+    if (!handler) {
+      throw new Error(
+        `No export handler for registered table "${entry.table}". ` +
+          "Add one in personal-data.ts or set exported: false in the registry."
+      );
+    }
+    const rows = await handler(ctx);
+    tables[entry.table] = {
+      disposition: entry.disposition,
+      reach: entry.reach,
+      rowCount: rows.length,
+      truncated: rows.length >= limit,
+      withheldColumns: entry.withheldColumns ?? [],
+      rows: mask(rows, entry)
+    };
+  }
+
+  return {
+    format: "nodetool.personal-data-export/1",
+    subjectUserId: userId,
+    generatedAt: new Date().toISOString(),
+    tables,
+    excluded
+  };
+}
+
+/** Tables erasure actually walks. The audit compares it to the registry. */
+export const ERASURE_HANDLED_TABLES: readonly string[] = ERASURE_STEPS.map(
+  (step) => step.table
+);
+
+/** Registry entries erasure must handle. Exported for the audit. */
+export function actionableEntries(): readonly PersonalDataEntry[] {
+  return PERSONAL_DATA_REGISTRY.filter(isActionable);
+}

--- a/packages/models/src/schema-pg/index.ts
+++ b/packages/models/src/schema-pg/index.ts
@@ -38,6 +38,7 @@ export { triggerRegistrations } from "./trigger-registrations.js";
 export { creditLedger, userSubscriptions } from "./credits.js";
 export { accessTokens } from "./access-tokens.js";
 export { externalIdentities } from "./external-identities.js";
+export { userEvents } from "./user-events.js";
 export {
   mcpOauthClients,
   mcpOauthGrants,

--- a/packages/models/src/schema-pg/user-events.ts
+++ b/packages/models/src/schema-pg/user-events.ts
@@ -1,0 +1,41 @@
+import { pgTable, text, index } from "drizzle-orm/pg-core";
+import { jsonText } from "./helpers.js";
+
+/**
+ * PostgreSQL twin of `schema/user-events.ts`.
+ *
+ * A narrow, privacy-scoped audit log keyed by user: authentication and
+ * credential changes, irreversible or outward-facing actions, and
+ * consent/policy/data-subject-rights events. Behavioral analytics stays
+ * aggregate in Plausible and is never keyed to a user id.
+ *
+ * Deliberately absent, in both dialects: `ip_address` and `user_agent` (both
+ * personal data that widen the retention and disclosure obligation without
+ * adding audit value on rows already attributed to an authenticated user),
+ * and any free-text column (the path by which prompt text, file contents or
+ * third-party PII would reach a log that outlives the data it describes).
+ * Structured facts go in `metadata`, filtered by the per-event-type
+ * allowlist in `user-event.ts`.
+ */
+export const userEvents = pgTable(
+  "nodetool_user_events",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    event_type: text("event_type").notNull(),
+    /** Kind of thing acted on: "workflow", "asset", "secret", "application". */
+    subject_type: text("subject_type"),
+    /** Id of the thing acted on. Null for events with no subject (sign-in). */
+    subject_id: text("subject_id"),
+    /** Allowlisted scalar facts only — see `sanitizeUserEventMetadata`. */
+    metadata: jsonText<Record<string, string | number | boolean>>()("metadata"),
+    created_at: text("created_at").notNull()
+  },
+  (table) => [
+    // Serves the erasure and export range scans.
+    index("idx_user_event_user_created").on(table.user_id, table.created_at),
+    // Serves the retention sweep, which walks by type because the
+    // consent/policy/DSR types are never pruned.
+    index("idx_user_event_type_created").on(table.event_type, table.created_at)
+  ]
+);

--- a/packages/models/src/schema/index.ts
+++ b/packages/models/src/schema/index.ts
@@ -39,6 +39,7 @@ export { triggerRegistrations } from "./trigger-registrations.js";
 export { creditLedger, userSubscriptions } from "./credits.js";
 export { accessTokens } from "./access-tokens.js";
 export { externalIdentities } from "./external-identities.js";
+export { userEvents } from "./user-events.js";
 export {
   mcpOauthClients,
   mcpOauthGrants,

--- a/packages/models/src/schema/user-events.ts
+++ b/packages/models/src/schema/user-events.ts
@@ -1,0 +1,54 @@
+import { sqliteTable, text, index } from "drizzle-orm/sqlite-core";
+import { jsonText } from "./helpers.js";
+
+/**
+ * A narrow, privacy-scoped audit log keyed by user.
+ *
+ * Only three classes of action land here: authentication and credential
+ * changes (GDPR Art. 6(1)(f), legitimate interest in account security),
+ * irreversible or outward-facing actions (deletes, shares, deploys — the
+ * audit trail that answers "who removed this"), and consent, policy and
+ * data-subject-rights events (Art. 7(1) requires being able to *demonstrate*
+ * consent; the DSR rows are the record that an export or erasure was asked
+ * for and carried out).
+ *
+ * Behavioral analytics is deliberately not in scope. Clicks, node drags,
+ * panel opens, page views, session duration and feature funnels stay
+ * aggregate in Plausible and are never keyed to a user id.
+ *
+ * Columns that are deliberately absent:
+ *   - **No `ip_address`.** An IP is personal data under GDPR and would drag
+ *     this table into a far wider retention and disclosure obligation than
+ *     the audit trail needs. The events recorded here are already attributed
+ *     to an authenticated user id, so the IP adds no audit value.
+ *   - **No `user_agent`.** Same reasoning, plus it is a passive
+ *     fingerprinting surface.
+ *   - **No free-text column.** Anything shaped like `note`, `description` or
+ *     `message` becomes the path of least resistance for prompt text, file
+ *     contents or third-party PII to end up in an audit log that outlives the
+ *     data it describes. Structured facts go in `metadata`, and only keys on
+ *     the per-event-type allowlist in `user-event.ts` survive the write.
+ *
+ * The `(user_id, created_at)` index serves the erasure and export range
+ * scans; `(event_type, created_at)` serves the retention sweep, which walks
+ * by type because consent/policy/DSR events are never pruned.
+ */
+export const userEvents = sqliteTable(
+  "nodetool_user_events",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    event_type: text("event_type").notNull(),
+    /** Kind of thing acted on: "workflow", "asset", "secret", "application". */
+    subject_type: text("subject_type"),
+    /** Id of the thing acted on. Null for events with no subject (sign-in). */
+    subject_id: text("subject_id"),
+    /** Allowlisted scalar facts only — see `sanitizeUserEventMetadata`. */
+    metadata: jsonText<Record<string, string | number | boolean>>()("metadata"),
+    created_at: text("created_at").notNull()
+  },
+  (table) => [
+    index("idx_user_event_user_created").on(table.user_id, table.created_at),
+    index("idx_user_event_type_created").on(table.event_type, table.created_at)
+  ]
+);

--- a/packages/models/src/storage-maintenance.ts
+++ b/packages/models/src/storage-maintenance.ts
@@ -1,14 +1,22 @@
 /**
  * Database history retention and maintenance.
  *
- * This service only removes historical workflow snapshots and run records.
- * Current workflows, assets, messages, and user-authored documents are never
- * candidates.
+ * This service removes historical workflow snapshots, run records, and the
+ * machine-generated exhaust a run leaves behind (run events, and the request
+ * payload stored on a prediction). Current workflows, assets, messages,
+ * memories, and user-authored documents are never candidates.
+ *
+ * Predictions are billing records, so their rows survive; the sweep only nulls
+ * the columns that carry personal data with no accounting purpose
+ * (`parameters`, `metadata`, `logs`), leaving cost, tokens, model, provider,
+ * timestamps and ids intact.
  */
 import { statSync } from "node:fs";
-import { desc, eq, inArray } from "drizzle-orm";
+import { and, count, desc, eq, inArray, isNotNull, lt, or } from "drizzle-orm";
+import { isAutomaticStorageCleanupEnabled } from "@nodetool-ai/config";
 import { getDb, getDbType, getRawDb } from "./db.js";
 import { jobs } from "./schema/jobs.js";
+import { predictions } from "./schema/predictions.js";
 import { runEvents } from "./schema/run-events.js";
 import { runInboxMessages } from "./schema/run-inbox-messages.js";
 import { triggerInputs } from "./schema/trigger-inputs.js";
@@ -19,6 +27,19 @@ export interface StorageRetentionPolicy {
   autosaveRetentionDays: number;
   manualVersionRetentionDays: number;
   terminalJobRetentionDays: number;
+  /**
+   * How long a run's per-node event log is kept. Unset means
+   * `DEFAULT_STORAGE_RETENTION_POLICY.runEventRetentionDays` — optional so a
+   * policy built before this sweep existed still resolves to the default
+   * instead of to zero days.
+   */
+  runEventRetentionDays?: number;
+  /**
+   * How long a prediction keeps its request payload. The row itself is never
+   * deleted. Unset means
+   * `DEFAULT_STORAGE_RETENTION_POLICY.predictionRetentionDays`.
+   */
+  predictionRetentionDays?: number;
   automaticCleanup: boolean;
 }
 
@@ -27,13 +48,25 @@ export const DEFAULT_STORAGE_RETENTION_POLICY: StorageRetentionPolicy = {
   autosaveRetentionDays: 7,
   manualVersionRetentionDays: 90,
   terminalJobRetentionDays: 30,
-  automaticCleanup: false
+  runEventRetentionDays: 30,
+  predictionRetentionDays: 400,
+  // A local install cleans up when asked. A hosted deployment sets
+  // NODETOOL_STORAGE_AUTO_CLEANUP=1 so the sweep runs on its own.
+  automaticCleanup: isAutomaticStorageCleanupEnabled()
 };
 
 export interface StorageCleanupPreview {
   autosaves: number;
   manualVersions: number;
   terminalJobs: number;
+  /**
+   * Run events removed by age. Events belonging to a job this pass deletes are
+   * counted under `terminalJobs`, not here — the job takes them with it.
+   */
+  runEvents: number;
+  /** Prediction rows whose payload columns are nulled. Rows are kept. */
+  redactedPredictions: number;
+  /** Records deleted. Redactions are not deletions, so they are not in it. */
   total: number;
 }
 
@@ -46,6 +79,10 @@ export interface StorageStatus {
   manualVersions: number;
   jobs: number;
   terminalJobs: number;
+  /** Events recorded against this user's runs. */
+  runEvents: number;
+  /** Prediction rows still holding `parameters`, `metadata`, or `logs`. */
+  predictionsWithPayload: number;
   cleanup: StorageCleanupPreview;
 }
 
@@ -81,6 +118,20 @@ function isBefore(value: string | null, cutoff: number): boolean {
   return Number.isFinite(timestamp) && timestamp < cutoff;
 }
 
+function retentionDays(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+}
+
+function batches<T>(items: T[], size = DELETE_BATCH_SIZE): T[][] {
+  const out: T[][] = [];
+  for (let offset = 0; offset < items.length; offset += size) {
+    out.push(items.slice(offset, offset + size));
+  }
+  return out;
+}
+
 async function retentionRows(userId: string): Promise<{
   versions: VersionRetentionRow[];
   jobs: JobRetentionRow[];
@@ -113,15 +164,22 @@ async function retentionRows(userId: string): Promise<{
   return { versions: versionRows, jobs: jobRows };
 }
 
+interface VersionAndJobCandidates {
+  autosaveIds: string[];
+  manualVersionIds: string[];
+  terminalJobIds: string[];
+  /**
+   * Runs that survive this pass. Their events are the only ones the age sweep
+   * looks at, because a deleted job already takes its events with it.
+   */
+  survivingRunIds: string[];
+}
+
 function cleanupCandidates(
   rows: Awaited<ReturnType<typeof retentionRows>>,
   policy: StorageRetentionPolicy,
   now: Date
-): {
-  autosaveIds: string[];
-  manualVersionIds: string[];
-  terminalJobIds: string[];
-} {
+): VersionAndJobCandidates {
   const autosaveCutoff = cutoffTime(now, policy.autosaveRetentionDays);
   const manualCutoff = cutoffTime(now, policy.manualVersionRetentionDays);
   const jobCutoff = cutoffTime(now, policy.terminalJobRetentionDays);
@@ -129,6 +187,7 @@ function cleanupCandidates(
   const autosaveIds: string[] = [];
   const manualVersionIds: string[] = [];
   const terminalJobIds: string[] = [];
+  const survivingRunIds: string[] = [];
 
   for (const row of rows.versions) {
     if (row.saveType === "autosave") {
@@ -156,23 +215,159 @@ function cleanupCandidates(
       isBefore(row.finishedAt ?? row.updatedAt, jobCutoff)
     ) {
       terminalJobIds.push(row.id);
+    } else {
+      survivingRunIds.push(row.id);
     }
   }
 
-  return { autosaveIds, manualVersionIds, terminalJobIds };
+  return { autosaveIds, manualVersionIds, terminalJobIds, survivingRunIds };
+}
+
+/**
+ * `run_events` has no `user_id`. The run it belongs to does, so the sweep is
+ * scoped by joining through the user's job ids — the same rows `retentionRows`
+ * already loaded — and filtered by `event_time` in SQL, one indexed
+ * `run_id IN (…) AND event_time < cutoff` per batch of run ids. Nothing walks
+ * the events in JavaScript, so the cost is one indexed scan per batch rather
+ * than events × runs.
+ *
+ * Events whose job row is already gone cannot be attributed to a user and are
+ * left alone; the job delete path below removes a run's events with the job.
+ */
+async function countRunEvents(
+  runIds: string[],
+  cutoffIso: string | null
+): Promise<number> {
+  const db = getDb();
+  let total = 0;
+  for (const batch of batches(runIds)) {
+    const scope = inArray(runEvents.run_id, batch);
+    const [row] = await db
+      .select({ value: count() })
+      .from(runEvents)
+      .where(
+        cutoffIso ? and(scope, lt(runEvents.event_time, cutoffIso)) : scope
+      );
+    total += Number(row?.value ?? 0);
+  }
+  return total;
+}
+
+async function deleteExpiredRunEvents(
+  runIds: string[],
+  cutoffIso: string
+): Promise<void> {
+  const db = getDb();
+  for (const batch of batches(runIds)) {
+    await db
+      .delete(runEvents)
+      .where(
+        and(
+          inArray(runEvents.run_id, batch),
+          lt(runEvents.event_time, cutoffIso)
+        )
+      );
+  }
+}
+
+/**
+ * Prediction rows that still carry a request payload past the retention window.
+ * A row with no `created_at` cannot be aged and is skipped; a row already
+ * redacted no longer matches, so a second pass reports zero instead of
+ * recounting it.
+ */
+async function redactablePredictionIds(
+  userId: string,
+  cutoffIso: string | null
+): Promise<string[]> {
+  const db = getDb();
+  const hasPayload = or(
+    isNotNull(predictions.parameters),
+    isNotNull(predictions.metadata),
+    isNotNull(predictions.logs)
+  );
+  const rows = await db
+    .select({ id: predictions.id })
+    .from(predictions)
+    .where(
+      and(
+        eq(predictions.user_id, userId),
+        cutoffIso ? lt(predictions.created_at, cutoffIso) : undefined,
+        hasPayload
+      )
+    );
+  return rows.map((row: { id: string }) => row.id);
+}
+
+async function redactPredictions(ids: string[]): Promise<void> {
+  const db = getDb();
+  for (const batch of batches(ids)) {
+    await db
+      .update(predictions)
+      .set({ parameters: null, metadata: null, logs: null })
+      .where(inArray(predictions.id, batch));
+  }
+}
+
+interface CleanupCandidates extends VersionAndJobCandidates {
+  runEventCutoff: string;
+  expiredRunEvents: number;
+  redactablePredictionIds: string[];
+}
+
+async function collectCandidates(
+  userId: string,
+  rows: Awaited<ReturnType<typeof retentionRows>>,
+  policy: StorageRetentionPolicy,
+  now: Date
+): Promise<CleanupCandidates> {
+  const base = cleanupCandidates(rows, policy, now);
+  const runEventCutoff = new Date(
+    cutoffTime(
+      now,
+      retentionDays(
+        policy.runEventRetentionDays,
+        DEFAULT_STORAGE_RETENTION_POLICY.runEventRetentionDays ?? 30
+      )
+    )
+  ).toISOString();
+  const predictionCutoff = new Date(
+    cutoffTime(
+      now,
+      retentionDays(
+        policy.predictionRetentionDays,
+        DEFAULT_STORAGE_RETENTION_POLICY.predictionRetentionDays ?? 400
+      )
+    )
+  ).toISOString();
+  return {
+    ...base,
+    runEventCutoff,
+    expiredRunEvents: await countRunEvents(
+      base.survivingRunIds,
+      runEventCutoff
+    ),
+    redactablePredictionIds: await redactablePredictionIds(
+      userId,
+      predictionCutoff
+    )
+  };
 }
 
 function previewFromCandidates(
-  candidates: ReturnType<typeof cleanupCandidates>
+  candidates: CleanupCandidates
 ): StorageCleanupPreview {
   const autosaves = candidates.autosaveIds.length;
   const manualVersions = candidates.manualVersionIds.length;
   const terminalJobs = candidates.terminalJobIds.length;
+  const runEventCount = candidates.expiredRunEvents;
   return {
     autosaves,
     manualVersions,
     terminalJobs,
-    total: autosaves + manualVersions + terminalJobs
+    runEvents: runEventCount,
+    redactedPredictions: candidates.redactablePredictionIds.length,
+    total: autosaves + manualVersions + terminalJobs + runEventCount
   };
 }
 
@@ -203,7 +398,7 @@ export async function getStorageStatus(
   now = new Date()
 ): Promise<StorageStatus> {
   const rows = await retentionRows(userId);
-  const candidates = cleanupCandidates(rows, policy, now);
+  const candidates = await collectCandidates(userId, rows, policy, now);
   const autosaves = rows.versions.filter(
     (row) => row.saveType === "autosave"
   ).length;
@@ -223,28 +418,28 @@ export async function getStorageStatus(
     manualVersions,
     jobs: rows.jobs.length,
     terminalJobs,
+    runEvents: await countRunEvents(
+      rows.jobs.map((row) => row.id),
+      null
+    ),
+    predictionsWithPayload: (await redactablePredictionIds(userId, null))
+      .length,
     cleanup: previewFromCandidates(candidates)
   };
 }
 
 async function deleteVersions(ids: string[]): Promise<void> {
   const db = getDb();
-  for (let offset = 0; offset < ids.length; offset += DELETE_BATCH_SIZE) {
+  for (const batch of batches(ids)) {
     await db
       .delete(workflowVersions)
-      .where(
-        inArray(
-          workflowVersions.id,
-          ids.slice(offset, offset + DELETE_BATCH_SIZE)
-        )
-      );
+      .where(inArray(workflowVersions.id, batch));
   }
 }
 
 async function deleteJobs(ids: string[]): Promise<void> {
   const db = getDb();
-  for (let offset = 0; offset < ids.length; offset += DELETE_BATCH_SIZE) {
-    const batch = ids.slice(offset, offset + DELETE_BATCH_SIZE);
+  for (const batch of batches(ids)) {
     await db.delete(runEvents).where(inArray(runEvents.run_id, batch));
     await db
       .delete(runInboxMessages)
@@ -259,7 +454,8 @@ export async function cleanupStorage(
   policy: StorageRetentionPolicy,
   now = new Date()
 ): Promise<StorageCleanupResult> {
-  const candidates = cleanupCandidates(
+  const candidates = await collectCandidates(
+    userId,
     await retentionRows(userId),
     policy,
     now
@@ -268,7 +464,12 @@ export async function cleanupStorage(
     ...candidates.autosaveIds,
     ...candidates.manualVersionIds
   ]);
+  await deleteExpiredRunEvents(
+    candidates.survivingRunIds,
+    candidates.runEventCutoff
+  );
   await deleteJobs(candidates.terminalJobIds);
+  await redactPredictions(candidates.redactablePredictionIds);
   return {
     ...previewFromCandidates(candidates),
     completedAt: now.toISOString()

--- a/packages/models/src/user-event.ts
+++ b/packages/models/src/user-event.ts
@@ -1,0 +1,380 @@
+/**
+ * UserEvent — the narrow, privacy-scoped audit log keyed by user id.
+ *
+ * What may be written here is fixed by {@link UserEventType} and what may be
+ * written *about* it is fixed by {@link USER_EVENT_METADATA_ALLOWLIST}. Those
+ * two lists are the privacy control: a caller cannot widen the table by
+ * passing a richer object, because everything off the allowlist is dropped
+ * before the insert.
+ *
+ * See `schema/user-events.ts` for the columns and for why there is no IP
+ * address, no user agent and no free-text column.
+ */
+
+import { and, desc, eq, gte, inArray, lt, lte, notInArray } from "drizzle-orm";
+import { createLogger } from "@nodetool-ai/config";
+import { createTimeOrderedUuid } from "./base-model.js";
+import { getDb } from "./db.js";
+import { userEvents } from "./schema/user-events.js";
+
+const log = createLogger("nodetool.models.user-event");
+
+// ── Event vocabulary ─────────────────────────────────────────────────
+
+/**
+ * Every action this table records, grouped by the reason it is lawful to
+ * record it. Nothing outside these three groups belongs in a user-keyed log.
+ */
+export const UserEventType = {
+  // Auth and credentials — Art. 6(1)(f), legitimate interest in security.
+  SIGN_IN: "sign_in",
+  SIGN_OUT: "sign_out",
+  ACCESS_TOKEN_ISSUED: "access_token_issued",
+  ACCESS_TOKEN_REVOKED: "access_token_revoked",
+  EXTERNAL_IDENTITY_LINKED: "external_identity_linked",
+  EXTERNAL_IDENTITY_UNLINKED: "external_identity_unlinked",
+
+  // Irreversible or outward-facing — the audit trail.
+  WORKFLOW_DELETED: "workflow_deleted",
+  ASSET_DELETED: "asset_deleted",
+  SECRET_WRITTEN: "secret_written",
+  SECRET_REVOKED: "secret_revoked",
+  WORKFLOW_SHARED: "workflow_shared",
+  WORKFLOW_UNSHARED: "workflow_unshared",
+  APP_DEPLOYED: "app_deployed",
+  APP_PUBLISHED: "app_published",
+  APP_UNPUBLISHED: "app_unpublished",
+
+  // Consent, policy and data-subject rights — Art. 7(1) demonstrability,
+  // plus our own proof that a DSR request was received and answered.
+  CONSENT_GIVEN: "consent_given",
+  CONSENT_WITHDRAWN: "consent_withdrawn",
+  TERMS_ACCEPTED: "terms_accepted",
+  DATA_EXPORT_REQUESTED: "data_export_requested",
+  DATA_ERASURE_REQUESTED: "data_erasure_requested",
+  DATA_ERASURE_COMPLETED: "data_erasure_completed"
+} as const;
+
+export type UserEventType = (typeof UserEventType)[keyof typeof UserEventType];
+
+const ALL_USER_EVENT_TYPES = Object.values(UserEventType);
+
+/** True when `value` is one of the recorded event types. */
+export function isUserEventType(value: unknown): value is UserEventType {
+  return (
+    typeof value === "string" &&
+    (ALL_USER_EVENT_TYPES as readonly string[]).includes(value)
+  );
+}
+
+// ── Metadata allowlist ───────────────────────────────────────────────
+
+/** The only value shapes a metadata field may hold. */
+export type UserEventMetadataValue = string | number | boolean;
+
+export type UserEventMetadata = Record<string, UserEventMetadataValue>;
+
+/**
+ * A string longer than this is not a structured fact — it is prose, and prose
+ * is how prompt text, model output and third-party PII leak into an audit
+ * log. Over-long strings are dropped rather than truncated, so a caller
+ * notices the field is missing instead of silently storing half a prompt.
+ */
+export const MAX_USER_EVENT_STRING_LENGTH = 200;
+
+/**
+ * The scalar keys each event type may carry, and nothing else.
+ *
+ * Every key here names a structured fact about the action, never its content:
+ * which provider, which token id, which policy version. No key holds
+ * user-authored text, a prompt, a graph, an asset body or a secret value —
+ * adding one that does defeats the purpose of the table.
+ */
+export const USER_EVENT_METADATA_ALLOWLIST: Readonly<
+  Record<UserEventType, readonly string[]>
+> = {
+  // Auth and credentials.
+  sign_in: ["method", "provider"],
+  sign_out: ["reason"],
+  access_token_issued: ["token_id", "expires_at"],
+  access_token_revoked: ["token_id", "reason"],
+  external_identity_linked: ["provider"],
+  external_identity_unlinked: ["provider"],
+
+  // Irreversible or outward-facing.
+  workflow_deleted: ["soft_delete"],
+  asset_deleted: ["content_type", "soft_delete"],
+  // `secret_name` is the credential's key name ("OPENAI_API_KEY"), never its
+  // value — the value never leaves the secret store.
+  secret_written: ["secret_name"],
+  secret_revoked: ["secret_name"],
+  workflow_shared: ["share_scope", "recipient_count"],
+  workflow_unshared: ["share_scope"],
+  app_deployed: ["application_id", "version", "target"],
+  app_published: ["application_id", "version"],
+  app_unpublished: ["application_id", "version"],
+
+  // Consent, policy and DSR.
+  consent_given: ["policy", "policy_version", "channel"],
+  consent_withdrawn: ["policy", "policy_version", "channel"],
+  terms_accepted: ["policy_version", "channel"],
+  data_export_requested: ["request_id", "format"],
+  data_erasure_requested: ["request_id"],
+  data_erasure_completed: ["request_id", "rows_deleted"]
+};
+
+function isAllowedValue(value: unknown): value is UserEventMetadataValue {
+  if (typeof value === "boolean") return true;
+  if (typeof value === "number") return Number.isFinite(value);
+  if (typeof value === "string") {
+    return value.length > 0 && value.length <= MAX_USER_EVENT_STRING_LENGTH;
+  }
+  return false;
+}
+
+/**
+ * Reduce a caller's object to the allowlisted scalar fields for `eventType`.
+ *
+ * Returns `null` when nothing survives, so "no metadata" and "metadata that
+ * was entirely rejected" are the same stored value. Exported because this is
+ * the control worth asserting on directly in tests, not only through a write.
+ */
+export function sanitizeUserEventMetadata(
+  eventType: UserEventType,
+  metadata: Record<string, unknown> | null | undefined
+): UserEventMetadata | null {
+  if (!metadata || typeof metadata !== "object") return null;
+
+  const allowed = USER_EVENT_METADATA_ALLOWLIST[eventType] ?? [];
+  const kept: UserEventMetadata = {};
+  for (const key of allowed) {
+    const value = metadata[key];
+    if (isAllowedValue(value)) kept[key] = value;
+  }
+  return Object.keys(kept).length > 0 ? kept : null;
+}
+
+/**
+ * Subject columns hold ids, not prose. An over-long value is dropped for the
+ * same reason an over-long metadata string is.
+ */
+function sanitizeSubject(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  if (value.length === 0 || value.length > MAX_USER_EVENT_STRING_LENGTH) {
+    return null;
+  }
+  return value;
+}
+
+// ── Retention ────────────────────────────────────────────────────────
+
+/**
+ * How long an auth or audit-trail event is kept. Long enough to investigate
+ * an account compromise or a disputed deletion, short enough that the log is
+ * not an indefinite behavioral record.
+ */
+export const DEFAULT_USER_EVENT_RETENTION_DAYS = 180;
+
+/**
+ * Consent, policy and data-subject-rights events are never pruned.
+ *
+ * Art. 7(1) requires being able to demonstrate that consent was given, and
+ * the DSR rows are our own evidence that an export or erasure request was
+ * received and completed. Deleting them on a timer would delete the proof.
+ */
+export const NEVER_PRUNED_USER_EVENT_TYPES: readonly UserEventType[] = [
+  UserEventType.CONSENT_GIVEN,
+  UserEventType.CONSENT_WITHDRAWN,
+  UserEventType.TERMS_ACCEPTED,
+  UserEventType.DATA_EXPORT_REQUESTED,
+  UserEventType.DATA_ERASURE_REQUESTED,
+  UserEventType.DATA_ERASURE_COMPLETED
+];
+
+/** True when the retention sweep must leave this event type alone. */
+export function isNeverPrunedUserEventType(eventType: UserEventType): boolean {
+  return NEVER_PRUNED_USER_EVENT_TYPES.includes(eventType);
+}
+
+// ── Rows ─────────────────────────────────────────────────────────────
+
+export interface UserEventRow {
+  id: string;
+  user_id: string;
+  event_type: UserEventType;
+  subject_type: string | null;
+  subject_id: string | null;
+  metadata: UserEventMetadata | null;
+  created_at: string;
+}
+
+export interface RecordUserEventInput {
+  userId: string;
+  eventType: UserEventType;
+  subjectType?: string | null;
+  subjectId?: string | null;
+  metadata?: Record<string, unknown> | null;
+  /** Override the timestamp. Defaults to now; tests and backfills use it. */
+  createdAt?: string;
+}
+
+export interface ListUserEventsOptions {
+  limit?: number;
+  eventTypes?: readonly UserEventType[];
+  /** Inclusive lower bound on `created_at`, ISO-8601. */
+  since?: string;
+  /** Inclusive upper bound on `created_at`, ISO-8601. */
+  until?: string;
+}
+
+const DEFAULT_LIST_LIMIT = 100;
+
+function toRow(row: Record<string, unknown>): UserEventRow {
+  return {
+    id: row.id as string,
+    user_id: row.user_id as string,
+    event_type: row.event_type as UserEventType,
+    subject_type: (row.subject_type as string | null) ?? null,
+    subject_id: (row.subject_id as string | null) ?? null,
+    metadata: (row.metadata as UserEventMetadata | null) ?? null,
+    created_at: row.created_at as string
+  };
+}
+
+// ── Write ────────────────────────────────────────────────────────────
+
+/**
+ * Append one audit event.
+ *
+ * Returns the stored row, or `null` when the write could not happen. It never
+ * throws: this is called from inside sign-in, delete and revoke paths, and an
+ * audit log that can fail a sign-out is worse than one that misses a row. The
+ * failure is logged, which is where it gets noticed.
+ */
+export async function recordUserEvent(
+  input: RecordUserEventInput
+): Promise<UserEventRow | null> {
+  if (!isUserEventType(input.eventType)) {
+    log.warn("Refusing to record an unknown user event type", {
+      eventType: String(input.eventType)
+    });
+    return null;
+  }
+  if (!input.userId) {
+    log.warn("Refusing to record a user event with no user id", {
+      eventType: input.eventType
+    });
+    return null;
+  }
+
+  const row: UserEventRow = {
+    id: createTimeOrderedUuid(),
+    user_id: input.userId,
+    event_type: input.eventType,
+    subject_type: sanitizeSubject(input.subjectType),
+    subject_id: sanitizeSubject(input.subjectId),
+    metadata: sanitizeUserEventMetadata(input.eventType, input.metadata),
+    created_at: input.createdAt ?? new Date().toISOString()
+  };
+
+  try {
+    await getDb().insert(userEvents).values(row);
+    return row;
+  } catch (error) {
+    // Swallowed on purpose: the audit write is a side effect of the caller's
+    // real work (a sign-in, a delete, a token revoke) and must not fail it.
+    // Logging is the alert path — a burst of these means the table or the
+    // connection is broken, not that the caller did something wrong.
+    log.error("Failed to record user event", {
+      eventType: row.event_type,
+      error: String(error)
+    });
+    return null;
+  }
+}
+
+// ── Read ─────────────────────────────────────────────────────────────
+
+/**
+ * Events for one user, newest first. Backs both the account activity view and
+ * the data-export path, which is why the time range is a first-class filter.
+ */
+export async function listUserEvents(
+  userId: string,
+  opts: ListUserEventsOptions = {}
+): Promise<UserEventRow[]> {
+  const { limit = DEFAULT_LIST_LIMIT, eventTypes, since, until } = opts;
+
+  const conditions = [eq(userEvents.user_id, userId)];
+  if (eventTypes && eventTypes.length > 0) {
+    conditions.push(inArray(userEvents.event_type, [...eventTypes]));
+  }
+  if (since) conditions.push(gte(userEvents.created_at, since));
+  if (until) conditions.push(lte(userEvents.created_at, until));
+
+  const rows = await getDb()
+    .select()
+    .from(userEvents)
+    .where(and(...conditions))
+    .orderBy(desc(userEvents.created_at), desc(userEvents.id))
+    .limit(limit);
+
+  return rows.map(toRow);
+}
+
+// ── Erasure and retention ────────────────────────────────────────────
+
+/**
+ * Delete every event for one user and report how many rows went.
+ *
+ * The erasure path calls this last, after the user's own data is gone: the
+ * audit trail is scoped to that user, so once the account is erased there is
+ * nothing left for it to be evidence about. The count is read before the
+ * delete because the two dialects report affected rows differently.
+ */
+export async function deleteUserEventsForUser(userId: string): Promise<number> {
+  const db = getDb();
+  const existing = await db
+    .select({ id: userEvents.id })
+    .from(userEvents)
+    .where(eq(userEvents.user_id, userId));
+
+  if (existing.length === 0) return 0;
+
+  await db.delete(userEvents).where(eq(userEvents.user_id, userId));
+  return existing.length;
+}
+
+/**
+ * Drop auth and audit-trail events older than `retentionDays`.
+ *
+ * Consent, policy and DSR events are excluded by type, not by age — see
+ * {@link NEVER_PRUNED_USER_EVENT_TYPES}. Returns the number of rows removed.
+ */
+export async function pruneUserEvents(
+  retentionDays: number = DEFAULT_USER_EVENT_RETENTION_DAYS
+): Promise<number> {
+  if (!Number.isFinite(retentionDays) || retentionDays < 0) {
+    throw new Error(`Invalid retention window: ${retentionDays}`);
+  }
+
+  const cutoff = new Date(
+    Date.now() - retentionDays * 24 * 60 * 60 * 1000
+  ).toISOString();
+
+  const prunable = and(
+    lt(userEvents.created_at, cutoff),
+    notInArray(userEvents.event_type, [...NEVER_PRUNED_USER_EVENT_TYPES])
+  );
+
+  const db = getDb();
+  const doomed = await db
+    .select({ id: userEvents.id })
+    .from(userEvents)
+    .where(prunable);
+
+  if (doomed.length === 0) return 0;
+
+  await db.delete(userEvents).where(prunable);
+  return doomed.length;
+}

--- a/packages/models/tests/migrations.test.ts
+++ b/packages/models/tests/migrations.test.ts
@@ -423,7 +423,7 @@ describe("MigrationRunner", () => {
 // ── Built-in migrations smoke test ───────────────────────────────────
 
 describe("Built-in migrations", () => {
-  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 75;
+  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 76;
 
   it("should have correct count of migrations", () => {
     expect(migrations.length).toBe(EXPECTED_BUILT_IN_MIGRATION_COUNT);

--- a/packages/models/tests/personal-data-audit.test.ts
+++ b/packages/models/tests/personal-data-audit.test.ts
@@ -1,0 +1,201 @@
+/**
+ * The personal-data registry is only worth what this audit proves.
+ *
+ * A hand-written "tables to delete on an erasure request" list rots on the
+ * first PR that adds a table, and the failure is silent: someone's data stays
+ * behind and nothing complains. So this reads the schema instead of trusting
+ * prose. It walks every table exported from `src/schema/index.ts`, resolves
+ * its real name and columns through Drizzle, and requires the registry to
+ * classify all of them — with the strictest rule reserved for the case that
+ * actually happens: a new table carrying `user_id`.
+ *
+ * It asserts it *found* tables before it asserts anything about them. A
+ * broken walk would otherwise pass by classifying an empty set, which is the
+ * exact failure mode AGENTS.md § Claims, Checks, and Measurements names.
+ */
+import { describe, expect, it } from "vitest";
+import { Table, getTableColumns, getTableName, is } from "drizzle-orm";
+
+import * as schema from "../src/schema/index.js";
+import {
+  PERSONAL_DATA_REGISTRY,
+  isActionable,
+  type PersonalDataEntry
+} from "../src/personal-data-registry.js";
+import {
+  ERASURE_HANDLED_TABLES,
+  EXPORT_HANDLERS
+} from "../src/personal-data.js";
+
+interface SchemaTable {
+  /** Export name in `src/schema/index.ts`. */
+  schemaExport: string;
+  /** Physical table name. */
+  table: string;
+  columns: string[];
+}
+
+/** Every table the schema barrel exports, read from Drizzle, not from a list. */
+function schemaTables(): SchemaTable[] {
+  const out: SchemaTable[] = [];
+  for (const [schemaExport, value] of Object.entries(schema)) {
+    if (!is(value as object, Table)) continue;
+    const table = value as unknown as Table;
+    out.push({
+      schemaExport,
+      table: getTableName(table),
+      columns: Object.values(getTableColumns(table)).map(
+        (column) => (column as { name: string }).name
+      )
+    });
+  }
+  return out.sort((a, b) => a.table.localeCompare(b.table));
+}
+
+const tables = schemaTables();
+const byTable = new Map(tables.map((t) => [t.table, t]));
+const userKeyed = tables.filter((t) => t.columns.includes("user_id"));
+
+const entries = new Map<string, PersonalDataEntry>();
+const duplicates: string[] = [];
+for (const entry of PERSONAL_DATA_REGISTRY) {
+  if (entries.has(entry.table)) duplicates.push(entry.table);
+  entries.set(entry.table, entry);
+}
+
+describe("personal data registry audit", () => {
+  it("reads a real schema and finds user-keyed tables in it", () => {
+    // The positive control. Every assertion below is vacuous if this walk
+    // stops finding tables, so prove it found them first.
+    expect(tables.length).toBeGreaterThanOrEqual(40);
+    expect(userKeyed.length).toBeGreaterThanOrEqual(30);
+    expect(PERSONAL_DATA_REGISTRY.length).toBeGreaterThanOrEqual(40);
+    expect(tables.every((t) => t.columns.length > 0)).toBe(true);
+  });
+
+  it("classifies every table in the schema", () => {
+    // The ratchet. A new table with no registry entry fails here, by name.
+    const unregistered = tables
+      .filter((t) => !entries.has(t.table))
+      .map((t) => `${t.table} (schema export: ${t.schemaExport})`);
+    expect(unregistered).toEqual([]);
+  });
+
+  it("has no stale or duplicated entries", () => {
+    const stale = PERSONAL_DATA_REGISTRY.filter(
+      (entry) => !byTable.has(entry.table)
+    ).map((entry) => entry.table);
+    expect(stale).toEqual([]);
+    expect(duplicates).toEqual([]);
+  });
+
+  it("names the right schema export for every entry", () => {
+    const wrong = PERSONAL_DATA_REGISTRY.filter((entry) => {
+      const table = byTable.get(entry.table);
+      return !table || table.schemaExport !== entry.schemaExport;
+    }).map((entry) => `${entry.table} -> ${entry.schemaExport}`);
+    expect(wrong).toEqual([]);
+  });
+
+  it("reaches every user_id table directly by user_id", () => {
+    // The rule that catches the realistic mistake: a new user-keyed table
+    // filed as infrastructure, or reached through a join it does not need.
+    const wrong = userKeyed
+      .map((t) => ({ t, entry: entries.get(t.table) }))
+      .filter(
+        ({ entry }) =>
+          !entry ||
+          entry.disposition === "not-personal" ||
+          entry.reach.kind !== "direct" ||
+          entry.reach.column !== "user_id"
+      )
+      .map(({ t }) => t.table);
+    expect(wrong).toEqual([]);
+  });
+
+  it("points every reach at a column that exists", () => {
+    const broken: string[] = [];
+    for (const entry of PERSONAL_DATA_REGISTRY) {
+      const table = byTable.get(entry.table);
+      if (!table) continue;
+      if (entry.reach.kind === "none") continue;
+      if (!table.columns.includes(entry.reach.column)) {
+        broken.push(`${entry.table}.${entry.reach.column}`);
+      }
+      if (entry.reach.kind === "indirect" && !byTable.has(entry.reach.parent)) {
+        broken.push(`${entry.table} -> missing parent ${entry.reach.parent}`);
+      }
+    }
+    expect(broken).toEqual([]);
+  });
+
+  it("names real columns in every redaction and every withholding", () => {
+    const broken: string[] = [];
+    for (const entry of PERSONAL_DATA_REGISTRY) {
+      const table = byTable.get(entry.table);
+      if (!table) continue;
+      const named = [
+        ...(entry.redactedColumns ?? []),
+        ...(entry.withheldColumns ?? [])
+      ];
+      for (const column of named) {
+        if (!table.columns.includes(column)) {
+          broken.push(`${entry.table}.${column}`);
+        }
+      }
+      if (entry.disposition === "redact" && !entry.redactedColumns?.length) {
+        broken.push(`${entry.table}: redact with no redactedColumns`);
+      }
+      if (entry.disposition !== "redact" && entry.redactedColumns?.length) {
+        broken.push(`${entry.table}: redactedColumns on a ${entry.disposition}`);
+      }
+    }
+    expect(broken).toEqual([]);
+  });
+
+  it("writes a justification somebody could defend", () => {
+    // Short enough to be a label rather than a reason is the failure mode.
+    const thin = PERSONAL_DATA_REGISTRY.filter(
+      (entry) => entry.justification.trim().length < 40
+    ).map((entry) => entry.table);
+    expect(thin).toEqual([]);
+  });
+
+  it("wires every actionable entry into erasure", () => {
+    // A registry entry nobody implemented is worse than no entry: it reads
+    // like coverage. This is what makes the registry self-enforcing.
+    const handled = new Set(ERASURE_HANDLED_TABLES);
+    const missing = PERSONAL_DATA_REGISTRY.filter(
+      (entry) => isActionable(entry) && !handled.has(entry.table)
+    ).map((entry) => entry.table);
+    expect(missing).toEqual([]);
+  });
+
+  it("erases nothing the registry did not register as actionable", () => {
+    const actionable = new Set(
+      PERSONAL_DATA_REGISTRY.filter(isActionable).map((entry) => entry.table)
+    );
+    const unregistered = ERASURE_HANDLED_TABLES.filter(
+      (table) => !actionable.has(table)
+    );
+    expect(unregistered).toEqual([]);
+    expect(new Set(ERASURE_HANDLED_TABLES).size).toBe(
+      ERASURE_HANDLED_TABLES.length
+    );
+  });
+
+  it("wires every exported entry into the export, and nothing else", () => {
+    const exported = PERSONAL_DATA_REGISTRY.filter((entry) => entry.exported)
+      .map((entry) => entry.table)
+      .sort();
+    expect(Object.keys(EXPORT_HANDLERS).sort()).toEqual(exported);
+    expect(exported.length).toBeGreaterThanOrEqual(30);
+  });
+
+  it("never exports a table it classified as holding no personal data", () => {
+    const wrong = PERSONAL_DATA_REGISTRY.filter(
+      (entry) => entry.disposition === "not-personal" && entry.exported
+    ).map((entry) => entry.table);
+    expect(wrong).toEqual([]);
+  });
+});

--- a/packages/models/tests/personal-data.test.ts
+++ b/packages/models/tests/personal-data.test.ts
@@ -1,0 +1,530 @@
+/**
+ * Erasure and export, exercised against a database seeded from the registry
+ * itself.
+ *
+ * The seeding is generic on purpose: it walks `PERSONAL_DATA_REGISTRY`, reads
+ * each table's columns from Drizzle, and writes one row per table reachable
+ * from the subject. A table added to the registry is therefore seeded and
+ * asserted on without anyone editing this file — the same reason the registry
+ * exists in the first place.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { Table, count, eq, getTableColumns, getTableName, is } from "drizzle-orm";
+import type { SQLiteTable } from "drizzle-orm/sqlite-core";
+
+import * as schema from "../src/schema/index.js";
+import { getDb, initTestDb } from "../src/db.js";
+import {
+  PERSONAL_DATA_REGISTRY,
+  WITHHELD_VALUE,
+  type PersonalDataEntry
+} from "../src/personal-data-registry.js";
+import {
+  erasePersonalData,
+  exportPersonalData,
+  type ErasureObjectStore
+} from "../src/personal-data.js";
+import { predictions } from "../src/schema/predictions.js";
+import { secrets } from "../src/schema/secrets.js";
+import { userEvents } from "../src/schema/user-events.js";
+import { workflowCollaborators } from "../src/schema/workflow-sharing.js";
+import { UserEventType, recordUserEvent } from "../src/user-event.js";
+
+const SUBJECT = "user-subject";
+const OTHER = "user-other";
+
+interface ColumnMeta {
+  name: string;
+  notNull: boolean;
+  hasDefault: boolean;
+  columnType: string;
+}
+
+const tablesByName = new Map<string, SQLiteTable>();
+for (const value of Object.values(schema)) {
+  if (!is(value as object, Table)) continue;
+  tablesByName.set(getTableName(value as unknown as Table), value as SQLiteTable);
+}
+
+function columnsOf(table: SQLiteTable): ColumnMeta[] {
+  return Object.values(getTableColumns(table)).map(
+    (column) => column as unknown as ColumnMeta
+  );
+}
+
+/** A value SQLite accepts for a required column, by Drizzle column type. */
+function filler(column: ColumnMeta, tag: string): unknown {
+  switch (column.columnType) {
+    case "SQLiteInteger":
+    case "SQLiteReal":
+      return 1;
+    case "SQLiteBoolean":
+      return false;
+    case "SQLiteCustomColumn":
+      // Every custom column here is `jsonText`, which JSON-stringifies.
+      return {};
+    default:
+      return `${tag}-${column.name}`;
+  }
+}
+
+/** Ids the seeded rows are wired to, so foreign keys resolve. */
+function links(tag: string): Record<string, string> {
+  return {
+    application_id: `${tag}-application`,
+    run_id: `${tag}-job`,
+    grant_id: `${tag}-grant`,
+    workflow_id: `${tag}-workflow`,
+    image_document_id: `${tag}-image-document`,
+    js_script_id: `${tag}-js-script`,
+    timeline_id: `${tag}-timeline-sequence`,
+    project_id: `${tag}-project`,
+    thread_id: `${tag}-thread`
+  };
+}
+
+/** Ids the parents must be created with, so the links above point at them. */
+function parentIds(tag: string): Record<string, string> {
+  return {
+    applications: `${tag}-application`,
+    nodetool_jobs: `${tag}-job`,
+    mcp_oauth_grants: `${tag}-grant`,
+    nodetool_workflows: `${tag}-workflow`,
+    image_documents: `${tag}-image-document`,
+    js_scripts: `${tag}-js-script`,
+    timeline_sequences: `${tag}-timeline-sequence`,
+    projects: `${tag}-project`,
+    nodetool_threads: `${tag}-thread`
+  };
+}
+
+/** Parents before children, so a foreign key never dangles at insert time. */
+const SEED_ORDER = [
+  "nodetool_workflows",
+  "projects",
+  "nodetool_threads",
+  "applications",
+  "nodetool_jobs",
+  "mcp_oauth_grants",
+  "image_documents",
+  "js_scripts",
+  "timeline_sequences"
+];
+
+function orderedEntries(): PersonalDataEntry[] {
+  return [...PERSONAL_DATA_REGISTRY].sort((a, b) => {
+    const ia = SEED_ORDER.indexOf(a.table);
+    const ib = SEED_ORDER.indexOf(b.table);
+    return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib);
+  });
+}
+
+/**
+ * Write one row per registry table, reachable from `userId`.
+ *
+ * `not-personal` tables are seeded too — erasure must leave them alone, and a
+ * test that never creates them cannot notice if it does not.
+ */
+async function seedUser(userId: string, tag: string): Promise<void> {
+  const db = getDb();
+  const link = links(tag);
+  const parents = parentIds(tag);
+
+  for (const entry of orderedEntries()) {
+    const table = tablesByName.get(entry.table);
+    if (!table) throw new Error(`No schema table for ${entry.table}`);
+
+    const row: Record<string, unknown> = {};
+    for (const column of columnsOf(table)) {
+      if (column.name === "id" && parents[entry.table]) {
+        row.id = parents[entry.table];
+        continue;
+      }
+      if (column.name === "id") {
+        row.id = `${tag}-${entry.table}`;
+        continue;
+      }
+      if (link[column.name] !== undefined) {
+        row[column.name] = link[column.name];
+        continue;
+      }
+      if (column.name === "user_id" || column.name === "created_by") {
+        row[column.name] = userId;
+        continue;
+      }
+      if (column.notNull && !column.hasDefault) {
+        row[column.name] = filler(column, tag);
+      }
+    }
+
+    // The columns the assertions below actually look at.
+    if (entry.table === "nodetool_predictions") {
+      row.parameters = { prompt: "a private prompt" };
+      row.metadata = { note: "private" };
+      row.logs = "a private log line";
+      row.cost = 1.25;
+      row.model = "gpt-4o-mini";
+      row.created_at = "2026-01-01T00:00:00.000Z";
+    }
+    if (entry.table === "run_events") {
+      row.payload = { prompt: "a private prompt", output: "a private answer" };
+      row.event_time = "2026-01-01T00:00:00.000Z";
+    }
+    if (entry.table === "nodetool_secrets") {
+      row.key = "OPENAI_API_KEY";
+      row.encrypted_value = "ciphertext-never-exported";
+    }
+    if (entry.table === "nodetool_user_events") {
+      row.event_type = UserEventType.SIGN_IN;
+    }
+    if (entry.table === "nodetool_user_subscriptions") {
+      row.user_id = userId;
+    }
+
+    await db.insert(table).values(row);
+  }
+}
+
+/** How many rows the subject still has in `entry`'s table. */
+async function remaining(entry: PersonalDataEntry, tag: string): Promise<number> {
+  const table = tablesByName.get(entry.table);
+  if (!table || entry.reach.kind === "none") return 0;
+  const columns = getTableColumns(table) as Record<string, never>;
+  const column = columns[entry.reach.column];
+  const value =
+    entry.reach.kind === "direct" ? SUBJECT : links(tag)[entry.reach.column];
+  const [row] = await getDb()
+    .select({ value: count() })
+    .from(table)
+    .where(eq(column, value));
+  return Number((row as { value: number } | undefined)?.value ?? 0);
+}
+
+async function rowCount(table: SQLiteTable): Promise<number> {
+  const [row] = await getDb().select({ value: count() }).from(table);
+  return Number((row as { value: number } | undefined)?.value ?? 0);
+}
+
+describe("erasePersonalData", () => {
+  beforeEach(async () => {
+    initTestDb();
+    await seedUser(SUBJECT, "s");
+    await seedUser(OTHER, "o");
+  });
+
+  it("seeds a row in every registered table", async () => {
+    // Positive control: the assertions below are vacuous against an empty DB.
+    const empty: string[] = [];
+    for (const entry of PERSONAL_DATA_REGISTRY) {
+      const table = tablesByName.get(entry.table);
+      if (table && (await rowCount(table)) === 0) empty.push(entry.table);
+    }
+    expect(empty).toEqual([]);
+    expect(PERSONAL_DATA_REGISTRY.length).toBeGreaterThanOrEqual(40);
+  });
+
+  it("removes the subject's rows from every delete table", async () => {
+    await erasePersonalData(SUBJECT);
+    const left: string[] = [];
+    for (const entry of PERSONAL_DATA_REGISTRY) {
+      if (entry.disposition !== "delete") continue;
+      if ((await remaining(entry, "s")) !== 0) left.push(entry.table);
+    }
+    expect(left).toEqual([]);
+  });
+
+  it("reaches the run-scoped tables that have no user_id", async () => {
+    // The failure this guards: deleting nodetool_jobs first, which orphans
+    // run_events and leaves prompt text unreachable and undeleted.
+    const indirect = PERSONAL_DATA_REGISTRY.filter(
+      (entry) => entry.reach.kind === "indirect"
+    );
+    expect(indirect.map((entry) => entry.table).sort()).toEqual([
+      "application_budgets",
+      "mcp_oauth_tokens",
+      "run_events",
+      "run_inbox_messages",
+      "trigger_inputs"
+    ]);
+    await erasePersonalData(SUBJECT);
+    for (const entry of indirect) {
+      expect([entry.table, await remaining(entry, "s")]).toEqual([
+        entry.table,
+        0
+      ]);
+    }
+  });
+
+  it("redacts a prediction's payload and keeps its billing columns", async () => {
+    await erasePersonalData(SUBJECT);
+    const [row] = await getDb()
+      .select()
+      .from(predictions)
+      .where(eq(predictions.user_id, SUBJECT));
+    const prediction = row as Record<string, unknown>;
+    expect(prediction).toBeDefined();
+    expect(prediction.parameters).toBeNull();
+    expect(prediction.metadata).toBeNull();
+    expect(prediction.logs).toBeNull();
+    expect(prediction.cost).toBe(1.25);
+    expect(prediction.model).toBe("gpt-4o-mini");
+    expect(prediction.user_id).toBe(SUBJECT);
+  });
+
+  it("keeps consent and data-subject-request events, drops the rest", async () => {
+    await recordUserEvent({
+      userId: SUBJECT,
+      eventType: UserEventType.CONSENT_GIVEN,
+      metadata: { policy: "privacy", policy_version: "2026-01" }
+    });
+    await recordUserEvent({
+      userId: SUBJECT,
+      eventType: UserEventType.DATA_ERASURE_REQUESTED,
+      metadata: { request_id: "dsr-1" }
+    });
+
+    await erasePersonalData(SUBJECT, { requestId: "dsr-1" });
+
+    const rows = (await getDb()
+      .select()
+      .from(userEvents)
+      .where(eq(userEvents.user_id, SUBJECT))) as { event_type: string }[];
+    const types = rows.map((row) => row.event_type).sort();
+    expect(types).toEqual([
+      "consent_given",
+      "data_erasure_completed",
+      "data_erasure_requested"
+    ]);
+    // The sign_in row seeded for the subject is operational, so it went.
+    expect(types).not.toContain("sign_in");
+  });
+
+  it("purges the evidence only when explicitly told to", async () => {
+    await recordUserEvent({
+      userId: SUBJECT,
+      eventType: UserEventType.CONSENT_GIVEN,
+      metadata: { policy: "privacy" }
+    });
+    await erasePersonalData(SUBJECT, { purgeComplianceEvidence: true });
+    const [row] = await getDb()
+      .select({ value: count() })
+      .from(userEvents)
+      .where(eq(userEvents.user_id, SUBJECT));
+    expect(Number((row as { value: number }).value)).toBe(0);
+  });
+
+  it("leaves every other user's rows alone", async () => {
+    await erasePersonalData(SUBJECT);
+    const missing: string[] = [];
+    for (const entry of PERSONAL_DATA_REGISTRY) {
+      if (entry.reach.kind === "none") continue;
+      const table = tablesByName.get(entry.table);
+      if (!table) continue;
+      const columns = getTableColumns(table) as Record<string, never>;
+      const value =
+        entry.reach.kind === "direct" ? OTHER : links("o")[entry.reach.column];
+      const [row] = await getDb()
+        .select({ value: count() })
+        .from(table)
+        .where(eq(columns[entry.reach.column], value));
+      if (Number((row as { value: number }).value) !== 1) {
+        missing.push(entry.table);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it("leaves the infrastructure tables alone", async () => {
+    await erasePersonalData(SUBJECT);
+    for (const entry of PERSONAL_DATA_REGISTRY) {
+      if (entry.disposition !== "not-personal") continue;
+      const table = tablesByName.get(entry.table);
+      if (!table) continue;
+      expect([entry.table, await rowCount(table)]).toEqual([entry.table, 2]);
+    }
+  });
+
+  it("is idempotent", async () => {
+    const first = await erasePersonalData(SUBJECT);
+    expect(first.deleted).toBeGreaterThan(0);
+    expect(first.redacted).toBe(1);
+
+    const second = await erasePersonalData(SUBJECT);
+    expect(second.deleted).toBe(0);
+    expect(second.redacted).toBe(0);
+    expect(second.retained).toBe(first.retained);
+
+    const left: string[] = [];
+    for (const entry of PERSONAL_DATA_REGISTRY) {
+      if (entry.disposition !== "delete") continue;
+      if ((await remaining(entry, "s")) !== 0) left.push(entry.table);
+    }
+    expect(left).toEqual([]);
+  });
+
+  it("reports what it did, per table", async () => {
+    const report = await erasePersonalData(SUBJECT);
+    const byTable = new Map(report.tables.map((row) => [row.table, row]));
+    expect(byTable.get("nodetool_messages")?.deleted).toBe(1);
+    expect(byTable.get("run_events")?.deleted).toBe(1);
+    expect(byTable.get("nodetool_predictions")?.redacted).toBe(1);
+    expect(byTable.get("nodetool_credit_ledger")?.retained).toBe(1);
+    expect(byTable.get("nodetool_credit_ledger")?.deleted).toBe(0);
+    // Every actionable registry entry appears in the report exactly once.
+    expect(report.tables.length).toBe(
+      PERSONAL_DATA_REGISTRY.filter(
+        (entry) => entry.disposition !== "not-personal"
+      ).length
+    );
+  });
+
+  it("says the blobs were skipped when no object store is injected", async () => {
+    const report = await erasePersonalData(SUBJECT);
+    expect(report.objectKeysDeleted).toBeNull();
+  });
+
+  it("deletes the subject's stored objects through the injected store", async () => {
+    const asked: string[] = [];
+    const store: ErasureObjectStore = {
+      async deleteObjectsForUser(userId) {
+        asked.push(userId);
+        return [`${userId}/asset-1.png`, `${userId}/asset-1_thumb.jpg`];
+      }
+    };
+    const report = await erasePersonalData(SUBJECT, { objectStore: store });
+    expect(asked).toEqual([SUBJECT]);
+    expect(report.objectKeysDeleted).toEqual([
+      "user-subject/asset-1.png",
+      "user-subject/asset-1_thumb.jpg"
+    ]);
+  });
+});
+
+describe("exportPersonalData", () => {
+  beforeEach(async () => {
+    initTestDb();
+    await seedUser(SUBJECT, "s");
+    await seedUser(OTHER, "o");
+    // Someone else, collaborating on the subject's workflow. Reachable from
+    // the subject through `workflow_id`, and not theirs to receive — so every
+    // assertion below runs against a database where the leak is possible.
+    await getDb().insert(workflowCollaborators).values({
+      id: "collab-foreign",
+      workflow_id: "s-workflow",
+      user_id: OTHER,
+      role: "viewer",
+      invited_by: SUBJECT,
+      created_at: "2026-01-01T00:00:00.000Z"
+    });
+  });
+
+  it("returns a row for every exported table", async () => {
+    const dump = await exportPersonalData(SUBJECT);
+    const empty = PERSONAL_DATA_REGISTRY.filter(
+      (entry) => entry.exported && dump.tables[entry.table]?.rowCount !== 1
+    ).map((entry) => entry.table);
+    expect(empty).toEqual([]);
+    expect(Object.keys(dump.tables).length).toBeGreaterThanOrEqual(30);
+  });
+
+  it("never emits a secret, a token or a hash in plaintext", async () => {
+    const dump = await exportPersonalData(SUBJECT);
+    const serialized = JSON.stringify(dump);
+
+    expect(dump.tables.nodetool_secrets.rows[0].key).toBe("OPENAI_API_KEY");
+    expect(dump.tables.nodetool_secrets.rows[0].encrypted_value).toBe(
+      WITHHELD_VALUE
+    );
+    expect(serialized).not.toContain("ciphertext-never-exported");
+
+    // Every column any entry marked withheld is blanked, not just the ones
+    // this test names.
+    for (const entry of PERSONAL_DATA_REGISTRY) {
+      for (const column of entry.withheldColumns ?? []) {
+        const rows = dump.tables[entry.table]?.rows ?? [];
+        for (const row of rows) {
+          expect([entry.table, column, row[column]]).toEqual([
+            entry.table,
+            column,
+            WITHHELD_VALUE
+          ]);
+        }
+      }
+    }
+    // The seeded plaintext for those columns must be gone from the payload.
+    expect(serialized).not.toContain("s-secret_hash");
+    expect(serialized).not.toContain("s-token");
+  });
+
+  it("still confirms the withheld records exist", async () => {
+    const dump = await exportPersonalData(SUBJECT);
+    expect(dump.tables.nodetool_secrets.withheldColumns).toEqual([
+      "encrypted_value"
+    ]);
+    expect(dump.tables.nodetool_oauth_credentials.rows[0].provider).toBe(
+      "s-provider"
+    );
+  });
+
+  it("excludes other users' data reachable through the sharing tables", async () => {
+    const dump = await exportPersonalData(SUBJECT);
+    const rows = dump.tables.nodetool_workflow_collaborators.rows;
+    expect(rows.map((row) => row.user_id)).toEqual([SUBJECT]);
+    expect(JSON.stringify(dump)).not.toContain("collab-foreign");
+
+    // …and erasure still removes it, because it points at a deleted graph.
+    await erasePersonalData(SUBJECT);
+    const [row] = await getDb()
+      .select({ value: count() })
+      .from(workflowCollaborators)
+      .where(eq(workflowCollaborators.workflow_id, "s-workflow"));
+    expect(Number((row as { value: number }).value)).toBe(0);
+  });
+
+  it("carries no row belonging to another user", async () => {
+    const dump = await exportPersonalData(SUBJECT);
+    const leaked: string[] = [];
+    for (const [table, payload] of Object.entries(dump.tables)) {
+      for (const row of payload.rows) {
+        if (row.user_id !== undefined && row.user_id !== SUBJECT) {
+          leaked.push(`${table}.user_id=${String(row.user_id)}`);
+        }
+        if (row.created_by !== undefined && row.created_by !== SUBJECT) {
+          leaked.push(`${table}.created_by=${String(row.created_by)}`);
+        }
+      }
+    }
+    expect(leaked).toEqual([]);
+    expect(JSON.stringify(dump)).not.toContain(OTHER);
+  });
+
+  it("says which tables it left out and why", async () => {
+    const dump = await exportPersonalData(SUBJECT);
+    const excluded = dump.excluded.map((row) => row.table).sort();
+    expect(excluded).toEqual([
+      "mcp_oauth_clients",
+      "mcp_oauth_tokens",
+      "nodetool_team_tasks",
+      "run_inbox_messages",
+      "worker_instances",
+      "worker_profiles"
+    ]);
+    expect(dump.excluded.every((row) => row.reason.length > 40)).toBe(true);
+  });
+
+  it("caps a table and says so", async () => {
+    const dump = await exportPersonalData(SUBJECT, { maxRowsPerTable: 1 });
+    expect(dump.tables.nodetool_messages.rowCount).toBe(1);
+    expect(dump.tables.nodetool_messages.truncated).toBe(true);
+  });
+
+  it("exports the encrypted secret column as present but blanked", async () => {
+    const [row] = await getDb()
+      .select()
+      .from(secrets)
+      .where(eq(secrets.user_id, SUBJECT));
+    expect((row as Record<string, unknown>).encrypted_value).toBe(
+      "ciphertext-never-exported"
+    );
+  });
+});

--- a/packages/models/tests/storage-maintenance.test.ts
+++ b/packages/models/tests/storage-maintenance.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../src/storage-maintenance.js";
 import { getDb, initTestDb } from "../src/db.js";
 import { Job } from "../src/job.js";
+import { Prediction } from "../src/prediction.js";
 import { RunEvent } from "../src/run-event.js";
 import { WorkflowVersion } from "../src/workflow-version.js";
 import { runEvents } from "../src/schema/run-events.js";
@@ -50,6 +51,51 @@ async function job(input: {
   });
 }
 
+async function runEvent(input: {
+  id: string;
+  runId: string;
+  seq: number;
+  ageDays: number;
+}): Promise<void> {
+  await RunEvent.create<RunEvent>({
+    id: input.id,
+    run_id: input.runId,
+    seq: input.seq,
+    event_type: "NodeCompleted",
+    event_time: daysAgo(input.ageDays),
+    node_id: "node-1",
+    payload: { prompt: "a private prompt", output: "a private answer" }
+  });
+}
+
+async function prediction(input: {
+  id: string;
+  userId?: string;
+  ageDays: number;
+}): Promise<void> {
+  await Prediction.create<Prediction>({
+    id: input.id,
+    user_id: input.userId ?? "user-1",
+    provider: "openai",
+    model: "gpt-4o-mini",
+    status: "completed",
+    cost: 0.0125,
+    input_tokens: 1000,
+    output_tokens: 250,
+    total_tokens: 1250,
+    created_at: daysAgo(input.ageDays),
+    completed_at: daysAgo(input.ageDays),
+    logs: "raw provider log line",
+    parameters: { prompt: "a private prompt" },
+    metadata: { user_agent: "nodetool/1.0" }
+  });
+}
+
+async function eventIds(): Promise<string[]> {
+  const rows = await getDb().select().from(runEvents);
+  return rows.map((row: { id: string }) => row.id).sort();
+}
+
 describe("storage maintenance", () => {
   beforeEach(() => initTestDb());
 
@@ -76,6 +122,8 @@ describe("storage maintenance", () => {
       autosaves: 1,
       manualVersions: 1,
       terminalJobs: 1,
+      runEvents: 0,
+      redactedPredictions: 0,
       total: 3
     });
     expect(status.jobs).toBe(2);
@@ -147,6 +195,209 @@ describe("storage maintenance", () => {
     expect(await WorkflowVersion.get("checkpoint")).not.toBeNull();
     const events = await getDb().select().from(runEvents);
     expect(events).toHaveLength(0);
+  });
+
+  it("sweeps run events past the window on runs that survive the pass", async () => {
+    await job({ id: "active-job", status: "running", ageDays: 200 });
+    await runEvent({
+      id: "stale-event",
+      runId: "active-job",
+      seq: 1,
+      ageDays: 31
+    });
+    await runEvent({
+      id: "fresh-event",
+      runId: "active-job",
+      seq: 2,
+      ageDays: 2
+    });
+    await Job.create<Job>({
+      id: "other-job",
+      user_id: "user-2",
+      workflow_id: "wf-other",
+      job_type: "workflow",
+      status: "running",
+      created_at: daysAgo(200),
+      updated_at: daysAgo(200)
+    });
+    await runEvent({
+      id: "other-event",
+      runId: "other-job",
+      seq: 1,
+      ageDays: 90
+    });
+
+    const status = await getStorageStatus(
+      "user-1",
+      DEFAULT_STORAGE_RETENTION_POLICY,
+      NOW
+    );
+    expect(status.runEvents).toBe(2);
+    expect(status.cleanup.runEvents).toBe(1);
+    expect(status.cleanup.total).toBe(1);
+
+    const result = await cleanupStorage(
+      "user-1",
+      DEFAULT_STORAGE_RETENTION_POLICY,
+      NOW
+    );
+
+    expect(result.runEvents).toBe(1);
+    // The run itself is untouched; only its expired events are gone. Another
+    // user's events are out of scope because run_events is joined to jobs.
+    expect(await Job.get("active-job")).not.toBeNull();
+    expect(await eventIds()).toEqual(["fresh-event", "other-event"]);
+  });
+
+  it("keeps every run event when the window still covers them", async () => {
+    await job({ id: "active-job", status: "running", ageDays: 200 });
+    await runEvent({
+      id: "stale-event",
+      runId: "active-job",
+      seq: 1,
+      ageDays: 31
+    });
+    await runEvent({
+      id: "fresh-event",
+      runId: "active-job",
+      seq: 2,
+      ageDays: 2
+    });
+
+    const policy = {
+      ...DEFAULT_STORAGE_RETENTION_POLICY,
+      runEventRetentionDays: 3650
+    };
+    const status = await getStorageStatus("user-1", policy, NOW);
+    expect(status.cleanup.runEvents).toBe(0);
+
+    const result = await cleanupStorage("user-1", policy, NOW);
+    expect(result.runEvents).toBe(0);
+    expect(await eventIds()).toEqual(["fresh-event", "stale-event"]);
+  });
+
+  it("redacts the payload of an expired prediction and keeps the billing row", async () => {
+    await prediction({ id: "old-prediction", ageDays: 401 });
+
+    const status = await getStorageStatus(
+      "user-1",
+      DEFAULT_STORAGE_RETENTION_POLICY,
+      NOW
+    );
+    expect(status.predictionsWithPayload).toBe(1);
+    expect(status.cleanup.redactedPredictions).toBe(1);
+    // Redaction is not deletion, so it stays out of the deleted total.
+    expect(status.cleanup.total).toBe(0);
+
+    const result = await cleanupStorage(
+      "user-1",
+      DEFAULT_STORAGE_RETENTION_POLICY,
+      NOW
+    );
+    expect(result.redactedPredictions).toBe(1);
+
+    const row = await Prediction.find("old-prediction");
+    expect(row).not.toBeNull();
+    expect(row?.parameters).toBeNull();
+    expect(row?.metadata).toBeNull();
+    expect(row?.logs).toBeNull();
+    expect(row?.cost).toBe(0.0125);
+    expect(row?.input_tokens).toBe(1000);
+    expect(row?.output_tokens).toBe(250);
+    expect(row?.total_tokens).toBe(1250);
+    expect(row?.model).toBe("gpt-4o-mini");
+    expect(row?.provider).toBe("openai");
+    expect(row?.status).toBe("completed");
+    expect(row?.created_at).toBe(daysAgo(401));
+    expect(row?.completed_at).toBe(daysAgo(401));
+
+    // A second pass has nothing left to redact.
+    const second = await cleanupStorage(
+      "user-1",
+      DEFAULT_STORAGE_RETENTION_POLICY,
+      NOW
+    );
+    expect(second.redactedPredictions).toBe(0);
+  });
+
+  it("leaves recent predictions and other users' predictions intact", async () => {
+    await prediction({ id: "recent-prediction", ageDays: 10 });
+    await prediction({
+      id: "other-prediction",
+      userId: "user-2",
+      ageDays: 401
+    });
+
+    const result = await cleanupStorage(
+      "user-1",
+      DEFAULT_STORAGE_RETENTION_POLICY,
+      NOW
+    );
+
+    expect(result.redactedPredictions).toBe(0);
+    expect((await Prediction.find("recent-prediction"))?.parameters).toEqual({
+      prompt: "a private prompt"
+    });
+    expect((await Prediction.find("other-prediction"))?.parameters).toEqual({
+      prompt: "a private prompt"
+    });
+  });
+
+  it("previews exactly what the cleanup then removes", async () => {
+    await version({ id: "a1", version: 1, saveType: "autosave", ageDays: 8 });
+    await version({ id: "m1", version: 2, saveType: "manual", ageDays: 91 });
+    await job({ id: "old-job", status: "completed", ageDays: 31 });
+    await job({ id: "active-job", status: "running", ageDays: 200 });
+    await runEvent({
+      id: "stale-event",
+      runId: "active-job",
+      seq: 1,
+      ageDays: 31
+    });
+    await runEvent({
+      id: "fresh-event",
+      runId: "active-job",
+      seq: 2,
+      ageDays: 2
+    });
+    await prediction({ id: "old-prediction", ageDays: 401 });
+
+    const preview = (
+      await getStorageStatus("user-1", DEFAULT_STORAGE_RETENTION_POLICY, NOW)
+    ).cleanup;
+    const result = await cleanupStorage(
+      "user-1",
+      DEFAULT_STORAGE_RETENTION_POLICY,
+      NOW
+    );
+
+    const { completedAt, ...counts } = result;
+    expect(completedAt).toBe(NOW.toISOString());
+    expect(counts).toEqual(preview);
+    // Every sweep in this fixture has work to do — a sweep that matched
+    // nothing would report zeroes and fail here.
+    expect(preview).toEqual({
+      autosaves: 1,
+      manualVersions: 1,
+      terminalJobs: 1,
+      runEvents: 1,
+      redactedPredictions: 1,
+      total: 4
+    });
+
+    const after = await getStorageStatus(
+      "user-1",
+      DEFAULT_STORAGE_RETENTION_POLICY,
+      NOW
+    );
+    expect(after.cleanup.total).toBe(0);
+    expect(after.cleanup.redactedPredictions).toBe(0);
+  });
+
+  it("keeps automatic cleanup off by default and names the new windows", () => {
+    expect(DEFAULT_STORAGE_RETENTION_POLICY.automaticCleanup).toBe(false);
+    expect(DEFAULT_STORAGE_RETENTION_POLICY.runEventRetentionDays).toBe(30);
+    expect(DEFAULT_STORAGE_RETENTION_POLICY.predictionRetentionDays).toBe(400);
   });
 
   it("never touches another user's history", async () => {

--- a/packages/models/tests/user-event.test.ts
+++ b/packages/models/tests/user-event.test.ts
@@ -1,0 +1,518 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { getTableColumns } from "drizzle-orm";
+import { ModelObserver } from "../src/base-model.js";
+import { getRawDb, initTestDb } from "../src/db.js";
+import { SQLiteMigrationAdapter, migrations } from "../src/migrations/index.js";
+import { userEvents } from "../src/schema/user-events.js";
+import {
+  DEFAULT_USER_EVENT_RETENTION_DAYS,
+  MAX_USER_EVENT_STRING_LENGTH,
+  NEVER_PRUNED_USER_EVENT_TYPES,
+  USER_EVENT_METADATA_ALLOWLIST,
+  UserEventType,
+  deleteUserEventsForUser,
+  isNeverPrunedUserEventType,
+  isUserEventType,
+  listUserEvents,
+  pruneUserEvents,
+  recordUserEvent,
+  sanitizeUserEventMetadata
+} from "../src/user-event.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The compliance-evidence event types, written out rather than read from
+ * `NEVER_PRUNED_USER_EVENT_TYPES`. Deriving this from the production constant
+ * would make the carve-out tests agree with whatever the constant says —
+ * dropping a type from it would shrink the test instead of failing it.
+ */
+const EXPECTED_NEVER_PRUNED = [
+  "consent_given",
+  "consent_withdrawn",
+  "terms_accepted",
+  "data_export_requested",
+  "data_erasure_requested",
+  "data_erasure_completed"
+] as const;
+
+/** ISO timestamp `days` in the past. */
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * DAY_MS).toISOString();
+}
+
+/**
+ * `initTestDb()` already creates the table from the schema SQL in `db.ts`.
+ * Running the migration on top of it is what pins the two definitions
+ * together: if `create_user_events` ever stops being idempotent, or drifts
+ * from the `db.ts` shape, every test below fails here rather than in
+ * production on a database that took the migration path.
+ */
+async function setupDb(): Promise<void> {
+  initTestDb();
+  const migration = migrations.find((m) => m.name === "create_user_events");
+  if (!migration) {
+    throw new Error("create_user_events migration is missing from versions.ts");
+  }
+  await migration.up(new SQLiteMigrationAdapter(getRawDb()));
+}
+
+describe("user_events schema", () => {
+  beforeEach(() => setupDb());
+  afterEach(() => ModelObserver.clear());
+
+  it("has exactly the seven privacy-scoped columns and no more", () => {
+    expect(Object.keys(getTableColumns(userEvents)).sort()).toEqual([
+      "created_at",
+      "event_type",
+      "id",
+      "metadata",
+      "subject_id",
+      "subject_type",
+      "user_id"
+    ]);
+  });
+
+  it("carries no IP address, user agent, or free-text column", () => {
+    const columns = Object.keys(getTableColumns(userEvents));
+    for (const forbidden of [
+      "ip",
+      "ip_address",
+      "user_agent",
+      "note",
+      "notes",
+      "description",
+      "message",
+      "comment",
+      "prompt",
+      "content",
+      "body",
+      "text"
+    ]) {
+      expect(columns).not.toContain(forbidden);
+    }
+  });
+});
+
+describe("user event vocabulary", () => {
+  it("recognizes every declared type and nothing else", () => {
+    for (const type of Object.values(UserEventType)) {
+      expect(isUserEventType(type)).toBe(true);
+    }
+    expect(isUserEventType("page_view")).toBe(false);
+    expect(isUserEventType("node_dragged")).toBe(false);
+    expect(isUserEventType(undefined)).toBe(false);
+  });
+
+  it("gives every event type an explicit metadata allowlist", () => {
+    for (const type of Object.values(UserEventType)) {
+      expect(USER_EVENT_METADATA_ALLOWLIST[type]).toBeDefined();
+      expect(Array.isArray(USER_EVENT_METADATA_ALLOWLIST[type])).toBe(true);
+    }
+  });
+
+  it("marks exactly the consent, policy and DSR types as never pruned", () => {
+    expect([...NEVER_PRUNED_USER_EVENT_TYPES].sort()).toEqual(
+      [...EXPECTED_NEVER_PRUNED].sort()
+    );
+    for (const type of EXPECTED_NEVER_PRUNED) {
+      expect(isNeverPrunedUserEventType(type)).toBe(true);
+    }
+    // Auth and audit-trail events are on the 180-day clock, not exempt.
+    for (const type of [
+      UserEventType.SIGN_IN,
+      UserEventType.ACCESS_TOKEN_ISSUED,
+      UserEventType.WORKFLOW_DELETED,
+      UserEventType.APP_PUBLISHED
+    ]) {
+      expect(isNeverPrunedUserEventType(type)).toBe(false);
+    }
+  });
+
+  it("allowlists no key that reads as free text", () => {
+    const freeText = [
+      "note",
+      "notes",
+      "description",
+      "message",
+      "comment",
+      "prompt",
+      "content",
+      "body",
+      "text",
+      "query",
+      "input",
+      "output",
+      "graph",
+      "value",
+      "secret_value",
+      "ip",
+      "ip_address",
+      "user_agent"
+    ];
+    for (const [type, keys] of Object.entries(
+      USER_EVENT_METADATA_ALLOWLIST
+    )) {
+      for (const key of keys) {
+        expect(
+          freeText.includes(key),
+          `${type} allowlists free-text key "${key}"`
+        ).toBe(false);
+      }
+    }
+  });
+});
+
+describe("sanitizeUserEventMetadata", () => {
+  it("keeps allowlisted scalars and drops everything else", () => {
+    const kept = sanitizeUserEventMetadata(UserEventType.SIGN_IN, {
+      method: "oauth",
+      provider: "google",
+      // Not on sign_in's allowlist — the smuggling case this table exists to
+      // prevent.
+      prompt: "write me a poem about my medical history",
+      email: "someone@example.com",
+      graph: { nodes: [] }
+    });
+    expect(kept).toEqual({ method: "oauth", provider: "google" });
+  });
+
+  it("drops non-scalar values on allowlisted keys", () => {
+    expect(
+      sanitizeUserEventMetadata(UserEventType.APP_DEPLOYED, {
+        application_id: { id: "nested" },
+        version: [1, 2, 3],
+        target: null
+      })
+    ).toBeNull();
+  });
+
+  it("drops non-finite numbers and empty strings", () => {
+    expect(
+      sanitizeUserEventMetadata(UserEventType.WORKFLOW_SHARED, {
+        recipient_count: Number.NaN,
+        share_scope: ""
+      })
+    ).toBeNull();
+
+    expect(
+      sanitizeUserEventMetadata(UserEventType.WORKFLOW_SHARED, {
+        recipient_count: 0,
+        share_scope: "link"
+      })
+    ).toEqual({ recipient_count: 0, share_scope: "link" });
+  });
+
+  it("drops a string long enough to be prose rather than a fact", () => {
+    const prose = "a".repeat(MAX_USER_EVENT_STRING_LENGTH + 1);
+    expect(
+      sanitizeUserEventMetadata(UserEventType.SIGN_IN, { method: prose })
+    ).toBeNull();
+
+    const atLimit = "b".repeat(MAX_USER_EVENT_STRING_LENGTH);
+    expect(
+      sanitizeUserEventMetadata(UserEventType.SIGN_IN, { method: atLimit })
+    ).toEqual({ method: atLimit });
+  });
+
+  it("scopes the allowlist per event type", () => {
+    // `provider` is a sign_in fact, not a workflow_deleted one.
+    expect(
+      sanitizeUserEventMetadata(UserEventType.WORKFLOW_DELETED, {
+        provider: "google",
+        soft_delete: true
+      })
+    ).toEqual({ soft_delete: true });
+  });
+
+  it("returns null for absent or empty metadata", () => {
+    expect(sanitizeUserEventMetadata(UserEventType.SIGN_OUT, undefined)).toBeNull();
+    expect(sanitizeUserEventMetadata(UserEventType.SIGN_OUT, null)).toBeNull();
+    expect(sanitizeUserEventMetadata(UserEventType.SIGN_OUT, {})).toBeNull();
+  });
+});
+
+describe("recordUserEvent", () => {
+  beforeEach(() => setupDb());
+  afterEach(() => ModelObserver.clear());
+
+  it("stores only the allowlisted metadata, not what the caller passed", async () => {
+    const recorded = await recordUserEvent({
+      userId: "user-a",
+      eventType: UserEventType.SECRET_WRITTEN,
+      subjectType: "secret",
+      subjectId: "secret-1",
+      metadata: {
+        secret_name: "OPENAI_API_KEY",
+        secret_value: "sk-live-should-never-be-logged",
+        note: "rotated after the incident"
+      }
+    });
+
+    expect(recorded).not.toBeNull();
+    const [stored] = await listUserEvents("user-a");
+    expect(stored.metadata).toEqual({ secret_name: "OPENAI_API_KEY" });
+    expect(JSON.stringify(stored)).not.toContain("sk-live");
+    expect(JSON.stringify(stored)).not.toContain("rotated after");
+  });
+
+  it("stores null metadata when nothing survives the allowlist", async () => {
+    await recordUserEvent({
+      userId: "user-a",
+      eventType: UserEventType.SIGN_IN,
+      metadata: { utm_source: "newsletter", session_duration_ms: 44012 }
+    });
+
+    const [stored] = await listUserEvents("user-a");
+    expect(stored.metadata).toBeNull();
+  });
+
+  it("drops a subject id long enough to be prose", async () => {
+    await recordUserEvent({
+      userId: "user-a",
+      eventType: UserEventType.ASSET_DELETED,
+      subjectType: "asset",
+      subjectId: "x".repeat(MAX_USER_EVENT_STRING_LENGTH + 1)
+    });
+
+    const [stored] = await listUserEvents("user-a");
+    expect(stored.subject_type).toBe("asset");
+    expect(stored.subject_id).toBeNull();
+  });
+
+  it("refuses an unknown event type", async () => {
+    const recorded = await recordUserEvent({
+      userId: "user-a",
+      // Behavioral analytics has no business in this table.
+      eventType: "page_view" as never
+    });
+    expect(recorded).toBeNull();
+    expect(await listUserEvents("user-a")).toHaveLength(0);
+  });
+
+  it("refuses an event with no user id", async () => {
+    const recorded = await recordUserEvent({
+      userId: "",
+      eventType: UserEventType.SIGN_IN
+    });
+    expect(recorded).toBeNull();
+  });
+
+  it("never throws into the caller when the write fails", async () => {
+    // A sign-out must not fail because the audit table is unreachable.
+    getRawDb().exec("DROP TABLE nodetool_user_events");
+
+    await expect(
+      recordUserEvent({ userId: "user-a", eventType: UserEventType.SIGN_OUT })
+    ).resolves.toBeNull();
+  });
+});
+
+describe("listUserEvents", () => {
+  beforeEach(async () => {
+    await setupDb();
+    await recordUserEvent({
+      userId: "user-a",
+      eventType: UserEventType.SIGN_IN,
+      createdAt: daysAgo(10)
+    });
+    await recordUserEvent({
+      userId: "user-a",
+      eventType: UserEventType.WORKFLOW_DELETED,
+      subjectType: "workflow",
+      subjectId: "wf-1",
+      createdAt: daysAgo(5)
+    });
+    await recordUserEvent({
+      userId: "user-a",
+      eventType: UserEventType.CONSENT_GIVEN,
+      metadata: { policy: "marketing", policy_version: "2026-01" },
+      createdAt: daysAgo(1)
+    });
+    await recordUserEvent({
+      userId: "user-b",
+      eventType: UserEventType.SIGN_IN,
+      createdAt: daysAgo(2)
+    });
+  });
+  afterEach(() => ModelObserver.clear());
+
+  it("returns one user's events, newest first", async () => {
+    const rows = await listUserEvents("user-a");
+    expect(rows.map((r) => r.event_type)).toEqual([
+      "consent_given",
+      "workflow_deleted",
+      "sign_in"
+    ]);
+    expect(rows.every((r) => r.user_id === "user-a")).toBe(true);
+  });
+
+  it("honors the limit", async () => {
+    const rows = await listUserEvents("user-a", { limit: 2 });
+    expect(rows).toHaveLength(2);
+    expect(rows[0].event_type).toBe("consent_given");
+  });
+
+  it("filters by event type", async () => {
+    const rows = await listUserEvents("user-a", {
+      eventTypes: [UserEventType.SIGN_IN, UserEventType.CONSENT_GIVEN]
+    });
+    expect(rows.map((r) => r.event_type)).toEqual([
+      "consent_given",
+      "sign_in"
+    ]);
+  });
+
+  it("filters by time range", async () => {
+    const rows = await listUserEvents("user-a", {
+      since: daysAgo(7),
+      until: daysAgo(2)
+    });
+    expect(rows.map((r) => r.event_type)).toEqual(["workflow_deleted"]);
+  });
+
+  it("round-trips the subject columns and metadata", async () => {
+    const [deleted] = await listUserEvents("user-a", {
+      eventTypes: [UserEventType.WORKFLOW_DELETED]
+    });
+    expect(deleted.subject_type).toBe("workflow");
+    expect(deleted.subject_id).toBe("wf-1");
+
+    const [consent] = await listUserEvents("user-a", {
+      eventTypes: [UserEventType.CONSENT_GIVEN]
+    });
+    expect(consent.metadata).toEqual({
+      policy: "marketing",
+      policy_version: "2026-01"
+    });
+  });
+
+  it("returns nothing for a user with no events", async () => {
+    expect(await listUserEvents("nobody")).toEqual([]);
+  });
+});
+
+describe("deleteUserEventsForUser", () => {
+  beforeEach(() => setupDb());
+  afterEach(() => ModelObserver.clear());
+
+  it("removes one user's rows, including the never-pruned ones, and counts them", async () => {
+    await recordUserEvent({
+      userId: "user-a",
+      eventType: UserEventType.SIGN_IN
+    });
+    await recordUserEvent({
+      userId: "user-a",
+      eventType: UserEventType.CONSENT_GIVEN,
+      metadata: { policy: "marketing" }
+    });
+    await recordUserEvent({
+      userId: "user-b",
+      eventType: UserEventType.SIGN_IN
+    });
+
+    expect(await deleteUserEventsForUser("user-a")).toBe(2);
+    expect(await listUserEvents("user-a")).toEqual([]);
+    expect(await listUserEvents("user-b")).toHaveLength(1);
+  });
+
+  it("returns 0 when the user has no events", async () => {
+    expect(await deleteUserEventsForUser("nobody")).toBe(0);
+  });
+});
+
+describe("pruneUserEvents", () => {
+  beforeEach(() => setupDb());
+  afterEach(() => {
+    ModelObserver.clear();
+    vi.useRealTimers();
+  });
+
+  it("drops auth and audit-trail events past the retention window", async () => {
+    await recordUserEvent({
+      userId: "user-a",
+      eventType: UserEventType.SIGN_IN,
+      createdAt: daysAgo(400)
+    });
+    await recordUserEvent({
+      userId: "user-a",
+      eventType: UserEventType.WORKFLOW_DELETED,
+      createdAt: daysAgo(200)
+    });
+    await recordUserEvent({
+      userId: "user-a",
+      eventType: UserEventType.ACCESS_TOKEN_REVOKED,
+      createdAt: daysAgo(10)
+    });
+
+    expect(await pruneUserEvents()).toBe(2);
+    expect((await listUserEvents("user-a")).map((r) => r.event_type)).toEqual([
+      "access_token_revoked"
+    ]);
+  });
+
+  it("never prunes consent, policy or DSR events, however old", async () => {
+    for (const eventType of EXPECTED_NEVER_PRUNED) {
+      await recordUserEvent({
+        userId: "user-a",
+        eventType,
+        createdAt: daysAgo(5000)
+      });
+    }
+    // One prunable neighbour of the same age, so a sweep that ignored the
+    // carve-out would have taken everything.
+    await recordUserEvent({
+      userId: "user-a",
+      eventType: UserEventType.SIGN_IN,
+      createdAt: daysAgo(5000)
+    });
+
+    expect(await pruneUserEvents()).toBe(1);
+
+    const survivors = await listUserEvents("user-a", { limit: 100 });
+    expect(survivors.map((r) => r.event_type).sort()).toEqual(
+      [...EXPECTED_NEVER_PRUNED].sort()
+    );
+    for (const row of survivors) {
+      expect(isNeverPrunedUserEventType(row.event_type)).toBe(true);
+    }
+  });
+
+  it("defaults to a 180-day window", async () => {
+    expect(DEFAULT_USER_EVENT_RETENTION_DAYS).toBe(180);
+
+    await recordUserEvent({
+      userId: "user-a",
+      eventType: UserEventType.SIGN_IN,
+      createdAt: daysAgo(179)
+    });
+    await recordUserEvent({
+      userId: "user-a",
+      eventType: UserEventType.SIGN_OUT,
+      createdAt: daysAgo(181)
+    });
+
+    expect(await pruneUserEvents()).toBe(1);
+    expect((await listUserEvents("user-a")).map((r) => r.event_type)).toEqual([
+      "sign_in"
+    ]);
+  });
+
+  it("honors an explicit window and reports 0 when nothing is stale", async () => {
+    await recordUserEvent({
+      userId: "user-a",
+      eventType: UserEventType.SIGN_IN,
+      createdAt: daysAgo(10)
+    });
+
+    expect(await pruneUserEvents(30)).toBe(0);
+    expect(await pruneUserEvents(7)).toBe(1);
+  });
+
+  it("rejects a nonsensical retention window", async () => {
+    await expect(pruneUserEvents(-1)).rejects.toThrow(/Invalid retention/);
+    await expect(pruneUserEvents(Number.NaN)).rejects.toThrow(
+      /Invalid retention/
+    );
+  });
+});

--- a/packages/protocol/src/api-schemas/settings.ts
+++ b/packages/protocol/src/api-schemas/settings.ts
@@ -110,6 +110,13 @@ export const storageRetentionPolicy = z.object({
   autosaveRetentionDays: z.number().int().min(1).max(3650),
   manualVersionRetentionDays: z.number().int().min(1).max(3650),
   terminalJobRetentionDays: z.number().int().min(1).max(3650),
+  /**
+   * Optional to mirror `StorageRetentionPolicy` in `@nodetool-ai/models`: a
+   * policy stored before these sweeps existed resolves to the server default
+   * rather than to zero days.
+   */
+  runEventRetentionDays: z.number().int().min(1).max(3650).optional(),
+  predictionRetentionDays: z.number().int().min(1).max(3650).optional(),
   automaticCleanup: z.boolean()
 });
 export type StorageRetentionPolicy = z.infer<typeof storageRetentionPolicy>;
@@ -118,6 +125,10 @@ export const storageCleanupPreview = z.object({
   autosaves: z.number().int().nonnegative(),
   manualVersions: z.number().int().nonnegative(),
   terminalJobs: z.number().int().nonnegative(),
+  runEvents: z.number().int().nonnegative(),
+  /** Prediction rows whose payload columns are cleared. Rows are kept. */
+  redactedPredictions: z.number().int().nonnegative(),
+  /** Records deleted. Redactions are not deletions, so they are not in it. */
   total: z.number().int().nonnegative()
 });
 
@@ -130,6 +141,8 @@ export const storageStatus = z.object({
   manualVersions: z.number().int().nonnegative(),
   jobs: z.number().int().nonnegative(),
   terminalJobs: z.number().int().nonnegative(),
+  runEvents: z.number().int().nonnegative(),
+  predictionsWithPayload: z.number().int().nonnegative(),
   cleanup: storageCleanupPreview
 });
 

--- a/packages/websocket/src/routes/account.ts
+++ b/packages/websocket/src/routes/account.ts
@@ -1,0 +1,239 @@
+/**
+ * Data-subject-rights endpoints — the HTTP door onto `@nodetool-ai/models`'
+ * `exportPersonalData` / `erasePersonalData`.
+ *
+ *   GET    /api/account/export   → Art. 20 portability
+ *   DELETE /api/account          → Art. 17 erasure
+ *
+ * The published privacy policy promises both in-product; this is what it
+ * points at. Neither route decides policy: `PERSONAL_DATA_REGISTRY` says what
+ * happens to each table and the library walks it.
+ *
+ * ## The subject is always the caller
+ *
+ * There is no admin path here and no way to name a subject. Both handlers get
+ * their user id from `getUserId`, reading the request that `bridge` built —
+ * and `bridge` deletes any client-supplied identity header before setting it
+ * from `req.userId`, the id the server's own auth hook decided. No id is read
+ * from the path, the query or the body: the erase body's schema declares
+ * `confirm` and nothing else, and the routes carry no `:id` segment for one to
+ * hide in. A caller wanting somebody else's data would have to change this
+ * file, not the request. `req.userId == null` is refused with 401 rather than
+ * falling back to `getUserId`'s default of user "1".
+ *
+ * ## The erasure contract
+ *
+ * `DELETE /api/account` is irreversible, so it is deliberate by construction:
+ *
+ * - The body must be `{"confirm": "DELETE MY ACCOUNT"}` — the exact string,
+ *   case-sensitive. A bare `DELETE` with no body, an empty object, a typo, or
+ *   any other value is `400` and nothing is touched. A stray or replayed
+ *   `DELETE` therefore cannot erase anything.
+ * - It is idempotent. The library re-runs the same sweep; a second call finds
+ *   nothing left and reports zeros. Both calls answer `200`.
+ * - It returns the per-table report — deleted/redacted/retained counts keyed
+ *   by table — plus the `requestId` that ties the two audit rows together.
+ * - Audit: this route writes `data_erasure_requested` *before* the sweep, so
+ *   the request is on record even if the sweep then throws.
+ *   `erasePersonalData` writes `data_erasure_completed` itself once it is
+ *   given a `requestId`; this route does not write that event a second time.
+ *   Both types are in `NEVER_PRUNED_USER_EVENT_TYPES`, so the sweep it runs
+ *   leaves them behind as the evidence the request was answered.
+ *
+ * ## Bytes, not just rows
+ *
+ * `erasePersonalData` takes an {@link ErasureObjectStore} and reports
+ * `objectKeysDeleted: null` without one — deleting the asset row and leaving
+ * the object readable to anyone holding a URL. `assetErasureStore` below wires
+ * the real `StorageAdapter`, so the report names the keys it removed.
+ *
+ * Two things that adapter does on purpose. It filters the listing to keys
+ * under `<userId>/` rather than trusting the prefix scoping: `list()`
+ * normalizes `"u1/"` to `"u1"`, and on the S3 and Supabase backends — which
+ * match a prefix as a string, not as a directory — that would also match
+ * `u10/…`. And it only ever deletes what that filter passes, so the blast
+ * radius is one user's prefix whatever the backend does with the argument.
+ * Objects stored before the owner prefix existed sit at a flat
+ * `<assetId>.<ext>` and are not reachable by any per-user prefix; they are not
+ * swept here.
+ *
+ * ## Why the body is validated with Zod rather than a Fastify `schema`
+ *
+ * These are bridged routes. The server installs an app-wide
+ * `addContentTypeParser("*", { parseAs: "buffer" })`, so `req.body` reaches a
+ * route as raw bytes and a JSON-schema `schema.body` would reject every
+ * request as "not an object". Validation therefore happens where the bytes
+ * are — one `safeParse` at the boundary, before anything reads a field —
+ * which is the pattern the other bridged routes in this package use and what
+ * `packages/AGENTS.md` means by "Zod is the canonical validator".
+ */
+
+import type { FastifyPluginAsync } from "fastify";
+import { randomUUID } from "node:crypto";
+import {
+  UserEventType,
+  erasePersonalData,
+  exportPersonalData,
+  recordUserEvent,
+  type ErasureObjectStore
+} from "@nodetool-ai/models";
+import type { StorageAdapter } from "@nodetool-ai/storage";
+import { z } from "zod";
+
+import { bridge } from "../lib/bridge.js";
+import { getUserId, type HttpApiOptions } from "../http-api.js";
+import { getAssetAdapter } from "../lib/storage.js";
+
+interface RouteOptions {
+  apiOptions: HttpApiOptions;
+  /** Object store swept on erasure. Defaults to the asset adapter. */
+  storage?: StorageAdapter;
+}
+
+/** The exact phrase `DELETE /api/account` requires in its body. */
+export const ERASURE_CONFIRMATION = "DELETE MY ACCOUNT";
+
+/**
+ * The one field the erase body may carry.
+ *
+ * `z.literal` rather than a free string so the gate is the phrase itself, and
+ * `strict()` so an unexpected field — `user_id`, `userId`, `subject` — is a
+ * `400` rather than something a later reader might mistake for an instruction.
+ */
+export const erasureRequest = z
+  .object({ confirm: z.literal(ERASURE_CONFIRMATION) })
+  .strict();
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data ?? null), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store" }
+  });
+}
+
+/** The parsed JSON body, or `null` when there is nothing parseable. */
+async function readJsonBody(request: Request): Promise<unknown> {
+  try {
+    const text = await request.text();
+    return text.length > 0 ? JSON.parse(text) : null;
+  } catch {
+    // Unparseable bytes are "no body", answered by the schema below as a 400.
+    return null;
+  }
+}
+
+/**
+ * A {@link ErasureObjectStore} over a `StorageAdapter` — the adapter shape the
+ * doc comment on `ErasureObjectStore` sketches, with the prefix guard the
+ * string-prefix backends need.
+ */
+export function assetErasureStore(
+  adapter: StorageAdapter
+): ErasureObjectStore {
+  return {
+    async deleteObjectsForUser(userId: string): Promise<readonly string[]> {
+      const prefix = `${userId}/`;
+      const { entries } = await adapter.list(prefix);
+      const deleted: string[] = [];
+      for (const entry of entries) {
+        if (!entry.key.startsWith(prefix)) continue;
+        if (await adapter.delete(entry.uri)) deleted.push(entry.key);
+      }
+      return deleted;
+    }
+  };
+}
+
+/** Filename a browser saves the export as. */
+function exportFilename(generatedAt: string): string {
+  const day = generatedAt.slice(0, 10);
+  return `nodetool-personal-data-export-${day}.json`;
+}
+
+const accountRoutes: FastifyPluginAsync<RouteOptions> = async (app, opts) => {
+  const { apiOptions } = opts;
+  const userIdHeader = apiOptions.userIdHeader ?? "x-user-id";
+
+  app.get("/api/account/export", async (req, reply) => {
+    // No authenticated identity means no subject. `getUserId` would answer "1"
+    // here, which is a real account on a local install.
+    if (req.userId == null) {
+      reply
+        .code(401)
+        .header("cache-control", "no-store")
+        .send({ detail: "Authentication required" });
+      return;
+    }
+    await bridge(
+      req,
+      reply,
+      async (request) => {
+        const userId = getUserId(request, userIdHeader);
+        const data = await exportPersonalData(userId);
+        await recordUserEvent({
+          userId,
+          eventType: UserEventType.DATA_EXPORT_REQUESTED,
+          metadata: { request_id: randomUUID(), format: data.format }
+        });
+        return new Response(JSON.stringify(data), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "cache-control": "no-store",
+            "content-disposition": `attachment; filename="${exportFilename(
+              data.generatedAt
+            )}"`
+          }
+        });
+      },
+      userIdHeader
+    );
+  });
+
+  app.delete("/api/account", async (req, reply) => {
+    if (req.userId == null) {
+      reply
+        .code(401)
+        .header("cache-control", "no-store")
+        .send({ detail: "Authentication required" });
+      return;
+    }
+    await bridge(
+      req,
+      reply,
+      async (request) => {
+        const parsed = erasureRequest.safeParse(await readJsonBody(request));
+        if (!parsed.success) {
+          return jsonResponse(
+            {
+              detail:
+                "Erasure is irreversible. Send " +
+                `{"confirm": "${ERASURE_CONFIRMATION}"} to confirm.`
+            },
+            400
+          );
+        }
+
+        const userId = getUserId(request, userIdHeader);
+        const requestId = randomUUID();
+        // Before the sweep: this row is the record that the request arrived,
+        // and it has to survive a sweep that then fails part-way.
+        await recordUserEvent({
+          userId,
+          eventType: UserEventType.DATA_ERASURE_REQUESTED,
+          metadata: { request_id: requestId }
+        });
+
+        const report = await erasePersonalData(userId, {
+          objectStore: assetErasureStore(opts.storage ?? getAssetAdapter()),
+          // `erasePersonalData` writes `data_erasure_completed` from this id.
+          requestId
+        });
+        return jsonResponse({ requestId, report });
+      },
+      userIdHeader
+    );
+  });
+};
+
+export default accountRoutes;

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -167,6 +167,7 @@ import collectionsRoutes from "./routes/collections.js";
 import applicationsRoutes from "./routes/applications.js";
 import publicAppRoutes from "./routes/public-apps.js";
 import { appDeploymentsEnabled } from "./lib/app-deployment-service.js";
+import accountRoutes from "./routes/account.js";
 import jsScriptsRoutes from "./routes/js-scripts.js";
 import timelineAnimationRoutes from "./routes/timeline-animations.js";
 import storyboardsRoutes from "./routes/storyboards.js";
@@ -1577,6 +1578,9 @@ await app.register(publicAppRoutes, { appSessionSigningKey });
 await app.register(jsScriptsRoutes, routeOpts);
 await app.register(timelineAnimationRoutes, routeOpts);
 await app.register(storyboardsRoutes, routeOpts);
+// Art. 20 export and Art. 17 erasure. The subject is always the caller:
+// no admin path, no subject id anywhere in the URL or body.
+await app.register(accountRoutes, routeOpts);
 await app.register(sandboxModulesRoutes);
 await app.register(falCreditsRoute);
 await app.register(falPricingRoute);

--- a/packages/websocket/src/storage-retention.ts
+++ b/packages/websocket/src/storage-retention.ts
@@ -11,6 +11,8 @@ const KEYS = {
   autosaveRetentionDays: "storage.retention.autosaveRetentionDays",
   manualVersionRetentionDays: "storage.retention.manualVersionRetentionDays",
   terminalJobRetentionDays: "storage.retention.terminalJobRetentionDays",
+  runEventRetentionDays: "storage.retention.runEventRetentionDays",
+  predictionRetentionDays: "storage.retention.predictionRetentionDays",
   automaticCleanup: "storage.retention.automaticCleanup",
   lastCleanupAt: "storage.retention.lastCleanupAt"
 } as const;
@@ -62,6 +64,18 @@ export async function getStorageRetentionSettings(userId: string): Promise<{
         1,
         3650
       ),
+      runEventRetentionDays: boundedInteger(
+        values.get(KEYS.runEventRetentionDays),
+        DEFAULT_STORAGE_RETENTION_POLICY.runEventRetentionDays ?? 30,
+        1,
+        3650
+      ),
+      predictionRetentionDays: boundedInteger(
+        values.get(KEYS.predictionRetentionDays),
+        DEFAULT_STORAGE_RETENTION_POLICY.predictionRetentionDays ?? 400,
+        1,
+        3650
+      ),
       automaticCleanup:
         values.get(KEYS.automaticCleanup) === undefined
           ? DEFAULT_STORAGE_RETENTION_POLICY.automaticCleanup
@@ -76,14 +90,18 @@ export async function saveStorageRetentionPolicy(
   policy: StorageRetentionPolicy
 ): Promise<void> {
   await Promise.all(
-    (Object.keys(policy) as Array<keyof StorageRetentionPolicy>).map((key) =>
-      Setting.upsert({
-        userId,
-        key: KEYS[key],
-        value: String(policy[key]),
-        description: "Database history retention policy"
-      })
-    )
+    (Object.keys(policy) as Array<keyof StorageRetentionPolicy>)
+      // The two retention windows are optional on the policy type; a key
+      // present with an undefined value would persist the string "undefined".
+      .filter((key) => policy[key] !== undefined)
+      .map((key) =>
+        Setting.upsert({
+          userId,
+          key: KEYS[key],
+          value: String(policy[key]),
+          description: "Database history retention policy"
+        })
+      )
   );
 }
 

--- a/packages/websocket/tests/account-routes.test.ts
+++ b/packages/websocket/tests/account-routes.test.ts
@@ -1,0 +1,392 @@
+/**
+ * `GET /api/account/export` and `DELETE /api/account` — the DSR door.
+ *
+ * Real database, real storage adapter, real library calls. What is worth
+ * pinning here is not that the library works (its own suite does that) but
+ * that the HTTP surface cannot be pointed at anybody but the caller, and that
+ * an irreversible operation needs a deliberate confirmation to happen.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import {
+  Asset,
+  Secret,
+  UserEventType,
+  WITHHELD_VALUE,
+  Workflow,
+  initTestDb,
+  listUserEvents
+} from "@nodetool-ai/models";
+import {
+  FileStorageAdapter,
+  type StorageAdapter,
+  type StorageListResult
+} from "@nodetool-ai/storage";
+
+import accountRoutes, {
+  ERASURE_CONFIRMATION,
+  assetErasureStore
+} from "../src/routes/account.js";
+
+const USER_A = "user-a";
+const USER_B = "user-b";
+
+interface ErasureTableReport {
+  table: string;
+  deleted: number;
+  redacted: number;
+  retained: number;
+}
+
+interface ErasureBody {
+  requestId: string;
+  report: {
+    userId: string;
+    deleted: number;
+    redacted: number;
+    retained: number;
+    tables: ErasureTableReport[];
+    objectKeysDeleted: string[] | null;
+  };
+}
+
+interface ExportBody {
+  format: string;
+  subjectUserId: string;
+  tables: Record<string, { rowCount: number; rows: Record<string, unknown>[] }>;
+}
+
+async function buildServer(
+  userId: string | null,
+  storage: StorageAdapter
+): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  app.decorateRequest("userId", null);
+  app.addHook("onRequest", async (req) => {
+    req.userId = userId;
+  });
+  await app.register(accountRoutes, { apiOptions: {}, storage });
+  await app.ready();
+  return app;
+}
+
+async function seedUser(
+  userId: string,
+  storage: StorageAdapter
+): Promise<void> {
+  await new Workflow({
+    user_id: userId,
+    name: `${userId} workflow`,
+    graph: { nodes: [], edges: [] }
+  }).save();
+  await new Asset({
+    user_id: userId,
+    name: `${userId}.png`,
+    content_type: "image/png"
+  }).save();
+  await new Secret({
+    user_id: userId,
+    key: "OPENAI_API_KEY",
+    encrypted_value: `ciphertext-for-${userId}`
+  }).save();
+  await storage.store(`${userId}/object.bin`, new Uint8Array([1, 2, 3]));
+}
+
+async function workflowCount(userId: string): Promise<number> {
+  const [rows] = await Workflow.paginate(userId, { limit: 100 });
+  return rows.length;
+}
+
+describe("account DSR routes", () => {
+  let app: FastifyInstance | null = null;
+  let dir = "";
+  let storage: StorageAdapter;
+
+  beforeEach(async () => {
+    await initTestDb();
+    dir = await mkdtemp(join(tmpdir(), "account-routes-"));
+    storage = new FileStorageAdapter(dir);
+    await seedUser(USER_A, storage);
+    await seedUser(USER_B, storage);
+  });
+
+  afterEach(async () => {
+    await app?.close();
+    app = null;
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  // ── Export ─────────────────────────────────────────────────────────
+
+  it("exports the caller's own rows and withholds credential values", async () => {
+    app = await buildServer(USER_A, storage);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/account/export"
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["content-disposition"]).toMatch(
+      /^attachment; filename="nodetool-personal-data-export-\d{4}-\d{2}-\d{2}\.json"$/
+    );
+    const body = response.json() as ExportBody;
+    expect(body.format).toBe("nodetool.personal-data-export/1");
+    expect(body.subjectUserId).toBe(USER_A);
+
+    const workflows = body.tables.nodetool_workflows;
+    expect(workflows.rowCount).toBe(1);
+    expect(workflows.rows[0]?.user_id).toBe(USER_A);
+
+    const secrets = body.tables.nodetool_secrets;
+    expect(secrets.rowCount).toBe(1);
+    expect(secrets.rows[0]?.key).toBe("OPENAI_API_KEY");
+    // The record is visible; the credential is not.
+    expect(secrets.rows[0]?.encrypted_value).toBe(WITHHELD_VALUE);
+    expect(JSON.stringify(body)).not.toContain(`ciphertext-for-${USER_A}`);
+  });
+
+  it("records data_export_requested for the caller", async () => {
+    app = await buildServer(USER_A, storage);
+    await app.inject({ method: "GET", url: "/api/account/export" });
+
+    const events = await listUserEvents(USER_A, {
+      eventTypes: [UserEventType.DATA_EXPORT_REQUESTED]
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]?.metadata?.format).toBe(
+      "nodetool.personal-data-export/1"
+    );
+    expect(typeof events[0]?.metadata?.request_id).toBe("string");
+    expect(
+      await listUserEvents(USER_B, {
+        eventTypes: [UserEventType.DATA_EXPORT_REQUESTED]
+      })
+    ).toHaveLength(0);
+  });
+
+  it("refuses an unauthenticated export", async () => {
+    app = await buildServer(null, storage);
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/account/export"
+    });
+    expect(response.statusCode).toBe(401);
+  });
+
+  // ── Cross-user access ──────────────────────────────────────────────
+  //
+  // The security test that matters. There is no subject parameter anywhere in
+  // these routes, so the only thing an attacker can try is to smuggle one in
+  // through a channel the handler might read. Every channel is tried here.
+
+  it("cannot export another user, whatever the request claims", async () => {
+    app = await buildServer(USER_B, storage);
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/account/export?userId=${USER_A}&user_id=${USER_A}&subject=${USER_A}`,
+      headers: {
+        "x-user-id": USER_A,
+        "x-nodetool-user-id": USER_A,
+        "x-forwarded-user": USER_A
+      }
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as ExportBody;
+    expect(body.subjectUserId).toBe(USER_B);
+    expect(body.tables.nodetool_workflows.rows[0]?.user_id).toBe(USER_B);
+    // Nothing of user A's anywhere in the payload.
+    expect(JSON.stringify(body)).not.toContain(`${USER_A} workflow`);
+    expect(JSON.stringify(body)).not.toContain(`ciphertext-for-${USER_A}`);
+  });
+
+  it("cannot erase another user, whatever the request claims", async () => {
+    app = await buildServer(USER_B, storage);
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: `/api/account?userId=${USER_A}&user_id=${USER_A}`,
+      headers: { "x-user-id": USER_A, "x-forwarded-user": USER_A },
+      payload: { confirm: ERASURE_CONFIRMATION }
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as ErasureBody;
+    expect(body.report.userId).toBe(USER_B);
+
+    // User A is untouched: rows, credential and bytes all still there.
+    expect(await workflowCount(USER_A)).toBe(1);
+    expect(await workflowCount(USER_B)).toBe(0);
+    expect(await Secret.find(USER_A, "OPENAI_API_KEY")).not.toBeNull();
+    expect(await Secret.find(USER_B, "OPENAI_API_KEY")).toBeNull();
+    expect(
+      await storage.exists(storage.uriForKey(`${USER_A}/object.bin`))
+    ).toBe(true);
+    expect(
+      await storage.exists(storage.uriForKey(`${USER_B}/object.bin`))
+    ).toBe(false);
+  });
+
+  it("rejects a subject id smuggled into the erase body", async () => {
+    app = await buildServer(USER_B, storage);
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/api/account",
+      payload: { confirm: ERASURE_CONFIRMATION, userId: USER_A }
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(await workflowCount(USER_A)).toBe(1);
+    expect(await workflowCount(USER_B)).toBe(1);
+  });
+
+  // ── The confirmation gate ──────────────────────────────────────────
+
+  it.each([
+    ["no body at all", undefined],
+    ["an empty object", {}],
+    ["a near-miss phrase", { confirm: "delete my account" }],
+    ["a truthy non-phrase", { confirm: true }]
+  ])("refuses erasure with %s", async (_label, payload) => {
+    app = await buildServer(USER_A, storage);
+
+    const response = await app.inject(
+      payload === undefined
+        ? { method: "DELETE", url: "/api/account" }
+        : { method: "DELETE", url: "/api/account", payload }
+    );
+
+    expect(response.statusCode).toBe(400);
+    expect((response.json() as { detail: string }).detail).toContain(
+      ERASURE_CONFIRMATION
+    );
+    // Nothing happened.
+    expect(await workflowCount(USER_A)).toBe(1);
+    expect(
+      await storage.exists(storage.uriForKey(`${USER_A}/object.bin`))
+    ).toBe(true);
+    expect(
+      await listUserEvents(USER_A, {
+        eventTypes: [UserEventType.DATA_ERASURE_REQUESTED]
+      })
+    ).toHaveLength(0);
+  });
+
+  // ── Erasure ────────────────────────────────────────────────────────
+
+  it("reports per-table counts and deletes the caller's objects", async () => {
+    app = await buildServer(USER_A, storage);
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/api/account",
+      payload: { confirm: ERASURE_CONFIRMATION }
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as ErasureBody;
+    expect(body.report.userId).toBe(USER_A);
+    expect(typeof body.requestId).toBe("string");
+
+    const byTable = new Map(body.report.tables.map((t) => [t.table, t]));
+    expect(byTable.get("nodetool_workflows")?.deleted).toBe(1);
+    expect(byTable.get("nodetool_assets")?.deleted).toBe(1);
+    expect(byTable.get("nodetool_secrets")?.deleted).toBe(1);
+    expect(body.report.deleted).toBeGreaterThanOrEqual(3);
+
+    // Bytes, not only rows.
+    expect(body.report.objectKeysDeleted).toEqual([`${USER_A}/object.bin`]);
+    expect(
+      await storage.exists(storage.uriForKey(`${USER_A}/object.bin`))
+    ).toBe(false);
+    expect(
+      await storage.exists(storage.uriForKey(`${USER_B}/object.bin`))
+    ).toBe(true);
+  });
+
+  it("writes the requested event before the sweep and exactly one completed event", async () => {
+    app = await buildServer(USER_A, storage);
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/api/account",
+      payload: { confirm: ERASURE_CONFIRMATION }
+    });
+    const { requestId } = response.json() as ErasureBody;
+
+    const requested = await listUserEvents(USER_A, {
+      eventTypes: [UserEventType.DATA_ERASURE_REQUESTED]
+    });
+    const completed = await listUserEvents(USER_A, {
+      eventTypes: [UserEventType.DATA_ERASURE_COMPLETED]
+    });
+    // Both survive the sweep they describe — they are its evidence.
+    expect(requested).toHaveLength(1);
+    expect(requested[0]?.metadata?.request_id).toBe(requestId);
+    // `erasePersonalData` writes this one; the route must not write a second.
+    expect(completed).toHaveLength(1);
+    expect(completed[0]?.metadata?.request_id).toBe(requestId);
+  });
+
+  it("is idempotent — a second erasure succeeds and reports nothing left", async () => {
+    app = await buildServer(USER_A, storage);
+    const erase = () =>
+      app!.inject({
+        method: "DELETE",
+        url: "/api/account",
+        payload: { confirm: ERASURE_CONFIRMATION }
+      });
+
+    const first = (await erase()).json() as ErasureBody;
+    const secondResponse = await erase();
+    expect(secondResponse.statusCode).toBe(200);
+    const second = secondResponse.json() as ErasureBody;
+
+    expect(first.report.deleted).toBeGreaterThan(0);
+    expect(second.report.deleted).toBe(0);
+    expect(second.report.objectKeysDeleted).toEqual([]);
+    expect(second.report.tables.map((t) => t.table)).toEqual(
+      first.report.tables.map((t) => t.table)
+    );
+    expect(second.requestId).not.toBe(first.requestId);
+  });
+});
+
+describe("assetErasureStore", () => {
+  /**
+   * S3 and Supabase match a listing prefix as a string, and `list()` strips
+   * the trailing slash — so `user-1/` reaches the backend as `user-1` and the
+   * response can carry `user-10/…`. The adapter must not delete those.
+   */
+  it("never deletes a key outside the user's own prefix", async () => {
+    const deleted: string[] = [];
+    const listed: StorageListResult = {
+      entries: [
+        { key: "user-1/a.bin", uri: "s3://b/user-1/a.bin", size: 1, modifiedAt: 0 },
+        { key: "user-10/b.bin", uri: "s3://b/user-10/b.bin", size: 1, modifiedAt: 0 },
+        { key: "user-1x.bin", uri: "s3://b/user-1x.bin", size: 1, modifiedAt: 0 }
+      ],
+      commonPrefixes: []
+    };
+    const adapter = {
+      async list(): Promise<StorageListResult> {
+        return listed;
+      },
+      async delete(uri: string): Promise<boolean> {
+        deleted.push(uri);
+        return true;
+      }
+    } as unknown as StorageAdapter;
+
+    const keys = await assetErasureStore(adapter).deleteObjectsForUser("user-1");
+
+    expect(keys).toEqual(["user-1/a.bin"]);
+    expect(deleted).toEqual(["s3://b/user-1/a.bin"]);
+  });
+});

--- a/web/src/components/settings/StorageHistorySettings.tsx
+++ b/web/src/components/settings/StorageHistorySettings.tsx
@@ -98,6 +98,9 @@ export default function StorageHistorySettings() {
     history.isUpdating || history.isCleaning || history.isCompacting;
   const cleanupCount = status.cleanup.total;
   const redactionCount = status.cleanup.redactedPredictions;
+  // Records this sweep will change: the ones it removes plus the ones it
+  // clears. `cleanup.total` counts removals only, so it cannot stand in here.
+  const pendingCount = cleanupCount + redactionCount;
   const isSqlite = status.dialect === "sqlite";
 
   return (
@@ -207,9 +210,9 @@ export default function StorageHistorySettings() {
           <EditorButton
             variant="outlined"
             onClick={() => setConfirmation("cleanup")}
-            disabled={disabled || (cleanupCount === 0 && redactionCount === 0)}
+            disabled={disabled || pendingCount === 0}
           >
-            {history.isCleaning ? "Cleaning…" : `Clean now (${cleanupCount})`}
+            {history.isCleaning ? "Cleaning…" : `Clean now (${pendingCount})`}
           </EditorButton>
           {isSqlite && (
             <EditorButton

--- a/web/src/components/settings/StorageHistorySettings.tsx
+++ b/web/src/components/settings/StorageHistorySettings.tsx
@@ -50,9 +50,13 @@ export default function StorageHistorySettings() {
       void history
         .cleanup()
         .then((result) => {
+          const { total, redactedPredictions } = result.deleted;
           addNotification({
             type: "success",
-            content: `Removed ${result.deleted.total} old history records.`
+            content:
+              redactedPredictions > 0
+                ? `Removed ${total} old history records and cleared prompt data from ${redactedPredictions} generation records.`
+                : `Removed ${total} old history records.`
           });
         })
         .catch((error) => {
@@ -93,6 +97,7 @@ export default function StorageHistorySettings() {
   const disabled =
     history.isUpdating || history.isCleaning || history.isCompacting;
   const cleanupCount = status.cleanup.total;
+  const redactionCount = status.cleanup.redactedPredictions;
   const isSqlite = status.dialect === "sqlite";
 
   return (
@@ -150,6 +155,30 @@ export default function StorageHistorySettings() {
         />
       </div>
       <div className="settings-item">
+        <NumberSetting
+          label="Keep run event logs (days)"
+          description="Per-node event logs from a run are removed after this many days. The run record itself follows the limit above."
+          value={policy.runEventRetentionDays ?? 30}
+          onCommit={(value) => updatePolicy({ runEventRetentionDays: value })}
+          min={1}
+          max={3650}
+          fallback={30}
+          disabled={disabled}
+        />
+      </div>
+      <div className="settings-item">
+        <NumberSetting
+          label="Keep generation details (days)"
+          description="After this many days, prompts, parameters, and logs are cleared from generation records. The billing record — model, provider, tokens, cost, and date — is kept."
+          value={policy.predictionRetentionDays ?? 400}
+          onCommit={(value) => updatePolicy({ predictionRetentionDays: value })}
+          min={1}
+          max={3650}
+          fallback={400}
+          disabled={disabled}
+        />
+      </div>
+      <div className="settings-item">
         <LabeledSwitch
           label="Automatic history cleanup"
           checked={policy.automaticCleanup}
@@ -161,18 +190,24 @@ export default function StorageHistorySettings() {
       <div className="settings-item">
         <Text>
           Database: {formatBytes(status.databaseBytes)} ·{" "}
-          {status.workflowVersions} workflow versions · {status.jobs} runs
+          {status.workflowVersions} workflow versions · {status.jobs} runs ·{" "}
+          {status.runEvents} run events
         </Text>
         <Text className="description">
           {cleanupCount} records exceed the current limits. Deleted SQLite pages
           currently use {formatBytes(status.unusedBytes)} and are returned to
           disk only after compaction.
         </Text>
+        <Text className="description">
+          {redactionCount} of {status.predictionsWithPayload} generation records
+          still holding prompts and parameters are past the limit. Cleaning
+          clears that text and keeps the billing record.
+        </Text>
         <FlexRow gap={2} wrap sx={{ marginTop: 2 }}>
           <EditorButton
             variant="outlined"
             onClick={() => setConfirmation("cleanup")}
-            disabled={disabled || cleanupCount === 0}
+            disabled={disabled || (cleanupCount === 0 && redactionCount === 0)}
           >
             {history.isCleaning ? "Cleaning…" : `Clean now (${cleanupCount})`}
           </EditorButton>
@@ -199,7 +234,7 @@ export default function StorageHistorySettings() {
         content={
           confirmation === "compact"
             ? "Compaction returns unused SQLite pages to disk. It can pause database writes while it rebuilds a large local database."
-            : `Remove ${cleanupCount} old workflow-history and completed-run records? Current workflows, assets, checkpoints, and active runs are not changed.`
+            : `Remove ${cleanupCount} old workflow-history, completed-run, and run-event records, and clear prompts and parameters from ${redactionCount} generation records? The billing record for each generation is kept. Current workflows, assets, checkpoints, and active runs are not changed.`
         }
         confirmText={confirmation === "compact" ? "Compact" : "Clean"}
         cancelText="Cancel"


### PR DESCRIPTION
## What changed

The hosted service stores personal data across 44 tables, 34 of them keyed by `user_id` — messages, memories, assets, prediction parameters — with no retention on most of it, no way to erase or export an account, and a privacy policy that still described NodeTool as a purely local-first desktop app. This branch narrows what gets recorded about a user, gives the recorded data an expiry, makes erasure and export mechanical, and brings the published policy in line with what the code does.

A `nodetool_user_events` audit table records only authentication events, irreversible or outward-facing actions (deletes, secret writes, shares, deploys, publishes), and consent/terms/data-subject-request records. No clicks, page views, IP addresses, user agents or free-text columns — behavioural analytics stays aggregate in Plausible and is never keyed to a user. Metadata passes a per-event-type allowlist before the insert, so a caller cannot smuggle prompt text into the audit log.

Retention now covers the two tables that held personal data and never expired. `run_events` is swept by age through its parent job. `nodetool_predictions` is redacted rather than deleted: `parameters`, `metadata` and `logs` are nulled while every billing column survives, so the charge stays auditable and the prompt does not.

Erasure and export are driven by a single registry that names every table once — its disposition, how the user is reached, and why. An audit test fails when a table with a `user_id` has no entry, when an entry has no handler, and when a handler touches a table not in the registry, so the three cannot drift apart. Dispositions are not uniform: credit ledger and subscription rows are retained under Art. 17(3)(b), predictions are redacted, and consent and data-subject-request events are kept because they are the proof a request was honoured. `GET /api/account/export` and `DELETE /api/account` expose it.

## Two findings worth a reviewer's attention

**A blob-erasure bug that would have deleted other people's files.** The object sweep lists by the user's prefix, but the S3 and Supabase adapters match a prefix as a plain string and `normalizeStorageKey` strips the trailing slash — so listing `user-1/` also returns `user-10/` and `user-1x/`. Erasing account `user-1` would have deleted another account's objects. Filtered and tested.

**Three tables a `user_id` sweep silently misses.** `nodetool_workflow_shares` is keyed on `created_by`, so live share tokens would outlive the workflows they point at. `mcp_oauth_tokens` hangs off the grant, so live tokens would outlive it. `application_budgets` hangs off the application. These were found by enumerating the schema through Drizzle's metadata rather than grepping for the column — grepping undercounts, because six schema files define more than one table.

## Verification

- `npm run test --workspace=packages/websocket` — 2872 passed, 253 files (2858 before, no regressions)
- `npm run test --workspace=packages/models` — 979 passed, 65 files (947 before)
- `npm run test --workspace=packages/config` — 149 passed
- `npm run test --workspace=packages/protocol` — 1055 passed
- `npm run build` for `models`, `config`, `protocol`, `websocket` — clean
- `web` typecheck — exit 0; `npm run lint` — exit 0
- `npx tsc --noEmit` on the changed privacy files — clean

Known unrelated failure: root `npm run typecheck` fails on the `mobile` leg because `mobile/node_modules` is not installed in this container. No mobile source touches these schemas.

- [x] `npm run test:affected` — covered by the per-workspace runs above
- [x] `npm run typecheck` — passes for every workspace this diff touches; `mobile` fails for the reason above
- [x] `npm run lint`
- [ ] `npm run dev:nodetool -- harness gate --base main` — not run

## Agent capabilities

No capability is added and no declared contract changes.

## New checks

Every new check was inverted and observed failing, then reverted.

**Registry audit** — a new `user_id` table with no entry turned 2 tests red, naming it by table and schema export. Also inverted: deleting a registry entry (3 red), deleting an erasure step while keeping the entry (5 red, the registered-but-unimplemented case), selecting collaborators by `workflow_id` instead of the subject (3 red, a cross-user leak), and removing `withheldColumns` from `nodetool_secrets` (2 red, ciphertext in the export).

**Cross-user access** — pointing the subject at a caller-supplied query param turned both tests red with `expected 'user-a' to be 'user-b'`. The erase case actually erased the wrong user's rows and objects in that run, so it exercises the whole path rather than a report field.

**Retention sweeps** — a no-op sweep turned 3 tests red; a sweep ignoring the retention window turned 3 different tests red.

Positive controls: the audit asserts it found at least 40 tables and 30 user-keyed ones before asserting anything, so it cannot pass by matching nothing. One test was found tautological and rewritten — the retention carve-out test iterated the constant it was testing, so deleting an entry shrank the test instead of failing it.

- [x] The check was inverted and observed failing
- [x] An audit asserts it found its targets

## Open items needing a human decision

Not code. Items 1–3 are reasons not to publish the policy yet.

1. **Controller identity.** The policy says "the NodeTool team"; Art. 13(1)(a) requires a named legal entity. `marketing/src/app/imprint/page.tsx` names an individual as the § 5 DDG provider, and `marketing/LEGAL_OPEN_ITEMS.md` assumes a Dutch entity that appears nowhere else. Left untouched rather than guessed at.
2. **Art. 28 processor agreements** with Fly.io, Supabase, Cloudflare and Plausible are asserted by the inherited policy text. Nothing in the repo evidences one exists.
3. **The 14-day server-log commitment has no implementation.** `fly.toml` configures no drain or retention, `packages/config/src/logging.ts` has no rotation or age-based deletion, and `server.ts` sets `logger: false` so the application never writes the IP/user-agent tuple the policy describes — Fly and Cloudflare produce it, outside this repo. The only rotation anywhere is `docker-compose.yml` json-file at 10 MB × 3, size-based and self-hosting only. Nothing would fail if retention were 90 days.
4. **`NODETOOL_STORAGE_AUTO_CLEANUP=1` must be set on the Fly deployment**, or the retention schedule the policy promises does not run in production.
5. **No age gate** exists in the hosted sign-up path, while the policy retains a section on children's data.

Two limitations are recorded in the code rather than papered over: objects written before the owner prefix existed sit at flat keys no per-user sweep can reach, and `nodetool_team_tasks` is classified not-personal because no writer for it exists anywhere in the repo — flagged to revisit in whatever PR adds one.

The policy was written to be accurate about the code, which is not the same as being sufficient as a legal document. It should be reviewed by a qualified data protection advisor before publication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bcqFMby7BNbRJigzfmE13