### PR TITLE
fix(timeline,media): close the gaps a motion-graphics build fell into

### DIFF
--- a/packages/agents/src/capabilities/media.specs.ts
+++ b/packages/agents/src/capabilities/media.specs.ts
@@ -694,18 +694,18 @@ export const FFPROBE_SCHEMA: JsonSchema = {
     path: {
       type: "string" as const,
       description:
-        "Workspace-relative media file to inspect. Cannot escape the " +
-        "workspace. To inspect an asset, name it in `inputs` under this path."
+        "Media to inspect: a workspace-relative path, or an `asset://` URI " +
+        "or `/api/storage/` key, which is staged into the workspace for you. " +
+        "Any other URL is refused — nothing here fetches the network."
     },
     inputs: {
       type: "object" as const,
       description:
         "Files to copy into the workspace before the run, as " +
         "{\"<workspace-relative name>\": \"<asset:// URI, /api/storage/ key, " +
-        "or data: URI>\"} — the same staging `ffmpeg` takes. This is how an " +
-        "asset reaches ffprobe: stage it, then name it in `path`. At most 8 " +
-        "files, 100 MB each. " +
-        "Example: {\"clip.mp4\": \"asset://<id>.mp4\"} with path \"clip.mp4\".",
+        "or data: URI>\"} — the same staging `ffmpeg` takes. `path` stages an " +
+        "asset by itself, so this is for the extra files a probe needs. At " +
+        "most 8 files, 100 MB each.",
       additionalProperties: { type: "string" as const }
     },
     timeout_seconds: {
@@ -721,8 +721,9 @@ export const ffprobeSpec: CapabilitySpec = {
   description:
     "Read a media file's format and streams with ffprobe: duration, size, " +
     "bit rate, and per-stream codec/resolution/frame rate/channels. Takes a " +
-    "workspace path, not argv; put asset:// URIs in `inputs` to stage them " +
-    "first. ffprobe reports every number as a string, so the answer also " +
+    "workspace path, not argv — or an `asset://` URI / `/api/storage/` key " +
+    "in `path` directly, which it stages for itself; `inputs` stages the " +
+    "rest. ffprobe reports every number as a string, so the answer also " +
     "carries a `summary` with duration_seconds/width/height/has_audio as " +
     "real numbers and booleans. Use it before ffmpeg to decide what to do.",
   inputSchema: FFPROBE_SCHEMA,

--- a/packages/agents/src/capabilities/media.ts
+++ b/packages/agents/src/capabilities/media.ts
@@ -53,6 +53,7 @@ import {
   assertResolvedHostAllowed
 } from "../network-guard.js";
 import { encodeBase64 as encodeMediaBase64 } from "../sandbox-bytes.js";
+import { imagePixelSize } from "../sandbox-media.js";
 import {
   DEFAULT_MIME,
   MAX_MEDIA_REF_BYTES,
@@ -650,6 +651,75 @@ const segmentImage: CapabilityExport = {
   }
 };
 
+/**
+ * Read a generation parameter under any of the spellings a caller reaches for.
+ *
+ * The schemas are snake_case, the JS guest API takes an options bag, and the
+ * `TextToVideo` node's own property is `duration` — so a build asked for a
+ * 15-second clip with `{duration: 15}`, was billed for the model's 5-second
+ * default, and had nothing in the result saying the argument had been dropped.
+ * A silently ignored parameter on a call that spends money is the expensive
+ * kind of typo, and every one of these spellings means one thing.
+ */
+function aliased(
+  params: Record<string, unknown>,
+  canonical: string,
+  ...aliases: string[]
+): unknown {
+  for (const key of [canonical, ...aliases]) {
+    const value = params[key];
+    if (value !== undefined && value !== null) return value;
+  }
+  return undefined;
+}
+
+/** The generation parameters every video capability forwards, de-aliased. */
+function videoShapeParams(params: Record<string, unknown>): {
+  num_frames: unknown;
+  duration_seconds: unknown;
+  aspect_ratio: unknown;
+  resolution: unknown;
+} {
+  return {
+    num_frames: aliased(params, "num_frames", "numFrames", "frames"),
+    duration_seconds: aliased(
+      params,
+      "duration_seconds",
+      "durationSeconds",
+      "duration"
+    ),
+    aspect_ratio: aliased(params, "aspect_ratio", "aspectRatio", "aspect"),
+    resolution: aliased(params, "resolution")
+  };
+}
+
+/** The aspect ratios the video providers name, as width/height. */
+const ASPECT_RATIOS: ReadonlyArray<readonly [string, number]> = [
+  ["21:9", 21 / 9],
+  ["16:9", 16 / 9],
+  ["4:3", 4 / 3],
+  ["1:1", 1],
+  ["3:4", 3 / 4],
+  ["9:16", 9 / 16]
+];
+
+/** The listed ratio closest to `width/height`, or null for a bad size. */
+export function nearestAspectRatio(
+  width: number,
+  height: number
+): string | null {
+  if (!Number.isFinite(width) || !Number.isFinite(height)) return null;
+  if (width <= 0 || height <= 0) return null;
+  const target = width / height;
+  let best = ASPECT_RATIOS[0]!;
+  for (const candidate of ASPECT_RATIOS) {
+    if (Math.abs(candidate[1] - target) < Math.abs(best[1] - target)) {
+      best = candidate;
+    }
+  }
+  return best[0];
+}
+
 const generateVideo: CapabilityExport = {
   spec: generateVideoSpec,
   impl: async (run, params) => {
@@ -666,11 +736,8 @@ const generateVideo: CapabilityExport = {
       mime: "video/mp4",
       params: {
         prompt,
-        negative_prompt: params["negative_prompt"],
-        num_frames: params["num_frames"],
-        duration_seconds: params["duration_seconds"],
-        aspect_ratio: params["aspect_ratio"],
-        resolution: params["resolution"]
+        negative_prompt: aliased(params, "negative_prompt", "negativePrompt"),
+        ...videoShapeParams(params)
       }
     });
   }
@@ -691,20 +758,26 @@ const animateImage: CapabilityExport = {
     } catch (e) {
       return predictionError("image_to_video", m, e);
     }
+    const shape = videoShapeParams(params);
+    // A vertical still animated at the provider's default aspect comes back
+    // 16:9, cropped or padded, and the caller finds out when the ad is cut:
+    // three 1280x720 beds under a 1080x1920 sequence. The source image is the
+    // best statement of intent available, so it sets the ratio when the call
+    // does not.
+    if (shape.aspect_ratio === undefined) {
+      const size = imagePixelSize(image);
+      const derived = size
+        ? nearestAspectRatio(size.width, size.height)
+        : null;
+      if (derived) shape.aspect_ratio = derived;
+    }
     return runMediaGeneration(run, params, {
       capability: "image_to_video",
       m,
       type: "video",
       namePrefix: "animated-video",
       mime: "video/mp4",
-      params: {
-        image,
-        prompt: params["prompt"],
-        num_frames: params["num_frames"],
-        duration_seconds: params["duration_seconds"],
-        aspect_ratio: params["aspect_ratio"],
-        resolution: params["resolution"]
-      }
+      params: { image, prompt: params["prompt"], ...shape }
     });
   }
 };
@@ -1073,7 +1146,12 @@ const generateMusic: CapabilityExport = {
     const musicParams = {
       prompt,
       lyrics: params["lyrics"],
-      duration_seconds: params["duration_seconds"],
+      duration_seconds: aliased(
+        params,
+        "duration_seconds",
+        "durationSeconds",
+        "duration"
+      ),
       audioFormat: desiredFormat
     };
     const req: GenerationRequest = {
@@ -2127,6 +2205,30 @@ export function ffprobeSummary(parsed: Record<string, unknown>): Record<
 }
 
 /**
+ * Refs `ffprobe` stages for itself, rather than refusing.
+ *
+ * These are the forms NodeTool's own tools hand back, so a caller probing a
+ * clip it just generated is passing the string it was given. An http(s) URL is
+ * not here: fetching one is egress, and egress belongs to the surfaces that
+ * declare it.
+ */
+function isStageableProbeRef(value: string): boolean {
+  return (
+    value.startsWith("asset://") ||
+    value.startsWith("/api/storage/") ||
+    value.startsWith("data:")
+  );
+}
+
+/** A workspace file name for a staged probe target, from the ref itself. */
+function probeStagingName(ref: string): string {
+  if (ref.startsWith("data:")) return "ffprobe-input/input";
+  const tail = ref.split("/").pop() ?? "input";
+  const safe = tail.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 64);
+  return `ffprobe-input/${safe || "input"}`;
+}
+
+/**
  * ffprobe with an argv NodeTool writes, not the caller.
  *
  * Everything a caller can say is one workspace path, so the whole boundary is
@@ -2146,20 +2248,33 @@ const ffprobe: CapabilityExport = {
     if (!isNonBlankString(target)) {
       return { error: "path is required" };
     }
+    const requested = target.trim();
+    // ffprobe's whole argv is this one path, so an `asset://` here can only
+    // mean "probe that": there is no flag to smuggle and nothing else to
+    // confine. Refusing it made the two halves of one loop disagree — the
+    // guest's own `video.info(asset://…)` reads a ref happily — and a caller
+    // who just wanted a duration had to stage the file by hand first.
+    const autoStaged = isStageableProbeRef(requested);
+    const probePath = autoStaged ? probeStagingName(requested) : requested;
+    let toStage = params["inputs"];
+    if (autoStaged) {
+      const extra = isRecord(toStage) ? toStage : {};
+      toStage = { ...extra, [probePath]: requested };
+    }
     const stagedResult = await stageInputs(
       run.context,
       workspace,
       cwd,
-      params["inputs"]
+      toStage
     );
     if ("error" in stagedResult) return stagedResult;
     const refusal = await confineArgvToWorkspace(
-      [target.trim()],
+      [probePath],
       cwd,
       FFPROBE_REMEDY
     );
     if (refusal) return refusal;
-    await stageHostBinaryInputs(workspace, [target.trim()]);
+    await stageHostBinaryInputs(workspace, [probePath]);
 
     const timeoutMs =
       clampTimeoutSeconds(params["timeout_seconds"], 30, 120) * 1000;
@@ -2173,7 +2288,7 @@ const ffprobe: CapabilityExport = {
           "json",
           "-show_format",
           "-show_streams",
-          target.trim()
+          probePath
         ],
         { cwd, timeoutMs }
       );
@@ -2187,7 +2302,7 @@ const ffprobe: CapabilityExport = {
         return { error: "ffprobe returned no readable JSON" };
       }
       const report: Record<string, unknown> = {
-        path: target.trim(),
+        path: requested,
         ...parsed,
         summary: ffprobeSummary(parsed)
       };

--- a/packages/agents/src/evals/surfaces/timeline.ts
+++ b/packages/agents/src/evals/surfaces/timeline.ts
@@ -83,6 +83,10 @@ import {
   maskParams,
   matteParams,
   partialTextStyleParams,
+  deleteTrackShape,
+  resolveDeleteTrackArgs,
+  withTextClipRemedies,
+  DELETE_TRACK_DESCRIPTION,
   setParentParams,
   setTimeRemapParams,
   timeRemapParams,
@@ -1010,17 +1014,19 @@ export function createTimelineToolBridge(
     tool(
       "ui_timeline_add_text_clip",
       ADD_TEXT_CLIP_DESCRIPTION,
-      z
-        .object({
-          text: z.string().trim().min(1),
-          trackId: z.string().optional(),
-          startMs: z.number().optional(),
-          durationMs: z.number().optional(),
-          opacity: clipOpacityParam,
-          style: partialTextStyleParams.optional()
-        })
-        .merge(partialTextStyleParams)
-        .strict(),
+      withTextClipRemedies(
+        z
+          .object({
+            text: z.string().trim().min(1),
+            trackId: z.string().optional(),
+            startMs: z.number().optional(),
+            durationMs: z.number().optional(),
+            opacity: clipOpacityParam,
+            style: partialTextStyleParams.optional()
+          })
+          .merge(partialTextStyleParams)
+          .strict()
+      ),
       async ({
         text,
         trackId,
@@ -1056,6 +1062,52 @@ export function createTimelineToolBridge(
         clips.push(clip);
         selectedClipIds = [clip.id];
         return { ok: true, clip: serializeClip(clip) };
+      }
+    ),
+
+    tool(
+      "ui_timeline_delete_track",
+      DELETE_TRACK_DESCRIPTION,
+      z.object(deleteTrackShape).strict(),
+      async (args) => {
+        const { target, deleteClips } = resolveDeleteTrackArgs(args);
+        const track = resolveTrack(target);
+        const onIt = clips.filter((c) => c.trackId === track.id);
+        if (onIt.length > 0 && !deleteClips) {
+          throw new Error(
+            `Track "${track.name}" still holds ${onIt.length} clip(s): ` +
+              `${onIt.map((c) => c.id).join(", ")}. Move them first, or pass ` +
+              "deleteClips: true to delete them with the track."
+          );
+        }
+        const removedClipIds = onIt.map((c) => c.id);
+        const kept = clips.filter((c) => c.trackId !== track.id);
+        clips.length = 0;
+        clips.push(...kept);
+        // A parent that went with the track would leave its children pointing
+        // at a clip that no longer exists, which the validator reads as a
+        // broken document rather than a deletion.
+        for (const clip of clips) {
+          if (clip.parentId && removedClipIds.includes(clip.parentId)) {
+            delete clip.parentId;
+          }
+        }
+        selectedClipIds = selectedClipIds.filter(
+          (id) => !removedClipIds.includes(id)
+        );
+        const remaining = tracks.filter((t) => t.id !== track.id);
+        tracks.length = 0;
+        // Index is z-order, so the stack has to close over the gap.
+        remaining.forEach((t, i) => {
+          t.index = i;
+          tracks.push(t);
+        });
+        return {
+          ok: true,
+          deleted: { id: track.id, name: track.name, type: track.type },
+          deletedClipIds: removedClipIds,
+          tracks: tracks.map(serializeTrack)
+        };
       }
     ),
 

--- a/packages/agents/src/sandbox-media.ts
+++ b/packages/agents/src/sandbox-media.ts
@@ -441,6 +441,80 @@ export function sniffImageFormat(bytes: Uint8Array): string {
 }
 
 /**
+ * An image's pixel size from its header alone.
+ *
+ * Decoding to ask how big something is costs a full rasterization and, for the
+ * formats the backend does not build with, fails outright — so this reads the
+ * four formats whose dimensions sit in a fixed place near the front. An
+ * unrecognized format is null: a caller wanting a shape has to cope with not
+ * knowing it, and a wrong guess is worse than none.
+ */
+export function imagePixelSize(
+  bytes: Uint8Array
+): { width: number; height: number } | null {
+  const at = (i: number): number => bytes[i] ?? 0;
+  const be16 = (i: number): number => (at(i) << 8) | at(i + 1);
+  const be32 = (i: number): number =>
+    at(i) * 0x1000000 + (at(i + 1) << 16) + (at(i + 2) << 8) + at(i + 3);
+  const le16 = (i: number): number => at(i) | (at(i + 1) << 8);
+  const format = sniffImageFormat(bytes);
+
+  if (format === "png" && bytes.length >= 24) {
+    return { width: be32(16), height: be32(20) };
+  }
+  if (format === "gif" && bytes.length >= 10) {
+    return { width: le16(6), height: le16(8) };
+  }
+  if (format === "jpeg") {
+    // Walk the segment chain to the frame header; SOF0..SOF15 carry the size,
+    // minus the four that are not frames (DHT, JPG, DAC, and the restarts).
+    let offset = 2;
+    while (offset + 9 < bytes.length) {
+      if (at(offset) !== 0xff) {
+        offset += 1;
+        continue;
+      }
+      const marker = at(offset + 1);
+      const size = be16(offset + 2);
+      if (size < 2) return null;
+      const isFrame =
+        marker >= 0xc0 &&
+        marker <= 0xcf &&
+        marker !== 0xc4 &&
+        marker !== 0xc8 &&
+        marker !== 0xcc;
+      if (isFrame) {
+        return { height: be16(offset + 5), width: be16(offset + 7) };
+      }
+      offset += 2 + size;
+    }
+    return null;
+  }
+  if (format === "webp" && bytes.length >= 30) {
+    // VP8X carries a 24-bit canvas size; lossy (VP8 ) and lossless (VP8L)
+    // each spell it differently.
+    const chunk = String.fromCharCode(at(12), at(13), at(14), at(15));
+    if (chunk === "VP8X") {
+      const dim = (i: number): number =>
+        (at(i) | (at(i + 1) << 8) | (at(i + 2) << 16)) + 1;
+      return { width: dim(24), height: dim(27) };
+    }
+    if (chunk === "VP8 ") {
+      return { width: le16(26) & 0x3fff, height: le16(28) & 0x3fff };
+    }
+    if (chunk === "VP8L") {
+      const bits = at(21) | (at(22) << 8) | (at(23) << 16) | (at(24) << 24);
+      return {
+        width: (bits & 0x3fff) + 1,
+        height: ((bits >> 14) & 0x3fff) + 1
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Structural check before the native decoder sees the bytes./**
  * Structural check before the native decoder sees the bytes.
  *
  * `@napi-rs/canvas` does not merely fail on a truncated image — on linux-x64 it

--- a/packages/agents/tests/capabilities-media-ffprobe.test.ts
+++ b/packages/agents/tests/capabilities-media-ffprobe.test.ts
@@ -52,6 +52,27 @@ describe("ffprobe staging", () => {
     }
   });
 
+  it("stages a ref named in `path` itself", async () => {
+    // The refusal told the caller to stage it and pass a workspace name — for
+    // a capability whose whole argv *is* that one path, with no flag surface
+    // to guard. The guest's own `video.info(asset://…)` never asked for that,
+    // so a build probing three generated clips spent a round trip per clip
+    // learning the rule and another staging around it.
+    const dir = await mkdtemp(join(tmpdir(), "ffprobe-path-"));
+    try {
+      // The binary may not be here; staging happens before the spawn, so the
+      // file on disk is what this pins.
+      await asTool(ffprobe).process(workspaceContext(dir), {
+        path: "data:text/plain;base64,aGk="
+      });
+      expect(await readFile(join(dir, "ffprobe-input/input"), "utf8")).toBe(
+        "hi"
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("ffprobe refuses an inputs name that escapes the workspace", async () => {
     const dir = await mkdtemp(join(tmpdir(), "ffprobe-inputs-"));
     try {

--- a/packages/agents/tests/capabilities-media.test.ts
+++ b/packages/agents/tests/capabilities-media.test.ts
@@ -34,6 +34,7 @@ import {
   generateMusic,
   generateSpeech,
   generateVideo,
+  nearestAspectRatio,
   scoreImageAdherence,
   transcribeAudio,
   understandVideo,
@@ -788,5 +789,116 @@ describe("clip length on the video capabilities", () => {
     });
     const params = paramsOf(context);
     expect(params["duration_seconds"]).toBe(6);
+  });
+
+  /**
+   * `{duration: 15}` bought a 5-second clip: the schemas are snake_case, the
+   * guest API takes an options bag, and the `TextToVideo` node's own property
+   * is `duration`, so the spelling a caller reaches for is the one that was
+   * dropped without a word.
+   */
+  it("reads the length under the spellings a caller reaches for", async () => {
+    for (const [key, value] of [
+      ["duration", 15],
+      ["durationSeconds", 12]
+    ] as const) {
+      const context = videoContext();
+      await asTool(generateVideo).process(context, {
+        provider: "fal_ai",
+        model: "bytedance/seedance-2.0/text-to-video",
+        prompt: "a glowing node graph",
+        [key]: value
+      });
+      expect(paramsOf(context)["duration_seconds"]).toBe(value);
+    }
+  });
+
+  it("reads aspect_ratio and negative_prompt under their camel spellings", async () => {
+    const context = videoContext();
+    await asTool(generateVideo).process(context, {
+      provider: "fal_ai",
+      model: "bytedance/seedance-2.0/text-to-video",
+      prompt: "a glowing node graph",
+      aspectRatio: "9:16",
+      negativePrompt: "no text"
+    });
+    const params = paramsOf(context);
+    expect(params["aspect_ratio"]).toBe("9:16");
+    expect(params["negative_prompt"]).toBe("no text");
+  });
+});
+
+/**
+ * A vertical still animated at the provider's default came back 1280x720, and
+ * the mismatch surfaced only when the beds were already under the type.
+ */
+describe("animate_image takes its shape from the still", () => {
+  /** A PNG header is enough: nothing decodes these bytes. */
+  function pngOf(width: number, height: number): Uint8Array {
+    const bytes = new Uint8Array(33);
+    bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    bytes.set([0x49, 0x48, 0x44, 0x52], 12);
+    new DataView(bytes.buffer).setUint32(16, width, false);
+    new DataView(bytes.buffer).setUint32(20, height, false);
+    return bytes;
+  }
+
+  function contextFor(image: Uint8Array): ProcessingContext {
+    return withGenerationSeam({
+      userId: "user-1",
+      runProviderPrediction: vi.fn(async () => new Uint8Array([1, 2, 3])),
+      workspace: {
+        localDir: null,
+        write: async () => {},
+        read: async () => image,
+        key: (p: string) => p
+      }
+    }) as unknown as ProcessingContext;
+  }
+
+  const sentParams = (context: ProcessingContext): Record<string, unknown> =>
+    (
+      (
+        context.runProviderPrediction as unknown as ReturnType<typeof vi.fn>
+      ).mock.calls[0][0] as Record<string, unknown>
+    )["params"] as Record<string, unknown>;
+
+  it("picks the closest named ratio, not an invented one", () => {
+    expect(nearestAspectRatio(1080, 1920)).toBe("9:16");
+    expect(nearestAspectRatio(1280, 720)).toBe("16:9");
+    expect(nearestAspectRatio(1024, 1024)).toBe("1:1");
+    expect(nearestAspectRatio(1536, 1152)).toBe("4:3");
+    expect(nearestAspectRatio(0, 100)).toBeNull();
+  });
+
+  it("derives 9:16 from a vertical still", async () => {
+    const context = contextFor(pngOf(720, 1280));
+    await asTool(animateImage).process(context, {
+      provider: "fal_ai",
+      model: "minimax/h3-max-turbo/image-to-video",
+      input_file: "still.png"
+    });
+    expect(sentParams(context)["aspect_ratio"]).toBe("9:16");
+  });
+
+  it("leaves an aspect the caller named alone", async () => {
+    const context = contextFor(pngOf(720, 1280));
+    await asTool(animateImage).process(context, {
+      provider: "fal_ai",
+      model: "minimax/h3-max-turbo/image-to-video",
+      input_file: "still.png",
+      aspect_ratio: "1:1"
+    });
+    expect(sentParams(context)["aspect_ratio"]).toBe("1:1");
+  });
+
+  it("says nothing when the bytes are not an image it can read", async () => {
+    const context = contextFor(new Uint8Array([9, 9, 9]));
+    await asTool(animateImage).process(context, {
+      provider: "fal_ai",
+      model: "minimax/h3-max-turbo/image-to-video",
+      input_file: "still.bin"
+    });
+    expect(sentParams(context)["aspect_ratio"]).toBeUndefined();
   });
 });

--- a/packages/agents/tests/js-sandbox-media.test.ts
+++ b/packages/agents/tests/js-sandbox-media.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   MAX_CANVAS_OPS,
   asImageBytes,
+  imagePixelSize,
   renderCanvas,
   sniffImageFormat
 } from "../src/sandbox-media.js";
@@ -412,6 +413,40 @@ describe("byte coercion and format sniffing", () => {
       sniffImageFormat(new TextEncoder().encode("RIFF????WEBPVP8 "))
     ).toBe("webp");
     expect(sniffImageFormat(new Uint8Array([1, 2, 3, 4]))).toBe("unknown");
+  });
+
+  /**
+   * Asking a picture how big it is used to mean decoding it. The one caller
+   * that needs the answer — `animate_image`, deciding what aspect to ask the
+   * provider for — wants a number, not a rasterization it throws away.
+   */
+  it("reads pixel size out of the header", () => {
+    const png = new Uint8Array(33);
+    png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    png.set([0x49, 0x48, 0x44, 0x52], 12);
+    const view = new DataView(png.buffer);
+    view.setUint32(16, 720, false);
+    view.setUint32(20, 1280, false);
+    expect(imagePixelSize(png)).toEqual({ width: 720, height: 1280 });
+
+    // JPEG: SOI, an APP0 to skip, then the SOF0 that carries the size.
+    const jpeg = new Uint8Array([
+      0xff, 0xd8, 0xff, 0xe0, 0x00, 0x04, 0x00, 0x00, 0xff, 0xc0, 0x00, 0x11,
+      0x08, 0x02, 0x80, 0x01, 0xe0, 0x03, 0x00, 0x00
+    ]);
+    expect(imagePixelSize(jpeg)).toEqual({ width: 480, height: 640 });
+
+    const gif = new TextEncoder().encode("GIF89a\u0000\u0000\u0000\u0000");
+    gif[6] = 0x20;
+    gif[7] = 0x03;
+    gif[8] = 0x00;
+    gif[9] = 0x02;
+    expect(imagePixelSize(gif)).toEqual({ width: 800, height: 512 });
+  });
+
+  it("says nothing for bytes it cannot read a size out of", () => {
+    expect(imagePixelSize(new Uint8Array([1, 2, 3, 4]))).toBeNull();
+    expect(imagePixelSize(new Uint8Array([0xff, 0xd8, 0xff]))).toBeNull();
   });
 });
 

--- a/packages/agents/tests/timeline-op-ergonomics.test.ts
+++ b/packages/agents/tests/timeline-op-ergonomics.test.ts
@@ -359,3 +359,116 @@ describe("clip opacity at creation", () => {
   });
 });
 
+
+/**
+ * The 10-second social ad that produced these cases: eight clips, three of
+ * them refused for a zero offset, one of them drawn white over the whole frame
+ * because the geometry and the fill arrived in different bags, and a track
+ * added by mistake that could not be taken back.
+ */
+describe("ui_timeline_delete_track", () => {
+  it("removes an empty track and closes the stack over it", async () => {
+    const { b, byName } = bridge();
+    await byName["ui_timeline_add_track"].execute({ type: "overlay" });
+    const before = await byName["ui_timeline_get_state"].execute({});
+    expect((before as { tracks: unknown[] }).tracks).toHaveLength(2);
+
+    const result = (await byName["ui_timeline_delete_track"].execute({
+      target: "Overlay 2"
+    })) as { deleted: { name: string }; tracks: Array<{ index: number }> };
+
+    expect(result.deleted.name).toBe("Overlay 2");
+    expect(result.tracks.map((t) => t.index)).toEqual([0]);
+    expect(b.finalState().tracks).toHaveLength(1);
+  });
+
+  it("refuses to take clips with it unless told to", async () => {
+    const { byName } = bridge();
+    await expect(
+      byName["ui_timeline_delete_track"].execute({ trackId: "Video 1" })
+    ).rejects.toThrow(/still holds 1 clip/);
+  });
+
+  it("deletes the clips when told to, and drops them from the selection", async () => {
+    const { b, byName } = bridge();
+    await byName["ui_timeline_select_clip"].execute({ target: "shot" });
+    const result = (await byName["ui_timeline_delete_track"].execute({
+      trackId: "Video 1",
+      deleteClips: true
+    })) as { deletedClipIds: string[] };
+
+    expect(result.deletedClipIds).toHaveLength(1);
+    expect(b.finalState().clips).toHaveLength(0);
+    const state = (await byName["ui_timeline_get_state"].execute({})) as {
+      selectedClipIds: string[];
+    };
+    expect(state.selectedClipIds).toEqual([]);
+  });
+});
+
+describe("ui_timeline_add_text_clip", () => {
+  it("takes a drop shadow without its zero offsets", async () => {
+    const { byName } = bridge();
+    const result = await byName["ui_timeline_add_text_clip"].execute({
+      text: "Build AI",
+      fontSizePx: 150,
+      color: "#FFFFFF",
+      shadow: { color: "#000000", blurPx: 24 }
+    });
+    expect(
+      (clipOf(result).textStyle as { shadow: unknown }).shadow
+    ).toEqual({ color: "#000000", blurPx: 24, offsetX: 0, offsetY: 0 });
+  });
+
+  it("sends a caller reaching for x/y to the anchors", async () => {
+    const { byName } = bridge();
+    expect(() =>
+      byName["ui_timeline_add_text_clip"].execute({
+        text: "Build AI",
+        x: 0.5,
+        y: 0.42
+      })
+    ).toThrow(/verticalAlign/);
+  });
+
+  it("refuses a misspelled key inside a style bag instead of dropping it", async () => {
+    const { byName } = bridge();
+    expect(() =>
+      byName["ui_timeline_add_text_clip"].execute({
+        text: "Start building — free",
+        background: { color: "#FFFFFF", paddingPx: 34, cornerRadius: 40 }
+      })
+    ).toThrow(/radiusPx/);
+  });
+});
+
+describe("ui_timeline_add_shape_clip merges the bags", () => {
+  it("refuses a geometry key spelled wrong inside `shape`", () => {
+    const { byName } = bridge();
+    expect(() =>
+      byName["ui_timeline_add_shape_clip"].execute({
+        shape: { kind: "rect", fill: "#6D5EF6", radius: 8 }
+      })
+    ).toThrow(/radius/);
+  });
+
+
+  it("keeps the fill from `shape` and the box from the op", async () => {
+    const { byName } = bridge();
+    const result = await byName["ui_timeline_add_shape_clip"].execute({
+      shape: { kind: "rect", fill: "#0B0E1A" },
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 0.5
+    });
+    expect(clipOf(result).shapeStyle).toEqual({
+      kind: "rect",
+      fill: "#0B0E1A",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 0.5
+    });
+  });
+});

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -435,7 +435,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "understand_video",
     module: "media",
     impl: "packages/agents/src/capabilities/media.ts",
-    contract: "a5a78285c120",
+    contract: "f5f8b48f6315",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-media.test.ts",
@@ -457,7 +457,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "ffprobe",
     module: "media",
     impl: "packages/agents/src/capabilities/media.ts",
-    contract: "4ac5df4ed873",
+    contract: "b4bba48ad634",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-media.test.ts",

--- a/packages/protocol/src/api-schemas/timeline-tool-params.ts
+++ b/packages/protocol/src/api-schemas/timeline-tool-params.ts
@@ -22,7 +22,8 @@
  */
 
 import { z } from "zod";
-import { isString } from "../predicates.js";
+import { isRecord, isString } from "../predicates.js";
+import { withKeyRemedies } from "../zod-schema.js";
 import {
   captionStyle,
   clipShapeStyle,
@@ -141,6 +142,57 @@ export function resolveMoveTrackArgs(input: {
   return args;
 }
 
+/**
+ * `delete_track`'s arguments.
+ *
+ * Tracks were add-only: a build that reached for `add_track` one time too many
+ * — or created a picture track and then decided the piece was typographic —
+ * had no way back, and the op list said so only by omission. The editor's own
+ * track menu has removed a track and its clips all along, so the gap was the
+ * agent surface's alone.
+ *
+ * Deleting a track deletes the clips on it, which is the one thing about this
+ * op that can lose work, so an occupied track is refused unless the caller
+ * says `deleteClips: true`.
+ */
+export const deleteTrackShape = {
+  target: trackTargetParam.optional(),
+  trackId: trackTargetParam.optional().describe("Alias for `target`."),
+  deleteClips: z
+    .boolean()
+    .optional()
+    .describe(
+      "Required to delete a track that still holds clips; they go with it."
+    )
+} as const;
+
+export interface DeleteTrackArgs {
+  target: string;
+  deleteClips: boolean;
+}
+
+export function resolveDeleteTrackArgs(input: {
+  target?: unknown;
+  trackId?: unknown;
+  deleteClips?: unknown;
+}): DeleteTrackArgs {
+  const target = (input.target ?? input.trackId) as string | undefined;
+  if (!isString(target) || target.trim() === "") {
+    throw new Error(
+      "delete_track needs the track to delete in `target` (a track id or name)."
+    );
+  }
+  return { target, deleteClips: input.deleteClips === true };
+}
+
+export const DELETE_TRACK_DESCRIPTION =
+  "Remove one track from the specified timeline sequence, named in `target` " +
+  "(a track id or name). Every track below it moves up one index, which is " +
+  "z-order, so the stack closes over the gap. A track that still holds clips " +
+  "is refused unless you pass `deleteClips: true` — then the clips go with " +
+  "it. An empty track draws nothing, so delete one to tidy the stack, not to " +
+  "fix a render.";
+
 export const MOVE_TRACK_DESCRIPTION =
   "Reorder one track in the stack, which is what decides z-order: index 0 " +
   "draws on top of every track below it. Name the track in `target` and its " +
@@ -181,6 +233,42 @@ export function withFieldNotes<T extends z.ZodRawShape>(
   return z.object(next) as unknown as z.ZodObject<T>;
 }
 
+/**
+ * The nested bags of a text clip's look, refusing a key by name.
+ *
+ * The document schema strips what it does not know, which is right for a
+ * stored document and wrong for a tool call: `background: {color, paddingPx,
+ * cornerRadius: 40}` saved a square plate and reported success, because the
+ * field is spelled `radiusPx`. The top level has refused unknown keys since
+ * strict schemas went in; these are the same refusal one level down, where
+ * three of the four fields are named after a CSS property that is spelled
+ * differently here.
+ *
+ * The offsets default rather than being required: `{color, blurPx}` is a
+ * complete description of a centred drop shadow, and demanding `offsetX: 0`
+ * cost a round trip on a call that was already right.
+ */
+const textShadowParams = z
+  .object({
+    color: z.string().default("#000000"),
+    blurPx: z.number().default(0),
+    offsetX: z.number().default(0).describe("Default 0."),
+    offsetY: z.number().default(0).describe("Default 0.")
+  })
+  .strict();
+
+const textStrokeParams = z
+  .object({ color: z.string(), widthPx: z.number() })
+  .strict();
+
+const textBackgroundParams = z
+  .object({
+    color: z.string(),
+    paddingPx: z.number(),
+    radiusPx: z.number().optional().describe("Corner rounding, in sequence px.")
+  })
+  .strict();
+
 /** A text clip's whole authored look, as `set_clip_params` replaces it. */
 export const textStyleParams = withFieldNotes(clipTextStyle, {
   fontSizePx: "Font size in sequence pixels, not CSS pixels.",
@@ -188,13 +276,6 @@ export const textStyleParams = withFieldNotes(clipTextStyle, {
   letterSpacingPx: "Extra advance between glyphs, in sequence px. Default 0.",
   lineHeight: "Line advance as a multiple of the font size. Default 1.2.",
   maxWidthFrac: "Wrap width as a fraction of frame width.",
-  stroke: "Outline drawn under the fill: {color, widthPx}.",
-  shadow:
-    "Drop shadow behind the glyphs: {color, blurPx, offsetX, offsetY}. The " +
-    "blur field is `blurPx`, not `blur`.",
-  background:
-    "Scrim drawn behind the wrapped block: {color, paddingPx, radiusPx?}. " +
-    "An 8-digit hex or rgba() colour keeps the picture visible through it.",
   fill:
     "Gradient or solid fill, {type: \"solid\"|\"linear\"|\"radial\", ...}. " +
     "Wins over `color` when set."
@@ -220,8 +301,52 @@ export const textStyleParams = withFieldNotes(clipTextStyle, {
     .describe(
       '"top", "middle" (default) or "bottom". Not "center" — that is the ' +
         "horizontal `align` spelling."
+    ),
+  shadow: textShadowParams
+    .optional()
+    .describe(
+      "Drop shadow behind the glyphs: {color, blurPx, offsetX?, offsetY?}. " +
+        "The blur field is `blurPx`, not `blur`; the offsets default to 0."
+    ),
+  stroke: textStrokeParams
+    .optional()
+    .describe("Outline drawn under the fill: {color, widthPx}."),
+  background: textBackgroundParams
+    .optional()
+    .describe(
+      "Scrim drawn behind the wrapped block: {color, paddingPx, radiusPx?}. " +
+        "The rounding field is `radiusPx`, not `cornerRadius`. An 8-digit " +
+        "hex or rgba() colour keeps the picture visible through it."
     )
 });
+
+/**
+ * Where a text clip is placed, for a caller that reached for x/y.
+ *
+ * Text has no coordinates: it is anchored to one of nine positions and wrapped
+ * to `maxWidthFrac`. The refusal listed thirteen style fields and no
+ * coordinates, which reads as "text cannot be positioned" rather than "text is
+ * positioned differently".
+ */
+export const TEXT_CLIP_KEY_REMEDIES: Record<string, string> = {
+  x: "Text has no x/y: place it with `align` (left/center/right) and `verticalAlign` (top/middle/bottom), and set its wrap with `maxWidthFrac`. For a nudge off that anchor, animate `offsetX`/`offsetY` with the `custom` preset.",
+  y: "Text has no x/y: place it with `align` (left/center/right) and `verticalAlign` (top/middle/bottom), and set its wrap with `maxWidthFrac`. For a nudge off that anchor, animate `offsetX`/`offsetY` with the `custom` preset.",
+  width:
+    "A text clip has no box: its wrap width is `maxWidthFrac`, a fraction of the frame.",
+  height:
+    "A text clip has no box: its height follows the wrapped lines. Set `fontSizePx` and `lineHeight`.",
+  fontSize: "Font size is `fontSizePx`, in sequence pixels.",
+  blur: "Blur belongs to the shadow bag: {shadow: {color, blurPx}}.",
+  cornerRadius:
+    "The plate behind the words is `background: {color, paddingPx, radiusPx}`."
+};
+
+/** Attach {@link TEXT_CLIP_KEY_REMEDIES} to a host's `add_text_clip` schema. */
+export function withTextClipRemedies<TSchema extends z.ZodType>(
+  schema: TSchema
+): TSchema {
+  return withKeyRemedies(schema, TEXT_CLIP_KEY_REMEDIES);
+}
 
 /**
  * The same look on `add_text_clip`, where the words come from `text` and every
@@ -259,7 +384,10 @@ export const shapeStyleParams = withFieldNotes(clipShapeStyle, {
   lineJoin: '"miter", "round" or "bevel".',
   trimStart: "Stroke only the sub-range [trimStart, trimEnd] of the path, 0..1.",
   trimEnd: "Stroke only the sub-range [trimStart, trimEnd] of the path, 0..1."
-});
+  // Strict for the same reason the text bags are: a geometry key spelled
+  // wrong inside `shape` was stripped, and the shape drew at its default
+  // somewhere else on the frame with nothing said about it.
+}).strict();
 
 /**
  * What `add_text_clip` and `add_shape_clip` tell the model, shared so the
@@ -301,34 +429,57 @@ export const ADD_SHAPE_CLIP_DESCRIPTION =
   "Shapes are rasterized for preview/export and take the standard motion " +
   "presets.";
 
+/** Every key that says where a shape is or what outline it follows. */
+const SHAPE_GEOMETRY_KEYS = [
+  "x",
+  "y",
+  "width",
+  "height",
+  "x2",
+  "y2",
+  "d",
+  "sides",
+  "innerRadius"
+] as const;
+
 /**
- * The shape geometry for `add_shape_clip`, from whichever of the three forms
- * the caller used: `shape`, `shapeStyle` (the name `set_clip_params` takes),
- * or the geometry keys spread at the top level. With none of them the shape is
- * a full-frame rect — a caller that asked for a shape and named no box wants
- * something it can see, not a schema error about a field it did not know
- * existed.
+ * The shape geometry for `add_shape_clip`, merged from all three forms the
+ * caller may have used: `shape`, `shapeStyle` (the name `set_clip_params`
+ * takes), and the keys spread at the top level.
+ *
+ * They are one description of one shape, so they merge — `shape` wins a
+ * contested key, then `shapeStyle`, then the top level. Taking the first bag
+ * whole and dropping the rest is what put a white full-frame rectangle over a
+ * finished ad: the kind and fill went in `shape`, the box at the top level,
+ * and the call reported success having read half of it.
+ *
+ * With no geometry at all the shape is a full-frame rect — a caller that asked
+ * for a shape and named no box wants something it can see, not a schema error
+ * about a field it did not know existed. Geometry that *is* named is left
+ * alone, so a line keeps its two points and gains no width.
  */
 export function resolveShapeArg(
   shape: unknown,
   shapeStyle: unknown,
   loose: Record<string, unknown>
 ): z.infer<typeof shapeStyleParams> {
-  const given = (shape ?? shapeStyle) as
-    | z.infer<typeof shapeStyleParams>
-    | undefined;
-  if (given) return given;
-  const bare = Object.fromEntries(
-    Object.entries(loose).filter(([, value]) => value !== undefined)
-  );
-  const parsed = shapeStyleParams.safeParse({
+  const defined = (bag: unknown): Record<string, unknown> =>
+    isRecord(bag)
+      ? Object.fromEntries(
+          Object.entries(bag).filter(([, value]) => value !== undefined)
+        )
+      : {};
+  const bare = defined(loose);
+  const merged: Record<string, unknown> = {
     kind: "rect",
-    x: 0,
-    y: 0,
-    width: 1,
-    height: 1,
-    ...bare
-  });
+    ...bare,
+    ...defined(shapeStyle),
+    ...defined(shape)
+  };
+  const placed = SHAPE_GEOMETRY_KEYS.some((key) => key in merged);
+  const parsed = shapeStyleParams.safeParse(
+    placed ? merged : { ...merged, x: 0, y: 0, width: 1, height: 1 }
+  );
   if (!parsed.success) {
     throw new Error(
       'add_shape_clip takes the geometry in `shape` (or `shapeStyle`): ' +
@@ -823,6 +974,7 @@ export const SHARED_TIMELINE_TOOL_NAMES = [
   "ui_timeline_get_state",
   "ui_timeline_add_track",
   "ui_timeline_move_track",
+  "ui_timeline_delete_track",
   "ui_timeline_add_media_clip",
   "ui_timeline_add_text_clip",
   "ui_timeline_add_shape_clip",

--- a/packages/protocol/src/zod-schema.ts
+++ b/packages/protocol/src/zod-schema.ts
@@ -169,8 +169,91 @@ function topLevelKeys(schema: ZodType): string[] {
 }
 
 /**
+ * The field map of the object a schema is, looking through the wrappers a
+ * field carries — `.optional()`, `.default()`, `.nullable()` — to the object
+ * underneath. Null for anything that is not an object schema.
+ */
+function objectShape(schema: unknown): Record<string, unknown> | null {
+  let current = schema;
+  for (let depth = 0; depth < 8; depth++) {
+    const shape = (current as { shape?: unknown } | undefined)?.shape;
+    if (isObjectLike(shape)) return shape as Record<string, unknown>;
+    const inner = (current as { _def?: { innerType?: unknown } } | undefined)
+      ?._def?.innerType;
+    if (inner === undefined) return null;
+    current = inner;
+  }
+  return null;
+}
+
+/**
+ * The keys accepted at `path`, for a refusal inside a nested bag.
+ *
+ * A strict style bag refuses `background.cornerRadius` by name and, without
+ * this, says nothing about `radiusPx` sitting right beside it — the same dead
+ * end {@link withAcceptedKeys} exists to close, one level down.
+ */
+function keysAtPath(schema: ZodType, path: readonly PropertyKey[]): string[] {
+  let current: unknown = schema;
+  for (const segment of path) {
+    const shape = objectShape(current);
+    if (!shape) return [];
+    current = shape[String(segment)];
+    if (current === undefined) return [];
+  }
+  return Object.keys(objectShape(current) ?? {});
+}
+
+/**
+ * Per-schema advice for a key that is refused but reasonable to have guessed.
+ *
+ * Listing the accepted keys answers "what may I send"; it does not answer
+ * "where did the thing I wanted go". `add_text_clip` refuses `x`/`y` and lists
+ * thirteen style fields, none of which is obviously the position — the caller
+ * reads the list, sees no coordinates, and concludes text cannot be placed.
+ * A key with a remedy says where it went instead.
+ */
+const KEY_REMEDIES = new WeakMap<ZodType, Record<string, string>>();
+
+/**
+ * Attach remedies to a schema, by the key each one is about. Returns the same
+ * schema so it can wrap a definition in place.
+ */
+export function withKeyRemedies<TSchema extends ZodType>(
+  schema: TSchema,
+  remedies: Record<string, string>
+): TSchema {
+  const accepted = new Set(topLevelKeys(schema));
+  for (const key of Object.keys(remedies)) {
+    if (accepted.has(key)) {
+      throw new Error(
+        `withKeyRemedies: "${key}" is a key this schema accepts, so it is ` +
+          "never refused and the remedy would never be read."
+      );
+    }
+  }
+  KEY_REMEDIES.set(schema, { ...(KEY_REMEDIES.get(schema) ?? {}), ...remedies });
+  return schema;
+}
+
+/** The remedies that apply to the keys one refusal actually named. */
+function remediesFor(schema: ZodType, keys: readonly string[]): string[] {
+  const table = KEY_REMEDIES.get(schema);
+  if (!table) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const key of keys) {
+    const remedy = table[key];
+    if (remedy === undefined || seen.has(remedy)) continue;
+    seen.add(remedy);
+    out.push(remedy);
+  }
+  return out;
+}
+
+/**
  * Rewrite a top-level `unrecognized_keys` issue to name the keys the schema
- * does accept.
+ * does accept, plus any remedy registered for the keys it refused.
  *
  * The error stays a `ZodError` so every caller that formats issues keeps
  * working; only the sentence the model reads gets longer.
@@ -180,13 +263,25 @@ function withAcceptedKeys(error: z.ZodError, schema: ZodType): z.ZodError {
   if (accepted.length === 0) return error;
   let changed = false;
   const issues = error.issues.map((issue) => {
-    if (issue.code !== "unrecognized_keys" || issue.path.length > 0) {
-      return issue;
+    if (issue.code !== "unrecognized_keys") return issue;
+    if (issue.path.length > 0) {
+      const nested = keysAtPath(schema, issue.path);
+      if (nested.length === 0) return issue;
+      changed = true;
+      return {
+        ...issue,
+        message:
+          `${issue.message}. \`${issue.path.join(".")}\` accepts: ` +
+          `${nested.join(", ")}.`
+      };
     }
     changed = true;
+    const advice = remediesFor(schema, issue.keys);
     return {
       ...issue,
-      message: `${issue.message}. This op accepts: ${accepted.join(", ")}.`
+      message:
+        `${issue.message}. This op accepts: ${accepted.join(", ")}.` +
+        (advice.length > 0 ? ` ${advice.join(" ")}` : "")
     };
   });
   return changed ? new z.ZodError(issues) : error;

--- a/packages/protocol/tests/api-schemas-timeline-tool-params.test.ts
+++ b/packages/protocol/tests/api-schemas-timeline-tool-params.test.ts
@@ -30,9 +30,13 @@ import {
   shapeStyleParams,
   textStyleParams,
   transitionParams,
+  resolveDeleteTrackArgs,
+  resolveShapeArg,
   withFieldNotes,
+  withTextClipRemedies,
   SHARED_TIMELINE_TOOL_NAMES
 } from "../src/api-schemas/timeline-tool-params.js";
+import { parseWithTypeCoercion } from "../src/zod-schema.js";
 
 const fields = (schema: z.ZodObject<z.ZodRawShape>) =>
   Object.keys(schema.shape).sort();
@@ -300,5 +304,102 @@ describe("textStyleParams — verticalAlign", () => {
         verticalAlign: "center"
       }).verticalAlign
     ).toBe("center");
+  });
+});
+
+/**
+ * Four refusals and one silent success, all from one motion-graphics build.
+ * Each cost a round trip or a wrong render, and none of them was the caller
+ * misunderstanding the document — they were the authoring surface being
+ * stricter, or quieter, than the thing it authors.
+ */
+describe("what a real build got wrong", () => {
+  it("takes a drop shadow without the zero offsets", () => {
+    const parsed = textStyleParams.parse({
+      text: "NodeTool",
+      fontSizePx: 176,
+      color: "#FFFFFF",
+      shadow: { color: "#000000", blurPx: 24 }
+    });
+    expect(parsed.shadow).toEqual({
+      color: "#000000",
+      blurPx: 24,
+      offsetX: 0,
+      offsetY: 0
+    });
+  });
+
+  it("refuses a misspelled field inside a style bag rather than dropping it", () => {
+    const parsed = textStyleParams.safeParse({
+      text: "Start building — free",
+      fontSizePx: 58,
+      color: "#0B0E1A",
+      background: { color: "#FFFFFF", paddingPx: 34, cornerRadius: 40 }
+    });
+    expect(parsed.success).toBe(false);
+    expect(JSON.stringify(parsed.error?.issues)).toContain("cornerRadius");
+  });
+
+  it("merges the three ways a shape's look can arrive", () => {
+    const shape = resolveShapeArg(
+      { kind: "rect", fill: "#0B0E1A" },
+      { kind: "rect", cornerRadius: 8 },
+      { x: 0.5, y: 0.5, width: 1, height: 1 }
+    );
+    expect(shape).toEqual({
+      kind: "rect",
+      fill: "#0B0E1A",
+      cornerRadius: 8,
+      x: 0.5,
+      y: 0.5,
+      width: 1,
+      height: 1
+    });
+  });
+
+  it("still fills the whole frame when no geometry is named at all", () => {
+    expect(resolveShapeArg({ kind: "rect", fill: "#0B0E1A" }, undefined, {}))
+      .toEqual({ kind: "rect", fill: "#0B0E1A", x: 0, y: 0, width: 1, height: 1 });
+  });
+
+  it("leaves a line's points alone instead of boxing it", () => {
+    const line = resolveShapeArg(undefined, undefined, {
+      kind: "line",
+      x: 0.1,
+      y: 0.5,
+      x2: 0.9,
+      y2: 0.5
+    });
+    expect(line.width).toBeUndefined();
+    expect(line.height).toBeUndefined();
+  });
+
+  it("names the track to delete in either spelling, and gates the clips", () => {
+    expect(resolveDeleteTrackArgs({ trackId: "track_1" })).toEqual({
+      target: "track_1",
+      deleteClips: false
+    });
+    expect(
+      resolveDeleteTrackArgs({ target: "Video 1", deleteClips: true })
+    ).toEqual({ target: "Video 1", deleteClips: true });
+    expect(() => resolveDeleteTrackArgs({})).toThrow(/track id or name/);
+  });
+
+  it("sends a caller reaching for text x/y to the anchors", () => {
+    const schema = withTextClipRemedies(
+      z
+        .object({ text: z.string() })
+        .merge(partialTextStyleParams)
+        .strict()
+    );
+    let message = "";
+    try {
+      parseWithTypeCoercion(schema, { text: "Build AI", x: 0.5, y: 0.42 });
+    } catch (e) {
+      message = e instanceof z.ZodError ? e.issues[0]!.message : String(e);
+    }
+    expect(message).toContain("This op accepts:");
+    expect(message).toContain("`align`");
+    expect(message).toContain("verticalAlign");
   });
 });

--- a/packages/protocol/tests/zod-schema-coverage.test.ts
+++ b/packages/protocol/tests/zod-schema-coverage.test.ts
@@ -8,7 +8,8 @@ import { z } from "zod";
 import {
   isZodSchema,
   zodToJsonSchema,
-  parseWithTypeCoercion
+  parseWithTypeCoercion,
+  withKeyRemedies
 } from "../src/zod-schema.js";
 
 describe("isZodSchema", () => {
@@ -197,6 +198,34 @@ describe("parseWithTypeCoercion — unrecognized keys name what the schema takes
       expect(message).toContain('Unrecognized keys: "trackId", "index"');
       expect(message).toContain("This op accepts: target, toIndex, before.");
     }
+  });
+
+  it("names the keys a nested bag accepts", () => {
+    const nested = z
+      .object({
+        background: z
+          .object({ color: z.string(), radiusPx: z.number().optional() })
+          .strict()
+          .optional()
+      })
+      .strict();
+    try {
+      parseWithTypeCoercion(nested, {
+        background: { color: "#fff", cornerRadius: 40 }
+      });
+      throw new Error("expected a refusal");
+    } catch (error) {
+      const message = (error as z.ZodError).issues
+        .map((issue) => issue.message)
+        .join(" ");
+      expect(message).toContain("`background` accepts: color, radiusPx.");
+    }
+  });
+
+  it("refuses to register a remedy for a key the schema accepts", () => {
+    expect(() => withKeyRemedies(schema, { target: "no" })).toThrow(
+      /never refused/
+    );
   });
 
   it("leaves an issue that is not about unknown keys alone", () => {

--- a/web/src/components/timeline/__tests__/timelineAgentBridge.test.ts
+++ b/web/src/components/timeline/__tests__/timelineAgentBridge.test.ts
@@ -10,6 +10,7 @@ const makeMockHandler = (): TimelineAgentHandler => ({
   getSnapshot: jest.fn(),
   addTrack: jest.fn(),
   moveTrack: jest.fn(),
+  deleteTrack: jest.fn(),
   addMediaClip: jest.fn(),
   addTextClip: jest.fn(),
   addShapeClip: jest.fn(),

--- a/web/src/components/timeline/timelineAgentBridge.ts
+++ b/web/src/components/timeline/timelineAgentBridge.ts
@@ -352,6 +352,16 @@ export interface TimelineAgentHandler {
     target: string,
     destination: { toIndex?: number; before?: string; after?: string }
   ) => TimelineTrackNode[];
+  /**
+   * Remove one track, and with it the clips on it when `deleteClips` says so.
+   * The editor's own track menu has done this all along; without it here the
+   * agent could add a track and never take it back. Returns the stack that is
+   * left, reindexed, plus the clips that went with it.
+   */
+  deleteTrack: (
+    target: string,
+    deleteClips: boolean
+  ) => { deleted: TimelineTrackNode; deletedClipIds: string[]; tracks: TimelineTrackNode[] };
   generateClip: (
     opts: TimelineGenerateOptions
   ) => Promise<TimelineGenerateResult>;

--- a/web/src/hooks/timeline/useTimelineAgentBridge.ts
+++ b/web/src/hooks/timeline/useTimelineAgentBridge.ts
@@ -362,6 +362,37 @@ export const useTimelineAgentBridge = (sequenceId: string | null): void => {
           .map((t) => toTrackNode(t, clipCount.get(t.id) ?? 0));
       },
 
+      deleteTrack(target, deleteClips) {
+        const track = requireTrack(target);
+        const onIt = doc
+          .getState()
+          .clips.filter((clip) => clip.trackId === track.id);
+        if (onIt.length > 0 && !deleteClips) {
+          throw new Error(
+            `Track "${track.name}" still holds ${onIt.length} clip(s): ` +
+              `${onIt.map((clip) => clip.id).join(", ")}. Move them first, ` +
+              "or pass deleteClips: true to delete them with the track."
+          );
+        }
+        const deleted = toTrackNode(track, onIt.length);
+        // The store's own removal — the same one the track menu calls — takes
+        // the clips with it and reindexes what is left.
+        doc.getState().removeTrack(track.id);
+        const clipCount = new Map<string, number>();
+        for (const clip of doc.getState().clips) {
+          clipCount.set(clip.trackId, (clipCount.get(clip.trackId) ?? 0) + 1);
+        }
+        return {
+          deleted,
+          deletedClipIds: onIt.map((clip) => clip.id),
+          tracks: doc
+            .getState()
+            .tracks.slice()
+            .sort((a, b) => a.index - b.index)
+            .map((t) => toTrackNode(t, clipCount.get(t.id) ?? 0))
+        };
+      },
+
       async generateClip(opts) {
         const kind = opts.kind;
         const store = doc.getState();

--- a/web/src/lib/tools/__tests__/timelineTools.test.ts
+++ b/web/src/lib/tools/__tests__/timelineTools.test.ts
@@ -68,6 +68,7 @@ const createMockHandler = (): jest.Mocked<TimelineAgentHandler> => ({
   getSnapshot: jest.fn(),
   addTrack: jest.fn(),
   moveTrack: jest.fn(),
+  deleteTrack: jest.fn(),
   addMediaClip: jest.fn(),
   addTextClip: jest.fn(),
   addShapeClip: jest.fn(),
@@ -151,6 +152,26 @@ describe("ui_timeline_* tools", () => {
         ctx
       )
     ).rejects.toThrow('No timeline sequence "seq-1" is open');
+  });
+
+  it("deletes a track through the handler, in either spelling", async () => {
+    const handler = createMockHandler();
+    handler.deleteTrack.mockReturnValue({
+      deleted: trackNode(),
+      deletedClipIds: [],
+      tracks: []
+    });
+    setTimelineAgentHandler(SEQ_ID, handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_timeline_delete_track",
+      { timeline_id: SEQ_ID, trackId: "Video 1", deleteClips: true },
+      "tc-del-track",
+      ctx
+    )) as { ok: boolean; deletedClipIds: string[] };
+
+    expect(handler.deleteTrack).toHaveBeenCalledWith("Video 1", true);
+    expect(result.ok).toBe(true);
   });
 
   it("returns the timeline snapshot through the handler", async () => {
@@ -287,8 +308,10 @@ describe("ui_timeline_* tools", () => {
       ctx
     );
 
+    // A shape that names no box is the full frame, written out rather than
+    // left to the renderer's default.
     expect(handler.addShapeClip).toHaveBeenCalledWith({
-      shape: { kind: "rect" }
+      shape: { kind: "rect", x: 0, y: 0, width: 1, height: 1 }
     });
   });
 

--- a/web/src/lib/tools/builtin/timeline.ts
+++ b/web/src/lib/tools/builtin/timeline.ts
@@ -16,7 +16,11 @@ import {
   ADD_SHAPE_CLIP_DESCRIPTION,
   ADD_TEXT_CLIP_DESCRIPTION,
   ADD_TRACK_DESCRIPTION,
+  DELETE_TRACK_DESCRIPTION,
   MOVE_TRACK_DESCRIPTION,
+  deleteTrackShape,
+  resolveDeleteTrackArgs,
+  withTextClipRemedies,
   clipOpacityParam,
   moveTrackShape,
   resolveMoveTrackArgs,
@@ -156,6 +160,22 @@ FrontendToolRegistry.register({
 });
 
 FrontendToolRegistry.register({
+  name: "ui_timeline_delete_track",
+  description: DELETE_TRACK_DESCRIPTION,
+  parameters: z
+    .object({ timeline_id: timelineIdParam, ...deleteTrackShape })
+    .strict(),
+  async execute({ timeline_id, ...rest }) {
+    const { target, deleteClips } = resolveDeleteTrackArgs(rest);
+    const result = getTimelineAgentHandler(timeline_id).deleteTrack(
+      target,
+      deleteClips
+    );
+    return { ok: true, ...result, url: docUrl("timeline", timeline_id) };
+  }
+});
+
+FrontendToolRegistry.register({
   name: "ui_timeline_add_media_clip",
   description:
     "Place an existing asset — a video, image, or audio file already in the library — on the specified timeline sequence. `asset` is an asset id or `asset://<id>.<ext>` URI. Without a track the clip lands on a track matching its media kind, creating one when needed; without `startMs` it is appended after that track's existing content, so calling this once per asset lays them end to end. Duration comes from the asset unless `durationMs` overrides it.",
@@ -180,18 +200,20 @@ FrontendToolRegistry.register({
 FrontendToolRegistry.register({
   name: "ui_timeline_add_text_clip",
   description: ADD_TEXT_CLIP_DESCRIPTION,
-  parameters: z
-    .object({
-      timeline_id: timelineIdParam,
-      text: z.string().trim().min(1),
-      trackId: z.string().optional(),
-      startMs: z.number().optional(),
-      durationMs: z.number().optional(),
-      opacity: clipOpacityParam,
-      style: partialTextStyleParams.optional()
-    })
-    .merge(partialTextStyleParams)
-    .strict(),
+  parameters: withTextClipRemedies(
+    z
+      .object({
+        timeline_id: timelineIdParam,
+        text: z.string().trim().min(1),
+        trackId: z.string().optional(),
+        startMs: z.number().optional(),
+        durationMs: z.number().optional(),
+        opacity: clipOpacityParam,
+        style: partialTextStyleParams.optional()
+      })
+      .merge(partialTextStyleParams)
+      .strict()
+  ),
   async execute({
     timeline_id,
     text,


### PR DESCRIPTION
## What changed

One 10-second social ad, built end to end through `edit_timeline` and the media capabilities, hit eight separate surfaces that either refused a reasonable call without saying what to send instead, or accepted one and did something else. This fixes each of them where the failure was the surface's, not the caller's: `delete_track` exists now, `add_shape_clip` merges the three ways a shape's look can arrive instead of reading one bag and dropping the rest, the text style bags refuse a misspelled nested key by name rather than stripping it, a drop shadow's offsets default to 0, `add_text_clip` answers an `x`/`y` with the anchors that actually place text, the generation capabilities read `duration` as well as `duration_seconds`, `animate_image` takes its aspect ratio from the source still, and `ffprobe` stages an `asset://` named in `path` for itself. Two of these were silent: a rectangle authored dark navy saved white over the whole frame, and a 15-second clip request bought the model's 5-second default with nothing in the result saying the argument had been dropped.

Details, one per failure:

- **`delete_track` (new).** Tracks were add-only from the agent surface while the editor's own track menu has removed them all along, so a track added by mistake stayed for the life of the sequence. Registered on both hosts (headless bridge and browser registry) and added to `SHARED_TIMELINE_TOOL_NAMES`, which is what forced both. An occupied track is refused unless the call passes `deleteClips: true`.
- **`add_shape_clip` merges `shape`, `shapeStyle` and the top-level geometry** rather than taking the first bag whole. The call that put `kind`/`fill` in `shape` and the box at the top level drew a white full-frame rect and reported success. `shape` still wins a contested key; a shape naming no geometry at all is still the full frame, and a line keeps its two points instead of gaining a width.
- **The text style bags are strict.** `background: {color, paddingPx, cornerRadius: 40}` saved a square plate, because the field is spelled `radiusPx`. `shapeStyleParams` is strict for the same reason. A nested refusal now names the keys that bag does accept, which is the top-level "This op accepts:" behaviour one level down.
- **A drop shadow's `offsetX`/`offsetY` default to 0.** `{color, blurPx}` is a whole shadow; requiring the zeros cost a round trip on three titles at once.
- **`add_text_clip` explains `x`/`y`.** Refusing them and listing thirteen style fields with no coordinates reads as "text cannot be positioned". A small remedy table on the schema (`withKeyRemedies`) names `align`/`verticalAlign`/`maxWidthFrac` and the `custom`-preset offset route.
- **Generation parameters read their other spellings.** The schemas are snake_case, the guest API takes an options bag, and the `TextToVideo` node's own property is `duration` — so `{duration: 15}` was dropped in silence on a call that spends money.
- **`animate_image` derives `aspect_ratio` from the still** when the call names none: a 720×1280 frame was animated to 1280×720 and the mismatch surfaced only once three landscape beds were sitting under the type in a 1080×1920 sequence. Header-only pixel size (`imagePixelSize`), no decode.
- **`ffprobe` stages an `asset://`, `/api/storage/` or `data:` ref named in `path`.** Its whole argv is that one path — no flag surface to guard — and the guest's own `video.info(asset://…)` already reads a ref, so the two halves of one loop disagreed. An http(s) URL stays refused: fetching one is egress.

Not fixed, and not reproduced: the same run had `image.grid` fail on one of three PNGs with `could not decode the image (png) — Invalid SVG image`. The bytes passed the terminator check, so the native decoder rejected a complete PNG; without the file or a repro I did not want to guess at a cause or ship a speculative fallback.

## Verification

- [x] `npm run test:affected` — passes except `@nodetool-ai/image-nodes`, which fails identically on `HEAD~1` with `VK_ERROR_INCOMPATIBLE_DRIVER` (no Vulkan ICD in this container; documented in AGENTS.md as a missing driver, not a broken test). Verified by stashing the diff and re-running.
- [x] `npm run test --workspace=packages/protocol` (1070), `--workspace=packages/agents` (4083), and the full `web` Jest suite (14266) all pass.
- [x] `npm run typecheck` — web and electron clean. The 450 remaining errors are all under `mobile/`, whose dependencies are not installed here (mobile is deliberately not a root workspace); no mobile file is in this diff.
- [x] `npm run lint`
- [x] `npm run dev:nodetool -- harness gate --base origin/main` → `Gate: 5/5 selfchecks passed`

## Agent capabilities

- [x] `npm run capabilities:check` passes (second commit is the generated re-sync: `ffprobe`'s declared contract moved).
- [x] No capability is added. `ffprobe` is the one re-declared contract; it is covered by `packages/agents/tests/capabilities-media-ffprobe.test.ts`, which gains a case for the new staging.

## New checks

The diff adds refusals rather than checks, and each one is pinned by a test that fails without it:

- `packages/protocol/tests/api-schemas-timeline-tool-params.test.ts` — the shadow defaults, the strict nested bag, the three-bag merge, the geometry-free full frame, the untouched line, `resolveDeleteTrackArgs`, and the x/y remedy.
- `packages/protocol/tests/zod-schema-coverage.test.ts` — nested accepted-key listing, and that a remedy for a key the schema *accepts* is refused at registration (it could never be read).
- `packages/agents/tests/timeline-op-ergonomics.test.ts` — the same cases end to end through the bridge, plus `delete_track`'s three behaviours.
- `packages/agents/tests/capabilities-media.test.ts` / `-ffprobe.test.ts` / `js-sandbox-media.test.ts` — the duration aliases, the derived aspect (and that an explicit one wins, and that unreadable bytes derive nothing), `nearestAspectRatio`, `imagePixelSize`, and `path`-staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TYMvAWnvZLT4iYkDF87rU

---
_Generated by [Claude Code](https://claude.ai/code/session_015TYMvAWnvZLT4iYkDF87rU)_