### PR TITLE
feat(chat): render sub-agents as unfoldable cards

### DIFF
--- a/packages/agents/src/codeact/codeact-executor.ts
+++ b/packages/agents/src/codeact/codeact-executor.ts
@@ -42,7 +42,8 @@ import {
   type ProcessingMessage,
   type StepResult,
   type TaskUpdate,
-  type ToolCallUpdate
+  type ToolCallUpdate,
+  type ToolResultUpdate
 } from "@nodetool-ai/protocol";
 import type { Step, Task } from "../types.js";
 import { Tool } from "../tools/base-tool.js";
@@ -73,6 +74,7 @@ import {
   toolSearchHit,
   CODEACT_PRELUDE,
   type ToolCallRecord,
+  type ToolResultRecord,
   type ToolSearchHit
 } from "./tool-api.js";
 import {
@@ -661,10 +663,27 @@ export class CodeActExecutor {
       } satisfies ToolCallUpdate);
     };
 
+    // What the call returned, so a rendered tool row can show its result the
+    // way the chat's own tool messages do. `tool_result_update.result` is a
+    // record, so a scalar return travels wrapped.
+    const onToolResult = (record: ToolResultRecord): void => {
+      ui.push({
+        type: "tool_result_update",
+        node_id: this.step.id,
+        tool_call_id: record.toolCallId,
+        name: record.name,
+        is_error: record.isError,
+        result: isRecord(record.result)
+          ? record.result
+          : { result: record.result }
+      } satisfies ToolResultUpdate);
+    };
+
     const bridge = buildToolBridge({
       tools: this.tools,
       context: this.context,
       onToolCall,
+      onToolResult,
       maxToolCallsPerAction: this.maxToolCallsPerAction
     });
 

--- a/packages/agents/src/codeact/tool-api.ts
+++ b/packages/agents/src/codeact/tool-api.ts
@@ -53,11 +53,22 @@ export interface ToolCallRecord {
   toolCallId: string;
 }
 
+/** What a bridged tool handed back, as the UI reports it. */
+export interface ToolResultRecord {
+  name: string;
+  toolCallId: string;
+  /** The tool's return value, or the error text when the call failed. */
+  result: unknown;
+  isError: boolean;
+}
+
 interface ToolBridgeOptions {
   tools: Tool[];
   context: ProcessingContext;
   /** Observability hook — fires before each bridged tool executes. */
   onToolCall?: (record: ToolCallRecord) => void;
+  /** Observability hook — fires with what the call returned. */
+  onToolResult?: (record: ToolResultRecord) => void;
   maxToolCallsPerAction?: number;
 }
 
@@ -189,9 +200,22 @@ export function buildToolBridge(options: ToolBridgeOptions): ToolBridge {
       }
       const errorPayload = extractErrorPayload(result);
       if (errorPayload !== null) {
+        options.onToolResult?.({
+          name,
+          toolCallId,
+          result: errorPayload,
+          isError: true
+        });
         return { ok: false, error: `tools.${name}: ${errorPayload}` };
       }
-      return { ok: true, result: toTransferable(result) };
+      const transferable = toTransferable(result);
+      options.onToolResult?.({
+        name,
+        toolCallId,
+        result: transferable,
+        isError: false
+      });
+      return { ok: true, result: transferable };
     } catch (e) {
       return {
         ok: false,

--- a/packages/agents/tests/codeact-executor.test.ts
+++ b/packages/agents/tests/codeact-executor.test.ts
@@ -171,6 +171,50 @@ describe("CodeActExecutor", () => {
     ]);
   });
 
+  it("reports what each bridged call returned", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    const add = new AddTool();
+    const provider = createLoopProvider([
+      {
+        toolCalls: [
+          codeAction(
+            "tc_1",
+            `import { add } from "@nodetool-ai/sandbox-nodetool/session";
+             const first = await add({a: 1, b: 2});
+             await finish({answer: first.sum});`
+          )
+        ]
+      }
+    ]);
+
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: [add]
+    });
+
+    const results: Array<Record<string, unknown>> = [];
+    for await (const msg of executor.execute()) {
+      if (msg.type === "tool_result_update") {
+        results.push(msg as unknown as Record<string, unknown>);
+      }
+    }
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      name: "add",
+      is_error: false,
+      result: { sum: 3 }
+    });
+    expect(results[0].tool_call_id).toBe(
+      "codeact_1"
+    );
+  });
+
   it("injects no state global — cross-action carry is thread memory", async () => {
     const { step, task } = makeStep(ANSWER_SCHEMA);
     const context = createMockContext();

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -667,6 +667,15 @@ export interface Message {
   system_prompt?: string | null;
   agent_execution_id?: string | null;
   execution_event_type?: string | null;
+  /**
+   * The tool_call_id of the enclosing `run_subtask` / `run_search` call when
+   * this message was produced inside a sub-agent. Null at the chat root. The
+   * chat renders such messages inside the spawning call's card rather than in
+   * the main timeline.
+   */
+  parent_tool_call_id?: string | null;
+  /** Sub-agent recursion depth: 0 at the chat root, 1 inside run_subtask. */
+  subtask_depth?: number | null;
   workflow_target?: string | null;
   created_at?: string | null;
   /**

--- a/web/src/components/chat/message/MessageView.tsx
+++ b/web/src/components/chat/message/MessageView.tsx
@@ -60,6 +60,7 @@ import {
 import { formatJavaScriptForDisplay } from "../../../utils/formatJavaScript";
 import type { MediaGenerationRequest } from "../../../stores/MediaGenerationStore";
 import { visibleToolArgs as visibleArgs } from "../../../core/chat/toolCallFields";
+import { subAgentTranscript } from "../../../core/chat/subAgentMessages";
 import { CodeBlock } from "./markdown_elements/CodeBlock";
 import { isObjectLike, isString } from "../../../utils/typePredicates";
 import {
@@ -105,6 +106,18 @@ function formatTime(dateStr?: string | null): string | null {
  */
 const RUN_SUBTASK_TOOL_NAME = "run_subtask";
 
+/** `run_search` is the read-only sibling of `run_subtask` — same child loop. */
+const RUN_SEARCH_TOOL_NAME = "run_search";
+
+/** Stable empty transcript so the store selector keeps its reference. */
+const EMPTY_TRANSCRIPT: Message[] = [];
+
+/** Both delegation calls render as an unfoldable sub-agent card. */
+const SUB_AGENT_TOOL_NAMES = new Set([
+  RUN_SUBTASK_TOOL_NAME,
+  RUN_SEARCH_TOOL_NAME
+]);
+
 /**
  * `execute_code` is the CodeAct action primitive (docs/codeact-design.md):
  * its one argument is a JavaScript program, so the row renders it as a
@@ -117,6 +130,66 @@ const EXECUTE_CODE_TOOL_NAME = "execute_code";
  * row shows it open rather than hiding it behind a JSON dump.
  */
 const CREATE_PLAN_TOOL_NAME = "create_plan";
+
+/**
+ * SubAgentTranscript — a delegated child's own conversation, rendered with the
+ * same MessageView the main thread uses so a sub-agent's tool rows, code
+ * actions and prose read identically one level down.
+ */
+const SubAgentTranscript: React.FC<{
+  messages: Message[];
+  threadId?: string | null;
+}> = React.memo(({ messages, threadId }) => {
+  const [expandedThoughts, setExpandedThoughts] = useState<
+    Record<string, boolean>
+  >({});
+  const isThoughtExpanded = useCallback(
+    (key: string) => expandedThoughts[key] ?? false,
+    [expandedThoughts]
+  );
+  const handleToggleThought = useCallback((key: string) => {
+    setExpandedThoughts((current) => ({ ...current, [key]: !current[key] }));
+  }, []);
+
+  const toolResultsByCallId = useMemo(() => {
+    const results: ToolResultLookup = {};
+    for (const message of messages) {
+      if (message.role === "tool" && message.tool_call_id) {
+        results[String(message.tool_call_id)] = {
+          name: message.name ?? undefined,
+          content: message.content,
+          createdAt: message.created_at ?? null
+        };
+      }
+    }
+    return results;
+  }, [messages]);
+
+  const visible = useMemo(
+    () => messages.filter((message) => message.role !== "tool"),
+    [messages]
+  );
+
+  if (visible.length === 0) {
+    return null;
+  }
+
+  return (
+    <FlexColumn className="subagent-transcript" gap={SPACING.xs}>
+      {visible.map((message, index) => (
+        <MessageView
+          key={message.id ?? `subagent-message-${index}`}
+          message={message}
+          threadId={threadId}
+          isThoughtExpanded={isThoughtExpanded}
+          onToggleThought={handleToggleThought}
+          toolResultsByCallId={toolResultsByCallId}
+        />
+      ))}
+    </FlexColumn>
+  );
+});
+SubAgentTranscript.displayName = "SubAgentTranscript";
 
 /**
  * ToolRowRail — the glyph column and the hairline that ties one row to the
@@ -146,8 +219,17 @@ const ToolCallRow: React.FC<{
   durationMs?: number | null;
   connected?: boolean;
   tight?: boolean;
-}> = React.memo(({ tc, result, durationMs, connected = false, tight = false }) => {
-  const isSubtask = tc.name === RUN_SUBTASK_TOOL_NAME;
+  /** Thread the call belongs to — the key its sub-agent transcript is under. */
+  threadId?: string | null;
+}> = React.memo(({
+  tc,
+  result,
+  durationMs,
+  connected = false,
+  tight = false,
+  threadId
+}) => {
+  const isSubtask = SUB_AGENT_TOOL_NAMES.has(tc.name);
   const isCodeAction = tc.name === EXECUTE_CODE_TOOL_NAME;
   const isPlan = tc.name === CREATE_PLAN_TOOL_NAME;
   const [open, setOpen] = useState(false);
@@ -155,6 +237,16 @@ const ToolCallRow: React.FC<{
     (s) => s.currentRunningToolCallId
   );
   const runningToolMessage = useGlobalChatStore((s) => s.currentToolMessage);
+  // The child's own messages, streamed under this call's id.
+  const transcript = useGlobalChatStore((s) =>
+    isSubtask ? subAgentTranscript(s.subAgentMessages, threadId, tc.id) : EMPTY_TRANSCRIPT
+  );
+  // Tool results ride in the transcript but render inside their call's row,
+  // so the folded count reports what the user would actually see.
+  const transcriptCount = useMemo(
+    () => transcript.filter((message) => message.role !== "tool").length,
+    [transcript]
+  );
   const activePredictions = useGlobalChatStore(
     (s) =>
       getThreadRuntime(s, s.currentThreadId).activePredictions ??
@@ -170,8 +262,10 @@ const ToolCallRow: React.FC<{
     isString(rawArgs?.[key])
       ? rawArgs[key].trim() || null
       : null;
+  // `run_subtask` names the job in `description`; `run_search` in `query`.
+  // Older rows in the DB used `title`.
   const subtaskTitle = isSubtask
-    ? (pickString("description") ?? pickString("title"))
+    ? (pickString("description") ?? pickString("title") ?? pickString("query"))
     : null;
   const subtaskInstructions = isSubtask
     ? (pickString("prompt") ?? pickString("instructions"))
@@ -198,7 +292,13 @@ const ToolCallRow: React.FC<{
     }
     if (!isSubtask) return base;
     const stripped = { ...base } satisfies Record<string, unknown>;
-    for (const k of ["description", "prompt", "title", "instructions"]) {
+    for (const k of [
+      "description",
+      "prompt",
+      "title",
+      "instructions",
+      "query"
+    ]) {
       delete stripped[k];
     }
     return Object.keys(stripped).length > 0 ? stripped : null;
@@ -215,6 +315,7 @@ const ToolCallRow: React.FC<{
     !planDocument &&
     (!!hasArgs ||
       (isSubtask && !!subtaskInstructions) ||
+      transcript.length > 0 ||
       !!actionCode ||
       hasResult);
   const isRunning = runningToolCallId && tc.id && runningToolCallId === tc.id;
@@ -239,7 +340,7 @@ const ToolCallRow: React.FC<{
   const liveMessage = isRunning ? runningToolMessage || tc.message : tc.message;
   const phrase = toolCallPhrase(tc);
   const label = isSubtask
-    ? subtaskTitle || formatToolName(tc.name)
+    ? subtaskTitle || liveMessage || phrase.label
     : isCodeAction
       ? actionTitle || liveMessage || formatToolName(tc.name)
       : isPlan
@@ -283,6 +384,13 @@ const ToolCallRow: React.FC<{
           </Text>
           {detail && <span className="tool-row-detail">{detail}</span>}
           <span className="tool-row-gap" />
+          {isSubtask && transcriptCount > 0 && !open && (
+            <span className="tool-row-detail">
+              {transcriptCount === 1
+                ? "1 message"
+                : `${transcriptCount} messages`}
+            </span>
+          )}
           {durationLabel && (
             <span className="tool-row-duration">{durationLabel}</span>
           )}
@@ -307,11 +415,14 @@ const ToolCallRow: React.FC<{
           <FlexColumn className="tool-row-details" gap={SPACING.xs}>
             {isSubtask && subtaskInstructions && (
               <FlexColumn gap={SPACING.xs}>
-                <Caption className="tool-section-title">Instructions</Caption>
+                <Caption className="tool-section-title">Objective</Caption>
                 <Text size="small" className="subtask-instructions">
                   {subtaskInstructions}
                 </Text>
               </FlexColumn>
+            )}
+            {transcript.length > 0 && (
+              <SubAgentTranscript messages={transcript} threadId={threadId} />
             )}
             {formattedActionCode && (
               <FlexColumn gap={SPACING.xs}>
@@ -375,7 +486,15 @@ const ToolCallCountRow: React.FC<{
   durationFor: (tc: ToolCall) => CallTiming;
   messageCreatedAt?: string | null;
   connected?: boolean;
-}> = React.memo(({ name, calls, durationFor, messageCreatedAt, connected = false }) => {
+  threadId?: string | null;
+}> = React.memo(({
+  name,
+  calls,
+  durationFor,
+  messageCreatedAt,
+  connected = false,
+  threadId
+}) => {
   const [open, setOpen] = useState(false);
   const runningToolCallId = useGlobalChatStore(
     (s) => s.currentRunningToolCallId
@@ -479,6 +598,7 @@ const ToolCallCountRow: React.FC<{
                   result={toolResult}
                   durationMs={callDuration}
                   tight={i > 0}
+                  threadId={threadId}
                 />
               );
             })}
@@ -542,7 +662,13 @@ const ToolCallTimeline: React.FC<{
   toolCalls: ToolCall[];
   toolResultsByCallId?: ToolResultLookup;
   messageCreatedAt?: string | null;
-}> = React.memo(({ toolCalls, toolResultsByCallId, messageCreatedAt }) => {
+  threadId?: string | null;
+}> = React.memo(({
+  toolCalls,
+  toolResultsByCallId,
+  messageCreatedAt,
+  threadId
+}) => {
   const [open, setOpen] = useState(true);
   const runningToolCallId = useGlobalChatStore(
     (s) => s.currentRunningToolCallId
@@ -592,6 +718,7 @@ const ToolCallTimeline: React.FC<{
             durationMs={durationMs}
             connected={connected}
             tight={row.tight}
+            threadId={threadId}
           />
         );
       }
@@ -603,10 +730,11 @@ const ToolCallTimeline: React.FC<{
           durationFor={durationFor}
           messageCreatedAt={messageCreatedAt}
           connected={connected}
+          threadId={threadId}
         />
       );
     },
-    [rows, durationFor, messageCreatedAt]
+    [rows, durationFor, messageCreatedAt, threadId]
   );
 
   const isRunning = toolCalls.some(
@@ -682,6 +810,8 @@ interface MessageViewProps {
     { name?: string | null; content: unknown; createdAt?: string | null }
   >;
   executionMessagesById?: Map<string, Message[]>;
+  /** Thread the message belongs to; keys sub-agent transcripts. */
+  threadId?: string | null;
   /**
    * Render the per-message meta layout: an avatar + a persistent header line
    * (role · time · model), left-aligned for both roles. Enabled only in the
@@ -700,6 +830,7 @@ export const MessageView: React.FC<
     onInsertCode,
     toolResultsByCallId,
     executionMessagesById,
+    threadId,
     showMeta = false
   }) => {
     const insertIntoEditor = useEditorInsertion();
@@ -913,6 +1044,7 @@ export const MessageView: React.FC<
                   toolCalls={message.tool_calls}
                   toolResultsByCallId={toolResultsByCallId}
                   messageCreatedAt={message.created_at}
+                  threadId={threadId ?? message.thread_id}
                 />
               )}
             {(message.role === "assistant" || message.role === "user") && (

--- a/web/src/components/chat/message/__tests__/MessageView.subAgent.test.tsx
+++ b/web/src/components/chat/message/__tests__/MessageView.subAgent.test.tsx
@@ -1,0 +1,115 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import { MessageView } from "../MessageView";
+import mockTheme from "../../../../__mocks__/themeMock";
+import { Message } from "../../../../stores/ApiTypes";
+
+const storeState = {
+  subAgentMessages: {
+    "thread-1": {
+      "call-1": [
+        {
+          id: "child-1",
+          role: "assistant",
+          type: "message",
+          content: "Checked three files.",
+          parent_tool_call_id: "call-1"
+        },
+        {
+          id: "child-2",
+          role: "assistant",
+          type: "message",
+          content: null,
+          parent_tool_call_id: "call-1",
+          tool_calls: [{ id: "grep-1", name: "search", args: { query: "todo" } }]
+        }
+      ]
+    }
+  }
+};
+
+jest.mock("../../../../stores/GlobalChatStore", () => ({
+  __esModule: true,
+  default: jest.fn(<T,>(selector: (s: unknown) => T) => selector(storeState))
+}));
+
+jest.mock("../../../../contexts/EditorInsertionContext", () => ({
+  useEditorInsertion: () => undefined
+}));
+
+jest.mock("../../../../hooks/browser/useClipboard", () => ({
+  useClipboard: () => ({ writeClipboard: jest.fn().mockResolvedValue(undefined) })
+}));
+
+jest.mock("../ChatMarkdown", () => ({
+  __esModule: true,
+  default: ({ content }: { content: string }) => <div>{content}</div>
+}));
+
+const subtaskMessage = {
+  id: "m1",
+  role: "assistant",
+  thread_id: "thread-1",
+  tool_calls: [
+    {
+      id: "call-1",
+      name: "run_subtask",
+      args: {
+        description: "Audit the config loader",
+        prompt: "Read every config file and report unused keys."
+      }
+    }
+  ]
+} as Message;
+
+const renderView = (message: Message) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <MessageView
+        message={message}
+        threadId="thread-1"
+        isThoughtExpanded={() => false}
+        onToggleThought={() => {}}
+      />
+    </ThemeProvider>
+  );
+
+describe("MessageView sub-agent card", () => {
+  it("shows the goal and message count while folded", () => {
+    renderView(subtaskMessage);
+
+    expect(screen.getByText("Audit the config loader")).toBeInTheDocument();
+    expect(screen.getByText("2 messages")).toBeInTheDocument();
+    expect(screen.queryByText("Checked three files.")).not.toBeInTheDocument();
+  });
+
+  it("renders the child's own messages when unfolded", async () => {
+    renderView(subtaskMessage);
+
+    await userEvent.click(screen.getByRole("button"));
+
+    expect(screen.getByText("Checked three files.")).toBeInTheDocument();
+    // The child's tool call renders as a row of its own, same as in the thread.
+    expect(
+      document.querySelectorAll(".subagent-transcript .tool-row")
+    ).toHaveLength(1);
+    expect(
+      screen.getByText("Read every config file and report unused keys.")
+    ).toBeInTheDocument();
+  });
+
+  it("stays a plain row when the child has said nothing yet", () => {
+    renderView({
+      id: "m2",
+      role: "assistant",
+      thread_id: "thread-1",
+      tool_calls: [
+        { id: "call-2", name: "run_search", args: { description: "Find it" } }
+      ]
+    } as Message);
+
+    expect(screen.queryByText(/messages/)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/chat/thread/ChatThreadView.styles.ts
+++ b/web/src/components/chat/thread/ChatThreadView.styles.ts
@@ -495,10 +495,33 @@ export const createStyles = (theme: Theme) => ({
       paddingBottom: theme.spacing(SPACING.xs)
     },
 
+    // The objective stays compact: enough to recognize the job, not a wall of
+    // prompt. The transcript below it is what the user unfolds the card for.
     ".subtask-instructions": {
       whiteSpace: "pre-wrap",
       color: theme.vars.palette.text.secondary,
-      lineHeight: 1.45
+      lineHeight: 1.45,
+      display: "-webkit-box",
+      WebkitBoxOrient: "vertical",
+      WebkitLineClamp: 3,
+      overflow: "hidden"
+    },
+
+    // A delegated child's own thread, one level in. The rule on the left is
+    // what marks its messages as the sub-agent's rather than the main reply's.
+    ".subagent-transcript": {
+      minWidth: 0,
+      paddingLeft: theme.spacing(SPACING.md),
+      borderLeft: `1px solid ${theme.vars.palette.divider}`,
+      ".chat-message": {
+        padding: 0,
+        margin: 0,
+        background: "transparent",
+        maxWidth: "100%"
+      },
+      ".message-actions": {
+        display: "none"
+      }
     },
 
     ".tool-timeline-footer": {

--- a/web/src/components/chat/thread/ChatThreadView.tsx
+++ b/web/src/components/chat/thread/ChatThreadView.tsx
@@ -962,6 +962,7 @@ const ChatThreadView: React.FC<ChatThreadViewProps> = ({
                     <MessageView
                       key={messageKey}
                       message={msg}
+                      threadId={visibleThreadId}
                       isThoughtExpanded={isThoughtExpanded}
                       onToggleThought={handleToggleThought}
                       onInsertCode={onInsertCode}

--- a/web/src/core/chat/__tests__/chatProtocol.test.ts
+++ b/web/src/core/chat/__tests__/chatProtocol.test.ts
@@ -1102,3 +1102,121 @@ describe("chatProtocol media predictions", () => {
     expect(state.threadRuntime["thread-1"].activePredictions).toEqual([]);
   });
 });
+
+describe("sub-agent events", () => {
+  const runtime = {
+    status: "streaming",
+    statusMessage: null,
+    progress: { current: 0, total: 0 },
+    error: null,
+    planningUpdate: null,
+    taskUpdate: null,
+    logUpdate: null,
+    runningToolCallId: null,
+    toolMessage: null,
+    sendMessageTimeoutId: null
+  };
+
+  const makeState = (): GlobalChatState =>
+    partialChatState({
+      status: "streaming",
+      currentThreadId: "thread-1",
+      threads: {
+        "thread-1": {
+          id: "thread-1",
+          title: "T",
+          updated_at: new Date().toISOString()
+        }
+      },
+      threadRuntime: { "thread-1": { ...runtime } },
+      messageCache: { "thread-1": [] },
+      subAgentMessages: {},
+      selectedModel: { provider: "", id: "" },
+      summarizeThread: jest.fn(),
+      updateThreadTitle: jest.fn()
+    });
+
+  const run = async (state: GlobalChatState, msg: WebSocketMessage) => {
+    let captured = state;
+    const set = jest.fn((updater) => {
+      captured = {
+        ...captured,
+        ...(isStateUpdater(updater) ? updater(captured) : updater)
+      };
+    });
+    await handleChatWebSocketMessage(msg, set, () => captured);
+    return captured;
+  };
+
+  it("keeps a child's text out of the parent's reply", async () => {
+    let state = makeState();
+    state = await run(state, {
+      type: "chunk",
+      thread_id: "thread-1",
+      content: "parent text"
+    });
+    state = await run(state, {
+      type: "chunk",
+      thread_id: "thread-1",
+      content: "child text",
+      parent_tool_call_id: "call-1"
+    });
+
+    const parentMessages = state.messageCache["thread-1"] as Message[];
+    expect(parentMessages).toHaveLength(1);
+    expect(parentMessages[0].content).toBe("parent text");
+    expect(state.subAgentMessages["thread-1"]["call-1"][0].content).toBe(
+      "child text"
+    );
+  });
+
+  it("a child's done chunk does not end the parent turn", async () => {
+    const state = await run(makeState(), {
+      type: "chunk",
+      thread_id: "thread-1",
+      content: "",
+      done: true,
+      parent_tool_call_id: "call-1"
+    });
+    expect(state.threadRuntime["thread-1"].status).toBe("streaming");
+  });
+
+  it("buckets a child's tool-call card and its result under the spawning call", async () => {
+    let state = makeState();
+    state = await run(state, {
+      type: "message",
+      role: "assistant",
+      thread_id: "thread-1",
+      content: null,
+      parent_tool_call_id: "call-1",
+      tool_calls: [{ id: "child-1", name: "search", args: { query: "x" } }]
+    });
+    state = await run(state, {
+      type: "tool_result_update",
+      node_id: "n1",
+      thread_id: "thread-1",
+      parent_tool_call_id: "call-1",
+      tool_call_id: "child-1",
+      name: "search",
+      result: { hits: 1 }
+    });
+
+    expect(state.messageCache["thread-1"]).toHaveLength(0);
+    const transcript = state.subAgentMessages["thread-1"]["call-1"];
+    expect(transcript).toHaveLength(2);
+    expect(transcript[1]).toEqual(
+      expect.objectContaining({ role: "tool", tool_call_id: "child-1" })
+    );
+  });
+
+  it("leaves a root-level tool result to the persisted tool message", async () => {
+    const state = await run(makeState(), {
+      type: "tool_result_update",
+      node_id: "n1",
+      thread_id: "thread-1",
+      tool_call_id: "root-1",
+      result: { ok: true }
+    });
+    expect(state.subAgentMessages).toEqual({});
+  });
+});

--- a/web/src/core/chat/__tests__/subAgentMessages.test.ts
+++ b/web/src/core/chat/__tests__/subAgentMessages.test.ts
@@ -1,0 +1,85 @@
+import {
+  appendSubAgentChunk,
+  appendSubAgentMessage,
+  appendSubAgentToolResult,
+  subAgentCallId,
+  subAgentTranscript,
+  type SubAgentMessages
+} from "../subAgentMessages";
+
+describe("subAgentMessages", () => {
+  it("reads the spawning call id only when one is tagged", () => {
+    expect(subAgentCallId({ parent_tool_call_id: "call-1" })).toBe("call-1");
+    expect(subAgentCallId({ parent_tool_call_id: null })).toBeNull();
+    expect(subAgentCallId({})).toBeNull();
+  });
+
+  it("folds consecutive chunks into one assistant message per call", () => {
+    let map: SubAgentMessages = {};
+    map = appendSubAgentChunk(map, "t1", "call-1", "Hello");
+    map = appendSubAgentChunk(map, "t1", "call-1", " world");
+    map = appendSubAgentChunk(map, "t1", "call-2", "other");
+
+    expect(subAgentTranscript(map, "t1", "call-1")).toEqual([
+      expect.objectContaining({ role: "assistant", content: "Hello world" })
+    ]);
+    expect(subAgentTranscript(map, "t1", "call-2")).toHaveLength(1);
+  });
+
+  it("replaces the streamed placeholder with the finalized message", () => {
+    let map: SubAgentMessages = {};
+    map = appendSubAgentChunk(map, "t1", "call-1", "Done");
+    map = appendSubAgentMessage(map, "t1", "call-1", {
+      id: "server-1",
+      role: "assistant",
+      type: "message",
+      content: "Done."
+    });
+
+    const transcript = subAgentTranscript(map, "t1", "call-1");
+    expect(transcript).toHaveLength(1);
+    expect(transcript[0].id).toBe("server-1");
+    expect(transcript[0].content).toBe("Done.");
+  });
+
+  it("appends a tool-call message rather than merging it into the stream", () => {
+    let map: SubAgentMessages = {};
+    map = appendSubAgentChunk(map, "t1", "call-1", "working");
+    map = appendSubAgentMessage(map, "t1", "call-1", {
+      role: "assistant",
+      type: "message",
+      content: null,
+      tool_calls: [{ id: "child-1", name: "search", args: {} }]
+    });
+
+    expect(subAgentTranscript(map, "t1", "call-1")).toHaveLength(2);
+  });
+
+  it("records a child tool result as a tool message", () => {
+    const map = appendSubAgentToolResult({}, "t1", "call-1", {
+      tool_call_id: "child-1",
+      name: "search",
+      result: { hits: 2 }
+    });
+
+    expect(subAgentTranscript(map, "t1", "call-1")[0]).toEqual(
+      expect.objectContaining({
+        role: "tool",
+        tool_call_id: "child-1",
+        content: { hits: 2 }
+      })
+    );
+  });
+
+  it("ignores a tool result with no call id", () => {
+    expect(
+      appendSubAgentToolResult({}, "t1", "call-1", { result: 1 })
+    ).toEqual({});
+  });
+
+  it("returns a stable empty transcript when nothing is recorded", () => {
+    expect(subAgentTranscript({}, "t1", "call-1")).toBe(
+      subAgentTranscript({}, "t2", "call-2")
+    );
+  });
+});

--- a/web/src/core/chat/chatProtocol.ts
+++ b/web/src/core/chat/chatProtocol.ts
@@ -10,6 +10,12 @@
  */
 
 import { visibleToolArgs } from "./toolCallFields";
+import {
+  appendSubAgentChunk,
+  appendSubAgentMessage,
+  appendSubAgentToolResult,
+  subAgentCallId
+} from "./subAgentMessages";
 
 // NOTE: There is deliberately no content-based chunk deduplication here.
 // The old cache keyed a chunk by (content, message-length-before-append) with a
@@ -41,7 +47,8 @@ import {
   StepResult,
   TaskUpdate,
   TodoUpdate,
-  ToolCallUpdate
+  ToolCallUpdate,
+  ToolResultUpdate
 } from "../../stores/ApiTypes";
 import { FrontendToolRegistry } from "../../lib/tools/frontendTools";
 import { getFrontendToolRuntimeState } from "../../lib/tools/frontendToolRuntimeState";
@@ -173,6 +180,7 @@ type MsgpackData =
   | EdgeUpdate
   | Message
   | ToolCallUpdate
+  | ToolResultUpdate
   | TaskUpdate
   | TodoUpdate
   | PlanningUpdate
@@ -423,6 +431,23 @@ const applyChunk = (
   if (!thread) {
     console.warn(`applyChunk: Thread ${threadId} not found, dropping chunk`);
     return noopUpdate;
+  }
+
+  // A sub-agent's text belongs to its own transcript, not to the parent's
+  // reply — and its `done` marks the child settling, not the turn.
+  const subAgentCall = subAgentCallId(chunk);
+  if (subAgentCall) {
+    const text = isString(chunk.content) ? chunk.content : "";
+    return {
+      update: {
+        subAgentMessages: appendSubAgentChunk(
+          state.subAgentMessages,
+          threadId,
+          subAgentCall,
+          text
+        )
+      }
+    };
   }
 
   const messages = state.messageCache[threadId] || [];
@@ -707,6 +732,34 @@ const applyToolCallUpdate = (
     patch.agentExecutionToolCalls = agentExecutionToolCalls;
   }
   return { update: patch };
+};
+
+/**
+ * Tool results from inside a sub-agent. The main thread gets its results as
+ * persisted `tool` messages, so only the child's transient
+ * `tool_result_update` events are recorded here — without them a nested tool
+ * row in a sub-agent card would never show what the call returned.
+ */
+const applyToolResultUpdate = (
+  state: GlobalChatState,
+  update: ToolResultUpdate,
+  routedThreadId: string | null
+): ReducerResult => {
+  const threadId = update.thread_id ?? routedThreadId ?? state.currentThreadId;
+  const subAgentCall = subAgentCallId(update);
+  if (!threadId || !subAgentCall) {
+    return noopUpdate;
+  }
+  return {
+    update: {
+      subAgentMessages: appendSubAgentToolResult(
+        state.subAgentMessages,
+        threadId,
+        subAgentCall,
+        update
+      )
+    }
+  };
 };
 
 interface AgentExecutionMessage extends Message {
@@ -1057,6 +1110,20 @@ const applyMessage = (
   if (!threadId) {
     return noopUpdate;
   }
+  const subAgentCall = subAgentCallId(msg);
+  if (subAgentCall) {
+    return {
+      update: {
+        subAgentMessages: appendSubAgentMessage(
+          state.subAgentMessages,
+          threadId,
+          subAgentCall,
+          msg
+        )
+      }
+    };
+  }
+
   const messages = state.messageCache[threadId] || [];
 
   if (isAgentExecutionMessage(msg)) {
@@ -1504,6 +1571,8 @@ export async function handleChatWebSocketMessage(
     applyReducer(applyOutputUpdate, data);
   } else if (data.type === "tool_call_update") {
     applyReducer(applyToolCallUpdate, data);
+  } else if (data.type === "tool_result_update") {
+    applyReducer(applyToolResultUpdate, data);
   } else if (data.type === "planning_update") {
     // Planners forward their progress as bare planning_update events rather
     // than agent_execution messages, so drive the thread runtime directly.

--- a/web/src/core/chat/subAgentMessages.ts
+++ b/web/src/core/chat/subAgentMessages.ts
@@ -1,0 +1,151 @@
+/**
+ * Sub-agent transcripts, kept out of the main thread.
+ *
+ * A `run_subtask` / `run_search` child streams its own chunks, tool calls and
+ * tool results back over the same socket, each tagged with the
+ * `parent_tool_call_id` of the call that spawned it. Appending those to the
+ * thread's message cache interleaves a child's prose with the parent's reply.
+ * They are bucketed here instead — one transcript per spawning call — and the
+ * chat renders each bucket inside that call's card.
+ */
+
+import type { Message } from "../../stores/ApiTypes";
+import { isString } from "../../utils/typePredicates";
+
+/** threadId → spawning tool_call_id → the child's messages, in arrival order. */
+export type SubAgentMessages = Record<string, Record<string, Message[]>>;
+
+interface SubAgentTagged {
+  parent_tool_call_id?: string | null;
+}
+
+/** The spawning call's id when this payload came from a sub-agent, else null. */
+export function subAgentCallId(payload: SubAgentTagged): string | null {
+  const id = payload.parent_tool_call_id;
+  return isString(id) && id.length > 0 ? id : null;
+}
+
+/** Shared empty result so selectors keep a stable reference. */
+const EMPTY_TRANSCRIPT: Message[] = [];
+
+/** The transcript for one spawning call. Empty array when there is none. */
+export function subAgentTranscript(
+  map: SubAgentMessages | undefined,
+  threadId: string | null | undefined,
+  callId: string | null | undefined
+): Message[] {
+  if (!map || !threadId || !callId) {
+    return EMPTY_TRANSCRIPT;
+  }
+  return map[threadId]?.[callId] ?? EMPTY_TRANSCRIPT;
+}
+
+function withTranscript(
+  map: SubAgentMessages,
+  threadId: string,
+  callId: string,
+  messages: Message[]
+): SubAgentMessages {
+  return {
+    ...map,
+    [threadId]: { ...(map[threadId] ?? {}), [callId]: messages }
+  };
+}
+
+const textOf = (message: Message): string =>
+  isString(message.content) ? message.content : "";
+
+/**
+ * Fold streamed text into the transcript's trailing assistant message, or
+ * start one. Mirrors what `applyChunk` does for the main thread.
+ */
+export function appendSubAgentChunk(
+  map: SubAgentMessages,
+  threadId: string,
+  callId: string,
+  text: string
+): SubAgentMessages {
+  if (!text) {
+    return map;
+  }
+  const messages = map[threadId]?.[callId] ?? [];
+  const last = messages[messages.length - 1];
+  if (last && last.role === "assistant" && !last.tool_calls) {
+    const merged: Message = { ...last, content: textOf(last) + text };
+    return withTranscript(map, threadId, callId, [
+      ...messages.slice(0, -1),
+      merged
+    ]);
+  }
+  const started: Message = {
+    id: `subagent-stream-${callId}-${messages.length}`,
+    role: "assistant",
+    type: "message",
+    content: text,
+    thread_id: threadId,
+    parent_tool_call_id: callId
+  };
+  return withTranscript(map, threadId, callId, [...messages, started]);
+}
+
+/**
+ * Append a server-authored child message. An assistant message that finalizes
+ * text already streamed into the transcript replaces that placeholder instead
+ * of doubling it.
+ */
+export function appendSubAgentMessage(
+  map: SubAgentMessages,
+  threadId: string,
+  callId: string,
+  message: Message
+): SubAgentMessages {
+  const messages = map[threadId]?.[callId] ?? [];
+  const last = messages[messages.length - 1];
+  const incomingText = textOf(message).trimEnd();
+  const lastText = last ? textOf(last).trimEnd() : "";
+  const finalizesStream =
+    message.role === "assistant" &&
+    last?.role === "assistant" &&
+    lastText.length > 0 &&
+    incomingText.startsWith(lastText);
+  if (finalizesStream) {
+    const replacement: Message = {
+      ...last,
+      ...message,
+      content: message.content ?? last.content
+    };
+    return withTranscript(map, threadId, callId, [
+      ...messages.slice(0, -1),
+      replacement
+    ]);
+  }
+  return withTranscript(map, threadId, callId, [...messages, message]);
+}
+
+/** Record a child tool result as the `tool` message the renderer looks up. */
+export function appendSubAgentToolResult(
+  map: SubAgentMessages,
+  threadId: string,
+  callId: string,
+  result: {
+    tool_call_id?: string | null;
+    name?: string | null;
+    result?: unknown;
+  }
+): SubAgentMessages {
+  const toolCallId = result.tool_call_id;
+  if (!isString(toolCallId) || !toolCallId) {
+    return map;
+  }
+  const message: Message = {
+    role: "tool",
+    type: "message",
+    name: result.name ?? null,
+    tool_call_id: toolCallId,
+    content: result.result as Message["content"],
+    thread_id: threadId,
+    parent_tool_call_id: callId,
+    created_at: new Date().toISOString()
+  };
+  return appendSubAgentMessage(map, threadId, callId, message);
+}

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -51,6 +51,7 @@ import { ConnectionState } from "../lib/websocket/WebSocketManager";
 import { globalWebSocketManager } from "../lib/websocket/GlobalWebSocketManager";
 import { FrontendToolRegistry } from "../lib/tools/frontendTools";
 import { handleChatWebSocketMessage } from "../core/chat/chatProtocol";
+import type { SubAgentMessages } from "../core/chat/subAgentMessages";
 import type { ChatOutgoingMessage } from "./MediaGenerationStore";
 import { useShallow } from "zustand/react/shallow";
 import {
@@ -257,6 +258,13 @@ export interface GlobalChatState {
 
   // Agent execution trace
   agentExecutionToolCalls: AgentExecutionToolCalls;
+
+  /**
+   * Sub-agent transcripts, keyed threadId → spawning tool_call_id. A
+   * `run_subtask` child's events never enter `messageCache`; the chat renders
+   * them inside the spawning call's card instead.
+   */
+  subAgentMessages: SubAgentMessages;
 
   // Selections
   selectedModel: LanguageModel;
@@ -553,6 +561,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
 
       // Agent execution trace
       agentExecutionToolCalls: {},
+      subAgentMessages: {},
 
       // Selections
       selectedModel: buildDefaultLanguageModel(),
@@ -1421,6 +1430,8 @@ const useGlobalChatStore = create<GlobalChatState>()(
             threadUnsubscribe?.();
             const { [threadId]: _deletedTodos, ...remainingTodos } =
               state.todosByThread;
+            const { [threadId]: _deletedSubAgents, ...remainingSubAgents } =
+              state.subAgentMessages;
             const {
               [threadId]: _deletedReplayCursor,
               ...remainingReplayCursors
@@ -1437,6 +1448,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
               messageCursors: remainingCursors,
               wsThreadSubscriptions: remainingSubscriptions,
               todosByThread: remainingTodos,
+              subAgentMessages: remainingSubAgents,
               threadRuntime: remainingRuntime,
               chatReplayCursors: remainingReplayCursors
             };


### PR DESCRIPTION
## What changed

Sub-agent events already reached the client tagged with `parent_tool_call_id`, but the web ignored the tag: a child's chunks were appended to the parent's assistant message and its tool-call cards landed flat in the main timeline, so a delegated loop read as the agent talking to itself. Child events now bucket per spawning call (`threadId → tool_call_id`, in `web/src/core/chat/subAgentMessages.ts`) and never enter the thread's message cache; a child's `done` chunk no longer ends the parent turn. The `run_subtask` / `run_search` row is the card: folded it shows the compact goal (`description`, or `query` for a search) and a message count, unfolded it shows the objective clamped to three lines and the child's transcript rendered by `MessageView` itself, so nested tool rows and prose read the same as in the main thread. The CodeAct sandbox bridge now emits `tool_result_update` — nothing emitted results for a child's tool calls before, so a nested row could never show what its call returned.

## Verification

- [x] `npm run test:affected` — one package fails, `@nodetool-ai/image-nodes`, entirely on `No WebGPU adapter available (Node/Dawn)`: this container has no Vulkan ICD. Unrelated to the diff (no image node is touched) and documented in AGENTS.md as an environment gap. Turbo's abort meant the web/electron/mobile legs did not run under this command, so the web suite was run directly: `npx jest` in `web/`.
- [x] `npm run typecheck` — clean on every changed file; the remaining errors in the tree are pre-existing `Cannot find module '@nodetool-ai/node-sdk/cost-estimate'` resolution failures.
- [x] `npm run lint` — clean on every changed file.
- [ ] `npm run dev:nodetool -- harness gate --base main` — not run; the diff adds no harness surface.

New tests: `web/src/core/chat/__tests__/subAgentMessages.test.ts` (bucketing, placeholder finalization, tool results), four routing cases in `chatProtocol.test.ts` (a child's text stays out of the parent reply, a child's `done` does not end the turn, a child's card and result bucket together, a root-level result is left alone), `MessageView.subAgent.test.tsx` (folded goal + count, unfolded transcript), and one case in `codeact-executor.test.ts` for the emitted result.

Proving the card test can fail — with the transcript render removed:

```
✓ shows the goal and message count while folded
✕ renders the child's own messages when unfolded
✓ stays a plain row when the child has said nothing yet
Tests: 1 failed, 2 passed, 3 total
```

## Agent capabilities

No capability is added and no declared contract changes. `buildToolBridge` gains an optional `onToolResult` observability hook alongside the existing `onToolCall`.

## New checks

No check, rule, or audit is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BCKPD6o6EFUVMYCMmAR2p

---
_Generated by [Claude Code](https://claude.ai/code/session_011BCKPD6o6EFUVMYCMmAR2p)_