### PR TITLE
feat(chat): surface errors, drop dead composer, mobile rails, a11y

### DIFF
--- a/web/src/components/chat/types/chat.types.ts
+++ b/web/src/components/chat/types/chat.types.ts
@@ -19,3 +19,22 @@ export type DroppedFile = {
 
 export const DOC_TYPES_REGEX =
   /application\/pdf|application\/msword|application\/vnd\.openxmlformats-officedocument\.*|application\/vnd\.ms-.*|application\/vnd\.apple\.*|application\/x-iwork.*/;
+
+/**
+ * Connection and generation state a chat surface renders. The socket states
+ * come from `ConnectionState`; `loading`/`streaming` are the turn in flight
+ * and `error`/`failed` are the two ways it ends badly.
+ */
+export type ChatStatus =
+  | "disconnected"
+  | "connecting"
+  | "connected"
+  | "loading"
+  | "error"
+  | "streaming"
+  | "reconnecting"
+  | "disconnecting"
+  | "failed";
+
+/** Width of the message column and the composer beneath it, in px. */
+export const CHAT_COLUMN_MAX_WIDTH = 800;


### PR DESCRIPTION
## What changed

Chat UI improvements from an analysis of `web/src/components/chat`. The first commit exports one `ChatStatus` type and one `CHAT_COLUMN_MAX_WIDTH` constant from `types/chat.types.ts`; the status union was copied into three components and the 800px column width into four style blocks. Follow-up commits on this branch (landing now) build on those contracts: an error banner with retry in `ChatView` so a failed turn is visible outside the canvas dock, removal of the unreachable "simple" composer path and its dead props, welcome suggestions that seed the composer instead of sending, chat keyboard shortcuts, a segmented rail toggle below the `md` breakpoint, the scroll state machine extracted from `ChatThreadView` into a hook, per-mode chip configuration in `MediaChatComposer`, real button semantics in thread rows with one confirm dialog per list, edit-and-resend and day labels on messages, a design-token sweep, and direct tests for the composer, panel header, permission selector and sidebars.

## Verification

Filled in when the follow-up commits are merged into this branch.

- [ ] `npm run test:affected`
- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run dev:nodetool -- harness gate --base main`

## Agent capabilities

Skipped: the diff adds no capability and changes no capability's declared contract.

## New checks

Skipped: the diff adds no check, rule, or audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PxAHRE4g2ZdV1q5vksRCA

---
_Generated by [Claude Code](https://claude.ai/code/session_017PxAHRE4g2ZdV1q5vksRCA)_