### PR TITLE
fix: four failure modes from a commercial beat-sheet run

### DIFF
--- a/packages/agents/src/capabilities/media.specs.ts
+++ b/packages/agents/src/capabilities/media.specs.ts
@@ -454,7 +454,10 @@ export const understandVideoSpec: CapabilitySpec = {
     "A provider that reads video natively (Gemini) gets the whole clip with " +
     "its audio; every other vision model is sent stills sampled from it, " +
     "which carry no audio and no motion between frames. For a single still " +
-    "use critique_image instead.",
+    "use critique_image instead. The reply carries `truncated`: a reasoning " +
+    "model can spend the whole token budget thinking and return a fragment, " +
+    "so a `truncated` answer is half an answer — raise max_tokens or read it " +
+    "again with a non-reasoning model rather than acting on it.",
   inputSchema: UNDERSTAND_VIDEO_SCHEMA,
   // Unlisted in `TOOL_PERMISSION_CATEGORIES`, so the gate classes it
   // `external` — the same category the vision judges carry.

--- a/packages/agents/src/capabilities/media.ts
+++ b/packages/agents/src/capabilities/media.ts
@@ -66,7 +66,10 @@ import {
 } from "../tools/asset-persist.js";
 import type { SavedOutput } from "../tools/asset-persist.js";
 import { persistBinaryOutput } from "../tools/binary-output.js";
-import { extractJSON } from "../utils/json-parser.js";
+import {
+  extractJSON,
+  extractJSONAllowingTruncation
+} from "../utils/json-parser.js";
 import { isYtDlpEnabled } from "../yt-dlp-gate.js";
 import {
   isFunction,
@@ -1316,6 +1319,21 @@ async function judgeCall(
   return messageText(result);
 }
 
+/**
+ * Whether a model reply reads as cut off rather than merely wrong.
+ *
+ * A judge on a reasoning model spends its ceiling thinking and returns half a
+ * sentence; the caller then sees "did not return parseable JSON" and re-runs
+ * the same call at the same budget. Naming the cause in the error is the
+ * difference between one retry and three.
+ */
+export function looksTruncated(text: string): boolean {
+  const trimmed = text.trimEnd();
+  if (trimmed.length === 0) return false;
+  if (/[.!?\]}"]$/.test(trimmed)) return false;
+  return true;
+}
+
 function tasteBlock(params: Record<string, unknown>): string {
   const profile = params["taste_profile"];
   if (!isNonBlankString(profile)) return "";
@@ -1338,8 +1356,17 @@ interface CritiqueResult {
   strengths: string[];
 }
 
+/**
+ * A critique out of a judge reply, whole or cut short.
+ *
+ * The reply is a report, not an instruction: a `verdict` plus two lists whose
+ * entries stand alone. A judge that hits its token ceiling mid-list has still
+ * said everything before the cut, so a truncated reply is salvaged rather than
+ * thrown away — before this, a run lost a usable verdict and every defect the
+ * judge had already named.
+ */
 function parseCritique(text: string): CritiqueResult | null {
-  const parsed = extractJSON(text);
+  const parsed = extractJSONAllowingTruncation(text);
   if (!isRecord(parsed)) {
     return null;
   }
@@ -1398,7 +1425,10 @@ const critiqueImage: CapabilityExport = {
       const critique = parseCritique(text);
       if (!critique) {
         return {
-          error: `Judge did not return parseable JSON: ${text.slice(0, 300)}`
+          error:
+            `Judge did not return parseable JSON` +
+            `${looksTruncated(text) ? " (the reply stops mid-sentence — it hit the token ceiling; raise max_tokens or pick a model that does not spend the budget on reasoning)" : ""}` +
+            `: ${text.slice(0, 300)}`
         };
       }
       return {
@@ -1430,7 +1460,7 @@ interface MatchRecord {
 function parsePairVerdict(
   text: string
 ): { winner: 1 | 2; reason: string } | null {
-  const parsed = extractJSON(text);
+  const parsed = extractJSONAllowingTruncation(text);
   if (!isRecord(parsed)) return null;
   const obj = parsed;
   const winner = Number(obj["winner"]);
@@ -1693,7 +1723,13 @@ const understandVideo: CapabilityExport = {
         text,
         provider: m.provider,
         model: m.model,
-        read_as: native ? "video" : "sampled_frames"
+        read_as: native ? "video" : "sampled_frames",
+        // A reasoning model spends `max_tokens` on thinking and returns a
+        // fragment. Without this the caller reads half an answer as the whole
+        // answer — one run acted on "the clip shows a man attempting to" and
+        // never learned the sentence had been cut.
+        truncated: looksTruncated(text),
+        max_tokens: maxTokens
       };
     } catch (e) {
       return {

--- a/packages/agents/src/capabilities/storyboards.ts
+++ b/packages/agents/src/capabilities/storyboards.ts
@@ -87,6 +87,7 @@ export {
   EXTRACT_SCRIPT_SCHEMA
 } from "./storyboards.specs.js";
 import { resolveProjectId } from "./project-scope.js";
+import { mp4DurationSeconds } from "../utils/video-duration.js";
 /** Shots one call may render, so a stray `targets: "all"` cannot bankrupt a run. */
 const MAX_SHOTS_PER_CALL = 24;
 /** Attempts to land a document write: the first try plus one re-read-and-reapply (ADR 0001). */
@@ -424,7 +425,10 @@ async function renderMedia(
   req: Omit<GenerationRequest, "origin" | "persist">,
   namePrefix: string,
   mime?: string
-): Promise<{ assetId: string; uri: string; generationId: string } | ToolError> {
+): Promise<
+  | { assetId: string; uri: string; generationId: string; output: unknown }
+  | ToolError
+> {
   const { randomUUID } = await import("node:crypto");
   const id = randomUUID();
   const persist: GenerationRequest["persist"] = { name: namePrefix };
@@ -442,7 +446,40 @@ async function renderMedia(
         "The render succeeded but could not be saved as an asset, so it cannot be attached to the shot. This host has no asset storage wired."
     };
   }
-  return { assetId: asset.asset_id, uri: asset.uri, generationId: id };
+  return {
+    assetId: asset.asset_id,
+    uri: asset.uri,
+    generationId: id,
+    output: result.output
+  };
+}
+
+/**
+ * The clip a render actually produced, with its real length when readable.
+ *
+ * A video model quantizes the duration it is asked for — a shot directed at
+ * 1.5s came back as 5.184s — and the ref carried only the asset id, so
+ * assembly laid down the *intended* 1.5s over five seconds of footage and
+ * threw the rest away without saying so. The bytes are already in hand here,
+ * so the length is free to read; a container we cannot parse leaves `duration`
+ * unset, which every reader treats as unknown rather than zero.
+ */
+export function renderedVideoRef(saved: {
+  assetId: string;
+  uri: string;
+  output: unknown;
+}): VideoRef {
+  const clip: VideoRef = {
+    type: "video",
+    asset_id: saved.assetId,
+    uri: saved.uri
+  };
+  const bytes = saved.output;
+  if (bytes instanceof Uint8Array) {
+    const seconds = mp4DurationSeconds(bytes);
+    if (seconds !== null) clip.duration = seconds;
+  }
+  return clip;
 }
 
 const errorMessage = (e: unknown): string =>
@@ -853,11 +890,7 @@ const renderStoryboardClips: CapabilityExport = {
           );
           if (isError(saved)) return { ...base, error: saved.error };
 
-          const clip: VideoRef = {
-            type: "video",
-            asset_id: saved.assetId,
-            uri: saved.uri
-          };
+          const clip = renderedVideoRef(saved);
           const updated = await patchShot(row.id, shot.id, (current) => {
             const versions =
               current.clip_versions ?? (current.clip ? [current.clip] : []);
@@ -948,11 +981,7 @@ const reviseStoryboardClip: CapabilityExport = {
       );
       if (isError(saved)) return saved;
 
-      const clip: VideoRef = {
-        type: "video",
-        asset_id: saved.assetId,
-        uri: saved.uri
-      };
+      const clip = renderedVideoRef(saved);
       const updated = await patchShot(row.id, shot.id, (current) => {
         const versions =
           current.clip_versions ?? (current.clip ? [current.clip] : []);
@@ -1030,6 +1059,23 @@ const assembleStoryboardTimeline: CapabilityExport = {
         });
     const skippedLineIds =
       "skippedLineIds" in assembled ? assembled.skippedLineIds : [];
+    // A model returns the length it returns: shots directed at 1.5s come back
+    // at 5.2s, and the cut then shows each shot's head. Saying which shots
+    // that happened to, and by how much, is what turns a silent mismatch into
+    // a decision the caller can make.
+    if (assembled.trimmedShots.length > 0) {
+      const worst = assembled.trimmedShots.reduce((a, b) =>
+        Math.abs(b.sourceMs - b.usedMs) > Math.abs(a.sourceMs - a.usedMs)
+          ? b
+          : a
+      );
+      warnings.push(
+        `${assembled.trimmedShots.length} shot(s) do not match their rendered footage — ` +
+          `the longest gap is ${Math.round(Math.abs(worst.sourceMs - worst.usedMs))}ms on shot ${worst.shotId} ` +
+          `(${worst.usedMs}ms in the cut, ${worst.sourceMs}ms rendered). ` +
+          `Re-time the clips, or set each shot's duration_seconds to the length its model produces.`
+      );
+    }
     if (assembled.clips.length === 0) {
       return {
         error:
@@ -1094,7 +1140,8 @@ const assembleStoryboardTimeline: CapabilityExport = {
         track_count: assembled.tracks.length,
         script_id: script ? scriptId : null,
         skipped_shot_ids: assembled.skippedShotIds,
-        skipped_line_ids: skippedLineIds
+        skipped_line_ids: skippedLineIds,
+        trimmed_shots: assembled.trimmedShots
       };
       if (warnings.length) {
         created.warnings = warnings;
@@ -1177,7 +1224,8 @@ const assembleStoryboardTimeline: CapabilityExport = {
         track_count: tracks.length,
         script_id: script ? scriptId : null,
         skipped_shot_ids: assembled.skippedShotIds,
-        skipped_line_ids: skippedLineIds
+        skipped_line_ids: skippedLineIds,
+        trimmed_shots: assembled.trimmedShots
       };
       if (warnings.length) {
         result.warnings = warnings;
@@ -1213,8 +1261,33 @@ const BOARD_OPS = [
 
 type BoardOpName = (typeof BOARD_OPS)[number];
 
+/**
+ * Op names an agent reaches for that mean one of {@link BOARD_OPS}.
+ *
+ * The browser tool that casts entities is `ui_storyboard_set_entities`, so a
+ * script written against it calls `{op: "set_entities", entity_ids: [...]}`
+ * here and was refused — the rejection listed the five real ops without
+ * saying which one takes `entity_ids`, and the caller had to go read the tool
+ * catalogue mid-task. The alias resolves to the op that already does the work.
+ */
+const BOARD_OP_ALIASES: Readonly<Record<string, BoardOpName>> = {
+  set_entities: "set_board",
+  set_storyboard: "set_board",
+  add_shots: "add_shot",
+  edit_shot: "update_shot",
+  delete_shot: "remove_shot",
+  move_shot: "reorder_shot"
+};
+
 const isBoardOpName = (value: string): value is BoardOpName =>
   (BOARD_OPS as readonly string[]).includes(value);
+
+/** The op a name selects, following {@link BOARD_OP_ALIASES}. */
+export const resolveBoardOpName = (value: string): BoardOpName | null => {
+  const name = value.trim();
+  if (isBoardOpName(name)) return name;
+  return BOARD_OP_ALIASES[name] ?? null;
+};
 
 interface ParsedBoardOp {
   op: BoardOpName;
@@ -1239,12 +1312,13 @@ function parseBoardOps(raw: unknown): ParsedBoardOp[] | ToolError {
       return { error: `ops[${index}] must be an object.` };
     }
     const { op, ...args } = entry as Record<string, unknown>;
-    if (!isString(op) || !isBoardOpName(op.trim())) {
+    const resolved = isString(op) ? resolveBoardOpName(op) : null;
+    if (!resolved) {
       return {
         error: `ops[${index}] names "${String(op)}"; expected one of ${BOARD_OPS.join(", ")}.`
       };
     }
-    parsed.push({ op: op.trim() as BoardOpName, args });
+    parsed.push({ op: resolved, args });
   }
   return parsed;
 }

--- a/packages/agents/src/utils/json-parser.ts
+++ b/packages/agents/src/utils/json-parser.ts
@@ -106,3 +106,120 @@ export function extractJSON(text: string): JsonValue | null {
 
   return null;
 }
+
+/**
+ * The largest reply {@link salvageTruncatedJSON} will try to repair.
+ *
+ * Repair walks candidate cut points and re-parses at each, so an unbounded
+ * input is quadratic. A judge reply that runs past this is not a truncated
+ * object; it is something else.
+ */
+const MAX_SALVAGE_CHARS = 200_000;
+
+/** How many cut points a single salvage may try before giving up. */
+const MAX_SALVAGE_ATTEMPTS = 300;
+
+/** Characters that can legally end a complete JSON value. */
+const VALUE_END = new Set([
+  "}",
+  "]",
+  '"',
+  "e", // true / false
+  "l", // null
+  "0",
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9"
+]);
+
+/**
+ * Recover the complete prefix of a JSON object that was cut off mid-write.
+ *
+ * A vision judge asked for `{"verdict": …, "defects": […]}` and stopped at its
+ * token ceiling three defects in. {@link extractJSON} returns null for that —
+ * every strategy needs a balanced document — so the caller reported "did not
+ * return parseable JSON" and threw away a verdict and two usable defects that
+ * were fully written.
+ *
+ * This drops the incomplete tail: it walks back from the end to the last point
+ * where a value had just closed, closes the brackets that were still open
+ * there, and parses that. Returns null when nothing parses — a reply that is
+ * not JSON at all stays an error, and a *complete* document is
+ * {@link extractJSON}'s job, so try that first.
+ */
+export function salvageTruncatedJSON(text: string): JsonValue | null {
+  if (text.length > MAX_SALVAGE_CHARS) return null;
+  const fence = text.match(/```(?:json)?\s*\n?([\s\S]*)$/);
+  const body = fence?.[1] ?? text;
+  const start = (() => {
+    const brace = body.indexOf("{");
+    const bracket = body.indexOf("[");
+    if (brace === -1) return bracket;
+    if (bracket === -1) return brace;
+    return Math.min(brace, bracket);
+  })();
+  if (start === -1) return null;
+
+  // Forward pass: for every index, the bracket stack in force and whether the
+  // scanner is inside a string literal there.
+  const stacks: string[][] = [];
+  const inString: boolean[] = [];
+  const stack: string[] = [];
+  let open = false;
+  let escape = false;
+  for (let i = start; i < body.length; i++) {
+    stacks.push([...stack]);
+    inString.push(open);
+    const ch = body[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (open) {
+      if (ch === "\\") escape = true;
+      else if (ch === '"') open = false;
+      continue;
+    }
+    if (ch === '"') open = true;
+    else if (ch === "{") stack.push("}");
+    else if (ch === "[") stack.push("]");
+    else if (ch === "}" || ch === "]") stack.pop();
+  }
+  stacks.push([...stack]);
+  inString.push(open);
+
+  let attempts = 0;
+  for (let cut = body.length; cut > start; cut--) {
+    const rel = cut - start;
+    if (inString[rel]) continue;
+    const prev = body[cut - 1];
+    if (!VALUE_END.has(prev)) continue;
+    const closers = stacks[rel];
+    if (closers.length === 0) continue; // a balanced document is extractJSON's
+    if (++attempts > MAX_SALVAGE_ATTEMPTS) break;
+    const candidate = body.slice(start, cut) + closers.slice().reverse().join("");
+    try {
+      return JSON.parse(candidate) as JsonValue;
+    } catch {
+      // keep walking back
+    }
+  }
+  return null;
+}
+
+/**
+ * {@link extractJSON}, falling back to {@link salvageTruncatedJSON}.
+ *
+ * For callers where a partial answer beats no answer — a critique whose
+ * defects list was cut short is still a critique. Never use it where a
+ * truncated document would be mistaken for a complete instruction.
+ */
+export function extractJSONAllowingTruncation(text: string): JsonValue | null {
+  return extractJSON(text) ?? salvageTruncatedJSON(text);
+}

--- a/packages/agents/src/utils/video-duration.ts
+++ b/packages/agents/src/utils/video-duration.ts
@@ -1,0 +1,102 @@
+/**
+ * How long a rendered video actually is, read from its own container.
+ *
+ * A video model quantizes the length it is asked for: a shot directed at 1.5s
+ * comes back as 5.184s, and nothing downstream knew. The storyboard then laid
+ * a 1.5s clip over 5.184s of footage, silently discarding the rest, and the
+ * cut no longer matched what had been paid for. Recording the real length at
+ * render time is what lets assembly trim on purpose instead of by accident.
+ *
+ * Reads the MP4 `mvhd` header only — no decode, no codecs, no host binary —
+ * so it can run on the bytes already in hand. Returns null for anything that
+ * is not an MP4 with a readable movie header; the caller treats an unknown
+ * length as unknown, never as zero.
+ */
+
+/** Bytes of header a probe will scan before giving up. */
+const MAX_SCAN_BYTES = 64 * 1024 * 1024;
+
+const BOX_HEADER_BYTES = 8;
+
+/** Containers whose `moov` may sit after the payload still parse: we walk all boxes. */
+export function mp4DurationSeconds(bytes: Uint8Array): number | null {
+  const view = new DataView(
+    bytes.buffer,
+    bytes.byteOffset,
+    bytes.byteLength
+  );
+  const moov = findBox(view, 0, Math.min(view.byteLength, MAX_SCAN_BYTES), "moov");
+  if (!moov) return null;
+  const mvhd = findBox(view, moov.start, moov.end, "mvhd");
+  if (!mvhd) return null;
+  return readMvhdDuration(view, mvhd.start, mvhd.end);
+}
+
+interface BoxRange {
+  /** First byte of the box payload. */
+  start: number;
+  /** One past the last byte of the box payload. */
+  end: number;
+}
+
+/** The first `type` box whose header lies in [from, to). */
+function findBox(
+  view: DataView,
+  from: number,
+  to: number,
+  type: string
+): BoxRange | null {
+  let offset = from;
+  while (offset + BOX_HEADER_BYTES <= to) {
+    let size = view.getUint32(offset);
+    const name = String.fromCharCode(
+      view.getUint8(offset + 4),
+      view.getUint8(offset + 5),
+      view.getUint8(offset + 6),
+      view.getUint8(offset + 7)
+    );
+    let headerBytes = BOX_HEADER_BYTES;
+    if (size === 1) {
+      // 64-bit largesize follows the header.
+      if (offset + 16 > to) return null;
+      const high = view.getUint32(offset + 8);
+      const low = view.getUint32(offset + 12);
+      size = high * 2 ** 32 + low;
+      headerBytes = 16;
+    } else if (size === 0) {
+      size = to - offset; // extends to the end of the enclosing range
+    }
+    if (size < headerBytes) return null; // malformed: a box cannot be shorter than its header
+    const end = Math.min(offset + size, to);
+    if (name === type) return { start: offset + headerBytes, end };
+    offset += size;
+  }
+  return null;
+}
+
+/** Duration in seconds from an `mvhd` payload, or null when it reads as zero. */
+function readMvhdDuration(
+  view: DataView,
+  start: number,
+  end: number
+): number | null {
+  if (start + 4 > end) return null;
+  const version = view.getUint8(start);
+  let timescale: number;
+  let duration: number;
+  if (version === 1) {
+    // version(1) flags(3) creation(8) modification(8) timescale(4) duration(8)
+    if (start + 32 > end) return null;
+    timescale = view.getUint32(start + 20);
+    duration =
+      view.getUint32(start + 24) * 2 ** 32 + view.getUint32(start + 28);
+  } else {
+    // version(1) flags(3) creation(4) modification(4) timescale(4) duration(4)
+    if (start + 20 > end) return null;
+    timescale = view.getUint32(start + 12);
+    duration = view.getUint32(start + 16);
+  }
+  if (!timescale || !Number.isFinite(duration) || duration <= 0) return null;
+  const seconds = duration / timescale;
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : null;
+}

--- a/packages/agents/tests/capabilities-media.test.ts
+++ b/packages/agents/tests/capabilities-media.test.ts
@@ -17,6 +17,7 @@ import type { Message, MessageContent } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { createLocalWorkspace } from "@nodetool-ai/runtime";
 import { toolFromCapability } from "../src/capabilities/adapters.js";
+import { DEFAULT_UNDERSTAND_VIDEO_TOKENS } from "../src/capabilities/media.specs.js";
 import { UNGATED, createCapabilityRun } from "../src/capabilities/invoke.js";
 import {
   capabilityModuleDrift,
@@ -359,7 +360,10 @@ describe("understand_video through the adapter", () => {
       text: "A fox crosses a snowfield.",
       provider: "gemini",
       model: "gemini-3-pro",
-      read_as: "video"
+      read_as: "video",
+      // An answer that ends on a full stop is a whole answer.
+      truncated: false,
+      max_tokens: DEFAULT_UNDERSTAND_VIDEO_TOKENS
     });
     expect(partsOf(predict)).toEqual([
       { type: "text", text: "What happens?" },
@@ -461,7 +465,9 @@ describe("understand_video through the adapter", () => {
       text: "A fox crosses a snowfield.",
       provider: "atlascloud",
       model: "google/gemini-2.5-flash",
-      read_as: "sampled_frames"
+      read_as: "sampled_frames",
+      truncated: false,
+      max_tokens: DEFAULT_UNDERSTAND_VIDEO_TOKENS
     });
     expect(predict).toHaveBeenCalledOnce();
   });

--- a/packages/agents/tests/capabilities-storyboards.test.ts
+++ b/packages/agents/tests/capabilities-storyboards.test.ts
@@ -285,6 +285,40 @@ describe("storyboards capability behaviour", () => {
     });
   });
 
+  it("casts entities through the op name the browser tool goes by", async () => {
+    const context = ctx();
+    const created = (await run(context).invoke("create_storyboard", {
+      name: "Cast"
+    })) as { storyboard_id: string };
+
+    // The browser tool is `ui_storyboard_set_entities`, so a script written
+    // against it reaches for `set_entities` here. That used to be refused with
+    // a list of five op names, none of which said which one takes entity_ids.
+    const edited = (await run(context).invoke("edit_storyboard", {
+      storyboard_id: created.storyboard_id,
+      ops: [{ op: "set_entities", entity_ids: ["style-1", "char-1"] }]
+    })) as { applied: number; failed: number };
+    expect(edited.failed).toBe(0);
+    expect(edited.applied).toBe(1);
+
+    const read = (await run(context).invoke("get_storyboard", {
+      storyboard_id: created.storyboard_id
+    })) as { entity_ids: string[] };
+    expect(read.entity_ids).toEqual(["style-1", "char-1"]);
+  });
+
+  it("still refuses an op name that means nothing", async () => {
+    const context = ctx();
+    const created = (await run(context).invoke("create_storyboard", {
+      name: "Bogus"
+    })) as { storyboard_id: string };
+    const refused = (await run(context).invoke("edit_storyboard", {
+      storyboard_id: created.storyboard_id,
+      ops: [{ op: "set_everything", entity_ids: ["a"] }]
+    })) as { error?: string };
+    expect(refused.error).toMatch(/expected one of/);
+  });
+
   it("set_board clears a model when passed null", async () => {
     const context = ctx();
     const created = (await run(context).invoke("create_storyboard", {

--- a/packages/agents/tests/json-parser-truncation.test.ts
+++ b/packages/agents/tests/json-parser-truncation.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for salvaging a JSON reply that was cut off at a token ceiling.
+ *
+ * Reproduction of the shipped failure: a vision judge on a reasoning model
+ * spent its budget thinking and stopped mid-defect, so `critique_image`
+ * reported "Judge did not return parseable JSON" and threw away a verdict plus
+ * every defect the judge had already finished writing.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  extractJSON,
+  extractJSONAllowingTruncation,
+  salvageTruncatedJSON
+} from "../src/utils/json-parser.js";
+
+const CUT_OFF = `\`\`\`json
+{
+  "verdict": "revise",
+  "defects": [
+    { "defect": "Airborne liquid", "location": "upper left", "fix": "remove the mist" },
+    { "defect": "Malformed finger", "location": "index finger", "fix": "redraw the grip" },
+    { "defect": "The athlete's fingernails are noticeably long and appear un`;
+
+describe("salvageTruncatedJSON", () => {
+  it("recovers the complete prefix of a reply cut off mid-value", () => {
+    expect(extractJSON(CUT_OFF)).toBeNull();
+    const salvaged = salvageTruncatedJSON(CUT_OFF) as {
+      verdict: string;
+      defects: { defect: string }[];
+    };
+    expect(salvaged.verdict).toBe("revise");
+    expect(salvaged.defects.map((d) => d.defect)).toEqual([
+      "Airborne liquid",
+      "Malformed finger"
+    ]);
+  });
+
+  it("drops a trailing key whose value never arrived", () => {
+    const salvaged = salvageTruncatedJSON(
+      '{"winner": 1, "reason": "sharper", "notes"'
+    ) as { winner: number; reason: string };
+    expect(salvaged).toEqual({ winner: 1, reason: "sharper" });
+  });
+
+  it("closes nested containers in the right order", () => {
+    const salvaged = salvageTruncatedJSON(
+      '{"a": {"b": [1, 2, {"c": "d"}, 3'
+    ) as { a: { b: unknown[] } };
+    expect(salvaged.a.b).toEqual([1, 2, { c: "d" }, 3]);
+  });
+
+  it("is not fooled by brackets and quotes inside a string", () => {
+    const salvaged = salvageTruncatedJSON(
+      '{"note": "a }] \\" trap", "next": "half'
+    ) as { note: string };
+    expect(salvaged).toEqual({ note: 'a }] " trap' });
+  });
+
+  it("returns null when the reply is not JSON at all", () => {
+    expect(salvageTruncatedJSON("I'm sorry, I cannot help with that")).toBeNull();
+    expect(salvageTruncatedJSON("")).toBeNull();
+  });
+
+  it("leaves a complete document to extractJSON, unchanged", () => {
+    const whole = '{"verdict": "pass", "defects": []}';
+    expect(extractJSONAllowingTruncation(whole)).toEqual({
+      verdict: "pass",
+      defects: []
+    });
+    // Salvaging one is a no-op rather than a second reading of it.
+    expect(salvageTruncatedJSON(whole)).toEqual({
+      verdict: "pass",
+      defects: []
+    });
+  });
+
+  it("gives up on an input too large to walk", () => {
+    expect(salvageTruncatedJSON(`{"a": "${"x".repeat(300_000)}`)).toBeNull();
+  });
+});

--- a/packages/agents/tests/video-duration.test.ts
+++ b/packages/agents/tests/video-duration.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the MP4 movie-header duration probe.
+ *
+ * The probe exists because a video model quantizes the length it is asked for
+ * (1.5s directed, 5.184s delivered) and nothing recorded the difference. It
+ * reads the container header only, so these fixtures are hand-built boxes.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mp4DurationSeconds } from "../src/utils/video-duration.js";
+import { renderedVideoRef } from "../src/capabilities/storyboards.js";
+
+function box(type: string, payload: Uint8Array): Uint8Array {
+  const out = new Uint8Array(8 + payload.length);
+  new DataView(out.buffer).setUint32(0, out.length);
+  for (let i = 0; i < 4; i++) out[4 + i] = type.charCodeAt(i);
+  out.set(payload, 8);
+  return out;
+}
+
+function mvhdV0(timescale: number, duration: number): Uint8Array {
+  const payload = new Uint8Array(100);
+  const view = new DataView(payload.buffer);
+  view.setUint8(0, 0); // version 0
+  view.setUint32(12, timescale);
+  view.setUint32(16, duration);
+  return box("mvhd", payload);
+}
+
+function mvhdV1(timescale: number, duration: number): Uint8Array {
+  const payload = new Uint8Array(112);
+  const view = new DataView(payload.buffer);
+  view.setUint8(0, 1); // version 1
+  view.setUint32(20, timescale);
+  view.setUint32(24, Math.floor(duration / 2 ** 32));
+  view.setUint32(28, duration >>> 0);
+  return box("mvhd", payload);
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let at = 0;
+  for (const p of parts) {
+    out.set(p, at);
+    at += p.length;
+  }
+  return out;
+}
+
+const ftyp = box("ftyp", new Uint8Array(16));
+const mdat = box("mdat", new Uint8Array(64));
+
+describe("mp4DurationSeconds", () => {
+  it("reads the length a model actually delivered", () => {
+    const file = concat(ftyp, mdat, box("moov", mvhdV0(1000, 5184)));
+    expect(mp4DurationSeconds(file)).toBeCloseTo(5.184, 5);
+  });
+
+  it("reads a 64-bit movie header", () => {
+    const file = concat(ftyp, box("moov", mvhdV1(600, 3110)));
+    expect(mp4DurationSeconds(file)).toBeCloseTo(3110 / 600, 5);
+  });
+
+  it("finds a moov that sits after the payload", () => {
+    const file = concat(ftyp, mdat, mdat, box("moov", mvhdV0(24, 125)));
+    expect(mp4DurationSeconds(file)).toBeCloseTo(125 / 24, 5);
+  });
+
+  it("returns null rather than zero for bytes it cannot read", () => {
+    expect(mp4DurationSeconds(new Uint8Array(0))).toBeNull();
+    expect(mp4DurationSeconds(new Uint8Array([1, 2, 3, 4, 5]))).toBeNull();
+    expect(mp4DurationSeconds(concat(ftyp, mdat))).toBeNull();
+    // A moov with no movie header, and a header claiming zero length.
+    expect(mp4DurationSeconds(concat(ftyp, box("moov", new Uint8Array(8))))).toBeNull();
+    expect(mp4DurationSeconds(concat(ftyp, box("moov", mvhdV0(1000, 0))))).toBeNull();
+  });
+
+  it("does not loop forever on a box that declares an impossible size", () => {
+    const bad = new Uint8Array(16);
+    new DataView(bad.buffer).setUint32(0, 2); // smaller than its own header
+    expect(mp4DurationSeconds(bad)).toBeNull();
+  });
+});
+
+describe("renderedVideoRef", () => {
+  const saved = (output: unknown) => ({
+    assetId: "asset-1",
+    uri: "asset://asset-1.mp4",
+    output
+  });
+
+  it("stamps the length the model actually returned", () => {
+    const bytes = concat(ftyp, box("moov", mvhdV0(1000, 5184)));
+    expect(renderedVideoRef(saved(bytes))).toEqual({
+      type: "video",
+      asset_id: "asset-1",
+      uri: "asset://asset-1.mp4",
+      duration: 5.184
+    });
+  });
+
+  it("leaves duration unset when the bytes say nothing", () => {
+    // A provider that hands back a URL rather than bytes, or a container the
+    // header probe cannot read: unknown stays unknown, never zero.
+    expect(renderedVideoRef(saved("https://example.test/a.mp4")).duration).toBeUndefined();
+    expect(renderedVideoRef(saved(concat(ftyp, mdat))).duration).toBeUndefined();
+  });
+});

--- a/packages/timeline/src/linked.ts
+++ b/packages/timeline/src/linked.ts
@@ -39,7 +39,9 @@ import {
   isAssemblableShot,
   shotAudioClip,
   shotDurationMs,
-  type AssembledTimeline
+  shotSourceDurationMs,
+  type AssembledTimeline,
+  type TrimmedShot
 } from "./storyboard.js";
 import type { TimelineClip, TimelineTrack } from "./types.js";
 
@@ -82,6 +84,7 @@ export function buildLinkedTimeline(
       : undefined;
 
   let cursorMs = 0;
+  const trimmedShots: TrimmedShot[] = [];
   for (const shot of ordered) {
     const lineIds = shot.script_line_ids ?? [];
     if (!isAssemblableShot(shot)) {
@@ -91,8 +94,17 @@ export function buildLinkedTimeline(
     }
 
     const shotStartMs = cursorMs;
+    // A linked shot runs as long as the lines it covers — the words drive the
+    // cut here, not the footage — so the source length is reported, never
+    // imposed. A shot whose render is shorter than its lines still shows up in
+    // `trimmedShots` with a negative headroom of its own kind: `sourceMs`
+    // under `usedMs` is the caller's cue that the picture runs out first.
     const durationMs =
       linkedShotDurationMs(shot, linesById) ?? shotDurationMs(shot);
+    const sourceMs = shotSourceDurationMs(shot);
+    if (sourceMs !== null && sourceMs !== durationMs) {
+      trimmedShots.push({ shotId: shot.id, usedMs: durationMs, sourceMs });
+    }
     const videoClip = makeClip({
       trackId: shotTrack.id,
       name: shot.slug ?? `Shot ${shot.index + 1}`,
@@ -176,6 +188,7 @@ export function buildLinkedTimeline(
     clips,
     durationMs: cursorMs,
     skippedShotIds,
-    skippedLineIds
+    skippedLineIds,
+    trimmedShots
   };
 }

--- a/packages/timeline/src/storyboard.ts
+++ b/packages/timeline/src/storyboard.ts
@@ -154,8 +154,6 @@ export interface ShotLayout {
   outPointMs?: number;
   /** Footage the cut leaves unused, in ms. Zero when nothing was discarded. */
   unusedSourceMs: number;
-  /** The direction asked for more than the render produced. */
-  short: boolean;
 }
 
 /**
@@ -173,15 +171,14 @@ export function layoutShot(shot: Shot): ShotLayout {
   const intended = shotDurationMs(shot);
   const source = shotSourceDurationMs(shot);
   if (source === null) {
-    return { durationMs: intended, unusedSourceMs: 0, short: false };
+    return { durationMs: intended, unusedSourceMs: 0 };
   }
   const durationMs = Math.min(intended, source);
   return {
     durationMs,
     inPointMs: 0,
     outPointMs: durationMs,
-    unusedSourceMs: source - durationMs,
-    short: intended > source
+    unusedSourceMs: source - durationMs
   };
 }
 
@@ -353,7 +350,7 @@ export function buildStoryboardPreviewTimeline(
     // real clip gets fitted to its footage.
     const layout: ShotLayout = clipAssetId
       ? layoutShot(shot)
-      : { durationMs: shotDurationMs(shot), unusedSourceMs: 0, short: false };
+      : { durationMs: shotDurationMs(shot), unusedSourceMs: 0 };
     const durationMs = layout.durationMs;
     const shotClip = makeClip({
       trackId: shotTrack.id,

--- a/packages/timeline/src/storyboard.ts
+++ b/packages/timeline/src/storyboard.ts
@@ -100,6 +100,22 @@ export interface AssembledTimeline {
   durationMs: number;
   /** Shots skipped because they have no persisted clip asset. */
   skippedShotIds: string[];
+  /**
+   * Shots whose render is longer than the direction asked for, and by how
+   * much. The cut takes the head of each and leaves the rest; saying so is
+   * what lets a caller re-time on purpose instead of discovering it in
+   * playback.
+   */
+  trimmedShots: TrimmedShot[];
+}
+
+/** A shot whose source footage outruns its place in the cut. */
+export interface TrimmedShot {
+  shotId: string;
+  /** Length used on the timeline. */
+  usedMs: number;
+  /** Length of the rendered source. */
+  sourceMs: number;
 }
 
 /** A shot is assemblable when its clip landed as a persisted asset. */
@@ -115,11 +131,59 @@ const assetIdOf = (ref: { asset_id?: string | null } | null | undefined) =>
     ? ref.asset_id
     : undefined;
 
-/** Clip length for a shot: its target duration, or the default. */
+/** Clip length a shot was directed at: its target duration, or the default. */
 export const shotDurationMs = (shot: Shot): number =>
   typeof shot.duration_seconds === "number" && shot.duration_seconds > 0
     ? Math.round(shot.duration_seconds * 1000)
     : DEFAULT_SHOT_MS;
+
+/** Length of the footage a shot's selected clip actually holds, when known. */
+export const shotSourceDurationMs = (shot: Shot): number | null => {
+  const seconds = shot.clip?.duration;
+  return typeof seconds === "number" && seconds > 0
+    ? Math.round(seconds * 1000)
+    : null;
+};
+
+/** How a shot's laid-down length was decided, and what it cost. */
+export interface ShotLayout {
+  /** Length on the timeline. */
+  durationMs: number;
+  /** Explicit source window, set whenever the source length is known. */
+  inPointMs?: number;
+  outPointMs?: number;
+  /** Footage the cut leaves unused, in ms. Zero when nothing was discarded. */
+  unusedSourceMs: number;
+  /** The direction asked for more than the render produced. */
+  short: boolean;
+}
+
+/**
+ * Fit a shot's directed length to the footage that came back.
+ *
+ * A video model returns what it returns: eight shots directed at 1.0–3.5s all
+ * rendered as 5.184s. Assembly used to write the directed length and nothing
+ * else, so each clip played its source's head and dropped the remainder with
+ * no in/out point to show for it — the cut said 1.5s, the media was 5.2s, and
+ * the two never met. Now the window is explicit: a shot keeps its directed
+ * length, capped at the footage that exists, and reports what it left on the
+ * floor so a caller can re-time deliberately.
+ */
+export function layoutShot(shot: Shot): ShotLayout {
+  const intended = shotDurationMs(shot);
+  const source = shotSourceDurationMs(shot);
+  if (source === null) {
+    return { durationMs: intended, unusedSourceMs: 0, short: false };
+  }
+  const durationMs = Math.min(intended, source);
+  return {
+    durationMs,
+    inPointMs: 0,
+    outPointMs: durationMs,
+    unusedSourceMs: source - durationMs,
+    short: intended > source
+  };
+}
 
 export function buildStoryboardTimeline(
   input: StoryboardAssemblyInput
@@ -140,13 +204,25 @@ export function buildStoryboardTimeline(
   const clips: TimelineClip[] = [];
 
   let cursorMs = 0;
+  const trimmedShots: TrimmedShot[] = [];
   for (const shot of assemblable) {
-    const durationMs = shotDurationMs(shot);
+    const layout = layoutShot(shot);
+    const durationMs = layout.durationMs;
+    if (layout.unusedSourceMs > 0) {
+      trimmedShots.push({
+        shotId: shot.id,
+        usedMs: durationMs,
+        sourceMs: durationMs + layout.unusedSourceMs
+      });
+    }
     const videoClip = makeClip({
       trackId: shotTrack.id,
       name: shot.slug ?? `Shot ${shot.index + 1}`,
       startMs: cursorMs,
       durationMs,
+      ...(layout.inPointMs !== undefined
+        ? { inPointMs: layout.inPointMs, outPointMs: layout.outPointMs }
+        : {}),
       mediaType: "video",
       sourceType: "imported",
       status: "generated",
@@ -211,7 +287,7 @@ export function buildStoryboardTimeline(
     );
   }
 
-  return { tracks, clips, durationMs: cursorMs, skippedShotIds };
+  return { tracks, clips, durationMs: cursorMs, skippedShotIds, trimmedShots };
 }
 
 export interface StoryboardPreviewInput {
@@ -273,12 +349,20 @@ export function buildStoryboardPreviewTimeline(
       stillShotIds.push(shot.id);
     }
 
-    const durationMs = shotDurationMs(shot);
+    // A held keyframe is a still with no source length of its own; only a
+    // real clip gets fitted to its footage.
+    const layout: ShotLayout = clipAssetId
+      ? layoutShot(shot)
+      : { durationMs: shotDurationMs(shot), unusedSourceMs: 0, short: false };
+    const durationMs = layout.durationMs;
     const shotClip = makeClip({
       trackId: shotTrack.id,
       name: shot.slug ?? `Shot ${shot.index + 1}`,
       startMs: cursorMs,
       durationMs,
+      ...(layout.inPointMs !== undefined
+        ? { inPointMs: layout.inPointMs, outPointMs: layout.outPointMs }
+        : {}),
       mediaType: clipAssetId ? "video" : "image",
       sourceType: "imported",
       status: "generated",

--- a/packages/timeline/src/storyboard.ts
+++ b/packages/timeline/src/storyboard.ts
@@ -217,9 +217,6 @@ export function buildStoryboardTimeline(
       name: shot.slug ?? `Shot ${shot.index + 1}`,
       startMs: cursorMs,
       durationMs,
-      ...(layout.inPointMs !== undefined
-        ? { inPointMs: layout.inPointMs, outPointMs: layout.outPointMs }
-        : {}),
       mediaType: "video",
       sourceType: "imported",
       status: "generated",
@@ -229,6 +226,12 @@ export function buildStoryboardTimeline(
       storyboardShotId: shot.id,
       versions: []
     });
+    // The window is written only when the source length is known: an unknown
+    // length leaves the clip exactly as it was before assembly could read one.
+    if (layout.inPointMs !== undefined) {
+      videoClip.inPointMs = layout.inPointMs;
+      videoClip.outPointMs = layout.outPointMs;
+    }
     clips.push(videoClip, shotAudioClip(videoClip, shotAudioTrack.id));
     cursorMs += durationMs;
   }
@@ -357,9 +360,6 @@ export function buildStoryboardPreviewTimeline(
       name: shot.slug ?? `Shot ${shot.index + 1}`,
       startMs: cursorMs,
       durationMs,
-      ...(layout.inPointMs !== undefined
-        ? { inPointMs: layout.inPointMs, outPointMs: layout.outPointMs }
-        : {}),
       mediaType: clipAssetId ? "video" : "image",
       sourceType: "imported",
       status: "generated",
@@ -369,6 +369,10 @@ export function buildStoryboardPreviewTimeline(
       storyboardShotId: shot.id,
       versions: []
     });
+    if (layout.inPointMs !== undefined) {
+      shotClip.inPointMs = layout.inPointMs;
+      shotClip.outPointMs = layout.outPointMs;
+    }
     clips.push(shotClip);
     // A held keyframe is a still: there is no rendered clip to take sound from.
     if (clipAssetId) {

--- a/packages/timeline/tests/storyboard.test.ts
+++ b/packages/timeline/tests/storyboard.test.ts
@@ -341,3 +341,115 @@ describe("buildStoryboardPreviewTimeline", () => {
     expect(picture.map((c) => c.name)).toEqual(["Shot 1", "Shot 2"]);
   });
 });
+
+// ── rendered length vs directed length ────────────────────────────────
+//
+// Reproduction of the shipped failure: eight shots directed at 1.0–3.5s all
+// came back from the model at 5.184s, and assembly laid down the directed
+// length with no in/out point — so every clip played its source's head and
+// discarded the rest without saying so.
+
+describe("assembly against the footage that came back", () => {
+  const renderedShot = (
+    id: string,
+    index: number,
+    directedSeconds: number,
+    sourceSeconds?: number
+  ): Shot =>
+    makeShot({
+      id,
+      index,
+      status: "rendered",
+      duration_seconds: directedSeconds,
+      clip:
+        sourceSeconds === undefined
+          ? { type: "video", asset_id: `asset-${id}` }
+          : { type: "video", asset_id: `asset-${id}`, duration: sourceSeconds }
+    });
+
+  it("writes an explicit source window and reports the unused footage", () => {
+    const result = buildStoryboardTimeline({
+      boardId: "board-1",
+      shots: [renderedShot("a", 0, 1.5, 5.184)]
+    });
+    const [picture] = pictureClips(result.clips);
+    expect(picture.durationMs).toBe(1500);
+    expect(picture.inPointMs).toBe(0);
+    expect(picture.outPointMs).toBe(1500);
+    expect(result.trimmedShots).toEqual([
+      { shotId: "a", usedMs: 1500, sourceMs: 5184 }
+    ]);
+  });
+
+  it("never lays down more timeline than the render holds", () => {
+    const result = buildStoryboardTimeline({
+      boardId: "board-1",
+      shots: [renderedShot("a", 0, 8, 5.184)]
+    });
+    const [picture] = pictureClips(result.clips);
+    expect(picture.durationMs).toBe(5184);
+    expect(result.durationMs).toBe(5184);
+    expect(result.trimmedShots).toEqual([]);
+  });
+
+  it("leaves a shot whose source length is unknown exactly as before", () => {
+    const result = buildStoryboardTimeline({
+      boardId: "board-1",
+      shots: [renderedShot("a", 0, 1.5)]
+    });
+    const [picture] = pictureClips(result.clips);
+    expect(picture.durationMs).toBe(1500);
+    expect(picture.inPointMs).toBeUndefined();
+    expect(result.trimmedShots).toEqual([]);
+  });
+
+  it("keeps the audio twin on the same window as its picture", () => {
+    const result = buildStoryboardTimeline({
+      boardId: "board-1",
+      shots: [renderedShot("a", 0, 1.5, 5.184)]
+    });
+    const audio = result.clips.filter((c) => c.mediaType === "audio");
+    expect(audio).toHaveLength(1);
+    expect(audio[0].durationMs).toBe(1500);
+  });
+
+  it("lays the whole board end to end without gaps or overlaps", () => {
+    const result = buildStoryboardTimeline({
+      boardId: "board-1",
+      shots: [
+        renderedShot("a", 0, 1.5, 5.184),
+        renderedShot("b", 1, 1.0, 5.184),
+        renderedShot("c", 2, 2.0, 5.184)
+      ]
+    });
+    expect(pictureClips(result.clips).map((c) => [c.startMs, c.durationMs])).toEqual(
+      [
+        [0, 1500],
+        [1500, 1000],
+        [2500, 2000]
+      ]
+    );
+    expect(result.durationMs).toBe(4500);
+    expect(result.trimmedShots).toHaveLength(3);
+  });
+
+  it("fits a preview clip to its footage too, and leaves stills alone", () => {
+    const result = buildStoryboardPreviewTimeline({
+      boardId: "board-1",
+      shots: [
+        renderedShot("a", 0, 8, 5.184),
+        makeShot({
+          id: "b",
+          index: 1,
+          status: "keyframe_ready",
+          duration_seconds: 3,
+          keyframe: keyframeRef("still-b")
+        })
+      ]
+    });
+    const [clip, still] = pictureClips(result.clips);
+    expect(clip.durationMs).toBe(5184);
+    expect(still.durationMs).toBe(3000);
+    expect(still.inPointMs).toBeUndefined();
+  });
+});

--- a/web/src/hooks/timeline/__tests__/useTimelineAgentBridge.test.tsx
+++ b/web/src/hooks/timeline/__tests__/useTimelineAgentBridge.test.tsx
@@ -190,3 +190,83 @@ describe("useTimelineAgentBridge setTimeRemap", () => {
     expect(clipById("clip-1").timeRemap).toBeUndefined();
   });
 });
+
+// The frame extractor and the asset lookup are the two things a frame grab
+// touches outside the store; both are stubbed so the test is about which
+// times the bridge asks for.
+jest.mock("../../../components/timeline/Tracks/clipThumbnails", () => ({
+  extractVideoFrames: jest.fn(
+    async (_url: string, timesSec: number[], width: number) =>
+      timesSec.map((time) => ({
+        time,
+        width,
+        height: width,
+        dataUrl: "data:image/jpeg;base64,"
+      }))
+  )
+}));
+jest.mock("../../../stores/AssetStore", () => ({
+  useAssetStore: {
+    getState: () => ({
+      get: async () => ({ id: "asset-1", get_url: "https://example.test/a.mp4" })
+    })
+  }
+}));
+
+describe("useTimelineAgentBridge getClipFrames", () => {
+  /** A clip whose media starts a long way into the cut, as an assembly lays it. */
+  const seedLateClip = (): void => {
+    mockDoc.getState().addTrack("video", "Shots");
+    const trackId = mockDoc.getState().tracks[0].id;
+    mockDoc.getState().addClip(
+      makeClip({
+        id: "shot-4",
+        name: "Shot 4",
+        trackId,
+        mediaType: "video",
+        sourceType: "imported",
+        status: "generated",
+        currentAssetId: "asset-1",
+        startMs: 15552,
+        durationMs: 5184
+      })
+    );
+  };
+
+  it("reads clip-relative times on a clip that does not start at zero", async () => {
+    seedLateClip();
+    renderHook(() => useTimelineAgentBridge(SEQ_ID));
+
+    // "200ms into this clip" is what a caller inspecting one clip means. It
+    // used to be refused outright: `Frame time 200ms is outside clip "Shot 4"`.
+    const result = await getTimelineAgentHandler(SEQ_ID).getClipFrames(
+      "shot-4",
+      { timesMs: [200, 1800] }
+    );
+    expect(result.frames.map((f) => f.timelineTimeMs)).toEqual([15752, 17352]);
+    expect(result.frames.map((f) => f.sourceTimeMs)).toEqual([200, 1800]);
+  });
+
+  it("still reads a timeline time inside the clip as a timeline time", async () => {
+    seedLateClip();
+    renderHook(() => useTimelineAgentBridge(SEQ_ID));
+
+    const result = await getTimelineAgentHandler(SEQ_ID).getClipFrames(
+      "shot-4",
+      { timesMs: [15752, 20400] }
+    );
+    expect(result.frames.map((f) => f.timelineTimeMs)).toEqual([15752, 20400]);
+    expect(result.frames.map((f) => f.sourceTimeMs)).toEqual([200, 4848]);
+  });
+
+  it("names both accepted ranges when a time fits neither", async () => {
+    seedLateClip();
+    renderHook(() => useTimelineAgentBridge(SEQ_ID));
+
+    await expect(
+      getTimelineAgentHandler(SEQ_ID).getClipFrames("shot-4", {
+        timesMs: [90000]
+      })
+    ).rejects.toThrow(/15552–20736ms.*0–5184ms/s);
+  });
+});

--- a/web/src/hooks/timeline/useTimelineAgentBridge.ts
+++ b/web/src/hooks/timeline/useTimelineAgentBridge.ts
@@ -101,6 +101,31 @@ function sampleClipTimelineTimes(clip: TimelineClip, count: number): number[] {
   );
 }
 
+/**
+ * Resolve a caller's frame time to a timeline time.
+ *
+ * `timesMs` is documented as timeline time, but a caller inspecting one clip
+ * thinks in that clip's own time — "show me 200ms in" — and a clip that starts
+ * at 15552ms then rejected every number a reasonable caller passed. Both
+ * readings are accepted: a time inside the clip's timeline span is timeline
+ * time, and otherwise a time inside `0…durationMs` is clip-relative. The two
+ * only overlap on a clip that starts at 0, where they mean the same frame.
+ */
+function timelineTimeForFrameRequest(
+  clip: TimelineClip,
+  requestedMs: number
+): number {
+  const clipStart = clip.startMs;
+  const clipEnd = clip.startMs + clip.durationMs;
+  if (requestedMs >= clipStart && requestedMs <= clipEnd) return requestedMs;
+  if (requestedMs >= 0 && requestedMs <= clip.durationMs) {
+    return clipStart + requestedMs;
+  }
+  throw new Error(
+    `Frame time ${requestedMs}ms is outside clip "${clip.name}": pass a timeline time in ${clipStart}–${clipEnd}ms, or a clip-relative time in 0–${clip.durationMs}ms.`
+  );
+}
+
 function sourceTimeForTimelineTime(
   clip: TimelineClip,
   timelineTimeMs: number
@@ -743,9 +768,10 @@ export const useTimelineAgentBridge = (sequenceId: string | null): void => {
           opts.timesMs && opts.timesMs.length > 0
             ? opts.timesMs
                 .slice(0, MAX_FRAME_COUNT)
-                .map((time) => Math.round(time))
+                .map((time) =>
+                  timelineTimeForFrameRequest(clip, Math.round(time))
+                )
             : sampleClipTimelineTimes(clip, opts.count ?? DEFAULT_FRAME_COUNT);
-        timelineTimes.forEach((time) => sourceTimeForTimelineTime(clip, time));
         const width = clampNumber(
           Math.round(opts.width ?? DEFAULT_FRAME_WIDTH),
           1,


### PR DESCRIPTION
## What changed

A `/commercial-beat-sheet` session hit four walls; each is fixed at its cause, with a test that reproduces the failure first. **(1)** `render_storyboard_clips` never recorded how long a render actually was, so eight shots directed at 1.0–3.5s that all came back at 5.184s were laid down at their directed length with no in/out point — the cut played each source's head and discarded the rest silently ("the clips are all 5 seconds but the timeline is cut differently"). The render now reads the length from the MP4 movie header (pure, no ffprobe, on bytes already in hand), assembly fits a shot to the footage that exists and writes an explicit source window, and `assemble_storyboard_timeline` reports the mismatch instead of leaving it to be found in playback. **(2)** `edit_storyboard` refused `set_entities` — the name of the browser tool a script is written against — with a list of five ops, none of which said which one takes `entity_ids`; that name and five other near-misses now resolve, while a name that means nothing is still refused. **(3)** `ui_timeline_get_clip_frames` rejected clip-relative times, so "200ms into this clip" on a clip starting at 15552ms answered `Frame time 200ms is outside clip`; both readings are now accepted and the error names both ranges. **(4)** A vision judge that spends its token ceiling on reasoning stops mid-JSON, and `critique_image` returned "did not return parseable JSON", discarding a finished verdict and the defects written before the cut — truncated replies are now salvaged to their last complete value, the error names the cause when nothing parses, and `understand_video` reports `truncated` so half an answer is not read as the whole one.

Not addressed here, and still open from the same transcript: `ui_timeline_get_state` truncating its reply on a large sequence with no compact or paged mode; `nodetool.timelines.get()` returning `{timeline: …}` where `ui_timeline_get_state` returns a flat shape, which cost the run three calls to discover; and one observed case where a `set_clip_params` mute reported `ok` but the render that followed did not carry it (re-applying worked) — I could not reproduce that one.

## Verification

An earlier revision of this description ticked `typecheck` and `lint` on exit codes read from a background wrapper rather than from the scripts themselves. That was wrong, and CI caught it: `lint` was failing on this diff (`no-conditional-empty-object-spread`, twice in `packages/timeline/src/storyboard.ts`). Fixed in d3a224fd — the in/out points are assigned after the clip is built instead of spread conditionally, which is the same behavior. Re-run directly since:

- [x] `npm run lint` — exits 0 (was failing; the error was reproduced locally first with `npx oxlint -c .oxlintrc.anti-slop-enforced.json packages/timeline/src/storyboard.ts`)
- [x] `npm run typecheck` — **web and electron only.** The mobile leg cannot run in this container: `mobile/node_modules` does not exist (mobile is not a root workspace), so `tsc` fails on `File 'expo/tsconfig.base' not found` before reading any source. CI runs that leg properly.
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — `Gate: 4/4 selfchecks passed`, `exit=0`. Its first run caught two `capabilities-media` assertions that compare the whole `understand_video` reply and so had to name the new fields; fixed in bb335b59 and green on re-run.
- [x] `npm run test:affected` — one unrelated failure: `packages/video-nodes` `timeline-time-remap-decode.test.ts` times out in a `beforeAll` that shells out to ffmpeg to encode a fixture (`Hook timed out in 60000ms`), with all 7 of its own tests skipped for want of a WebGPU device. It imports nothing in this diff.

Inverted to prove each new check can fail:

- Assembly: `const source = shotSourceDurationMs(shot)` → `null` ⇒ `Tests 4 failed | 16 passed` in `packages/timeline/tests/storyboard.test.ts`.
- Op alias: `resolveBoardOpName` returning `null` for every alias ⇒ `FAIL … casts entities through the op name the browser tool goes by`.
- Clip-relative times: dropping the clip-relative branch ⇒ `✕ reads clip-relative times on a clip that does not start at zero`.
- JSON salvage: the reproduction asserts `extractJSON(CUT_OFF)` is `null` in the same test that asserts the salvage recovers the verdict, so the new path is the only thing that can make it pass.

## Agent capabilities

No capability is added and no declared contract changes: `understand_video` gains two fields on its *result* (its input schema, name, description text aside, and permission category are unchanged), and `edit_storyboard` accepts a superset of the op names it accepted before.

- [x] `npm run capabilities:check` passes (`capability table is current (264 capabilities)`)

## New checks

- [x] Each new check was inverted once and observed failing; the commands and their output are in **Verification** above.
- [x] The MP4 probe's tests assert it *finds* a duration in four hand-built containers, so it cannot pass by reading nothing, and separately assert it returns `null` rather than `0` for bytes it cannot parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Byjp8B18PuB3oPXJ8CXmzM