### PR TITLE
fix(sketch): fit on open, pin tool bar actions, zoom controls

### DIFF
--- a/web/src/components/sketch/SketchCanvas.tsx
+++ b/web/src/components/sketch/SketchCanvas.tsx
@@ -158,6 +158,8 @@ export interface SketchCanvasRef {
   getLayerCanvas: (layerId: string) => HTMLCanvasElement | null;
   /** Current CSS size of the scrolling viewport that clips the artboard, or null before mount. */
   getViewportSize: () => { width: number; height: number } | null;
+  /** The viewport element itself, for callers that need its position in the page. */
+  getViewportElement: () => HTMLElement | null;
 }
 
 // ─── Props ───────────────────────────────────────────────────────────────────

--- a/web/src/components/sketch/SketchEditor.tsx
+++ b/web/src/components/sketch/SketchEditor.tsx
@@ -246,6 +246,17 @@ function SketchEditor({
     }
   }, [isMobile, assistantPanelOpen, mobilePanelsOpen, setMobilePanelsOpen]);
 
+  // The assistant remembers being open across sessions, which on desktop is
+  // a docked column beside the canvas. On a phone it is a sheet over the
+  // whole canvas, so a remembered "open" meant the editor came up with no
+  // canvas in sight. Close it on entering the mobile layout without touching
+  // the remembered preference; the tool bar toggle reopens it.
+  useEffect(() => {
+    if (isMobile) {
+      setAssistantPanelOpen(false, { persist: false });
+    }
+  }, [isMobile, setAssistantPanelOpen]);
+
   // Register the agent bridge under this document's id so the `ui_sketch_*`
   // tools can address it whether or not this surface is focused. The session
   // store is the authority: a never-saved document has no id yet, and gains
@@ -642,7 +653,8 @@ function SketchEditor({
               flexShrink: 0,
               backgroundColor: theme.vars.palette.background.paper,
               borderLeft: `1px solid ${theme.vars.palette.divider}`,
-              overflow: "hidden"
+              overflow: "hidden",
+              userSelect: "none"
             }}
             gap={0}
           >

--- a/web/src/components/sketch/SketchToolTopBar.tsx
+++ b/web/src/components/sketch/SketchToolTopBar.tsx
@@ -46,11 +46,8 @@ const styles = (theme: Theme) =>
   css({
     display: "flex",
     flexDirection: "row",
-    alignItems: "center",
-    // Between groups, not between controls: the group's own gap is tighter,
-    // so a wrapped bar still reads as clusters rather than one long queue.
+    alignItems: "flex-start",
     columnGap: getSpacingPx(SPACING.xxl),
-    rowGap: getSpacingPx(SPACING.md),
     padding: `${getSpacingPx(SPACING.md)} ${getSpacingPx(SPACING.lg)}`,
     // Sit on the same chrome tier as the editor's other bars (mode/prompt,
     // tool rail, status): grey[900] surface with a grey[800] hairline. The
@@ -59,15 +56,33 @@ const styles = (theme: Theme) =>
     backgroundColor: theme.vars.palette.grey[900],
     borderBottom: `1px solid ${theme.vars.palette.grey[800]}`,
     minHeight: "40px",
-    overflowX: "auto",
-    flexWrap: "wrap",
-    // Wrapped rows anchor to the top of the bar instead of being
-    // re-centered when the row count changes. Without this, toggling
-    // the Advanced disclosure (which adds a wrapped row below) made
-    // the first row shift by 1px because `alignContent: center` had
-    // free space inside `minHeight` only when there was one row.
-    alignContent: "flex-start",
     flexShrink: 0,
+    // The bar is chrome: a drag that starts on a label must not start a
+    // text selection that then sweeps across the whole page.
+    userSelect: "none",
+    // Two columns: the settings wrap inside the first, the editor actions
+    // stay pinned to the top-right corner. With one wrapping row the actions
+    // fell to a row of their own whenever the settings wrapped, adding a
+    // fourth strip of chrome over the canvas for a three-row tool.
+    "& .tool-top-bar__settings": {
+      flex: "1 1 auto",
+      minWidth: 0,
+      display: "flex",
+      flexDirection: "row",
+      alignItems: "center",
+      flexWrap: "wrap",
+      // Between groups, not between controls: the group's own gap is
+      // tighter, so a wrapped bar still reads as clusters rather than one
+      // long queue.
+      columnGap: getSpacingPx(SPACING.xxl),
+      rowGap: getSpacingPx(SPACING.md),
+      // Wrapped rows anchor to the top of the bar instead of being
+      // re-centered when the row count changes. Without this, toggling
+      // the Advanced disclosure (which adds a wrapped row below) made
+      // the first row shift by 1px because `alignContent: center` had
+      // free space inside `minHeight` only when there was one row.
+      alignContent: "flex-start"
+    },
     "& .MuiIconButton-root": {
       padding: theme.spacing(1)
     },
@@ -210,113 +225,117 @@ const SketchToolTopBar: React.FC<SketchToolTopBarProps> = ({
 
   return (
     <FlexRow className="sketch-tool-top-bar" css={styles(theme)}>
-      <FlexRow
-        align="center"
-        gap={0.5}
-        className="tool-top-bar__tool-label"
-        sx={{ flexShrink: 0 }}
-      >
-        <Text
-          sx={{
-            ...TYPOGRAPHY.sans.caption,
-            color: theme.vars.palette.text.secondary,
-            textTransform: "uppercase",
-            letterSpacing: "0.06em"
-          }}
+      <div className="tool-top-bar__settings">
+        <FlexRow
+          align="center"
+          gap={0.5}
+          className="tool-top-bar__tool-label"
+          sx={{ flexShrink: 0 }}
         >
-          Tool
-        </Text>
-        <Text sx={{ ...TYPOGRAPHY.sans.label, fontWeight: 600 }}>
-          {getToolSettingsLabel(activeTool)}
-        </Text>
-        {onToggleSettingsCollapsed && (
-          <Tooltip
-            title={
-              settingsCollapsed ? "Show tool settings" : "Hide tool settings"
-            }
+          <Text
+            sx={{
+              ...TYPOGRAPHY.sans.caption,
+              color: theme.vars.palette.text.secondary,
+              textTransform: "uppercase",
+              letterSpacing: "0.06em"
+            }}
           >
-            <IconButton
-              size="small"
-              onClick={onToggleSettingsCollapsed}
-              aria-expanded={!settingsCollapsed}
-              aria-label={
+            Tool
+          </Text>
+          <Text sx={{ ...TYPOGRAPHY.sans.label, fontWeight: 600 }}>
+            {getToolSettingsLabel(activeTool)}
+          </Text>
+          {onToggleSettingsCollapsed && (
+            <Tooltip
+              title={
                 settingsCollapsed ? "Show tool settings" : "Hide tool settings"
               }
-              data-testid="sketch-toggle-tool-settings"
             >
-              {settingsCollapsed ? (
-                <ExpandMoreIcon fontSize="small" />
-              ) : (
-                <ExpandLessIcon fontSize="small" />
-              )}
-            </IconButton>
-          </Tooltip>
-        )}
-      </FlexRow>
+              <IconButton
+                size="small"
+                onClick={onToggleSettingsCollapsed}
+                aria-expanded={!settingsCollapsed}
+                aria-label={
+                  settingsCollapsed
+                    ? "Show tool settings"
+                    : "Hide tool settings"
+                }
+                data-testid="sketch-toggle-tool-settings"
+              >
+                {settingsCollapsed ? (
+                  <ExpandMoreIcon fontSize="small" />
+                ) : (
+                  <ExpandLessIcon fontSize="small" />
+                )}
+              </IconButton>
+            </Tooltip>
+          )}
+        </FlexRow>
 
-      {!settingsCollapsed && (
-        <ToolSettingsPanel
-          activeTool={activeTool}
-          brushSettings={brushSettings}
-          pencilSettings={pencilSettings}
-          eraserSettings={eraserSettings}
-          shapeSettings={shapeSettings}
-          fillSettings={fillSettings}
-          blurSettings={blurSettings}
-          gradientSettings={gradientSettings}
-          cloneStampSettings={cloneStampSettings}
-          selectSettings={selectSettings}
-          hasActiveSelection={hasActiveSelection}
-          adjustBrightness={adjustBrightness}
-          adjustContrast={adjustContrast}
-          adjustSaturation={adjustSaturation}
-          onBrushSettingsChange={onBrushSettingsChange}
-          onPencilSettingsChange={onPencilSettingsChange}
-          onEraserSettingsChange={onEraserSettingsChange}
-          onShapeSettingsChange={onShapeSettingsChange}
-          onFillSettingsChange={onFillSettingsChange}
-          onBlurSettingsChange={onBlurSettingsChange}
-          onGradientSettingsChange={onGradientSettingsChange}
-          onCloneStampSettingsChange={onCloneStampSettingsChange}
-          onSelectSettingsChange={onSelectSettingsChange}
-          onInvertSelection={onInvertSelection}
-          onCropCanvasToSelection={onCropCanvasToSelection}
-          onFeatherSelection={onFeatherSelection}
-          onSmoothSelectionBorders={onSmoothSelectionBorders}
-          onConvertSelectionToBorder={onConvertSelectionToBorder}
-          onAdjustBrightnessChange={onAdjustBrightnessChange}
-          onAdjustContrastChange={onAdjustContrastChange}
-          onAdjustSaturationChange={onAdjustSaturationChange}
-          onAdjustApply={onAdjustApply}
-          onAdjustCancel={onAdjustCancel}
-          transformScaleX={transformScaleX}
-          transformScaleY={transformScaleY}
-          transformRotation={transformRotation}
-          onTransformCommit={onTransformCommit}
-          onTransformCancel={onTransformCancel}
-          onTransformReset={onTransformReset}
-          transformAutoSelect={transformAutoSelect}
-          transformMode={transformMode}
-          onTransformAutoSelectChange={onTransformAutoSelectChange}
-          onTransformModeChange={onTransformModeChange}
-          moveAutoSelect={moveAutoSelect}
-          onMoveAutoSelectChange={onMoveAutoSelectChange}
-          cropHasPendingRect={cropHasPendingRect}
-          onCropApply={onCropApply}
-          onCropCancelPreview={onCropCancelPreview}
-          segmentSettings={segmentSettings}
-          onSegmentSettingsChange={onSegmentSettingsChange}
-          segmentationStatus={segmentationStatus}
-          segmentationError={segmentationError}
-          segmentModelInfo={segmentModelInfo}
-          onRunSegmentation={onRunSegmentation}
-          onApplySegmentResult={onApplySegmentResult}
-          onDiscardSegmentResult={onDiscardSegmentResult}
-          onCancelSegmentation={onCancelSegmentation}
-          onClearSegmentPrompts={onClearSegmentPrompts}
-          onCheckSegmentModel={onCheckSegmentModel}
-        />
-      )}
+        {!settingsCollapsed && (
+          <ToolSettingsPanel
+            activeTool={activeTool}
+            brushSettings={brushSettings}
+            pencilSettings={pencilSettings}
+            eraserSettings={eraserSettings}
+            shapeSettings={shapeSettings}
+            fillSettings={fillSettings}
+            blurSettings={blurSettings}
+            gradientSettings={gradientSettings}
+            cloneStampSettings={cloneStampSettings}
+            selectSettings={selectSettings}
+            hasActiveSelection={hasActiveSelection}
+            adjustBrightness={adjustBrightness}
+            adjustContrast={adjustContrast}
+            adjustSaturation={adjustSaturation}
+            onBrushSettingsChange={onBrushSettingsChange}
+            onPencilSettingsChange={onPencilSettingsChange}
+            onEraserSettingsChange={onEraserSettingsChange}
+            onShapeSettingsChange={onShapeSettingsChange}
+            onFillSettingsChange={onFillSettingsChange}
+            onBlurSettingsChange={onBlurSettingsChange}
+            onGradientSettingsChange={onGradientSettingsChange}
+            onCloneStampSettingsChange={onCloneStampSettingsChange}
+            onSelectSettingsChange={onSelectSettingsChange}
+            onInvertSelection={onInvertSelection}
+            onCropCanvasToSelection={onCropCanvasToSelection}
+            onFeatherSelection={onFeatherSelection}
+            onSmoothSelectionBorders={onSmoothSelectionBorders}
+            onConvertSelectionToBorder={onConvertSelectionToBorder}
+            onAdjustBrightnessChange={onAdjustBrightnessChange}
+            onAdjustContrastChange={onAdjustContrastChange}
+            onAdjustSaturationChange={onAdjustSaturationChange}
+            onAdjustApply={onAdjustApply}
+            onAdjustCancel={onAdjustCancel}
+            transformScaleX={transformScaleX}
+            transformScaleY={transformScaleY}
+            transformRotation={transformRotation}
+            onTransformCommit={onTransformCommit}
+            onTransformCancel={onTransformCancel}
+            onTransformReset={onTransformReset}
+            transformAutoSelect={transformAutoSelect}
+            transformMode={transformMode}
+            onTransformAutoSelectChange={onTransformAutoSelectChange}
+            onTransformModeChange={onTransformModeChange}
+            moveAutoSelect={moveAutoSelect}
+            onMoveAutoSelectChange={onMoveAutoSelectChange}
+            cropHasPendingRect={cropHasPendingRect}
+            onCropApply={onCropApply}
+            onCropCancelPreview={onCropCancelPreview}
+            segmentSettings={segmentSettings}
+            onSegmentSettingsChange={onSegmentSettingsChange}
+            segmentationStatus={segmentationStatus}
+            segmentationError={segmentationError}
+            segmentModelInfo={segmentModelInfo}
+            onRunSegmentation={onRunSegmentation}
+            onApplySegmentResult={onApplySegmentResult}
+            onDiscardSegmentResult={onDiscardSegmentResult}
+            onCancelSegmentation={onCancelSegmentation}
+            onClearSegmentPrompts={onClearSegmentPrompts}
+            onCheckSegmentModel={onCheckSegmentModel}
+          />
+        )}
+      </div>
 
       {trailingActions}
     </FlexRow>

--- a/web/src/components/sketch/SketchToolbar.tsx
+++ b/web/src/components/sketch/SketchToolbar.tsx
@@ -46,6 +46,7 @@ const styles = (theme: Theme) =>
     width: `${BTN + 8 + 2}px`, // single column + padding + border
     overflowY: "auto",
     flexShrink: 0,
+    userSelect: "none",
     // Larger gap between tool groups; tighter even spacing within a group.
     "& .tool-sections": {
       display: "flex",

--- a/web/src/components/sketch/__tests__/sketchCanvasPresentation.test.tsx
+++ b/web/src/components/sketch/__tests__/sketchCanvasPresentation.test.tsx
@@ -13,6 +13,7 @@ import { useSketchStore } from "../state";
 import { cursorStyleForTool } from "../sketchCursorStyle";
 import {
   canvasTransformStyle,
+  computeFitView,
   computeFitZoom
 } from "../sketchCanvasPresentation.helpers";
 import { TransformTool } from "../tools/TransformTool";
@@ -167,13 +168,35 @@ describe("computeFitZoom", () => {
   });
 });
 
+// ─── computeFitView ──────────────────────────────────────────────────────────
+
+describe("computeFitView", () => {
+  it("is a plain centred fit when nothing covers the viewport", () => {
+    expect(computeFitView(2000, 400, 1000, 1000)).toEqual({
+      zoom: computeFitZoom(2000, 400, 1000, 1000),
+      pan: { x: 0, y: 0 }
+    });
+  });
+
+  it("fits below the floating tool bar and centres in the uncovered band", () => {
+    const fit = computeFitView(800, 900, 1024, 1024, 150);
+    // Height is limiting: (900 - 150) / 1024 * 0.9.
+    expect(fit.zoom).toBeCloseTo(0.659, 3);
+    expect(fit.pan).toEqual({ x: 0, y: 75 });
+  });
+
+  it("ignores an inset that would leave no room", () => {
+    expect(computeFitView(800, 300, 1024, 1024, 200)).toEqual(
+      computeFitView(800, 300, 1024, 1024)
+    );
+  });
+});
+
 // ─── SketchCanvasPresentation ────────────────────────────────────────────────
 
 describe("SketchCanvasPresentation", () => {
   it("renders canvas elements", () => {
-    const { container } = render(
-      <SketchCanvasPresentation {...makeProps()} />
-    );
+    const { container } = render(<SketchCanvasPresentation {...makeProps()} />);
     // Should have at least the bootstrap, display, overlay, GPU selection, selection, cursor, gizmo canvases.
     const canvases = container.querySelectorAll("canvas");
     expect(canvases.length).toBeGreaterThanOrEqual(7);
@@ -219,9 +242,7 @@ describe("SketchCanvasPresentation", () => {
 
   it("renders resize handles when onCanvasResize is provided", () => {
     const { queryByTestId } = render(
-      <SketchCanvasPresentation
-        {...makeProps({ onCanvasResize: jest.fn() })}
-      />
+      <SketchCanvasPresentation {...makeProps({ onCanvasResize: jest.fn() })} />
     );
     expect(queryByTestId("resize-handles")).toBeTruthy();
   });
@@ -236,5 +257,4 @@ describe("SketchCanvasPresentation", () => {
     expect(root!.className).toContain("sketch-canvas");
     expect(root!.className).toContain("my-test-class");
   });
-
 });

--- a/web/src/components/sketch/editor-shell/ConnectedEditorActions.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedEditorActions.tsx
@@ -31,6 +31,7 @@ import {
 } from "../../ui_primitives";
 import { useSketchStore, SKETCH_ZOOM_MIN, SKETCH_ZOOM_MAX } from "../state";
 import { useSketchSessionStore } from "../../../stores/sketch/SketchSessionStore";
+import { useSketchCanvasRefStore } from "../../../stores/sketch/SketchCanvasRefStore";
 import { ConnectedGeneratePopover } from "./ConnectedGeneratePopover";
 
 export interface ConnectedEditorActionsProps {
@@ -45,7 +46,11 @@ export interface ConnectedEditorActionsProps {
   menuItems?: (close: () => void) => React.ReactNode[];
 }
 
-/** Zoom the document to fit the canvas region, with a small margin. */
+/**
+ * Fallback fit when the canvas has not registered its own `fitViewToScreen`
+ * (which measures the real viewport and clears the floating tool bar): zoom
+ * the document to fit the canvas region, with a small margin.
+ */
 function fitToViewport(): void {
   const root = globalThis.document;
   const region = root?.querySelector(".sketch-editor__canvas-region");
@@ -74,6 +79,7 @@ export const ConnectedEditorActions = memo(function ConnectedEditorActions({
   const togglePanelsHidden = useSketchStore((s) => s.togglePanelsHidden);
 
   const documentId = useSketchSessionStore((s) => s.documentId);
+  const fitViewToScreen = useSketchCanvasRefStore((s) => s.fitViewToScreen);
 
   const generateAnchorRef = useRef<HTMLButtonElement>(null);
   const [generateOpen, setGenerateOpen] = useState(false);
@@ -92,8 +98,12 @@ export const ConnectedEditorActions = memo(function ConnectedEditorActions({
 
   const handleFit = useCallback(() => {
     closeMenu();
-    fitToViewport();
-  }, [closeMenu]);
+    if (fitViewToScreen) {
+      fitViewToScreen();
+    } else {
+      fitToViewport();
+    }
+  }, [closeMenu, fitViewToScreen]);
 
   const handleHidePanels = useCallback(() => {
     closeMenu();
@@ -138,15 +148,11 @@ export const ConnectedEditorActions = memo(function ConnectedEditorActions({
         </>
       )}
 
-      <Tooltip
-        title={assistantPanelOpen ? "Hide Assistant" : "Show Assistant"}
-      >
+      <Tooltip title={assistantPanelOpen ? "Hide Assistant" : "Show Assistant"}>
         <IconButton
           size="small"
           onClick={handleAssistant}
-          aria-label={
-            assistantPanelOpen ? "Hide Assistant" : "Show Assistant"
-          }
+          aria-label={assistantPanelOpen ? "Hide Assistant" : "Show Assistant"}
           aria-pressed={assistantPanelOpen}
           data-testid="sketch-assistant-toggle"
         >

--- a/web/src/components/sketch/editor-shell/ConnectedStatusBar.tsx
+++ b/web/src/components/sketch/editor-shell/ConnectedStatusBar.tsx
@@ -1,6 +1,7 @@
 /**
  * ConnectedStatusBar — full-width status strip at the bottom of the standalone
- * image editor. Shows canvas dimensions, color space / bit depth, zoom, the
+ * image editor. Shows canvas dimensions, color space / bit depth, zoom (with
+ * step buttons and a fit-to-screen readout), the
  * active foreground color, live cursor position, selection size, what
  * regenerating the document's generated layers costs, and layer count — all
  * from real store state. It replaces the floating info pill in the
@@ -13,10 +14,17 @@
  * shown as never-changing labels.
  */
 
-import React, { memo, useMemo } from "react";
+import React, { memo, useCallback, useMemo } from "react";
 import { useTheme } from "@mui/material/styles";
+import AddIcon from "@mui/icons-material/Add";
+import RemoveIcon from "@mui/icons-material/Remove";
 
-import { ColorSwatch, FlexRow, Tooltip } from "../../ui_primitives";
+import {
+  ColorSwatch,
+  FlexRow,
+  ToolbarIconButton,
+  Tooltip
+} from "../../ui_primitives";
 import CostEstimateLine from "../../costs/CostEstimateLine";
 import { useSketchCostEstimate } from "../../../hooks/sketch/useSketchCostEstimate";
 import { useSketchStore } from "../state/useSketchStore";
@@ -29,6 +37,18 @@ import { SKETCH_FONT } from "../sketchStyles";
 
 /** OS-aware combo for the fit-to-screen action ("⌘0" on Mac, "Ctrl+0" elsewhere). */
 const FIT_LABEL = `Fit to screen (${displayCombo("zoom-fit")})`;
+const ZOOM_IN_LABEL = `Zoom in (${displayCombo("zoom-in")})`;
+const ZOOM_OUT_LABEL = `Zoom out (${displayCombo("zoom-out")})`;
+/** Same step as the keyboard shortcuts and the wheel. */
+const ZOOM_STEP = 1.3;
+
+const zoomButtonSx = {
+  width: 18,
+  height: 18,
+  padding: 0,
+  color: "inherit",
+  "& svg": { fontSize: 14 }
+} as const;
 
 const ConnectedStatusBarInner: React.FC = () => {
   const theme = useTheme();
@@ -43,7 +63,11 @@ const ConnectedStatusBarInner: React.FC = () => {
   const selection = useSketchStore((s) => s.selection);
   const hasActiveSelection = useSketchStore((s) => s.hasActiveSelection);
   const fitViewToScreen = useSketchCanvasRefStore((s) => s.fitViewToScreen);
+  const setZoom = useSketchStore((s) => s.setZoom);
   const costEstimate = useSketchCostEstimate();
+
+  const zoomIn = useCallback(() => setZoom(zoom * ZOOM_STEP), [setZoom, zoom]);
+  const zoomOut = useCallback(() => setZoom(zoom / ZOOM_STEP), [setZoom, zoom]);
 
   const selBounds = useMemo(
     () =>
@@ -82,6 +106,15 @@ const ConnectedStatusBarInner: React.FC = () => {
         <span>
           {docW} × {docH} · sRGB · 8-bit ·
         </span>
+        <ToolbarIconButton
+          aria-label={ZOOM_OUT_LABEL}
+          tooltip={ZOOM_OUT_LABEL}
+          onClick={zoomOut}
+          sx={zoomButtonSx}
+          data-testid="sketch-status-zoom-out"
+        >
+          <RemoveIcon />
+        </ToolbarIconButton>
         <Tooltip title={FIT_LABEL} disabled={!fitViewToScreen}>
           <button
             type="button"
@@ -101,6 +134,15 @@ const ConnectedStatusBarInner: React.FC = () => {
             {Math.round(zoom * 100)}%
           </button>
         </Tooltip>
+        <ToolbarIconButton
+          aria-label={ZOOM_IN_LABEL}
+          tooltip={ZOOM_IN_LABEL}
+          onClick={zoomIn}
+          sx={zoomButtonSx}
+          data-testid="sketch-status-zoom-in"
+        >
+          <AddIcon />
+        </ToolbarIconButton>
       </FlexRow>
 
       <FlexRow align="center" gap={0.5}>

--- a/web/src/components/sketch/hooks/useCanvasGeometryActions.ts
+++ b/web/src/components/sketch/hooks/useCanvasGeometryActions.ts
@@ -32,7 +32,7 @@ import {
   getLayerGeometry
 } from "../transform/geometry/layerGeometry";
 import { getSelectionBounds, selectionHasAnyPixels } from "../selection";
-import { computeFitZoom } from "../sketchCanvasPresentation.helpers";
+import { computeFitView } from "../sketchCanvasPresentation.helpers";
 import {
   buildSketchInternalClipboardCanvas,
   drawSketchPasteOnLayerContext,
@@ -513,23 +513,33 @@ export function useCanvasGeometryActions({
     [setZoom]
   );
   /**
-   * Fit the whole artboard into the viewport and re-center it. Falls back to
-   * 100% when the viewport size is not yet known. `setZoom` clamps the result
-   * to the sketch zoom range.
+   * Fit the whole artboard into the viewport, below the floating tool bar,
+   * and centre it there. Falls back to 100% when the viewport size is not yet
+   * known. `setZoom` clamps the result to the sketch zoom range.
    */
   const handleZoomFit = useCallback(() => {
-    const viewport = canvasRef.current?.getViewportSize() ?? null;
+    const canvas = canvasRef.current;
+    const viewport = canvas?.getViewportSize() ?? null;
+    if (!canvas || !viewport) {
+      setZoom(1);
+      setPan({ x: 0, y: 0 });
+      return;
+    }
     const { document: doc } = useSketchStore.getState();
-    const fit = viewport
-      ? computeFitZoom(
-          viewport.width,
-          viewport.height,
-          doc.canvas.width,
-          doc.canvas.height
-        )
-      : 1;
-    setZoom(fit);
-    setPan({ x: 0, y: 0 });
+    const topBar = canvas
+      .getViewportElement()
+      ?.closest(".sketch-editor")
+      ?.querySelector(".sketch-tool-top-bar");
+    const topInset = topBar?.getBoundingClientRect().height ?? 0;
+    const fit = computeFitView(
+      viewport.width,
+      viewport.height,
+      doc.canvas.width,
+      doc.canvas.height,
+      topInset
+    );
+    setZoom(fit.zoom);
+    setPan(fit.pan);
   }, [canvasRef, setZoom, setPan]);
 
   // ─── Crop completion ───────────────────────────────────────────

--- a/web/src/components/sketch/hooks/useEditorLifecycle.ts
+++ b/web/src/components/sketch/hooks/useEditorLifecycle.ts
@@ -24,7 +24,11 @@ import { hydrateSketchStore } from "../state";
 import { useSketchInstance } from "../../../stores/sketch/SketchInstance";
 import type { useCanvasActions } from "./useCanvasActions";
 import type { useSegmentation } from "./useSegmentation";
-import type { SketchPersistenceSnapshot } from "../../../stores/sketch/persistence";
+import {
+  DEFAULT_SKETCH_PAN,
+  DEFAULT_SKETCH_ZOOM,
+  type SketchPersistenceSnapshot
+} from "../../../stores/sketch/persistence";
 
 const SKETCH_CANVAS_RESIZE_HANDLES_STORAGE_KEY =
   "nodetool-sketch-canvas-resize-handles";
@@ -98,6 +102,16 @@ export function useEditorLifecycle({
 
   // Snapshot of the document as it was when the editor first loaded
   const initialDocumentRef = useRef(initialDocument);
+
+  // Set by the hydrate below when the document arrives with the default
+  // viewport (100%, no pan) — a new document, or one whose view was never
+  // changed. That view shows a 1024px artboard cropped on every side in a
+  // typical window, so the first paint fits it to the viewport instead. A
+  // saved non-default view is restored as is. Consumed by the effect after
+  // the canvas mounts, when the viewport has a size to fit into.
+  const pendingInitialFitRef = useRef(false);
+  const canvasActionsRef = useRef(canvasActions);
+  canvasActionsRef.current = canvasActions;
 
   // ─── Canvas-resize-handles preference ─────────────────────────────
   const [canvasResizeHandlesEnabled, setCanvasResizeHandlesEnabled] = useState(
@@ -174,6 +188,11 @@ export function useEditorLifecycle({
     const isSameDocRevisit =
       documentId !== undefined && session.hydratedDocumentId === documentId;
     if (!isSameDocRevisit) {
+      pendingInitialFitRef.current =
+        !initialEditorState ||
+        (initialEditorState.zoom === DEFAULT_SKETCH_ZOOM &&
+          initialEditorState.pan.x === DEFAULT_SKETCH_PAN.x &&
+          initialEditorState.pan.y === DEFAULT_SKETCH_PAN.y);
       if (initialEditorState) {
         hydrateSketchStore(instance.editor, {
           document: initialEditorState.document,
@@ -192,6 +211,22 @@ export function useEditorLifecycle({
     }
     setCanvasReady(true);
   }, [documentId, initialDocument, initialEditorState, setDocument, instance]);
+
+  // The canvas mounts in the commit that flips `canvasReady`; one frame later
+  // its container has been laid out and `handleZoomFit` can measure it.
+  useEffect(() => {
+    if (!canvasReady || !pendingInitialFitRef.current) {
+      return;
+    }
+    const frame = requestAnimationFrame(() => {
+      if (!pendingInitialFitRef.current) {
+        return;
+      }
+      pendingInitialFitRef.current = false;
+      canvasActionsRef.current.handleZoomFit();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [canvasReady, documentId]);
 
   // ─── Autosave on document changes ─────────────────────────────────
   // ## Autosave boundary contract

--- a/web/src/components/sketch/sketchCanvasHooks/useCanvasImperativeHandle.ts
+++ b/web/src/components/sketch/sketchCanvasHooks/useCanvasImperativeHandle.ts
@@ -347,7 +347,8 @@ export function useCanvasImperativeHandle({
           width: container.clientWidth,
           height: container.clientHeight
         };
-      }
+      },
+      getViewportElement: (): HTMLElement | null => containerRef.current
     }),
     [
       doc,

--- a/web/src/components/sketch/sketchCanvasPresentation.helpers.ts
+++ b/web/src/components/sketch/sketchCanvasPresentation.helpers.ts
@@ -31,6 +31,35 @@ export function computeFitZoom(
     return 1;
   }
   return (
-    Math.min(viewportWidth / canvasWidth, viewportHeight / canvasHeight) * margin
+    Math.min(viewportWidth / canvasWidth, viewportHeight / canvasHeight) *
+    margin
   );
+}
+
+/**
+ * Zoom and pan that fit the artboard into the part of the viewport nothing
+ * covers. The tool bar floats over the top of the viewport (it takes no flex
+ * height, so wrapping its settings never shifts the image), which means a
+ * plain centre fit tucks the top of a tall document under it. `topInset` is
+ * the bar's height: the fit uses the height below it and pans down by half
+ * of it so the artboard is centred in the uncovered band. Falls back to the
+ * whole viewport when the inset would leave no room.
+ */
+export function computeFitView(
+  viewportWidth: number,
+  viewportHeight: number,
+  canvasWidth: number,
+  canvasHeight: number,
+  topInset = 0
+): { zoom: number; pan: Point } {
+  const inset = topInset > 0 && topInset < viewportHeight * 0.5 ? topInset : 0;
+  return {
+    zoom: computeFitZoom(
+      viewportWidth,
+      viewportHeight - inset,
+      canvasWidth,
+      canvasHeight
+    ),
+    pan: { x: 0, y: inset / 2 }
+  };
 }

--- a/web/src/components/sketch/state/slices/uiSlice.ts
+++ b/web/src/components/sketch/state/slices/uiSlice.ts
@@ -53,7 +53,11 @@ export interface UiSlice {
   /** Whether the AI assistant chat panel is open (right side of the editor). */
   assistantPanelOpen: boolean;
   toggleAssistantPanel: () => void;
-  setAssistantPanelOpen: (open: boolean) => void;
+  /** `persist: false` changes the panel without updating the remembered preference. */
+  setAssistantPanelOpen: (
+    open: boolean,
+    options?: { persist?: boolean }
+  ) => void;
 
   /**
    * Whether the mobile panels sheet (color / layers / canvas) is open. On
@@ -126,8 +130,10 @@ export const createUiSlice: StateCreator<SketchStore, [], [], UiSlice> = (
       writeAssistantPanelOpen(assistantPanelOpen);
       return { assistantPanelOpen };
     }),
-  setAssistantPanelOpen: (open: boolean) => {
-    writeAssistantPanelOpen(open);
+  setAssistantPanelOpen: (open, options) => {
+    if (options?.persist !== false) {
+      writeAssistantPanelOpen(open);
+    }
     set({ assistantPanelOpen: open });
   },
 

--- a/web/src/components/sketch/tool-settings-panels/__tests__/getToolSettingsLabel.test.ts
+++ b/web/src/components/sketch/tool-settings-panels/__tests__/getToolSettingsLabel.test.ts
@@ -20,17 +20,14 @@ describe("getToolSettingsLabel", () => {
     ["transform", "Transform"]
   ];
 
-  it.each(expectedLabels)(
-    'returns "%s" → "%s"',
-    (tool, expected) => {
-      expect(getToolSettingsLabel(tool)).toBe(expected);
-    }
-  );
+  it.each(expectedLabels)('returns "%s" → "%s"', (tool, expected) => {
+    expect(getToolSettingsLabel(tool)).toBe(expected);
+  });
 
-  it('returns "Settings" for tools without a specific label', () => {
-    expect(getToolSettingsLabel("move")).toBe("Settings");
-    expect(getToolSettingsLabel("eyedropper")).toBe("Settings");
-    expect(getToolSettingsLabel("clone_stamp")).toBe("Settings");
+  it("names the tools that have no settings of their own", () => {
+    expect(getToolSettingsLabel("move")).toBe("Move");
+    expect(getToolSettingsLabel("eyedropper")).toBe("Color Picker");
+    expect(getToolSettingsLabel("clone_stamp")).toBe("Clone Stamp");
   });
 
   it('returns "Settings" for unknown tool values', () => {

--- a/web/src/components/sketch/tool-settings-panels/adjustMoveCropPanels.tsx
+++ b/web/src/components/sketch/tool-settings-panels/adjustMoveCropPanels.tsx
@@ -52,7 +52,7 @@ export const AdjustmentsSettingsPanel = memo(function AdjustmentsSettingsPanel({
   return (
     <>
       <Box className="setting-row">
-        <Text className="setting-label">Bright</Text>
+        <Text className="setting-label">Brightness</Text>
         <Slider
           sx={sketchSliderSx}
           size="small"
@@ -76,7 +76,7 @@ export const AdjustmentsSettingsPanel = memo(function AdjustmentsSettingsPanel({
         <Text className="setting-value">{contrast}</Text>
       </Box>
       <Box className="setting-row">
-        <Text className="setting-label">Satur.</Text>
+        <Text className="setting-label">Saturation</Text>
         <Slider
           sx={sketchSliderSx}
           size="small"

--- a/web/src/components/sketch/tool-settings-panels/getToolSettingsLabel.ts
+++ b/web/src/components/sketch/tool-settings-panels/getToolSettingsLabel.ts
@@ -26,6 +26,12 @@ export function getToolSettingsLabel(tool: SketchTool): string {
       return "Shape";
     case "transform":
       return "Transform";
+    case "move":
+      return "Move";
+    case "eyedropper":
+      return "Color Picker";
+    case "clone_stamp":
+      return "Clone Stamp";
     default:
       return "Settings";
   }


### PR DESCRIPTION
## What changed

Drove the standalone image editor in Chromium (Playwright against `npm run dev`) and fixed what the screenshots showed. A new document opened at 100% with a 1024px artboard cropped on every side and its top hidden under the floating tool bar; the editor now fits the artboard into the band below the bar on first open when the saved view is the default (100%, no pan), and `handleZoomFit` / the Fit menu entry clear the bar the same way (`computeFitView`). The tool bar's Generate / assistant / menu cluster shared one wrapping row with the settings, so any tool with two rows of settings pushed the cluster onto a row of its own; it is now a second column pinned to the top-right. Smaller fixes from the same pass: Move, Color Picker and Clone Stamp were labelled "Settings" in the bar; the status bar gains zoom step buttons beside the readout; the adjustment sliders say Brightness and Saturation instead of "Bright" and "Satur."; a drag that starts on chrome no longer sweeps a text selection across the page; and on a phone the remembered-open assistant sheet no longer covers the whole canvas on load (closed on entering the mobile layout without overwriting the preference).

## Verification

- [x] `npm run test:affected` — web, 244 suites, 2260 passed, 3 skipped
- [x] `npm run typecheck` (web)
- [x] `npm run lint` (web)
- [ ] `npm run dev:nodetool -- harness gate --base main` — not run; the diff touches only web UI components

`getToolSettingsLabel.test.ts` was updated to expect the new names (it previously pinned "Settings" for those three tools and failed until the label change landed). `computeFitView` has three new cases in `sketchCanvasPresentation.test.tsx`.

## Agent capabilities

No capability added or changed.

## New checks

No check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRMny5nfbTnDfWgRvxBFf5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRMny5nfbTnDfWgRvxBFf5)_