### PR TITLE
feat(harness): close the coverage holes in the harness gate and registry

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -412,13 +412,15 @@ jobs:
           # --base origin/main`) has the commits to diff.
           fetch-depth: ${{ matrix.fetch-depth }}
 
-      # `harness-gate` diffs against the named ref `origin/main`, not a SHA,
-      # so it needs the branch itself fetched under that name — fetch-depth: 0
-      # above brings in the commits but not necessarily the remote-tracking
-      # ref. A no-op on every other leg.
+      # `harness-gate` diffs against the named ref `origin/main`, not a SHA.
+      # fetch-depth: 0 above already fetches every head into refs/remotes/
+      # origin/*; this refreshes `main` in case the checkout ran against a
+      # stale mirror. Never add `--prune` here: with a single refspec it
+      # deleted `origin/main` instead of updating it. A no-op on every other
+      # leg.
       - name: Fetch origin/main for the harness gate
         if: matrix.check == 'harness-gate'
-        run: git fetch --no-tags --prune origin main:refs/remotes/origin/main
+        run: git fetch --no-tags origin main:refs/remotes/origin/main
 
       - name: Set up Node, install deps
         uses: ./.github/actions/setup-build

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -212,9 +212,30 @@ jobs:
   # its real work, and the account-wide runner cap (~20 concurrent jobs) makes
   # each extra leg queue time for the whole PR. The cheap checks are therefore
   # chained inside one leg — `typecheck` runs typecheck + parity + examples,
-  # `bundle` runs the packaged-backend smoke + Ring 0 reliability. Chained with
-  # `&&`, mirroring the `deps` leg: the first failure stops the chain, so a red
-  # leg names one problem at a time.
+  # `bundle` runs the packaged-backend smoke. Chained with `&&`, mirroring the
+  # `deps` leg: the first failure stops the chain, so a red leg names one
+  # problem at a time.
+  #
+  # `harness-gate` runs `nodetool harness gate` (docs/HARNESS_FIRST.md § The
+  # gate): it maps the diff against `origin/main` onto the surfaces in
+  # `packages/cli/src/harness/registry.ts` and runs the keyless selfcheck of
+  # every harness covering a touched surface — the diff selects the checks,
+  # not this file. This is what replaced the old `reliability:ring0` half of
+  # the `bundle` leg (still runs on any diff touching `packages/kernel/` —
+  # see the `workflow-execution` surface in the registry) and the standalone
+  # `app-build` leg (its two deterministic cases are the `app-build`
+  # harness's selfcheck, run when a diff touches `packages/agents/src/app-build/`).
+  # A changed code file no surface claims fails the leg (see
+  # docs/harnesses.md § nodetool harness); `--strict` is left off so a diff
+  # touching a documented gap (mobile/, electron/) still passes;
+  # `--timeout` bounds each selfcheck so a hang fails the leg
+  # instead of the job's own timeout cutting it off with no verdict. A PR that
+  # touches nothing the registry maps runs no selfcheck at all — intended, not
+  # a gap: see docs/HARNESS_FIRST.md. On push to main there is no PR diff to
+  # read, so the leg runs every selfcheck instead (`--all`). Either way the
+  # gate skips `cost: "expensive"` selfchecks (Blender render, the packaged
+  # backend, …) unless `--expensive` is passed, so `backend:smoke` stays a
+  # leg of its own rather than folding into this one.
   #
   # The backend suite goes the other way: it is split across four runners
   # (`test-packages-*`). As one leg it was the gate's critical path by about
@@ -343,52 +364,61 @@ jobs:
             extra-apt: ""
             is-test: "true"
             fetch-depth: "1"
-          # Two release gates in one leg:
-          #   1. `npm run backend:smoke` stages the packaged backend and boots
-          #      it. Nothing outside the release workflow used to build the
-          #      bundle, so a packaging regression only surfaced once a release
-          #      was cut — and the release's smoke-launch spawns the Electron
-          #      main process, which survives its backend child dying.
-          #      v0.7.1-nightly.20260728.713 shipped a sharp/@img major skew
-          #      that killed server.mjs on import with every other check green.
-          #   2. `npm run reliability:ring0` (docs/RELIABILITY_TASKS.md Track F,
-          #      task F2; docs/RELIABILITY_ARCHITECTURE.md §11): the five
-          #      fastest golden journeys (linear-text-pipeline,
-          #      fan-out-fan-in-dag, error-in-one-branch, mid-run-cancel-node,
-          #      mid-run-cancel-streaming — journeys 1/3/6a/6b/13) on the kernel
-          #      surface, strict lifecycle mode always on
-          #      (reliability/harness/src/drivers/kernel.ts). No network, no
-          #      cross-surface diff — that's Ring 1.
-          # is-test:false — these are release gates, not unit suites, so they
-          # stay required even when skip-tests drops the bulk test legs
-          # (matching the Ring 0 flake budget of zero).
+          # The packaged-backend release gate: `npm run backend:smoke` stages
+          # the packaged backend and boots it. Nothing outside the release
+          # workflow used to build the bundle, so a packaging regression only
+          # surfaced once a release was cut — and the release's smoke-launch
+          # spawns the Electron main process, which survives its backend child
+          # dying. v0.7.1-nightly.20260728.713 shipped a sharp/@img major skew
+          # that killed server.mjs on import with every other check green.
+          # `nodetool harness gate`'s `backend-smoke` selfcheck runs the same
+          # command but is `cost: "expensive"`, so the default gate (below)
+          # skips it — this leg is what keeps it on every PR. The Ring 0
+          # golden journeys used to run here too
+          # (docs/RELIABILITY_TASKS.md Track F, task F2); they moved to the
+          # `harness-gate` leg's `reliability-ring0` selfcheck, which runs on
+          # any diff touching `packages/kernel/` (or the other
+          # `workflow-execution` surface paths) without hand-listing them here.
+          # is-test:false — a release gate, not a unit suite, so it stays
+          # required even when skip-tests drops the bulk test legs.
           - check: bundle
-            command: npm run backend:smoke && npm run reliability:ring0
+            command: npm run backend:smoke
             mobile-deps: "false"
             extra-apt: ""
             is-test: "false"
             fetch-depth: "1"
-          # The `app-build` suite's two deterministic cases: a pinned spec over
-          # template graphs, authored by a script instead of a model, run on the
-          # real kernel. They call no provider, so no API key is needed — the
-          # `-p ollama -m none` provider is constructed and never used. This is
-          # the mini-app build harness's regression gate (the full suite runs
-          # nightly in app-build-eval.yml, where a model is in the loop).
-          # --min-success 1 because a deterministic case has no variance: if it
-          # is not green, the harness broke.
-          - check: app-build
-            command: npm run dev:nodetool -- eval app-build --cases greeting-card,draft-then-publish -p ollama -m none --no-find-model --min-success 1
+          # `nodetool harness gate` — see the `built` job's header comment
+          # above for what it does and why the old `reliability:ring0` half of
+          # `bundle` and the standalone `app-build` leg both folded into it.
+          # `$GITHUB_EVENT_NAME` is a default runner env var, so no `${{ }}`
+          # templating is needed inside the matrix command. `--json` for a
+          # machine-readable log (rule 6, docs/HARNESS_FIRST.md). is-test:false
+          # for the same reason as
+          # `bundle`: this is a gate, not a unit suite.
+          - check: harness-gate
+            command: if [ "$GITHUB_EVENT_NAME" = "push" ]; then npm run dev:nodetool -- harness gate --all --json --timeout 900; else npm run dev:nodetool -- harness gate --base origin/main --json --timeout 900; fi
             mobile-deps: "false"
             extra-apt: ""
             is-test: "false"
-            fetch-depth: "1"
+            fetch-depth: "0"
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
-          # Most legs only need the tip; the test-packages shards need full
-          # history so Turbo's `--affected` can diff against the PR base commit.
+          # Most legs only need the tip; the test-packages shards and
+          # harness-gate need full history — the former for Turbo's
+          # `--affected` diff against the PR base commit, the latter so
+          # `git diff --name-only origin/main...HEAD` (inside `harness gate
+          # --base origin/main`) has the commits to diff.
           fetch-depth: ${{ matrix.fetch-depth }}
+
+      # `harness-gate` diffs against the named ref `origin/main`, not a SHA,
+      # so it needs the branch itself fetched under that name — fetch-depth: 0
+      # above brings in the commits but not necessarily the remote-tracking
+      # ref. A no-op on every other leg.
+      - name: Fetch origin/main for the harness gate
+        if: matrix.check == 'harness-gate'
+        run: git fetch --no-tags --prune origin main:refs/remotes/origin/main
 
       - name: Set up Node, install deps
         uses: ./.github/actions/setup-build
@@ -403,12 +433,14 @@ jobs:
           name: packages-dist
           path: packages
 
-      # See the matching upload step in the `build` job above — the Ring 0
-      # reliability run (the `bundle` leg's second command) needs
-      # @nodetool-ai/reliability-harness's dist (the CLI dynamic-imports it at
-      # run time) alongside the packages-dist download.
+      # See the matching upload step in the `build` job above — a Ring 0
+      # reliability run needs @nodetool-ai/reliability-harness's dist (the CLI
+      # dynamic-imports it at run time) alongside the packages-dist download.
+      # Only `harness-gate` can trigger one now: its `reliability-ring0`
+      # selfcheck runs on any diff touching `packages/kernel/`, or on every
+      # selfcheck via `--all` on push to main.
       - name: Download reliability harness dist
-        if: matrix.check == 'bundle'
+        if: matrix.check == 'harness-gate'
         uses: actions/download-artifact@v8
         with:
           name: reliability-harness-dist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,17 +358,25 @@ npm run electron:dev        # Electron against Vite server (requires conda env)
 
 ### Mandatory Post-Change Verification
 
-After **any** code change, run these three — and only these three:
+After **any** code change, run these four — and only these four:
 
 ```bash
 npm run test:affected # Only the suites that depend on what changed
 npm run typecheck     # Type check web, electron, and mobile
 npm run lint          # Lint packages/*/src, web/src, electron, mobile/src
+npm run dev:nodetool -- harness gate --base origin/main # Only the harness selfchecks this diff demands
 ```
 
-All three must pass before the task is complete. Do not reach for the full
+All four must pass before the task is complete. Do not reach for the full
 `npm run test` + `npm run test:packages` pass instead: it is minutes of wall
 clock on a two-file change, and CI runs it on the PR anyway.
+
+`harness gate` reads the same diff and maps it onto the harness registry
+(`packages/cli/src/harness/registry.ts`): a change under `packages/kernel/`
+runs the Ring 0 reliability journeys, a change under `packages/agents/src/app-build/`
+runs the app-build harness's deterministic cases, and so on — see
+[docs/HARNESS_FIRST.md](docs/HARNESS_FIRST.md). `--dry-run` prints the plan
+without running anything, so a diff that maps to nothing costs nothing.
 
 `npm run test:affected` maps the diff — committed since the merge-base with
 `origin/main`, plus the working tree — onto workspaces with the same
@@ -485,6 +493,7 @@ reference is [docs/harnesses.md](docs/harnesses.md) plus [docs/cli.md](docs/cli.
 | Run a workflow (id, JSON, or DSL `.ts`) | `nodetool run <file>` / `nodetool workflows run <id> [--params …]` | `run_workflow`, `start_background_job` | varies |
 | Map changed files → minimal workspaces to rebuild/test | `nodetool affected [--base main]` | — | instant |
 | Run only the suites that depend on changed code (the pre-commit test pass) | `npm run test:affected [-- --dry-run]` | — | seconds–minutes |
+| Run the harness selfchecks this diff demands | `nodetool harness gate [--base main] [--strict]` | — | seconds–minutes |
 | Ask whether the product let an agent finish a real job, and keep the transcript | `nodetool jtbd run` / `jtbd optimize` | — | minutes |
 | Check that every agent capability names a check | `nodetool harness capabilities`; `npm run capabilities:check` | — | seconds |
 | Check a provider's live response against the decoder that reads it | `npm run probe:providers` (nightly; offline half runs on every provider diff) | — | seconds |

--- a/docs/HARNESS_FIRST.md
+++ b/docs/HARNESS_FIRST.md
@@ -104,6 +104,18 @@ every harness (id, canonical command, capabilities, agent tool, selfcheck,
 docs pointer) and every surface (the harnesses covering it, the code paths it
 owns, or its gap note).
 
+A surface with a harness is only useful if the gate can find it. `paths`
+routes a diff to the surfaces it touches, so a package with no entry
+anywhere is invisible to `nodetool harness gate` even when the harness that
+would have covered it exists — a diff there selects nothing, silently.
+`UNCLAIMED_PATHS` closes that hole from the other side: every directory under
+`packages/`, plus `web/`, `electron/`, `mobile/`, must appear in some
+surface's `paths` or in `UNCLAIMED_PATHS`, which names the reason nothing
+claims it yet and what closing that gap would need.
+`packages/cli/tests/harness-registry.test.ts` walks the real repo tree and
+fails the build on one that is in neither — the same shape as the
+harness-coverage invariant above, one layer below it.
+
 ```bash
 npm run dev:nodetool -- harness list            # every harness + capabilities
 npm run dev:nodetool -- harness audit           # surface coverage + gaps
@@ -190,7 +202,12 @@ second, driftable copy of the selection logic.
 
 ## Current gaps
 
-Run `nodetool harness audit` for the live list. As of this writing: the
-mobile app (the tool contract exists — drive it headlessly like the tool-loop
-evals do) and the Electron shell (unit tests only; a harness would boot the
-packaged shell under Playwright's Electron driver).
+Run `nodetool harness audit` for the live surface gaps: the mobile app (the
+tool contract exists — drive it headlessly like the tool-loop evals do) and
+the Electron shell (unit tests only; a harness would boot the packaged shell
+under Playwright's Electron driver).
+
+For the path-claim layer below that — a package with no harness *and* no
+surface even naming it — read `UNCLAIMED_PATHS` in the registry directly: each
+entry says what a diff there cannot verify headlessly today and what closing
+it would need.

--- a/docs/fly-production-deploy.md
+++ b/docs/fly-production-deploy.md
@@ -4,7 +4,7 @@ How `main` reaches https://api.nodetool.ai, what the rolling deploy does to each
 machine, and what to do when it stops half way. Self-hosting somebody else's
 NodeTool is a different job — see [Self-Hosted Deployment](self-hosted-deployment.md).
 
-The app is `nodetool` on Fly.io, configured by [`fly.toml`](../fly.toml) at the
+The app is `nodetool` on Fly.io, configured by [`fly.toml`](https://github.com/nodetool-ai/nodetool/blob/main/fly.toml) at the
 repo root. Its machines run in `fra`, next to the Supabase database, and the
 deploy replaces them one at a time so the others keep serving. That needs at
 least two machines (`fly scale count 2`); with one, the drain is an outage
@@ -14,7 +14,7 @@ window rather than a handover.
 
 A push to `main` starts two workflows independently: `docker.yml` builds and
 pushes the GHCR image, and `user-journeys.yml` runs the `reliability-ring1`
-suite. [`fly-deploy.yml`](../.github/workflows/fly-deploy.yml) triggers on the
+suite. [`fly-deploy.yml`](https://github.com/nodetool-ai/nodetool/blob/main/.github/workflows/fly-deploy.yml) triggers on the
 *completion* of either, and its `gate` job polls the other for the same commit.
 Whichever finishes second is the run that reaches the rollout; both must be
 green.
@@ -31,7 +31,7 @@ conclusion next to a later `success` on the same commit is not a failure.
 
 ## What the rollout does
 
-[`scripts/fly-rolling-deploy.sh`](../scripts/fly-rolling-deploy.sh) takes the
+[`scripts/fly-rolling-deploy.sh`](https://github.com/nodetool-ai/nodetool/blob/main/scripts/fly-rolling-deploy.sh) takes the
 image ref and does the whole release. In order:
 
 1. **Migrate.** `flyctl machine run --rm --restart no node /app/backend/db-migrate.mjs`

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -1513,7 +1513,9 @@ and runs the selfcheck of every harness covering a touched surface — keyless,
 deterministic invocations like `validate:examples`, the Ring 0 reliability
 journeys, a shipped-bundle wiring check, the app-build deterministic cases.
 The diff selects the checks, not the author. Harnesses that need a target or
-key are printed as manual work, never silently skipped.
+key are printed as manual work, never silently skipped. A selfcheck with
+`cost: "expensive"` (a Blender render, the packaged-backend bundle) is skipped
+by default even when its surface is touched; pass `--expensive` to include it.
 
 ```bash
 npm run dev:nodetool -- harness list             # every harness + capabilities
@@ -1522,8 +1524,23 @@ npm run dev:nodetool -- harness audit --strict   # exit 1 while any gap remains
 npm run dev:nodetool -- harness gate --base main # run the selfchecks this diff demands
 npm run dev:nodetool -- harness gate --dry-run   # plan only
 npm run dev:nodetool -- harness gate --all       # every selfcheck (--expensive to widen)
+npm run dev:nodetool -- harness gate --strict    # also fail on a touched gap surface
+npm run dev:nodetool -- harness gate --timeout 900   # per-selfcheck timeout, in seconds
 npm run dev:nodetool -- harness capabilities     # capability coverage + documented gaps
 ```
+
+A changed file the registry's `paths` cannot place on any surface fails the
+gate outright, as long as it looks like source rather than prose, a test, or
+config: a new file the registry has never heard of is exactly the case a
+coarse-grained `paths` list is meant to catch. `--strict` widens that to a
+touched surface only a gap note covers, the ratchet to pull once a gap is
+closed. `--timeout <seconds>` bounds each selfcheck; one that runs past it is
+killed and counted as a failure, so a hang fails the gate instead of the CI
+job's own timeout cutting it off with no verdict. The Quality Gate's
+`harness-gate` leg (`.github/workflows/quality-checks.yml`) runs `harness
+gate --base origin/main --timeout 900` on every PR and `harness gate --all`
+on push to main, so this is exercised on every diff, not only when an agent
+remembers to run it locally.
 
 `capabilities` is the same invariant one rung down, over
 `packages/cli/src/harness/capability-table.ts`: every exported agent capability

--- a/packages/agents/src/evals/tool-loop-cases.ts
+++ b/packages/agents/src/evals/tool-loop-cases.ts
@@ -173,6 +173,56 @@ const EXTEND_SEED_EDGES: HeadlessEdge[] = [
   }
 ];
 
+/** Seeded positions for the `rewire-and-relabel` case, read back by its layout predicate. */
+const REWIRE_SEED_POSITIONS: Record<"in1" | "agent1" | "out1", { x: number; y: number }> = {
+  in1: { x: 60, y: 60 },
+  agent1: { x: 60, y: 260 },
+  out1: { x: 60, y: 460 }
+};
+
+/**
+ * Pre-seeded input→agent→output graph for `rewire-and-relabel`, with the
+ * output wired straight from the input (bypassing the agent) and the agent's
+ * required `prompt` left empty.
+ */
+const REWIRE_SEED_NODES: HeadlessNode[] = [
+  {
+    id: "in1",
+    type: "nodetool.input.StringInput",
+    position: { ...REWIRE_SEED_POSITIONS.in1 },
+    data: { properties: { name: "text", value: "" } }
+  },
+  {
+    id: "agent1",
+    type: "nodetool.agents.Agent",
+    position: { ...REWIRE_SEED_POSITIONS.agent1 },
+    data: { properties: { prompt: "", input: "" } }
+  },
+  {
+    id: "out1",
+    type: "nodetool.output.StringOutput",
+    position: { ...REWIRE_SEED_POSITIONS.out1 },
+    data: { properties: { name: "summary", value: "" } }
+  }
+];
+
+const REWIRE_SEED_EDGES: HeadlessEdge[] = [
+  {
+    id: "edge_seed_1",
+    source: "in1",
+    target: "agent1",
+    sourceHandle: "output",
+    targetHandle: "input"
+  },
+  {
+    id: "edge_seed_2",
+    source: "in1",
+    target: "out1",
+    sourceHandle: "output",
+    targetHandle: "value"
+  }
+];
+
 export const TOOL_LOOP_EVAL_CASES: readonly ToolLoopEvalCase<ToolLoopFinalState>[] =
   [
     {
@@ -243,6 +293,89 @@ export const TOOL_LOOP_EVAL_CASES: readonly ToolLoopEvalCase<ToolLoopFinalState>
             name: "agentWired",
             detail: "agent1 output not connected onward",
             test: (s) => s.edges.some((e) => e.source === "agent1")
+          }
+        ]
+      }
+    },
+    {
+      id: "rewire-and-relabel",
+      description:
+        "Read a seeded graph, fill an unset required property, delete a bypass edge, rewire through the agent, retitle every node, and reposition them",
+      objective:
+        "This workflow already has a StringInput ('text', id=in1) feeding an Agent step (id=agent1), whose prompt property is empty. The StringOutput (id=out1) is currently wired directly from in1, bypassing the agent entirely. Inspect the current graph first, then fix it: fill in agent1's prompt with a real instruction (e.g. 'Summarize the input text'); delete the edge that connects in1 straight to out1; connect agent1's output to out1 so the summary reaches the output instead; give in1, agent1 and out1 clearer titles describing what each one does; and reposition the three nodes into a clearer left-to-right layout.",
+      createBridge: () =>
+        createToolLoopBridge({
+          nodeMetadata: TOOL_LOOP_NODE_CATALOG,
+          nodes: REWIRE_SEED_NODES,
+          edges: REWIRE_SEED_EDGES
+        }),
+      expect: {
+        requiredTools: [
+          "ui_get_graph",
+          "ui_update_node_data",
+          "ui_delete_edge",
+          "ui_connect_nodes",
+          "ui_move_node",
+          "ui_set_node_title"
+        ],
+        ordering: [
+          ["ui_get_graph", "ui_delete_edge"],
+          ["ui_get_graph", "ui_update_node_data"]
+        ],
+        noErrorResults: true,
+        minToolCalls: 6,
+        maxToolCalls: 30,
+        finalState: [
+          {
+            name: "promptFilled",
+            detail: "agent1's prompt property is still empty",
+            test: (s) => {
+              const agent = s.nodes.find((n) => n.id === "agent1");
+              const value = agent?.data.properties.prompt;
+              return typeof value === "string" && value.trim().length > 0;
+            }
+          },
+          {
+            name: "bypassEdgeRemoved",
+            detail: "the seeded in1 -> out1 bypass edge is still present",
+            test: (s) =>
+              !s.edges.some((e) => e.source === "in1" && e.target === "out1")
+          },
+          {
+            name: "agentWiredToOutput",
+            detail: "agent1's output is not connected to out1's value input",
+            test: (s) =>
+              s.edges.some(
+                (e) =>
+                  e.source === "agent1" &&
+                  e.target === "out1" &&
+                  e.targetHandle === "value"
+              )
+          },
+          {
+            name: "nodesRepositioned",
+            detail: "one or more seeded nodes were not moved from their seeded position",
+            test: (s) =>
+              (["in1", "agent1", "out1"] as const).every((id) => {
+                const node = s.nodes.find((n) => n.id === id);
+                if (!node) return false;
+                const seed = REWIRE_SEED_POSITIONS[id];
+                return (
+                  Math.hypot(
+                    node.position.x - seed.x,
+                    node.position.y - seed.y
+                  ) > 40
+                );
+              })
+          },
+          {
+            name: "titlesSet",
+            detail: "in1, agent1 and out1 were not all given titles",
+            test: (s) =>
+              (["in1", "agent1", "out1"] as const).every((id) => {
+                const node = s.nodes.find((n) => n.id === id);
+                return !!node?.data.title && node.data.title.trim().length > 0;
+              })
           }
         ]
       }

--- a/packages/cli/src/commands/harness.ts
+++ b/packages/cli/src/commands/harness.ts
@@ -8,7 +8,11 @@
  * and the documented gaps (`--strict` exits non-zero while any gap remains);
  * `gate` maps a diff onto surfaces and runs the selfcheck of every harness
  * covering a touched surface — the checks are selected by the diff, not by
- * the author.
+ * the author. `gate`'s changed-file collection (rename handling, deleted
+ * files, base-ref + working-tree merge) lives in ../harness/changed-files.ts;
+ * `--timeout <seconds>` bounds each selfcheck (default 900s, fails closed on
+ * timeout); `--strict` also fails when the diff leaves a real code file
+ * mapped to no surface at all.
  */
 import type { Command } from "commander";
 import {
@@ -24,6 +28,13 @@ import {
 } from "../harness/capability-coverage.js";
 import { CAPABILITY_COVERAGE } from "../harness/capability-table.js";
 import { declaredCapabilities } from "../harness/declared-capabilities.js";
+import {
+  collectChangedFiles,
+  isGateRelevantCodeFile
+} from "../harness/changed-files.js";
+
+/** Sentinel exit code for a selfcheck the gate had to kill on timeout. */
+const TIMEOUT_EXIT_CODE = 124;
 
 /** Where the coverage table lives, as git sees it. */
 const CAPABILITY_TABLE_PATH =
@@ -184,7 +195,12 @@ export function registerHarnessCommands(program: Command): void {
     .option("--json", "Print the plan (and results, unless --dry-run) as JSON")
     .option(
       "--strict",
-      "Exit non-zero when the diff touches a surface no harness covers"
+      "Exit non-zero when the diff touches a surface no harness covers, or leaves a code file mapped to none"
+    )
+    .option(
+      "--timeout <seconds>",
+      "Kill a selfcheck that runs longer than this many seconds (default 900)",
+      "900"
     )
     .action(
       async (
@@ -196,6 +212,7 @@ export function registerHarnessCommands(program: Command): void {
           dryRun?: boolean;
           json?: boolean;
           strict?: boolean;
+          timeout?: string;
         }
       ) => {
         const { execSync, spawnSync } = await import("node:child_process");
@@ -206,18 +223,29 @@ export function registerHarnessCommands(program: Command): void {
         // dist layout: packages/cli/dist/commands → repo root is four up.
         const repoRoot = resolve(here, "..", "..", "..", "..");
 
+        const timeoutSeconds = Number(opts.timeout ?? "900");
+        const timeoutMs =
+          Number.isFinite(timeoutSeconds) && timeoutSeconds > 0
+            ? timeoutSeconds * 1000
+            : 900_000;
+
         let changedFiles = files;
         if (changedFiles.length === 0 && !opts.all) {
-          const cmd = opts.base
-            ? `git diff --name-only ${opts.base}...HEAD`
-            : "git status --porcelain";
-          const out = execSync(cmd, { cwd: repoRoot, encoding: "utf8" });
-          changedFiles = opts.base
-            ? out.split("\n").map((l) => l.trim()).filter(Boolean)
-            : out
-                .split("\n")
-                .map((l) => l.slice(3).trim())
-                .filter(Boolean);
+          const statusOutput = execSync("git status --porcelain", {
+            cwd: repoRoot,
+            encoding: "utf8"
+          });
+          const diffOutput = opts.base
+            ? execSync(`git diff --name-only ${opts.base}...HEAD`, {
+                cwd: repoRoot,
+                encoding: "utf8"
+              })
+            : undefined;
+          changedFiles = collectChangedFiles({
+            base: opts.base,
+            statusOutput,
+            diffOutput
+          });
         }
 
         const mappingViolations = opts.all
@@ -256,18 +284,35 @@ export function registerHarnessCommands(program: Command): void {
         const skippedExpensive = plan.checks.filter(
           (c) => !opts.expensive && c.cost === "expensive"
         );
+        const unmappedCodeFiles = plan.unmappedFiles.filter(
+          isGateRelevantCodeFile
+        );
 
         if (!opts.json) {
           printGatePlan(plan, toRun.length, skippedExpensive.length, opts.all);
+          if (unmappedCodeFiles.length > 0) {
+            console.log(
+              "\nCode files no surface claims (--strict fails on these):"
+            );
+            for (const f of unmappedCodeFiles) console.log(`  ${f}`);
+          }
         }
 
         if (opts.dryRun) {
           if (opts.json) {
-            console.log(JSON.stringify({ plan, mappingViolations }, null, 2));
+            console.log(
+              JSON.stringify(
+                { plan, mappingViolations, unmappedCodeFiles },
+                null,
+                2
+              )
+            );
           }
           if (
             mappingViolations.length > 0 ||
-            (opts.strict && plan.uncoveredSurfaces.length > 0)
+            (opts.strict &&
+              (plan.uncoveredSurfaces.length > 0 ||
+                unmappedCodeFiles.length > 0))
           ) {
             process.exit(1);
           }
@@ -279,6 +324,7 @@ export function registerHarnessCommands(program: Command): void {
           command: string;
           ok: boolean;
           exitCode: number;
+          timedOut: boolean;
         }> = [];
         for (const check of toRun) {
           if (!opts.json) {
@@ -296,6 +342,8 @@ export function registerHarnessCommands(program: Command): void {
             shell: true,
             stdio: opts.json ? "pipe" : "inherit",
             encoding: "utf8",
+            timeout: timeoutMs,
+            killSignal: "SIGKILL",
             env: {
               ...process.env,
               ...(nodeOptions
@@ -303,26 +351,47 @@ export function registerHarnessCommands(program: Command): void {
                 : { NODE_OPTIONS: "" })
             }
           });
-          const exitCode = r.status ?? 1;
+          // spawnSync fails closed on a kill: a timeout or any other signal
+          // leaves `status` null, which must count as a failure, never as
+          // the "no exit code, assume ok" case.
+          const timedOut =
+            (r.error as NodeJS.ErrnoException | undefined)?.code ===
+              "ETIMEDOUT" || r.signal != null;
+          const exitCode = timedOut
+            ? TIMEOUT_EXIT_CODE
+            : (r.status ?? 1);
+          if (!opts.json && timedOut) {
+            console.log(
+              `\nTIMEOUT ${check.harnessId} exceeded ${timeoutSeconds}s: ${check.command}`
+            );
+          }
           results.push({
             harnessId: check.harnessId,
             command: check.command,
-            ok: exitCode === 0,
-            exitCode
+            ok: !timedOut && exitCode === 0,
+            exitCode,
+            timedOut
           });
         }
 
         const failed = results.filter((r) => !r.ok);
         if (opts.json) {
           console.log(
-            JSON.stringify({ plan, results, mappingViolations }, null, 2)
+            JSON.stringify(
+              { plan, results, mappingViolations, unmappedCodeFiles },
+              null,
+              2
+            )
           );
         } else if (toRun.length > 0) {
           console.log(
             `\nGate: ${results.length - failed.length}/${results.length} selfchecks passed`
           );
           for (const r of failed) {
-            console.log(`  FAIL ${r.harnessId} (exit ${r.exitCode}): ${r.command}`);
+            const label = r.timedOut ? "TIMEOUT" : "FAIL";
+            console.log(
+              `  ${label} ${r.harnessId} (exit ${r.exitCode}): ${r.command}`
+            );
           }
           console.log("");
         }
@@ -330,7 +399,9 @@ export function registerHarnessCommands(program: Command): void {
         if (
           failed.length > 0 ||
           mappingViolations.length > 0 ||
-          (opts.strict && plan.uncoveredSurfaces.length > 0)
+          (opts.strict &&
+            (plan.uncoveredSurfaces.length > 0 ||
+              unmappedCodeFiles.length > 0))
         ) {
           process.exit(1);
         }

--- a/packages/cli/src/commands/harness.ts
+++ b/packages/cli/src/commands/harness.ts
@@ -11,8 +11,8 @@
  * the author. `gate`'s changed-file collection (rename handling, deleted
  * files, base-ref + working-tree merge) lives in ../harness/changed-files.ts;
  * `--timeout <seconds>` bounds each selfcheck (default 900s, fails closed on
- * timeout); `--strict` also fails when the diff leaves a real code file
- * mapped to no surface at all.
+ * timeout); a code file no surface claims fails the gate outright, and
+ * `--strict` also fails on a touched surface only a gap note covers.
  */
 import type { Command } from "commander";
 import {
@@ -195,7 +195,7 @@ export function registerHarnessCommands(program: Command): void {
     .option("--json", "Print the plan (and results, unless --dry-run) as JSON")
     .option(
       "--strict",
-      "Exit non-zero when the diff touches a surface no harness covers, or leaves a code file mapped to none"
+      "Exit non-zero when the diff touches a surface only a gap note covers"
     )
     .option(
       "--timeout <seconds>",
@@ -292,7 +292,7 @@ export function registerHarnessCommands(program: Command): void {
           printGatePlan(plan, toRun.length, skippedExpensive.length, opts.all);
           if (unmappedCodeFiles.length > 0) {
             console.log(
-              "\nCode files no surface claims (--strict fails on these):"
+              "\nCode files no surface claims (the gate fails on these):"
             );
             for (const f of unmappedCodeFiles) console.log(`  ${f}`);
           }
@@ -310,9 +310,8 @@ export function registerHarnessCommands(program: Command): void {
           }
           if (
             mappingViolations.length > 0 ||
-            (opts.strict &&
-              (plan.uncoveredSurfaces.length > 0 ||
-                unmappedCodeFiles.length > 0))
+            unmappedCodeFiles.length > 0 ||
+            (opts.strict && plan.uncoveredSurfaces.length > 0)
           ) {
             process.exit(1);
           }
@@ -399,9 +398,8 @@ export function registerHarnessCommands(program: Command): void {
         if (
           failed.length > 0 ||
           mappingViolations.length > 0 ||
-          (opts.strict &&
-            (plan.uncoveredSurfaces.length > 0 ||
-              unmappedCodeFiles.length > 0))
+          unmappedCodeFiles.length > 0 ||
+          (opts.strict && plan.uncoveredSurfaces.length > 0)
         ) {
           process.exit(1);
         }

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -2672,12 +2672,12 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     module: "ui",
     impl: "packages/agents/src/capabilities/ui.ts",
     contract: "c758c2ba012f",
-    gap:
-      "Schema-only capability: the implementation is the browser's " +
-      "(web/src/lib/tools/builtin), and the headless graph bridge the " +
-      "tool-loop eval drives seeds its own state instead of reading " +
-      "it back. A case whose objective needs the current graph before " +
-      "editing it would close it.",
+    evals: [
+      {
+        file: "packages/agents/src/evals/tool-loop-cases.ts",
+        cases: ["rewire-and-relabel"],
+      },
+    ],
   },
   {
     name: "ui_add_node",
@@ -2707,7 +2707,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
       },
       {
         file: "packages/agents/src/evals/tool-loop-cases.ts",
-        cases: ["extend-existing", "summarize"],
+        cases: ["extend-existing", "rewire-and-relabel", "summarize"],
       },
     ],
   },
@@ -2716,11 +2716,12 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     module: "ui",
     impl: "packages/agents/src/capabilities/ui.ts",
     contract: "53ad5b26a7d1",
-    gap:
-      "Schema-only capability routed to the browser. The graph " +
-      "tool-loop cases add and connect nodes; none sets a property " +
-      "afterwards. A case that builds a graph and then fills a " +
-      "required property would close it.",
+    evals: [
+      {
+        file: "packages/agents/src/evals/tool-loop-cases.ts",
+        cases: ["rewire-and-relabel"],
+      },
+    ],
   },
   {
     name: "ui_delete_node",
@@ -2739,29 +2740,36 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     module: "ui",
     impl: "packages/agents/src/capabilities/ui.ts",
     contract: "43bb0e75e132",
-    gap:
-      "Schema-only capability routed to the browser. No tool-loop " +
-      "case rewires a seeded graph. A case that disconnects and " +
-      "reconnects an edge would close it.",
+    evals: [
+      {
+        file: "packages/agents/src/evals/tool-loop-cases.ts",
+        cases: ["rewire-and-relabel"],
+      },
+    ],
   },
   {
     name: "ui_move_node",
     module: "ui",
     impl: "packages/agents/src/capabilities/ui.ts",
     contract: "35780f769033",
-    gap:
-      "Schema-only capability routed to the browser. Layout is not " +
-      "scored by any case. A case whose final-state predicate reads " +
-      "node positions would close it.",
+    evals: [
+      {
+        file: "packages/agents/src/evals/tool-loop-cases.ts",
+        cases: ["rewire-and-relabel"],
+      },
+    ],
   },
   {
     name: "ui_set_node_title",
     module: "ui",
     impl: "packages/agents/src/capabilities/ui.ts",
     contract: "b8500a8d6207",
-    gap:
-      "Schema-only capability routed to the browser. No case renames " +
-      "a node. A case that titles the nodes it adds would close it.",
+    evals: [
+      {
+        file: "packages/agents/src/evals/tool-loop-cases.ts",
+        cases: ["rewire-and-relabel"],
+      },
+    ],
   },
   {
     name: "search_apify_actors",

--- a/packages/cli/src/harness/changed-files.ts
+++ b/packages/cli/src/harness/changed-files.ts
@@ -1,0 +1,105 @@
+/**
+ * Changed-file collection for `nodetool harness gate` — pure parsing over
+ * git command output, so rename handling, deleted-file inclusion, and the
+ * base-ref + working-tree merge are unit-testable without a git repo.
+ */
+
+export interface CollectChangedFilesInput {
+  /** When set, `diffOutput` must carry `git diff --name-only <base>...HEAD`. */
+  base?: string;
+  /**
+   * `git status --porcelain` output for the working tree. Always read —
+   * with `base` set, uncommitted work would otherwise be invisible to a
+   * diff against a merge-base ref.
+   */
+  statusOutput: string;
+  /** `git diff --name-only <base>...HEAD` output. Read only when `base` is set. */
+  diffOutput?: string;
+}
+
+/**
+ * Resolve the files a gate run should consider: the working tree always,
+ * plus (with `--base`) everything that differs from that ref, deduped.
+ */
+export function collectChangedFiles({
+  base,
+  statusOutput,
+  diffOutput
+}: CollectChangedFilesInput): string[] {
+  const fromStatus = parsePorcelainStatus(statusOutput);
+  if (!base) {
+    return fromStatus;
+  }
+  const fromDiff = parseNameOnlyDiff(diffOutput ?? "");
+  return dedupe([...fromDiff, ...fromStatus]);
+}
+
+/** Parse every line of `git status --porcelain` output into touched paths. */
+export function parsePorcelainStatus(output: string): string[] {
+  return output
+    .split("\n")
+    .map(parsePorcelainLine)
+    .filter((f): f is string => f !== null);
+}
+
+/**
+ * One `git status --porcelain` line → the path it touches, or `null` for a
+ * blank line. Status codes occupy columns 1-2, a separator space is column
+ * 3, and the path starts at column 4 (index 3) — true for ordinary
+ * modify/add/delete lines (`D  path`, ` D path`, deletions included) and for
+ * rename/copy lines (`R  old -> new`, `RM old -> new`, `C  a -> b`), which
+ * resolve to the NEW path: the old path no longer exists on disk, so there
+ * is nothing there for a surface check to lint or type-check.
+ */
+export function parsePorcelainLine(line: string): string | null {
+  if (line.length <= 3) {
+    return null;
+  }
+  const rest = line.slice(3).trim();
+  if (!rest) {
+    return null;
+  }
+  const arrow = rest.indexOf(" -> ");
+  return arrow >= 0 ? rest.slice(arrow + 4).trim() : rest;
+}
+
+function parseNameOnlyDiff(output: string): string[] {
+  return output
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+function dedupe(files: string[]): string[] {
+  return [...new Set(files)];
+}
+
+const GATE_RELEVANT_CODE_EXTENSIONS = [
+  ".ts",
+  ".tsx",
+  ".js",
+  ".mjs",
+  ".cjs",
+  ".mts"
+];
+
+/**
+ * A changed file `--strict` should hold to account: real source, not a test
+ * file or documentation. Used to fail the gate when a diff leaves a code
+ * file mapped to no surface at all (`plan.unmappedFiles`).
+ */
+export function isGateRelevantCodeFile(path: string): boolean {
+  if (/\.(test|spec)\./.test(path)) {
+    return false;
+  }
+  if (/(^|\/)(__tests__|tests)\//.test(path)) {
+    return false;
+  }
+  if (/(^|\/)docs\//.test(path)) {
+    return false;
+  }
+  if (/\.(md|markdown)$/i.test(path)) {
+    return false;
+  }
+  return GATE_RELEVANT_CODE_EXTENSIONS.some((ext) => path.endsWith(ext));
+}

--- a/packages/cli/src/harness/registry.ts
+++ b/packages/cli/src/harness/registry.ts
@@ -35,7 +35,8 @@ export type HarnessCapability =
   | "interact" // scripted interaction sequences
   | "browser" // real-browser surface (Playwright)
   | "no-db" // can run hermetically, no database
-  | "gated"; // wired into CI as a pass/fail gate
+  | "gated:pr" // wired into CI as a pass/fail gate on every pull request
+  | "gated:nightly"; // wired into CI as a pass/fail gate on a nightly schedule only
 
 interface HarnessSelfcheck {
   /** Keyless, deterministic, target-free invocation from the repo root. */
@@ -91,9 +92,9 @@ export const HARNESSES: HarnessEntry[] = [
     title: "Static workflow check",
     command: "nodetool validate <id|file.json|file.ts>",
     kind: "static",
-    capabilities: ["json", "no-db", "gated"],
+    capabilities: ["json", "no-db", "gated:pr"],
     agentTool: "validate_workflow",
-    docs: "AGENTS.md § nodetool validate",
+    docs: "docs/harnesses.md § nodetool validate",
     selfcheck: { command: "npm run validate:examples", cost: "cheap" }
   },
   {
@@ -101,17 +102,18 @@ export const HARNESSES: HarnessEntry[] = [
     title: "Workflow debug harness (server + browser surfaces)",
     command: "nodetool debug <id|file> [--browser --trace --watch --supervise]",
     kind: "execution",
-    capabilities: ["json", "watch", "supervise", "browser", "gated"],
+    capabilities: ["json", "watch", "supervise", "browser", "gated:nightly"],
     agentTool: "debug_workflow",
-    docs: "AGENTS.md § nodetool debug"
+    docs: "docs/harnesses.md § nodetool debug",
+    selfcheck: { command: "npm run examples:smoke", cost: "expensive" }
   },
   {
     id: "reliability-ring0",
     title: "Reliability Ring 0 (golden journeys on the kernel, strict lifecycle)",
     command: "npm run reliability:ring0",
     kind: "execution",
-    capabilities: ["gated"],
-    docs: "docs/RELIABILITY_ARCHITECTURE.md",
+    capabilities: ["gated:pr"],
+    docs: "docs/harnesses.md § nodetool reliability",
     selfcheck: { command: "npm run reliability:ring0", cost: "cheap" }
   },
   {
@@ -120,7 +122,7 @@ export const HARNESSES: HarnessEntry[] = [
     command: "nodetool node run <type> --props '{...}' [--no-secrets]",
     kind: "execution",
     capabilities: ["json", "no-db"],
-    docs: "AGENTS.md § nodetool node run",
+    docs: "docs/harnesses.md § nodetool node run",
     selfcheck: {
       command:
         "npm run dev:nodetool -- node run nodetool.text.Concat --props '{\"a\":\"harness-\",\"b\":\"gate\"}' --no-secrets",
@@ -168,7 +170,7 @@ export const HARNESSES: HarnessEntry[] = [
     command: "nodetool app debug <id|bundle.json> [--interact ... --no-run]",
     kind: "execution",
     capabilities: ["json", "interact", "no-db"],
-    docs: "AGENTS.md § nodetool app debug",
+    docs: "docs/harnesses.md § nodetool app debug",
     selfcheck: {
       command:
         "npm run dev:nodetool -- app debug packages/base-nodes/nodetool/examples/apps/ask-your-documents.app.json --no-run",
@@ -180,8 +182,8 @@ export const HARNESSES: HarnessEntry[] = [
     title: "Mini-app build harness (spec→plan→author→check→run→judge)",
     command: "nodetool app build <prompt|spec.json> -p <provider> -m <model>",
     kind: "execution",
-    capabilities: ["json", "watch", "supervise", "gated"],
-    docs: "AGENTS.md § nodetool app build",
+    capabilities: ["json", "watch", "supervise", "gated:pr"],
+    docs: "docs/harnesses.md § nodetool app build",
     selfcheck: {
       // The suite's two deterministic cases: scripted author, real kernel,
       // provider constructed but never called — the same invocation the
@@ -198,7 +200,7 @@ export const HARNESSES: HarnessEntry[] = [
     kind: "static",
     capabilities: ["json", "no-db"],
     agentTool: "validate_timeline",
-    docs: "AGENTS.md § nodetool timeline validate / debug"
+    docs: "docs/harnesses.md § nodetool timeline validate / debug"
   },
   {
     id: "timeline-debug",
@@ -206,7 +208,7 @@ export const HARNESSES: HarnessEntry[] = [
     command: "nodetool timeline debug <id|file.json> --interact '[...]'",
     kind: "execution",
     capabilities: ["json", "interact", "no-db"],
-    docs: "AGENTS.md § nodetool timeline validate / debug"
+    docs: "docs/harnesses.md § nodetool timeline validate / debug"
   },
   {
     id: "timeline-versions",
@@ -216,7 +218,7 @@ export const HARNESSES: HarnessEntry[] = [
     kind: "execution",
     capabilities: ["json"],
     agentTool: "restore_timeline_version",
-    docs: "AGENTS.md § nodetool timeline versions"
+    docs: "docs/harnesses.md § nodetool timeline versions"
   },
   {
     id: "sketch-validate",
@@ -225,7 +227,7 @@ export const HARNESSES: HarnessEntry[] = [
     kind: "static",
     capabilities: ["json", "no-db"],
     agentTool: "validate_sketch",
-    docs: "AGENTS.md § nodetool sketch validate / debug"
+    docs: "docs/harnesses.md § nodetool sketch validate / debug"
   },
   {
     id: "sketch-debug",
@@ -233,7 +235,7 @@ export const HARNESSES: HarnessEntry[] = [
     command: "nodetool sketch debug <id|file.json> --interact '[...]'",
     kind: "execution",
     capabilities: ["json", "interact", "no-db"],
-    docs: "AGENTS.md § nodetool sketch validate / debug"
+    docs: "docs/harnesses.md § nodetool sketch validate / debug"
   },
   {
     id: "sketch-versions",
@@ -243,7 +245,7 @@ export const HARNESSES: HarnessEntry[] = [
     kind: "execution",
     capabilities: ["json"],
     agentTool: "restore_sketch_version",
-    docs: "AGENTS.md § nodetool sketch versions"
+    docs: "docs/harnesses.md § nodetool sketch versions"
   },
   {
     id: "jsscript-validate",
@@ -252,7 +254,7 @@ export const HARNESSES: HarnessEntry[] = [
     kind: "static",
     capabilities: ["json", "no-db"],
     agentTool: "validate_js_script",
-    docs: "AGENTS.md § nodetool jsscript"
+    docs: "docs/harnesses.md § nodetool jsscript"
   },
   {
     id: "jsscript-run",
@@ -261,7 +263,7 @@ export const HARNESSES: HarnessEntry[] = [
     kind: "execution",
     capabilities: ["json", "no-db"],
     agentTool: "run_js_script",
-    docs: "AGENTS.md § nodetool jsscript"
+    docs: "docs/harnesses.md § nodetool jsscript"
   },
   {
     id: "jsscript-test",
@@ -270,7 +272,7 @@ export const HARNESSES: HarnessEntry[] = [
     kind: "execution",
     capabilities: ["json", "no-db"],
     agentTool: "test_js_script",
-    docs: "AGENTS.md § nodetool jsscript",
+    docs: "docs/harnesses.md § nodetool jsscript",
     selfcheck: {
       // Two checked-in fixtures with deterministic cases: no network, no
       // secrets, no database. One sums a buffered list input; the other reads
@@ -287,7 +289,7 @@ export const HARNESSES: HarnessEntry[] = [
     command: "nodetool jsscript debug <id|file.json> --interact '[...]'",
     kind: "execution",
     capabilities: ["json", "interact", "no-db"],
-    docs: "AGENTS.md § nodetool jsscript"
+    docs: "docs/harnesses.md § nodetool jsscript"
   },
   {
     id: "jsscript-versions",
@@ -297,15 +299,17 @@ export const HARNESSES: HarnessEntry[] = [
       "nodetool jsscript versions list|show|create|restore|delete <id> [<version>]",
     kind: "execution",
     capabilities: ["json"],
-    docs: "AGENTS.md § nodetool jsscript"
+    docs: "docs/harnesses.md § nodetool jsscript"
   },
   {
     id: "eval",
     title:
-      "Agent evaluation suites (graph-planner, graph-e2e, code-gen, task-planner, subtask, codeact, tool-loop×8, app-build)",
+      "Agent evaluation suites (graph-planner, graph-e2e, code-gen, task-planner, subtask, codeact, tool-loop variants, app-build)",
     command: "nodetool eval <suite> -p <provider> -m <model> [--min-success N]",
     kind: "eval",
-    capabilities: ["json", "gated"],
+    // workflow_dispatch only (.github/workflows/agent-eval.yml) — no PR or
+    // schedule trigger, so this is not a `gated:*` harness.
+    capabilities: ["json"],
     docs: "packages/agents/AGENTS.md"
   },
   {
@@ -314,7 +318,7 @@ export const HARNESSES: HarnessEntry[] = [
     command: 'echo "<prompt>" | nodetool-chat -p <provider> -m <model>',
     kind: "execution",
     capabilities: [],
-    docs: "AGENTS.md § nodetool chat"
+    docs: "docs/harnesses.md § nodetool chat"
   },
   {
     id: "telegram-bridge",
@@ -337,8 +341,8 @@ export const HARNESSES: HarnessEntry[] = [
     title: "Packaged-backend smoke (bundle staging + /health boot)",
     command: "npm run backend:smoke",
     kind: "meta",
-    capabilities: ["gated"],
-    docs: "AGENTS.md § Common Pitfalls (bundle-backend)",
+    capabilities: ["gated:pr"],
+    docs: "AGENTS.md § Common Pitfalls",
     selfcheck: { command: "npm run backend:smoke", cost: "expensive" }
   },
   {
@@ -346,8 +350,8 @@ export const HARNESSES: HarnessEntry[] = [
     title: "Deploy-image smoke (build, boot, load app in a browser)",
     command: "node scripts/docker-smoke.mjs http://localhost:7777",
     kind: "meta",
-    capabilities: ["browser", "gated"],
-    docs: "AGENTS.md § Common Pitfalls (deploy)"
+    capabilities: ["browser", "gated:pr"],
+    docs: "AGENTS.md § Common Pitfalls"
   },
   {
     id: "provider-contract",
@@ -355,7 +359,10 @@ export const HARNESSES: HarnessEntry[] = [
       "Provider contract probes (raw response fixtures + one live request per provider)",
     command: "npm run probe:providers [--json] [--out report.json]",
     kind: "meta",
-    capabilities: ["json", "gated"],
+    // Nightly-only (.github/workflows/provider-contract-probe.yml: schedule +
+    // workflow_dispatch, no pull_request) — the offline selfcheck below is
+    // exercised there, not on every PR.
+    capabilities: ["json", "gated:nightly"],
     docs: "docs/provider-contract-probes.md",
     selfcheck: {
       // The offline half: every manifest entry decodes its checked-in raw
@@ -372,7 +379,7 @@ export const HARNESSES: HarnessEntry[] = [
     command: "nodetool affected [--base main]",
     kind: "meta",
     capabilities: ["json", "no-db"],
-    docs: "AGENTS.md § nodetool affected"
+    docs: "docs/harnesses.md § nodetool affected"
   },
   {
     id: "packs-compile",
@@ -422,7 +429,10 @@ export const HARNESSES: HarnessEntry[] = [
       "sandbox-package-docs sandbox-package-listing browser-tools " +
       "timelines-op-input",
     kind: "static",
-    capabilities: ["no-db", "gated"],
+    // Runs in CI as part of the whole-package `--filter=@nodetool-ai/agents`
+    // leg, but no workflow names this filtered command specifically, so it
+    // is not a `gated:*` harness by the substring-in-a-workflow rule.
+    capabilities: ["no-db"],
     docs: "packages/agents/AGENTS.md § Capability coverage",
     selfcheck: {
       // `capabilities:check` re-derives the table from the live registry, so
@@ -443,7 +453,7 @@ export const HARNESSES: HarnessEntry[] = [
       "nodetool jtbd <list|run|optimize> [-p <provider> -m <model>]",
     kind: "eval",
     capabilities: ["json"],
-    docs: "AGENTS.md § nodetool jtbd",
+    docs: "docs/harnesses.md § nodetool jtbd",
     selfcheck: {
       // Keyless: the catalogue's own invariants (every job states a purpose,
       // grades an outcome, and fails its checks on an untouched world) plus
@@ -459,8 +469,8 @@ export const HARNESSES: HarnessEntry[] = [
     command:
       "npm run generate:fal:check && npm run generate:kie:check",
     kind: "static",
-    capabilities: ["json", "no-db", "gated"],
-    docs: "AGENTS.md § Generated provider metadata has a drift gate",
+    capabilities: ["json", "no-db", "gated:pr"],
+    docs: "AGENTS.md § Common Pitfalls",
     selfcheck: {
       command:
         "npm run generate:fal:check -- --strict && " +
@@ -469,14 +479,128 @@ export const HARNESSES: HarnessEntry[] = [
     }
   },
   {
+    id: "repo-scripts",
+    title: "Repo tooling scripts (test selection, validators, generators)",
+    // The scripts a contributor and CI run from the repo root. Their pure
+    // logic (test-affected's plan builder, the validators' rules) is pinned
+    // by the suites under scripts/__tests__; a script with no suite is
+    // covered only by the CI leg that runs it.
+    command: "npm run test:scripts",
+    kind: "meta",
+    capabilities: ["json", "no-db"],
+    docs: "AGENTS.md § Build, Lint & Test Commands",
+    selfcheck: { command: "npm run test:scripts", cost: "cheap" }
+  },
+  {
     id: "harness-audit",
     title: "Harness coverage audit (this registry)",
     command: "nodetool harness audit [--strict]",
     kind: "meta",
-    capabilities: ["json", "no-db", "gated"],
+    // Not run by name in any workflow today (the invariant it checks is
+    // enforced by the registry test below, in the normal test:packages leg),
+    // so it carries no `gated:*` tag under the substring-in-a-workflow rule.
+    capabilities: ["json", "no-db"],
     docs: "docs/HARNESS_FIRST.md",
     selfcheck: {
-      command: "npm run dev:nodetool -- harness audit",
+      command:
+        "npm run dev:nodetool -- harness audit && " +
+        "npx vitest run tests/harness-registry.test.ts --root packages/cli",
+      cost: "cheap"
+    }
+  },
+  {
+    id: "api-routes",
+    title: "API server routes (Fastify HTTP + WebSocket)",
+    command: "nodetool serve",
+    kind: "execution",
+    capabilities: ["no-db"],
+    docs: "docs/harnesses.md § nodetool serve",
+    selfcheck: {
+      // The websocket package's own suite: routes, the /ws runner, MCP tool
+      // resolution, drain/shutdown. Multi-minute (255 files), so this stays
+      // an --expensive selfcheck rather than the default gate.
+      command: "npm run test --workspace=packages/websocket",
+      cost: "expensive"
+    }
+  },
+  {
+    id: "data-models",
+    title: "Data models (Drizzle ORM persistence layer)",
+    command: "npm run test --workspace=packages/models",
+    kind: "static",
+    capabilities: ["no-db"],
+    docs: "packages/models/AGENTS.md",
+    selfcheck: {
+      command: "npm run test --workspace=packages/models",
+      cost: "cheap"
+    }
+  },
+  {
+    id: "storage-and-security",
+    title: "Storage, security, auth, and config packages",
+    command:
+      "npm run test --workspace=packages/storage && " +
+      "npm run test --workspace=packages/security && " +
+      "npm run test --workspace=packages/auth && " +
+      "npm run test --workspace=packages/config",
+    kind: "static",
+    capabilities: ["no-db"],
+    docs: "packages/AGENTS.md",
+    selfcheck: {
+      command:
+        "npm run test --workspace=packages/storage && " +
+        "npm run test --workspace=packages/security && " +
+        "npm run test --workspace=packages/auth && " +
+        "npm run test --workspace=packages/config",
+      cost: "cheap"
+    }
+  },
+  {
+    id: "node-pack-parity",
+    title:
+      "Node-pack example-workflow parity (every shipped node covered by an example)",
+    command: "npm test --workspace=@nodetool-ai/base-nodes -- parity example-workflows",
+    kind: "static",
+    // Runs in the quality-checks.yml typecheck leg (pull_request-triggered),
+    // by this exact command.
+    capabilities: ["no-db", "gated:pr"],
+    docs: "packages/base-nodes/AGENTS.md",
+    selfcheck: {
+      command:
+        "npm test --workspace=@nodetool-ai/base-nodes -- parity example-workflows",
+      cost: "cheap"
+    }
+  },
+  {
+    id: "shared-services",
+    title: "Shared service libraries (vector store, model pricing)",
+    command:
+      "npm run test --workspace=packages/vectorstore && " +
+      "npm run test --workspace=packages/model-pricing",
+    kind: "static",
+    capabilities: ["no-db"],
+    docs: "packages/AGENTS.md",
+    selfcheck: {
+      command:
+        "npm run test --workspace=packages/vectorstore && " +
+        "npm run test --workspace=packages/model-pricing",
+      cost: "cheap"
+    }
+  },
+  {
+    id: "execution-session-audit",
+    title:
+      "Execution session hydration audit (registry handed without a resolver)",
+    command:
+      "npm run test --workspace=packages/execution -- execution-session-hydration-audit",
+    kind: "static",
+    // No workflow names this test file by substring today (it runs inside
+    // the whole-package `packages/execution` leg), so no `gated:*` tag.
+    capabilities: ["no-db"],
+    docs: "docs/HARNESS_FIRST.md",
+    selfcheck: {
+      command:
+        "npm run test --workspace=packages/execution -- execution-session-hydration-audit",
       cost: "cheap"
     }
   }
@@ -499,7 +623,13 @@ export const SURFACES: SurfaceEntry[] = [
   {
     id: "workflow-execution",
     title: "Workflow execution (kernel runner)",
-    harnesses: ["validate", "debug", "node-run", "reliability-ring0"],
+    harnesses: [
+      "validate",
+      "debug",
+      "node-run",
+      "reliability-ring0",
+      "execution-session-audit"
+    ],
     paths: [
       "packages/protocol/",
       "packages/kernel/",
@@ -571,7 +701,13 @@ export const SURFACES: SurfaceEntry[] = [
     id: "provider-clients",
     title: "LLM and media provider clients (request shaping + response decoding)",
     harnesses: ["provider-contract", "eval"],
-    paths: ["packages/runtime/src/providers/"]
+    paths: [
+      "packages/runtime/src/providers/",
+      // Local-models BaseProvider (transformers.js/kokoro-js) — same request/
+      // response contract as the hosted providers, packaged separately
+      // because its weights and native deps are optional.
+      "packages/transformers-js-provider/"
+    ]
   },
   {
     id: "workflow-authoring",
@@ -625,6 +761,9 @@ export const SURFACES: SurfaceEntry[] = [
     title: "Sketches (image documents, ui_sketch_* tools, version history)",
     harnesses: ["sketch-validate", "sketch-debug", "sketch-versions", "eval"],
     paths: [
+      // The paint core behind sketches: types, dependency hashing, seeded
+      // layer templates, host-neutral raster ops.
+      "packages/image-editor/",
       "packages/execution/src/sketch-debug/",
       "packages/cli/src/sketch-debug/",
       "packages/cli/src/commands/sketch-versions.ts",
@@ -794,11 +933,15 @@ export const SURFACES: SurfaceEntry[] = [
   },
   {
     id: "provider-codegen",
-    title: "Generated FAL and KIE provider metadata (node manifests, node source)",
+    title: "Generated FAL, KIE, and Replicate provider metadata (node manifests, node source)",
     harnesses: ["provider-codegen"],
     paths: [
       "packages/fal-codegen/",
       "packages/kie-codegen/",
+      // Replicate's generator has no fixture-mode drift check of its own yet
+      // (unlike fal/kie) — a diff here still runs the fal/kie selfcheck,
+      // which is the closest real coverage until one is written.
+      "packages/replicate-codegen/",
       "packages/fal-nodes/src/fal-manifest.json",
       "packages/kie-nodes/src/kie-manifest.json",
       "scripts/provider-codegen-check.mjs"
@@ -858,8 +1001,129 @@ export const SURFACES: SurfaceEntry[] = [
       "Covered by Jest unit tests only. A harness would boot the packaged " +
       "shell headlessly (Playwright's Electron driver), assert the " +
       "IPC surface, and reuse backend-smoke for the server half."
+  },
+  {
+    id: "api-server",
+    title: "API server (Fastify HTTP + WebSocket routes)",
+    harnesses: ["api-routes"],
+    paths: ["packages/websocket/"]
+  },
+  {
+    id: "data-models",
+    title: "Data models (SQLite/Postgres persistence, Drizzle ORM)",
+    harnesses: ["data-models"],
+    paths: ["packages/models/"]
+  },
+  {
+    id: "storage-and-security",
+    title: "Storage, secrets, auth middleware, and config loading",
+    harnesses: ["storage-and-security"],
+    paths: [
+      "packages/storage/",
+      "packages/security/",
+      "packages/auth/",
+      "packages/config/"
+    ]
+  },
+  {
+    id: "domain-nodes",
+    title: "Domain node packages (provider and media node factories)",
+    harnesses: ["node-run", "validate", "node-pack-parity"],
+    paths: [
+      "packages/atlascloud-nodes/",
+      "packages/audio-nodes/",
+      "packages/automation-nodes/",
+      "packages/code-nodes/",
+      "packages/core-nodes/",
+      "packages/data-nodes/",
+      "packages/document-nodes/",
+      "packages/elevenlabs-nodes/",
+      "packages/fal-nodes/",
+      // Shared by the node packages, not a node package itself: the blend-mode
+      // catalog/WGSL functions (gpu) and HuggingFace cache/discovery
+      // (huggingface, paired with huggingface-nodes). CI groups both with the
+      // `*-nodes` filter in quality-checks.yml's test-packages-nodes leg.
+      "packages/gpu/",
+      "packages/huggingface/",
+      "packages/huggingface-nodes/",
+      "packages/image-nodes/",
+      "packages/integration-nodes/",
+      "packages/kie-nodes/",
+      "packages/llm-nodes/",
+      "packages/minimax-nodes/",
+      "packages/nodes-utils/",
+      "packages/replicate-nodes/",
+      "packages/reve-nodes/",
+      "packages/text-nodes/",
+      "packages/together-nodes/",
+      "packages/topaz-nodes/",
+      "packages/transformers-js-nodes/",
+      "packages/video-nodes/",
+      // Portable runner (graph + registry → a Request/Response handler); CI
+      // groups it with the node packages for the same reason.
+      "packages/workflow-runner/"
+    ]
+  },
+  {
+    id: "shared-services",
+    title: "Shared service libraries (vector store, model pricing)",
+    harnesses: ["shared-services"],
+    paths: ["packages/vectorstore/", "packages/model-pricing/"]
+  },
+  {
+    id: "repo-scripts",
+    title: "Repo tooling scripts (scripts/)",
+    harnesses: ["repo-scripts"],
+    // Overlaps with the surfaces that claim individual scripts (bundle
+    // staging, codegen drift, docker smoke); a diff there runs both.
+    paths: ["scripts/"]
+  },
+  {
+    id: "harness-registry",
+    title: "Harness registry (this file, its tests, capability sync)",
+    harnesses: ["harness-audit"],
+    paths: [
+      "packages/cli/src/harness/",
+      "packages/cli/tests/harness-registry.test.ts",
+      "packages/cli/tests/capability-coverage.test.ts",
+      "scripts/sync-capability-coverage.mjs"
+    ]
   }
 ];
+
+/**
+ * Package/app directories with no `SurfaceEntry.paths` prefix pointing into
+ * them, and why: what a diff there cannot verify headlessly today, and what
+ * closing the gap would need. This is the layer below `SurfaceEntry.gap` — a
+ * surface can be uncovered by a *harness* and still claim its paths (mobile,
+ * electron-shell do exactly that); an entry here has no *surface* touching it
+ * at all, so a diff under it selects nothing in `nodetool harness gate` and
+ * `auditPathClaims` would report it silently otherwise.
+ *
+ * Every directory under `packages/`, plus `web/`, `electron/`, `mobile/`,
+ * must appear in some `SurfaceEntry.paths` or here —
+ * `tests/harness-registry.test.ts` walks the real repo and fails the build on
+ * one that is in neither.
+ */
+export const UNCLAIMED_PATHS: Record<string, string> = {
+  "packages/compute/":
+    "Provisions and reaps real RunPod/Vast.ai GPU workers; only its hermetic " +
+    "unit tests run headlessly today. A harness needs a recorded-fixture " +
+    "mode against a fake provider API, the way `blender` and " +
+    "`provider-contract` fake their externals.",
+  "packages/deploy/":
+    "The `nodetool deploy` toolkit (Docker/SSH/RunPod/GCP/Supabase " +
+    "self-hosting) needs a real target to prove a rollout; only its " +
+    "planning-logic unit tests run headlessly today.",
+  "packages/sdk/":
+    "Generated TypeScript client re-exporting the tRPC/WebSocket surface; " +
+    "has no test script of its own (build + lint only) — exercised " +
+    "indirectly through the `api-routes` suite it wraps.",
+  "packages/system-skills/":
+    "Not an npm workspace, just SKILL.md files staged into the packaged " +
+    "backend by scripts/bundle-backend.mjs; verify-backend-bundle.mjs " +
+    "checks every directory ships, not the skill content."
+};
 
 interface HarnessAuditResult {
   surfaces: Array<{
@@ -912,10 +1176,32 @@ export function auditHarnessCoverage(
     unknownHarnessRefs,
     orphanHarnesses: harnesses
       .map((h) => h.id)
-      .filter(
-        (id) => !referenced.has(id) && id !== "harness-audit" && id !== "affected"
-      )
+      .filter((id) => !referenced.has(id) && id !== "affected")
   };
+}
+
+/**
+ * Directories under `packages/` (plus `web/`, `electron/`, `mobile/`) that no
+ * `SurfaceEntry.paths` prefix and no `UNCLAIMED_PATHS` entry references. A
+ * non-empty result means a diff under one of them selects nothing in
+ * `nodetool harness gate` — silently, since no surface even names the path.
+ *
+ * `rootDirs` are repo-relative directory paths (e.g. `"packages/models"`, a
+ * trailing slash is added if missing). A directory is claimed when some
+ * surface path or `UNCLAIMED_PATHS` key falls inside it, equals it, or is one
+ * of its ancestors — the same "prefix either way" relationship `planGate`
+ * uses to route a changed file to a surface.
+ */
+export function auditPathClaims(
+  rootDirs: string[],
+  surfaces: SurfaceEntry[] = SURFACES,
+  unclaimed: Record<string, string> = UNCLAIMED_PATHS
+): string[] {
+  const claims = [...surfaces.flatMap((s) => s.paths), ...Object.keys(unclaimed)];
+  return rootDirs.filter((dir) => {
+    const prefix = dir.endsWith("/") ? dir : `${dir}/`;
+    return !claims.some((p) => p.startsWith(prefix) || prefix.startsWith(p));
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/tests/harness-gate-cli.test.ts
+++ b/packages/cli/tests/harness-gate-cli.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Unit tests for the pure helpers behind `nodetool harness gate`
+ * (packages/cli/src/harness/changed-files.ts): changed-file collection from
+ * git command output, and the code-file predicate `--strict` uses to fail on
+ * an unmapped surface.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  collectChangedFiles,
+  isGateRelevantCodeFile,
+  parsePorcelainLine,
+  parsePorcelainStatus
+} from "../src/harness/changed-files.js";
+
+describe("parsePorcelainLine", () => {
+  it("parses an ordinary modified line", () => {
+    expect(parsePorcelainLine(" M packages/cli/src/commands/harness.ts")).toBe(
+      "packages/cli/src/commands/harness.ts"
+    );
+  });
+
+  it("parses an untracked line", () => {
+    expect(parsePorcelainLine("?? packages/cli/src/new-file.ts")).toBe(
+      "packages/cli/src/new-file.ts"
+    );
+  });
+
+  it("resolves a staged+unmodified rename to the NEW path", () => {
+    expect(parsePorcelainLine("R  old.ts -> new.ts")).toBe("new.ts");
+  });
+
+  it("resolves a rename with a modified working copy to the NEW path", () => {
+    expect(parsePorcelainLine("RM old.ts -> new.ts")).toBe("new.ts");
+  });
+
+  it("resolves a copy to the NEW path", () => {
+    expect(parsePorcelainLine("C  a.ts -> b.ts")).toBe("b.ts");
+  });
+
+  it("resolves a rename under a directory to the NEW path", () => {
+    expect(
+      parsePorcelainLine(
+        "R  packages/cli/src/old-dir/foo.ts -> packages/cli/src/new-dir/foo.ts"
+      )
+    ).toBe("packages/cli/src/new-dir/foo.ts");
+  });
+
+  it("still reports a staged delete (status 'D ')", () => {
+    expect(parsePorcelainLine("D  packages/cli/src/deleted.ts")).toBe(
+      "packages/cli/src/deleted.ts"
+    );
+  });
+
+  it("still reports an unstaged delete (status ' D')", () => {
+    expect(parsePorcelainLine(" D packages/cli/src/deleted.ts")).toBe(
+      "packages/cli/src/deleted.ts"
+    );
+  });
+
+  it("returns null for a blank line", () => {
+    expect(parsePorcelainLine("")).toBeNull();
+  });
+
+  it("returns null for a line with no path", () => {
+    expect(parsePorcelainLine(" M ")).toBeNull();
+  });
+});
+
+describe("parsePorcelainStatus", () => {
+  it("parses a multi-line status block, dropping blanks", () => {
+    const status = [
+      " M packages/cli/src/commands/harness.ts",
+      "R  packages/cli/src/old.ts -> packages/cli/src/new.ts",
+      "D  packages/cli/src/gone.ts",
+      "?? packages/cli/src/added.ts",
+      ""
+    ].join("\n");
+    expect(parsePorcelainStatus(status)).toEqual([
+      "packages/cli/src/commands/harness.ts",
+      "packages/cli/src/new.ts",
+      "packages/cli/src/gone.ts",
+      "packages/cli/src/added.ts"
+    ]);
+  });
+});
+
+describe("collectChangedFiles", () => {
+  it("without --base, reads only the working tree (git status)", () => {
+    const statusOutput = [
+      " M packages/cli/src/a.ts",
+      "?? packages/cli/src/b.ts"
+    ].join("\n");
+    expect(collectChangedFiles({ statusOutput })).toEqual([
+      "packages/cli/src/a.ts",
+      "packages/cli/src/b.ts"
+    ]);
+  });
+
+  it("with --base, merges the base diff and the working tree, deduped", () => {
+    const diffOutput = [
+      "packages/cli/src/a.ts",
+      "packages/cli/src/shared.ts"
+    ].join("\n");
+    const statusOutput = [
+      " M packages/cli/src/shared.ts", // already in the diff — deduped
+      "?? packages/cli/src/uncommitted.ts" // only in the working tree
+    ].join("\n");
+    expect(
+      collectChangedFiles({ base: "origin/main", diffOutput, statusOutput })
+    ).toEqual([
+      "packages/cli/src/a.ts",
+      "packages/cli/src/shared.ts",
+      "packages/cli/src/uncommitted.ts"
+    ]);
+  });
+
+  it("with --base, still surfaces working-tree-only files not in the diff", () => {
+    const diffOutput = "";
+    const statusOutput = " M packages/cli/src/only-uncommitted.ts";
+    expect(
+      collectChangedFiles({ base: "origin/main", diffOutput, statusOutput })
+    ).toEqual(["packages/cli/src/only-uncommitted.ts"]);
+  });
+
+  it("with --base, still resolves renames from the working tree to the NEW path", () => {
+    const diffOutput = "";
+    const statusOutput = "R  packages/cli/src/old.ts -> packages/cli/src/new.ts";
+    expect(
+      collectChangedFiles({ base: "origin/main", diffOutput, statusOutput })
+    ).toEqual(["packages/cli/src/new.ts"]);
+  });
+});
+
+describe("isGateRelevantCodeFile", () => {
+  it("accepts each recognized code extension", () => {
+    for (const f of [
+      "packages/cli/src/harness.ts",
+      "web/src/App.tsx",
+      "scripts/build.js",
+      "scripts/build.mjs",
+      "scripts/build.cjs",
+      "packages/cli/src/x.mts"
+    ]) {
+      expect(isGateRelevantCodeFile(f)).toBe(true);
+    }
+  });
+
+  it("rejects a test file by *.test.* / *.spec.*", () => {
+    expect(isGateRelevantCodeFile("packages/cli/src/harness.test.ts")).toBe(
+      false
+    );
+    expect(isGateRelevantCodeFile("web/src/App.spec.tsx")).toBe(false);
+  });
+
+  it("rejects a file under a __tests__ or tests directory", () => {
+    expect(
+      isGateRelevantCodeFile("packages/cli/src/__tests__/harness.ts")
+    ).toBe(false);
+    expect(isGateRelevantCodeFile("packages/cli/tests/harness.ts")).toBe(
+      false
+    );
+  });
+
+  it("rejects a file under docs/", () => {
+    expect(isGateRelevantCodeFile("docs/example.ts")).toBe(false);
+  });
+
+  it("rejects markdown", () => {
+    expect(isGateRelevantCodeFile("AGENTS.md")).toBe(false);
+    expect(isGateRelevantCodeFile("docs/notes.markdown")).toBe(false);
+  });
+
+  it("rejects an extension outside the recognized code set", () => {
+    expect(isGateRelevantCodeFile("packages/cli/README.txt")).toBe(false);
+    expect(isGateRelevantCodeFile("packages/cli/package.json")).toBe(false);
+  });
+});

--- a/packages/cli/tests/harness-registry.test.ts
+++ b/packages/cli/tests/harness-registry.test.ts
@@ -6,10 +6,15 @@
  * build, not just a CLI run someone has to remember to make.
  */
 import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   HARNESSES,
   SURFACES,
+  UNCLAIMED_PATHS,
   auditHarnessCoverage,
+  auditPathClaims,
   planGate
 } from "../src/harness/registry.js";
 import {
@@ -69,6 +74,179 @@ describe("harness registry", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Path claims: every packages/* dir (plus web/, electron/, mobile/) is
+// referenced by a surface's paths or documented in UNCLAIMED_PATHS. Without
+// this, a diff under an unreferenced package selects nothing in
+// `nodetool harness gate` and nobody is told.
+// ---------------------------------------------------------------------------
+
+const repoRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../.."
+);
+
+/** Repo-relative top-level directories under `packages/`, plus the apps. */
+function realRootDirs(): string[] {
+  const packagesDir = join(repoRoot, "packages");
+  const pkgDirs = readdirSync(packagesDir)
+    .filter((d) => statSync(join(packagesDir, d)).isDirectory())
+    .map((d) => `packages/${d}`);
+  return [...pkgDirs, "web", "electron", "mobile"];
+}
+
+describe("path claims", () => {
+  it("claims every real packages/* directory (plus web/, electron/, mobile/)", () => {
+    const unclaimed = auditPathClaims(realRootDirs(), SURFACES, UNCLAIMED_PATHS);
+    expect(unclaimed).toEqual([]);
+  });
+
+  it("every UNCLAIMED_PATHS entry is a real, still-unclaimed directory", () => {
+    // A stale entry — the directory was deleted, or a surface grew a path
+    // that now claims it too — should fail so the map does not silently
+    // paper over drift.
+    for (const key of Object.keys(UNCLAIMED_PATHS)) {
+      const dirPath = join(repoRoot, key.replace(/\/$/, ""));
+      const exists = statSync(dirPath, { throwIfNoEntry: false })?.isDirectory();
+      expect(exists, `${key} no longer exists`).toBe(true);
+
+      const claimedBySurface = SURFACES.some((s) =>
+        s.paths.some((p) => p.startsWith(key) || key.startsWith(p))
+      );
+      expect(
+        claimedBySurface,
+        `${key} is in UNCLAIMED_PATHS but a surface already claims it`
+      ).toBe(false);
+
+      expect(UNCLAIMED_PATHS[key], key).toBeTruthy();
+    }
+  });
+
+  it("audit catches a directory no surface or UNCLAIMED_PATHS entry claims", () => {
+    const unclaimed = auditPathClaims(
+      ["packages/models", "packages/totally-not-a-real-package"],
+      SURFACES,
+      UNCLAIMED_PATHS
+    );
+    expect(unclaimed).toEqual(["packages/totally-not-a-real-package"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gated:pr / gated:nightly: every harness tagged with either must be findable
+// in the workflow that is claimed to gate it, by a substring of its own
+// selfcheck (or command, when it has no selfcheck).
+// ---------------------------------------------------------------------------
+
+describe("gated capability matches a real CI trigger", () => {
+  const workflowsDir = join(repoRoot, ".github", "workflows");
+  const workflowFiles = readdirSync(workflowsDir).filter(
+    (f) => f.endsWith(".yml") || f.endsWith(".yaml")
+  );
+  const workflowText = workflowFiles
+    .map((f) => readFileSync(join(workflowsDir, f), "utf-8"))
+    .join("\n");
+
+  /**
+   * One hand-verified, distinctive substring per gated harness — chosen by
+   * reading .github/workflows/*.yml, not derived from the command string, so
+   * a harness that changes its selfcheck wording does not silently pass on a
+   * coincidental match. `reliability-ring0` and `app-build` no longer appear
+   * as literal, hand-written commands: quality-checks.yml's `harness-gate`
+   * leg (docs/HARNESS_FIRST.md § The gate) runs `nodetool harness gate` on
+   * every pull request and picks up any harness with a cheap selfcheck whose
+   * surface the diff touches, so their evidence is that invocation plus the
+   * harness's own selfcheck being cheap enough for the gate to run it.
+   */
+  const GATED_EVIDENCE: Record<string, string> = {
+    validate: "npm run validate:examples",
+    debug: "npm run examples:smoke",
+    "reliability-ring0": "dev:nodetool -- harness gate",
+    "app-build": "dev:nodetool -- harness gate",
+    "backend-smoke": "npm run backend:smoke",
+    "docker-smoke": "docker-smoke.mjs http://localhost:7777",
+    "provider-contract": "provider-contract-probes",
+    "provider-codegen": "npm run generate:fal:check -- --strict",
+    "node-pack-parity": "parity example-workflows"
+  };
+
+  const gated = HARNESSES.filter((h) =>
+    h.capabilities.some((c) => c === "gated:pr" || c === "gated:nightly")
+  );
+
+  it("found at least one gated harness", () => {
+    expect(gated.length).toBeGreaterThan(0);
+  });
+
+  it("every gated harness has a hand-verified evidence entry", () => {
+    // Catches a harness that picked up `gated:*` without anyone checking —
+    // and a stale evidence entry left behind for a harness that dropped it.
+    const gatedIds = gated.map((h) => h.id).sort();
+    expect(Object.keys(GATED_EVIDENCE).sort()).toEqual(gatedIds);
+  });
+
+  for (const h of gated) {
+    it(`${h.id} (${h.capabilities.find((c) => c.startsWith("gated"))}) appears in a workflow`, () => {
+      const needle = GATED_EVIDENCE[h.id];
+      expect(needle, `${h.id} has no GATED_EVIDENCE entry`).toBeTruthy();
+      expect(
+        workflowText,
+        `expected to find "${needle}" for ${h.id}`
+      ).toContain(needle);
+      if (needle === "dev:nodetool -- harness gate") {
+        // The generic gate only reaches a harness through its selfcheck.
+        expect(h.selfcheck?.cost, h.id).toBe("cheap");
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Docs pointers: `docs: "<file>"` or `docs: "<file> § <heading prefix>"`.
+// Every one must resolve — the file must exist, and a heading fragment must
+// be a case-insensitive prefix of some markdown heading line in that file.
+// ---------------------------------------------------------------------------
+
+describe("docs pointers resolve", () => {
+  function resolveDocsPointer(pointer: string): { file: string; heading?: string } {
+    const [file, heading] = pointer.split(" § ").map((s) => s.trim());
+    return { file: file!, heading };
+  }
+
+  const headingCache = new Map<string, string[]>();
+  function headingsOf(file: string): string[] {
+    const cached = headingCache.get(file);
+    if (cached) return cached;
+    const text = readFileSync(join(repoRoot, file), "utf-8");
+    const headings = text
+      .split("\n")
+      .filter((line) => /^#{1,6}\s/.test(line))
+      .map((line) => line.replace(/^#{1,6}\s+/, "").trim());
+    headingCache.set(file, headings);
+    return headings;
+  }
+
+  for (const h of HARNESSES) {
+    it(`${h.id}: docs pointer "${h.docs}" resolves`, () => {
+      const { file, heading } = resolveDocsPointer(h.docs);
+      const filePath = join(repoRoot, file);
+      expect(
+        statSync(filePath, { throwIfNoEntry: false })?.isFile(),
+        `${h.id}: ${file} does not exist`
+      ).toBe(true);
+      if (heading) {
+        const headings = headingsOf(file);
+        const needle = heading.toLowerCase();
+        const hit = headings.some((line) => line.toLowerCase().startsWith(needle));
+        expect(
+          hit,
+          `${h.id}: no heading in ${file} starts with "${heading}"`
+        ).toBe(true);
+      }
+    });
+  }
+});
+
 describe("harness gate", () => {
   it("maps a kernel change to workflow-execution selfchecks", () => {
     const plan = planGate(["packages/kernel/src/runner.ts"]);
@@ -77,8 +255,12 @@ describe("harness gate", () => {
     expect(ids).toContain("validate");
     expect(ids).toContain("reliability-ring0");
     expect(ids).toContain("node-run");
-    // debug has no selfcheck — it needs a target, so it lands in manual.
-    expect(plan.manual.map((m) => m.harnessId)).toContain("debug");
+    // debug's selfcheck (`examples:smoke`) is expensive, so it lands in
+    // checks (as an expensive one) rather than manual — it still runs, just
+    // not in the default `harness gate` without `--expensive`.
+    expect(ids).toContain("debug");
+    const debugCheck = plan.checks.find((c) => c.harnessId === "debug");
+    expect(debugCheck?.cost).toBe("expensive");
   });
 
   it("dedupes a selfcheck shared by several touched surfaces", () => {
@@ -400,7 +582,10 @@ describe("capability mapping gate", () => {
     // A deploy-image change touches a surface with its own harness and no
     // capability at all: the table is untouched, so the gate is silent.
     const plan = planGate(["Dockerfile", "scripts/docker-smoke.mjs"]);
-    expect(plan.surfaces.map((s) => s.id)).toEqual(["deploy-image"]);
+    // scripts/ is also claimed by repo-scripts; the point is that no
+    // agent surface is.
+    expect(plan.surfaces.map((s) => s.id)).toContain("deploy-image");
+    expect(plan.surfaces.map((s) => s.id)).not.toContain("agent-capabilities");
     const same = table([block("a", "1111")]);
     expect(planCapabilityMappingGate(same, same).violations).toEqual([]);
   });

--- a/scripts/__tests__/test-affected.test.mjs
+++ b/scripts/__tests__/test-affected.test.mjs
@@ -6,7 +6,7 @@
 import { describe, expect, it } from "vitest";
 
 import { computeAffected } from "../../packages/cli/src/affected/affected.ts";
-import { buildPlan, DOC_ONLY, MOBILE_DEPS } from "../test-affected.mjs";
+import { buildGateArgv, buildPlan, DOC_ONLY, MOBILE_DEPS } from "../test-affected.mjs";
 
 /** web and electron are named after the product, not their directories. */
 const PACKAGES = [
@@ -89,6 +89,21 @@ describe("buildPlan", () => {
     const { steps, globalFiles } = plan(["docs/DESIGN.md", "AGENTS.md", ".github/x.yml"]);
     expect(globalFiles).toEqual([]);
     expect(steps).toEqual([]);
+  });
+});
+
+describe("buildGateArgv", () => {
+  it("asks the harness registry for a dry-run plan over the same files", () => {
+    expect(buildGateArgv(["packages/kernel/src/runner.ts", "web/src/index.tsx"])).toEqual([
+      "run",
+      "dev:nodetool",
+      "--",
+      "harness",
+      "gate",
+      "--dry-run",
+      "packages/kernel/src/runner.ts",
+      "web/src/index.tsx"
+    ]);
   });
 });
 

--- a/scripts/test-affected.mjs
+++ b/scripts/test-affected.mjs
@@ -18,8 +18,10 @@
  *     documentation (root configs, `scripts/`, the lockfile).
  *
  * Flags: `--base <ref>` (default: merge-base with origin/main, plus the working
- * tree), `--all` (skip selection), `--dry-run` (print the plan), or explicit
- * file paths to ask what a given change would select.
+ * tree), `--all` (skip selection), `--dry-run` (print the plan), `--gate`
+ * (also print `nodetool harness gate`'s plan for the same changed files —
+ * see AGENTS.md § Mandatory Post-Change Verification), or explicit file paths
+ * to ask what a given change would select.
  */
 import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
@@ -210,6 +212,16 @@ function readPackages(extraWorkspacePaths) {
   return packages;
 }
 
+/**
+ * The argv for `npm run dev:nodetool -- harness gate --dry-run <files...>`,
+ * asking the harness registry what it would run over the same changed files
+ * `test:affected` just selected suites for. Pure so the shape is unit-testable
+ * without shelling out.
+ */
+export function buildGateArgv(files) {
+  return ["run", "dev:nodetool", "--", "harness", "gate", "--dry-run", ...files];
+}
+
 function run(command, args) {
   const bin =
     process.platform === "win32" && (command === "npm" || command === "npx")
@@ -224,11 +236,12 @@ function run(command, args) {
 async function main(argv) {
   if (argv.includes("--help") || argv.includes("-h")) {
     console.log(
-      "Usage: npm run test:affected -- [files...] [--base <ref>] [--all] [--dry-run]"
+      "Usage: npm run test:affected -- [files...] [--base <ref>] [--all] [--dry-run] [--gate]"
     );
     return 0;
   }
   const dryRun = argv.includes("--dry-run");
+  const gate = argv.includes("--gate");
   const baseIndex = argv.indexOf("--base");
   const baseArg = baseIndex >= 0 ? argv[baseIndex + 1] : undefined;
   const explicit = argv.filter(
@@ -243,6 +256,7 @@ async function main(argv) {
 
   let steps;
   let reason;
+  let gateFiles = [];
   if (argv.includes("--all")) {
     steps = fullPlan();
     reason = "--all";
@@ -254,6 +268,7 @@ async function main(argv) {
       console.log("No changed files — nothing to test.");
       return 0;
     }
+    gateFiles = files;
     reason = explicit.length
       ? `${files.length} file(s) given on the command line`
       : base
@@ -272,10 +287,19 @@ async function main(argv) {
   console.log(`\nAffected test plan (${reason}):`);
   if (steps.length === 0) {
     console.log("  nothing — no workspace owns the changed files.");
-    return 0;
+  } else {
+    for (const step of steps) console.log(`  - ${step.label}`);
   }
-  for (const step of steps) console.log(`  - ${step.label}`);
-  if (dryRun) return 0;
+
+  // `--gate` is a separate, opt-in report: what `nodetool harness gate` would
+  // run over the same changed files. It shells out (`--dry-run`, so nothing
+  // actually runs) rather than duplicating the registry's selection logic.
+  if (gate && gateFiles.length > 0) {
+    console.log("\nHarness gate plan for the same diff:");
+    run("npm", buildGateArgv(gateFiles));
+  }
+
+  if (steps.length === 0 || dryRun) return 0;
 
   for (const step of steps) {
     const status = run(step.command, step.args);


### PR DESCRIPTION
## What changed

The harness registry measured coverage over the surfaces someone had registered, not over the repo: most `packages/*` directories (the API server, models, storage, every domain node package) and `scripts/` were claimed by no surface, so `nodetool harness gate` selected nothing for diffs there, and nothing objected. The gate itself was run by no workflow, misread renames, ignored the working tree under `--base`, and could hang on a stuck selfcheck. This PR closes those holes:

- **Registry coverage.** New surfaces for the API server, data models, storage/security/auth/config, every domain node package, vectorstore and pricing, `scripts/`, and the registry itself, each with a keyless workspace-suite selfcheck. An `UNCLAIMED_PATHS` map holds the few packages that still need a real target, and a test walks the repo tree so an unclaimed directory fails the build. `debug` gains the nightly example smoke as its selfcheck; the hydration audit joins the workflow-execution surface.
- **Verified claims.** `gated:pr` / `gated:nightly` replace the self-declared `gated` tag and each must be found in a workflow file. Every `docs` pointer must resolve to a file and heading (sixteen stale pointers fixed).
- **Gate mechanics.** Rename lines resolve to the new path, deletions count, `--base` also includes the working tree, each selfcheck has a `--timeout` that counts as failure, and a code file no surface claims fails the gate outright. `--strict` stays the ratchet for touched gap surfaces.
- **CI and the loop.** A `harness-gate` leg runs the gate against `origin/main` on PRs and `--all` on push to main; the hand-copied `reliability:ring0` and `app-build` legs fold into it. The gate joins the mandated post-change commands in AGENTS.md, and `test:affected --gate` prints its plan.
- **Capability gaps.** One tool-loop eval case (`rewire-and-relabel`) closes the five `ui_*` capability gaps; the table is regenerated.
- **Ported fix.** `docs/fly-production-deploy.md` linked repo files relatively, which the docs-site check (PR-only, never run on main) rejects; the links now use GitHub URLs like the other docs.

## Verification

- [x] `npm run dev:nodetool -- harness gate --base origin/main --timeout 900` → `Gate: 5/5 selfchecks passed` (capability-suites, jtbd, validate, repo-scripts, harness-audit)
- [x] `npx vitest run --root packages/cli` → 60 files, 774 tests pass (includes the 87 registry tests and 21 gate CLI tests)
- [x] `npm run test --workspace=packages/agents -- tool-loop-eval capability capability-coverage capabilities` → 804 tests pass
- [x] `npm run test:scripts` → pass; `npm run check:agents-docs` → pass; `npm run capabilities:check` → table current
- [x] `npm run typecheck` → web and electron pass; mobile fails only because `mobile/node_modules` is not installed in this container (untouched by the diff)
- [x] `npm run lint` → pass
- [x] Inverted checks: `harness gate --dry-run packages/image-nodes/src/x.ts` exits 1 (unmapped code file); `--dry-run mobile/foo.ts` exits 0 without and 1 with `--strict`; deleting the `domain-nodes` surface fails the path-claim test; `git fetch --prune origin main:refs/remotes/origin/main` reproduced the `origin/main` deletion locally that broke the first CI run of the leg
- [x] Live eval: `nodetool eval tool-loop --cases rewire-and-relabel` → PASS score 1.00

## Agent capabilities

- [x] `npm run capabilities:check` passes
- [x] Every added or re-declared capability names an eval case or a suite in `packages/cli/src/harness/capability-table.ts`, or carries a gap note (the five `ui_*` gaps now name `rewire-and-relabel`; the three apify/serpapi gaps are unchanged)

## New checks

- [x] The check was inverted once and observed failing; the failing commands are in **Verification** above
- [x] An audit asserts it found its targets, so it cannot pass by matching nothing (path-claim audit fails on a fake unclaimed dir; the gated-tag test asserts at least one gated harness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U35qvdG2Zv18zQ7rXXhPhx