### PR TITLE
fix(web): keep canvas composer chips on one line

### DIFF
--- a/web/src/components/chat/composer/MediaChatComposer.styles.ts
+++ b/web/src/components/chat/composer/MediaChatComposer.styles.ts
@@ -108,6 +108,14 @@ export const createMediaComposerStyles = (theme: Theme) =>
       flexWrap: "nowrap"
     },
 
+    // The canvas dock (host actions after the chips) keeps the cluster on one
+    // line at every width: a wrapping cluster drops the workspace chip under
+    // the model chip while the model chip still sits at its max width, since
+    // flex wraps before it shrinks. Single-line, the model chip truncates.
+    ".media-chip-row.has-trailing .media-chip-main": {
+      flexWrap: "nowrap"
+    },
+
     ".media-chip-row .divider-dot": {
       width: 4,
       height: 4,


### PR DESCRIPTION
## What changed

In the node editor dock the media composer's chip row wrapped the workspace chip onto a second line while the model chip still sat at its 320px max width, because a wrapping flex container wraps items before it shrinks them. The canvas dock is the only host that passes `trailingActions` (the `has-trailing` class), so this adds one rule that keeps the chip cluster single-line there. The model chip already has `grow`/`truncate`, so it shrinks and truncates instead. The chat panel, project agent, and mobile layouts are untouched.

## Verification

- [x] `jest src/components/panels/__tests__/CanvasMediaComposer.test.tsx` — 3 passed
- [x] `oxlint` on the changed file — clean
- [ ] `npm run typecheck` — fails locally on an unrelated file (`web/src/utils/generationCostEstimate.ts`, unbuilt `@nodetool-ai/node-sdk/cost-estimate` export) before and after this change; CI builds packages first
- [ ] `npm run dev:nodetool -- harness gate --base main` — not run, CSS-only change

## Agent capabilities

Skipped: no capability changes.

## New checks

Skipped: no checks added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F15nPhcPxP9CTcUMLTFTbE

---
_Generated by [Claude Code](https://claude.ai/code/session_01F15nPhcPxP9CTcUMLTFTbE)_