### PR TITLE
feat(system-skills): prompting guides for six more model lines

### DIFF
--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -2437,10 +2437,13 @@ sandbox packs, and for the same reason: nothing imports them, so they are not
 workspaces and npm links nothing. `bundle-backend.mjs` stages them and
 `verify-backend-bundle.mjs` fails a build that ships none.
 
-Seven shipped skills carry a generation model line's prompting rules
-(`nano-banana-pro-prompting`, `gpt-image-2-prompting`,
-`flux-2-klein-prompting`, `seedance-2-prompting`, `veo-3-prompting`,
-`minimax-h3-prompting`, `wan-2-6-prompting`). `MODEL_PROMPTING_SKILLS` in
+The `*-prompting` skills carry a generation model line's prompting rules —
+image (`nano-banana-pro-prompting`, `gpt-image-2-prompting`,
+`flux-2-klein-prompting`, `seedream-prompting`, `qwen-image-prompting`), video
+(`seedance-2-prompting`, `veo-3-prompting`, `minimax-h3-prompting`,
+`wan-2-6-prompting`, `kling-video-prompting`, `hailuo-prompting`) and audio
+(`elevenlabs-audio-prompting`, `stable-audio-prompting`).
+`MODEL_PROMPTING_SKILLS` in
 `model-prompting-skills.ts` maps a model id onto one, and `find_model` attaches
 the answer as `prompting_skill` on every matching route — the catalog line is
 the other path in, for an agent that never called `find_model`.

--- a/packages/agents/src/model-prompting-skills.ts
+++ b/packages/agents/src/model-prompting-skills.ts
@@ -76,6 +76,46 @@ export const MODEL_PROMPTING_SKILLS: readonly ModelPromptingSkill[] = [
     skill: "wan-2-6-prompting",
     line: "Wan 2.6",
     pattern: /wan-?2[.-]6/
+  },
+  {
+    // Kling from 2.5-turbo on: the versions with a shot list, tagged elements
+    // and native audio. The alternation is what keeps 1.x, 2.0 and 2.1 out,
+    // and requiring a version right after the family name is what keeps
+    // `kling-image` — a different model with different rules — out too.
+    skill: "kling-video-prompting",
+    line: "Kling video 2.5-turbo and later",
+    pattern: /kling(?:-video)?[-/]v?(?:2[.-][56]|3(?:\.0)?|o[13])(?![.\d])/
+  },
+  {
+    // MiniMax's earlier video line. H3 is a separate guide, and no Hailuo id
+    // carries `minimax/h3`, so the two never contend for the same model.
+    skill: "hailuo-prompting",
+    line: "MiniMax Hailuo",
+    pattern: /hailuo|minimax\/video-01/
+  },
+  {
+    skill: "seedream-prompting",
+    line: "Seedream 4 and 5",
+    pattern: /seedream[/-]v?[45](?![\d])/
+  },
+  {
+    // The whole Qwen-Image family — text-to-image, the edit checkpoints and
+    // the layered variants share one set of house rules for typography.
+    skill: "qwen-image-prompting",
+    line: "Qwen-Image",
+    pattern: /qwen-image/
+  },
+  {
+    // Only the endpoints that take a prompt. Scribe, dubbing, isolation and
+    // voice-changer are ElevenLabs too and have nothing to prompt.
+    skill: "elevenlabs-audio-prompting",
+    line: "ElevenLabs speech, dialogue, sound effects and music",
+    pattern: /elevenlabs\/(?:tts|music|sound-effects|text-to-speech|text-to-dialogue|v3|v2-multilingual|turbo|flash)/
+  },
+  {
+    skill: "stable-audio-prompting",
+    line: "Stable Audio",
+    pattern: /stable-audio/
   }
 ];
 

--- a/packages/agents/tests/model-prompting-skills.test.ts
+++ b/packages/agents/tests/model-prompting-skills.test.ts
@@ -59,7 +59,12 @@ function manifestModelIds(): string[] {
       : Object.values(parsed as Record<string, unknown>).flat();
     for (const row of rows) {
       if (typeof row !== "object" || row === null) continue;
-      const id = (row as Record<string, unknown>)["endpointId"];
+      // FAL and Replicate name the route `endpointId`; kie and AtlasCloud name
+      // it `modelId`. Reading only the first spelling left two providers'
+      // catalogs out of every check below, so a pattern could match nothing
+      // they serve and still pass.
+      const record = row as Record<string, unknown>;
+      const id = record["endpointId"] ?? record["modelId"];
       if (typeof id === "string") ids.add(id.toLowerCase());
     }
   }
@@ -143,7 +148,31 @@ describe("the model-line prompting table", () => {
     ["minimax/h3/text-to-video", "minimax-h3-prompting"],
     ["minimax/h3-max-turbo/image-to-video", "minimax-h3-prompting"],
     ["alibaba/wan-2.6/text-to-video", "wan-2-6-prompting"],
-    ["wan-video/wan2.6-i2v-flash", "wan-2-6-prompting"]
+    ["wan-video/wan2.6-i2v-flash", "wan-2-6-prompting"],
+    ["fal-ai/kling-video/v3/pro/text-to-video", "kling-video-prompting"],
+    ["fal-ai/kling-video/o3/pro/reference-to-video", "kling-video-prompting"],
+    ["fal-ai/kling-video/v2.5-turbo/pro/text-to-video", "kling-video-prompting"],
+    ["kling-3.0-omni/text-to-video", "kling-video-prompting"],
+    ["kling/v2-5-turbo-text-to-video-pro", "kling-video-prompting"],
+    ["kwaivgi/kling-video-o3-pro/text-to-video", "kling-video-prompting"],
+    ["kwaivgi/kling-o1", "kling-video-prompting"],
+    ["fal-ai/minimax/hailuo-2.3/pro/text-to-video", "hailuo-prompting"],
+    ["minimax/hailuo-2.3/t2v-pro", "hailuo-prompting"],
+    ["fal-ai/minimax/hailuo-02-fast/image-to-video", "hailuo-prompting"],
+    ["fal-ai/minimax/video-01-director", "hailuo-prompting"],
+    ["bytedance/seedream/v5/pro/text-to-image", "seedream-prompting"],
+    ["fal-ai/bytedance/seedream/v4.5/edit", "seedream-prompting"],
+    ["seedream/5-pro-image-to-image", "seedream-prompting"],
+    ["bytedance/seedream-v4.5", "seedream-prompting"],
+    ["alibaba/qwen-image-3/text-to-image", "qwen-image-prompting"],
+    ["qwen-image-3.0-pro/edit", "qwen-image-prompting"],
+    ["qwen/qwen-image-edit-plus", "qwen-image-prompting"],
+    ["fal-ai/elevenlabs/tts/eleven-v3", "elevenlabs-audio-prompting"],
+    ["fal-ai/elevenlabs/sound-effects/v2", "elevenlabs-audio-prompting"],
+    ["elevenlabs/text-to-dialogue-v3", "elevenlabs-audio-prompting"],
+    ["elevenlabs/music", "elevenlabs-audio-prompting"],
+    ["fal-ai/stable-audio-25/text-to-audio", "stable-audio-prompting"],
+    ["stability-ai/stable-audio-2.5", "stable-audio-prompting"]
   ])("routes %s to %s", (id, skill) => {
     expect(promptingSkillFor(id)).toBe(skill);
   });
@@ -157,10 +186,23 @@ describe("the model-line prompting table", () => {
     "black-forest-labs/flux-2-dev",
     "bytedance/seedance-1.5-pro",
     "fal-ai/bytedance/seedance/v1/pro/text-to-video",
-    "fal-ai/minimax/hailuo-2.3/pro/text-to-video",
-    "minimax/hailuo-2.3/t2v-pro",
     "wan-video/wan-2.5-t2v",
-    "alibaba/wan-2.7/text-to-video"
+    "alibaba/wan-2.7/text-to-video",
+    // Kling before the shot list, and Kling Image, which is not the video line
+    // at all.
+    "fal-ai/kling-video/v1/standard/text-to-video",
+    "fal-ai/kling-video/v2.1/pro/image-to-video",
+    "kwaivgi/kling-v1.6-pro",
+    "fal-ai/kling-image/v3/text-to-image",
+    "fal-ai/kling-image/o3/image-to-image",
+    "fal-ai/kling-video/lipsync/text-to-video",
+    "bytedance/seedream-3",
+    "fal-ai/bytedance/seedream/v3/text-to-image",
+    // ElevenLabs endpoints that take no prompt.
+    "fal-ai/elevenlabs/speech-to-text/scribe-v2",
+    "fal-ai/elevenlabs/audio-isolation",
+    "fal-ai/elevenlabs/dubbing",
+    "elevenlabs/scribe-v2"
   ])("claims nothing for %s", (id) => {
     expect(promptingSkillFor(id)).toBeNull();
   });
@@ -196,6 +238,13 @@ describe("the shipped prompting skills", () => {
    * the skill keeps teaching the old spelling. Same protection the motion
    * skills get from motion-graphics-skill-names.test.ts.
    */
+  /**
+   * Provider request fields a guide has to name that collide with a capability
+   * prefix. `generate_audio` is Kling's own boolean, not a capability, and the
+   * skill would be wrong to spell it any other way.
+   */
+  const PROVIDER_PARAMETER_NAMES = new Set(["generate_audio"]);
+
   it("names only capabilities that exist", () => {
     const known = new Set(listCapabilitySpecs().map((spec) => spec.name));
     const prefixes = [
@@ -215,7 +264,10 @@ describe("the shipped prompting skills", () => {
     for (const name of names) {
       for (const match of skillBody(name).matchAll(/\b([a-z][a-z0-9_]*)\b/g)) {
         const token = match[1] as string;
-        if (prefixes.some((prefix) => token.startsWith(prefix))) {
+        if (
+          prefixes.some((prefix) => token.startsWith(prefix)) &&
+          !PROVIDER_PARAMETER_NAMES.has(token)
+        ) {
           named.add(token);
         }
       }

--- a/packages/system-skills/README.md
+++ b/packages/system-skills/README.md
@@ -35,8 +35,14 @@ directory ships with no other change.
 | `veo-3-prompting` | Veo 3: the five-element structure, cinematography vocabulary, duration and audio economics |
 | `minimax-h3-prompting` | MiniMax H3: which endpoint, a job per reference, timed shot lists, native audio direction |
 | `wan-2-6-prompting` | Wan 2.6: the three modes and the prompt shape each one wants |
+| `kling-video-prompting` | Kling 2.5-turbo and later: the shot list, tagged elements, the labelled dialogue format |
+| `hailuo-prompting` | MiniMax Hailuo: beats in order, the Director bracket commands, no negative prompt |
+| `seedream-prompting` | Seedream 4 and 5: the six-layer brief, quoted copy, pinning what an edit must not change |
+| `qwen-image-prompting` | Qwen-Image: typography — exact copy, relative layout, twelve scripts, expansion off |
+| `elevenlabs-audio-prompting` | ElevenLabs: audio tags and stability, the dialogue list, sound-effect briefs, composition plans |
+| `stable-audio-prompting` | Stable Audio: genre/instruments/mood/BPM, the TrackType tags, which dials the distilled checkpoints ignore |
 
-The seven `*-prompting` skills are the model-line guides. Each one is triggered
+The `*-prompting` skills are the model-line guides. Each one is triggered
 twice: its description names the model ids across every provider that serves the
 line, and `find_model` attaches `prompting_skill` to a matching route so the
 guide surfaces at the step before the prompt is written. The table behind the

--- a/packages/system-skills/elevenlabs-audio-prompting/SKILL.md
+++ b/packages/system-skills/elevenlabs-audio-prompting/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: elevenlabs-audio-prompting
+description: Direct ElevenLabs speech, dialogue, sound effects and music — the bracketed audio tags v3 acts on and why the voice decides whether a tag lands, stability as the delivery dial, punctuation instead of SSML for pacing, the per-line dialogue format for several speakers, source-action-space sound-effect briefs with prompt_influence and looping, and the music composition plan that pins a song's sections. Use whenever the model id names an ElevenLabs generation endpoint (fal-ai/elevenlabs/tts/eleven-v3, fal-ai/elevenlabs/tts/multilingual-v2, fal-ai/elevenlabs/text-to-dialogue/eleven-v3, fal-ai/elevenlabs/sound-effects/v2, fal-ai/elevenlabs/music, elevenlabs/text-to-speech-multilingual-v2, elevenlabs/text-to-dialogue-v3, elevenlabs/v2-multilingual, elevenlabs/turbo-v2.5) on generate_speech, generate_music or a TextToSpeech node. Not for the transcription, dubbing or isolation endpoints, which take no prompt.
+---
+
+# ElevenLabs → direct the read, don't just submit the text
+
+The text is the smallest part of an ElevenLabs request. What decides whether it
+sounds directed is the voice you picked, the stability you set, and the tags
+and punctuation carrying the performance.
+
+Reach speech with `find_model` for `text_to_speech`, then `generate_speech`;
+music with `find_model` for `text_to_music`, then `generate_music`. The
+sound-effects endpoint is not in either catalog — run its node with
+`search_nodes` and `invoke_node`.
+
+## Voice first, then tags
+
+A tag only does what the voice can already do. `[shouts]` on a voice trained on
+soft narration produces a slightly louder narration. Pick a voice whose range
+covers the delivery you want, then direct within it.
+
+- **Emotionally varied** voices take direction across a scene.
+- **Narrow, consistent** voices are right when every line is the same register.
+- **Neutral** voices are the most stable across languages and styles.
+
+## Stability is the delivery dial
+
+The single most consequential setting. ElevenLabs exposes it as three named
+settings; the numeric APIs take the same three values, and the dialogue
+endpoint rounds anything else to the nearest of them.
+
+| Value | Behaviour | Use for |
+| :--- | :--- | :--- |
+| 0.0 — creative | Most expressive, most responsive to tags, occasional hallucination | Character work, dialogue, anything with `[whispers]` or `[laughs]` |
+| 0.5 — natural | Balanced, closest to the reference recording | Narration, most production reads |
+| 1.0 — robust | Very consistent, largely ignores directional tags | Long documents, repeated renders that must match |
+
+At 1.0 your tags stop working. If a tag is being ignored, check stability
+before rewriting the tag.
+
+## Audio tags
+
+Bracketed, inline, and they act from that point in the line. They are a v3
+feature: on multilingual-v2, turbo and flash there is nothing to act on them,
+and punctuation plus sentence structure are the only direction you have.
+
+- **Delivery**: `[whispers]`, `[shouts]`, `[sarcastic]`, `[curious]`,
+  `[excited]`, `[mischievously]`
+- **Reactions**: `[laughs]`, `[sighs]`, `[crying]`, `[clears throat]`,
+  `[snorts]`
+- **Environment**: `[applause]`, `[clapping]`, `[gunshot]`, `[explosion]`
+- **Experimental**: `[sings]`, `[strong French accent]`
+
+Punctuation carries the rest, and v3 does not support SSML break tags. Ellipses
+are pauses and hesitation, capitals are emphasis, ordinary commas and full
+stops set the rhythm:
+
+> [sighs] It was a VERY long day … nobody listens any more. [quietly] Maybe
+> that's the point.
+
+Give the model a few sentences rather than a fragment. Short isolated lines
+deliver inconsistently because there is no context to read the register from.
+`language_code` forces a language when the text alone is ambiguous.
+
+## Several speakers
+
+The dialogue endpoint takes a list of `inputs`, each with its own text and
+voice, rather than one block of text with names in it. Tag each line for its
+own delivery, and write interruptions as they happen:
+
+```
+[Ana, voice A]  "You said you'd call." [flat]
+[Ruben, voice B] [defensive] "I did — twice —"
+[Ana, voice A]  [cutting in] "Once. And you hung up."
+```
+
+Distinct voices per speaker is what makes it a conversation; the same voice
+twice reads as one person talking to themselves.
+
+## Sound effects
+
+Brief them as source, action and space: what makes the sound, what happens to
+it, and the room it happens in.
+
+> A heavy oak door swinging shut and latching in a stone corridor, long natural
+> reverb tail, close mic on the latch.
+
+- `duration_seconds` runs 0.5–22; leave it unset and the model infers a length
+  from the prompt. Impacts want 1–3 s, beds want 10–20 s.
+- `prompt_influence` defaults to 0.3. Raise it toward 1 to follow the brief
+  closely and lose variation; lower it when you want takes to choose from.
+- `loop` makes the tail blend into the head — the setting for ambience and game
+  audio, and pointless for a one-shot.
+
+## Music
+
+A prompt gets you a track: genre, instrumentation with character, tempo in bpm,
+emotional arc, and what it is for.
+
+> Fast-paced electronic chase cue for a game trailer, driving synth arpeggios,
+> punchy drums, distorted bass, rising tension with abrupt transitions,
+> 130–150 bpm.
+
+When the structure matters more than the vibe, send a `composition_plan`
+instead: an ordered list of sections, each with its own `durationMs`,
+`positiveStyles` and `negativeStyles`. That is what makes an intro stay sparse
+and a drop actually land where you wanted it. `respect_sections_durations`
+enforces those lengths; `music_length_ms` applies only to the prompt path.
+`force_instrumental` guarantees no vocal — without it, a prompt that does not
+mention vocals may still come back sung.
+
+Naming an artist, a band or copyrighted lyrics is rejected outright; the error
+carries a rephrasing suggestion. Describe the sound instead of the reference.
+
+## Symptoms
+
+| What went wrong | What to change |
+| :--- | :--- |
+| Tags do nothing | Lower stability to 0.5 or 0.0, and check the voice can do that delivery |
+| The read is flat | Add punctuation and a delivery tag; stop relying on the words alone |
+| Pauses are ignored | Use ellipses and line structure — SSML breaks are not supported |
+| Two speakers sound the same | Assign a different voice per `inputs` entry |
+| The effect is too variable | Raise `prompt_influence`, and set an explicit duration |
+| A loop clicks | Set `loop` true and regenerate rather than trimming |
+| A song ignores its structure | Move from a prompt to a `composition_plan` |
+| The prompt was refused | Remove artist and band names; describe the sound |
+
+Check the result with `analyze_audio` and `detect_audio_events` rather than
+listening through it, and `transcribe_audio` when you need to prove the words
+landed as written.
+
+Adapted from the ElevenLabs prompting documentation for Eleven v3, sound
+effects and music:
+https://elevenlabs.io/docs/best-practices/prompting/eleven-v3
+https://elevenlabs.io/docs/overview/capabilities/sound-effects
+https://elevenlabs.io/docs/eleven-api/guides/cookbooks/music.md

--- a/packages/system-skills/hailuo-prompting/SKILL.md
+++ b/packages/system-skills/hailuo-prompting/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: hailuo-prompting
+description: Prompt MiniMax's Hailuo video line — the chronological beat order it animates from, the fifteen bracketed camera commands the Director endpoints accept and the three-per-bracket rule, when to switch prompt_optimizer off, why there is no negative prompt to fall back on, and prompting the delta on image-to-video. Use whenever the model id names Hailuo or MiniMax video-01 (fal-ai/minimax/hailuo-2.3/pro/text-to-video, fal-ai/minimax/hailuo-02/pro/image-to-video, fal-ai/minimax/hailuo-02-fast/image-to-video, fal-ai/minimax/video-01-director, fal-ai/minimax/video-01-subject-reference, hailuo/2-3-image-to-video-pro, minimax/hailuo-2.3, minimax/hailuo-02-fast) on generate_video, animate_image or a TextToVideo node. Not for MiniMax H3, which has its own guide.
+---
+
+# Hailuo → a sequence of beats, in order
+
+Hailuo animates the order it reads. It has no negative prompt, no shot list and
+no CFG dial, so every control you get is in the wording: what happens, in what
+order, and how the camera behaves while it happens. Clips run 6 or 10 seconds
+(10 s is unavailable at 1080p on Hailuo 02).
+
+Reach it with `find_model` for `text_to_video` or `image_to_video`, then
+`generate_video` / `animate_image`.
+
+## Write the action as beats
+
+Break one motion into the beats it is made of and connect them with sequencing
+words — first, then, as, finally. The model animates that order.
+
+> A skateboarder rolls toward a handrail in an empty underground car park.
+> First he crouches low over the deck, then he pops the tail and the board
+> snaps up under him, and as he lands on the rail the trucks grind along the
+> steel, sparks trailing behind. Finally he drops off the end and rolls out of
+> frame past a pillar.
+
+Compare "a skateboarder does a trick on a rail", which gives the model the
+whole choreography to invent and no reason to resolve it the way you meant.
+
+Emotional beats work the same way. "She reads the letter with growing concern,
+tears well up, then she crumples the paper and throws it" is three animatable
+states; "she is sad about the letter" is one adjective.
+
+## Camera
+
+On the Director endpoints (`video-01-director` and its image-to-video form),
+camera moves are commands in square brackets. Fifteen are supported:
+
+`[Truck left]` `[Truck right]` `[Pan left]` `[Pan right]` `[Push in]`
+`[Pull out]` `[Pedestal up]` `[Pedestal down]` `[Tilt up]` `[Tilt down]`
+`[Zoom in]` `[Zoom out]` `[Shake]` `[Tracking shot]` `[Static shot]`
+
+Two placement rules carry all of it. Commands inside one bracket happen at the
+same time, capped at three: `[Truck left, Pan right, Zoom in]`. Commands at
+different points in the prompt happen in that order:
+
+```
+[Static shot] The chef sets the plate down under the pass light. [Push in]
+He wipes the rim with a cloth, then looks up. [Tilt up, Pan right] The dining
+room comes into view behind him.
+```
+
+Every other Hailuo endpoint takes camera direction as prose only — "a slow
+tracking shot follows her", "the camera racks focus from the leaves to her
+face". Brackets there are just text.
+
+## prompt_optimizer
+
+On by default across the whole line, it rewrites your prompt with an LLM before
+generation. Leave it on for a short prompt: it fills in the detail you did not
+write. Switch it off once your prompt is a deliberate brief — it will otherwise
+rewrite away the specific wardrobe, the specific light, and the beat order you
+just spent effort on.
+
+## Image to video
+
+The frame is already decided. Prompt only what changes: motion, camera, light
+over time, environment animation. Naming the subject briefly to anchor the
+reference is fine — "the red-haired woman turns slowly to face camera" — but a
+paragraph re-describing the still is a paragraph not spent on the delta.
+
+Keep the framing consistent with the source. Asking a close-up input for a wide
+establishing move is how you get a hallucinated body.
+
+`video-01-subject-reference` holds a face across the clip from one reference
+image; describe the person's action, not their appearance.
+
+## No negative prompt
+
+There is no field, and "no text, no watermark, not blurry" in the prompt is
+read as content. Say what should be there instead. Empty sky, not "no birds".
+A bare concrete wall, not "no graffiti".
+
+## Symptoms
+
+| What went wrong | What to change |
+| :--- | :--- |
+| The action resolves in the wrong order | Number the beats with first / then / as / finally |
+| The camera drifts | Use a bracketed command on a Director endpoint, or name the move in prose |
+| Your specifics disappeared | Set `prompt_optimizer` false |
+| A body appears where the input image was cropped | Match the prompt's framing to the input |
+| The thing you excluded shows up anyway | Rewrite the exclusion as a positive description |
+
+Grade the render with `analyze_video` and `detect_video_scenes`, and
+`understand_video` when you need a written read of what landed.
+
+Adapted from MiniMax's camera-movement contract as documented on the fal
+Director endpoints, and Akool's Hailuo prompt guide:
+https://fal.ai/models/fal-ai/minimax/video-01-director/api
+https://akool.com/blog-posts/minimax-hailuo-video-prompt-guide

--- a/packages/system-skills/kling-video-prompting/SKILL.md
+++ b/packages/system-skills/kling-video-prompting/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: kling-video-prompting
+description: Prompt Kuaishou's Kling video line from 2.5-turbo onward — which version exposes a shot list, tagged elements, native audio and a CFG dial at all, one shot per entry in multi_prompt rather than one paragraph, characters tagged @Element1/@Element2 so a face survives a cut, the labelled dialogue format native audio lip-syncs to, a negative prompt aimed at the artifacts Kling actually produces, and what motion-control takes instead of a prompt. Use whenever the model id names Kling 2.5-turbo, 2.6, v3, O1 or O3 (fal-ai/kling-video/v3/pro/text-to-video, fal-ai/kling-video/o3/pro/reference-to-video, fal-ai/kling-video/v2.6/pro/image-to-video, kling-3.0-omni/text-to-video, kling-2.6/text-to-video, kwaivgi/kling-v3.0-pro, kwaivgi/kling-video-o3-pro, kwaivgi/kling-o1) on generate_video, animate_image or a TextToVideo node. Not for Kling 1.x, 2.0 or 2.1, and not for Kling Image.
+---
+
+# Kling → write shots, not paragraphs
+
+The newer Kling versions take a shot list rather than a prompt: one call
+carries several shots, generates native audio with lip sync, and holds a tagged
+character across every cut. A single dense paragraph throws all three away and
+comes back as one drifting take.
+
+Which of those you get depends on the version, so check before you write:
+
+| Version | Shot list | Tagged elements | Native audio | cfg_scale / negative prompt |
+| :--- | :--- | :--- | :--- | :--- |
+| 2.5-turbo | — | — | — | yes |
+| 2.6 | — | — | yes, on by default | yes |
+| O1 | — | on the reference and video-to-video routes | — | — |
+| v3 | yes | yes | yes, on by default | yes |
+| O3 | yes | yes | yes, **off** by default | — |
+
+Reach it with `find_model` for `text_to_video` or `image_to_video`, then
+`generate_video` / `animate_image`. Clips run 3–15 seconds, 720p to 4K,
+in 16:9, 9:16 or 1:1. The prompt caps at 3072 characters.
+
+## One shot per prompt
+
+On v3 and O3, `multi_prompt` takes the shots and `prompt` takes a single shot;
+they are mutually exclusive, so send one or the other. With `shot_type` (fal)
+or `customize_multi_shots` (kie) set to customize, your shot boundaries are
+used verbatim; set `intelligent` / `prefer_multi_shots` and the model cuts the
+narrative itself. Pick customize whenever you know the beats. kie's omni
+endpoint takes up to six shots.
+
+On 2.5-turbo, 2.6 and O1 there is no shot list — one call is one shot, and a
+sequence is several calls cut together in the timeline. Writing three labelled
+shots into a single `prompt` there gets you one confused take.
+
+Two to five sentences per shot is the working range. Each one names framing,
+subject action, and camera behaviour:
+
+```
+Shot 1 (4s): Wide. A courier in a wet orange jacket steps off a tram into
+  a night market, steam rising off the food stalls. Camera locked off.
+Shot 2 (3s): Close on her hands unfolding a paper note, the ink running.
+  Slow push-in, shallow focus.
+Shot 3 (5s): Medium tracking shot alongside her as she pushes through the
+  crowd toward a lit doorway, neon reflections sliding over the jacket.
+```
+
+Repeat the subject description in every shot that contains it. A pronoun in
+shot 3 is a new person.
+
+## Elements keep a face across the cut
+
+`elements` takes reference images or a reference video per character or object;
+the prompt addresses them as `@Element1`, `@Element2`. It is on v3, O3, and
+O1's reference- and video-to-video routes. On the reference-to-video endpoints,
+style references come in separately through `images` and are addressed as
+`@Image1`. Elements plus reference images cap at four when a video reference is
+in play; kie's omni endpoint takes up to seven image subjects, or three video
+character subjects.
+
+```
+@Element1 sets the espresso cup down on the counter beside @Element2 without
+looking up. Medium two-shot, warm window light from the left.
+```
+
+Tagging is what gives Kling three or more distinct characters in one clip
+without their faces blending. Describe each element once, then refer to it by
+tag only.
+
+## Dialogue and native audio
+
+`generate_audio` is on by default on 2.6 and v3, and **off** on every O3 route
+— an O3 clip comes back silent unless you ask. It produces dialogue with lip
+sync, plus ambience. Direct it with a labelled line:
+
+```
+[Detective Voss, low and tired]: "You left the light on."
+Immediately, [Marla, brittle, too fast]: "I was coming back."
+```
+
+Four rules the format depends on:
+
+- **Labels are unique and constant.** `Detective Voss` in every line, never
+  "he" and never "the detective".
+- **Bind each line to an action.** Write the action first, then the line. An
+  unanchored line drifts off the picture.
+- **Sequence with a linking word.** "Immediately", "after a beat", "as she
+  turns" — without one, two lines overlap into mush.
+- **Case matters for English speech.** Write it lowercase; reserve capitals for
+  acronyms and proper nouns, which is how the model decides to spell a word out.
+
+Chinese and English are voiced natively. Anything else is translated to English
+before it is spoken, so write the line in the language you want heard.
+
+## Controls
+
+| Parameter | Where it exists | What to do with it |
+| :--- | :--- | :--- |
+| `cfg_scale` | 2.5-turbo, 2.6, v3 | 0.5 default; 0.3 for a freer read, 0.7 only when spatial layout is fixed |
+| `negative_prompt` | 2.5-turbo, 2.6, v3 | Default is "blur, distort, and low quality"; add what you see — sliding feet, extra fingers, warped faces, jittery camera |
+| `duration` | every route | 3–15s; each shot in a multi-shot list gets its own |
+| `generate_audio` | 2.6, v3, O3 | Off costs less per second; leave it off when you are scoring in the timeline anyway |
+
+Negative prompts earn their place here more than on most lines: Kling's
+failures are limb and contact artifacts during fast motion, and naming the one
+you are actually seeing suppresses it. O1 and O3 expose neither dial, so on
+those the prompt is the whole instrument — spend the words the parameters would
+have saved.
+
+## Image to video
+
+The image is the anchor. Prompt only the change — camera move, what the subject
+does next, how the light shifts. Re-describing what is already in the frame
+spends words and invites the model to re-render it slightly differently.
+`start_image` and `end_image` together give you a move with a fixed landing
+frame. Aspect ratio follows the input image; the parameter is ignored.
+
+## Motion control is not a prompt job
+
+The motion-control endpoints copy character motion from a reference video onto
+a reference image, and the prompt only colours the result. What decides the
+output is `character_orientation`: `video` matches the reference clip's
+orientation and handles complex motion up to 30 s; `image` matches the still
+and follows camera movement better, capped at 10 s. The reference image needs
+an unobstructed figure occupying more than 5% of the frame.
+
+## Symptoms
+
+| What went wrong | What to change |
+| :--- | :--- |
+| One drifting take instead of beats | Move the shots into `multi_prompt` with `shot_type: customize`, or move to v3/O3 if your version has no shot list |
+| An O3 clip came back silent | `generate_audio` defaults to false there |
+| A character changes face at the cut | Give them an element and tag every mention |
+| Two lines of dialogue collide | Add a linking word and bind each line to an action |
+| Sliding feet, bent fingers | Name that artifact in `negative_prompt` |
+| Composition ignores a stated layout | Raise `cfg_scale` toward 0.7 |
+| Spoken line comes out in the wrong language | Write the line in Chinese or English — everything else is translated |
+
+Grade the render with `analyze_video` and `detect_video_scenes` rather than
+watching it, and `understand_video` when you need a written read of what
+landed.
+
+Adapted from fal's Kling 3.0 prompting guide and Kling 3.0 Pro usage notes:
+https://blog.fal.ai/kling-3-0-prompting-guide/
+https://fal.ai/learn/tools/how-to-use-kling-3-0-pro

--- a/packages/system-skills/qwen-image-prompting/SKILL.md
+++ b/packages/system-skills/qwen-image-prompting/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: qwen-image-prompting
+description: Prompt Alibaba's Qwen-Image line for the typography work it is built for — quoting exact copy so the model stops inventing it, switching prompt expansion off before it rewrites your strings, describing layout in relative position and weight rather than point sizes, writing non-Latin scripts as characters, and addressing edit references as image 1/2/3. Use whenever the model id names Qwen-Image (alibaba/qwen-image-3/text-to-image, alibaba/qwen-image-3/edit, fal-ai/qwen-image-2/pro/text-to-image, fal-ai/qwen-image-edit-2511, fal-ai/qwen-image-2512, fal-ai/qwen-image-layered, qwen-image-3.0-pro/edit, qwen/qwen-image-edit-plus) on generate_image, edit_image or a TextToImage node.
+---
+
+# Qwen-Image → the model you reach for when the image has words in it
+
+Qwen-Image renders text other image models garble: twelve scripts natively,
+legible down to roughly 10 px, long layout instructions honoured. That is the
+reason to pick it, and the prompt should spend its length on the copy and the
+layout rather than on adjectives.
+
+Reach it with `find_model` for `text_to_image` or `image_to_image`, then
+`generate_image` / `edit_image`. Prompts run to 5000 characters; the negative
+prompt caps at 500.
+
+## Quote the copy
+
+Anything in quotation marks is treated as literal copy. Anything you describe
+instead, the model writes for you — usually plausibly and never what you meant.
+
+> A vertical science poster. Title "轨道力学" in large bold characters across the
+> upper third, subtitle "Orbital Mechanics" in small widely-spaced capitals
+> directly beneath. Three labelled diagram panels down the centre, captions
+> "近地点", "远地点", "转移轨道" under each. A thin rule separates the diagram block
+> from a footer reading "第三版 · 2026". Flat editorial illustration, two-colour
+> palette. No other text.
+
+Three habits that make it land:
+
+- **Write the characters, never describe them.** Paste the Chinese, Japanese,
+  Korean or Spanish string itself, with its diacritics. "The Chinese word for
+  orbit" produces something that is not that word.
+- **State the relationship between scripts** in a bilingual layout — "on the
+  same line", "stacked directly beneath" — and match their size and weight, or
+  one language reads as an afterthought.
+- **Close with "no other text".** Left to itself, the model fills empty margins
+  with invented lettering.
+
+## Turn prompt expansion off for typography
+
+On the hosted tiers — Qwen-Image-2, Max and 3 — `enable_prompt_expansion`
+defaults to true and runs an LLM over your prompt first. It helps a three-word
+prompt and ruins a typographic one: it edits the strings you quoted and adds
+signage you did not ask for. Set it false whenever exact copy matters.
+
+The open-weight checkpoints (`fal-ai/qwen-image`, the `qwen-image-edit-*`
+releases) have no such flag and take your prompt as written. What they expose
+instead is `guidance_scale`, `num_inference_steps` and LoRAs — raise guidance
+when the layout is being loosely interpreted, and leave the step count alone
+until the prompt is settled.
+
+## Layout is relative, not metric
+
+Point sizes and pixel coordinates mean nothing here. Vertical order, relative
+size and relative weight mean everything. "Large bold capitals across the top,
+small widely-spaced capitals directly beneath, body copy in two columns below
+the rule" is a layout the model can execute. "24pt heading at x=120" is not.
+
+For dense label sets, add structural marks — rules, borders, panels. Without
+them a block of labels renders as a list.
+
+## Size
+
+On Qwen-Image-3, text-to-image runs 512×512 to 2048×2048 total pixels and
+editing runs 512×512 to 1440×1440; the other checkpoints have their own
+ceilings, so read the endpoint. Small type needs the pixels: draft the
+composition small, then render the deliverable near the ceiling, and choose a
+taller canvas when the fine print has to survive.
+
+## Editing
+
+Qwen-Image-3 Edit takes one to three reference images and **order matters** —
+the prompt addresses them as "image 1", "image 2", "image 3". References run
+384–2048 px per side, 10 MB each, JPEG/PNG without alpha or WEBP. The earlier
+edit checkpoints take a list too, and the same "image N" convention applies.
+
+> Place the bottle from image 1 on the marble surface from image 2, keeping the
+> bottle's label, proportions and cap exactly as they are. Match the lighting
+> direction of image 2. Replace the label copy with "SERIES 04" in white
+> sans-serif capitals.
+
+Name what stays as explicitly as what changes. Recolouring a packshot, carrying
+a product into a new scene, and staging two products together are all the same
+instruction shape: what comes from which image, what must not move.
+
+## Symptoms
+
+| What went wrong | What to change |
+| :--- | :--- |
+| The text is close to yours but not yours | Quote it, and set `enable_prompt_expansion` false |
+| Invented words in the margins | Add "no other text" |
+| Non-Latin script renders as garbage | Paste the characters instead of describing them |
+| Small type is illegible | Render nearer the pixel ceiling, or use a taller canvas |
+| The wrong reference supplied the subject | Say "image 1" / "image 2" explicitly and check the order you sent |
+| Hierarchy is flat | Give each line a relative size and weight, not a size in points |
+
+Grade the result with `critique_image` and `score_image_adherence`, which will
+tell you whether the copy rendered as written before you look at the picture.
+
+Adapted from Runware's Qwen-Image-3.0 text and typography guide:
+https://runware.ai/docs/models/alibaba-qwen-image-3-0/guides/text-and-typography

--- a/packages/system-skills/seedream-prompting/SKILL.md
+++ b/packages/system-skills/seedream-prompting/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: seedream-prompting
+description: Prompt ByteDance's Seedream 4 and 5 image line — the six-layer brief it reads in order, the word budget past which it starts dropping clauses, quoting in-image copy and placing it, pinning what must not change before an edit, addressing up to ten references by content instead of by index, and the size to iterate at versus the size to deliver. Use whenever the model id names Seedream 4 or 5 (bytedance/seedream/v5/pro/text-to-image, bytedance/seedream/v5/lite/edit, fal-ai/bytedance/seedream/v4.5/edit, fal-ai/bytedance/seedream/v4/text-to-image, bytedance/seedream-v5.0-pro/edit, bytedance/seedream-v4.5, seedream/5-pro-image-to-image, seedream/4.5-text-to-image, bytedance/seedream-4.5) on generate_image, edit_image or a TextToImage node. Not for Seedream 3.
+---
+
+# Seedream → a production brief, not a caption
+
+Seedream rewards a brief written the way you would hand one to a retoucher:
+what the deliverable is, who is in it, where everything sits, how it is lit,
+what it says, and what it looks like. Captions get caption results.
+
+Reach it with `find_model` for `text_to_image` or `image_to_image`, then
+`generate_image` / `edit_image`.
+
+## Six layers, in this order
+
+Earlier clauses carry more weight, so the order is part of the instruction.
+
+1. **Format** — the deliverable. "Fashion editorial magazine cover", "packshot
+   on plain white", "streaming poster".
+2. **Subject** — identity, wardrobe, materials, styling. Concrete beats
+   flattering: "a woman in her 40s, close-cropped grey hair, oversized charcoal
+   wool coat" over "a stylish woman".
+3. **Composition** — where things sit and how the frame is cut. "Subject on the
+   left vertical third, product centred at the lower edge, generous headroom".
+4. **Lighting** — direction and quality. "Hard key from camera left, deep
+   falloff, one bounce card filling the shadow side".
+5. **In-image text** — the exact copy, in quotes, with its position.
+6. **Style** — the aesthetic anchor. "Editorial photorealism, 85mm, shallow
+   focus, muted film grade".
+
+An omitted layer is a decision handed to the model's defaults, and its defaults
+are centred, evenly lit and generic.
+
+## Word budget
+
+Aim for 30–100 words on Seedream 4.x. Seedream 5 accepts a much longer brief
+and starts scattering attention past roughly 600 English words. Specificity
+buys more than length: past the budget the model drops clauses, and which ones
+it drops is not yours to choose.
+
+## Text in the image
+
+Put the literal copy in quotation marks and say where it goes. Anything you
+describe rather than quote, the model writes for you.
+
+> Fashion editorial cover, 3:4. Masthead "ATRIUM" in tall thin capitals across
+> the top edge, one cover line "The Quiet Season" in small italics at the lower
+> left. A model in a raw-edged linen coat against a bare plaster wall, three-
+> quarter turn, looking off-frame right. Soft north light from the left, long
+> shadow across the plaster. Editorial photorealism, medium format, muted
+> palette. No other text.
+
+Closing with "no other text" is what stops the model filling the margins with
+invented lettering.
+
+## Editing: pin before you change
+
+Reference-guided editing takes up to ten images — send more and only the last
+ten are used. The failure mode is not the edit — it is everything you did not mention drifting. State the pins:
+
+> Change only the bottle's label to matte black with "SERIES 04" in white
+> sans-serif capitals. Keep the exact bottle silhouette, the exact camera
+> angle, the exact backdrop and the exact studio lighting from the reference.
+
+Address references by what they contain, not by position: "the tan leather
+journal", not "the second image". Content descriptions survive re-ordering and
+disambiguate two references that look alike. For product identity, feed
+packshots on white — a lifestyle photo carries a scene the model will try to
+keep.
+
+Seedream 5 Pro adds region-precise editing and layer separation, which is what
+makes it the pick when one element must change and the rest of the frame must
+be provably untouched.
+
+## Size and tiers
+
+`image_size` runs from 1024×1024 to 2048×2048 total pixels, aspect ratios 1:16
+to 16:1, and defaults to `auto_2K`. Work the composition at the smaller tier
+while you iterate and render the deliverable at 2K. Match the ratio to the
+brief rather than defaulting to square: 3:4 for a cover, 9:16 for a poster, 4:3
+for a still life.
+
+## Symptoms
+
+| What went wrong | What to change |
+| :--- | :--- |
+| Subject differs from what you described | Move the subject description earlier and make its defining features concrete |
+| An unwanted illustrative style | Name the style you want and negate the one you got explicitly |
+| Elements land in the wrong place | State spatial relationships; cut the number of things in the frame |
+| Copy is paraphrased or invented | Quote it exactly, place it, and close with "no other text" |
+| An untouched region changed in an edit | Add the pins — silhouette, angle, backdrop, lighting |
+| Clauses at the end were ignored | You are over budget; cut to the layers that matter |
+
+Grade the result with `critique_image` and `score_image_adherence` rather than
+eyeballing it, and `compare_images` when you are choosing between candidates.
+
+Adapted from fal's Seedream v4.5 prompt guide and Runware's Seedream 5.0 Pro
+prompting guide:
+https://fal.ai/learn/devs/seedream-v4-5-prompt-guide
+https://runware.ai/docs/models/bytedance-seedream-5-0-pro/guides/prompting

--- a/packages/system-skills/stable-audio-prompting/SKILL.md
+++ b/packages/system-skills/stable-audio-prompting/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: stable-audio-prompting
+description: Prompt Stability's Stable Audio line — the genre/instruments/mood/BPM order its training metadata expects, the TrackType and VocalType tags that separate music, stems and sound effects on Stable Audio 3, matching duration to what you described, which checkpoints guidance_scale and step count actually affect, and prompting the inpaint, outpaint and audio-to-audio variants where the surrounding audio outranks the prompt. Use whenever the model id names Stable Audio (fal-ai/stable-audio-25/text-to-audio, fal-ai/stable-audio-3/medium/text-to-audio, fal-ai/stable-audio-3/small/music/text-to-audio, fal-ai/stable-audio-3/small/sfx/text-to-audio, fal-ai/stable-audio-3/medium/audio-to-audio, fal-ai/stable-audio-25/inpaint, stability-ai/stable-audio-2.5) on generate_music or an audio generation node.
+---
+
+# Stable Audio → write the metadata, not a mood
+
+Stable Audio was trained on library-music metadata, so it responds to prompts
+shaped like library-music metadata: what the genre is, what is playing, how it
+feels, how fast it goes. Poetic descriptions of a feeling get a generic bed.
+
+Reach the music endpoints with `find_model` for `text_to_music`, then
+`generate_music`. The SFX checkpoints and the audio-to-audio, inpaint and
+outpaint variants are not in the music catalog — run those nodes with
+`search_nodes` and `invoke_node`.
+
+## Music prompts
+
+Four elements, in this order:
+
+1. **Genre** — the core style, first.
+2. **Instruments** — with character, not just names. "Smooth electric piano",
+   "textural percussion", "distorted bass" carry more than "piano, drums,
+   bass".
+3. **Mood and production** — the feel, plus the production era or treatment.
+4. **BPM** — and the key when it matters.
+
+> An exciting breakbeat instrumental for a fast-paced game, funky electric
+> guitar chords, steady break drums, smooth electric piano and supporting bass.
+> Fresh, modern and adventurous, 105 BPM.
+
+Two habits that measurably help: vary the vocabulary instead of repeating the
+same adjective, and reference an era to describe production — "80s gated
+reverb", "90s grunge distortion" — which encodes a whole chain in three words.
+
+On Stable Audio 3, prefix the type. `TrackType: Music, VocalType: Instrumental`
+is the tag pair for instrumental beds and is worth setting explicitly; the
+model otherwise decides whether to bring in a vocal.
+
+## Stems and single instruments
+
+Start with `TrackType: Instrument`, then the instrument, genre, mood and BPM.
+This is the path for something that has to sit in a mix rather than be the mix.
+Playing technique, recording environment and effects all read: "close-mic'd
+upright bass, fingered, small wooden room, light tape saturation".
+
+## Sound effects
+
+`TrackType: SFX`, then three things:
+
+1. **Source** — the object or instrument making the sound.
+2. **Action** — how it is triggered, how long it rings, how it decays.
+3. **Production** — mic placement, room character, processing.
+
+> TrackType: SFX. A steel toolbox lid slamming shut on a concrete workshop
+> floor, sharp metallic impact with a short rattling decay, close mic, small
+> room with a hard early reflection.
+
+Then set a short duration. Most effects are under two seconds, and a 30-second
+request for a door slam gets you a door slam followed by 28 seconds of room.
+
+## Duration and parameters
+
+Match the duration to what you described. The Stable Audio 3 medium checkpoint
+goes to 380 seconds, but a prompt describing a loop or a hit produces its best
+result when the length fits the description; for a music bed, 60–90 seconds is
+the range the guide recommends. Note the field changes name — `seconds_total`
+on 2.5, `duration` on 3 — and 2.5 defaults to 190 seconds, which is three
+minutes of audio nobody asked for.
+
+| Parameter | What it does | Where to sit |
+| :--- | :--- | :--- |
+| `num_inference_steps` | Sampling steps | The distilled checkpoints are tuned for the default 8 and gain little above it; raise it only on a `base` checkpoint |
+| `guidance_scale` | Prompt adherence | On Stable Audio 3, effective only on `base` (non-distilled) checkpoints — raising it on a distilled one changes nothing |
+| `negative_prompt` | Qualities to avoid (Stable Audio 3 only) | Name the artifact you hear: "clipping", "muddy low end", "vocal chops" |
+| `enable_prompt_expansion` | LLM prompt rewrite | Off by default; useful for a three-word prompt, harmful once your prompt is already metadata |
+| `seed` | Comparability | Pin it while you change one element at a time |
+
+The `base` versus distilled split is the one that catches people: on a
+distilled Stable Audio 3 checkpoint the two dials most people reach for do
+nothing, and the prompt is the whole instrument.
+
+## Editing existing audio
+
+**Audio-to-audio** seeds generation from a clip, and the dial has two names.
+Stable Audio 3 takes `init_noise_level` (0.9 default): 0.1 keeps the source
+close, 1.0 replaces it with noise and generates outright. Stable Audio 2.5
+takes `strength` (0.8 default), which runs the same way — 0 returns the input.
+Low keeps melody and rhythm; high strips them and keeps only broad character.
+
+**Inpaint and outpaint** hold everything outside a masked region and regenerate
+inside it — `mask_start_seconds` / `mask_end_seconds` on Stable Audio 3,
+`mask_start` / `mask_end` on 2.5. Here the surrounding audio matters more than
+the prompt: a short mask is pulled hard toward its context regardless of what
+you wrote, and only a wide mask gives the prompt room. If an inpaint is
+ignoring you, widen the mask before rewriting the prompt.
+
+## Symptoms
+
+| What went wrong | What to change |
+| :--- | :--- |
+| A generic bed | Rewrite as genre, instruments with character, mood, BPM |
+| An unwanted vocal | Add `TrackType: Music, VocalType: Instrumental` to the prompt |
+| The effect is padded with room tone | Cut the duration to the length of the actual event |
+| Raising guidance changed nothing | You are on a distilled checkpoint — switch to `base` or fix the prompt |
+| An inpaint ignores the prompt | Widen the masked region |
+| Two takes are not comparable | Pin the seed and change one element |
+
+Check the result with `analyze_audio`, `analyze_audio_spectrum` and
+`detect_audio_events` rather than listening for it — a missing instrument or a
+clipped peak shows up there faster than by ear.
+
+Adapted from Stability's Stable Audio 2.5 prompt guide and the Stable Audio 3
+prompting guide:
+https://stability.ai/implementations/stable-audio-25-prompt-guide
+https://github.com/Stability-AI/stable-audio-3/blob/main/docs/guides/prompting.md


### PR DESCRIPTION
## What changed

Six more generation model lines get a shipped prompting guide, two per modality: **Kling** (2.5-turbo and later) and **MiniMax Hailuo** for video, **Seedream 4/5** and **Qwen-Image** for image, **ElevenLabs** and **Stable Audio** for audio. Audio had no guide at all before this, so `find_model` for `text_to_speech` or `text_to_music` answered with a model and nothing about how to talk to it. Each guide is written against the vendor's own prompting documentation *and* against the parameters the shipped provider manifests actually declare, so it teaches the request an agent can really send: which Kling versions expose a shot list at all (`multi_prompt` is v3/O3 only), that O3 defaults `generate_audio` to false while 2.6 and v3 default it true, that Stable Audio's audio-to-audio dial is `strength` on 2.5 and `init_noise_level` on 3, that Qwen's `enable_prompt_expansion` rewrites the copy you quoted. They trigger the same two ways the existing seven do — the catalog description names the ids across every provider serving the line, and `find_model` attaches `prompting_skill` to a matching route.

One fix falls out of adding them: the table's manifest scan read `endpointId` only, so kie's and AtlasCloud's catalogs — which spell the field `modelId` — were invisible to every check in that test file, and a pattern matching nothing they serve would have passed. It reads both now, taking the scanned id set from ~2 200 to 2 527.

## Verification

- [x] `npm run test:affected` — all affected package suites, the web suite, and electron (63 suites / 690 tests) pass. `packages/agents` includes the 84 cases in `model-prompting-skills.test.ts`, up from 58.
- [x] `npm run typecheck` — passes for the packages, web and electron. Locally it still fails inside `mobile/`, which is intentionally not a root workspace and whose Expo dependencies this container never installed (`Cannot find module 'react-native'`, `expo/tsconfig.base` not found); CI's `Quality Gate / typecheck` job is green on this head.
- [x] `npm run lint` — clean; CI's `Quality Gate / lint` job is green.
- [x] `npm run check:agents-docs` — 37 `AGENTS.md`, each paired and reachable.

An earlier revision of this description reported `@nodetool-ai/image-nodes` failing and 61 `tsc` errors in `packages/agents`. Both were this container's state, not the diff: the first was the documented missing Vulkan ICD (`apt-get install mesa-vulkan-drivers` clears it, and the diff touches no shader code), the second an unbuilt `@nodetool-ai/execution` before `npm install` linked `@nodetool-ai/browser`. After a clean install and `build:packages` both are gone.

## New checks

The routing table gains six patterns, and both skill-facing assertions were inverted once and observed failing before being restored:

```
× kling-video-prompting: every model id in its description matches it
  AssertionError: named in this description, routed elsewhere:
    expected [ 'fal-ai/veo3/image-to-video' ] to deeply equal []

× names only capabilities that exist
  AssertionError: expected [ 'generate_soundtrack' ] to deeply equal []
```

The scan-found-something guard already in that file (`ids.length > 1000`) still holds, so the id checks cannot pass by matching nothing.

## Agent capabilities

No capability is added and no capability's declared contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTvHYarf8UFrBn2kBmyoQE