### PR TITLE
feat(projects): give the new-project prompt the composer's triggers

### DIFF
--- a/web/src/components/chat/composer/useTextareaSkillMention.tsx
+++ b/web/src/components/chat/composer/useTextareaSkillMention.tsx
@@ -139,6 +139,8 @@ interface UseTextareaSkillMentionOptions {
   textareaRef: React.RefObject<HTMLTextAreaElement | null>;
   value: string;
   setValue: (next: string) => void;
+  /** Called with the picked skill after its `/name` has been written in. */
+  onSelect?: (skill: Skill) => void;
 }
 
 interface UseTextareaSkillMention {
@@ -152,7 +154,8 @@ interface UseTextareaSkillMention {
 export const useTextareaSkillMention = ({
   textareaRef,
   value,
-  setValue
+  setValue,
+  onSelect
 }: UseTextareaSkillMentionOptions): UseTextareaSkillMention => {
   // The shipped skills answer to `/name` in a turn exactly as a user's own row
   // does, so the menu that completes that name offers both.
@@ -276,9 +279,10 @@ export const useTextareaSkillMention = ({
           value.slice(0, trigger.start) + inserted + value.slice(trigger.end)
         );
       }
+      onSelect?.(skill);
       close();
     },
-    [close, setValue, trigger, value]
+    [close, onSelect, setValue, trigger, value]
   );
 
   const selectIndex = useCallback(

--- a/web/src/components/projects/NewProjectSurface.tsx
+++ b/web/src/components/projects/NewProjectSurface.tsx
@@ -1,10 +1,12 @@
 /**
  * "What do you want to make?" — the surface a project is started from.
  *
- * The prompt goes to the project's own agent, which builds the documents. A
- * starter is one of the user's skills — their own or one NodeTool ships — and
- * picking one prefixes the opening turn with `/<name>`, the same slash command
- * the composer sends, so the agent reads that skill's instructions before it
+ * The prompt goes to the project's own agent, which builds the documents. The
+ * box takes the chat composer's triggers: `/` completes a skill and `@` picks
+ * an asset or a library entity, so the opening turn is written the same way
+ * every other turn is. A starter is one of the user's skills — their own or one
+ * NodeTool ships — picked from a chip or from `/`, and it prefixes the opening
+ * turn with `/<name>` so the agent reads that skill's instructions before it
  * plans anything. The picked skill is stored as the project's kind, which is
  * what its spend history is read back by. Blank documents keep their place at
  * the foot of the view, opening loose tabs the way the `+ New` menu always
@@ -33,8 +35,11 @@ import {
   TextInput,
   TYPOGRAPHY
 } from "../ui_primitives";
-import type { MessageContent } from "../../stores/ApiTypes";
+import type { Asset, MessageContent } from "../../stores/ApiTypes";
 import { useFileHandling } from "../chat/hooks/useFileHandling";
+import { useTextareaAssetMention } from "../chat/composer/useTextareaAssetMention";
+import { useTextareaSkillMention } from "../chat/composer/useTextareaSkillMention";
+import { assetToUri } from "../node_types/editing/promptComposer/promptTokens";
 import { useEntities } from "../../serverState/useEntities";
 import { useNotificationStore } from "../../stores/NotificationStore";
 import useGlobalChatStore from "../../stores/GlobalChatStore";
@@ -94,15 +99,16 @@ const NewProjectSurface = () => {
   const [entityAnchor, setEntityAnchor] = useState<HTMLElement | null>(null);
   const [submenu, setSubmenu] = useState<SubmenuAnchor | null>(null);
   const [starting, setStarting] = useState(false);
-  // The model the project agent will run on, picked here — this surface has no
-  // composer, so its menu is the only place to pick one before Start.
+  // The model the project agent will run on, picked here — the prompt box has
+  // no model chip, so this menu is the only place to pick one before Start.
   const [modelAnchor, setModelAnchor] = useState<HTMLElement | null>(null);
   // A start requested before a provider was configured, resumed once one is.
   const [pendingStart, setPendingStart] = useState(false);
   const refInputRef = useRef<HTMLInputElement>(null);
   const modelButtonRef = useRef<HTMLButtonElement>(null);
+  const promptRef = useRef<HTMLTextAreaElement>(null);
 
-  const { droppedFiles, addFiles, removeFile, getFileContents } =
+  const { droppedFiles, addFiles, addDroppedFiles, removeFile, getFileContents } =
     useFileHandling();
   const { data: entities } = useEntities();
   // Both the user's own skills and the ones NodeTool ships: either is a
@@ -172,6 +178,61 @@ const NewProjectSurface = () => {
         : [...ids, entity.id]
     );
   }, []);
+
+  // The prompt box carries the composer's own triggers: `@` picks an asset or
+  // a library entity, `/` picks the skill to start from. A picked asset is
+  // attached as an `asset://` reference the way a dropped file is; a picked
+  // entity is written inline as its `entity://<id>` token, which the server
+  // resolves per turn.
+  const handleSelectAsset = useCallback(
+    (asset: Asset) => {
+      addDroppedFiles([
+        {
+          id: "",
+          dataUri: asset.thumb_url || asset.get_url || "",
+          type: asset.content_type || "application/octet-stream",
+          name: asset.name || asset.id,
+          assetUri: assetToUri(asset)
+        }
+      ]);
+    },
+    [addDroppedFiles]
+  );
+
+  const { mentionMenu, handleKeyDown: handleMentionKeyDown } =
+    useTextareaAssetMention({
+      textareaRef: promptRef,
+      value: prompt,
+      setValue: setPrompt,
+      onSelectAsset: handleSelectAsset,
+      includeEntities: true
+    });
+
+  // A skill picked from `/` is the project's starter too — it is what the
+  // project's kind is stored as, and what its spend estimate reads back. The
+  // `/name` stays in the prompt where the user typed it; `composeFirstTurn`
+  // knows not to write a second one.
+  const { skillMenu, handleKeyDown: handleSkillKeyDown } =
+    useTextareaSkillMention({
+      textareaRef: promptRef,
+      value: prompt,
+      setValue: setPrompt,
+      onSelect: (skill) => setStarterName(skill.name)
+    });
+
+  // The handler rides the field wrapper, where MUI puts unknown props, and the
+  // keydown reaches it by bubbling from the textarea. Both pickers only read
+  // `key` and call `preventDefault`, so the retype is safe.
+  const handlePromptKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const keyEvent = event as unknown as React.KeyboardEvent<HTMLTextAreaElement>;
+      if (handleSkillKeyDown(keyEvent)) {
+        return;
+      }
+      handleMentionKeyDown(keyEvent);
+    },
+    [handleMentionKeyDown, handleSkillKeyDown]
+  );
 
   const handleRefImages = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -329,9 +390,13 @@ const NewProjectSurface = () => {
               rows={3}
               label="Project prompt"
               hideLabel
-              placeholder="A 30-second launch spot for our desk lamp — warm, minimal, night-time mood"
+              inputRef={promptRef}
+              placeholder="A 30-second launch spot for our desk lamp — warm, minimal, night-time mood. Type / for a skill, @ for an asset or entity."
               onChange={(event) => setPrompt(event.target.value)}
+              onKeyDown={handlePromptKeyDown}
             />
+            {mentionMenu}
+            {skillMenu}
 
             {droppedFiles.length > 0 && (
               <FlexRow gap={SPACING.md} wrap>

--- a/web/src/components/projects/__tests__/NewProjectSurface.test.tsx
+++ b/web/src/components/projects/__tests__/NewProjectSurface.test.tsx
@@ -2,7 +2,7 @@
  * Starting a project: what Start creates, what the agent is handed, and that
  * the blank-document strip still opens loose tabs.
  */
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";
@@ -169,6 +169,34 @@ const openPageTab = jest.fn();
 jest.mock("../../workspace/openPageTab", () => ({
   openPageTab: (key: string) => openPageTab(key)
 }));
+
+// The `@` picker's search fans out to the asset store and the entity library;
+// this surface only needs the picked row to reach the prompt.
+jest.mock(
+  "../../node_types/editing/promptComposer/useAssetMentionSearch",
+  () => ({
+    useAssetMentionSearch: (query: string | null) => ({
+      activeTab: "recent",
+      setActiveTab: jest.fn(),
+      entities:
+        query === null
+          ? []
+          : [
+              {
+                id: "e1",
+                kind: "prop",
+                name: "Aurora lamp",
+                descriptor: "a warm desk lamp",
+                reference_images: []
+              }
+            ],
+      displayedAssets: [],
+      hasMoreSaved: false,
+      loadMoreSaved: jest.fn(),
+      handleRename: jest.fn()
+    })
+  })
+);
 
 const handleCreateNewWorkflow = jest.fn(async () => undefined);
 jest.mock("../../../hooks/useWorkflowActions", () => ({
@@ -463,5 +491,44 @@ describe("NewProjectSurface", () => {
     expect(
       screen.getByPlaceholderText(/30-second launch spot/)
     ).toHaveValue("A spot for our desk lamp");
+  });
+  // The prompt box is the project's composer, so it carries the composer's own
+  // triggers rather than making the user reach for the buttons beside it.
+  it("completes a skill from `/` and starts the project on it", async () => {
+    renderSurface();
+    const prompt = screen.getByPlaceholderText(/30-second launch spot/);
+    await userEvent.type(prompt, "/launch");
+
+    await userEvent.click(
+      await screen.findByTestId("skill-option-launch-commercial")
+    );
+    expect(prompt).toHaveValue("/launch-commercial ");
+
+    await userEvent.type(prompt, "A spot for our desk lamp");
+    await userEvent.click(screen.getByRole("button", { name: "Start" }));
+
+    await waitFor(() => expect(createProject).toHaveBeenCalled());
+    // Picked from the prompt, the skill is still the project's kind.
+    expect(createProject).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "launch-commercial" })
+    );
+    const staged = takeProjectFirstTurn("p9");
+    // The `/name` the user typed is the only one — the starter is not written
+    // in a second time.
+    expect(staged?.[0]).toEqual({
+      type: "text",
+      text: "/launch-commercial A spot for our desk lamp"
+    });
+  });
+
+  it("writes an entity picked from `@` into the prompt as its token", async () => {
+    renderSurface();
+    const prompt = screen.getByPlaceholderText(/30-second launch spot/);
+    await userEvent.type(prompt, "A spot lit by @auro");
+
+    const menu = await screen.findByRole("listbox", { name: "Entities" });
+    await userEvent.click(within(menu).getByText("Aurora lamp"));
+
+    expect(prompt).toHaveValue("A spot lit by entity://e1 ");
   });
 });

--- a/web/src/components/projects/__tests__/projectStarters.test.ts
+++ b/web/src/components/projects/__tests__/projectStarters.test.ts
@@ -91,6 +91,29 @@ describe("composeFirstTurn", () => {
     );
   });
 
+  // The prompt's own `/` menu writes the command inline; a second copy above
+  // it would load the skill twice and read as a mistake.
+  it("writes no second copy when the prompt already invokes the starter", () => {
+    expect(
+      composeFirstTurn({
+        prompt: "/launch-commercial A spot for our desk lamp",
+        starter: launch,
+        entityNames: []
+      })
+    ).toBe("/launch-commercial A spot for our desk lamp");
+  });
+
+  // A different skill named in the prompt is not this project's starter.
+  it("still leads with the starter when the prompt invokes another skill", () => {
+    expect(
+      composeFirstTurn({
+        prompt: "/house-style A spot for our desk lamp",
+        starter: launch,
+        entityNames: []
+      })
+    ).toBe("/launch-commercial\n\n/house-style A spot for our desk lamp");
+  });
+
   // The host matches `/name` at the start of the text or after whitespace, so
   // the command must lead its own line and the prompt must survive verbatim.
   it("leaves a prompt of its own alone when no starter is picked", () => {

--- a/web/src/components/projects/projectStarters.ts
+++ b/web/src/components/projects/projectStarters.ts
@@ -64,21 +64,32 @@ interface FirstTurnInput {
   entityNames: readonly string[];
 }
 
+/** True when the prompt already invokes `/name` as a whitespace-delimited word. */
+const invokesStarter = (prompt: string, name: string): boolean => {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(^|\\s)/${escaped}(\\s|$)`).test(prompt);
+};
+
 /**
  * The first thing the project's agent reads: the starter it was given, what
  * the user asked for, and which library entities to season the prompts with.
  *
  * The starter leads on its own line as `/<name>`, which is what the host
  * matches to load the skill's instructions into the turn — a name after
- * whitespace, so the prompt below it is left exactly as written. Each part is
- * omitted when it says nothing.
+ * whitespace, so the prompt below it is left exactly as written. A prompt that
+ * already types that slash command (the composer's `/` menu writes it inline)
+ * keeps its own copy rather than getting a second one. Each part is omitted
+ * when it says nothing.
  */
 export const composeFirstTurn = ({
   prompt,
   starter,
   entityNames
 }: FirstTurnInput): string => {
-  const parts = starter ? [`/${starter.name}`] : [];
+  const parts =
+    starter && !invokesStarter(prompt, starter.name)
+      ? [`/${starter.name}`]
+      : [];
   parts.push(prompt.trim());
   if (entityNames.length > 0) {
     parts.push(`Use these entities: ${entityNames.join(", ")}.`);


### PR DESCRIPTION
## What changed

The box a project is started from was a plain textarea: skills had to be picked from the starter chips and entities from a button, while every other turn in the product is written with `/` and `@`. It now carries the same two pickers the chat composer uses — `useTextareaSkillMention` and `useTextareaAssetMention`. `/` completes a skill, writes `/name` where the caret is, and stores that skill as the project's kind, so a skill picked from the prompt still drives the spend estimate the chips do. `@` picks an asset — attached as an `asset://` reference the way a dropped file is — or a library entity, written inline as its `entity://<id>` token, which the server resolves per turn. `composeFirstTurn` no longer prefixes a starter the prompt already invokes, so a slash-picked skill is loaded once rather than twice. The skill hook gained an optional `onSelect` callback; `MediaChatComposer` passes nothing and is unchanged.

## Verification

- [x] `npm run test:affected` — exit 0
- [x] `npm run typecheck` — clean after `npm run build:packages` (the stale-`dist` module-resolution errors are unrelated to this diff and clear on a rebuild)
- [x] `npm run lint` — no new findings
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 3/3 selfchecks passed`, all 5 Ring 0 reliability journeys passed

Targeted suites: `npx jest src/components/chat/composer src/components/projects` — 21 suites, 176 tests, all passing. Four tests added: two on the surface (a `/` pick that reaches `createProject` with `kind: "launch-commercial"` and stages one copy of the command; an `@` pick that writes `entity://e1` into the prompt) and two on `composeFirstTurn` (no second copy when the prompt already invokes the starter; the starter still leads when the prompt names a different skill).

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JutNwXBrFs97e8H2sqoc4x

---
_Generated by [Claude Code](https://claude.ai/code/session_01JutNwXBrFs97e8H2sqoc4x)_