### PR TITLE
feat(credits): whitelist managed models and grant new users free credits

### DIFF
--- a/docs/agentic-video-product.md
+++ b/docs/agentic-video-product.md
@@ -91,10 +91,17 @@ Server-owned, in `packages/models/src/credits.ts` (`@nodetool-ai/models`):
   `@nodetool-ai/model-pricing` translates `nodetool/...` ids to the delegate
   before lookup so estimates are real numbers. Models appear in the pickers
   only when their platform key is set.
+- **The managed provider is cloud-only.** `nodetool` is in
+  `CLOUD_ONLY_PROVIDER_IDS` (`packages/protocol/src/cloud-profile.ts`) and the
+  provider index unregisters it whenever the cloud profile is off — a desktop
+  install and a self-hosted server (`NODETOOL_NODE_PROFILE=full`) both have
+  platform keys they do not own and no account to bill, so the provider would
+  only ever produce an error. Those users bring their own keys, unmetered.
 - **The operator picks which models the platform sells.**
   `NODETOOL_CREDIT_MODELS` is a comma/whitespace-separated list of curated
   model ids (`nodetool/flux-schnell nodetool/kokoro`); unset means the whole
-  catalog, which is what a local install wants. A model outside the list is
+  catalog, the right default for a staging server holding platform keys. A
+  model outside the list is
   hidden by the provider's listers, refused by `delegateFor` before a platform
   key is used, and refused by the gate before a run starts
   (`MODEL_NOT_AVAILABLE`, not `BUDGET_EXCEEDED` — a full balance does not

--- a/docs/agentic-video-product.md
+++ b/docs/agentic-video-product.md
@@ -65,10 +65,15 @@ Server-owned, in `packages/models/src/credits.ts` (`@nodetool-ai/models`):
 - **1 credit = $0.01 of provider spend.** Spend is never double-booked: the
   balance is `sum(grant ledger) - ceil(prediction spend / 1¢)`, read straight
   from the `nodetool_predictions` rows every provider call already writes.
-- **Ledger** (`nodetool_credit_ledger`) holds grants only: monthly plan
-  accruals, top-ups, adjustments. Plan grants use the row id
-  `plan:<userId>:<planId>:<YYYY-MM>`, so the lazy accrual (run on every
-  status read) is idempotent by primary key — no cron.
+- **Ledger** (`nodetool_credit_ledger`) holds grants only: the welcome grant,
+  monthly plan accruals, top-ups, adjustments. Grants are keyed so the lazy
+  accrual (run on every status read) is idempotent by primary key — no cron:
+  `signup:<userId>` once ever, `plan:<userId>:<planId>:<YYYY-MM>` per month.
+- **New users get free credits.** The first balance read for a user inserts
+  `NODETOOL_SIGNUP_CREDITS` (default 500) as a welcome grant, on top of the
+  free plan's monthly accrual. Raising the amount later reaches users who have
+  not signed up yet; it never re-grants one who already has the row. `0`
+  switches the welcome grant off.
 - **Plans** (`nodetool_user_subscriptions`, catalog `CREDIT_PLANS`): Free
   300/mo, Creator 3,000/mo ($12), Pro 10,000/mo ($40). Switching is instant
   and unbilled; a payment provider integration replaces the `topup` mutation
@@ -86,6 +91,18 @@ Server-owned, in `packages/models/src/credits.ts` (`@nodetool-ai/models`):
   `@nodetool-ai/model-pricing` translates `nodetool/...` ids to the delegate
   before lookup so estimates are real numbers. Models appear in the pickers
   only when their platform key is set.
+- **The operator picks which models the platform sells.**
+  `NODETOOL_CREDIT_MODELS` is a comma/whitespace-separated list of curated
+  model ids (`nodetool/flux-schnell nodetool/kokoro`); unset means the whole
+  catalog, which is what a local install wants. A model outside the list is
+  hidden by the provider's listers, refused by `delegateFor` before a platform
+  key is used, and refused by the gate before a run starts
+  (`MODEL_NOT_AVAILABLE`, not `BUDGET_EXCEEDED` — a full balance does not
+  change the answer). Parsing is `packages/config/src/credit-policy.ts`; the
+  surviving ids reach clients as `spendableModels` on `credits.status`, and
+  Studio's dropdowns show only those. `nodetool/director` drives the in-editor
+  assistants and is not user-selectable, so a whitelist that leaves it out
+  turns them off — name it alongside the models you sell.
 - **Enforcement follows the provider, not the deployment**
   (`packages/websocket/src/credit-gate.ts`): a workflow run is gated only on
   the slice of its estimate whose provider is `nodetool`
@@ -105,7 +122,8 @@ Still open, in order of value:
    (`getModelUnitPrice`) prices the curated models per unit, so shot cards
    and the voice-all button can show "≈ 3 credits" before the click.
 2. **Payments.** Stripe (or similar) in front of `setPlan`/`topup`; the
-   ledger and gate don't change.
+   ledger and gate don't change — a webhook writes `topup` rows and flips
+   `plan_id`, and the balance is read the same way.
 3. **Direct-RPC metering.** Done: `generate_media`, `generate_text` and
    `transcribe_audio` each write a prediction row on the managed provider
    (`direct.<mode>`, `direct.text`/`direct.structured`, `direct.transcription`),

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -2,7 +2,7 @@
 
 Two setups where a plain `npm install` or a plain test run does not work:
 locked-down containers, and machines without a Vulkan driver. The everyday
-setup is [AGENTS.md § Prerequisites](../AGENTS.md#prerequisites).
+setup is [AGENTS.md § Prerequisites](https://github.com/nodetool-ai/nodetool/blob/main/AGENTS.md#prerequisites).
 
 ### Install in sandboxed / proxied environments
 

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -3,7 +3,7 @@
 The full reference for every headless harness, CLI command, and agent tool
 surface: what it checks, what it does not simulate, and why it is shaped the
 way it is. The index — which harness answers which need — is
-[AGENTS.md § Agent Harnesses & Tooling](../AGENTS.md#agent-harnesses--tooling).
+[AGENTS.md § Agent Harnesses & Tooling](https://github.com/nodetool-ai/nodetool/blob/main/AGENTS.md#agent-harnesses--tooling).
 Flag-level reference for the CLI: [cli.md](cli.md).
 
 ## CLI
@@ -1106,7 +1106,7 @@ IS_SANDBOX=1 npm run dev:nodetool -- eval graph-planner -p claude_agent_sdk -m c
 ```
 
 Details on env stripping and the uid=0 blocker:
-[docs/AGENTS.md § Claude Agent SDK](AGENTS.md#claude-agent-sdk).
+[docs/AGENTS.md § Claude Agent SDK](https://github.com/nodetool-ai/nodetool/blob/main/docs/AGENTS.md#claude-agent-sdk).
 
 A **`graph-e2e`** suite takes the same planner all the way through: it plans a
 workflow, executes it on the kernel with the case's inputs, and has an LLM judge
@@ -1168,7 +1168,7 @@ structurally: `tool-loop` (graph editor), `workflow-escalation`, `script-tools`,
 `jsscript-tools`, `sketch-tools`, `timeline-tools`, `storyboard-tools`,
 `model3d-tools`, `app-tools`, `memory-tools`, and `creative-pipeline`.
 Same flags, metrics, and `--min-success` CI gate as `graph-planner`. Details:
-[packages/agents/AGENTS.md](../packages/agents/AGENTS.md).
+[packages/agents/AGENTS.md](https://github.com/nodetool-ai/nodetool/blob/main/packages/agents/AGENTS.md).
 
 `workflow-escalation` runs the graph tools over objectives that are missing
 something only the user can decide — a name, permission to delete, a choice
@@ -1302,7 +1302,7 @@ global — the `data.*` namespace is gone. The packs live in
 `packages/sandbox-packs/`, each a package.json manifest plus a SKILL.md, and
 every one of them is available out of the box. The current list — which library
 each wraps and whether it runs guest-side or host-side — is the table in
-[packages/sandbox-packs/README.md](../packages/sandbox-packs/README.md); read it
+[packages/sandbox-packs/README.md](https://github.com/nodetool-ai/nodetool/blob/main/packages/sandbox-packs/README.md); read it
 there rather than from a copy that drifts.
 
 **guest** means the compiler bundles the library into QuickJS. **host** means it
@@ -1444,7 +1444,7 @@ build that misses one. `shippedPackSearchPaths()`
 root last: a pack of the same name installed through the Package Manager
 shadows the copy in the app. Declaring a specifier from a pack this host does
 not carry still fails validation with "Install `<pack>`". See
-[packages/sandbox-packs/README.md](../packages/sandbox-packs/README.md).
+[packages/sandbox-packs/README.md](https://github.com/nodetool-ai/nodetool/blob/main/packages/sandbox-packs/README.md).
 
 ### nodetool affected (Changed-File → Workspace Mapping)
 
@@ -1533,7 +1533,7 @@ is stale or when a new capability arrives with no check and no gap note. It
 also carries a fingerprint of what each capability *declares*, so
 `harness gate --base <ref>` can refuse a contract change that left its coverage
 mapping untouched while saying nothing about an ordinary refactor. See
-[packages/agents/AGENTS.md § Capability coverage](../packages/agents/AGENTS.md).
+[packages/agents/AGENTS.md § Capability coverage](https://github.com/nodetool-ai/nodetool/blob/main/packages/agents/AGENTS.md).
 
 ### nodetool reliability (Cross-Surface Journey Diffs)
 
@@ -1788,7 +1788,7 @@ npm run dev:nodetool -- auth claude logout
 The same flow is exposed over HTTP at
 `/api/oauth/claude/{start,complete,tokens,disconnect}` and as a sign-in card on
 the **Models & Providers** settings page. Details:
-[packages/runtime/src/providers/oauth/README.md](../packages/runtime/src/providers/oauth/README.md).
+[packages/runtime/src/providers/oauth/README.md](https://github.com/nodetool-ai/nodetool/blob/main/packages/runtime/src/providers/oauth/README.md).
 
 ### nodetool secrets
 
@@ -1925,4 +1925,4 @@ Each line in the file is one span:
 }
 ```
 
-See [packages/agents/AGENTS.md](../packages/agents/AGENTS.md) for agent architecture, parallel execution, skills, and tuning.
+See [packages/agents/AGENTS.md](https://github.com/nodetool-ai/nodetool/blob/main/packages/agents/AGENTS.md) for agent architecture, parallel execution, skills, and tuning.

--- a/packages/config/src/__tests__/credit-policy.test.ts
+++ b/packages/config/src/__tests__/credit-policy.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  CREDIT_MODELS_ENV,
+  DEFAULT_SIGNUP_CREDITS,
+  SIGNUP_CREDITS_ENV,
+  creditModelAllowlist,
+  isCreditModelAllowed,
+  signupGrantCredits
+} from "../credit-policy.js";
+
+const env = (value: Record<string, string>) => value;
+
+describe("creditModelAllowlist", () => {
+  it("is null when the operator restricted nothing — the whole catalog", () => {
+    expect(creditModelAllowlist({})).toBeNull();
+    expect(creditModelAllowlist(env({ [CREDIT_MODELS_ENV]: "  " }))).toBeNull();
+    expect(creditModelAllowlist(env({ [CREDIT_MODELS_ENV]: ", ," }))).toBeNull();
+  });
+
+  it("splits on commas, spaces, and newlines", () => {
+    const allowed = creditModelAllowlist(
+      env({
+        [CREDIT_MODELS_ENV]:
+          "nodetool/flux-schnell, nodetool/kokoro\n nodetool/hailuo-fast"
+      })
+    );
+    expect([...allowed!].sort()).toEqual([
+      "nodetool/flux-schnell",
+      "nodetool/hailuo-fast",
+      "nodetool/kokoro"
+    ]);
+  });
+});
+
+describe("isCreditModelAllowed", () => {
+  it("allows everything when nothing is whitelisted", () => {
+    expect(isCreditModelAllowed("nodetool/seedream", {})).toBe(true);
+  });
+
+  it("allows only what the whitelist names", () => {
+    const configured = env({
+      [CREDIT_MODELS_ENV]: "nodetool/flux-schnell,nodetool/kokoro"
+    });
+    expect(isCreditModelAllowed("nodetool/flux-schnell", configured)).toBe(true);
+    expect(isCreditModelAllowed("nodetool/seedream", configured)).toBe(false);
+  });
+});
+
+describe("signupGrantCredits", () => {
+  it("defaults when unset or blank", () => {
+    expect(signupGrantCredits({})).toBe(DEFAULT_SIGNUP_CREDITS);
+    expect(signupGrantCredits(env({ [SIGNUP_CREDITS_ENV]: "  " }))).toBe(
+      DEFAULT_SIGNUP_CREDITS
+    );
+  });
+
+  it("reads a configured amount, floored to whole credits", () => {
+    expect(signupGrantCredits(env({ [SIGNUP_CREDITS_ENV]: "1200" }))).toBe(1200);
+    expect(signupGrantCredits(env({ [SIGNUP_CREDITS_ENV]: "12.9" }))).toBe(12);
+  });
+
+  it("treats zero, negatives, and junk as no welcome grant", () => {
+    for (const raw of ["0", "-5", "lots"]) {
+      expect(signupGrantCredits(env({ [SIGNUP_CREDITS_ENV]: raw }))).toBe(0);
+    }
+  });
+});

--- a/packages/config/src/credit-policy.ts
+++ b/packages/config/src/credit-policy.ts
@@ -3,11 +3,15 @@
  * with — the two knobs a production operator turns.
  *
  * NodeTool's `nodetool` provider runs curated delegates on platform-owned
- * keys, so every call through it spends the operator's money. On a shared
- * deployment the operator therefore decides which of the catalog's entries are
- * open for business: `NODETOOL_CREDIT_MODELS` names them, and anything else is
- * refused before a key is used. Unset means the whole catalog, which is what a
- * local install wants — there the platform keys are the user's own.
+ * keys, so every call through it spends the operator's money. The operator
+ * therefore decides which of the catalog's entries are open for business:
+ * `NODETOOL_CREDIT_MODELS` names them, and anything else is refused before a
+ * key is used. Unset means the whole catalog — the right default for a
+ * staging or dev server that holds platform keys.
+ *
+ * None of this reaches a local install: `nodetool` is a cloud-only provider
+ * (`CLOUD_ONLY_PROVIDER_IDS`), unregistered off the cloud profile, so a
+ * desktop or self-hosted server has no managed provider to whitelist.
  *
  * Parsing lives here rather than next to the catalog because the catalog
  * (`@nodetool-ai/protocol`) is browser-safe pure data with no environment to

--- a/packages/config/src/credit-policy.ts
+++ b/packages/config/src/credit-policy.ts
@@ -1,0 +1,67 @@
+/**
+ * Which managed models credits may be spent on, and what a new user starts
+ * with — the two knobs a production operator turns.
+ *
+ * NodeTool's `nodetool` provider runs curated delegates on platform-owned
+ * keys, so every call through it spends the operator's money. On a shared
+ * deployment the operator therefore decides which of the catalog's entries are
+ * open for business: `NODETOOL_CREDIT_MODELS` names them, and anything else is
+ * refused before a key is used. Unset means the whole catalog, which is what a
+ * local install wants — there the platform keys are the user's own.
+ *
+ * Parsing lives here rather than next to the catalog because the catalog
+ * (`@nodetool-ai/protocol`) is browser-safe pure data with no environment to
+ * read. Callers resolve names against the catalog themselves.
+ */
+import { safeProcessEnv } from "./node-import.js";
+
+/** Names the managed models credits may be spent on. */
+export const CREDIT_MODELS_ENV = "NODETOOL_CREDIT_MODELS";
+/** One-time welcome grant, in credits, for a user seen for the first time. */
+export const SIGNUP_CREDITS_ENV = "NODETOOL_SIGNUP_CREDITS";
+
+/** Credits a new user is granted when no override is configured. */
+export const DEFAULT_SIGNUP_CREDITS = 500;
+
+type Env = Record<string, string | undefined>;
+
+/**
+ * The configured allowlist of managed model ids, or `null` when the operator
+ * set none — `null` is "the whole catalog", not "nothing".
+ *
+ * Entries are separated by commas, whitespace, or newlines, so the variable
+ * reads the same in a `.env` file, a `fly secrets` line, and a Compose file.
+ */
+export function creditModelAllowlist(
+  env: Env = safeProcessEnv()
+): ReadonlySet<string> | null {
+  const raw = env[CREDIT_MODELS_ENV]?.trim();
+  if (!raw) return null;
+  const ids = raw
+    .split(/[\s,]+/)
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+  return ids.length > 0 ? new Set(ids) : null;
+}
+
+/** Whether `modelId` may be served by the managed provider on this server. */
+export function isCreditModelAllowed(
+  modelId: string,
+  env: Env = safeProcessEnv()
+): boolean {
+  const allowed = creditModelAllowlist(env);
+  return allowed === null || allowed.has(modelId);
+}
+
+/**
+ * Credits granted once, the first time a user is seen. `0` (or any negative
+ * or unparseable value) means no welcome grant — the monthly plan grant is
+ * then all a new user gets.
+ */
+export function signupGrantCredits(env: Env = safeProcessEnv()): number {
+  const raw = env[SIGNUP_CREDITS_ENV]?.trim();
+  if (raw === undefined || raw === "") return DEFAULT_SIGNUP_CREDITS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+  return Math.floor(parsed);
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -19,6 +19,15 @@ export { getByteLimitEnv } from "./byte-limits.js";
 
 export { isAuthEnforced } from "./deployment.js";
 
+export {
+  CREDIT_MODELS_ENV,
+  SIGNUP_CREDITS_ENV,
+  DEFAULT_SIGNUP_CREDITS,
+  creditModelAllowlist,
+  isCreditModelAllowed,
+  signupGrantCredits
+} from "./credit-policy.js";
+
 export { isGoogleWorkspaceEnabled } from "./google-workspace.js";
 
 export {

--- a/packages/models/src/credits.ts
+++ b/packages/models/src/credits.ts
@@ -102,10 +102,10 @@ export type CreditDecision =
     };
 
 /**
- * The managed models this server sells, or `null` when the operator
- * restricted none — `null` is the whole catalog, which is what a local
- * install wants. Callers that render a menu use it to hide what they could
- * not run anyway.
+ * The managed models this server sells: the operator's whitelist, or the whole
+ * catalog when they restricted none. Callers that render a menu use it to hide
+ * what they could not run anyway. Empty in practice off the cloud profile,
+ * where the `nodetool` provider is not registered at all.
  */
 export const spendableModelIds = (): string[] =>
   NODETOOL_MODELS.filter((def) => isCreditModelAllowed(def.id)).map(

--- a/packages/models/src/credits.ts
+++ b/packages/models/src/credits.ts
@@ -6,14 +6,17 @@
  *
  *   balance = sum(ledger.delta) - ceil(prediction spend / USD_PER_CREDIT)
  *
- * Plans accrue lazily: the first balance read in a month inserts that month's
- * grant, keyed `plan:<userId>:<periodKey>` so the primary key makes double
- * accrual impossible. No cron, no payment state — a payment provider webhook
- * would write `topup` rows and flip `plan_id`; until then plan switches are
- * instant and top-ups are stubbed.
+ * Grants accrue lazily on read, never on a schedule. A user seen for the
+ * first time gets the welcome grant (`signup:<userId>`); every balance read
+ * also inserts the current month's plan grant (`plan:<userId>:<planId>:
+ * <periodKey>`). Both are keyed so the primary key makes a double grant
+ * impossible — no cron, no payment state. A payment provider webhook would
+ * write `topup` rows and flip `plan_id`; until then plan switches are instant
+ * and top-ups are stubbed.
  */
 import { and, eq, sql } from "drizzle-orm";
-import { NODETOOL_PROVIDER_ID } from "@nodetool-ai/protocol";
+import { NODETOOL_MODELS, NODETOOL_PROVIDER_ID } from "@nodetool-ai/protocol";
+import { isCreditModelAllowed, signupGrantCredits } from "@nodetool-ai/config";
 
 import { getDb } from "./db.js";
 import { creditLedger, userSubscriptions } from "./schema/credits.js";
@@ -86,9 +89,28 @@ export interface CreditStatus {
   spentUsd: number;
 }
 
+/** Why a spend was refused — the caller maps it onto its own error code. */
+export type CreditRefusal = "model_not_allowed" | "insufficient_credits";
+
 export type CreditDecision =
   | { allowed: true; status: CreditStatus }
-  | { allowed: false; reason: string; status: CreditStatus };
+  | {
+      allowed: false;
+      refusal: CreditRefusal;
+      reason: string;
+      status: CreditStatus;
+    };
+
+/**
+ * The managed models this server sells, or `null` when the operator
+ * restricted none — `null` is the whole catalog, which is what a local
+ * install wants. Callers that render a menu use it to hide what they could
+ * not run anyway.
+ */
+export const spendableModelIds = (): string[] =>
+  NODETOOL_MODELS.filter((def) => isCreditModelAllowed(def.id)).map(
+    (def) => def.id
+  );
 
 const toSubscription = (row: Record<string, unknown>): UserSubscription => ({
   userId: String(row.user_id),
@@ -185,6 +207,43 @@ export async function ensureMonthlyGrant(
   }
 }
 
+/**
+ * Insert the one-time welcome grant for a user seen for the first time.
+ * Idempotent via the primary key `signup:<userId>`, so it survives every
+ * later balance read; a server configured with no welcome grant
+ * (`NODETOOL_SIGNUP_CREDITS=0`) writes nothing.
+ *
+ * The amount is read per call rather than captured at module load, so raising
+ * the grant reaches users who have not signed up yet without a restart — and
+ * never re-grants the ones who already have their row.
+ */
+export async function ensureSignupGrant(userId: string): Promise<void> {
+  const credits = signupGrantCredits();
+  if (credits <= 0) return;
+
+  const id = `signup:${userId}`;
+  const db = getDb();
+  const existing = await db
+    .select({ id: creditLedger.id })
+    .from(creditLedger)
+    .where(eq(creditLedger.id, id))
+    .limit(1);
+  if (existing[0]) return;
+  try {
+    await db.insert(creditLedger).values({
+      id,
+      user_id: userId,
+      delta: credits,
+      kind: "signup_grant",
+      description: "Welcome credits",
+      period_key: null,
+      created_at: new Date().toISOString()
+    });
+  } catch {
+    // Lost a race with a concurrent first read — already granted.
+  }
+}
+
 /** Record a top-up or manual adjustment. */
 export async function grantCredits(
   userId: string,
@@ -207,9 +266,10 @@ export async function grantCredits(
   });
 }
 
-/** Balance, plan, and totals — accrues the current month's grant first. */
+/** Balance, plan, and totals — accrues the welcome and month grants first. */
 export async function creditStatus(userId: string): Promise<CreditStatus> {
   const now = new Date();
+  await ensureSignupGrant(userId);
   await ensureMonthlyGrant(userId, now);
   const subscription = await getSubscription(userId);
   const plan = planById(subscription.planId) ?? planById(DEFAULT_PLAN_ID)!;
@@ -250,22 +310,41 @@ export async function creditStatus(userId: string): Promise<CreditStatus> {
 }
 
 /**
- * The pre-spend gate. `estimatedUsd` is a floor (unpriceable nodes estimate
- * 0), so the check is: the balance must cover the estimate, and must be
- * positive at all. Callers decide whether the gate is on at all
- * (NODETOOL_CREDITS_ENFORCED).
+ * The pre-spend gate: two refusals, in the order the user can act on them.
+ *
+ * First, `models` — the managed model ids the work names — must all be open
+ * for business on this server (`NODETOOL_CREDIT_MODELS`). A model the operator
+ * did not whitelist is refused however full the balance is, because the spend
+ * would land on a platform key the operator did not offer. Callers that do not
+ * know the models pass none, and only the balance is checked; the provider
+ * refuses a disallowed model again before it uses a key.
+ *
+ * Then the balance. `estimatedUsd` is a floor (unpriceable nodes estimate 0),
+ * so the check is: the balance must cover the estimate, and must be positive
+ * at all.
  */
 export async function checkCredits(
   userId: string,
-  estimatedUsd: number
+  estimatedUsd: number,
+  models: readonly string[] = []
 ): Promise<CreditDecision> {
   const status = await creditStatus(userId);
+  const refused = models.find((model) => !isCreditModelAllowed(model));
+  if (refused !== undefined) {
+    return {
+      allowed: false,
+      refusal: "model_not_allowed",
+      reason: `Model "${refused}" is not available on this server.`,
+      status
+    };
+  }
   const estimatedCredits = Math.ceil(
     Math.max(0, estimatedUsd) / USD_PER_CREDIT
   );
   if (status.balanceCredits <= 0) {
     return {
       allowed: false,
+      refusal: "insufficient_credits",
       reason: `Out of credits on the ${status.plan.name} plan. Upgrade or top up to continue.`,
       status
     };
@@ -273,6 +352,7 @@ export async function checkCredits(
   if (estimatedCredits > status.balanceCredits) {
     return {
       allowed: false,
+      refusal: "insufficient_credits",
       reason: `This run needs about ${estimatedCredits} credits but ${status.balanceCredits} remain.`,
       status
     };

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -423,15 +423,18 @@ export {
   checkCredits,
   creditStatus,
   ensureMonthlyGrant,
+  ensureSignupGrant,
   getSubscription,
   grantCredits,
   periodKeyFor,
   planById,
-  setSubscriptionPlan
+  setSubscriptionPlan,
+  spendableModelIds
 } from "./credits.js";
 export type {
   CreditDecision,
   CreditPlan,
+  CreditRefusal,
   CreditStatus,
   UserSubscription
 } from "./credits.js";

--- a/packages/models/tests/credits.test.ts
+++ b/packages/models/tests/credits.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import { initTestDb } from "../src/db.js";
 import { Prediction } from "../src/prediction.js";
@@ -8,10 +8,12 @@ import {
   checkCredits,
   creditStatus,
   ensureMonthlyGrant,
+  ensureSignupGrant,
   getSubscription,
   grantCredits,
   periodKeyFor,
-  setSubscriptionPlan
+  setSubscriptionPlan,
+  spendableModelIds
 } from "../src/credits.js";
 
 const USER = "u1";
@@ -28,9 +30,27 @@ const spend = (cost: number, provider = "nodetool") =>
     cost
   });
 
+/**
+ * The plan-grant and balance tests are about that arithmetic, so the welcome
+ * grant is switched off for them; it has its own block below.
+ */
 describe("credits", () => {
+  let savedSignup: string | undefined;
+  let savedModels: string | undefined;
+
   beforeEach(() => {
+    savedSignup = process.env.NODETOOL_SIGNUP_CREDITS;
+    savedModels = process.env.NODETOOL_CREDIT_MODELS;
+    process.env.NODETOOL_SIGNUP_CREDITS = "0";
+    delete process.env.NODETOOL_CREDIT_MODELS;
     initTestDb();
+  });
+
+  afterEach(() => {
+    if (savedSignup === undefined) delete process.env.NODETOOL_SIGNUP_CREDITS;
+    else process.env.NODETOOL_SIGNUP_CREDITS = savedSignup;
+    if (savedModels === undefined) delete process.env.NODETOOL_CREDIT_MODELS;
+    else process.env.NODETOOL_CREDIT_MODELS = savedModels;
   });
 
   it("defaults a new user to the free plan and accrues its monthly grant once", async () => {
@@ -119,5 +139,71 @@ describe("credits", () => {
     const other = await creditStatus("u2");
     expect(other.spentCredits).toBe(0);
     expect(other.balanceCredits).toBe(FREE.monthlyCredits);
+  });
+
+  it("grants welcome credits once, and only when configured", async () => {
+    const none = await creditStatus(USER);
+    expect(none.grantedCredits).toBe(FREE.monthlyCredits);
+
+    process.env.NODETOOL_SIGNUP_CREDITS = "500";
+    await ensureSignupGrant(USER);
+    await ensureSignupGrant(USER);
+    const welcomed = await creditStatus(USER);
+    expect(welcomed.grantedCredits).toBe(FREE.monthlyCredits + 500);
+
+    // Raising the amount later must not re-grant a user who already has it.
+    process.env.NODETOOL_SIGNUP_CREDITS = "5000";
+    await ensureSignupGrant(USER);
+    const unchanged = await creditStatus(USER);
+    expect(unchanged.grantedCredits).toBe(FREE.monthlyCredits + 500);
+  });
+
+  it("the welcome grant reaches a new user on the first balance read", async () => {
+    process.env.NODETOOL_SIGNUP_CREDITS = "250";
+    const status = await creditStatus("fresh-user");
+    expect(status.grantedCredits).toBe(FREE.monthlyCredits + 250);
+  });
+
+  it("refuses a model the operator did not whitelist, however full the balance", async () => {
+    process.env.NODETOOL_CREDIT_MODELS = "nodetool/flux-schnell";
+    await grantCredits(USER, 100_000, "adjustment", "plenty");
+
+    const allowed = await checkCredits(USER, 0, ["nodetool/flux-schnell"]);
+    expect(allowed.allowed).toBe(true);
+
+    const refused = await checkCredits(USER, 0, ["nodetool/seedream"]);
+    expect(refused.allowed).toBe(false);
+    if (!refused.allowed) {
+      expect(refused.refusal).toBe("model_not_allowed");
+      expect(refused.reason).toContain("nodetool/seedream");
+    }
+
+    // One bad model in a mixed run refuses the run.
+    const mixed = await checkCredits(USER, 0, [
+      "nodetool/flux-schnell",
+      "nodetool/seedream"
+    ]);
+    expect(mixed.allowed).toBe(false);
+  });
+
+  it("names the whitelist as the spendable catalog, and the whole catalog without one", async () => {
+    expect(spendableModelIds()).toContain("nodetool/seedream");
+
+    process.env.NODETOOL_CREDIT_MODELS =
+      "nodetool/flux-schnell, nodetool/kokoro";
+    expect(spendableModelIds()).toEqual([
+      "nodetool/flux-schnell",
+      "nodetool/kokoro"
+    ]);
+  });
+
+  it("an empty balance refuses on credits, not on the model", async () => {
+    await creditStatus(USER);
+    await spend(FREE.monthlyCredits * USD_PER_CREDIT);
+    const decision = await checkCredits(USER, 0, ["nodetool/flux-schnell"]);
+    expect(decision.allowed).toBe(false);
+    if (!decision.allowed) {
+      expect(decision.refusal).toBe("insufficient_credits");
+    }
   });
 });

--- a/packages/protocol/src/api-schemas/api-error-code.ts
+++ b/packages/protocol/src/api-schemas/api-error-code.ts
@@ -15,7 +15,13 @@ export enum ApiErrorCode {
   TIMELINE_NO_MEDIA_OUTPUT = "TIMELINE_NO_MEDIA_OUTPUT",
   SKETCH_NO_IMAGE_OUTPUT = "SKETCH_NO_IMAGE_OUTPUT",
   /** A published app's run would exceed its app-scoped spend budget. */
-  BUDGET_EXCEEDED = "BUDGET_EXCEEDED"
+  BUDGET_EXCEEDED = "BUDGET_EXCEEDED",
+  /**
+   * The run names a managed model this server does not sell — the operator's
+   * `NODETOOL_CREDIT_MODELS` whitelist leaves it out. A full balance does not
+   * change the answer.
+   */
+  MODEL_NOT_AVAILABLE = "MODEL_NOT_AVAILABLE"
 }
 
 export interface ApiErrorResponse {

--- a/packages/protocol/src/api-schemas/credits.ts
+++ b/packages/protocol/src/api-schemas/credits.ts
@@ -27,6 +27,13 @@ export const creditStatusOutput = z.object({
   meteredProvider: z.string(),
   /** True only on dev servers that opt into the no-payment test top-up. */
   testTopupEnabled: z.boolean(),
+  /**
+   * The managed model ids this server sells — the operator's
+   * `NODETOOL_CREDIT_MODELS` whitelist, or the whole curated catalog when the
+   * operator restricted none. Clients show these and hide the rest; the
+   * server refuses the rest regardless.
+   */
+  spendableModels: z.array(z.string()),
   plans: z.array(creditPlan)
 });
 export type CreditStatusOutput = z.infer<typeof creditStatusOutput>;

--- a/packages/protocol/src/cloud-profile.ts
+++ b/packages/protocol/src/cloud-profile.ts
@@ -240,6 +240,30 @@ export const NON_CLOUD_PROVIDER_IDS: readonly string[] = [
 ];
 
 /**
+ * Providers offered *only* by the cloud product — the mirror image of
+ * {@link NON_CLOUD_PROVIDER_IDS}.
+ *
+ * Same rule, reversed: a provider belongs here when only the commercial cloud
+ * can reach it. `nodetool` runs curated delegates on NodeTool's own platform
+ * keys and meters the spend against a credit balance, so it is the platform's
+ * wallet, not a key the user pastes into settings. A local install has neither
+ * the keys nor an account to bill, and a self-hosted server has no claim on
+ * NodeTool's; offering it there is a provider card that can only ever produce
+ * an error.
+ */
+export const CLOUD_ONLY_PROVIDER_IDS: readonly string[] = ["nodetool"];
+
+/**
+ * Whether `providerId` is reachable outside the cloud product. False only for
+ * {@link CLOUD_ONLY_PROVIDER_IDS}; an unknown id is treated as reachable, so a
+ * provider added to the registry keeps working on a laptop without a second
+ * edit here.
+ */
+export function isSelfServeProvider(providerId: string): boolean {
+  return !CLOUD_ONLY_PROVIDER_IDS.includes(providerId);
+}
+
+/**
  * Built-in node packs loaded under the cloud profile. `base` is required and
  * always loads; `fal` and `kie` are the only provider packs kept. Every other
  * provider pack (Replicate, Hugging Face, Together, MiniMax, Topaz, Reve,

--- a/packages/protocol/tests/cloud-profile.test.ts
+++ b/packages/protocol/tests/cloud-profile.test.ts
@@ -8,6 +8,8 @@ import {
   CLOUD_BUILTIN_PACK_IDS,
   isCloudNodeType,
   isCloudProvider,
+  isSelfServeProvider,
+  CLOUD_ONLY_PROVIDER_IDS,
   isCloudProfileActive
 } from "../src/cloud-profile.js";
 import { BUILTIN_NODE_PACKS } from "../src/builtin-packs.js";
@@ -246,5 +248,29 @@ describe("cloud provider + pack allowlists", () => {
     expect(new Set(NON_CLOUD_PROVIDER_IDS).size).toBe(
       NON_CLOUD_PROVIDER_IDS.length
     );
+  });
+
+  it("keeps the managed provider out of every self-serve install", () => {
+    expect(isSelfServeProvider("nodetool")).toBe(false);
+    // It is still a cloud provider — the two lists are opposite ends, not a
+    // single spectrum, and `nodetool` is the one id that is cloud-only.
+    expect(isCloudProvider("nodetool")).toBe(true);
+  });
+
+  it("treats an unknown provider id as self-serve", () => {
+    expect(isSelfServeProvider("some-future-byok-api")).toBe(true);
+    for (const id of ["ollama", "openai", "fal_ai", "anthropic"]) {
+      expect(isSelfServeProvider(id)).toBe(true);
+    }
+  });
+
+  it("cloud-only and non-cloud lists are unique and disjoint", () => {
+    expect(CLOUD_ONLY_PROVIDER_IDS.length).toBeGreaterThan(0);
+    expect(new Set(CLOUD_ONLY_PROVIDER_IDS).size).toBe(
+      CLOUD_ONLY_PROVIDER_IDS.length
+    );
+    for (const id of CLOUD_ONLY_PROVIDER_IDS) {
+      expect(NON_CLOUD_PROVIDER_IDS).not.toContain(id);
+    }
   });
 });

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -272,7 +272,8 @@ import {
   CLOUD_PROFILE_ENV,
   NODE_ENV_VAR,
   isCloudProfileActive,
-  isCloudProvider
+  isCloudProvider,
+  isSelfServeProvider
 } from "@nodetool-ai/protocol";
 export type {
   ProviderId,
@@ -546,5 +547,15 @@ if (
 if (_cloudProfile) {
   for (const id of listBuiltinProviderIds()) {
     if (!isCloudProvider(id)) unregisterBuiltinProvider(id);
+  }
+} else {
+  // Off the cloud profile — a desktop install, a dev checkout, or a
+  // self-hosted server (NODETOOL_NODE_PROFILE=full) — drop the mirror image:
+  // the providers only the commercial cloud can reach. `nodetool` spends
+  // NodeTool's own platform keys against a user's credit balance, so outside
+  // the cloud product it is a provider card with no wallet behind it. Users
+  // here bring their own keys, and every BYOK provider above still works.
+  for (const id of listBuiltinProviderIds()) {
+    if (!isSelfServeProvider(id)) unregisterBuiltinProvider(id);
   }
 }

--- a/packages/runtime/src/providers/nodetool-provider.ts
+++ b/packages/runtime/src/providers/nodetool-provider.ts
@@ -12,12 +12,20 @@
  * Cost is accounted at the delegate's price: each call absorbs the inner
  * provider's cost delta into this instance, so the host's prediction logging
  * records real USD under provider "nodetool".
+ *
+ * A model is served only when it is both **funded** (the delegate's platform
+ * key is set) and **allowed** (`NODETOOL_CREDIT_MODELS` names it, or names
+ * nothing at all). The listers hide what fails either test and `delegateFor`
+ * refuses it, so a whitelist an operator narrows can never be spent past by a
+ * client holding a stale menu.
  */
 import {
   NODETOOL_MODELS,
   nodetoolModelById,
+  type NodetoolModelDef,
   type NodetoolModelKind
 } from "@nodetool-ai/protocol";
+import { isCreditModelAllowed } from "@nodetool-ai/config";
 import { BaseProvider, type ProviderCapability } from "./base-provider.js";
 import type {
   EncodedAudioResult,
@@ -64,6 +72,11 @@ export class NodetoolProvider extends BaseProvider {
     return this.platformKey(delegateProvider) != null;
   }
 
+  /** Funded by a platform key and whitelisted for spend on this server. */
+  private isServable(def: NodetoolModelDef): boolean {
+    return this.isFunded(def.delegate.provider) && isCreditModelAllowed(def.id);
+  }
+
   /**
    * The delegate serving a nodetool model id, constructed on platform keys.
    * A fresh instance per call on purpose: cost is read off the delegate's
@@ -79,6 +92,11 @@ export class NodetoolProvider extends BaseProvider {
     const def = nodetoolModelById(modelId);
     if (!def) {
       throw new Error(`Unknown NodeTool model "${modelId}".`);
+    }
+    if (!isCreditModelAllowed(def.id)) {
+      throw new Error(
+        `NodeTool model "${modelId}" is not available on this server.`
+      );
     }
     const delegate =
       (task === "image_to_image" ? def.editDelegate : undefined) ??
@@ -126,7 +144,7 @@ export class NodetoolProvider extends BaseProvider {
   protected override declaredCapabilities(): ProviderCapability[] {
     const capabilities: ProviderCapability[] = [];
     for (const def of NODETOOL_MODELS) {
-      if (!this.isFunded(def.delegate.provider)) continue;
+      if (!this.isServable(def)) continue;
       if (def.kind === "language") capabilities.push("generate_message");
       if (def.kind === "image") {
         capabilities.push("text_to_image");
@@ -141,14 +159,14 @@ export class NodetoolProvider extends BaseProvider {
     return [...new Set(capabilities)];
   }
 
-  private fundedModels(kind: NodetoolModelKind) {
+  private servableModels(kind: NodetoolModelKind) {
     return NODETOOL_MODELS.filter(
-      (def) => def.kind === kind && this.isFunded(def.delegate.provider)
+      (def) => def.kind === kind && this.isServable(def)
     );
   }
 
   override async getAvailableLanguageModels(): Promise<LanguageModel[]> {
-    return this.fundedModels("language").map((def) => ({
+    return this.servableModels("language").map((def) => ({
       type: "language_model",
       id: def.id,
       name: def.name,
@@ -157,7 +175,7 @@ export class NodetoolProvider extends BaseProvider {
   }
 
   override async getAvailableImageModels(): Promise<ImageModel[]> {
-    return this.fundedModels("image").map((def) => ({
+    return this.servableModels("image").map((def) => ({
       type: "image_model",
       id: def.id,
       name: def.name,
@@ -167,7 +185,7 @@ export class NodetoolProvider extends BaseProvider {
   }
 
   override async getAvailableVideoModels(): Promise<VideoModel[]> {
-    return this.fundedModels("video").map((def) => ({
+    return this.servableModels("video").map((def) => ({
       type: "video_model",
       id: def.id,
       name: def.name,
@@ -177,7 +195,7 @@ export class NodetoolProvider extends BaseProvider {
   }
 
   override async getAvailableTTSModels(): Promise<TTSModel[]> {
-    return this.fundedModels("tts").map((def) => ({
+    return this.servableModels("tts").map((def) => ({
       id: def.id,
       name: def.name,
       provider: "nodetool",

--- a/packages/runtime/src/providers/nodetool-provider.ts
+++ b/packages/runtime/src/providers/nodetool-provider.ts
@@ -13,11 +13,14 @@
  * provider's cost delta into this instance, so the host's prediction logging
  * records real USD under provider "nodetool".
  *
- * A model is served only when it is both **funded** (the delegate's platform
- * key is set) and **allowed** (`NODETOOL_CREDIT_MODELS` names it, or names
- * nothing at all). The listers hide what fails either test and `delegateFor`
- * refuses it, so a whitelist an operator narrows can never be spent past by a
- * client holding a stale menu.
+ * The provider itself is cloud-only (`CLOUD_ONLY_PROVIDER_IDS`): off the cloud
+ * profile it is never registered, because a desktop or self-hosted server has
+ * no platform keys and no account to bill. Where it does run, a model is
+ * served only when it is both **funded** (the delegate's platform key is set)
+ * and **allowed** (`NODETOOL_CREDIT_MODELS` names it, or names nothing at
+ * all). The listers hide what fails either test and `delegateFor` refuses it,
+ * so a whitelist an operator narrows can never be spent past by a client
+ * holding a stale menu.
  */
 import {
   NODETOOL_MODELS,

--- a/packages/runtime/tests/nodetool-provider.test.ts
+++ b/packages/runtime/tests/nodetool-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 
 import { NODETOOL_MODELS, resolveNodetoolDelegate } from "@nodetool-ai/protocol";
 
@@ -105,5 +105,40 @@ describe("NodetoolProvider", () => {
         prompt: "a fox"
       })
     ).rejects.toThrow(/Unknown NodeTool model/);
+  });
+
+  describe("the operator's model whitelist", () => {
+    afterEach(() => {
+      delete process.env.NODETOOL_CREDIT_MODELS;
+    });
+
+    const funded = () =>
+      new NodetoolProvider({ NODETOOL_PLATFORM_FAL_KEY: "platform-key" });
+
+    it("hides a funded model the whitelist leaves out", async () => {
+      const before = await funded().getAvailableImageModels();
+      expect(before.map((m) => m.id)).toContain("nodetool/seedream");
+
+      process.env.NODETOOL_CREDIT_MODELS = "nodetool/flux-schnell";
+      const after = await funded().getAvailableImageModels();
+      expect(after.map((m) => m.id)).toEqual(["nodetool/flux-schnell"]);
+      expect(await funded().getAvailableVideoModels()).toEqual([]);
+      expect(await funded().getAvailableTTSModels()).toEqual([]);
+      expect(funded().getCapabilities()).not.toContain("image_to_video");
+    });
+
+    it("refuses to serve a model the whitelist leaves out", async () => {
+      process.env.NODETOOL_CREDIT_MODELS = "nodetool/flux-schnell";
+      await expect(
+        funded().textToImage({
+          model: {
+            type: "image_model",
+            id: "nodetool/seedream",
+            provider: "nodetool"
+          },
+          prompt: "a cat"
+        } as Parameters<NodetoolProvider["textToImage"]>[0])
+      ).rejects.toThrow(/not available on this server/);
+    });
   });
 });

--- a/packages/runtime/tests/provider-contract.test.ts
+++ b/packages/runtime/tests/provider-contract.test.ts
@@ -26,6 +26,7 @@ import {
 // hand-lists providers — `listRegisteredProviderIds()` below is the single
 // source of truth this suite enumerates.
 import "../src/providers/index.js";
+import { CLOUD_ONLY_PROVIDER_IDS } from "@nodetool-ai/protocol";
 import {
   CassetteProvider,
   CassetteStore
@@ -101,12 +102,32 @@ describe("provider registry enumeration", () => {
     expect(registeredIds.length).toBeGreaterThan(0);
   });
 
-  it("every MEDIA_ONLY_EXEMPTIONS entry names a currently registered provider", () => {
+  it("every MEDIA_ONLY_EXEMPTIONS entry names a live provider", () => {
     // Catches stale exemptions (a provider renamed/removed but the
     // exemption comment left behind) — the exemption list is only honest if
     // every entry is live.
+    //
+    // "Live" is not the same as "registered here": a cloud-only provider
+    // (`nodetool`) is deliberately unregistered off the cloud profile, which
+    // is the profile this suite runs under. Naming it in
+    // CLOUD_ONLY_PROVIDER_IDS is what keeps it live — delete the provider
+    // without deleting that entry and the protocol suite fails instead, so
+    // an exemption still cannot rot in either direction.
     for (const id of Object.keys(MEDIA_ONLY_EXEMPTIONS)) {
+      if (CLOUD_ONLY_PROVIDER_IDS.includes(id)) {
+        expect(registeredIds).not.toContain(id);
+        continue;
+      }
       expect(registeredIds).toContain(id);
+    }
+  });
+
+  it("the cloud-only providers really are absent under this profile", () => {
+    // Pins the premise the exemption check leans on: if a future edit
+    // registers `nodetool` everywhere again, this fails rather than the
+    // branch above quietly skipping a provider it should have covered.
+    for (const id of CLOUD_ONLY_PROVIDER_IDS) {
+      expect(registeredIds).not.toContain(id);
     }
   });
 });

--- a/packages/runtime/tests/providers/cloud-profile-providers.test.ts
+++ b/packages/runtime/tests/providers/cloud-profile-providers.test.ts
@@ -82,4 +82,33 @@ describe("cloud profile provider pruning", () => {
     for (const id of CLOUD) expect(ids).toContain(id);
     for (const id of OUT_OF_SCOPE) expect(ids).not.toContain(id);
   });
+
+  it("drops the managed provider when the profile is off", async () => {
+    delete process.env["NODETOOL_NODE_PROFILE"];
+    delete process.env["NODETOOL_ENV"];
+    vi.resetModules();
+    const mod = await import("../../src/providers/index.js");
+    // A desktop install, a dev checkout: no platform keys, no account to
+    // bill. Every BYOK provider is still there.
+    expect(mod.listRegisteredProviderIds()).not.toContain("nodetool");
+    expect(mod.listRegisteredProviderIds()).toContain("fal_ai");
+  });
+
+  it("drops the managed provider for a self-hosted server", async () => {
+    // docker-compose sets both: production, but the full catalog. A
+    // self-hoster has no claim on NodeTool's platform keys.
+    process.env["NODETOOL_ENV"] = "production";
+    process.env["NODETOOL_NODE_PROFILE"] = "full";
+    vi.resetModules();
+    const mod = await import("../../src/providers/index.js");
+    expect(mod.listRegisteredProviderIds()).not.toContain("nodetool");
+  });
+
+  it("keeps the managed provider under the cloud profile", async () => {
+    delete process.env["NODETOOL_ENV"];
+    process.env["NODETOOL_NODE_PROFILE"] = "cloud";
+    vi.resetModules();
+    const mod = await import("../../src/providers/index.js");
+    expect(mod.listRegisteredProviderIds()).toContain("nodetool");
+  });
 });

--- a/packages/websocket/src/credit-gate.ts
+++ b/packages/websocket/src/credit-gate.ts
@@ -6,14 +6,19 @@
  * providers are never gated: their spend rides the user's own keys, and both
  * models coexist on one server.
  *
+ * Two things can refuse a call: a model the operator did not whitelist
+ * (`NODETOOL_CREDIT_MODELS`), and a balance that cannot cover the estimate.
+ * Callers pass the managed model ids the work names so the first refusal
+ * arrives before the run starts, with the model in the message.
+ *
  * Like the application-budget gate, it fails open: metering must never take
  * the runner down.
  */
-import { checkCredits } from "@nodetool-ai/models";
+import { checkCredits, type CreditRefusal } from "@nodetool-ai/models";
 
 export type CreditGateResult =
   | { allowed: true }
-  | { allowed: false; reason: string };
+  | { allowed: false; refusal: CreditRefusal; reason: string };
 
 /**
  * In-flight reservations: spend admitted but not yet in the prediction
@@ -71,22 +76,28 @@ export function reservedSpendUsd(userId: string): number {
 
 /**
  * Decide whether `userId` may spend an estimated `estimatedUsd` through the
- * managed provider, counting spend already admitted but not yet settled.
- * Estimates are floors (unpriceable work estimates 0), so an empty balance
- * blocks even a 0-estimate call.
+ * managed provider on `models`, counting spend already admitted but not yet
+ * settled. Estimates are floors (unpriceable work estimates 0), so an empty
+ * balance blocks even a 0-estimate call.
  */
 export async function admitSpend(
   userId: string | null | undefined,
-  estimatedUsd: number
+  estimatedUsd: number,
+  models: readonly string[] = []
 ): Promise<CreditGateResult> {
   try {
     const decision = await checkCredits(
       userId ?? "1",
-      estimatedUsd + reservedSpendUsd(userId ?? "1")
+      estimatedUsd + reservedSpendUsd(userId ?? "1"),
+      models
     );
     return decision.allowed
       ? { allowed: true }
-      : { allowed: false, reason: decision.reason };
+      : {
+          allowed: false,
+          refusal: decision.refusal,
+          reason: decision.reason
+        };
   } catch (error) {
     console.error("Credit gate check failed (failing open):", error);
     return { allowed: true };

--- a/packages/websocket/src/session/inference.ts
+++ b/packages/websocket/src/session/inference.ts
@@ -359,7 +359,7 @@ export class DirectInferenceHandler {
     // so concurrent requests admit against each other, and record the real
     // token cost as a prediction row so the balance decrements.
     const estimatedUsd = estimateDirectTextSpend(req);
-    const decision = await admitSpend(userId, estimatedUsd);
+    const decision = await admitSpend(userId, estimatedUsd, [req.model]);
     if (!decision.allowed) {
       throw new Error(decision.reason);
     }
@@ -496,7 +496,7 @@ export class DirectInferenceHandler {
         ? unit.unit_price
         : 0;
     const estimatedUsd = unitPrice * variations;
-    const decision = await admitSpend(userId, estimatedUsd);
+    const decision = await admitSpend(userId, estimatedUsd, [req.model]);
     if (!decision.allowed) {
       throw new Error(decision.reason);
     }
@@ -1109,7 +1109,7 @@ export class DirectInferenceHandler {
 
     const userId = this.session.userId ?? "1";
     if (req.provider === "nodetool") {
-      const creditDecision = await admitSpend(userId, 0);
+      const creditDecision = await admitSpend(userId, 0, [req.model]);
       if (!creditDecision.allowed) {
         throw new Error(creditDecision.reason);
       }

--- a/packages/websocket/src/session/job-execution.ts
+++ b/packages/websocket/src/session/job-execution.ts
@@ -784,7 +784,7 @@ export class JobExecutionManager {
     try {
       const estimate = this.estimateGraphCost(req);
       if (!estimate) {
-        return { usesNodetool: false, estimatedUsd: 0 };
+        return { usesNodetool: false, estimatedUsd: 0, models: [] };
       }
       const items = estimate.items.filter(
         (item) => item.provider === "nodetool"
@@ -795,10 +795,17 @@ export class JobExecutionManager {
           (Number.isFinite(item.estimated_cost) ? item.estimated_cost : 0),
         0
       );
-      return { usesNodetool: items.length > 0, estimatedUsd: total };
+      const models = [
+        ...new Set(
+          items
+            .map((item) => item.model)
+            .filter((model): model is string => Boolean(model))
+        )
+      ];
+      return { usesNodetool: items.length > 0, estimatedUsd: total, models };
     } catch (err) {
       this.session.logError("nodetool spend estimate failed", err);
-      return { usesNodetool: false, estimatedUsd: 0 };
+      return { usesNodetool: false, estimatedUsd: 0, models: [] };
     }
   }
 
@@ -1010,23 +1017,26 @@ export class JobExecutionManager {
    * Gate a run on the user's credit balance — but only the part of the run
    * that spends through NodeTool's managed provider. A graph with no
    * `nodetool` models passes untouched (BYOK stays unmetered); one with them
-   * is refused when the balance is empty or can't cover the estimate.
-   * Estimates are floors, so an empty balance refuses even a 0-estimate
-   * nodetool call. Fails open on gate errors, like the application-budget
-   * gate above.
+   * is refused when it names a model this server does not sell, or when the
+   * balance is empty or can't cover the estimate. Estimates are floors, so an
+   * empty balance refuses even a 0-estimate nodetool call. Fails open on gate
+   * errors, like the application-budget gate above.
    */
   private async admitCreditRun(req: RunJobRequest): Promise<boolean> {
-    const { usesNodetool, estimatedUsd } = this.estimateNodetoolSpend(req);
+    const { usesNodetool, estimatedUsd, models } =
+      this.estimateNodetoolSpend(req);
     if (!usesNodetool) return true;
     // Pin the job id now so the reservation taken here can be released at the
     // run's terminal state (and on cancel-while-queued) under the same key.
     req.job_id ??= randomUUID();
-    const decision = await admitSpend(this.session.userId, estimatedUsd);
+    const decision = await admitSpend(this.session.userId, estimatedUsd, models);
     if (!decision.allowed) {
       return this.refuseRun(
         req,
         req.job_id,
-        ApiErrorCode.BUDGET_EXCEEDED,
+        decision.refusal === "model_not_allowed"
+          ? ApiErrorCode.MODEL_NOT_AVAILABLE
+          : ApiErrorCode.BUDGET_EXCEEDED,
         decision.reason
       );
     }

--- a/packages/websocket/src/trpc/error-formatter.ts
+++ b/packages/websocket/src/trpc/error-formatter.ts
@@ -72,7 +72,10 @@ const TRPC_CODE_BY_API_CODE = {
   [ApiErrorCode.SKETCH_NO_IMAGE_OUTPUT]: "BAD_REQUEST",
   // A budget refusal is the caller asking for more than the app is allowed to
   // spend, not a server fault.
-  [ApiErrorCode.BUDGET_EXCEEDED]: "FORBIDDEN"
+  [ApiErrorCode.BUDGET_EXCEEDED]: "FORBIDDEN",
+  // The operator does not sell this managed model here — a refusal, not a
+  // malformed request.
+  [ApiErrorCode.MODEL_NOT_AVAILABLE]: "FORBIDDEN"
 } satisfies Record<ApiErrorCode, TRPCError["code"]>;
 
 export function throwApiError(

--- a/packages/websocket/src/trpc/routers/credits.ts
+++ b/packages/websocket/src/trpc/routers/credits.ts
@@ -4,7 +4,8 @@ import {
   creditStatus,
   grantCredits,
   planById,
-  setSubscriptionPlan
+  setSubscriptionPlan,
+  spendableModelIds
 } from "@nodetool-ai/models";
 import { router } from "../index.js";
 import { protectedProcedure } from "../middleware.js";
@@ -31,6 +32,7 @@ const statusFor = async (userId: string) => {
     ...status,
     meteredProvider: NODETOOL_PROVIDER_ID,
     testTopupEnabled: testTopupEnabled(),
+    spendableModels: spendableModelIds(),
     plans: [...CREDIT_PLANS]
   };
 };

--- a/packages/websocket/tests/credit-gate.test.ts
+++ b/packages/websocket/tests/credit-gate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import { initTestDb, grantCredits, Prediction } from "@nodetool-ai/models";
 import {
@@ -11,8 +11,24 @@ import {
 const USER = "u1";
 
 describe("credit gate", () => {
+  let savedSignup: string | undefined;
+  let savedModels: string | undefined;
+
   beforeEach(() => {
+    // The balance arithmetic below is stated in the free plan's grant, so the
+    // welcome grant is off and the whitelist unset unless a test sets them.
+    savedSignup = process.env.NODETOOL_SIGNUP_CREDITS;
+    savedModels = process.env.NODETOOL_CREDIT_MODELS;
+    process.env.NODETOOL_SIGNUP_CREDITS = "0";
+    delete process.env.NODETOOL_CREDIT_MODELS;
     initTestDb();
+  });
+
+  afterEach(() => {
+    if (savedSignup === undefined) delete process.env.NODETOOL_SIGNUP_CREDITS;
+    else process.env.NODETOOL_SIGNUP_CREDITS = savedSignup;
+    if (savedModels === undefined) delete process.env.NODETOOL_CREDIT_MODELS;
+    else process.env.NODETOOL_CREDIT_MODELS = savedModels;
   });
 
   it("admits a funded user", async () => {
@@ -62,5 +78,27 @@ describe("credit gate", () => {
   it("releasing an unknown reservation is a no-op", () => {
     releaseSpend(USER, "never-reserved");
     expect(reservedSpendUsd(USER)).toBe(0);
+  });
+
+  it("refuses a model outside the operator's whitelist", async () => {
+    process.env.NODETOOL_CREDIT_MODELS = "nodetool/flux-schnell";
+
+    const allowed = await admitSpend(USER, 0.01, ["nodetool/flux-schnell"]);
+    expect(allowed.allowed).toBe(true);
+
+    const refused = await admitSpend(USER, 0.01, ["nodetool/seedream"]);
+    expect(refused.allowed).toBe(false);
+    if (!refused.allowed) {
+      expect(refused.refusal).toBe("model_not_allowed");
+      expect(refused.reason).toContain("nodetool/seedream");
+    }
+  });
+
+  it("names the balance, not the model, when no whitelist is configured", async () => {
+    const decision = await admitSpend(USER, 100, ["nodetool/seedream"]);
+    expect(decision.allowed).toBe(false);
+    if (!decision.allowed) {
+      expect(decision.refusal).toBe("insufficient_credits");
+    }
   });
 });

--- a/web/src/components/properties/curated/CuratedModelSelect.tsx
+++ b/web/src/components/properties/curated/CuratedModelSelect.tsx
@@ -3,11 +3,16 @@
  * curated options for one role, with the selected option's blurb underneath.
  * No provider browser, no search, no API keys — the shared model selects swap
  * themselves for this inside the Studio shell.
+ *
+ * The list is narrowed to the models the server sells, and a selection the
+ * server no longer sells is replaced with one it does — an operator can tighten
+ * the whitelist under a project that already picked something else.
  */
 
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { SelectField } from "../../ui_primitives";
 import type { CuratedOption } from "../../../studio/curatedModels";
+import { useSpendableOptions } from "../../../studio/useSpendableModels";
 
 interface CuratedModelSelectProps<T> {
   label: string;
@@ -25,21 +30,34 @@ function CuratedModelSelectInner<T>({
   onChange,
   disabled
 }: CuratedModelSelectProps<T>) {
+  const spendable = useSpendableOptions(options);
   const selectOptions = useMemo(
-    () => options.map((option) => ({ value: option.id, label: option.label })),
-    [options]
+    () => spendable.map((option) => ({ value: option.id, label: option.label })),
+    [spendable]
   );
   const selected = useMemo(
-    () => options.find((option) => option.id === value),
-    [options, value]
+    () => spendable.find((option) => option.id === value),
+    [spendable, value]
   );
   const handleChange = useCallback(
     (id: string) => {
-      const picked = options.find((option) => option.id === id);
+      const picked = spendable.find((option) => option.id === id);
       if (picked) onChange(picked.value);
     },
-    [options, onChange]
+    [spendable, onChange]
   );
+
+  // Correct an unavailable selection once per fallback. The ref is what makes
+  // it once: a parent that ignores the change (a read-only surface) would
+  // otherwise be told again on every render.
+  const corrected = useRef<string | null>(null);
+  const fallback = spendable[0];
+  useEffect(() => {
+    if (selected || !fallback) return;
+    if (corrected.current === fallback.id) return;
+    corrected.current = fallback.id;
+    onChange(fallback.value);
+  }, [selected, fallback, onChange]);
 
   return (
     <SelectField

--- a/web/src/studio/__tests__/curatedModelPickers.test.tsx
+++ b/web/src/studio/__tests__/curatedModelPickers.test.tsx
@@ -28,6 +28,20 @@ jest.mock("@tanstack/react-query", () => ({
   useQuery: () => ({ data: [] })
 }));
 
+// What the server says it sells. `null` is "balance unknown" — the pickers
+// then show the whole catalog and let the run refuse.
+let spendableModels: string[] | null = null;
+jest.mock("../useStudioCredits", () => ({
+  __esModule: true,
+  useStudioCredits: () => ({
+    status: spendableModels ? { spendableModels } : null,
+    remaining: 0,
+    loading: false,
+    unavailable: false,
+    refetch: jest.fn()
+  })
+}));
+
 const inStudio = (ui: React.ReactElement) =>
   render(
     <ThemeProvider theme={mockTheme}>
@@ -39,6 +53,10 @@ const inWorkspace = (ui: React.ReactElement) =>
   render(<ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>);
 
 describe("Studio curated model pickers", () => {
+  beforeEach(() => {
+    spendableModels = null;
+  });
+
   it("offers only the curated stills, and the full browser outside Studio", async () => {
     const user = userEvent.setup();
     const onChange = jest.fn();
@@ -87,5 +105,31 @@ describe("Studio curated model pickers", () => {
 
     expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
     expect(screen.getByTestId("image-model-dialog")).toBeInTheDocument();
+  });
+
+  it("offers only the stills this server sells", async () => {
+    const user = userEvent.setup();
+    spendableModels = [STUDIO_STILL_MODELS[0].modelId];
+    inStudio(
+      <ImageModelSelect
+        value={STUDIO_STILL_MODELS[0].id}
+        onChange={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent(STUDIO_STILL_MODELS[0].label);
+  });
+
+  it("moves a selection this server stopped selling onto one it sells", async () => {
+    const onChange = jest.fn();
+    spendableModels = [STUDIO_STILL_MODELS[1].modelId];
+    inStudio(
+      <ImageModelSelect value={STUDIO_STILL_MODELS[0].id} onChange={onChange} />
+    );
+
+    expect(onChange).toHaveBeenCalledWith(STUDIO_STILL_MODELS[1].value);
   });
 });

--- a/web/src/studio/curatedModels.ts
+++ b/web/src/studio/curatedModels.ts
@@ -64,6 +64,12 @@ export const STUDIO_DIRECTOR_MODEL: LanguageModelValue = {
 export interface CuratedOption<T> {
   /** What the dropdown selects on. The model id, or the voice id for voices. */
   id: string;
+  /**
+   * The curated model behind the option — the same as {@link id} except for a
+   * voice, where several options share one model. The server whitelist
+   * (`spendableModels`) is expressed in these ids.
+   */
+  modelId: string;
   value: T;
   /** User-facing name, e.g. "Balanced". */
   label: string;
@@ -79,6 +85,7 @@ const options = <T>(
 ): CuratedOption<T>[] =>
   nodetoolModelsOfKind(kind).map((def) => ({
     id: def.id,
+    modelId: def.id,
     value: map(def),
     label: def.name,
     blurb: def.blurb ?? "",
@@ -116,6 +123,7 @@ export const STUDIO_VOICES: CuratedOption<TTSModelValue>[] =
   nodetoolModelsOfKind("tts").flatMap((def) =>
     (def.voices ?? []).map((voice) => ({
       id: voice.id,
+      modelId: def.id,
       value: toTTSModel(def, voice.id),
       label: voice.name,
       blurb: "",

--- a/web/src/studio/useSpendableModels.ts
+++ b/web/src/studio/useSpendableModels.ts
@@ -1,0 +1,39 @@
+/**
+ * Which curated models this server sells.
+ *
+ * A production operator whitelists a subset of the catalog
+ * (`NODETOOL_CREDIT_MODELS`); the server refuses the rest and reports the
+ * survivors as `spendableModels` on the credit status. Studio's dropdowns are
+ * built from the static catalog, so they filter through this to avoid offering
+ * a model the run would refuse.
+ *
+ * Fails open, matching the server gate: while the status is loading or
+ * unavailable the full list shows, and the run is what refuses.
+ */
+
+import { useMemo } from "react";
+import { useStudioCredits } from "./useStudioCredits";
+import type { CuratedOption } from "./curatedModels";
+
+export function useSpendableModelIds(): ReadonlySet<string> | null {
+  const { status } = useStudioCredits();
+  return useMemo(
+    () => (status ? new Set(status.spendableModels) : null),
+    [status]
+  );
+}
+
+/** `options` narrowed to the ones whose model this server sells. */
+export function useSpendableOptions<T>(
+  options: CuratedOption<T>[]
+): CuratedOption<T>[] {
+  const spendable = useSpendableModelIds();
+  return useMemo(() => {
+    if (!spendable) return options;
+    const kept = options.filter((option) => spendable.has(option.modelId));
+    // An empty result means the whitelist and this picker's role do not
+    // overlap; showing the full list beats showing an empty dropdown, and the
+    // run still refuses.
+    return kept.length > 0 ? kept : options;
+  }, [options, spendable]);
+}


### PR DESCRIPTION
## What changed

Three commits. The first is the feature; the other two came out of review and CI.

**`ed5bc61c` — the credit system.** Production runs on platform-owned keys, so the operator decides which of the curated catalog is open for business and what a new account starts with. Two env vars, parsed in `packages/config/src/credit-policy.ts`:

- **`NODETOOL_CREDIT_MODELS`** — the managed model ids credits may be spent on, separated by commas/whitespace/newlines. Unset means the whole catalog: the right default for a staging server that holds platform keys. A model outside the list is hidden by `NodetoolProvider`'s listers, refused by `delegateFor` before a platform key is used, and refused by the gate before a run starts — with `MODEL_NOT_AVAILABLE` rather than `BUDGET_EXCEEDED`, so a full balance is not offered as the fix. The surviving ids reach clients as `spendableModels` on `credits.status` and narrow Studio's dropdowns; a project pinned to a model the operator stopped selling moves to one they do sell. `nodetool/director` drives the in-editor assistants and is not user-selectable, so a whitelist that leaves it out turns them off — called out in the docs.
- **`NODETOOL_SIGNUP_CREDITS`** — a one-time welcome grant, default 500, inserted on a user's first balance read. Keyed `signup:<userId>`, so raising it later reaches new users without re-granting existing ones; `0` switches it off. It rides the same lazy-accrual, idempotent-by-primary-key shape the monthly plan grant already uses — no cron.

`checkCredits` now takes the managed model ids the work names and refuses on the model before the balance, returning a typed `refusal` (`model_not_allowed` | `insufficient_credits`) that callers map onto their own error codes instead of sniffing the message. The three direct-inference RPCs and the graph run gate all pass their models through.

Buying credits is not in this diff. The `topup` mutation and ledger seam are unchanged, so a payment webhook still drops in behind them.

**`62e86ab2` — the managed provider is cloud-only.** `nodetool` spends NodeTool's own platform keys against a credit balance, so it is the platform's wallet rather than a key a user pastes into settings. A desktop install has neither the keys nor an account to bill, and a self-hosted server has no claim on NodeTool's. It is now in `CLOUD_ONLY_PROVIDER_IDS` — the mirror image of `NON_CLOUD_PROVIDER_IDS` — and the provider index prunes it off the cloud profile exactly as the local engines are pruned on it.

| | profile | `nodetool` |
|---|---|---|
| Electron desktop | `NODETOOL_NODE_PROFILE=full` | absent |
| dev checkout | unset | absent |
| self-hosted compose | `production` + `full` | absent |
| Fly production | `NODETOOL_ENV=production` | present |

This also corrected a wrong claim in the first commit's docs, which said an unset `NODETOOL_CREDIT_MODELS` was "what a local install wants". A local install has no managed provider to whitelist at all.

One test premise moved with it: the contract suite asserted every `MEDIA_ONLY_EXEMPTIONS` entry names a *registered* provider, which a conditionally-registered one breaks. It now accepts "live" — registered, or named in `CLOUD_ONLY_PROVIDER_IDS` — with a companion test pinning that the cloud-only ids really are absent under this profile, so the staleness guard still fails in both directions rather than quietly skipping a provider it should cover.

**`aa6900ea` — a docs-link fix this PR did not cause.** See [the comment below](https://github.com/nodetool-ai/nodetool/pull/5549#issuecomment-5532713823): Docs CI failed here with 9 broken internal links introduced by 79a3563d, in files this branch did not write. The check only runs on a PR touching `docs/**`, so nothing tripped it until this one did. No fix existed to port and the PR cannot merge without it, so the 9 are rewritten as absolute GitHub blob URLs — the convention already used in `docs/HARNESS_FIRST.md`, `docs/cli.md` and `docs/configuration.md`. Happy to split this into its own PR if you would rather keep this one to the credit system.

## Verification

- [x] `npm run test:affected` — one pre-existing environment failure: `@nodetool-ai/image-nodes` fails with `No WebGPU adapter available (Node/Dawn)` (no Vulkan ICD in this container; AGENTS.md documents this as a missing driver, not a broken test). Because turbo stops there, the affected suites were run directly instead:
  - `packages/protocol` 58 suites · `packages/config` 13 · `packages/models` 62 · `packages/websocket` 252 — all passed
  - `packages/runtime` 172/173 suites; the one failure is `tests/providers/video-frame-fallback.test.ts` on `Error: spawn ffmpeg ENOENT` (ffmpeg is not installed here)
  - `web` 1265 suites / 14 236 tests passed · `electron` 63 suites / 690 tests passed
- [x] `npm run typecheck` — web and electron clean. The mobile leg fails wholesale on `Cannot find module 'react-native'` etc.: `mobile/node_modules` does not exist in this container. This diff does not touch `mobile/`.
- [x] `npm run lint` — exit 0.
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — `Gate: 5/5 selfchecks passed`. (`--base main` errors with `no merge base` until `git fetch origin main`.)
- [x] Docs CI reproduced locally with the workflow's own commands — jekyll build then htmlproofer with the same flags and `LANG`/`LC_ALL=C.UTF-8`: 9 failures / exit 1 before, `HTML-Proofer finished successfully` / exit 0 after. The artifact and privacy-guard steps pass on the rebuilt site.

## Agent capabilities

No capability added and no declared contract changed. `npm run capabilities:check` reports `capability-table.ts is stale`, but that predates this branch: `git diff origin/main -- packages/agents packages/cli/src/harness/capability-table.ts` is empty, and the drift is in `generate_video`, `animate_image`, and `render_timeline`, none of which this diff touches.

## New checks

- [x] Every new rule was inverted and observed failing, then restored.

  Disabling the whitelist (`return allowed === null || allowed.has(modelId) || true;`) and rebuilding `@nodetool-ai/config`:

  ```
  ### models:     × refuses a model the operator did not whitelist, however full the balance
                  × names the whitelist as the spendable catalog, and the whole catalog without one
                  Tests  2 failed | 11 passed (13)
  ### runtime:    × hides a funded model the whitelist leaves out
                  × refuses to serve a model the whitelist leaves out
                  Tests  2 failed | 7 passed (9)
  ### websocket:  × refuses a model outside the operator's whitelist
                  Tests  1 failed | 6 passed (7)
  ### config:     × allows only what the whitelist names
                  Tests  1 failed | 6 passed (7)
  ```

  Disabling the welcome grant (`if (true) return;` in `ensureSignupGrant`):

  ```
  × grants welcome credits once, and only when configured
  × the welcome grant reaches a new user on the first balance read
  Tests  2 failed | 11 passed (13)
  ```

  Removing the cloud-only prune block from the provider index:

  ```
  × drops the managed provider when the profile is off
  × drops the managed provider for a self-hosted server
  Tests  2 failed | 4 passed (6)
  ```

  Worth recording: the first inversion attempt edited only `packages/config/src` and the models/runtime/websocket suites stayed green, because they resolve `@nodetool-ai/config` from `dist/`. The signal above is from the rebuilt package — a source-only inversion proves nothing across a package boundary here.

- [x] The tests assert both directions (a model the whitelist names is admitted, one it omits is refused; the provider is present under the cloud profile and absent off it), so they cannot pass by matching nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XXG1JVwY5sPjeMbMPfg3Dk