### PR TITLE
feat(web): offer Claude and OpenAI sign-in on first local launch

### DIFF
--- a/web/src/components/chat/containers/WelcomePlaceholder.tsx
+++ b/web/src/components/chat/containers/WelcomePlaceholder.tsx
@@ -17,6 +17,7 @@ import KeyRoundedIcon from "@mui/icons-material/KeyRounded";
 import { memo, useCallback, useMemo } from "react";
 import { useLanguageModelProviders } from "../../../hooks/useProviders";
 import { openProviderOnboarding } from "../../../stores/ProviderOnboardingStore";
+import { isElectron, isLocalhost } from "../../../lib/env";
 
 import openaiIcon from "../../../icons/providers/openai.svg";
 import anthropicIcon from "../../../icons/providers/anthropic.svg";
@@ -94,13 +95,23 @@ const SETUP_PROVIDERS = [
   { name: "Gemini", icon: geminiColorIcon, mono: false }
 ] as const;
 
+/**
+ * A desktop install can finish a Claude or OpenAI login on this machine, so it
+ * gets offered the sign-in first. A hosted deployment cannot, and is pointed
+ * at an API key instead.
+ */
+const SETUP_SUBTITLE =
+  isElectron || isLocalhost
+    ? "Sign in with Claude or OpenAI to use a subscription you already pay for, or add an API key. Your credentials are encrypted and stored securely."
+    : "Add an API key for OpenAI, Anthropic, or Gemini to start chatting. Your keys are encrypted and stored securely.";
+
 interface WelcomePlaceholderProps {
   onSuggestionClick?: (suggestion: string) => void;
 }
 
 /**
  * Shown when a chat thread has no messages yet. When no language-model
- * provider is configured we guide the user to add an API key first (otherwise
+ * provider is configured we guide the user to connect one first (otherwise
  * sending a message just fails); once a provider is available we show the
  * regular prompt suggestions.
  */
@@ -121,7 +132,10 @@ const WelcomePlaceholder: React.FC<WelcomePlaceholderProps> = ({
   const handleConnectProvider = useCallback(() => {
     openProviderOnboarding({
       capability: "generate_message",
-      reason: "Chat needs a language model. Connect a provider to start."
+      reason:
+        isElectron || isLocalhost
+          ? "Chat needs a language model. Sign in with Claude or OpenAI, or connect any provider with an API key."
+          : "Chat needs a language model. Connect a provider to start."
     });
   }, []);
 
@@ -140,8 +154,7 @@ const WelcomePlaceholder: React.FC<WelcomePlaceholderProps> = ({
               Connect an AI provider to get started
             </Text>
             <Text className="welcome-subtitle" sx={{ maxWidth: 520 }}>
-              Add an API key for OpenAI, Anthropic, or Gemini to start chatting.
-              Your keys are encrypted and stored securely.
+              {SETUP_SUBTITLE}
             </Text>
             <FlexRow gap={1} justify="center" wrap sx={{ mt: 0.5 }}>
               {SETUP_PROVIDERS.map((provider) => (

--- a/web/src/components/provider_onboarding/FirstRunProviderSignIn.tsx
+++ b/web/src/components/provider_onboarding/FirstRunProviderSignIn.tsx
@@ -1,0 +1,14 @@
+import { memo } from "react";
+
+import { useFirstRunProviderSignIn } from "../../hooks/useFirstRunProviderSignIn";
+
+/**
+ * Mount point for the first-run sign-in offer. Renders nothing — it exists so
+ * the hook runs for the whole session next to the dialog it opens.
+ */
+const FirstRunProviderSignIn: React.FC = () => {
+  useFirstRunProviderSignIn();
+  return null;
+};
+
+export default memo(FirstRunProviderSignIn);

--- a/web/src/components/provider_onboarding/ProviderOnboardingDialog.tsx
+++ b/web/src/components/provider_onboarding/ProviderOnboardingDialog.tsx
@@ -95,6 +95,12 @@ const ProviderOnboardingDialog: React.FC = () => {
     () => providers.filter((p) => p.oauth),
     [providers]
   );
+  // Name the sign-ins actually on offer rather than a fixed list: a hosted
+  // deployment drops the ones that can only finish on the server's machine.
+  const oauthNames = useMemo(
+    () => oauthProviders.map((p) => p.name).join(", "),
+    [oauthProviders]
+  );
   const keyProviders = useMemo(
     () => providers.filter((p) => !p.oauth),
     [providers]
@@ -141,8 +147,8 @@ const ProviderOnboardingDialog: React.FC = () => {
           <FlexColumn gap={SPACING.sm}>
             <SectionHeading
               icon={<BoltRoundedIcon sx={{ fontSize: 18 }} />}
-              title="Fastest way to start"
-              subtitle="Sign in with one click — no key to copy."
+              title="Sign in — fastest way to start"
+              subtitle={`One click with ${oauthNames}. No API key to create.`}
             />
             {oauthProviders.map((provider) => (
               <ProviderOnboardingCard

--- a/web/src/components/provider_onboarding/__tests__/ProviderOnboardingDialog.test.tsx
+++ b/web/src/components/provider_onboarding/__tests__/ProviderOnboardingDialog.test.tsx
@@ -90,6 +90,16 @@ describe("ProviderOnboardingDialog", () => {
     expect(screen.getByText("Connect an AI provider")).toBeInTheDocument();
   });
 
+  it("leads with a Claude and OpenAI sign-in", () => {
+    renderDialog();
+    const heading = screen.getByText(/sign in — fastest way to start/i);
+    expect(heading).toBeInTheDocument();
+    expect(screen.getByText(/one click with .*openai.*claude/i)).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("button", { name: /^sign in$/i }).length
+    ).toBeGreaterThanOrEqual(2);
+  });
+
   it("opens the settings tab via the router singleton, not useNavigate", async () => {
     useWorkspaceTabsStore.setState({ tabs: [], activeTabId: null });
     renderDialog();

--- a/web/src/hooks/__tests__/useFirstRunProviderSignIn.test.tsx
+++ b/web/src/hooks/__tests__/useFirstRunProviderSignIn.test.tsx
@@ -1,0 +1,125 @@
+import { renderHook } from "@testing-library/react";
+
+import {
+  useFirstRunProviderSignIn,
+  shouldOfferFirstRunSignIn,
+  FIRST_RUN_SIGN_IN_REASON
+} from "../useFirstRunProviderSignIn";
+import { useLanguageModelProviders } from "../useProviders";
+import { openProviderOnboarding } from "../../stores/ProviderOnboardingStore";
+import useOnboardingStore from "../../stores/OnboardingStore";
+import type { ProviderInfo } from "../../stores/ApiTypes";
+
+jest.mock("../useProviders");
+jest.mock("../../stores/ProviderOnboardingStore", () => ({
+  openProviderOnboarding: jest.fn()
+}));
+jest.mock("../../lib/env", () => ({ isElectron: false, isLocalhost: true }));
+
+const mockUseLanguageModelProviders = jest.mocked(useLanguageModelProviders);
+const mockOpen = jest.mocked(openProviderOnboarding);
+
+const providersResult = (
+  overrides: Partial<ReturnType<typeof useLanguageModelProviders>> = {}
+): ReturnType<typeof useLanguageModelProviders> => ({
+  providers: [],
+  isLoading: false,
+  isFetching: false,
+  error: null,
+  ...overrides
+});
+
+const languageProvider: ProviderInfo = {
+  provider: "openai",
+  capabilities: ["generate_message"],
+  access: "remote_api",
+  display_name: "OpenAI"
+} as ProviderInfo;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useOnboardingStore.setState({ providerSignInOffered: false });
+  mockUseLanguageModelProviders.mockReturnValue(providersResult());
+});
+
+describe("useFirstRunProviderSignIn", () => {
+  it("offers the sign-in once when nothing is configured", () => {
+    const { rerender } = renderHook(() => useFirstRunProviderSignIn());
+    expect(mockOpen).toHaveBeenCalledWith({
+      capability: "generate_message",
+      reason: FIRST_RUN_SIGN_IN_REASON
+    });
+    expect(useOnboardingStore.getState().providerSignInOffered).toBe(true);
+
+    rerender();
+    expect(mockOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("names Claude and OpenAI in the offer", () => {
+    expect(FIRST_RUN_SIGN_IN_REASON).toMatch(/Claude/);
+    expect(FIRST_RUN_SIGN_IN_REASON).toMatch(/OpenAI/);
+  });
+
+  it("stays quiet while the providers query is still loading", () => {
+    mockUseLanguageModelProviders.mockReturnValue(
+      providersResult({ isLoading: true })
+    );
+    renderHook(() => useFirstRunProviderSignIn());
+    expect(mockOpen).not.toHaveBeenCalled();
+    expect(useOnboardingStore.getState().providerSignInOffered).toBe(false);
+  });
+
+  it("stays quiet when the providers query failed", () => {
+    mockUseLanguageModelProviders.mockReturnValue(
+      providersResult({ error: new Error("offline") })
+    );
+    renderHook(() => useFirstRunProviderSignIn());
+    expect(mockOpen).not.toHaveBeenCalled();
+  });
+
+  it("stays quiet when a language model provider is already configured", () => {
+    mockUseLanguageModelProviders.mockReturnValue(
+      providersResult({ providers: [languageProvider] })
+    );
+    renderHook(() => useFirstRunProviderSignIn());
+    expect(mockOpen).not.toHaveBeenCalled();
+  });
+
+  it("does not ask again after the offer was already made", () => {
+    useOnboardingStore.setState({ providerSignInOffered: true });
+    renderHook(() => useFirstRunProviderSignIn());
+    expect(mockOpen).not.toHaveBeenCalled();
+  });
+
+});
+
+describe("shouldOfferFirstRunSignIn", () => {
+  const firstRun = {
+    isLocalApp: true,
+    offered: false,
+    isLoading: false,
+    hasError: false,
+    providerCount: 0
+  };
+
+  it("offers on a first local launch with nothing configured", () => {
+    expect(shouldOfferFirstRunSignIn(firstRun)).toBe(true);
+  });
+
+  it("stays quiet on a hosted deployment, where the sign-ins can't finish", () => {
+    expect(
+      shouldOfferFirstRunSignIn({ ...firstRun, isLocalApp: false })
+    ).toBe(false);
+  });
+
+  it.each([
+    ["already offered", { offered: true }],
+    ["still loading", { isLoading: true }],
+    ["query failed", { hasError: true }],
+    ["a provider is configured", { providerCount: 1 }]
+  ])("stays quiet when %s", (_label, overrides) => {
+    expect(shouldOfferFirstRunSignIn({ ...firstRun, ...overrides })).toBe(
+      false
+    );
+  });
+});

--- a/web/src/hooks/useFirstRunProviderSignIn.ts
+++ b/web/src/hooks/useFirstRunProviderSignIn.ts
@@ -1,0 +1,80 @@
+/**
+ * Offer a sign-in the first time the local app opens with no language model
+ * behind it.
+ *
+ * Nothing in NodeTool runs without a provider, and the fastest way to get one
+ * on a desktop install is a Claude or OpenAI login — both sign in against an
+ * existing subscription and write their credentials to this machine, so there
+ * is no key to create and paste. The provider onboarding dialog already leads
+ * with those two, so this opens that dialog once rather than building a second
+ * surface.
+ *
+ * It fires only on a local install (the sign-ins finish on the server's own
+ * loopback listener), only once the providers query has settled with nothing
+ * configured, and only once per install — a user who closed it gets the
+ * checklist and the in-context prompts, not the dialog again on every launch.
+ */
+
+import { useEffect } from "react";
+
+import { isElectron, isLocalhost } from "../lib/env";
+import useOnboardingStore from "../stores/OnboardingStore";
+import { openProviderOnboarding } from "../stores/ProviderOnboardingStore";
+import { useLanguageModelProviders } from "./useProviders";
+
+/** Copy for the dialog subtitle, naming the two logins the offer is about. */
+export const FIRST_RUN_SIGN_IN_REASON =
+  "Sign in with Claude or OpenAI to use a subscription you already pay for — or connect any other provider with an API key.";
+
+interface FirstRunSignInInput {
+  /** Browser and server share a machine, so a loopback sign-in can finish. */
+  isLocalApp: boolean;
+  /** The offer was already made once on this install. */
+  offered: boolean;
+  /** The providers query has not settled yet. */
+  isLoading: boolean;
+  /** The providers query failed — an empty list here means nothing. */
+  hasError: boolean;
+  /** Language-model providers the server reports as configured. */
+  providerCount: number;
+}
+
+/** Whether this launch is the one that should offer a sign-in. */
+export const shouldOfferFirstRunSignIn = ({
+  isLocalApp,
+  offered,
+  isLoading,
+  hasError,
+  providerCount
+}: FirstRunSignInInput): boolean =>
+  isLocalApp && !offered && !isLoading && !hasError && providerCount === 0;
+
+export const useFirstRunProviderSignIn = (): void => {
+  const { providers, isLoading, error } = useLanguageModelProviders();
+  const offered = useOnboardingStore((state) => state.providerSignInOffered);
+  const markOffered = useOnboardingStore(
+    (state) => state.markProviderSignInOffered
+  );
+
+  useEffect(() => {
+    const offer = shouldOfferFirstRunSignIn({
+      isLocalApp: isElectron || isLocalhost,
+      offered,
+      isLoading,
+      // A pending or failed query is not an empty one: prompting on either
+      // would interrupt a user who already has a provider.
+      hasError: error !== null,
+      providerCount: providers.length
+    });
+    if (!offer) {
+      return;
+    }
+    markOffered();
+    openProviderOnboarding({
+      capability: "generate_message",
+      reason: FIRST_RUN_SIGN_IN_REASON
+    });
+  }, [offered, isLoading, error, providers, markOffered]);
+};
+
+export default useFirstRunProviderSignIn;

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -70,6 +70,7 @@ const SearchProviderSetupDialog = React.lazy(
 const ProviderOnboardingDialog = React.lazy(
   () => import("./components/provider_onboarding/ProviderOnboardingDialog")
 );
+import FirstRunProviderSignIn from "./components/provider_onboarding/FirstRunProviderSignIn";
 import BugReportDialogHost from "./components/support/BugReportDialogHost";
 import ReportBugButton from "./components/support/ReportBugButton";
 import { installConsoleCapture } from "./utils/consoleCapture";
@@ -771,6 +772,7 @@ const AppWrapper = ({ configReady }: { configReady: Promise<unknown> }) => {
                       <RunWarningDialog />
                       <SearchProviderSetupDialog />
                       <ProviderOnboardingDialog />
+                      <FirstRunProviderSignIn />
                     </>
                   )}
                   {/* Outside the router gate: a boot failure is exactly when

--- a/web/src/stores/OnboardingStore.ts
+++ b/web/src/stores/OnboardingStore.ts
@@ -5,7 +5,8 @@
  * workflow, build your own) for the checklist on the new-project surface.
  * Persists to localStorage so progress survives reloads. The "connect a
  * provider" step is derived live from configured secrets and is not stored
- * here.
+ * here — only the fact that the first-run sign-in offer was already made, so
+ * a user who declined it is not asked again on every launch.
  */
 
 import { create } from "zustand";
@@ -38,8 +39,11 @@ export const isOnboardingFinished = ({
 interface OnboardingStore {
   completedSteps: OnboardingStepId[];
   dismissed: boolean;
+  /** The first-run provider sign-in offer has been shown once already. */
+  providerSignInOffered: boolean;
   markStep: (step: OnboardingStepId) => void;
   dismiss: () => void;
+  markProviderSignInOffered: () => void;
 }
 
 export const useOnboardingStore = create<OnboardingStore>()(
@@ -47,6 +51,7 @@ export const useOnboardingStore = create<OnboardingStore>()(
     (set) => ({
       completedSteps: [],
       dismissed: false,
+      providerSignInOffered: false,
 
       markStep: (step: OnboardingStepId) => {
         set((state) =>
@@ -58,6 +63,10 @@ export const useOnboardingStore = create<OnboardingStore>()(
 
       dismiss: () => {
         set({ dismissed: true });
+      },
+
+      markProviderSignInOffered: () => {
+        set({ providerSignInOffered: true });
       }
     }),
     {

--- a/web/src/stores/__tests__/OnboardingStore.test.ts
+++ b/web/src/stores/__tests__/OnboardingStore.test.ts
@@ -5,7 +5,11 @@ import useOnboardingStore, {
 
 describe("OnboardingStore", () => {
   beforeEach(() => {
-    useOnboardingStore.setState({ completedSteps: [], dismissed: false });
+    useOnboardingStore.setState({
+      completedSteps: [],
+      dismissed: false,
+      providerSignInOffered: false
+    });
   });
 
   it("marks a step as completed once", () => {
@@ -30,6 +34,12 @@ describe("OnboardingStore", () => {
   it("dismisses the checklist", () => {
     useOnboardingStore.getState().dismiss();
     expect(useOnboardingStore.getState().dismissed).toBe(true);
+  });
+
+  it("records that the first-run provider sign-in was offered", () => {
+    expect(useOnboardingStore.getState().providerSignInOffered).toBe(false);
+    useOnboardingStore.getState().markProviderSignInOffered();
+    expect(useOnboardingStore.getState().providerSignInOffered).toBe(true);
   });
 
   describe("isOnboardingFinished", () => {


### PR DESCRIPTION
## What changed

A desktop install with no provider configured only reached the provider onboarding dialog by getting blocked mid-task or by clicking the getting-started checklist. Claude and OpenAI both sign in against a subscription the user already pays for and finish on the server's own loopback listener, so on a local install they are the shortest path to a working model — and neither was offered up front. This opens the provider onboarding dialog once, on a local install (Electron or localhost), after the language-model providers query settles with nothing configured; `OnboardingStore` records that the offer was made so a user who closes it is not asked again on every launch. The dialog's first section now names the sign-ins actually on offer ("One click with OpenAI, Claude, Hugging Face" — a hosted deployment drops the ones it cannot finish) instead of describing them generically, and the chat welcome placeholder points local users at the sign-in before an API key.

The decision itself is a pure `shouldOfferFirstRunSignIn` predicate, so every branch — hosted deployment, query still loading, query failed, provider already configured, already offered — is testable without a render.

The Playwright suites are unaffected: `packages/websocket/src/screenshot-server.ts` seeds `OPENAI_API_KEY` and friends, so `models.providers` comes back non-empty and no dialog opens over the page.

## Verification

- [x] `npm run test:affected` — 201 suites, 1727 passed, 3 skipped
- [x] `npm run typecheck` — exit 0
- [x] `npm run lint` — exit 0
- [ ] `npm run dev:nodetool -- harness gate --base main` — could not run in this container: `node_modules/@nodetool-ai/browser` is missing from the workspace install, so `build:packages` fails on `@nodetool-ai/automation-nodes` (`error TS2307: Cannot find module '@nodetool-ai/browser'`) and the CLI cannot load. Unrelated to this diff, which touches only `web/src`; the Quality Gate `build` leg passes on a clean `npm ci`.

The new tests were inverted once to prove they can fail. Dropping `isLocalApp` and `!hasError` from the predicate:

```
✕ stays quiet when the providers query failed
✕ stays quiet on a hosted deployment, where the sign-ins can't finish
✕ stays quiet when query failed
Tests: 3 failed, 9 passed, 12 total
```

Restored, all 12 pass.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added — the new tests cover the new code only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161mrJEYNV8igN5Pr71tcLo