### PR TITLE
feat(timeline): clip and track editor improvements

### DIFF
--- a/web/src/components/timeline/TimelineShortcutsDialog.tsx
+++ b/web/src/components/timeline/TimelineShortcutsDialog.tsx
@@ -72,7 +72,8 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
     title: "Move",
     shortcuts: [
       { keys: ["←"], action: "Nudge one frame", alt: ["→"] },
-      { keys: ["Shift", "←"], action: "Nudge one second", alt: ["Shift", "→"] }
+      { keys: ["Shift", "←"], action: "Nudge one second", alt: ["Shift", "→"] },
+      { keys: ["Alt", "drag"], action: "Disable snapping while moving or trimming" }
     ]
   },
   {

--- a/web/src/components/timeline/Tracks/Clip.tsx
+++ b/web/src/components/timeline/Tracks/Clip.tsx
@@ -1,460 +1,40 @@
-/** @jsxImportSource @emotion/react */
 /**
  * Clip
  *
- * Generic clip component — handles the "chrome":
- *   - Selection ring (highlighted border)
- *   - Drag region (move clip / change track)
- *   - Two trim handles (start/end edges)
- *   - Status badge slot (StatusIndicator)
+ * One timeline clip: reads its own store slice, derives status, wires the
+ * drag and trim gestures (useClipDrag / useClipTrim) and the context menu,
+ * and hands stable props to the memoized ClipBody that draws it.
  *
- * The clip body content (waveform, thumbnail, placeholder) is a future concern
- * handled by NOD-304/NOD-308 child renderers; this component only manages
- * geometry interactions.
- *
- * Performance: subscribes only to this clip's own state (id selector),
- * selection membership (id selector), and msPerPx.
+ * Performance: subscribes only to this clip's own state (id selector), its
+ * track's lock flag (primitive selector), selection membership, and msPerPx.
  */
 
-import React, {
-  memo,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState
-} from "react";
-import { css } from "@emotion/react";
-import { useTheme } from "@mui/material/styles";
-import type { Theme } from "@mui/material/styles";
-import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
-import LoopOutlinedIcon from "@mui/icons-material/LoopOutlined";
+import React, { memo, useCallback, useMemo, useState } from "react";
 
-import type {
-  TimelineClip,
-  TimelineTrack,
-  ClipStatus
-} from "@nodetool-ai/timeline";
+import type { ClipStatus } from "@nodetool-ai/timeline";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
 import { findClipById } from "../../../stores/timeline/clipLookup";
-import { useTimelineHistoryBatch } from "../../../stores/timeline/useTimelineHistoryBatch";
 import {
   useTimelineUIStore,
   useIsClipSelected
 } from "../../../stores/timeline/TimelineUIStore";
-import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
 import { useLongPress } from "../../../hooks/timeline/useLongPress";
 import type { LongPressPoint } from "../../../hooks/timeline/useLongPress";
 import useWorkflowRunsStore from "../../../stores/WorkflowRunsStore";
-import { useAssetStore } from "../../../stores/AssetStore";
-import { getAssetUrl } from "../../../utils/assetHelpers";
 import useErrorStore, {
   hasNodeError,
   nodeErrorToDisplayString
 } from "../../../stores/ErrorStore";
 import { type NodeKey } from "../../../stores/nodeKey";
-import {
-  StatusIndicator,
-  BORDER_RADIUS,
-  SPACING,
-  getSpacingPx,
-  MagicGenerationFill,
-  Toast,
-  Z_INDEX
-} from "../../ui_primitives";
-import type { StatusType } from "../../ui_primitives";
+import { Toast } from "../../ui_primitives";
 import { deriveClipStatus } from "../status/clipStatusReducer";
 import type { ClipErrorState } from "../status/clipStatusReducer";
-import { useClipThumbnails } from "./useClipThumbnails";
-import { useAudioPeaks } from "./useAudioPeaks";
-import { samplePeaksWindow } from "./audioPeaks";
-import { isCompatibleWithTrack } from "../dnd/assetToClipAdapter";
-import { clipSurfaceTint, clipBorderTint } from "./trackVisuals";
+import { useClipSourceDuration } from "./useClipSourceDuration";
+import { useClipDrag } from "./useClipDrag";
+import { useClipTrim } from "./useClipTrim";
+import { ClipBody, CLIP_STATUS_MAP, MIN_CLIP_WIDTH_PX } from "./ClipBody";
 import { ClipContextMenu } from "./ClipContextMenu";
-import { GroupBracket } from "./GroupBracket";
 import { ReplaceOutputDialog } from "./ReplaceOutputDialog";
-import { deriveClipAnimationMarkers } from "./clipAnimationMarkers";
-import { openPersistedFold } from "../Inspector/usePersistedFold";
-
-/** Clip-side wrapper: TimelineClip.mediaType also includes "overlay";
- *  treat those as video-track-compatible. */
-function isClipCompatibleWithTrack(
-  clipMediaType: TimelineClip["mediaType"],
-  trackType: TimelineTrack["type"]
-): boolean {
-  if (
-    clipMediaType === "overlay" ||
-    clipMediaType === "text" ||
-    clipMediaType === "shape" ||
-    clipMediaType === "group"
-  ) {
-    return trackType === "video" || trackType === "overlay";
-  }
-  return isCompatibleWithTrack(clipMediaType, trackType);
-}
-
-const TRIM_HANDLE_WIDTH_PX = 8;
-/** Hit area for the same grip under a finger; the visible width stays 8px. */
-const TOUCH_TRIM_HANDLE_WIDTH_PX = 22;
-const MIN_CLIP_WIDTH_PX = 4;
-const CLIP_RADIUS_PX = parseFloat(BORDER_RADIUS.md);
-/** Width below which we suppress secondary chrome (duration label). */
-const COMPACT_THRESHOLD_PX = 96;
-
-// Status mapping (PRD §5.5)
-const CLIP_STATUS_MAP = {
-  draft: { status: "default", label: "Draft", pulse: false },
-  queued: { status: "pending", label: "Queued", pulse: false },
-  generating: { status: "pending", label: "Generating", pulse: true },
-  generated: { status: "success", label: "Generated", pulse: false },
-  stale: { status: "warning", label: "Stale", pulse: false },
-  failed: { status: "error", label: "Failed", pulse: false },
-  locked: { status: "info", label: "Locked", pulse: false },
-  missing: { status: "error", label: "Missing", pulse: false }
-} satisfies Record<ClipStatus, { status: StatusType; label: string; pulse: boolean }>;
-
-const clipStyles = (
-  theme: Theme,
-  selected: boolean,
-  locked: boolean,
-  mediaType: TimelineClip["mediaType"]
-) =>
-  css({
-    position: "absolute",
-    top: 6,
-    bottom: 6,
-    borderRadius: CLIP_RADIUS_PX,
-    overflow: "hidden",
-    backgroundColor: theme.vars.palette.background.paper,
-    backgroundImage: `linear-gradient(0deg, ${clipSurfaceTint(
-      mediaType
-    )}, ${clipSurfaceTint(mediaType)})`,
-    border: selected
-      ? `1.5px solid ${theme.vars.palette.secondary.main}`
-      : `1px solid ${clipBorderTint(theme, mediaType)}`,
-    boxShadow: selected
-      ? `0 0 0 3px rgba(var(--palette-secondary-mainChannel) / 0.18), 0 4px 12px ${theme.vars.palette.c_scrim_soft}`
-      : "none",
-    cursor: locked ? "not-allowed" : "grab",
-    "&:active": {
-      cursor: locked ? "not-allowed" : "grabbing"
-    },
-    userSelect: "none",
-    touchAction: "none",
-    minWidth: MIN_CLIP_WIDTH_PX,
-    boxSizing: "border-box"
-  });
-
-const clipHeaderRowStyles = css({
-  position: "absolute",
-  top: 0,
-  left: 0,
-  right: 0,
-  height: 18,
-  display: "flex",
-  alignItems: "center",
-  gap: getSpacingPx(SPACING.sm),
-  padding: `0 ${getSpacingPx(SPACING.md)}`,
-  pointerEvents: "none",
-  zIndex: Z_INDEX.base + 4
-});
-
-const clipDotStyles = (accent: string) =>
-  css({
-    width: 6,
-    height: 6,
-    borderRadius: BORDER_RADIUS.circle,
-    backgroundColor: accent,
-    boxShadow: `0 0 0 1px var(--palette-c_scrim)`,
-    flexShrink: 0
-  });
-
-const clipNameStyles = (theme: Theme) =>
-  css({
-    fontSize: "var(--fontSizeSmaller)",
-    fontWeight: 500,
-    letterSpacing: "-0.005em",
-    color: theme.vars.palette.text.primary,
-    whiteSpace: "nowrap",
-    overflow: "hidden",
-    textOverflow: "ellipsis",
-    pointerEvents: "none",
-    lineHeight: 1.4,
-    textShadow: `0 1px 2px ${theme.vars.palette.c_scrim}`,
-    flex: "1 1 auto",
-    minWidth: 0
-  });
-
-const clipDurationStyles = (theme: Theme) =>
-  css({
-    flexShrink: 0,
-    fontFamily:
-      "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace",
-    fontSize: "var(--fontSizeSmaller)",
-    fontWeight: 500,
-    color: theme.vars.palette.text.secondary,
-    letterSpacing: "0",
-    textShadow: `0 1px 2px ${theme.vars.palette.c_scrim}`
-  });
-
-const filmstripStyles = css({
-  position: "absolute",
-  left: 6,
-  right: 6,
-  top: 20,
-  bottom: 6,
-  display: "flex",
-  gap: getSpacingPx(SPACING.micro), // was 1px
-  pointerEvents: "none",
-  zIndex: 0,
-  borderRadius: BORDER_RADIUS.xs,
-  overflow: "hidden"
-});
-
-const waveformStyles = css({
-  position: "absolute",
-  inset: 0,
-  pointerEvents: "none",
-  zIndex: 0,
-  display: "block",
-  width: "100%",
-  height: "100%"
-});
-
-// Generating overlay for clips that are queued or actively generating —
-// the shared "magic" wash + shimmer reused from the sketch editor, so a
-// generating clip in the timeline reads identically to a generating layer
-// on the canvas. Clips to the clip's rounded body.
-const generatingOverlayStyles = css({
-  position: "absolute",
-  inset: 0,
-  pointerEvents: "none",
-  zIndex: Z_INDEX.base + 3,
-  overflow: "hidden",
-  borderRadius: CLIP_RADIUS_PX
-});
-
-interface WaveformCanvasProps {
-  url: string | undefined;
-  inPointMs: number;
-  outPointMs: number;
-  widthPx: number;
-}
-
-/** Draws audio peaks on a canvas, sized to the clip's pixel width. */
-const WaveformCanvas: React.FC<WaveformCanvasProps> = ({
-  url,
-  inPointMs,
-  outPointMs,
-  widthPx
-}) => {
-  const theme = useTheme();
-  const { peaks, durationMs } = useAudioPeaks(url);
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
-
-  // Coalesce redraws into a single animation frame. During a drag/resize the
-  // clip's widthPx changes on every pointermove (~60×/s); without this each
-  // change forced a synchronous canvas re-render. We also skip redraws when the
-  // width hasn't moved by at least a pixel, so sub-pixel jitter is a no-op.
-  const rafIdRef = useRef<number | null>(null);
-  const lastDrawnWidthRef = useRef<number>(-1);
-  const lastInputsKeyRef = useRef<string>("");
-
-  // Latest draw inputs, read inside the scheduled frame so it never goes stale.
-  const drawInputsRef = useRef({
-    peaks,
-    durationMs,
-    inPointMs,
-    outPointMs,
-    widthPx,
-    successColor: theme.vars.palette.success.main
-  });
-  drawInputsRef.current = {
-    peaks,
-    durationMs,
-    inPointMs,
-    outPointMs,
-    widthPx,
-    successColor: theme.vars.palette.success.main
-  };
-
-  const draw = useCallback(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const {
-      peaks: pk,
-      durationMs: dur,
-      inPointMs: inMs,
-      outPointMs: outMs,
-      widthPx: wPx,
-      successColor
-    } = drawInputsRef.current;
-
-    const dpr =
-      typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
-    const cssWidth = Math.max(1, Math.floor(wPx));
-    const cssHeight = canvas.clientHeight || 32;
-    canvas.width = cssWidth * dpr;
-    canvas.height = cssHeight * dpr;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-    ctx.scale(dpr, dpr);
-    ctx.clearRect(0, 0, cssWidth, cssHeight);
-
-    if (!pk || !dur) return;
-
-    // Visible audio window is the intersection of [inPointMs, outPointMs]
-    // with the source [0, durationMs]. Anything beyond the source renders
-    // as empty space rather than stretching the waveform.
-    const visibleInMs = Math.max(0, Math.min(dur, inMs));
-    const visibleOutMs = Math.max(visibleInMs, Math.min(dur, outMs));
-    const clipSpanMs = Math.max(1, outMs - inMs);
-    const visibleSpanMs = visibleOutMs - visibleInMs;
-    const visibleWidthPx = cssWidth * (visibleSpanMs / clipSpanMs);
-
-    const barCount = Math.max(1, Math.floor(visibleWidthPx / 2));
-    const slice = samplePeaksWindow(
-      pk,
-      dur,
-      visibleInMs,
-      visibleOutMs,
-      barCount
-    );
-    const mid = cssHeight / 2;
-    ctx.fillStyle = successColor;
-    for (let i = 0; i < slice.length; i += 1) {
-      const amp = slice[i];
-      const h = Math.max(1, amp * (cssHeight - 2));
-      const x = (i / slice.length) * visibleWidthPx;
-      const w = Math.max(1, visibleWidthPx / slice.length - 0.5);
-      ctx.fillRect(x, mid - h / 2, w, h);
-    }
-  }, []);
-
-  useEffect(() => {
-    // Decide whether anything beyond a sub-pixel width change actually
-    // happened. Width changes during a drag are gated to whole pixels (the
-    // canvas can't show finer detail); other inputs force a redraw.
-    const inputsKey = `${durationMs}|${inPointMs}|${outPointMs}|${url || ""}`;
-    const otherInputsChanged = inputsKey !== lastInputsKeyRef.current;
-    const widthChanged =
-      Math.abs(Math.floor(widthPx) - lastDrawnWidthRef.current) >= 1;
-    if (!otherInputsChanged && !widthChanged) return;
-
-    if (rafIdRef.current !== null) return;
-    rafIdRef.current = requestAnimationFrame(() => {
-      rafIdRef.current = null;
-      lastDrawnWidthRef.current = Math.floor(widthPx);
-      lastInputsKeyRef.current = inputsKey;
-      draw();
-    });
-    return () => {
-      if (rafIdRef.current !== null) {
-        cancelAnimationFrame(rafIdRef.current);
-        rafIdRef.current = null;
-      }
-    };
-  }, [peaks, durationMs, inPointMs, outPointMs, widthPx, url, draw]);
-
-  return <canvas ref={canvasRef} css={waveformStyles} aria-hidden />;
-};
-WaveformCanvas.displayName = "WaveformCanvas";
-
-// Static (no per-URL variant): backgroundImage is set via inline `style`
-// instead, so a distinct thumbnail data URL per cell doesn't make emotion
-// hash a multi-KB string and insert a permanent CSSOM rule per render.
-const filmstripCellStyles = css({
-  flex: 1,
-  height: "100%",
-  backgroundSize: "cover",
-  backgroundPosition: "center",
-  opacity: 0.78
-});
-
-const trimHandleStyles = (edge: "start" | "end", locked: boolean) =>
-  css({
-    position: "absolute",
-    top: 0,
-    bottom: 0,
-    width: TRIM_HANDLE_WIDTH_PX,
-    [edge === "start" ? "left" : "right"]: 0,
-    cursor: locked ? "not-allowed" : "ew-resize",
-    backgroundColor: "var(--palette-c_overlay_strong)",
-    "&:hover": {
-      backgroundColor: locked ? undefined : "var(--palette-c_overlay_strong)"
-    },
-    zIndex: Z_INDEX.base + 2,
-    // A fingertip covers far more than 8px. Widen the hit area on touch
-    // without widening the visible grip, via a transparent inset overlay —
-    // otherwise trimming a clip on a phone means repeatedly missing the
-    // handle and dragging the clip instead.
-    "@media (pointer: coarse)": {
-      "&::after": {
-        content: '""',
-        position: "absolute",
-        top: 0,
-        bottom: 0,
-        [edge === "start" ? "left" : "right"]: 0,
-        width: TOUCH_TRIM_HANDLE_WIDTH_PX
-      }
-    }
-  });
-
-const statusBadgeStyles = css({
-  position: "absolute",
-  bottom: 4,
-  right: 6,
-  zIndex: Z_INDEX.base + 3,
-  pointerEvents: "none"
-});
-
-const lockIconStyles = css({
-  position: "absolute",
-  bottom: 4,
-  left: 8,
-  zIndex: Z_INDEX.base + 3,
-  pointerEvents: "none",
-  opacity: 0.85,
-  fontSize: 12,
-  display: "flex",
-  alignItems: "center"
-});
-
-const animationZoneStyles = (theme: Theme, edge: "in" | "out") =>
-  css({
-    position: "absolute",
-    top: 0,
-    bottom: 0,
-    padding: 0,
-    border: 0,
-    cursor: "pointer",
-    zIndex: Z_INDEX.base + 1,
-    backgroundColor:
-      edge === "in"
-        ? `rgba(${theme.vars.palette.primary.mainChannel} / 0.2)`
-        : `rgba(${theme.vars.palette.secondary.mainChannel} / 0.2)`,
-    clipPath:
-      edge === "in"
-        ? "polygon(0 0, 100% 0, 75% 100%, 0 100%)"
-        : "polygon(0 0, 100% 0, 100% 100%, 25% 100%)"
-  });
-
-const animationLoopIconStyles = (theme: Theme) =>
-  css({
-    position: "absolute",
-    left: "50%",
-    bottom: 4,
-    transform: "translateX(-50%)",
-    color: theme.vars.palette.text.secondary,
-    padding: 0,
-    border: 0,
-    background: "none",
-    cursor: "pointer",
-    zIndex: Z_INDEX.base + 2,
-    display: "inline-flex",
-    opacity: 0.85,
-    "& svg": { fontSize: 12 }
-  });
 
 interface ClipProps {
   clipId: string;
@@ -465,61 +45,32 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
   // index keyed on `clips` identity, shared across every mounted Clip — vs.
   // O(n) per clip per store publish (O(n²) aggregate during a drag).
   const clip = useTimelineStore((s) => findClipById(s.clips, clipId));
+  // Primitive selector: re-renders only when this track's lock flag flips.
+  const trackId = clip?.trackId;
+  const trackLocked = useTimelineStore(
+    (s) =>
+      trackId !== undefined &&
+      (s.tracks.find((t) => t.id === trackId)?.locked ?? false)
+  );
+  const interactionLocked = (clip?.locked ?? false) || trackLocked;
 
   const isSelected = useIsClipSelected(clipId);
   const msPerPx = useTimelineUIStore((s) => s.msPerPx);
+  const activeTool = useTimelineUIStore((s) => s.activeTool);
 
   const selectClip = useTimelineUIStore((s) => s.selectClip);
   const addToSelection = useTimelineUIStore((s) => s.addToSelection);
   const toggleSelection = useTimelineUIStore((s) => s.toggleSelection);
 
-  const moveClip = useTimelineStore((s) => s.moveClip);
-  const moveSelectedClips = useTimelineStore((s) => s.moveSelectedClips);
-  const trimClipStart = useTimelineStore((s) => s.trimClipStart);
-  const trimClipEnd = useTimelineStore((s) => s.trimClipEnd);
-  const splitClipAtTime = useTimelineStore((s) => s.splitClipAtTime);
   const unlinkClip = useTimelineStore((s) => s.unlinkClip);
   const deleteSelected = useTimelineStore((s) => s.deleteSelected);
-  const activeTool = useTimelineUIStore((s) => s.activeTool);
 
-  // Source-duration cap for trim-end. Only enforced for audio clips —
-  // extending past the source has no sensible result (the playback engine
-  // stops at outPointMs and the waveform visually stretches).
-  //
-  // We resolve the URL here and decode the buffer via useAudioPeaks so the
-  // cap reflects the *actual* decoded duration rather than asset metadata
-  // (which can be null for some assets). The result is cached per URL.
-  const getAssetFromStore = useAssetStore((s) => s.get);
-  const [resolvedAudioUrl, setResolvedAudioUrl] = useState<string | undefined>(
-    undefined
-  );
-  useEffect(() => {
-    if (clip?.mediaType !== "audio" || !clip.currentAssetId) {
-      setResolvedAudioUrl(undefined);
-      return;
-    }
-    let cancelled = false;
-    getAssetFromStore(clip.currentAssetId)
-      .then((asset) => {
-        if (!cancelled) setResolvedAudioUrl(getAssetUrl(asset) ?? undefined);
-      })
-      .catch(() => {
-        // Asset unavailable — leave cap unset; trim falls back to free behavior.
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [clip?.mediaType, clip?.currentAssetId, getAssetFromStore]);
-
-  const { durationMs: decodedAudioDurationMs } =
-    useAudioPeaks(resolvedAudioUrl);
-  const audioSourceDurationMs =
-    clip?.mediaType === "audio" && decodedAudioDurationMs
-      ? decodedAudioDurationMs
-      : undefined;
+  // Source-duration cap for trim-end (audio decoded, video probed; nothing
+  // for image/text/shape clips).
+  const sourceDurationMs = useClipSourceDuration(clip);
 
   // Derived status (PRD §5.5).
-  // Node-level errors from ErrorStore. Error keys are now scoped per run
+  // Node-level errors from ErrorStore. Error keys are scoped per run
   // (`${wf}:${jobId}:${node}`), so restrict the scan to the workflow's focused
   // run; with no focused run there's no error to surface.
   //
@@ -550,7 +101,6 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
     [errorMessage]
   );
 
-  // Derive the displayed status badge.
   // For the "missing" check we trust clip.currentAssetId: if it's set,
   // the asset is assumed present unless the generation store knows otherwise.
   // A full async asset-existence check would require React Query per-clip,
@@ -561,17 +111,6 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
     }
     return deriveClipStatus(clip, errorState, true);
   }, [clip, errorState]);
-
-  // Undo batching: drag/trim gestures mutate the store on every pointermove. To collapse a
-  // whole gesture into a single undo entry we begin a batch on pointerdown,
-  // mark() after each mutation (which pauses history once the pre-gesture
-  // state has actually been checkpointed), and end() on pointerup. While
-  // paused, the temporal middleware records nothing — so one undo step reverts the entire drag.
-  const history = useTimelineHistoryBatch();
-
-  const dragStartXRef = useRef(0);
-  const dragStartMsRef = useRef(0);
-  const isDraggingRef = useRef(false);
 
   const [contextMenuPos, setContextMenuPos] = useState<{
     x: number;
@@ -587,194 +126,28 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
     }, [])
   );
 
-  const handleDragPointerDown = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      if (!clip || clip.locked) {
-        return;
-      }
-      // Cut tool: split the clip at the pointer's ms position instead of
-      // initiating a drag. Skip primary-button check so pen/touch also work.
-      if (activeTool === "cut" && e.button === 0) {
-        e.preventDefault();
-        e.stopPropagation();
-        const rect = e.currentTarget.getBoundingClientRect();
-        const localPx = e.clientX - rect.left;
-        const atMs = clip.startMs + localPx * msPerPx;
-        // Refuse no-op splits at the clip boundaries.
-        if (atMs > clip.startMs && atMs < clip.startMs + clip.durationMs) {
-          splitClipAtTime(clip.id, atMs);
-        }
-        return;
-      }
-      e.preventDefault();
-      e.stopPropagation();
+  const { handleDragPointerDown, isDraggingRef } = useClipDrag({
+    clip,
+    clipId,
+    msPerPx,
+    activeTool,
+    interactionLocked,
+    longPress: clipLongPress
+  });
 
-      // We use window-level pointer listeners (not setPointerCapture on this
-      // element) because moveClip(id, _, toTrackId) re-parents the clip into
-      // a different TrackLane mid-drag, which would unmount the captured
-      // element and abort the gesture. Window listeners survive remounts.
-      dragStartXRef.current = e.clientX;
-      dragStartMsRef.current = clip.startMs;
-      isDraggingRef.current = false;
-      clipLongPress.start(e);
-      history.begin();
-
-      // Snapshot the snap candidates ONCE at gesture start. The set of clip
-      // edges + second/playhead gridlines doesn't change during a drag (only
-      // the dragged clip moves, and it's excluded), so rebuilding the Set on
-      // every pointermove was pure waste. Captured here as a stable array.
-      const dragStartState = useTimelineStore.getState();
-      const dragStartPlayheadMs = useTimelinePlaybackStore
-        .getState()
-        .getTimeMs();
-      const snapCandidatesSet = new Set<number>();
-      snapCandidatesSet.add(dragStartPlayheadMs);
-      for (let t = 0; t <= dragStartState.durationMs + 1000; t += 1000) {
-        snapCandidatesSet.add(t);
-      }
-      for (const c of dragStartState.clips) {
-        if (c.id !== clipId) {
-          snapCandidatesSet.add(c.startMs);
-          snapCandidatesSet.add(c.startMs + c.durationMs);
-        }
-      }
-      const snapCandidates = Array.from(snapCandidatesSet);
-
-      // Cross-track hit-test is sampled at most once per animation frame.
-      // document.elementsFromPoint forces layout/style work, so calling it on
-      // every pointermove (~60–120×/s) is costly; we coalesce to one sample
-      // per frame using the latest pointer coordinates.
-      let crossTrackTargetId: string | undefined;
-      let lastPointer = { x: e.clientX, y: e.clientY };
-      let hitTestRafId: number | null = null;
-      const sampleCrossTrack = () => {
-        hitTestRafId = null;
-        const freshClip = useTimelineStore
-          .getState()
-          .clips.find((c) => c.id === clipId);
-        if (!freshClip) return;
-        const elements = document.elementsFromPoint(
-          lastPointer.x,
-          lastPointer.y
-        );
-        let foundLaneId: string | null = null;
-        for (const el of elements) {
-          if (!(el instanceof HTMLElement)) continue;
-          const lane = el.closest<HTMLElement>("[data-testid^='track-lane-']");
-          if (lane) {
-            foundLaneId =
-              lane.dataset.testid?.slice("track-lane-".length) ?? null;
-            break;
-          }
-        }
-        if (foundLaneId && foundLaneId !== freshClip.trackId) {
-          const targetTrack = useTimelineStore
-            .getState()
-            .tracks.find((t) => t.id === foundLaneId);
-          if (
-            targetTrack &&
-            !targetTrack.locked &&
-            isClipCompatibleWithTrack(freshClip.mediaType, targetTrack.type)
-          ) {
-            crossTrackTargetId = targetTrack.id;
-            return;
-          }
-        }
-        crossTrackTargetId = undefined;
-      };
-
-      const onMove = (ev: PointerEvent) => {
-        clipLongPress.move(ev);
-        if (ev.buttons !== 1) return;
-        const freshClip = useTimelineStore
-          .getState()
-          .clips.find((c) => c.id === clipId);
-        if (!freshClip || freshClip.locked) return;
-
-        const deltaPx = ev.clientX - dragStartXRef.current;
-        if (!isDraggingRef.current && Math.abs(deltaPx) < 3) {
-          return;
-        }
-        isDraggingRef.current = true;
-        const disableSnap = ev.altKey;
-
-        const pointerMs = deltaPx * msPerPx;
-        const alreadyAppliedMs = freshClip.startMs - dragStartMsRef.current;
-        const adjustedDeltaMs = pointerMs - alreadyAppliedMs;
-
-        const { selectedClipIds } = useTimelineUIStore.getState();
-        const isMulti =
-          selectedClipIds.has(freshClip.id) && selectedClipIds.size > 1;
-
-        if (isMulti) {
-          moveSelectedClips(
-            freshClip.id,
-            selectedClipIds,
-            adjustedDeltaMs,
-            undefined,
-            snapCandidates,
-            msPerPx,
-            disableSnap
-          );
-        } else {
-          // Cross-track hit-test (single-clip drags only). Sampled at most once
-          // per frame; we apply the latest known target immediately so the clip
-          // still follows the cursor into a new lane.
-          lastPointer = { x: ev.clientX, y: ev.clientY };
-          if (hitTestRafId === null) {
-            hitTestRafId = requestAnimationFrame(sampleCrossTrack);
-          }
-          moveClip(
-            freshClip.id,
-            adjustedDeltaMs,
-            crossTrackTargetId,
-            snapCandidates,
-            msPerPx,
-            disableSnap
-          );
-        }
-        // First effective mutation recorded the pre-drag state; batch the rest.
-        history.mark();
-      };
-
-      const onUpOrCancel = () => {
-        clipLongPress.cancel();
-        window.removeEventListener("pointermove", onMove);
-        window.removeEventListener("pointerup", onUpOrCancel);
-        window.removeEventListener("pointercancel", onUpOrCancel);
-        if (hitTestRafId !== null) {
-          cancelAnimationFrame(hitTestRafId);
-          hitTestRafId = null;
-        }
-        history.end();
-        // Defer dragging flag reset so the synthetic click that follows
-        // pointerup is still suppressed by handleClick.
-        const wasDragging = isDraggingRef.current;
-        if (wasDragging) {
-          setTimeout(() => {
-            isDraggingRef.current = false;
-          }, 0);
-        } else {
-          isDraggingRef.current = false;
-        }
-      };
-
-      window.addEventListener("pointermove", onMove);
-      window.addEventListener("pointerup", onUpOrCancel);
-      window.addEventListener("pointercancel", onUpOrCancel);
-    },
-    [
-      clip,
-      activeTool,
-      clipLongPress,
-      msPerPx,
-      splitClipAtTime,
-      clipId,
-      moveClip,
-      moveSelectedClips,
-      history
-    ]
-  );
+  const {
+    handleTrimStartPointerDown,
+    handleTrimStartPointerMove,
+    handleTrimEndPointerDown,
+    handleTrimEndPointerMove,
+    handleTrimPointerEnd
+  } = useClipTrim({
+    clip,
+    msPerPx,
+    activeTool,
+    interactionLocked,
+    sourceDurationMs
+  });
 
   const handleContextMenu = useCallback(
     (e: React.MouseEvent) => {
@@ -819,7 +192,7 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
         selectClip(clipId);
       }
     },
-    [clipId, selectClip, addToSelection, toggleSelection]
+    [clipId, isDraggingRef, selectClip, addToSelection, toggleSelection]
   );
 
   const handleKeyDown = useCallback(
@@ -831,118 +204,6 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
     },
     [clipId, selectClip]
   );
-
-  // Gesture-ownership flags: each trim handle's move handler only runs when
-  // *its own* pointerdown started the gesture. Without this, dragging another
-  // clip across the handle (with the primary button held) would fire the move
-  // handler and corrupt this clip's geometry.
-  const isTrimmingStartRef = useRef(false);
-  const isTrimmingEndRef = useRef(false);
-
-  const trimStartRef = useRef({ startX: 0, startMs: 0 });
-
-  const handleTrimStartPointerDown = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      if (!clip || clip.locked) {
-        return;
-      }
-      // In cut mode, let the event bubble up so the clip body splits instead.
-      if (activeTool === "cut") {
-        return;
-      }
-      e.preventDefault();
-      e.stopPropagation();
-      e.currentTarget.setPointerCapture(e.pointerId);
-      trimStartRef.current = { startX: e.clientX, startMs: clip.startMs };
-      isTrimmingStartRef.current = true;
-      history.begin();
-    },
-    [clip, activeTool, history]
-  );
-
-  const handleTrimStartPointerMove = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      if (
-        !isTrimmingStartRef.current ||
-        !clip ||
-        clip.locked ||
-        e.buttons !== 1
-      ) {
-        return;
-      }
-      // Stop bubbling so the parent clip body's drag-pointermove handler
-      // does not also fire and shift `startMs`. Without this the clip
-      // appears to move and shrink simultaneously.
-      e.stopPropagation();
-      const deltaPx = e.clientX - trimStartRef.current.startX;
-      const deltaMs = deltaPx * msPerPx;
-      // trimClip(edge="start", deltaMs) convention (from packages/timeline/src/trimClip.ts):
-      //   nextStartMs   = clip.startMs  - deltaMs   (positive = move start right = shrink)
-      //   nextDurationMs = clip.durationMs + deltaMs  (positive = grow from start)
-      // So: pointer moving right (+deltaPx) should shrink the clip from the start.
-      // We negate so that dragging the handle right correctly shrinks the clip start.
-      trimClipStart(clip.id, -deltaMs);
-      history.mark();
-      trimStartRef.current.startX = e.clientX;
-    },
-    [clip, msPerPx, trimClipStart, history]
-  );
-
-  const trimEndRef = useRef({ startX: 0, startMs: 0, startDuration: 0 });
-
-  const handleTrimEndPointerDown = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      if (!clip || clip.locked) {
-        return;
-      }
-      // In cut mode, let the event bubble up so the clip body splits instead.
-      if (activeTool === "cut") {
-        return;
-      }
-      e.preventDefault();
-      e.stopPropagation();
-      e.currentTarget.setPointerCapture(e.pointerId);
-      trimEndRef.current = {
-        startX: e.clientX,
-        startMs: clip.startMs,
-        startDuration: clip.durationMs
-      };
-      isTrimmingEndRef.current = true;
-      history.begin();
-    },
-    [clip, activeTool, history]
-  );
-
-  const handleTrimEndPointerMove = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      if (
-        !isTrimmingEndRef.current ||
-        !clip ||
-        clip.locked ||
-        e.buttons !== 1
-      ) {
-        return;
-      }
-      // Stop bubbling so the parent clip body's drag-pointermove handler
-      // does not also fire and shift `startMs`. Without this the clip
-      // appears to move and grow simultaneously.
-      e.stopPropagation();
-      const deltaPx = e.clientX - trimEndRef.current.startX;
-      const deltaMs = deltaPx * msPerPx;
-      trimClipEnd(clip.id, deltaMs, audioSourceDurationMs);
-      history.mark();
-      trimEndRef.current.startX = e.clientX;
-    },
-    [clip, msPerPx, trimClipEnd, audioSourceDurationMs, history]
-  );
-
-  // Shared end-of-trim handler (pointerup AND pointercancel): release the
-  // gesture flags and resume undo tracking.
-  const handleTrimPointerEnd = useCallback(() => {
-    isTrimmingStartRef.current = false;
-    isTrimmingEndRef.current = false;
-    history.end();
-  }, [history]);
 
   if (!clip) {
     return null;
@@ -957,431 +218,55 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
 
   return (
     <>
-    <ClipBody
-      clip={clip}
-      leftPx={leftPx}
-      widthPx={widthPx}
-      msPerPx={msPerPx}
-      isSelected={isSelected}
-      derivedStatus={derivedStatus}
-      statusInfo={statusInfo}
-      handleDragPointerDown={handleDragPointerDown}
-      handleClick={handleClick}
-      handleKeyDown={handleKeyDown}
-      handleContextMenu={handleContextMenu}
-      handleTrimStartPointerDown={handleTrimStartPointerDown}
-      handleTrimStartPointerMove={handleTrimStartPointerMove}
-      handleTrimEndPointerDown={handleTrimEndPointerDown}
-      handleTrimEndPointerMove={handleTrimEndPointerMove}
-      handleTrimPointerEnd={handleTrimPointerEnd}
-      cutMode={activeTool === "cut"}
-    />
-    {contextMenuPos && (
-      <ClipContextMenu
-        clipId={clipId}
-        position={contextMenuPos}
-        isLinked={Boolean(clip.linkId)}
-        onUnlink={handleUnlink}
-        onDelete={handleDelete}
-        onClose={handleCloseContextMenu}
-        onRequestReplace={setReplaceAssetId}
-        onError={setActionError}
+      <ClipBody
+        clip={clip}
+        leftPx={leftPx}
+        widthPx={widthPx}
+        msPerPx={msPerPx}
+        isSelected={isSelected}
+        derivedStatus={derivedStatus}
+        statusInfo={statusInfo}
+        handleDragPointerDown={handleDragPointerDown}
+        handleClick={handleClick}
+        handleKeyDown={handleKeyDown}
+        handleContextMenu={handleContextMenu}
+        handleTrimStartPointerDown={handleTrimStartPointerDown}
+        handleTrimStartPointerMove={handleTrimStartPointerMove}
+        handleTrimEndPointerDown={handleTrimEndPointerDown}
+        handleTrimEndPointerMove={handleTrimEndPointerMove}
+        handleTrimPointerEnd={handleTrimPointerEnd}
+        cutMode={activeTool === "cut"}
+        interactionLocked={interactionLocked}
       />
-    )}
-    {replaceAssetId !== null && (
-      <ReplaceOutputDialog
-        clipId={clipId}
-        initialAssetId={replaceAssetId}
-        onClose={handleCloseReplace}
+      {contextMenuPos && (
+        <ClipContextMenu
+          clipId={clipId}
+          position={contextMenuPos}
+          isLinked={Boolean(clip.linkId)}
+          onUnlink={handleUnlink}
+          onDelete={handleDelete}
+          onClose={handleCloseContextMenu}
+          onRequestReplace={setReplaceAssetId}
+          onError={setActionError}
+        />
+      )}
+      {replaceAssetId !== null && (
+        <ReplaceOutputDialog
+          clipId={clipId}
+          initialAssetId={replaceAssetId}
+          onClose={handleCloseReplace}
+        />
+      )}
+      <Toast
+        open={actionError !== null}
+        message={actionError ?? ""}
+        severity="error"
+        onClose={handleClearError}
+        vertical="top"
+        horizontal="center"
       />
-    )}
-    <Toast
-      open={actionError !== null}
-      message={actionError ?? ""}
-      severity="error"
-      onClose={handleClearError}
-      vertical="top"
-      horizontal="center"
-    />
     </>
   );
 });
-
-interface ClipBodyProps {
-  clip: TimelineClip;
-  leftPx: number;
-  widthPx: number;
-  msPerPx: number;
-  isSelected: boolean;
-  derivedStatus: ClipStatus;
-  statusInfo: (typeof CLIP_STATUS_MAP)[ClipStatus];
-  handleDragPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
-  handleClick: (e: React.MouseEvent<HTMLDivElement>) => void;
-  handleKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
-  handleContextMenu: (e: React.MouseEvent<HTMLDivElement>) => void;
-  handleTrimStartPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
-  handleTrimStartPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
-  handleTrimEndPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
-  handleTrimEndPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
-  handleTrimPointerEnd: () => void;
-  cutMode: boolean;
-}
-
-const ClipBody: React.FC<ClipBodyProps> = memo(
-  ({
-    clip,
-    leftPx,
-    widthPx,
-    msPerPx,
-    isSelected,
-    derivedStatus,
-    statusInfo,
-    handleDragPointerDown,
-    handleClick,
-    handleKeyDown,
-    handleContextMenu,
-    handleTrimStartPointerDown,
-    handleTrimStartPointerMove,
-    handleTrimEndPointerDown,
-    handleTrimEndPointerMove,
-    handleTrimPointerEnd,
-    cutMode
-  }) => {
-    const theme = useTheme();
-    const clipId = clip.id;
-
-    // Resolve asset URL for thumbnail extraction. Only video clips trigger
-    // a fetch — image clips are handled below with a single backgroundImage.
-    const assetIdForThumb =
-      clip.mediaType === "video" || clip.mediaType === "overlay"
-        ? clip.currentAssetId
-        : undefined;
-    const imageAssetId =
-      clip.mediaType === "image" ? clip.currentAssetId : undefined;
-    const audioAssetId =
-      clip.mediaType === "audio" ? clip.currentAssetId : undefined;
-
-    const getAsset = useAssetStore((s) => s.get);
-    const [videoUrl, setVideoUrl] = useState<string | undefined>(undefined);
-    const [imageUrl, setImageUrl] = useState<string | undefined>(undefined);
-    const [audioUrl, setAudioUrl] = useState<string | undefined>(undefined);
-
-    useEffect(() => {
-      let cancelled = false;
-      if (!assetIdForThumb) {
-        setVideoUrl(undefined);
-        return;
-      }
-      getAsset(assetIdForThumb)
-        .then((asset) => {
-          if (!cancelled) setVideoUrl(getAssetUrl(asset) ?? undefined);
-        })
-        .catch(() => {
-          // Asset unavailable — leave url undefined; clip renders without filmstrip.
-        });
-      return () => {
-        cancelled = true;
-      };
-    }, [assetIdForThumb, getAsset]);
-
-    useEffect(() => {
-      let cancelled = false;
-      if (!imageAssetId) {
-        setImageUrl(undefined);
-        return;
-      }
-      getAsset(imageAssetId)
-        .then((asset) => {
-          if (!cancelled) setImageUrl(getAssetUrl(asset) ?? undefined);
-        })
-        .catch(() => {
-          // ignored
-        });
-      return () => {
-        cancelled = true;
-      };
-    }, [imageAssetId, getAsset]);
-
-    useEffect(() => {
-      let cancelled = false;
-      if (!audioAssetId) {
-        setAudioUrl(undefined);
-        return;
-      }
-      getAsset(audioAssetId)
-        .then((asset) => {
-          if (!cancelled) setAudioUrl(getAssetUrl(asset) ?? undefined);
-        })
-        .catch(() => {
-          // Asset unavailable — leave url undefined; clip renders without waveform.
-        });
-      return () => {
-        cancelled = true;
-      };
-    }, [audioAssetId, getAsset]);
-
-    const thumbnails = useClipThumbnails(videoUrl);
-    // openreel uses ~60px per cell; matches their visual density.
-    const cellCount = Math.max(1, Math.floor(widthPx / 60));
-
-    const filmstripCells = useMemo(() => {
-      if (!thumbnails || thumbnails.length === 0) return null;
-      const cells: { url: string }[] = [];
-      for (let i = 0; i < cellCount; i++) {
-        const progress = cellCount === 1 ? 0 : i / (cellCount - 1);
-        const idx = Math.min(
-          Math.floor(progress * thumbnails.length),
-          thumbnails.length - 1
-        );
-        cells.push({ url: thumbnails[idx].dataUrl });
-      }
-      return cells;
-    }, [thumbnails, cellCount]);
-
-    const accent = (() => {
-      switch (clip.mediaType) {
-        case "audio":
-          return theme.vars.palette.success.main;
-        case "overlay":
-        case "text":
-        case "shape":
-        case "group":
-          return theme.vars.palette.secondary.main;
-        case "image":
-        case "video":
-        default:
-          return theme.vars.palette.info.main;
-      }
-    })();
-
-    const showDuration = widthPx >= COMPACT_THRESHOLD_PX;
-    const durationLabel = formatClipDuration(clip.durationMs);
-    const animationMarkers = deriveClipAnimationMarkers(
-      clip.animations,
-      msPerPx,
-      widthPx
-    );
-    const handleAnimationMarkerClick = (event: React.MouseEvent) => {
-      event.stopPropagation();
-      useTimelineUIStore.getState().selectClip(clipId);
-      openPersistedFold("animate");
-    };
-
-    const positionStyle = useMemo(
-      () => ({
-        left: leftPx,
-        width: widthPx,
-        cursor: cutMode ? ("crosshair" as const) : undefined
-      }),
-      [leftPx, widthPx, cutMode]
-    );
-
-    const imageStyle = useMemo(
-      () =>
-        imageUrl
-          ? {
-              backgroundImage: `url(${imageUrl})`,
-              backgroundSize: "cover" as const,
-              backgroundPosition: "center" as const,
-              opacity: 0.78
-            }
-          : undefined,
-      [imageUrl]
-    );
-
-    // Drag, trim, zoom and pan each change leftPx/widthPx, re-rendering this
-    // body once per frame per clip. None of the nine styles read geometry.
-    const locked = clip.locked;
-    const mediaType = clip.mediaType;
-    const rootCss = useMemo(
-      () => clipStyles(theme, isSelected, locked, mediaType),
-      [theme, isSelected, locked, mediaType]
-    );
-    const inZoneCss = useMemo(
-      () => animationZoneStyles(theme, "in"),
-      [theme]
-    );
-    const outZoneCss = useMemo(
-      () => animationZoneStyles(theme, "out"),
-      [theme]
-    );
-    const loopIconCss = useMemo(
-      () => animationLoopIconStyles(theme),
-      [theme]
-    );
-    const dotCss = useMemo(() => clipDotStyles(accent), [accent]);
-    const nameCss = useMemo(() => clipNameStyles(theme), [theme]);
-    const durationCss = useMemo(() => clipDurationStyles(theme), [theme]);
-    const trimStartCss = useMemo(
-      () => trimHandleStyles("start", locked),
-      [locked]
-    );
-    const trimEndCss = useMemo(() => trimHandleStyles("end", locked), [locked]);
-
-    return (
-      <div
-        css={rootCss}
-        style={positionStyle}
-        onPointerDown={handleDragPointerDown}
-        onClick={handleClick}
-        onKeyDown={handleKeyDown}
-        onContextMenu={handleContextMenu}
-        data-testid={`clip-${clipId}`}
-        aria-selected={isSelected}
-        role="option"
-        tabIndex={0}
-        aria-label={clip.name || `Clip ${clip.id}`}
-      >
-        {filmstripCells && (
-          <div css={filmstripStyles}>
-            {filmstripCells.map((cell, i) => (
-              <div
-                key={i}
-                css={filmstripCellStyles}
-                style={{ backgroundImage: `url(${cell.url})` }}
-              />
-            ))}
-          </div>
-        )}
-
-        {imageUrl && <div css={filmstripStyles} style={imageStyle} />}
-
-        {clip.mediaType === "group" && (
-          <GroupBracket
-            clipId={clipId}
-            startMs={clip.startMs}
-            durationMs={clip.durationMs}
-            widthPx={widthPx}
-          />
-        )}
-
-        {clip.mediaType === "audio" && (
-          <WaveformCanvas
-            url={audioUrl}
-            inPointMs={clip.inPointMs ?? 0}
-            outPointMs={(clip.inPointMs ?? 0) + clip.durationMs}
-            widthPx={widthPx}
-          />
-        )}
-
-        {animationMarkers.inZone && (
-          <button
-            type="button"
-            css={inZoneCss}
-            style={{
-              left: animationMarkers.inZone.offsetPx,
-              width: animationMarkers.inZone.widthPx
-            }}
-            onPointerDown={(event) => event.stopPropagation()}
-            onClick={handleAnimationMarkerClick}
-            aria-label="Open entrance animation controls"
-          />
-        )}
-
-        {animationMarkers.outZone && (
-          <button
-            type="button"
-            css={outZoneCss}
-            style={{
-              right: animationMarkers.outZone.offsetPx,
-              width: animationMarkers.outZone.widthPx
-            }}
-            onPointerDown={(event) => event.stopPropagation()}
-            onClick={handleAnimationMarkerClick}
-            aria-label="Open exit animation controls"
-          />
-        )}
-
-        {animationMarkers.hasLoopOrEmphasis && (
-          <button
-            type="button"
-            css={loopIconCss}
-            onPointerDown={(event) => event.stopPropagation()}
-            onClick={handleAnimationMarkerClick}
-            aria-label="Open loop and emphasis animation controls"
-          >
-            <LoopOutlinedIcon />
-          </button>
-        )}
-
-        {/* Header strip: type dot · name · duration */}
-        <div css={clipHeaderRowStyles}>
-          <span css={dotCss} aria-hidden />
-          <span css={nameCss}>{clip.name}</span>
-          {showDuration && (
-            <span css={durationCss}>{durationLabel}</span>
-          )}
-        </div>
-
-        <div
-          css={trimStartCss}
-          onPointerDown={handleTrimStartPointerDown}
-          onPointerMove={handleTrimStartPointerMove}
-          onPointerUp={handleTrimPointerEnd}
-          onPointerCancel={handleTrimPointerEnd}
-          aria-label="Trim clip start"
-          data-testid={`clip-trim-start-${clipId}`}
-        />
-
-        <div
-          css={trimEndCss}
-          onPointerDown={handleTrimEndPointerDown}
-          onPointerMove={handleTrimEndPointerMove}
-          onPointerUp={handleTrimPointerEnd}
-          onPointerCancel={handleTrimPointerEnd}
-          aria-label="Trim clip end"
-          data-testid={`clip-trim-end-${clipId}`}
-        />
-
-        {clip.locked && (
-          <div css={lockIconStyles}>
-            <LockOutlinedIcon sx={{ fontSize: 12 }} aria-label="Clip locked" />
-          </div>
-        )}
-
-        {(derivedStatus === "queued" || derivedStatus === "generating") && (
-          <div
-            css={generatingOverlayStyles}
-            aria-hidden
-            data-testid={`clip-generating-${clipId}`}
-          >
-            <MagicGenerationFill />
-          </div>
-        )}
-
-        {/* The badge surfaces lifecycle state for generated clips. Once a
-         *  clip has settled into "generated" it doesn't need a permanent green
-         *  dot, and imported clips have no lifecycle at all — so we render
-         *  only while something interesting is happening. */}
-        {clip.sourceType === "generated" &&
-          derivedStatus !== "draft" &&
-          derivedStatus !== "generated" && (
-            <div css={statusBadgeStyles}>
-              <StatusIndicator
-                status={statusInfo.status}
-                pulse={statusInfo.pulse}
-                tooltip={statusInfo.label}
-                size="small"
-              />
-            </div>
-          )}
-
-      </div>
-    );
-  }
-);
-ClipBody.displayName = "ClipBody";
-
-/** "4.6s" for sub-minute, "1:23" for ≥1 min. Shown when clip width ≥ compact threshold. */
-function formatClipDuration(durationMs: number): string {
-  if (durationMs < 60_000) {
-    const sec = durationMs / 1000;
-    return sec < 10 ? `${sec.toFixed(1)}s` : `${Math.round(sec)}s`;
-  }
-  const totalSec = Math.round(durationMs / 1000);
-  const m = Math.floor(totalSec / 60);
-  const s = totalSec % 60;
-  return `${m}:${String(s).padStart(2, "0")}`;
-}
 
 Clip.displayName = "Clip";

--- a/web/src/components/timeline/Tracks/ClipBody.tsx
+++ b/web/src/components/timeline/Tracks/ClipBody.tsx
@@ -1,0 +1,909 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * ClipBody
+ *
+ * The rendered clip: selection ring, header strip, filmstrip / waveform /
+ * image fill, animation markers, the two trim handles, lock and status badges.
+ * Pure presentation — every handler comes in as a stable prop from `Clip`, so
+ * the `memo` here holds across the parent's store-driven re-renders.
+ */
+
+import React, { memo, useCallback, useEffect, useMemo, useRef } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+import LoopOutlinedIcon from "@mui/icons-material/LoopOutlined";
+
+import type { TimelineClip, ClipStatus } from "@nodetool-ai/timeline";
+import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
+import {
+  StatusIndicator,
+  BORDER_RADIUS,
+  SPACING,
+  getSpacingPx,
+  MagicGenerationFill,
+  FONT_SIZE_MONO,
+  MOTION,
+  Z_INDEX
+} from "../../ui_primitives";
+import type { StatusType } from "../../ui_primitives";
+import { useClipThumbnails } from "./useClipThumbnails";
+import { useAudioPeaks } from "./useAudioPeaks";
+import { samplePeaksWindow } from "./audioPeaks";
+import { clipSurfaceTint, clipBorderTint } from "./trackVisuals";
+import { GroupBracket } from "./GroupBracket";
+import { deriveClipAnimationMarkers } from "./clipAnimationMarkers";
+import { deriveClipFadeMarkers } from "./clipFadeGeometry";
+import {
+  beyondSourceFraction,
+  clipSourceWindow,
+  selectFilmstripCells
+} from "./filmstripCells";
+import { useAssetUrl } from "./useAssetUrl";
+import { openPersistedFold } from "../Inspector/usePersistedFold";
+
+const TRIM_HANDLE_WIDTH_PX = 8;
+/** Hit area for the same grip under a finger; the visible width stays 8px. */
+const TOUCH_TRIM_HANDLE_WIDTH_PX = 22;
+/** Below this the two 8px grips would cover the whole clip and swallow the
+ *  body drag, so they are removed and the clip moves by its body alone. */
+const MIN_TRIM_HANDLE_CLIP_WIDTH_PX = 24;
+export const MIN_CLIP_WIDTH_PX = 4;
+const CLIP_RADIUS_PX = parseFloat(BORDER_RADIUS.md);
+/** Width below which we suppress secondary chrome (duration label). */
+const COMPACT_THRESHOLD_PX = 96;
+/** Below this the transition wedge shows no type label. */
+const TRANSITION_LABEL_MIN_PX = 48;
+/** openreel uses ~60px per filmstrip cell; matches their visual density. */
+const FILMSTRIP_CELL_PX = 60;
+/** Media whose clip carries an audible or visible fade ramp. */
+const FADE_MEDIA_TYPES: ReadonlySet<TimelineClip["mediaType"]> = new Set([
+  "audio",
+  "video",
+  "image",
+  "overlay"
+]);
+
+// Status mapping (PRD §5.5)
+export const CLIP_STATUS_MAP = {
+  draft: { status: "default", label: "Draft", pulse: false },
+  queued: { status: "pending", label: "Queued", pulse: false },
+  generating: { status: "pending", label: "Generating", pulse: true },
+  generated: { status: "success", label: "Generated", pulse: false },
+  stale: { status: "warning", label: "Stale", pulse: false },
+  failed: { status: "error", label: "Failed", pulse: false },
+  locked: { status: "info", label: "Locked", pulse: false },
+  missing: { status: "error", label: "Missing", pulse: false }
+} satisfies Record<ClipStatus, { status: StatusType; label: string; pulse: boolean }>;
+
+
+const clipStyles = (
+  theme: Theme,
+  selected: boolean,
+  interactionLocked: boolean,
+  mediaType: TimelineClip["mediaType"]
+) =>
+  css({
+    position: "absolute",
+    top: 6,
+    bottom: 6,
+    borderRadius: CLIP_RADIUS_PX,
+    overflow: "hidden",
+    backgroundColor: theme.vars.palette.background.paper,
+    backgroundImage: `linear-gradient(0deg, ${clipSurfaceTint(
+      mediaType
+    )}, ${clipSurfaceTint(mediaType)})`,
+    border: selected
+      ? `1.5px solid ${theme.vars.palette.secondary.main}`
+      : `1px solid ${clipBorderTint(theme, mediaType)}`,
+    boxShadow: selected
+      ? `0 0 0 3px rgba(var(--palette-secondary-mainChannel) / 0.18), 0 4px 12px ${theme.vars.palette.c_scrim_soft}`
+      : "none",
+    cursor: interactionLocked ? "not-allowed" : "grab",
+    "&:active": {
+      cursor: interactionLocked ? "not-allowed" : "grabbing"
+    },
+    userSelect: "none",
+    touchAction: "none",
+    minWidth: MIN_CLIP_WIDTH_PX,
+    boxSizing: "border-box",
+    // The trim grips stay invisible until the pointer is over the clip; the
+    // selected state and coarse pointers reveal them in `trimHandleStyles`.
+    "&:hover [data-clip-trim-handle]": {
+      opacity: 1
+    }
+  });
+
+const clipHeaderRowStyles = css({
+  position: "absolute",
+  top: 0,
+  left: 0,
+  right: 0,
+  height: 18,
+  display: "flex",
+  alignItems: "center",
+  gap: getSpacingPx(SPACING.sm),
+  padding: `0 ${getSpacingPx(SPACING.md)}`,
+  pointerEvents: "none",
+  zIndex: Z_INDEX.base + 4
+});
+
+const clipDotStyles = (accent: string) =>
+  css({
+    width: 6,
+    height: 6,
+    borderRadius: BORDER_RADIUS.circle,
+    backgroundColor: accent,
+    boxShadow: `0 0 0 1px var(--palette-c_scrim)`,
+    flexShrink: 0
+  });
+
+const clipNameStyles = (theme: Theme) =>
+  css({
+    fontSize: "var(--fontSizeSmaller)",
+    fontWeight: 500,
+    letterSpacing: "-0.005em",
+    color: theme.vars.palette.text.primary,
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    pointerEvents: "none",
+    lineHeight: 1.4,
+    textShadow: `0 1px 2px ${theme.vars.palette.c_scrim}`,
+    flex: "1 1 auto",
+    minWidth: 0
+  });
+
+const clipDurationStyles = (theme: Theme) =>
+  css({
+    flexShrink: 0,
+    fontFamily:
+      "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace",
+    fontSize: "var(--fontSizeSmaller)",
+    fontWeight: 500,
+    color: theme.vars.palette.text.secondary,
+    letterSpacing: "0",
+    textShadow: `0 1px 2px ${theme.vars.palette.c_scrim}`
+  });
+
+const filmstripStyles = css({
+  position: "absolute",
+  left: 6,
+  right: 6,
+  top: 20,
+  bottom: 6,
+  display: "flex",
+  gap: getSpacingPx(SPACING.micro), // was 1px
+  pointerEvents: "none",
+  zIndex: 0,
+  borderRadius: BORDER_RADIUS.xs,
+  overflow: "hidden"
+});
+
+const waveformStyles = css({
+  position: "absolute",
+  inset: 0,
+  pointerEvents: "none",
+  zIndex: 0,
+  display: "block",
+  width: "100%",
+  height: "100%"
+});
+
+// Generating overlay for clips that are queued or actively generating —
+// the shared "magic" wash + shimmer reused from the sketch editor, so a
+// generating clip in the timeline reads identically to a generating layer
+// on the canvas. Clips to the clip's rounded body.
+const generatingOverlayStyles = css({
+  position: "absolute",
+  inset: 0,
+  pointerEvents: "none",
+  zIndex: Z_INDEX.base + 3,
+  overflow: "hidden",
+  borderRadius: CLIP_RADIUS_PX
+});
+
+interface WaveformCanvasProps {
+  url: string | undefined;
+  inPointMs: number;
+  outPointMs: number;
+  widthPx: number;
+}
+
+/** Draws audio peaks on a canvas, sized to the clip's pixel width. */
+const WaveformCanvas: React.FC<WaveformCanvasProps> = ({
+  url,
+  inPointMs,
+  outPointMs,
+  widthPx
+}) => {
+  const theme = useTheme();
+  const { peaks, durationMs } = useAudioPeaks(url);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  // Coalesce redraws into a single animation frame. During a drag/resize the
+  // clip's widthPx changes on every pointermove (~60×/s); without this each
+  // change forced a synchronous canvas re-render. We also skip redraws when the
+  // width hasn't moved by at least a pixel, so sub-pixel jitter is a no-op.
+  const rafIdRef = useRef<number | null>(null);
+  const lastDrawnWidthRef = useRef<number>(-1);
+  const lastInputsKeyRef = useRef<string>("");
+
+  // Latest draw inputs, read inside the scheduled frame so it never goes stale.
+  const drawInputsRef = useRef({
+    peaks,
+    durationMs,
+    inPointMs,
+    outPointMs,
+    widthPx,
+    successColor: theme.vars.palette.success.main
+  });
+  drawInputsRef.current = {
+    peaks,
+    durationMs,
+    inPointMs,
+    outPointMs,
+    widthPx,
+    successColor: theme.vars.palette.success.main
+  };
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const {
+      peaks: pk,
+      durationMs: dur,
+      inPointMs: inMs,
+      outPointMs: outMs,
+      widthPx: wPx,
+      successColor
+    } = drawInputsRef.current;
+
+    const dpr =
+      typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
+    const cssWidth = Math.max(1, Math.floor(wPx));
+    const cssHeight = canvas.clientHeight || 32;
+    canvas.width = cssWidth * dpr;
+    canvas.height = cssHeight * dpr;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.scale(dpr, dpr);
+    ctx.clearRect(0, 0, cssWidth, cssHeight);
+
+    if (!pk || !dur) return;
+
+    // Visible audio window is the intersection of [inPointMs, outPointMs]
+    // with the source [0, durationMs]. Anything beyond the source renders
+    // as empty space rather than stretching the waveform.
+    const visibleInMs = Math.max(0, Math.min(dur, inMs));
+    const visibleOutMs = Math.max(visibleInMs, Math.min(dur, outMs));
+    const clipSpanMs = Math.max(1, outMs - inMs);
+    const visibleSpanMs = visibleOutMs - visibleInMs;
+    const visibleWidthPx = cssWidth * (visibleSpanMs / clipSpanMs);
+
+    const barCount = Math.max(1, Math.floor(visibleWidthPx / 2));
+    const slice = samplePeaksWindow(
+      pk,
+      dur,
+      visibleInMs,
+      visibleOutMs,
+      barCount
+    );
+    const mid = cssHeight / 2;
+    ctx.fillStyle = successColor;
+    for (let i = 0; i < slice.length; i += 1) {
+      const amp = slice[i];
+      const h = Math.max(1, amp * (cssHeight - 2));
+      const x = (i / slice.length) * visibleWidthPx;
+      const w = Math.max(1, visibleWidthPx / slice.length - 0.5);
+      ctx.fillRect(x, mid - h / 2, w, h);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Decide whether anything beyond a sub-pixel width change actually
+    // happened. Width changes during a drag are gated to whole pixels (the
+    // canvas can't show finer detail); other inputs force a redraw.
+    const inputsKey = `${durationMs}|${inPointMs}|${outPointMs}|${url || ""}`;
+    const otherInputsChanged = inputsKey !== lastInputsKeyRef.current;
+    const widthChanged =
+      Math.abs(Math.floor(widthPx) - lastDrawnWidthRef.current) >= 1;
+    if (!otherInputsChanged && !widthChanged) return;
+
+    if (rafIdRef.current !== null) return;
+    rafIdRef.current = requestAnimationFrame(() => {
+      rafIdRef.current = null;
+      lastDrawnWidthRef.current = Math.floor(widthPx);
+      lastInputsKeyRef.current = inputsKey;
+      draw();
+    });
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+    };
+  }, [peaks, durationMs, inPointMs, outPointMs, widthPx, url, draw]);
+
+  return <canvas ref={canvasRef} css={waveformStyles} aria-hidden />;
+};
+WaveformCanvas.displayName = "WaveformCanvas";
+
+// Static (no per-URL variant): backgroundImage is set via inline `style`
+// instead, so a distinct thumbnail data URL per cell doesn't make emotion
+// hash a multi-KB string and insert a permanent CSSOM rule per render.
+const filmstripCellStyles = css({
+  flex: 1,
+  height: "100%",
+  backgroundSize: "cover",
+  backgroundPosition: "center",
+  opacity: 0.78
+});
+
+// The part of the clip that runs past the end of its source: no frame exists
+// there, so the filmstrip shows stripes instead of repeating the last one.
+const beyondSourceStyles = css({
+  position: "absolute",
+  top: 0,
+  bottom: 0,
+  right: 0,
+  pointerEvents: "none",
+  backgroundImage:
+    "repeating-linear-gradient(135deg, var(--palette-c_overlay_strong) 0 3px, transparent 3px 8px)"
+});
+
+// Fade ramps: an SVG in unit space stretched over the fade's pixel span. The
+// shaded triangle is the part of the signal the fade removes; the ramp line
+// keeps a 1px stroke under the non-uniform scale.
+const fadeOverlayStyles = css({
+  position: "absolute",
+  top: 0,
+  bottom: 0,
+  height: "100%",
+  pointerEvents: "none",
+  zIndex: Z_INDEX.base + 1,
+  display: "block",
+  overflow: "visible"
+});
+
+const transitionWedgeStyles = (theme: Theme, tint: string, accent: string) =>
+  css({
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    left: 0,
+    pointerEvents: "none",
+    zIndex: Z_INDEX.base + 1,
+    boxSizing: "border-box",
+    borderRight: `1px solid ${accent}`,
+    backgroundImage: `repeating-linear-gradient(135deg, ${tint} 0 2px, transparent 2px 6px)`,
+    "& > span": {
+      position: "absolute",
+      left: getSpacingPx(SPACING.sm),
+      bottom: getSpacingPx(SPACING.xs),
+      fontFamily:
+        "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace",
+      fontSize: FONT_SIZE_MONO.caption,
+      fontWeight: 500,
+      lineHeight: 1,
+      color: theme.vars.palette.text.secondary,
+      textShadow: `0 1px 2px ${theme.vars.palette.c_scrim}`,
+      whiteSpace: "nowrap"
+    }
+  });
+
+/** Applied to both grips when the clip is too narrow to host them. */
+const HIDDEN_TRIM_HANDLE_STYLE: React.CSSProperties = {
+  display: "none",
+  pointerEvents: "none"
+};
+
+const trimHandleStyles = (
+  theme: Theme,
+  edge: "start" | "end",
+  interactionLocked: boolean,
+  selected: boolean
+) =>
+  css({
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    width: TRIM_HANDLE_WIDTH_PX,
+    [edge === "start" ? "left" : "right"]: 0,
+    cursor: interactionLocked ? "not-allowed" : "ew-resize",
+    backgroundColor: "var(--palette-c_overlay_strong)",
+    // Hidden until the clip is hovered (root selector), selected, or under a
+    // finger, where there is no hover to reveal it.
+    opacity: selected ? 1 : 0,
+    transition: `opacity ${MOTION.fast}, background-color ${MOTION.fast}`,
+    "&:hover": {
+      backgroundColor: interactionLocked
+        ? undefined
+        : `rgba(${theme.vars.palette.primary.mainChannel} / 0.5)`
+    },
+    zIndex: Z_INDEX.base + 2,
+    // A fingertip covers far more than 8px. Widen the hit area on touch
+    // without widening the visible grip, via a transparent inset overlay —
+    // otherwise trimming a clip on a phone means repeatedly missing the
+    // handle and dragging the clip instead.
+    "@media (pointer: coarse)": {
+      opacity: 1,
+      "&::after": {
+        content: '""',
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        [edge === "start" ? "left" : "right"]: 0,
+        width: TOUCH_TRIM_HANDLE_WIDTH_PX
+      }
+    }
+  });
+
+const statusBadgeStyles = css({
+  position: "absolute",
+  bottom: 4,
+  right: 6,
+  zIndex: Z_INDEX.base + 3,
+  pointerEvents: "none"
+});
+
+const lockIconStyles = css({
+  position: "absolute",
+  bottom: 4,
+  left: 8,
+  zIndex: Z_INDEX.base + 3,
+  pointerEvents: "none",
+  opacity: 0.85,
+  fontSize: 12,
+  display: "flex",
+  alignItems: "center"
+});
+
+const animationZoneStyles = (theme: Theme, edge: "in" | "out") =>
+  css({
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    padding: 0,
+    border: 0,
+    cursor: "pointer",
+    zIndex: Z_INDEX.base + 1,
+    backgroundColor:
+      edge === "in"
+        ? `rgba(${theme.vars.palette.primary.mainChannel} / 0.2)`
+        : `rgba(${theme.vars.palette.secondary.mainChannel} / 0.2)`,
+    clipPath:
+      edge === "in"
+        ? "polygon(0 0, 100% 0, 75% 100%, 0 100%)"
+        : "polygon(0 0, 100% 0, 100% 100%, 25% 100%)"
+  });
+
+const animationLoopIconStyles = (theme: Theme) =>
+  css({
+    position: "absolute",
+    left: "50%",
+    bottom: 4,
+    transform: "translateX(-50%)",
+    color: theme.vars.palette.text.secondary,
+    padding: 0,
+    border: 0,
+    background: "none",
+    cursor: "pointer",
+    zIndex: Z_INDEX.base + 2,
+    display: "inline-flex",
+    opacity: 0.85,
+    "& svg": { fontSize: 12 }
+  });
+
+export interface ClipBodyProps {
+  clip: TimelineClip;
+  leftPx: number;
+  widthPx: number;
+  msPerPx: number;
+  isSelected: boolean;
+  derivedStatus: ClipStatus;
+  statusInfo: (typeof CLIP_STATUS_MAP)[ClipStatus];
+  handleDragPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handleClick: (e: React.MouseEvent<HTMLDivElement>) => void;
+  handleKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  handleContextMenu: (e: React.MouseEvent<HTMLDivElement>) => void;
+  handleTrimStartPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handleTrimStartPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handleTrimEndPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handleTrimEndPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handleTrimPointerEnd: () => void;
+  cutMode: boolean;
+  /** clip.locked OR the clip's track is locked: drives the not-allowed cursor.
+   *  The lock badge below stays tied to clip.locked alone. */
+  interactionLocked: boolean;
+}
+
+export const ClipBody: React.FC<ClipBodyProps> = memo(
+  ({
+    clip,
+    leftPx,
+    widthPx,
+    msPerPx,
+    isSelected,
+    derivedStatus,
+    statusInfo,
+    handleDragPointerDown,
+    handleClick,
+    handleKeyDown,
+    handleContextMenu,
+    handleTrimStartPointerDown,
+    handleTrimStartPointerMove,
+    handleTrimEndPointerDown,
+    handleTrimEndPointerMove,
+    handleTrimPointerEnd,
+    cutMode,
+    interactionLocked
+  }) => {
+    const theme = useTheme();
+    const clipId = clip.id;
+
+    // Only video clips need a URL for thumbnail extraction; image clips use a
+    // single backgroundImage and audio clips a waveform.
+    const videoUrl = useAssetUrl(
+      clip.mediaType === "video" || clip.mediaType === "overlay"
+        ? clip.currentAssetId
+        : undefined
+    );
+    const imageUrl = useAssetUrl(
+      clip.mediaType === "image" ? clip.currentAssetId : undefined
+    );
+    const audioUrl = useAssetUrl(
+      clip.mediaType === "audio" ? clip.currentAssetId : undefined
+    );
+
+    const thumbnails = useClipThumbnails(videoUrl);
+    const cellCount = Math.max(1, Math.floor(widthPx / FILMSTRIP_CELL_PX));
+    const { inPointMs, outPointMs } = clipSourceWindow(clip);
+
+    const filmstripCells = useMemo(() => {
+      if (!thumbnails || thumbnails.length === 0) return null;
+      return selectFilmstripCells(thumbnails, cellCount, inPointMs, outPointMs);
+    }, [thumbnails, cellCount, inPointMs, outPointMs]);
+
+    // Stripe the tail that runs past the source, once it is at least a cell
+    // wide. The source length is estimated from the sample spacing, so a
+    // sub-cell overflow is within that estimate's error and stays unmarked.
+    const beyondSourceWidthPct = useMemo(() => {
+      if (!thumbnails || thumbnails.length === 0) return 0;
+      const fraction = beyondSourceFraction(thumbnails, inPointMs, outPointMs);
+      return fraction * widthPx >= FILMSTRIP_CELL_PX ? fraction * 100 : 0;
+    }, [thumbnails, inPointMs, outPointMs, widthPx]);
+
+    const accent = (() => {
+      switch (clip.mediaType) {
+        case "audio":
+          return theme.vars.palette.success.main;
+        case "overlay":
+        case "text":
+        case "shape":
+        case "group":
+          return theme.vars.palette.secondary.main;
+        case "image":
+        case "video":
+        default:
+          return theme.vars.palette.info.main;
+      }
+    })();
+
+    const showDuration = widthPx >= COMPACT_THRESHOLD_PX;
+    const durationLabel = formatClipDuration(clip.durationMs);
+    const animationMarkers = deriveClipAnimationMarkers(
+      clip.animations,
+      msPerPx,
+      widthPx
+    );
+    const fadeMarkers = deriveClipFadeMarkers(clip, msPerPx, widthPx);
+    const showFades = FADE_MEDIA_TYPES.has(clip.mediaType);
+    const trimHandleStyle =
+      widthPx < MIN_TRIM_HANDLE_CLIP_WIDTH_PX
+        ? HIDDEN_TRIM_HANDLE_STYLE
+        : undefined;
+    const handleAnimationMarkerClick = (event: React.MouseEvent) => {
+      event.stopPropagation();
+      useTimelineUIStore.getState().selectClip(clipId);
+      openPersistedFold("animate");
+    };
+
+    const positionStyle = useMemo(
+      () => ({
+        left: leftPx,
+        width: widthPx,
+        cursor: cutMode ? ("crosshair" as const) : undefined
+      }),
+      [leftPx, widthPx, cutMode]
+    );
+
+    const imageStyle = useMemo(
+      () =>
+        imageUrl
+          ? {
+              backgroundImage: `url(${imageUrl})`,
+              backgroundSize: "cover" as const,
+              backgroundPosition: "center" as const,
+              opacity: 0.78
+            }
+          : undefined,
+      [imageUrl]
+    );
+
+    // Drag, trim, zoom and pan each change leftPx/widthPx, re-rendering this
+    // body once per frame per clip. None of the nine styles read geometry.
+    const mediaType = clip.mediaType;
+    const rootCss = useMemo(
+      () => clipStyles(theme, isSelected, interactionLocked, mediaType),
+      [theme, isSelected, interactionLocked, mediaType]
+    );
+    const inZoneCss = useMemo(
+      () => animationZoneStyles(theme, "in"),
+      [theme]
+    );
+    const outZoneCss = useMemo(
+      () => animationZoneStyles(theme, "out"),
+      [theme]
+    );
+    const loopIconCss = useMemo(
+      () => animationLoopIconStyles(theme),
+      [theme]
+    );
+    const dotCss = useMemo(() => clipDotStyles(accent), [accent]);
+    const nameCss = useMemo(() => clipNameStyles(theme), [theme]);
+    const durationCss = useMemo(() => clipDurationStyles(theme), [theme]);
+    const trimStartCss = useMemo(
+      () => trimHandleStyles(theme, "start", interactionLocked, isSelected),
+      [theme, interactionLocked, isSelected]
+    );
+    const trimEndCss = useMemo(
+      () => trimHandleStyles(theme, "end", interactionLocked, isSelected),
+      [theme, interactionLocked, isSelected]
+    );
+    const transitionCss = useMemo(
+      () =>
+        transitionWedgeStyles(
+          theme,
+          clipBorderTint(theme, mediaType),
+          accent
+        ),
+      [theme, mediaType, accent]
+    );
+    const fadeColor = theme.vars.palette.text.primary;
+
+    return (
+      <div
+        css={rootCss}
+        style={positionStyle}
+        onPointerDown={handleDragPointerDown}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        onContextMenu={handleContextMenu}
+        data-testid={`clip-${clipId}`}
+        aria-selected={isSelected}
+        role="option"
+        tabIndex={0}
+        aria-label={clip.name || `Clip ${clip.id}`}
+      >
+        {filmstripCells && (
+          <div css={filmstripStyles}>
+            {filmstripCells.map((cell, i) => (
+              <div
+                key={i}
+                css={filmstripCellStyles}
+                style={{ backgroundImage: `url(${cell.url})` }}
+              />
+            ))}
+            {beyondSourceWidthPct > 0 && (
+              <div
+                css={beyondSourceStyles}
+                style={{ width: `${beyondSourceWidthPct}%` }}
+                aria-hidden
+                data-testid={`clip-beyond-source-${clipId}`}
+              />
+            )}
+          </div>
+        )}
+
+        {showFades && fadeMarkers.fadeIn && (
+          <svg
+            css={fadeOverlayStyles}
+            style={{ left: 0, width: fadeMarkers.fadeIn.widthPx }}
+            viewBox="0 0 1 1"
+            preserveAspectRatio="none"
+            aria-hidden
+            data-testid={`clip-fade-in-${clipId}`}
+          >
+            <polygon points="0,0 1,0 0,1" fill={fadeColor} fillOpacity="0.25" />
+            <line
+              x1="0"
+              y1="1"
+              x2="1"
+              y2="0"
+              stroke={fadeColor}
+              strokeWidth="1"
+              vectorEffect="non-scaling-stroke"
+            />
+          </svg>
+        )}
+
+        {showFades && fadeMarkers.fadeOut && (
+          <svg
+            css={fadeOverlayStyles}
+            style={{ right: 0, width: fadeMarkers.fadeOut.widthPx }}
+            viewBox="0 0 1 1"
+            preserveAspectRatio="none"
+            aria-hidden
+            data-testid={`clip-fade-out-${clipId}`}
+          >
+            <polygon points="0,0 1,0 1,1" fill={fadeColor} fillOpacity="0.25" />
+            <line
+              x1="0"
+              y1="0"
+              x2="1"
+              y2="1"
+              stroke={fadeColor}
+              strokeWidth="1"
+              vectorEffect="non-scaling-stroke"
+            />
+          </svg>
+        )}
+
+        {fadeMarkers.transitionIn && (
+          <div
+            css={transitionCss}
+            style={{ width: fadeMarkers.transitionIn.widthPx }}
+            aria-hidden
+            data-testid={`clip-transition-in-${clipId}`}
+          >
+            {fadeMarkers.transitionIn.widthPx >= TRANSITION_LABEL_MIN_PX && (
+              <span>{fadeMarkers.transitionIn.type}</span>
+            )}
+          </div>
+        )}
+
+        {imageUrl && <div css={filmstripStyles} style={imageStyle} />}
+
+        {clip.mediaType === "group" && (
+          <GroupBracket
+            clipId={clipId}
+            startMs={clip.startMs}
+            durationMs={clip.durationMs}
+            widthPx={widthPx}
+          />
+        )}
+
+        {clip.mediaType === "audio" && (
+          <WaveformCanvas
+            url={audioUrl}
+            inPointMs={clip.inPointMs ?? 0}
+            outPointMs={(clip.inPointMs ?? 0) + clip.durationMs}
+            widthPx={widthPx}
+          />
+        )}
+
+        {animationMarkers.inZone && (
+          <button
+            type="button"
+            css={inZoneCss}
+            style={{
+              left: animationMarkers.inZone.offsetPx,
+              width: animationMarkers.inZone.widthPx
+            }}
+            onPointerDown={(event) => event.stopPropagation()}
+            onClick={handleAnimationMarkerClick}
+            aria-label="Open entrance animation controls"
+          />
+        )}
+
+        {animationMarkers.outZone && (
+          <button
+            type="button"
+            css={outZoneCss}
+            style={{
+              right: animationMarkers.outZone.offsetPx,
+              width: animationMarkers.outZone.widthPx
+            }}
+            onPointerDown={(event) => event.stopPropagation()}
+            onClick={handleAnimationMarkerClick}
+            aria-label="Open exit animation controls"
+          />
+        )}
+
+        {animationMarkers.hasLoopOrEmphasis && (
+          <button
+            type="button"
+            css={loopIconCss}
+            onPointerDown={(event) => event.stopPropagation()}
+            onClick={handleAnimationMarkerClick}
+            aria-label="Open loop and emphasis animation controls"
+          >
+            <LoopOutlinedIcon />
+          </button>
+        )}
+
+        {/* Header strip: type dot · name · duration */}
+        <div css={clipHeaderRowStyles}>
+          <span css={dotCss} aria-hidden />
+          <span css={nameCss}>{clip.name}</span>
+          {showDuration && (
+            <span css={durationCss}>{durationLabel}</span>
+          )}
+        </div>
+
+        <div
+          css={trimStartCss}
+          style={trimHandleStyle}
+          data-clip-trim-handle
+          onPointerDown={handleTrimStartPointerDown}
+          onPointerMove={handleTrimStartPointerMove}
+          onPointerUp={handleTrimPointerEnd}
+          onPointerCancel={handleTrimPointerEnd}
+          aria-label="Trim clip start"
+          data-testid={`clip-trim-start-${clipId}`}
+        />
+
+        <div
+          css={trimEndCss}
+          style={trimHandleStyle}
+          data-clip-trim-handle
+          onPointerDown={handleTrimEndPointerDown}
+          onPointerMove={handleTrimEndPointerMove}
+          onPointerUp={handleTrimPointerEnd}
+          onPointerCancel={handleTrimPointerEnd}
+          aria-label="Trim clip end"
+          data-testid={`clip-trim-end-${clipId}`}
+        />
+
+        {clip.locked && (
+          <div css={lockIconStyles}>
+            <LockOutlinedIcon sx={{ fontSize: 12 }} aria-label="Clip locked" />
+          </div>
+        )}
+
+        {(derivedStatus === "queued" || derivedStatus === "generating") && (
+          <div
+            css={generatingOverlayStyles}
+            aria-hidden
+            data-testid={`clip-generating-${clipId}`}
+          >
+            <MagicGenerationFill />
+          </div>
+        )}
+
+        {/* The badge surfaces lifecycle state for generated clips. Once a
+         *  clip has settled into "generated" it doesn't need a permanent green
+         *  dot, and imported clips have no lifecycle at all — so we render
+         *  only while something interesting is happening. */}
+        {clip.sourceType === "generated" &&
+          derivedStatus !== "draft" &&
+          derivedStatus !== "generated" && (
+            <div css={statusBadgeStyles}>
+              <StatusIndicator
+                status={statusInfo.status}
+                pulse={statusInfo.pulse}
+                tooltip={statusInfo.label}
+                size="small"
+              />
+            </div>
+          )}
+
+      </div>
+    );
+  }
+);
+ClipBody.displayName = "ClipBody";
+
+/** "4.6s" for sub-minute, "1:23" for ≥1 min. Shown when clip width ≥ compact threshold. */
+function formatClipDuration(durationMs: number): string {
+  if (durationMs < 60_000) {
+    const sec = durationMs / 1000;
+    return sec < 10 ? `${sec.toFixed(1)}s` : `${Math.round(sec)}s`;
+  }
+  const totalSec = Math.round(durationMs / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}

--- a/web/src/components/timeline/Tracks/GestureReadout.tsx
+++ b/web/src/components/timeline/Tracks/GestureReadout.tsx
@@ -1,0 +1,101 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * GestureReadout
+ *
+ * A mono timecode pill showing the live geometry of the clip under a drag or
+ * trim gesture:
+ *   move       start · duration
+ *   trim-start in    · duration
+ *   trim-end   duration · end
+ *
+ * It sits pinned to the top-left corner of the visible lanes viewport. The
+ * wrapper is a zero-size sticky box placed first in the lanes container, so
+ * it takes no layout space and stays put while the lanes scroll on both axes.
+ */
+
+import React, { memo, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+
+import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
+import type { GestureReadout as GestureReadoutValue } from "../../../stores/timeline/TimelineUIStore";
+import { formatTimecode } from "../Inspector/InspectorPrimitives.helpers";
+import {
+  BORDER_RADIUS,
+  FONT_SIZE_MONO,
+  FONT_WEIGHT,
+  SPACING,
+  Z_INDEX,
+  getSpacingPx
+} from "../../ui_primitives";
+
+const anchorStyles = css({
+  position: "sticky",
+  top: 0,
+  left: 0,
+  width: 0,
+  height: 0,
+  zIndex: Z_INDEX.sticky + 1,
+  pointerEvents: "none"
+});
+
+const pillStyles = (theme: Theme) =>
+  css({
+    position: "absolute",
+    top: getSpacingPx(SPACING.xs),
+    left: getSpacingPx(SPACING.xs),
+    height: 18,
+    padding: `0 ${getSpacingPx(SPACING.sm)}`,
+    display: "inline-flex",
+    alignItems: "center",
+    borderRadius: BORDER_RADIUS.sm,
+    border: `1px solid ${theme.vars.palette.divider}`,
+    backgroundColor: theme.vars.palette.background.paper,
+    color: theme.vars.palette.text.secondary,
+    fontFamily:
+      "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace",
+    fontSize: FONT_SIZE_MONO.caption,
+    fontWeight: FONT_WEIGHT.semibold,
+    letterSpacing: "0.04em",
+    whiteSpace: "nowrap",
+    boxShadow: `0 2px 6px ${theme.vars.palette.c_scrim_soft}`
+  });
+
+/** The two timecodes the pill shows for a gesture kind. */
+export function readoutText(
+  readout: GestureReadoutValue,
+  fps: number
+): string {
+  const tc = (ms: number) => formatTimecode(ms, fps);
+  switch (readout.kind) {
+    case "move":
+      return `${tc(readout.startMs)} · ${tc(readout.durationMs)}`;
+    case "trim-start":
+      return `${tc(readout.inPointMs)} · ${tc(readout.durationMs)}`;
+    case "trim-end":
+      return `${tc(readout.durationMs)} · ${tc(readout.startMs + readout.durationMs)}`;
+  }
+}
+
+export const GestureReadout: React.FC = memo(() => {
+  const theme = useTheme();
+  const readout = useTimelineUIStore((s) => s.gestureReadout);
+  const fps = useTimelineStore((s) => s.fps);
+  const pillCss = useMemo(() => pillStyles(theme), [theme]);
+
+  if (!readout) {
+    return null;
+  }
+
+  return (
+    <div css={anchorStyles} aria-hidden="true">
+      <div css={pillCss} data-testid="timeline-gesture-readout">
+        {readoutText(readout, fps)}
+      </div>
+    </div>
+  );
+});
+
+GestureReadout.displayName = "GestureReadout";

--- a/web/src/components/timeline/Tracks/SnapGuideOverlay.tsx
+++ b/web/src/components/timeline/Tracks/SnapGuideOverlay.tsx
@@ -1,0 +1,49 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * SnapGuideOverlay
+ *
+ * A 1px vertical line at the position a drag or trim gesture is snapped to.
+ * Renders in the lanes container so it spans every track, like the
+ * rubber-band marquee.
+ */
+
+import React, { memo, useMemo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+
+import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
+import { Z_INDEX } from "../../ui_primitives";
+
+const guideStyles = (theme: Theme) =>
+  css({
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    width: 1,
+    backgroundColor: theme.vars.palette.secondary.main,
+    pointerEvents: "none",
+    zIndex: Z_INDEX.sticky
+  });
+
+export const SnapGuideOverlay: React.FC = memo(() => {
+  const theme = useTheme();
+  const snapGuideMs = useTimelineUIStore((s) => s.snapGuideMs);
+  const msPerPx = useTimelineUIStore((s) => s.msPerPx);
+  const guideCss = useMemo(() => guideStyles(theme), [theme]);
+
+  if (snapGuideMs === null) {
+    return null;
+  }
+
+  return (
+    <div
+      css={guideCss}
+      data-testid="timeline-snap-guide"
+      style={{ left: snapGuideMs / msPerPx }}
+      aria-hidden="true"
+    />
+  );
+});
+
+SnapGuideOverlay.displayName = "SnapGuideOverlay";

--- a/web/src/components/timeline/Tracks/TrackHeader.tsx
+++ b/web/src/components/timeline/Tracks/TrackHeader.tsx
@@ -6,6 +6,8 @@
  *   - Type glyph + name + index chip (V1, A1, …) on the top row
  *   - Visibility / lock / mute / solo / fx / delete row beneath
  *   - Height resize handle at the bottom edge
+ *   - Right-click (or touch hold) context menu: rename, duplicate, insert a
+ *     same-type track above/below, remove
  */
 
 import React, { memo, useCallback, useMemo, useRef, useState } from "react";
@@ -21,6 +23,10 @@ import VolumeUpOutlinedIcon from "@mui/icons-material/VolumeUpOutlined";
 import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
 import GraphicEqOutlinedIcon from "@mui/icons-material/GraphicEqOutlined";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
+import DriveFileRenameOutlineIcon from "@mui/icons-material/DriveFileRenameOutline";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import VerticalAlignTopIcon from "@mui/icons-material/VerticalAlignTop";
+import VerticalAlignBottomIcon from "@mui/icons-material/VerticalAlignBottom";
 
 import type { TimelineTrack } from "@nodetool-ai/timeline";
 import {
@@ -36,7 +42,21 @@ import {
   computeReorderedTrackIds,
   type TrackDropPosition
 } from "./trackReorder";
-import { Tooltip, MOTION, BORDER_RADIUS, FONT_SIZE_SANS, FONT_SIZE_MONO, FONT_WEIGHT, SPACING, getSpacingPx, Z_INDEX } from "../../ui_primitives";
+import {
+  ContextMenu,
+  MenuItemPrimitive,
+  Tooltip,
+  MOTION,
+  BORDER_RADIUS,
+  FONT_SIZE_SANS,
+  FONT_SIZE_MONO,
+  FONT_WEIGHT,
+  SPACING,
+  getSpacingPx,
+  Z_INDEX
+} from "../../ui_primitives";
+import { useLongPress } from "../../../hooks/timeline/useLongPress";
+import type { LongPressPoint } from "../../../hooks/timeline/useLongPress";
 import { DEFAULT_TRACK_HEIGHT_PX as SHARED_DEFAULT_TRACK_HEIGHT_PX } from "./trackHeight";
 import {
   trackTypeMeta,
@@ -291,6 +311,8 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
   const setTrackName = useTimelineStore((s) => s.setTrackName);
   const removeTrack = useTimelineStore((s) => s.removeTrack);
   const reorderTracks = useTimelineStore((s) => s.reorderTracks);
+  const insertTrack = useTimelineStore((s) => s.insertTrack);
+  const duplicateTrack = useTimelineStore((s) => s.duplicateTrack);
 
   const heightPx = track.heightPx ?? DEFAULT_TRACK_HEIGHT_PX;
   const meta = trackTypeMeta(track.type);
@@ -300,12 +322,21 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
   const [editingName, setEditingName] = useState(false);
   const [localName, setLocalName] = useState(track.name);
   const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false);
+  const [contextMenuPos, setContextMenuPos] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const handleNameDoubleClick = useCallback(() => {
+  const startRename = useCallback(() => {
     setEditingName(true);
     setLocalName(track.name);
-    setTimeout(() => inputRef.current?.select(), 0);
+    // The input is read-only until the re-render above lands; the deferred
+    // focus also outruns the closing menu's own focus handling.
+    setTimeout(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }, 0);
   }, [track.name]);
 
   const commitName = useCallback(() => {
@@ -380,6 +411,78 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
     isResizingRef.current = false;
     history.end();
   }, [history]);
+
+  // Context menu: right-click anywhere on the header, or a touch hold. The
+  // resize handle and the drag grip stop pointer/contextmenu propagation so a
+  // resize or reorder gesture never opens it.
+
+  const openHeaderMenuAt = useCallback(
+    (x: number, y: number) => {
+      if (editingName) {
+        return;
+      }
+      setContextMenuPos({ x, y });
+    },
+    [editingName]
+  );
+
+  const headerLongPress = useLongPress(
+    useCallback(
+      (point: LongPressPoint) => {
+        openHeaderMenuAt(point.clientX, point.clientY);
+      },
+      [openHeaderMenuAt]
+    )
+  );
+
+  const handleHeaderContextMenu = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (editingName) {
+        return;
+      }
+      e.preventDefault();
+      openHeaderMenuAt(e.clientX, e.clientY);
+    },
+    [editingName, openHeaderMenuAt]
+  );
+
+  const closeContextMenu = useCallback(() => setContextMenuPos(null), []);
+
+  const stopPointerPropagation = useCallback(
+    (e: React.SyntheticEvent) => e.stopPropagation(),
+    []
+  );
+
+  const positionOf = useCallback(
+    () =>
+      timelineStoreApi.getState().tracks.findIndex((t) => t.id === track.id),
+    [timelineStoreApi, track.id]
+  );
+
+  const handleMenuRename = useCallback(() => {
+    closeContextMenu();
+    startRename();
+  }, [closeContextMenu, startRename]);
+
+  const handleMenuDuplicate = useCallback(() => {
+    closeContextMenu();
+    duplicateTrack(track.id);
+  }, [closeContextMenu, duplicateTrack, track.id]);
+
+  const handleMenuInsertAbove = useCallback(() => {
+    closeContextMenu();
+    insertTrack(track.type, positionOf());
+  }, [closeContextMenu, insertTrack, positionOf, track.type]);
+
+  const handleMenuInsertBelow = useCallback(() => {
+    closeContextMenu();
+    insertTrack(track.type, positionOf() + 1);
+  }, [closeContextMenu, insertTrack, positionOf, track.type]);
+
+  const handleMenuRemove = useCallback(() => {
+    closeContextMenu();
+    setConfirmRemoveOpen(true);
+  }, [closeContextMenu]);
 
   const isAudioTrack = track.type === "audio";
   const supportsEffects =
@@ -512,6 +615,11 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
       data-testid={`track-header-${track.id}`}
       onDragOver={handleDragOver}
       onDrop={handleDrop}
+      onContextMenu={handleHeaderContextMenu}
+      onPointerDown={headerLongPress.start}
+      onPointerMove={headerLongPress.move}
+      onPointerUp={headerLongPress.cancel}
+      onPointerCancel={headerLongPress.cancel}
     >
       {dropEdge && (
         <div
@@ -529,6 +637,8 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
               draggable
               onDragStart={handleDragStart}
               onDragEnd={handleDragEnd}
+              onPointerDown={stopPointerPropagation}
+              onContextMenu={stopPointerPropagation}
               aria-label={`Reorder ${track.name}`}
               role="button"
               tabIndex={-1}
@@ -553,10 +663,11 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
             value={editingName ? localName : track.name}
             readOnly={!editingName}
             onChange={(e) => setLocalName(e.target.value)}
-            onDoubleClick={handleNameDoubleClick}
+            onDoubleClick={startRename}
             onBlur={commitName}
             onKeyDown={handleNameKeyDown}
             aria-label={`Track name: ${track.name}`}
+            title={editingName ? undefined : "Double-click to rename"}
           />
           <span
             css={indexChipCss}
@@ -678,11 +789,53 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
         onPointerMove={handleResizePointerMove}
         onPointerUp={handleResizePointerEnd}
         onPointerCancel={handleResizePointerEnd}
+        onContextMenu={stopPointerPropagation}
         aria-label="Resize track height"
         role="separator"
         aria-orientation="horizontal"
       />
     </div>
+    <ContextMenu
+      open={contextMenuPos !== null}
+      position={contextMenuPos}
+      onClose={closeContextMenu}
+      disableRestoreFocus
+      compact
+      data-testid={`track-context-menu-${track.id}`}
+    >
+      <MenuItemPrimitive
+        label="Rename"
+        icon={<DriveFileRenameOutlineIcon fontSize="small" />}
+        onClick={handleMenuRename}
+        compact
+      />
+      <MenuItemPrimitive
+        label="Duplicate track"
+        icon={<ContentCopyIcon fontSize="small" />}
+        onClick={handleMenuDuplicate}
+        compact
+      />
+      <MenuItemPrimitive
+        label={`Insert ${meta.label} track above`}
+        icon={<VerticalAlignTopIcon fontSize="small" />}
+        onClick={handleMenuInsertAbove}
+        compact
+      />
+      <MenuItemPrimitive
+        label={`Insert ${meta.label} track below`}
+        icon={<VerticalAlignBottomIcon fontSize="small" />}
+        onClick={handleMenuInsertBelow}
+        compact
+      />
+      <MenuItemPrimitive
+        label="Remove track"
+        icon={<DeleteOutlineOutlinedIcon fontSize="small" />}
+        onClick={handleMenuRemove}
+        color="error"
+        dividerBefore
+        compact
+      />
+    </ContextMenu>
     <ConfirmDialog
       open={confirmRemoveOpen}
       onClose={() => setConfirmRemoveOpen(false)}

--- a/web/src/components/timeline/Tracks/TrackLane.tsx
+++ b/web/src/components/timeline/Tracks/TrackLane.tsx
@@ -41,6 +41,7 @@ import {
   useTimelineStore,
   useTimelineStoreApi
 } from "../../../stores/timeline/TimelineStore";
+import { clipIdsByTrack } from "../../../stores/timeline/clipLookup";
 import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
 import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
 import { useStoreWithEqualityFn } from "zustand/traditional";
@@ -58,6 +59,7 @@ import { useLongPress } from "../../../hooks/timeline/useLongPress";
 import type { LongPressPoint } from "../../../hooks/timeline/useLongPress";
 
 const DEFAULT_TRACK_HEIGHT_PX = 64;
+const NO_CLIP_IDS: string[] = [];
 /** Duration (ms) the mismatch warning banner remains visible. */
 const WARNING_DISMISS_MS = 3000;
 
@@ -101,14 +103,12 @@ interface TrackLaneProps {
 export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
   const theme = useTheme();
 
-  // Get only the clip IDs for this track (stable list of ids)
+  // Only this track's clip ids. clipIdsByTrack is cached per `clips` array
+  // identity, so one store publish builds the index once for every lane.
   const timelineStore = useTimelineStoreApi();
   const clipIds = useStoreWithEqualityFn(
     timelineStore,
-    (s) =>
-      s.clips
-        .filter((c) => c.trackId === track.id)
-        .map((c) => c.id),
+    (s) => clipIdsByTrack(s.clips).get(track.id) ?? NO_CLIP_IDS,
     // Shallow-compare the resulting string array
     (a: string[], b: string[]) =>
       a.length === b.length && a.every((id, i) => id === b[i])

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -74,6 +74,8 @@ import {
 import { TrackHeader } from "./TrackHeader";
 import { TrackLane } from "./TrackLane";
 import { RubberBandOverlay } from "./RubberBandOverlay";
+import { SnapGuideOverlay } from "./SnapGuideOverlay";
+import { GestureReadout } from "./GestureReadout";
 import { TimeRuler } from "./TimeRuler";
 import { Playhead } from "./Playhead";
 import { AddTrackButton } from "./AddTrackButton";
@@ -1044,6 +1046,9 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
               style={{ minWidth: totalWidthPx, width: "100%", height: totalTracksHeight }}
               data-timeline-lanes="true"
             >
+              {/* Zero-size sticky anchor: must be the first child so its
+                  in-flow position is the container's top-left corner. */}
+              <GestureReadout />
               {tracks.map((track) => (
                 <React.Fragment key={track.id}>
                   {hasScript && track.id === scriptBeforeTrackId && (
@@ -1071,6 +1076,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
               {/* Marquee rect — drawn here, above every lane, because a band
                   started on one lane may cover several. */}
               <RubberBandOverlay />
+              <SnapGuideOverlay />
             </div>
           </div>
         </FlexRow>

--- a/web/src/components/timeline/Tracks/__tests__/Clip.gestures.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/Clip.gestures.test.tsx
@@ -1,0 +1,295 @@
+/**
+ * Clip pointer gestures: drag, trim-start, trim-end, lock refusal, and
+ * multi-selection drags — driven through the real TrackLane/Clip tree against
+ * the default timeline store instance.
+ *
+ * Drag moves arrive through window listeners (the clip may re-parent into
+ * another lane mid-gesture), so pointermove fires on `window`; trim moves are
+ * React handlers on the handle itself.
+ */
+
+import { installGlobal } from "../../../../test-utils/doubles";
+import { act, render, screen, fireEvent } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../../__mocks__/themeMock";
+
+// Polyfill PointerEvent for jsdom (which doesn't support it natively).
+if (typeof window !== "undefined" && !window.PointerEvent) {
+  installGlobal(
+    "PointerEvent",
+    class PointerEvent extends MouseEvent {
+      readonly pointerId: number;
+      readonly pointerType: string;
+      readonly isPrimary: boolean;
+
+      constructor(type: string, params: PointerEventInit & MouseEventInit = {}) {
+        super(type, params);
+        this.pointerId = params.pointerId ?? 0;
+        this.pointerType = params.pointerType ?? "";
+        this.isPrimary = params.isPrimary ?? false;
+      }
+    }
+  );
+}
+
+jest.mock("../useClipThumbnails", () => ({
+  useClipThumbnails: () => null
+}));
+jest.mock("../useAudioPeaks", () => ({
+  useAudioPeaks: () => ({ peaks: null, durationMs: null })
+}));
+jest.mock("../../../../stores/AssetStore", () => ({
+  useAssetStore: <T,>(sel: (s: { get: () => Promise<null> }) => T) =>
+    sel({ get: () => Promise.resolve(null) })
+}));
+jest.mock("../../../../stores/WorkflowRunsStore", () => ({
+  __esModule: true,
+  default: <T,>(sel: (s: { focusedJob: Record<string, string> }) => T) =>
+    sel({ focusedJob: {} })
+}));
+jest.mock("../../../../stores/ErrorStore", () => ({
+  __esModule: true,
+  default: <T,>(sel: (s: { errors: Record<string, unknown> }) => T) =>
+    sel({ errors: {} }),
+  hasNodeError: () => false,
+  nodeErrorToDisplayString: () => ""
+}));
+jest.mock("../../../../stores/timeline/TimelineGenerationStore", () => ({
+  useTimelineGenerationStore: <T,>(
+    sel: (s: { clipJobs: Record<string, unknown> }) => T
+  ) => sel({ clipJobs: {} })
+}));
+
+import type { TimelineClip, TimelineTrack } from "@nodetool-ai/timeline";
+import { TrackLane } from "../TrackLane";
+import { useTimelineStore } from "../../../../stores/timeline/TimelineStore";
+import { useTimelineUIStore } from "../../../../stores/timeline/TimelineUIStore";
+import { useTimelinePlaybackStore } from "../../../../stores/timeline/TimelinePlaybackStore";
+
+// jsdom does not implement pointer capture.
+beforeAll(() => {
+  HTMLElement.prototype.setPointerCapture = jest.fn();
+  HTMLElement.prototype.releasePointerCapture = jest.fn();
+});
+
+const makeTrack = (
+  id: string,
+  index: number,
+  locked = false
+): TimelineTrack => ({
+  id,
+  name: `Video ${index + 1}`,
+  type: "video",
+  index,
+  visible: true,
+  locked
+});
+
+const makeClip = (
+  id: string,
+  trackId: string,
+  startMs: number,
+  durationMs: number,
+  locked = false
+): TimelineClip => ({
+  id,
+  trackId,
+  name: id,
+  startMs,
+  durationMs,
+  mediaType: "video",
+  sourceType: "imported",
+  status: "draft",
+  locked,
+  versions: []
+});
+
+/** 10 ms per px, so 30 px of pointer travel is 300 ms — clear of the 8 px
+ *  snap threshold around the 1 s gridlines and the other clips' edges. */
+const MS_PER_PX = 10;
+const DRAG_PX = 30;
+const DRAG_MS = DRAG_PX * MS_PER_PX;
+
+const clipState = (id: string) => {
+  const clip = useTimelineStore.getState().clips.find((c) => c.id === id);
+  if (!clip) {
+    throw new Error(`clip ${id} missing`);
+  }
+  return { trackId: clip.trackId, startMs: clip.startMs, durationMs: clip.durationMs };
+};
+
+const seed = ({ lockTrackB = false } = {}) => {
+  useTimelineStore.setState({
+    tracks: [makeTrack("t1", 0), makeTrack("t2", 1, lockTrackB)],
+    clips: [
+      makeClip("a1", "t1", 2000, 1000),
+      makeClip("a2", "t1", 6000, 1000, true),
+      makeClip("a3", "t1", 8500, 1000),
+      makeClip("b1", "t2", 2000, 1000)
+    ],
+    durationMs: 12_000
+  });
+  useTimelineUIStore.setState({
+    msPerPx: MS_PER_PX,
+    scrollLeftPx: 0,
+    activeTool: "select",
+    selectedClipIds: new Set<string>(),
+    rubberBand: null
+  });
+  useTimelinePlaybackStore.setState({ currentTimeMs: 0 });
+};
+
+const renderLanes = () => {
+  const { tracks } = useTimelineStore.getState();
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <div data-timeline-lanes="true">
+        {tracks.map((t) => (
+          <TrackLane key={t.id} track={t} />
+        ))}
+      </div>
+    </ThemeProvider>
+  );
+};
+
+const dragClip = (clipId: string, fromX: number, toX: number) => {
+  const el = screen.getByTestId(`clip-${clipId}`);
+  fireEvent.pointerDown(el, { button: 0, buttons: 1, clientX: fromX, clientY: 20, pointerId: 1 });
+  fireEvent.pointerMove(window, { buttons: 1, clientX: toX, clientY: 20, pointerId: 1 });
+  fireEvent.pointerUp(window, { pointerId: 1 });
+};
+
+const dragHandle = (
+  clipId: string,
+  edge: "start" | "end",
+  fromX: number,
+  toX: number
+) => {
+  const el = screen.getByTestId(`clip-trim-${edge}-${clipId}`);
+  fireEvent.pointerDown(el, { button: 0, buttons: 1, clientX: fromX, pointerId: 1 });
+  fireEvent.pointerMove(el, { buttons: 1, clientX: toX, pointerId: 1 });
+  fireEvent.pointerUp(el, { pointerId: 1 });
+};
+
+beforeEach(() => {
+  seed();
+});
+
+describe("Clip drag", () => {
+  it("moves startMs by the pointer travel", () => {
+    renderLanes();
+    dragClip("a1", 100, 100 + DRAG_PX);
+    expect(clipState("a1")).toEqual({ trackId: "t1", startMs: 2000 + DRAG_MS, durationMs: 1000 });
+  });
+
+  it("ignores travel below the drag threshold", () => {
+    renderLanes();
+    dragClip("a1", 100, 102);
+    expect(clipState("a1").startMs).toBe(2000);
+  });
+
+  it("keeps the relative offset of two selected clips", () => {
+    useTimelineUIStore.setState({ selectedClipIds: new Set(["a1", "a3"]) });
+    renderLanes();
+    dragClip("a1", 100, 100 + DRAG_PX);
+    expect(clipState("a1").startMs).toBe(2000 + DRAG_MS);
+    expect(clipState("a3").startMs).toBe(8500 + DRAG_MS);
+    expect(clipState("a3").startMs - clipState("a1").startMs).toBe(6500);
+  });
+});
+
+describe("Clip drag across tracks", () => {
+  let rafSpy: jest.SpyInstance;
+  beforeEach(() => {
+    // The hit test is coalesced to one sample per frame; run it synchronously
+    // so the first pointermove already sees the lane under the pointer.
+    rafSpy = jest
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb) => {
+        cb(0);
+        return 1;
+      });
+  });
+  afterEach(() => {
+    rafSpy.mockRestore();
+    // jsdom lacks elementsFromPoint; drop the stub so other suites see none.
+    Reflect.deleteProperty(document, "elementsFromPoint");
+  });
+
+  const pointerOverLane = (trackId: string) => {
+    const lane = screen.getByTestId(`track-lane-${trackId}`);
+    document.elementsFromPoint = () => [lane];
+  };
+
+  it("re-parents a single clip into the lane under the pointer", () => {
+    renderLanes();
+    pointerOverLane("t2");
+    dragClip("a1", 100, 100 + DRAG_PX);
+    expect(clipState("a1")).toEqual({ trackId: "t2", startMs: 2000 + DRAG_MS, durationMs: 1000 });
+  });
+
+  it("moves only the primary clip of a multi-selection to the new lane", () => {
+    useTimelineUIStore.setState({ selectedClipIds: new Set(["a1", "a3"]) });
+    renderLanes();
+    pointerOverLane("t2");
+    dragClip("a1", 100, 100 + DRAG_PX);
+    expect(clipState("a1")).toEqual({ trackId: "t2", startMs: 2000 + DRAG_MS, durationMs: 1000 });
+    expect(clipState("a3")).toEqual({ trackId: "t1", startMs: 8500 + DRAG_MS, durationMs: 1000 });
+  });
+
+  it("refuses a locked target lane and keeps moving on the source lane", () => {
+    seed({ lockTrackB: true });
+    renderLanes();
+    pointerOverLane("t2");
+    dragClip("a1", 100, 100 + DRAG_PX);
+    expect(clipState("a1")).toEqual({ trackId: "t1", startMs: 2000 + DRAG_MS, durationMs: 1000 });
+  });
+});
+
+describe("Clip trim", () => {
+  it("trim-end changes durationMs only", () => {
+    renderLanes();
+    dragHandle("a1", "end", 200, 200 + DRAG_PX);
+    expect(clipState("a1")).toEqual({ trackId: "t1", startMs: 2000, durationMs: 1000 + DRAG_MS });
+  });
+
+  it("trim-start moves startMs and shrinks durationMs together", () => {
+    renderLanes();
+    dragHandle("a1", "start", 100, 100 + DRAG_PX);
+    expect(clipState("a1")).toEqual({ trackId: "t1", startMs: 2000 + DRAG_MS, durationMs: 1000 - DRAG_MS });
+  });
+});
+
+describe("Clip lock", () => {
+  it("a clip on a locked track neither moves nor trims", () => {
+    seed({ lockTrackB: true });
+    renderLanes();
+    const before = clipState("b1");
+    dragClip("b1", 100, 100 + DRAG_PX);
+    dragHandle("b1", "start", 100, 100 + DRAG_PX);
+    dragHandle("b1", "end", 200, 200 + DRAG_PX);
+    expect(clipState("b1")).toEqual(before);
+  });
+
+  it("a locked clip neither moves nor trims", () => {
+    renderLanes();
+    const before = clipState("a2");
+    dragClip("a2", 100, 100 + DRAG_PX);
+    dragHandle("a2", "start", 100, 100 + DRAG_PX);
+    dragHandle("a2", "end", 200, 200 + DRAG_PX);
+    expect(clipState("a2")).toEqual(before);
+  });
+
+  it("the cut tool refuses to split a clip on a locked track", () => {
+    seed({ lockTrackB: true });
+    useTimelineUIStore.setState({ activeTool: "cut" });
+    renderLanes();
+    const el = screen.getByTestId("clip-b1");
+    el.getBoundingClientRect = () =>
+      ({ left: 200, right: 300, top: 0, bottom: 64, width: 100, height: 64, x: 200, y: 0, toJSON: () => ({}) }) as DOMRect;
+    act(() => {
+      fireEvent.pointerDown(el, { button: 0, buttons: 1, clientX: 250, pointerId: 1 });
+    });
+    expect(useTimelineStore.getState().clips.filter((c) => c.trackId === "t2")).toHaveLength(1);
+  });
+});

--- a/web/src/components/timeline/Tracks/__tests__/Clip.snap.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/Clip.snap.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * Snap feedback during clip gestures: a dragged clip's edges lock onto
+ * neighbouring clip edges, Alt disables it, trim handles snap the moving edge,
+ * and the snap guide / gesture readout in the UI store follow the gesture and
+ * clear on pointerup.
+ */
+
+jest.mock("../useClipThumbnails", () => ({
+  useClipThumbnails: () => null
+}));
+jest.mock("../useAudioPeaks", () => ({
+  useAudioPeaks: () => ({ peaks: null, durationMs: null })
+}));
+jest.mock("../../../../stores/AssetStore", () => ({
+  useAssetStore: <T,>(sel: (s: { get: () => Promise<null> }) => T) =>
+    sel({ get: () => Promise.resolve(null) })
+}));
+jest.mock("../../../../stores/WorkflowRunsStore", () => ({
+  __esModule: true,
+  default: <T,>(sel: (s: { focusedJob: Record<string, string> }) => T) =>
+    sel({ focusedJob: {} })
+}));
+jest.mock("../../../../stores/ErrorStore", () => ({
+  __esModule: true,
+  default: <T,>(sel: (s: { errors: Record<string, unknown> }) => T) =>
+    sel({ errors: {} }),
+  hasNodeError: () => false,
+  nodeErrorToDisplayString: () => ""
+}));
+jest.mock("../../../../stores/timeline/TimelineGenerationStore", () => ({
+  useTimelineGenerationStore: <T,>(
+    sel: (s: { clipJobs: Record<string, unknown> }) => T
+  ) => sel({ clipJobs: {} })
+}));
+
+import {
+  installPointerEvent,
+  makeTrack,
+  makeClip,
+  seedTimeline,
+  renderLanes,
+  clipState,
+  dragClip,
+  dragHandle,
+  pressClip,
+  moveClipPointer,
+  releaseClipPointer,
+  pressHandle,
+  moveHandle,
+  releaseHandle
+} from "../../../../test-utils/timelineClipHarness";
+import { useTimelineUIStore } from "../../../../stores/timeline/TimelineUIStore";
+
+beforeAll(installPointerEvent);
+
+// a1 2000–3000, a4 4200–5200, a3 8500–9500 on one track; a gridline sits on
+// every whole second, so the neighbours' edges are deliberately off-grid. a4
+// starts 2 s into its source so its start edge has room to grow leftwards.
+beforeEach(() => {
+  seedTimeline(
+    [makeTrack("t1", 0), makeTrack("t2", 1)],
+    [
+      makeClip("a1", "t1", 2000, 1000),
+      makeClip("a4", "t1", 4200, 1000, { inPointMs: 2000 }),
+      makeClip("a3", "t1", 8500, 1000),
+      makeClip("b1", "t2", 2000, 1000)
+    ]
+  );
+});
+
+const ui = () => useTimelineUIStore.getState();
+
+describe("drag snapping", () => {
+  it("snaps the start edge onto a neighbour's end and shows the guide", () => {
+    renderLanes();
+    // 755 px = 7550 ms: raw start 9550, 50 ms (5 px) past a3's end at 9500.
+    pressClip("a1", 100);
+    moveClipPointer(100 + 755);
+    expect(clipState("a1").startMs).toBe(9500);
+    expect(ui().snapGuideMs).toBe(9500);
+    releaseClipPointer();
+  });
+
+  it("snaps the end edge when it is the closer hit", () => {
+    renderLanes();
+    // raw start 3150 → end 4150, 50 ms short of a4's start at 4200; the start
+    // edge is 150 ms from the 3000 gridline, outside the 80 ms threshold.
+    pressClip("a1", 100);
+    moveClipPointer(100 + 115);
+    expect(clipState("a1").startMs).toBe(3200);
+    expect(ui().snapGuideMs).toBe(4200);
+    releaseClipPointer();
+  });
+
+  it("does not snap while Alt is held", () => {
+    renderLanes();
+    pressClip("a1", 100);
+    moveClipPointer(100 + 755, { altKey: true });
+    expect(clipState("a1").startMs).toBe(9550);
+    expect(ui().snapGuideMs).toBeNull();
+    releaseClipPointer();
+  });
+
+  it("clears the guide and the readout on pointerup", () => {
+    renderLanes();
+    dragClip("a1", 100, 100 + 755);
+    expect(clipState("a1").startMs).toBe(9500);
+    expect(ui().snapGuideMs).toBeNull();
+    expect(ui().gestureReadout).toBeNull();
+  });
+});
+
+describe("gesture readout", () => {
+  it("publishes the live geometry of a moving clip", () => {
+    renderLanes();
+    pressClip("a1", 100);
+    moveClipPointer(130);
+    expect(ui().gestureReadout).toEqual({
+      clipId: "a1",
+      kind: "move",
+      startMs: 2300,
+      durationMs: 1000,
+      inPointMs: 0
+    });
+    moveClipPointer(150);
+    expect(ui().gestureReadout?.startMs).toBe(2500);
+    releaseClipPointer();
+  });
+
+  it("publishes trim-end geometry and clears it on release", () => {
+    renderLanes();
+    const el = pressHandle("a1", "end", 200);
+    moveHandle(el, 230);
+    expect(ui().gestureReadout).toEqual({
+      clipId: "a1",
+      kind: "trim-end",
+      startMs: 2000,
+      durationMs: 1300,
+      inPointMs: 0
+    });
+    releaseHandle(el);
+    expect(ui().gestureReadout).toBeNull();
+    expect(ui().snapGuideMs).toBeNull();
+  });
+});
+
+describe("trim snapping", () => {
+  it("trim-end snaps the end edge onto a neighbour's start", () => {
+    renderLanes();
+    // raw end 3000 + 1150 = 4150, 50 ms short of a4's start.
+    const el = pressHandle("a1", "end", 200);
+    moveHandle(el, 200 + 115);
+    expect(clipState("a1")).toEqual({ trackId: "t1", startMs: 2000, durationMs: 2200 });
+    expect(ui().snapGuideMs).toBe(4200);
+    releaseHandle(el);
+  });
+
+  it("trim-end does not snap while Alt is held", () => {
+    renderLanes();
+    dragHandle("a1", "end", 200, 200 + 115, { altKey: true });
+    expect(clipState("a1").durationMs).toBe(2150);
+  });
+
+  it("trim-start snaps the start edge onto a neighbour's end", () => {
+    renderLanes();
+    // a4's start edge dragged left: raw 4200 - 1150 = 3050, 50 ms past a1's
+    // end at 3000 (the 3000 gridline coincides with it).
+    dragHandle("a4", "start", 300, 300 - 115);
+    expect(clipState("a4")).toEqual({ trackId: "t1", startMs: 3000, durationMs: 2200 });
+  });
+
+  it("targets the edge from the pointer, not from the last snapped position", () => {
+    renderLanes();
+    // Snap onto 4200, then keep dragging: the edge must leave the snap and
+    // land where the pointer says (4500 → gridline-free at 4550).
+    const el = pressHandle("a1", "end", 200);
+    moveHandle(el, 200 + 115);
+    expect(clipState("a1").durationMs).toBe(2200);
+    moveHandle(el, 200 + 155);
+    expect(clipState("a1").durationMs).toBe(2550);
+    expect(ui().snapGuideMs).toBeNull();
+    releaseHandle(el);
+  });
+});

--- a/web/src/components/timeline/Tracks/__tests__/Clip.sourceCap.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/Clip.sourceCap.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Trim-end source cap: a video clip cannot grow past the probed length of its
+ * source; clips with no source length (image) are not capped.
+ */
+
+jest.mock("../useClipThumbnails", () => ({
+  useClipThumbnails: () => null
+}));
+jest.mock("../useAudioPeaks", () => ({
+  useAudioPeaks: () => ({ peaks: null, durationMs: null })
+}));
+jest.mock("../useAssetUrl", () => ({
+  useAssetUrl: (assetId: string | undefined) =>
+    assetId ? `blob:${assetId}` : undefined
+}));
+jest.mock("../../../../utils/probeMediaDuration", () => ({
+  probeMediaDurationMs: jest.fn()
+}));
+jest.mock("../../../../stores/WorkflowRunsStore", () => ({
+  __esModule: true,
+  default: <T,>(sel: (s: { focusedJob: Record<string, string> }) => T) =>
+    sel({ focusedJob: {} })
+}));
+jest.mock("../../../../stores/ErrorStore", () => ({
+  __esModule: true,
+  default: <T,>(sel: (s: { errors: Record<string, unknown> }) => T) =>
+    sel({ errors: {} }),
+  hasNodeError: () => false,
+  nodeErrorToDisplayString: () => ""
+}));
+jest.mock("../../../../stores/timeline/TimelineGenerationStore", () => ({
+  useTimelineGenerationStore: <T,>(
+    sel: (s: { clipJobs: Record<string, unknown> }) => T
+  ) => sel({ clipJobs: {} })
+}));
+
+import { act, waitFor } from "@testing-library/react";
+import {
+  installPointerEvent,
+  makeTrack,
+  makeClip,
+  seedTimeline,
+  renderLanes,
+  clipState,
+  dragHandle
+} from "../../../../test-utils/timelineClipHarness";
+import { probeMediaDurationMs } from "../../../../utils/probeMediaDuration";
+import { resetVideoDurationCache } from "../useClipSourceDuration";
+
+const probe = probeMediaDurationMs as jest.MockedFunction<
+  typeof probeMediaDurationMs
+>;
+
+beforeAll(installPointerEvent);
+
+beforeEach(() => {
+  resetVideoDurationCache();
+  probe.mockReset();
+});
+
+// Pointer travel of 30 px = 300 ms, clear of every snap candidate.
+const GROW_PX = 30;
+
+/** Let a resolved probe travel through the cache and into the hook's state. */
+const flushProbe = () =>
+  act(async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  });
+
+describe("trim-end source cap", () => {
+  it("caps a video clip at the probed source duration", async () => {
+    probe.mockResolvedValue(1200);
+    seedTimeline(
+      [makeTrack("t1", 0)],
+      [makeClip("v1", "t1", 2000, 1000, { currentAssetId: "vid" })]
+    );
+    renderLanes();
+    await waitFor(() => expect(probe).toHaveBeenCalledWith("blob:vid", "video"));
+    await flushProbe();
+
+    dragHandle("v1", "end", 200, 200 + GROW_PX);
+    expect(clipState("v1").durationMs).toBe(1200);
+  });
+
+  it("probes once per URL across clips sharing an asset", async () => {
+    probe.mockResolvedValue(5000);
+    seedTimeline(
+      [makeTrack("t1", 0)],
+      [
+        makeClip("v1", "t1", 0, 1000, { currentAssetId: "vid" }),
+        makeClip("v2", "t1", 3000, 1000, { currentAssetId: "vid" }),
+        makeClip("v3", "t1", 6000, 1000, { currentAssetId: "vid" })
+      ]
+    );
+    renderLanes();
+    await waitFor(() => expect(probe).toHaveBeenCalled());
+    await flushProbe();
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves an image clip uncapped and never probes it", async () => {
+    seedTimeline(
+      [makeTrack("t1", 0)],
+      [
+        makeClip("i1", "t1", 2000, 1000, {
+          mediaType: "image",
+          currentAssetId: "img"
+        })
+      ]
+    );
+    renderLanes();
+    await flushProbe();
+    dragHandle("i1", "end", 200, 200 + GROW_PX);
+    expect(clipState("i1").durationMs).toBe(1300);
+    expect(probe).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/timeline/Tracks/__tests__/ClipBody.render.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/ClipBody.render.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * ClipBody rendering: fade ramps, the incoming-transition wedge, the
+ * trim-aware filmstrip's beyond-source stripes, and trim-handle visibility.
+ * Mounts the body directly with a plain clip and jest.fn() handlers.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import type { TimelineClip } from "@nodetool-ai/timeline";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import type { ClipThumbnail } from "../clipThumbnails";
+
+let mockThumbnails: ClipThumbnail[] | null = null;
+jest.mock("../useClipThumbnails", () => ({
+  useClipThumbnails: () => mockThumbnails
+}));
+jest.mock("../useAudioPeaks", () => ({
+  useAudioPeaks: () => ({ peaks: null, durationMs: null })
+}));
+jest.mock("../useAssetUrl", () => ({
+  useAssetUrl: (id: string | undefined) => (id ? `blob:${id}` : undefined)
+}));
+
+import { ClipBody, CLIP_STATUS_MAP } from "../ClipBody";
+
+const makeClip = (overrides: Partial<TimelineClip> = {}): TimelineClip => ({
+  id: "c1",
+  trackId: "t1",
+  name: "Shot",
+  startMs: 0,
+  durationMs: 4000,
+  mediaType: "video",
+  sourceType: "imported",
+  status: "draft",
+  locked: false,
+  versions: [],
+  ...overrides
+});
+
+const renderBody = (
+  clip: TimelineClip,
+  props: { widthPx?: number; isSelected?: boolean } = {}
+) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ClipBody
+        clip={clip}
+        leftPx={0}
+        widthPx={props.widthPx ?? 400}
+        msPerPx={10}
+        isSelected={props.isSelected ?? false}
+        derivedStatus="draft"
+        statusInfo={CLIP_STATUS_MAP.draft}
+        handleDragPointerDown={jest.fn()}
+        handleClick={jest.fn()}
+        handleKeyDown={jest.fn()}
+        handleContextMenu={jest.fn()}
+        handleTrimStartPointerDown={jest.fn()}
+        handleTrimStartPointerMove={jest.fn()}
+        handleTrimEndPointerDown={jest.fn()}
+        handleTrimEndPointerMove={jest.fn()}
+        handleTrimPointerEnd={jest.fn()}
+        cutMode={false}
+        interactionLocked={false}
+      />
+    </ThemeProvider>
+  );
+
+beforeEach(() => {
+  mockThumbnails = null;
+});
+
+describe("ClipBody fades and transitions", () => {
+  it("draws fade ramps sized to the fade durations", () => {
+    renderBody(makeClip({ fadeInMs: 500, fadeOutMs: 1000 }));
+    expect(screen.getByTestId("clip-fade-in-c1")).toHaveStyle({
+      width: "50px"
+    });
+    expect(screen.getByTestId("clip-fade-out-c1")).toHaveStyle({
+      width: "100px"
+    });
+  });
+
+  it("draws nothing when the clip has no fades or transition", () => {
+    renderBody(makeClip());
+    expect(screen.queryByTestId("clip-fade-in-c1")).toBeNull();
+    expect(screen.queryByTestId("clip-fade-out-c1")).toBeNull();
+    expect(screen.queryByTestId("clip-transition-in-c1")).toBeNull();
+  });
+
+  it("skips fades on media that cannot fade", () => {
+    renderBody(makeClip({ mediaType: "text", fadeInMs: 500 }));
+    expect(screen.queryByTestId("clip-fade-in-c1")).toBeNull();
+  });
+
+  it("draws the incoming transition with its type when wide enough", () => {
+    renderBody(
+      makeClip({ transitionIn: { type: "crossfade", durationMs: 800 } })
+    );
+    const wedge = screen.getByTestId("clip-transition-in-c1");
+    expect(wedge).toHaveStyle({ width: "80px" });
+    expect(wedge).toHaveTextContent("crossfade");
+  });
+
+  it("drops the transition label on a narrow wedge", () => {
+    renderBody(makeClip({ transitionIn: { type: "wipe", durationMs: 300 } }));
+    const wedge = screen.getByTestId("clip-transition-in-c1");
+    expect(wedge).toHaveStyle({ width: "30px" });
+    expect(wedge).toHaveTextContent("");
+  });
+});
+
+describe("ClipBody filmstrip", () => {
+  const thumbnails: ClipThumbnail[] = Array.from({ length: 24 }, (_, k) => ({
+    time: k,
+    dataUrl: `frame-${k}`
+  }));
+
+  it("starts the strip at the trimmed in-point", () => {
+    mockThumbnails = thumbnails;
+    // 2 cells over source [10 s, 12 s].
+    renderBody(
+      makeClip({ currentAssetId: "a", inPointMs: 10_000, durationMs: 2000 }),
+      { widthPx: 120 }
+    );
+    const strip = screen.getByTestId("clip-c1").querySelector(
+      "div[style*='background-image']"
+    );
+    expect(strip).not.toBeNull();
+    expect(strip).toHaveStyle({ backgroundImage: "url(frame-10)" });
+  });
+
+  it("stripes the part of the clip that runs past the source", () => {
+    mockThumbnails = thumbnails;
+    // Source ends at ~24 s; the clip shows [20 s, 28 s], half of it past the end.
+    renderBody(
+      makeClip({ currentAssetId: "a", inPointMs: 20_000, durationMs: 8000 }),
+      { widthPx: 400 }
+    );
+    expect(screen.getByTestId("clip-beyond-source-c1")).toHaveStyle({
+      width: "50%"
+    });
+  });
+
+  it("leaves a clip inside its source unstriped", () => {
+    mockThumbnails = thumbnails;
+    renderBody(makeClip({ currentAssetId: "a", durationMs: 8000 }), {
+      widthPx: 400
+    });
+    expect(screen.queryByTestId("clip-beyond-source-c1")).toBeNull();
+  });
+});
+
+describe("ClipBody trim handles", () => {
+  it("keeps both grips on a wide clip", () => {
+    renderBody(makeClip(), { widthPx: 120 });
+    expect(screen.getByTestId("clip-trim-start-c1")).not.toHaveStyle({
+      display: "none"
+    });
+    expect(screen.getByTestId("clip-trim-end-c1")).not.toHaveStyle({
+      display: "none"
+    });
+  });
+
+  it("removes both grips from a clip too narrow to host them", () => {
+    renderBody(makeClip(), { widthPx: 12 });
+    const start = screen.getByTestId("clip-trim-start-c1");
+    const end = screen.getByTestId("clip-trim-end-c1");
+    expect(start).toHaveStyle({ display: "none", pointerEvents: "none" });
+    expect(end).toHaveStyle({ display: "none", pointerEvents: "none" });
+  });
+
+  it("shows the grips on a selected clip and hides them otherwise", () => {
+    const { unmount } = renderBody(makeClip(), { isSelected: true });
+    expect(screen.getByTestId("clip-trim-start-c1")).toHaveStyle({
+      opacity: "1"
+    });
+    unmount();
+    renderBody(makeClip(), { isSelected: false });
+    expect(screen.getByTestId("clip-trim-start-c1")).toHaveStyle({
+      opacity: "0"
+    });
+  });
+});

--- a/web/src/components/timeline/Tracks/__tests__/GestureReadout.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/GestureReadout.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import { GestureReadout, readoutText } from "../GestureReadout";
+import { useTimelineStore } from "../../../../stores/timeline/TimelineStore";
+import { useTimelineUIStore } from "../../../../stores/timeline/TimelineUIStore";
+
+const renderReadout = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <GestureReadout />
+    </ThemeProvider>
+  );
+
+beforeEach(() => {
+  useTimelineStore.setState({ fps: 30 });
+  useTimelineUIStore.setState({ gestureReadout: null });
+});
+
+describe("readoutText", () => {
+  const base = { clipId: "c", startMs: 2000, durationMs: 1500, inPointMs: 500 };
+
+  it("shows start · duration for a move", () => {
+    expect(readoutText({ ...base, kind: "move" }, 30)).toBe(
+      "00:00:02:00 · 00:00:01:15"
+    );
+  });
+
+  it("shows in · duration for trim-start", () => {
+    expect(readoutText({ ...base, kind: "trim-start" }, 30)).toBe(
+      "00:00:00:15 · 00:00:01:15"
+    );
+  });
+
+  it("shows duration · end for trim-end", () => {
+    expect(readoutText({ ...base, kind: "trim-end" }, 30)).toBe(
+      "00:00:01:15 · 00:00:03:15"
+    );
+  });
+});
+
+describe("GestureReadout", () => {
+  it("renders nothing without an active gesture", () => {
+    renderReadout();
+    expect(screen.queryByTestId("timeline-gesture-readout")).toBeNull();
+  });
+
+  it("renders the pill text for the published gesture", () => {
+    useTimelineUIStore.setState({
+      gestureReadout: {
+        clipId: "c",
+        kind: "move",
+        startMs: 2000,
+        durationMs: 1000,
+        inPointMs: 0
+      }
+    });
+    renderReadout();
+    expect(screen.getByTestId("timeline-gesture-readout")).toHaveTextContent(
+      "00:00:02:00 · 00:00:01:00"
+    );
+  });
+});

--- a/web/src/components/timeline/Tracks/__tests__/SnapGuideOverlay.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/SnapGuideOverlay.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import { SnapGuideOverlay } from "../SnapGuideOverlay";
+import { useTimelineUIStore } from "../../../../stores/timeline/TimelineUIStore";
+
+const renderOverlay = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <SnapGuideOverlay />
+    </ThemeProvider>
+  );
+
+beforeEach(() => {
+  useTimelineUIStore.setState({ msPerPx: 10, snapGuideMs: null });
+});
+
+describe("SnapGuideOverlay", () => {
+  it("renders nothing while no snap is engaged", () => {
+    renderOverlay();
+    expect(screen.queryByTestId("timeline-snap-guide")).toBeNull();
+  });
+
+  it("draws the guide at snapGuideMs / msPerPx", () => {
+    useTimelineUIStore.setState({ snapGuideMs: 8500 });
+    renderOverlay();
+    expect(screen.getByTestId("timeline-snap-guide")).toHaveStyle({
+      left: "850px"
+    });
+  });
+
+  it("follows the zoom level", () => {
+    useTimelineUIStore.setState({ snapGuideMs: 8500, msPerPx: 20 });
+    renderOverlay();
+    expect(screen.getByTestId("timeline-snap-guide")).toHaveStyle({
+      left: "425px"
+    });
+  });
+});

--- a/web/src/components/timeline/Tracks/__tests__/TrackHeaderContextMenu.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/TrackHeaderContextMenu.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * TrackHeader context menu — right-click (or a touch hold) on the header opens
+ * a menu whose items rename, duplicate, insert a same-type track above/below,
+ * or remove the track.
+ *
+ * Setup runs AFTER render: TimelineProvider creates a fresh store instance on
+ * mount and pushes it active, so static getState() only reaches that instance
+ * once the provider is rendered.
+ */
+import { describe, it, expect, jest, afterEach } from "@jest/globals";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import { makeClip } from "@nodetool-ai/timeline";
+
+import mockTheme from "../../../../__mocks__/themeMock";
+import { TracksRegion } from "../TracksRegion";
+import { TimelineProvider } from "../../../../stores/timeline/TimelineInstance";
+import { useTimelineStore } from "../../../../stores/timeline/TimelineStore";
+
+const renderRegion = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <TimelineProvider>
+        <TracksRegion heightPx={400} />
+      </TimelineProvider>
+    </ThemeProvider>
+  );
+
+/** Two video tracks and one audio track; returns their ids in order. */
+function seedTracks(): string[] {
+  act(() => {
+    const s = useTimelineStore.getState();
+    s.reset();
+    s.addTrack("video", "Video 1");
+    s.addTrack("video", "Video 2");
+    s.addTrack("audio", "Audio 1");
+  });
+  return trackIds();
+}
+
+function trackIds(): string[] {
+  return useTimelineStore.getState().tracks.map((t) => t.id);
+}
+
+function openMenu(trackId: string): HTMLElement {
+  fireEvent.contextMenu(screen.getByTestId(`track-header-${trackId}`), {
+    clientX: 40,
+    clientY: 20
+  });
+  return screen.getByTestId(`track-context-menu-${trackId}`);
+}
+
+const MENU_LABELS = [
+  "Rename",
+  "Duplicate track",
+  "Insert Video track above",
+  "Insert Video track below",
+  "Remove track"
+];
+
+describe("TrackHeader context menu", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("right-click opens the menu with the five track items", () => {
+    renderRegion();
+    const [, v2] = seedTracks();
+
+    const menu = openMenu(v2);
+
+    expect(menu).toBeInTheDocument();
+    const items = screen.getAllByRole("menuitem").map((el) => el.textContent);
+    expect(items).toEqual(MENU_LABELS);
+  });
+
+  it("labels the insert items with the header's own track type", () => {
+    renderRegion();
+    const [, , audio] = seedTracks();
+
+    openMenu(audio);
+
+    expect(screen.getByText("Insert Audio track above")).toBeInTheDocument();
+    expect(screen.getByText("Insert Audio track below")).toBeInTheDocument();
+  });
+
+  it("Insert Video track above inserts a track before this one", async () => {
+    renderRegion();
+    const [v1, v2, audio] = seedTracks();
+
+    openMenu(v2);
+    await userEvent.click(screen.getByText("Insert Video track above"));
+
+    const ids = trackIds();
+    expect(ids).toHaveLength(4);
+    expect(ids[0]).toBe(v1);
+    expect(ids[2]).toBe(v2);
+    expect(ids[3]).toBe(audio);
+    const inserted = useTimelineStore.getState().tracks[1];
+    expect(inserted.type).toBe("video");
+    expect(useTimelineStore.getState().tracks.map((t) => t.index)).toEqual([
+      0, 1, 2, 3
+    ]);
+  });
+
+  it("Insert Video track below inserts a track after this one", async () => {
+    renderRegion();
+    const [v1, v2] = seedTracks();
+
+    openMenu(v1);
+    await userEvent.click(screen.getByText("Insert Video track below"));
+
+    const ids = trackIds();
+    expect(ids[0]).toBe(v1);
+    expect(ids[2]).toBe(v2);
+    expect(useTimelineStore.getState().tracks[1].type).toBe("video");
+  });
+
+  it("Duplicate track adds a copy right after with the clips copied", async () => {
+    renderRegion();
+    const [v1, v2, audio] = seedTracks();
+    act(() => {
+      useTimelineStore.setState({
+        clips: [
+          makeClip({ id: "c1", trackId: v1, startMs: 0, durationMs: 1000 }),
+          makeClip({ id: "c2", trackId: v1, startMs: 2000, durationMs: 500 })
+        ]
+      });
+    });
+
+    openMenu(v1);
+    await userEvent.click(screen.getByText("Duplicate track"));
+
+    const ids = trackIds();
+    expect(ids).toHaveLength(4);
+    const copyId = ids[1];
+    expect([v1, v2, audio]).not.toContain(copyId);
+    expect(ids[2]).toBe(v2);
+    expect(useTimelineStore.getState().tracks[1].name).toBe("Video 1 copy");
+
+    const clips = useTimelineStore.getState().clips;
+    const copies = clips.filter((c) => c.trackId === copyId);
+    expect(copies).toHaveLength(2);
+    expect(copies.map((c) => c.id)).not.toContain("c1");
+    expect(copies.map((c) => c.id)).not.toContain("c2");
+    expect(copies.map((c) => c.startMs).sort()).toEqual([0, 2000]);
+    expect(clips.filter((c) => c.trackId === v1)).toHaveLength(2);
+  });
+
+  it("Rename puts the name input in edit mode", async () => {
+    renderRegion();
+    const [v1] = seedTracks();
+    const input = screen.getByLabelText("Track name: Video 1");
+    expect(input).toHaveAttribute("readonly");
+    expect(input).toHaveAttribute("title", "Double-click to rename");
+
+    openMenu(v1);
+    await userEvent.click(screen.getByText("Rename"));
+
+    expect(input).not.toHaveAttribute("readonly");
+    expect(input).not.toHaveAttribute("title");
+  });
+
+  it("Remove track opens the confirm dialog", async () => {
+    renderRegion();
+    const [, v2] = seedTracks();
+
+    openMenu(v2);
+    await userEvent.click(screen.getByText("Remove track"));
+
+    expect(
+      screen.getByText('Remove track "Video 2" and all its clips?')
+    ).toBeInTheDocument();
+    expect(trackIds()).toHaveLength(3);
+  });
+
+  it("does not open while a name edit is active", () => {
+    renderRegion();
+    const [v1] = seedTracks();
+    fireEvent.doubleClick(screen.getByLabelText("Track name: Video 1"));
+
+    fireEvent.contextMenu(screen.getByTestId(`track-header-${v1}`));
+
+    expect(
+      screen.queryByTestId(`track-context-menu-${v1}`)
+    ).not.toBeInTheDocument();
+  });
+
+  it("a touch hold on the header opens the same menu", () => {
+    jest.useFakeTimers();
+    renderRegion();
+    const [v1] = seedTracks();
+    const header = screen.getByTestId(`track-header-${v1}`);
+
+    const down = new MouseEvent("pointerdown", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 30,
+      clientY: 10
+    });
+    Object.defineProperty(down, "pointerType", { value: "touch" });
+    Object.defineProperty(down, "pointerId", { value: 1 });
+    fireEvent(header, down);
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+
+    expect(screen.getByTestId(`track-context-menu-${v1}`)).toBeInTheDocument();
+  });
+
+  it("a touch hold on the resize handle does not open the menu", () => {
+    jest.useFakeTimers();
+    renderRegion();
+    const [v1] = seedTracks();
+    const handle = screen
+      .getByTestId(`track-header-${v1}`)
+      .querySelector('[aria-label="Resize track height"]') as HTMLElement;
+    handle.setPointerCapture = () => {};
+
+    const down = new MouseEvent("pointerdown", {
+      bubbles: true,
+      cancelable: true
+    });
+    Object.defineProperty(down, "pointerType", { value: "touch" });
+    Object.defineProperty(down, "pointerId", { value: 1 });
+    fireEvent(handle, down);
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+
+    expect(
+      screen.queryByTestId(`track-context-menu-${v1}`)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/timeline/Tracks/__tests__/clipFadeGeometry.test.ts
+++ b/web/src/components/timeline/Tracks/__tests__/clipFadeGeometry.test.ts
@@ -1,0 +1,66 @@
+import { deriveClipFadeMarkers } from "../clipFadeGeometry";
+
+describe("deriveClipFadeMarkers", () => {
+  it("maps fade and transition durations to pixels at the current zoom", () => {
+    expect(
+      deriveClipFadeMarkers(
+        {
+          fadeInMs: 500,
+          fadeOutMs: 300,
+          transitionIn: { type: "crossfade", durationMs: 800 }
+        },
+        10,
+        400
+      )
+    ).toEqual({
+      fadeIn: { widthPx: 50 },
+      fadeOut: { widthPx: 30 },
+      transitionIn: { widthPx: 80, type: "crossfade" }
+    });
+  });
+
+  it("leaves every marker out when the clip carries none", () => {
+    expect(deriveClipFadeMarkers({}, 10, 400)).toEqual({
+      fadeIn: undefined,
+      fadeOut: undefined,
+      transitionIn: undefined
+    });
+    expect(deriveClipFadeMarkers({ fadeInMs: 0 }, 10, 400).fadeIn).toBeUndefined();
+  });
+
+  it("clamps a single fade to the clip width", () => {
+    expect(deriveClipFadeMarkers({ fadeInMs: 9000 }, 10, 100).fadeIn).toEqual({
+      widthPx: 100
+    });
+    expect(
+      deriveClipFadeMarkers(
+        { transitionIn: { type: "wipe", durationMs: 9000 } },
+        10,
+        100
+      ).transitionIn
+    ).toEqual({ widthPx: 100, type: "wipe" });
+  });
+
+  it("clamps overlapping fades to half the clip each", () => {
+    const markers = deriveClipFadeMarkers(
+      { fadeInMs: 800, fadeOutMs: 800 },
+      10,
+      100
+    );
+    expect(markers.fadeIn).toEqual({ widthPx: 50 });
+    expect(markers.fadeOut).toEqual({ widthPx: 50 });
+
+    // Only the longer one is clamped when the shorter fits in its half.
+    const uneven = deriveClipFadeMarkers(
+      { fadeInMs: 200, fadeOutMs: 900 },
+      10,
+      100
+    );
+    expect(uneven.fadeIn).toEqual({ widthPx: 20 });
+    expect(uneven.fadeOut).toEqual({ widthPx: 50 });
+  });
+
+  it("drops sub-pixel ramps", () => {
+    expect(deriveClipFadeMarkers({ fadeInMs: 10 }, 10, 400).fadeIn).toBeUndefined();
+  });
+});

--- a/web/src/components/timeline/Tracks/__tests__/clipSnap.test.ts
+++ b/web/src/components/timeline/Tracks/__tests__/clipSnap.test.ts
@@ -1,0 +1,91 @@
+import type { TimelineClip } from "@nodetool-ai/timeline";
+import {
+  collectSnapCandidates,
+  snapClipWindow,
+  snapEdge,
+  SNAP_THRESHOLD_PX
+} from "../clipSnap";
+
+const clip = (
+  id: string,
+  startMs: number,
+  durationMs: number,
+  linkId?: string
+): TimelineClip => ({
+  id,
+  trackId: "t1",
+  name: id,
+  startMs,
+  durationMs,
+  mediaType: "video",
+  sourceType: "imported",
+  status: "draft",
+  locked: false,
+  versions: [],
+  linkId
+});
+
+const MS_PER_PX = 10;
+const THRESHOLD_MS = SNAP_THRESHOLD_PX * MS_PER_PX;
+
+describe("collectSnapCandidates", () => {
+  it("includes the playhead, second gridlines and other clips' edges", () => {
+    const out = collectSnapCandidates(
+      [clip("a", 2500, 1000), clip("b", 6200, 800)],
+      3000,
+      1234,
+      new Set(["a"])
+    );
+    expect(out).toEqual([0, 1000, 1234, 2000, 3000, 4000, 6200, 7000]);
+  });
+
+  it("drops the linked siblings of an excluded clip", () => {
+    const out = collectSnapCandidates(
+      [clip("v", 2500, 1000, "L"), clip("a", 2500, 1000, "L"), clip("x", 6200, 100)],
+      0,
+      0,
+      new Set(["v"])
+    );
+    expect(out).not.toContain(2500);
+    expect(out).not.toContain(3500);
+    expect(out).toContain(6200);
+  });
+});
+
+describe("snapEdge", () => {
+  it("locks onto a candidate inside the threshold", () => {
+    expect(snapEdge(4150, [4200], MS_PER_PX)).toEqual({ valueMs: 4200, guideMs: 4200 });
+  });
+
+  it("leaves the edge alone outside the threshold", () => {
+    expect(snapEdge(4000, [4000 + THRESHOLD_MS + 1], MS_PER_PX)).toEqual({
+      valueMs: 4000,
+      guideMs: null
+    });
+  });
+});
+
+describe("snapClipWindow", () => {
+  it("prefers the start edge when it is the closer hit", () => {
+    // start 1050 is 50 from 1000; end 2050 is 70 from 2120.
+    expect(snapClipWindow(1050, 1000, [1000, 2120], MS_PER_PX)).toEqual({
+      startMs: 1000,
+      guideMs: 1000
+    });
+  });
+
+  it("shifts the start so the end lands when the end edge is closer", () => {
+    // start 1070 is 70 from 1000; end 2070 is 30 from 2100.
+    expect(snapClipWindow(1070, 1000, [1000, 2100], MS_PER_PX)).toEqual({
+      startMs: 1100,
+      guideMs: 2100
+    });
+  });
+
+  it("returns the raw start with no guide when neither edge hits", () => {
+    expect(snapClipWindow(1500, 1000, [1000, 3000], MS_PER_PX)).toEqual({
+      startMs: 1500,
+      guideMs: null
+    });
+  });
+});

--- a/web/src/components/timeline/Tracks/__tests__/filmstripCells.test.ts
+++ b/web/src/components/timeline/Tracks/__tests__/filmstripCells.test.ts
@@ -1,0 +1,95 @@
+import type { ClipThumbnail } from "../clipThumbnails";
+import {
+  beyondSourceFraction,
+  clipSourceWindow,
+  selectFilmstripCells
+} from "../filmstripCells";
+
+/** 24 samples spread uniformly over a 23 s source: frame k at k seconds. */
+const thumbnails: ClipThumbnail[] = Array.from({ length: 24 }, (_, k) => ({
+  time: k,
+  dataUrl: `frame-${k}`
+}));
+
+const urls = (cells: { url: string }[]) => cells.map((c) => c.url);
+
+describe("selectFilmstripCells", () => {
+  it("spreads an untrimmed clip uniformly over the whole source", () => {
+    expect(
+      urls(selectFilmstripCells(thumbnails, 4, 0, 23_000))
+    ).toEqual(["frame-0", "frame-8", "frame-15", "frame-23"]);
+  });
+
+  it("starts at the in-point when the clip is trimmed", () => {
+    expect(
+      urls(selectFilmstripCells(thumbnails, 3, 10_000, 20_000))
+    ).toEqual(["frame-10", "frame-15", "frame-20"]);
+  });
+
+  it("repeats the in-point frame for a single cell", () => {
+    expect(urls(selectFilmstripCells(thumbnails, 1, 7_000, 12_000))).toEqual([
+      "frame-7"
+    ]);
+  });
+
+  it("picks the nearest sample when the target falls between two", () => {
+    // 4 cells over [0, 10 s]: targets 0, 3.33, 6.67, 10.
+    expect(
+      urls(selectFilmstripCells(thumbnails, 4, 0, 10_000))
+    ).toEqual(["frame-0", "frame-3", "frame-7", "frame-10"]);
+  });
+
+  it("clamps to the last frame past the source end", () => {
+    expect(urls(selectFilmstripCells(thumbnails, 2, 20_000, 40_000))).toEqual([
+      "frame-20",
+      "frame-23"
+    ]);
+  });
+
+  it("returns nothing without thumbnails or cells", () => {
+    expect(selectFilmstripCells([], 4, 0, 1000)).toEqual([]);
+    expect(selectFilmstripCells(thumbnails, 0, 0, 1000)).toEqual([]);
+  });
+});
+
+describe("clipSourceWindow", () => {
+  it("derives the out-point from duration and speed when unset", () => {
+    expect(
+      clipSourceWindow({ inPointMs: 1000, durationMs: 4000, speedMultiplier: 2 })
+    ).toEqual({ inPointMs: 1000, outPointMs: 9000 });
+  });
+
+  it("plays 1:1 once the speed is baked", () => {
+    expect(
+      clipSourceWindow({
+        durationMs: 4000,
+        speedMultiplier: 2,
+        speedBaked: true
+      })
+    ).toEqual({ inPointMs: 0, outPointMs: 4000 });
+  });
+
+  it("prefers an explicit out-point", () => {
+    expect(
+      clipSourceWindow({ inPointMs: 500, outPointMs: 2500, durationMs: 9999 })
+    ).toEqual({ inPointMs: 500, outPointMs: 2500 });
+  });
+});
+
+describe("beyondSourceFraction", () => {
+  it("is zero while the clip ends inside the source", () => {
+    // Estimated source end: 23 s + 1 s interval = 24 s.
+    expect(beyondSourceFraction(thumbnails, 0, 24_000)).toBe(0);
+    expect(beyondSourceFraction(thumbnails, 5_000, 12_000)).toBe(0);
+  });
+
+  it("is the share of the clip past the estimated source end", () => {
+    // [20 s, 28 s] is 8 s wide; 4 s of it lie past 24 s.
+    expect(beyondSourceFraction(thumbnails, 20_000, 28_000)).toBeCloseTo(0.5);
+  });
+
+  it("caps at the whole clip and needs two samples to estimate", () => {
+    expect(beyondSourceFraction(thumbnails, 30_000, 40_000)).toBe(1);
+    expect(beyondSourceFraction([thumbnails[0]], 0, 99_000)).toBe(0);
+  });
+});

--- a/web/src/components/timeline/Tracks/__tests__/useClipDrag.autoScroll.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/useClipDrag.autoScroll.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Edge auto-scroll during a clip drag: the lanes scroll while the pointer
+ * sits in the edge zone, the clip follows by the scrolled distance, and the
+ * loop stops when the pointer leaves the zone or the gesture ends.
+ */
+
+jest.mock("../useClipThumbnails", () => ({
+  useClipThumbnails: () => null
+}));
+jest.mock("../useAudioPeaks", () => ({
+  useAudioPeaks: () => ({ peaks: null, durationMs: null })
+}));
+jest.mock("../../../../stores/AssetStore", () => ({
+  useAssetStore: <T,>(sel: (s: { get: () => Promise<null> }) => T) =>
+    sel({ get: () => Promise.resolve(null) })
+}));
+jest.mock("../../../../stores/WorkflowRunsStore", () => ({
+  __esModule: true,
+  default: <T,>(sel: (s: { focusedJob: Record<string, string> }) => T) =>
+    sel({ focusedJob: {} })
+}));
+jest.mock("../../../../stores/ErrorStore", () => ({
+  __esModule: true,
+  default: <T,>(sel: (s: { errors: Record<string, unknown> }) => T) =>
+    sel({ errors: {} }),
+  hasNodeError: () => false,
+  nodeErrorToDisplayString: () => ""
+}));
+jest.mock("../../../../stores/timeline/TimelineGenerationStore", () => ({
+  useTimelineGenerationStore: <T,>(
+    sel: (s: { clipJobs: Record<string, unknown> }) => T
+  ) => sel({ clipJobs: {} })
+}));
+
+import React from "react";
+import { act, screen } from "@testing-library/react";
+import {
+  installPointerEvent,
+  makeTrack,
+  makeClip,
+  seedTimeline,
+  renderLanes,
+  clipState,
+  pressClip,
+  moveClipPointer,
+  releaseClipPointer
+} from "../../../../test-utils/timelineClipHarness";
+import {
+  autoScrollSpeed,
+  AUTO_SCROLL_EDGE_PX,
+  AUTO_SCROLL_MAX_PX_PER_FRAME
+} from "../useClipDrag";
+
+beforeAll(installPointerEvent);
+
+const VIEWPORT = { left: 0, right: 400 };
+
+describe("autoScrollSpeed", () => {
+  it("is zero away from both edges", () => {
+    expect(autoScrollSpeed(200, VIEWPORT)).toBe(0);
+    expect(autoScrollSpeed(AUTO_SCROLL_EDGE_PX, VIEWPORT)).toBe(0);
+  });
+
+  it("grows with the overshoot and is capped at the edge", () => {
+    const half = autoScrollSpeed(400 - AUTO_SCROLL_EDGE_PX / 2, VIEWPORT);
+    expect(half).toBeCloseTo(AUTO_SCROLL_MAX_PX_PER_FRAME / 2);
+    expect(autoScrollSpeed(400, VIEWPORT)).toBe(AUTO_SCROLL_MAX_PX_PER_FRAME);
+    expect(autoScrollSpeed(900, VIEWPORT)).toBe(AUTO_SCROLL_MAX_PX_PER_FRAME);
+  });
+
+  it("is negative near the left edge", () => {
+    expect(autoScrollSpeed(0, VIEWPORT)).toBe(-AUTO_SCROLL_MAX_PX_PER_FRAME);
+  });
+});
+
+describe("edge auto-scroll while dragging", () => {
+  // Hand-stepped frame queue: rAF enqueues, cAF removes, flushFrame runs one
+  // frame's worth of callbacks.
+  let frames: Map<number, FrameRequestCallback>;
+  let nextFrameId: number;
+  let rafSpy: jest.SpyInstance;
+
+  const flushFrame = () => {
+    const pending = [...frames.values()];
+    frames.clear();
+    act(() => {
+      for (const cb of pending) {
+        cb(0);
+      }
+    });
+  };
+
+  beforeEach(() => {
+    frames = new Map();
+    nextFrameId = 1;
+    rafSpy = jest
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb) => {
+        const id = nextFrameId++;
+        frames.set(id, cb);
+        return id;
+      });
+    jest.spyOn(window, "cancelAnimationFrame").mockImplementation((id) => {
+      frames.delete(id);
+    });
+    // The cross-track hit test also runs on a frame; jsdom has no
+    // elementsFromPoint.
+    document.elementsFromPoint = () => [];
+    seedTimeline(
+      [makeTrack("t1", 0)],
+      [makeClip("a1", "t1", 2000, 1000)],
+      40_000
+    );
+  });
+
+  afterEach(() => {
+    rafSpy.mockRestore();
+    jest.restoreAllMocks();
+    Reflect.deleteProperty(document, "elementsFromPoint");
+  });
+
+  /** A 400 px viewport over 2000 px of content, scrolled to `scrollLeft`. */
+  const renderInScrollArea = (scrollLeft = 0) => {
+    renderLanes((lanes) => (
+      <div data-testid="tracks-scroll-area">{lanes}</div>
+    ));
+    const area = screen.getByTestId("tracks-scroll-area");
+    area.getBoundingClientRect = () =>
+      ({ ...VIEWPORT, top: 0, bottom: 100, width: 400, height: 100, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect;
+    Object.defineProperty(area, "scrollWidth", { value: 2000, configurable: true });
+    Object.defineProperty(area, "clientWidth", { value: 400, configurable: true });
+    area.scrollLeft = scrollLeft;
+    return area;
+  };
+
+  it("scrolls the lanes and carries the clip while the pointer is at the edge", () => {
+    const area = renderInScrollArea();
+    pressClip("a1", 100);
+    // At the right edge: full speed. Alt keeps snapping out of the arithmetic.
+    moveClipPointer(400, { altKey: true });
+    expect(clipState("a1").startMs).toBe(2000 + 300 * 10);
+    expect(area.scrollLeft).toBe(0);
+
+    flushFrame();
+    expect(area.scrollLeft).toBe(AUTO_SCROLL_MAX_PX_PER_FRAME);
+    // The scrolled distance is added to the pointer travel.
+    expect(clipState("a1").startMs).toBe(
+      2000 + (300 + AUTO_SCROLL_MAX_PX_PER_FRAME) * 10
+    );
+
+    flushFrame();
+    expect(area.scrollLeft).toBe(2 * AUTO_SCROLL_MAX_PX_PER_FRAME);
+    releaseClipPointer();
+  });
+
+  it("stops when the pointer leaves the edge zone", () => {
+    const area = renderInScrollArea();
+    pressClip("a1", 100);
+    moveClipPointer(400, { altKey: true });
+    flushFrame();
+    expect(area.scrollLeft).toBe(AUTO_SCROLL_MAX_PX_PER_FRAME);
+
+    moveClipPointer(200, { altKey: true });
+    flushFrame();
+    flushFrame();
+    expect(area.scrollLeft).toBe(AUTO_SCROLL_MAX_PX_PER_FRAME);
+    releaseClipPointer();
+  });
+
+  it("stops on pointerup", () => {
+    const area = renderInScrollArea();
+    pressClip("a1", 100);
+    moveClipPointer(400, { altKey: true });
+    flushFrame();
+    releaseClipPointer();
+    const after = area.scrollLeft;
+    flushFrame();
+    flushFrame();
+    expect(area.scrollLeft).toBe(after);
+  });
+
+  it("does not scroll past the end of the content", () => {
+    const area = renderInScrollArea(2000 - 400);
+    pressClip("a1", 100);
+    moveClipPointer(400, { altKey: true });
+    flushFrame();
+    expect(area.scrollLeft).toBe(1600);
+    expect(clipState("a1").startMs).toBe(2000 + 300 * 10);
+    releaseClipPointer();
+  });
+});

--- a/web/src/components/timeline/Tracks/clipFadeGeometry.ts
+++ b/web/src/components/timeline/Tracks/clipFadeGeometry.ts
@@ -1,0 +1,54 @@
+import type { TimelineClip } from "@nodetool-ai/timeline";
+
+interface FadeMarker {
+  widthPx: number;
+}
+
+interface TransitionMarker {
+  widthPx: number;
+  type: string;
+}
+
+export interface ClipFadeMarkers {
+  fadeIn?: FadeMarker;
+  fadeOut?: FadeMarker;
+  transitionIn?: TransitionMarker;
+}
+
+/** Below this the ramp is sub-pixel noise; leave it out. */
+const MIN_MARKER_WIDTH_PX = 2;
+
+/**
+ * Pixel geometry for a clip's fade ramps and incoming transition at the
+ * current zoom. Each width is `ms / msPerPx` clamped to the clip; when the two
+ * fades together would exceed the clip, each is clamped to half so they meet
+ * in the middle rather than cross.
+ */
+export function deriveClipFadeMarkers(
+  clip: Pick<TimelineClip, "fadeInMs" | "fadeOutMs" | "transitionIn">,
+  msPerPx: number,
+  clipWidthPx: number
+): ClipFadeMarkers {
+  const toPx = (ms: number): number =>
+    Math.min(clipWidthPx, Math.max(0, ms / msPerPx));
+
+  let fadeInPx = toPx(clip.fadeInMs ?? 0);
+  let fadeOutPx = toPx(clip.fadeOutMs ?? 0);
+  if (fadeInPx + fadeOutPx > clipWidthPx) {
+    const half = clipWidthPx / 2;
+    fadeInPx = Math.min(fadeInPx, half);
+    fadeOutPx = Math.min(fadeOutPx, half);
+  }
+
+  const transitionPx = toPx(clip.transitionIn?.durationMs ?? 0);
+
+  return {
+    fadeIn: fadeInPx >= MIN_MARKER_WIDTH_PX ? { widthPx: fadeInPx } : undefined,
+    fadeOut:
+      fadeOutPx >= MIN_MARKER_WIDTH_PX ? { widthPx: fadeOutPx } : undefined,
+    transitionIn:
+      clip.transitionIn && transitionPx >= MIN_MARKER_WIDTH_PX
+        ? { widthPx: transitionPx, type: clip.transitionIn.type }
+        : undefined
+  };
+}

--- a/web/src/components/timeline/Tracks/clipSnap.ts
+++ b/web/src/components/timeline/Tracks/clipSnap.ts
@@ -1,0 +1,164 @@
+/**
+ * clipSnap
+ *
+ * Snap resolution shared by the clip drag and trim gestures. The hooks snap
+ * the edge they move and hand the store an already-snapped delta, so the
+ * store never snaps on its own during a pointer gesture.
+ *
+ * Also owns the gesture-feedback publishing (snap guide + geometry readout)
+ * so both hooks write the UI store the same way: only when a value changed,
+ * and cleared together on gesture end.
+ */
+
+import { buildSnapPoints, resolveSnap } from "@nodetool-ai/timeline";
+import type { TimelineClip } from "@nodetool-ai/timeline";
+import type {
+  GestureReadout,
+  TimelineUIState
+} from "../../../stores/timeline/TimelineUIStore";
+
+/** Pointer distance (px) within which an edge locks onto a candidate. */
+export const SNAP_THRESHOLD_PX = 8;
+
+/** Gridline spacing for the tick candidates. */
+const TICK_INTERVAL_MS = 1000;
+
+/**
+ * The candidate set for one gesture, snapshotted at pointerdown: the
+ * playhead, every second gridline across the document, and every clip edge
+ * except those of `excludeClipIds`. Linked siblings of the excluded clips are
+ * excluded too — they move with the gesture and share its edges, so keeping
+ * them would glue the clip to where it started.
+ */
+export function collectSnapCandidates(
+  clips: readonly TimelineClip[],
+  durationMs: number,
+  playheadMs: number,
+  excludeClipIds: ReadonlySet<string>
+): number[] {
+  const linkIds = new Set<string>();
+  for (const c of clips) {
+    if (excludeClipIds.has(c.id) && c.linkId !== undefined) {
+      linkIds.add(c.linkId);
+    }
+  }
+  const exclude = new Set(excludeClipIds);
+  if (linkIds.size > 0) {
+    for (const c of clips) {
+      if (c.linkId !== undefined && linkIds.has(c.linkId)) {
+        exclude.add(c.id);
+      }
+    }
+  }
+  return buildSnapPoints({
+    clips,
+    excludeClipIds: exclude,
+    playheadMs,
+    tickIntervalMs: TICK_INTERVAL_MS,
+    maxTimeMs: durationMs + TICK_INTERVAL_MS
+  });
+}
+
+export interface EdgeSnap {
+  /** The edge position after snapping (unchanged when nothing hit). */
+  valueMs: number;
+  /** The candidate the edge locked onto, or null when it did not snap. */
+  guideMs: number | null;
+}
+
+/** Snap one edge to the closest candidate within the threshold. */
+export function snapEdge(
+  edgeMs: number,
+  candidates: number[],
+  msPerPx: number
+): EdgeSnap {
+  const hit = resolveSnap(edgeMs, candidates, SNAP_THRESHOLD_PX, msPerPx);
+  return { valueMs: hit.value, guideMs: hit.snapped ? hit.value : null };
+}
+
+export interface WindowSnap {
+  /** The clip's start after snapping whichever edge was closer to a hit. */
+  startMs: number;
+  /** The candidate an edge locked onto, or null when neither edge snapped. */
+  guideMs: number | null;
+}
+
+/**
+ * Snap a whole clip window: try both the start and the end edge and keep
+ * the closer hit, shifting the start so that edge lands on its candidate.
+ */
+export function snapClipWindow(
+  startMs: number,
+  durationMs: number,
+  candidates: number[],
+  msPerPx: number
+): WindowSnap {
+  const start = resolveSnap(startMs, candidates, SNAP_THRESHOLD_PX, msPerPx);
+  const end = resolveSnap(
+    startMs + durationMs,
+    candidates,
+    SNAP_THRESHOLD_PX,
+    msPerPx
+  );
+  if (start.snapped && (!end.snapped || start.distanceMs <= end.distanceMs)) {
+    return { startMs: start.value, guideMs: start.value };
+  }
+  if (end.snapped) {
+    return { startMs: end.value - durationMs, guideMs: end.value };
+  }
+  return { startMs, guideMs: null };
+}
+
+type FeedbackStore = Pick<
+  TimelineUIState,
+  "snapGuideMs" | "gestureReadout" | "setSnapGuide" | "setGestureReadout"
+>;
+
+/** Build the readout for a clip's current geometry. */
+export function readoutFor(
+  clip: TimelineClip,
+  kind: GestureReadout["kind"]
+): GestureReadout {
+  return {
+    clipId: clip.id,
+    kind,
+    startMs: clip.startMs,
+    durationMs: clip.durationMs,
+    inPointMs: clip.inPointMs ?? 0
+  };
+}
+
+const sameReadout = (a: GestureReadout | null, b: GestureReadout) =>
+  a !== null &&
+  a.clipId === b.clipId &&
+  a.kind === b.kind &&
+  a.startMs === b.startMs &&
+  a.durationMs === b.durationMs &&
+  a.inPointMs === b.inPointMs;
+
+/**
+ * Write the guide and readout, publishing only the values that changed —
+ * pointermove fires far more often than either value moves.
+ */
+export function publishGestureFeedback(
+  ui: FeedbackStore,
+  guideMs: number | null,
+  readout: GestureReadout
+): void {
+  if (ui.snapGuideMs !== guideMs) {
+    ui.setSnapGuide(guideMs);
+  }
+  if (!sameReadout(ui.gestureReadout, readout)) {
+    ui.setGestureReadout(readout);
+  }
+}
+
+/** Clear both on pointerup/cancel. No-op when nothing was published. */
+export function clearGestureFeedback(ui: FeedbackStore): void {
+  if (ui.snapGuideMs !== null) {
+    ui.setSnapGuide(null);
+  }
+  if (ui.gestureReadout !== null) {
+    ui.setGestureReadout(null);
+  }
+}

--- a/web/src/components/timeline/Tracks/filmstripCells.ts
+++ b/web/src/components/timeline/Tracks/filmstripCells.ts
@@ -1,0 +1,84 @@
+import { sourceRate } from "@nodetool-ai/timeline";
+import type { TimelineClip } from "@nodetool-ai/timeline";
+
+import type { ClipThumbnail } from "./clipThumbnails";
+
+export interface FilmstripCell {
+  url: string;
+}
+
+/** Source window a clip shows, in source milliseconds. Mirrors `trimClip`. */
+export function clipSourceWindow(
+  clip: Pick<
+    TimelineClip,
+    "inPointMs" | "outPointMs" | "durationMs" | "speedMultiplier" | "speedBaked"
+  >
+): { inPointMs: number; outPointMs: number } {
+  const inPointMs = clip.inPointMs ?? 0;
+  const outPointMs =
+    clip.outPointMs ?? inPointMs + clip.durationMs * sourceRate(clip);
+  return { inPointMs, outPointMs };
+}
+
+/**
+ * Pick one thumbnail per filmstrip cell across the clip's source window.
+ * Cell `i` sits at `inPointMs + i / (cellCount - 1) * (outPointMs - inPointMs)`
+ * and takes the thumbnail whose `time` is nearest, so a trimmed in-point shows
+ * later frames instead of always starting at the source's first frame.
+ * `thumbnails` is assumed sorted by `time`, as the extractor emits them.
+ */
+export function selectFilmstripCells(
+  thumbnails: readonly ClipThumbnail[],
+  cellCount: number,
+  inPointMs: number,
+  outPointMs: number
+): FilmstripCell[] {
+  if (thumbnails.length === 0 || cellCount <= 0) return [];
+  const spanMs = Math.max(0, outPointMs - inPointMs);
+  const steps = Math.max(1, cellCount - 1);
+  const cells: FilmstripCell[] = [];
+  for (let i = 0; i < cellCount; i += 1) {
+    const targetSec = (inPointMs + (i / steps) * spanMs) / 1000;
+    cells.push({ url: nearestThumbnail(thumbnails, targetSec).dataUrl });
+  }
+  return cells;
+}
+
+function nearestThumbnail(
+  thumbnails: readonly ClipThumbnail[],
+  targetSec: number
+): ClipThumbnail {
+  let best = thumbnails[0];
+  let bestDelta = Math.abs(best.time - targetSec);
+  for (let i = 1; i < thumbnails.length; i += 1) {
+    const delta = Math.abs(thumbnails[i].time - targetSec);
+    if (delta < bestDelta) {
+      best = thumbnails[i];
+      bestDelta = delta;
+    } else if (delta > bestDelta) {
+      break;
+    }
+  }
+  return best;
+}
+
+/**
+ * Width of the region past the source's end, as a fraction of the clip
+ * (0 when the clip ends inside the source). The source end is estimated from
+ * the sampled thumbnails: the last sample's time plus one sample interval,
+ * since the extractor spreads samples uniformly over the whole source.
+ */
+export function beyondSourceFraction(
+  thumbnails: readonly ClipThumbnail[],
+  inPointMs: number,
+  outPointMs: number
+): number {
+  if (thumbnails.length < 2) return 0;
+  const first = thumbnails[0].time;
+  const last = thumbnails[thumbnails.length - 1].time;
+  const intervalSec = (last - first) / (thumbnails.length - 1);
+  const sourceEndMs = (last + intervalSec) * 1000;
+  const spanMs = outPointMs - inPointMs;
+  if (spanMs <= 0 || outPointMs <= sourceEndMs) return 0;
+  return Math.min(1, (outPointMs - sourceEndMs) / spanMs);
+}

--- a/web/src/components/timeline/Tracks/useAssetUrl.ts
+++ b/web/src/components/timeline/Tracks/useAssetUrl.ts
@@ -1,0 +1,39 @@
+/**
+ * useAssetUrl
+ *
+ * Resolves a stored asset id to its fetchable URL through the AssetStore.
+ * Returns undefined until the asset resolves, when there is no id, or when the
+ * asset is unavailable. A resolution still in flight when the id changes is
+ * discarded so a slow earlier asset can never overwrite a newer one.
+ */
+
+import { useEffect, useState } from "react";
+import { useAssetStore } from "../../../stores/AssetStore";
+import { getAssetUrl } from "../../../utils/assetHelpers";
+
+export function useAssetUrl(assetId: string | undefined): string | undefined {
+  const getAsset = useAssetStore((s) => s.get);
+  const [url, setUrl] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!assetId) {
+      setUrl(undefined);
+      return;
+    }
+    let cancelled = false;
+    getAsset(assetId)
+      .then((asset) => {
+        if (!cancelled) {
+          setUrl(getAssetUrl(asset) ?? undefined);
+        }
+      })
+      .catch(() => {
+        // Asset unavailable — leave the url unset; the caller renders without it.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [assetId, getAsset]);
+
+  return url;
+}

--- a/web/src/components/timeline/Tracks/useClipDrag.ts
+++ b/web/src/components/timeline/Tracks/useClipDrag.ts
@@ -1,0 +1,400 @@
+/**
+ * useClipDrag
+ *
+ * The clip body's pointer gesture: move the clip along its lane, carry a
+ * multi-selection with it, re-parent it into another lane, or — with the cut
+ * tool active — split it where the pointer landed.
+ *
+ * Snapping happens here, not in the store: both edges of the primary clip are
+ * resolved against a candidate set snapshotted at pointerdown, the closer hit
+ * wins, and the store receives the already-snapped delta with snapping off.
+ * Alt held disables it. The engaged candidate is published as the snap guide
+ * and the clip's live geometry as the gesture readout.
+ *
+ * When the pointer nears either edge of the scroll container the lanes
+ * auto-scroll, and the move is re-applied with the new scroll offset so the
+ * clip keeps following the pointer.
+ */
+
+import { useCallback, useRef } from "react";
+import type React from "react";
+
+import type { TimelineClip, TimelineTrack } from "@nodetool-ai/timeline";
+import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { findClipById } from "../../../stores/timeline/clipLookup";
+import { useTimelineHistoryBatch } from "../../../stores/timeline/useTimelineHistoryBatch";
+import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
+import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
+import type { useLongPress } from "../../../hooks/timeline/useLongPress";
+import type { TimelineTool } from "../../../stores/timeline/TimelineUIStore";
+import { isCompatibleWithTrack } from "../dnd/assetToClipAdapter";
+import {
+  clearGestureFeedback,
+  collectSnapCandidates,
+  publishGestureFeedback,
+  readoutFor,
+  snapClipWindow
+} from "./clipSnap";
+
+/** Clip-side wrapper: TimelineClip.mediaType also includes "overlay";
+ *  treat those as video-track-compatible. */
+export function isClipCompatibleWithTrack(
+  clipMediaType: TimelineClip["mediaType"],
+  trackType: TimelineTrack["type"]
+): boolean {
+  if (
+    clipMediaType === "overlay" ||
+    clipMediaType === "text" ||
+    clipMediaType === "shape" ||
+    clipMediaType === "group"
+  ) {
+    return trackType === "video" || trackType === "overlay";
+  }
+  return isCompatibleWithTrack(clipMediaType, trackType);
+}
+
+/** Pointer travel below which a press is a click, not a drag. */
+const DRAG_THRESHOLD_PX = 3;
+
+/** Distance from a scroll-container edge inside which auto-scroll engages. */
+export const AUTO_SCROLL_EDGE_PX = 32;
+/** Fastest auto-scroll, reached when the pointer is at or past the edge. */
+export const AUTO_SCROLL_MAX_PX_PER_FRAME = 24;
+
+const SCROLL_AREA_SELECTOR = "[data-testid='tracks-scroll-area']";
+
+function isTrackLocked(tracks: readonly TimelineTrack[], trackId: string) {
+  return tracks.find((t) => t.id === trackId)?.locked ?? false;
+}
+
+/**
+ * Signed auto-scroll speed for a pointer x against the container's edges:
+ * negative scrolls left, positive right, 0 outside both edge zones. Grows
+ * linearly with how far into the zone the pointer is, capped at the max.
+ */
+export function autoScrollSpeed(
+  pointerX: number,
+  rect: { left: number; right: number }
+): number {
+  const leftOvershoot = rect.left + AUTO_SCROLL_EDGE_PX - pointerX;
+  const rightOvershoot = pointerX - (rect.right - AUTO_SCROLL_EDGE_PX);
+  const scale = AUTO_SCROLL_MAX_PX_PER_FRAME / AUTO_SCROLL_EDGE_PX;
+  if (leftOvershoot > 0) {
+    return -Math.min(AUTO_SCROLL_MAX_PX_PER_FRAME, leftOvershoot * scale);
+  }
+  if (rightOvershoot > 0) {
+    return Math.min(AUTO_SCROLL_MAX_PX_PER_FRAME, rightOvershoot * scale);
+  }
+  return 0;
+}
+
+interface UseClipDragOptions {
+  clip: TimelineClip | undefined;
+  clipId: string;
+  msPerPx: number;
+  activeTool: TimelineTool;
+  /** True when the clip or its track is locked: the gesture is refused. */
+  interactionLocked: boolean;
+  longPress: ReturnType<typeof useLongPress>;
+}
+
+interface ClipDragHandlers {
+  handleDragPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
+  /** True from the first effective move until just after pointerup, so the
+   *  click that follows a drag can be told apart from a plain click. */
+  isDraggingRef: React.MutableRefObject<boolean>;
+}
+
+export function useClipDrag({
+  clip,
+  clipId,
+  msPerPx,
+  activeTool,
+  interactionLocked,
+  longPress
+}: UseClipDragOptions): ClipDragHandlers {
+  const moveClip = useTimelineStore((s) => s.moveClip);
+  const moveSelectedClips = useTimelineStore((s) => s.moveSelectedClips);
+  const splitClipAtTime = useTimelineStore((s) => s.splitClipAtTime);
+
+  // Undo batching: the gesture mutates the store on every pointermove. begin()
+  // on pointerdown, mark() after each mutation (pauses history once the
+  // pre-gesture state has actually been checkpointed), end() on pointerup —
+  // so one undo step reverts the whole drag.
+  const history = useTimelineHistoryBatch();
+
+  const dragStartXRef = useRef(0);
+  const dragStartMsRef = useRef(0);
+  const isDraggingRef = useRef(false);
+
+  const handleDragPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!clip || interactionLocked) {
+        return;
+      }
+      // Cut tool: split the clip at the pointer's ms position instead of
+      // initiating a drag. Skip primary-button check so pen/touch also work.
+      if (activeTool === "cut" && e.button === 0) {
+        e.preventDefault();
+        e.stopPropagation();
+        const rect = e.currentTarget.getBoundingClientRect();
+        const localPx = e.clientX - rect.left;
+        const atMs = clip.startMs + localPx * msPerPx;
+        // Refuse no-op splits at the clip boundaries.
+        if (atMs > clip.startMs && atMs < clip.startMs + clip.durationMs) {
+          splitClipAtTime(clip.id, atMs);
+        }
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+
+      // We use window-level pointer listeners (not setPointerCapture on this
+      // element) because moveClip(id, _, toTrackId) re-parents the clip into
+      // a different TrackLane mid-drag, which would unmount the captured
+      // element and abort the gesture. Window listeners survive remounts.
+      dragStartXRef.current = e.clientX;
+      dragStartMsRef.current = clip.startMs;
+      isDraggingRef.current = false;
+      longPress.start(e);
+      history.begin();
+
+      // The scroll container, for edge auto-scroll. Its rect and scroll
+      // offset are captured once: the container does not move during a drag,
+      // and the pixel delta must include how far the lanes scrolled since
+      // pointerdown or the clip would fall behind the pointer.
+      const scrollArea =
+        e.currentTarget.closest<HTMLElement>(SCROLL_AREA_SELECTOR);
+      const scrollAreaRect = scrollArea?.getBoundingClientRect() ?? null;
+      const scrollLeftAtStart = scrollArea?.scrollLeft ?? 0;
+
+      // Snapshot the snap candidates ONCE at gesture start. Only the dragged
+      // clip (and, in a multi-selection, its companions) moves, and those are
+      // excluded, so the set is stable for the whole gesture.
+      const dragStartState = useTimelineStore.getState();
+      const dragStartPlayheadMs = useTimelinePlaybackStore
+        .getState()
+        .getTimeMs();
+      const startSelection = useTimelineUIStore.getState().selectedClipIds;
+      const excludeIds = new Set<string>([clipId]);
+      if (startSelection.has(clipId) && startSelection.size > 1) {
+        for (const id of startSelection) {
+          excludeIds.add(id);
+        }
+      }
+      const snapCandidates = collectSnapCandidates(
+        dragStartState.clips,
+        dragStartState.durationMs,
+        dragStartPlayheadMs,
+        excludeIds
+      );
+
+      // Cross-track hit-test is sampled at most once per animation frame.
+      // document.elementsFromPoint forces layout/style work, so calling it on
+      // every pointermove (~60–120×/s) is costly; we coalesce to one sample
+      // per frame using the latest pointer coordinates.
+      let crossTrackTargetId: string | undefined;
+      let lastPointer = { x: e.clientX, y: e.clientY, altKey: e.altKey };
+      let hitTestRafId: number | null = null;
+      const sampleCrossTrack = () => {
+        hitTestRafId = null;
+        const state = useTimelineStore.getState();
+        const freshClip = findClipById(state.clips, clipId);
+        if (!freshClip) return;
+        const elements = document.elementsFromPoint(
+          lastPointer.x,
+          lastPointer.y
+        );
+        let foundLaneId: string | undefined;
+        for (const el of elements) {
+          if (!(el instanceof HTMLElement)) continue;
+          const lane = el.closest<HTMLElement>("[data-track-lane-id]");
+          if (lane) {
+            foundLaneId = lane.dataset.trackLaneId;
+            break;
+          }
+        }
+        if (foundLaneId && foundLaneId !== freshClip.trackId) {
+          const targetTrack = state.tracks.find((t) => t.id === foundLaneId);
+          if (
+            targetTrack &&
+            !targetTrack.locked &&
+            isClipCompatibleWithTrack(freshClip.mediaType, targetTrack.type)
+          ) {
+            crossTrackTargetId = targetTrack.id;
+            return;
+          }
+        }
+        crossTrackTargetId = undefined;
+      };
+
+      // Apply the move for the latest known pointer position. Called from
+      // pointermove and again from the auto-scroll loop after each scroll
+      // step, so the clip tracks the pointer while the lanes slide under it.
+      const applyMove = () => {
+        const state = useTimelineStore.getState();
+        const freshClip = findClipById(state.clips, clipId);
+        if (
+          !freshClip ||
+          freshClip.locked ||
+          isTrackLocked(state.tracks, freshClip.trackId)
+        ) {
+          return;
+        }
+
+        const scrollDeltaPx = (scrollArea?.scrollLeft ?? 0) - scrollLeftAtStart;
+        const deltaPx = lastPointer.x - dragStartXRef.current + scrollDeltaPx;
+        if (!isDraggingRef.current && Math.abs(deltaPx) < DRAG_THRESHOLD_PX) {
+          return;
+        }
+        isDraggingRef.current = true;
+
+        const rawStartMs = Math.max(
+          0,
+          dragStartMsRef.current + deltaPx * msPerPx
+        );
+        const { startMs: targetStartMs, guideMs } = lastPointer.altKey
+          ? { startMs: rawStartMs, guideMs: null }
+          : snapClipWindow(
+              rawStartMs,
+              freshClip.durationMs,
+              snapCandidates,
+              msPerPx
+            );
+        const adjustedDeltaMs = Math.max(0, targetStartMs) - freshClip.startMs;
+
+        const ui = useTimelineUIStore.getState();
+        const { selectedClipIds } = ui;
+        const isMulti =
+          selectedClipIds.has(freshClip.id) && selectedClipIds.size > 1;
+
+        // In a multi-selection only the primary (pointer) clip changes track;
+        // the others keep their lanes and follow by the same delta. Snapping
+        // is already resolved here, so the store gets it disabled.
+        if (isMulti) {
+          moveSelectedClips(
+            freshClip.id,
+            selectedClipIds,
+            adjustedDeltaMs,
+            crossTrackTargetId,
+            undefined,
+            undefined,
+            true
+          );
+        } else {
+          moveClip(
+            freshClip.id,
+            adjustedDeltaMs,
+            crossTrackTargetId,
+            undefined,
+            undefined,
+            true
+          );
+        }
+        // First effective mutation recorded the pre-drag state; batch the rest.
+        history.mark();
+
+        const movedClip = findClipById(
+          useTimelineStore.getState().clips,
+          clipId
+        );
+        if (movedClip) {
+          // The store clamps at t=0; a snap that got clamped away is no snap.
+          const applied = movedClip.startMs === targetStartMs ? guideMs : null;
+          publishGestureFeedback(ui, applied, readoutFor(movedClip, "move"));
+        }
+      };
+
+      // Edge auto-scroll: one rAF loop that runs only while the pointer is in
+      // an edge zone and the container can still scroll that way.
+      let autoScrollRafId: number | null = null;
+      const stopAutoScroll = () => {
+        if (autoScrollRafId !== null) {
+          cancelAnimationFrame(autoScrollRafId);
+          autoScrollRafId = null;
+        }
+      };
+      const autoScrollStep = () => {
+        autoScrollRafId = null;
+        if (!scrollArea || !scrollAreaRect) return;
+        const speed = autoScrollSpeed(lastPointer.x, scrollAreaRect);
+        if (speed === 0) return;
+        const maxScrollLeft = scrollArea.scrollWidth - scrollArea.clientWidth;
+        const next = Math.max(
+          0,
+          Math.min(maxScrollLeft, scrollArea.scrollLeft + speed)
+        );
+        if (next === scrollArea.scrollLeft) return;
+        scrollArea.scrollLeft = next;
+        applyMove();
+        autoScrollRafId = requestAnimationFrame(autoScrollStep);
+      };
+      const updateAutoScroll = () => {
+        if (!scrollAreaRect) return;
+        const inZone = autoScrollSpeed(lastPointer.x, scrollAreaRect) !== 0;
+        if (!inZone) {
+          stopAutoScroll();
+        } else if (autoScrollRafId === null) {
+          autoScrollRafId = requestAnimationFrame(autoScrollStep);
+        }
+      };
+
+      const onMove = (ev: PointerEvent) => {
+        longPress.move(ev);
+        if (ev.buttons !== 1) return;
+        lastPointer = { x: ev.clientX, y: ev.clientY, altKey: ev.altKey };
+        // Sampled at most once per frame; the latest known target is applied
+        // immediately so the clip still follows the cursor into a new lane.
+        if (hitTestRafId === null) {
+          hitTestRafId = requestAnimationFrame(sampleCrossTrack);
+        }
+        applyMove();
+        if (isDraggingRef.current) {
+          updateAutoScroll();
+        }
+      };
+
+      const onUpOrCancel = () => {
+        longPress.cancel();
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUpOrCancel);
+        window.removeEventListener("pointercancel", onUpOrCancel);
+        if (hitTestRafId !== null) {
+          cancelAnimationFrame(hitTestRafId);
+          hitTestRafId = null;
+        }
+        stopAutoScroll();
+        clearGestureFeedback(useTimelineUIStore.getState());
+        history.end();
+        // Defer dragging flag reset so the synthetic click that follows
+        // pointerup is still suppressed by handleClick.
+        const wasDragging = isDraggingRef.current;
+        if (wasDragging) {
+          setTimeout(() => {
+            isDraggingRef.current = false;
+          }, 0);
+        } else {
+          isDraggingRef.current = false;
+        }
+      };
+
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUpOrCancel);
+      window.addEventListener("pointercancel", onUpOrCancel);
+    },
+    [
+      clip,
+      clipId,
+      activeTool,
+      interactionLocked,
+      longPress,
+      msPerPx,
+      splitClipAtTime,
+      moveClip,
+      moveSelectedClips,
+      history
+    ]
+  );
+
+  return { handleDragPointerDown, isDraggingRef };
+}

--- a/web/src/components/timeline/Tracks/useClipSourceDuration.ts
+++ b/web/src/components/timeline/Tracks/useClipSourceDuration.ts
@@ -1,0 +1,93 @@
+/**
+ * useClipSourceDuration
+ *
+ * The real length of a clip's source media, used to cap trim-end: extending
+ * a clip past its source has no sensible result (playback stops at
+ * outPointMs and the thumbnails/waveform stretch).
+ *
+ * Audio comes from the decoded buffer (useAudioPeaks, cached per URL) so the
+ * cap reflects the actual decoded length rather than asset metadata, which
+ * can be null. Video is probed through a detached media element, cached at
+ * module level per URL so hundreds of clips on one asset probe it once.
+ * Image, text, shape and group clips have no source length and return
+ * undefined.
+ */
+
+import { useEffect, useState } from "react";
+
+import type { TimelineClip } from "@nodetool-ai/timeline";
+import { probeMediaDurationMs } from "../../../utils/probeMediaDuration";
+import { useAssetUrl } from "./useAssetUrl";
+import { useAudioPeaks } from "./useAudioPeaks";
+
+const videoDurationCache = new Map<string, number | null>();
+const videoProbesInFlight = new Map<string, Promise<number | null>>();
+
+function probeVideoDuration(url: string): Promise<number | null> {
+  const cached = videoDurationCache.get(url);
+  if (cached !== undefined) {
+    return Promise.resolve(cached);
+  }
+  const pending = videoProbesInFlight.get(url);
+  if (pending) {
+    return pending;
+  }
+  const probe = probeMediaDurationMs(url, "video").then((ms) => {
+    videoDurationCache.set(url, ms);
+    videoProbesInFlight.delete(url);
+    return ms;
+  });
+  videoProbesInFlight.set(url, probe);
+  return probe;
+}
+
+/** Test seam: forget every probed duration. */
+export function resetVideoDurationCache(): void {
+  videoDurationCache.clear();
+  videoProbesInFlight.clear();
+}
+
+function useVideoDuration(url: string | undefined): number | undefined {
+  const [durationMs, setDurationMs] = useState<number | undefined>(() =>
+    url ? (videoDurationCache.get(url) ?? undefined) : undefined
+  );
+
+  useEffect(() => {
+    if (!url) {
+      setDurationMs(undefined);
+      return;
+    }
+    let cancelled = false;
+    void probeVideoDuration(url).then((ms) => {
+      if (!cancelled) {
+        setDurationMs(ms ?? undefined);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  return durationMs;
+}
+
+export function useClipSourceDuration(
+  clip: TimelineClip | undefined
+): number | undefined {
+  const mediaType = clip?.mediaType;
+  const hasSource = mediaType === "audio" || mediaType === "video";
+  const url = useAssetUrl(hasSource ? clip?.currentAssetId : undefined);
+
+  const { durationMs: audioMs } = useAudioPeaks(
+    mediaType === "audio" ? url : undefined
+  );
+  const videoMs = useVideoDuration(mediaType === "video" ? url : undefined);
+
+  if (mediaType === "audio") {
+    return audioMs && audioMs > 0 ? audioMs : undefined;
+  }
+  if (mediaType === "video") {
+    return videoMs && videoMs > 0 ? videoMs : undefined;
+  }
+  return undefined;
+}

--- a/web/src/components/timeline/Tracks/useClipTrim.ts
+++ b/web/src/components/timeline/Tracks/useClipTrim.ts
@@ -1,0 +1,245 @@
+/**
+ * useClipTrim
+ *
+ * Pointer gestures for a clip's two trim handles. The start handle moves the
+ * clip's in-point (startMs and durationMs change together); the end handle
+ * changes durationMs only, capped at the source length when one is known.
+ *
+ * The moving edge is targeted absolutely from the pointer (edge at
+ * pointerdown + pointer travel), snapped against a candidate set snapshotted
+ * at pointerdown unless Alt is held, and converted to the delta the store's
+ * trim convention expects from the clip's *current* edge. The engaged
+ * candidate is published as the snap guide and the clip's live geometry as
+ * the gesture readout.
+ */
+
+import { useCallback, useRef } from "react";
+import type React from "react";
+
+import type { TimelineClip } from "@nodetool-ai/timeline";
+import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { findClipById } from "../../../stores/timeline/clipLookup";
+import { useTimelineHistoryBatch } from "../../../stores/timeline/useTimelineHistoryBatch";
+import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
+import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
+import type { TimelineTool } from "../../../stores/timeline/TimelineUIStore";
+import {
+  clearGestureFeedback,
+  collectSnapCandidates,
+  publishGestureFeedback,
+  readoutFor,
+  snapEdge
+} from "./clipSnap";
+
+interface UseClipTrimOptions {
+  clip: TimelineClip | undefined;
+  msPerPx: number;
+  activeTool: TimelineTool;
+  /** True when the clip or its track is locked: the gesture is refused. */
+  interactionLocked: boolean;
+  /** Source length (audio decoded, video probed); trim-end cannot grow past it. */
+  sourceDurationMs: number | undefined;
+}
+
+type TrimPointerHandler = (e: React.PointerEvent<HTMLDivElement>) => void;
+
+interface ClipTrimHandlers {
+  handleTrimStartPointerDown: TrimPointerHandler;
+  handleTrimStartPointerMove: TrimPointerHandler;
+  handleTrimEndPointerDown: TrimPointerHandler;
+  handleTrimEndPointerMove: TrimPointerHandler;
+  /** Shared end-of-trim handler (pointerup AND pointercancel). */
+  handleTrimPointerEnd: () => void;
+}
+
+interface TrimGesture {
+  /** Pointer x at pointerdown. */
+  startX: number;
+  /** Where the moving edge was at pointerdown. */
+  edgeMsAtStart: number;
+  /** Snap candidates snapshotted at pointerdown. */
+  candidates: number[];
+}
+
+/** The snapped edge the pointer is asking for, and the guide to show. */
+function targetEdge(
+  gesture: TrimGesture,
+  e: React.PointerEvent<HTMLDivElement>,
+  msPerPx: number
+) {
+  const rawMs = gesture.edgeMsAtStart + (e.clientX - gesture.startX) * msPerPx;
+  if (e.altKey) {
+    return { valueMs: rawMs, guideMs: null };
+  }
+  return snapEdge(rawMs, gesture.candidates, msPerPx);
+}
+
+export function useClipTrim({
+  clip,
+  msPerPx,
+  activeTool,
+  interactionLocked,
+  sourceDurationMs
+}: UseClipTrimOptions): ClipTrimHandlers {
+  const trimClipStart = useTimelineStore((s) => s.trimClipStart);
+  const trimClipEnd = useTimelineStore((s) => s.trimClipEnd);
+
+  // One undo entry per trim gesture; see useTimelineHistoryBatch.
+  const history = useTimelineHistoryBatch();
+
+  // Gesture-ownership flags: each trim handle's move handler only runs when
+  // *its own* pointerdown started the gesture. Without this, dragging another
+  // clip across the handle (with the primary button held) would fire the move
+  // handler and corrupt this clip's geometry.
+  const isTrimmingStartRef = useRef(false);
+  const isTrimmingEndRef = useRef(false);
+
+  const gestureRef = useRef<TrimGesture>({
+    startX: 0,
+    edgeMsAtStart: 0,
+    candidates: []
+  });
+
+  const beginGesture = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>, edge: "start" | "end") => {
+      if (!clip) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      e.currentTarget.setPointerCapture(e.pointerId);
+      const state = useTimelineStore.getState();
+      gestureRef.current = {
+        startX: e.clientX,
+        edgeMsAtStart:
+          edge === "start" ? clip.startMs : clip.startMs + clip.durationMs,
+        candidates: collectSnapCandidates(
+          state.clips,
+          state.durationMs,
+          useTimelinePlaybackStore.getState().getTimeMs(),
+          new Set([clip.id])
+        )
+      };
+      history.begin();
+    },
+    [clip, history]
+  );
+
+  const handleTrimStartPointerDown = useCallback<TrimPointerHandler>(
+    (e) => {
+      // In cut mode, let the event bubble up so the clip body splits instead.
+      if (!clip || interactionLocked || activeTool === "cut") {
+        return;
+      }
+      beginGesture(e, "start");
+      isTrimmingStartRef.current = true;
+    },
+    [clip, interactionLocked, activeTool, beginGesture]
+  );
+
+  const handleTrimStartPointerMove = useCallback<TrimPointerHandler>(
+    (e) => {
+      if (
+        !isTrimmingStartRef.current ||
+        !clip ||
+        interactionLocked ||
+        e.buttons !== 1
+      ) {
+        return;
+      }
+      // Stop bubbling so the parent clip body's drag-pointermove handler
+      // does not also fire and shift `startMs`. Without this the clip
+      // appears to move and shrink simultaneously.
+      e.stopPropagation();
+      const fresh = findClipById(useTimelineStore.getState().clips, clip.id);
+      if (!fresh) {
+        return;
+      }
+      const { valueMs, guideMs } = targetEdge(gestureRef.current, e, msPerPx);
+      // trimClip(edge="start", deltaMs) convention (packages/timeline/src/trimClip.ts):
+      //   nextStartMs    = clip.startMs    - deltaMs  (positive = move start left = grow)
+      //   nextDurationMs = clip.durationMs + deltaMs
+      // so the delta that lands the start edge on `valueMs` is start - value.
+      trimClipStart(clip.id, fresh.startMs - valueMs);
+      history.mark();
+      const trimmed = findClipById(useTimelineStore.getState().clips, clip.id);
+      if (trimmed) {
+        // An invalid trim leaves the clip alone; then the snap did not land.
+        const applied = trimmed.startMs === valueMs ? guideMs : null;
+        publishGestureFeedback(
+          useTimelineUIStore.getState(),
+          applied,
+          readoutFor(trimmed, "trim-start")
+        );
+      }
+    },
+    [clip, interactionLocked, msPerPx, trimClipStart, history]
+  );
+
+  const handleTrimEndPointerDown = useCallback<TrimPointerHandler>(
+    (e) => {
+      // In cut mode, let the event bubble up so the clip body splits instead.
+      if (!clip || interactionLocked || activeTool === "cut") {
+        return;
+      }
+      beginGesture(e, "end");
+      isTrimmingEndRef.current = true;
+    },
+    [clip, interactionLocked, activeTool, beginGesture]
+  );
+
+  const handleTrimEndPointerMove = useCallback<TrimPointerHandler>(
+    (e) => {
+      if (
+        !isTrimmingEndRef.current ||
+        !clip ||
+        interactionLocked ||
+        e.buttons !== 1
+      ) {
+        return;
+      }
+      // Stop bubbling so the parent clip body's drag-pointermove handler
+      // does not also fire and shift `startMs`. Without this the clip
+      // appears to move and grow simultaneously.
+      e.stopPropagation();
+      const fresh = findClipById(useTimelineStore.getState().clips, clip.id);
+      if (!fresh) {
+        return;
+      }
+      const { valueMs, guideMs } = targetEdge(gestureRef.current, e, msPerPx);
+      // trimClip(edge="end", deltaMs): nextDurationMs = durationMs + deltaMs,
+      // so the delta that lands the end edge on `valueMs` is value - end.
+      const currentEndMs = fresh.startMs + fresh.durationMs;
+      trimClipEnd(clip.id, valueMs - currentEndMs, sourceDurationMs);
+      history.mark();
+      const trimmed = findClipById(useTimelineStore.getState().clips, clip.id);
+      if (trimmed) {
+        // The source cap or an invalid trim can stop the edge short of the
+        // candidate; only a landed snap shows a guide.
+        const applied =
+          trimmed.startMs + trimmed.durationMs === valueMs ? guideMs : null;
+        publishGestureFeedback(
+          useTimelineUIStore.getState(),
+          applied,
+          readoutFor(trimmed, "trim-end")
+        );
+      }
+    },
+    [clip, interactionLocked, msPerPx, trimClipEnd, sourceDurationMs, history]
+  );
+
+  const handleTrimPointerEnd = useCallback(() => {
+    isTrimmingStartRef.current = false;
+    isTrimmingEndRef.current = false;
+    clearGestureFeedback(useTimelineUIStore.getState());
+    history.end();
+  }, [history]);
+
+  return {
+    handleTrimStartPointerDown,
+    handleTrimStartPointerMove,
+    handleTrimEndPointerDown,
+    handleTrimEndPointerMove,
+    handleTrimPointerEnd
+  };
+}

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -8,7 +8,8 @@
  *   - Holds an in-memory copy of the TimelineSequence document
  *     (tracks + clips + markers).
  *   - Exposes pure-reducer actions: move, trim, split, duplicate, delete,
- *     addTrack, removeTrack, reorderTracks, setTrackHeight.
+ *     addTrack, insertTrack, duplicateTrack, removeTrack, reorderTracks,
+ *     setTrackHeight.
  *   - Undo granularity: the temporal `equality` option dedupes no-op sets so
  *     guard-returns never create history entries, and drag handlers (e.g. in
  *     Clip.tsx) call the temporal middleware's `pause()` / `resume()` from the outside so each
@@ -56,6 +57,7 @@ import type { Asset } from "../ApiTypes";
 import { assetToClip } from "../../components/timeline/dnd/assetToClipAdapter";
 import { useLastModelStore, modelKindForBinding } from "../lastModelStore";
 import { trpcClient } from "../../trpc/client";
+import { cloneClipsToTrack } from "./clipboardOps";
 import {
   migrateTranscriptToClips,
   reflowGenerated,
@@ -164,6 +166,21 @@ export interface TimelineStoreState {
   // ── Track mutations ──────────────────────────────────────────────────────
 
   addTrack: (type: TimelineTrack["type"], name?: string) => void;
+  /**
+   * Insert a new track at `atIndex` (clamped to 0..tracks.length) and
+   * renumber `index` on every track. Returns the new track id.
+   */
+  insertTrack: (
+    type: TimelineTrack["type"],
+    atIndex: number,
+    name?: string
+  ) => string;
+  /**
+   * Copy a track (fresh id, "<name> copy", same settings, effects re-id'd)
+   * right after the source, with every clip on it copied under fresh ids.
+   * Returns the new track id, or null when `trackId` is unknown.
+   */
+  duplicateTrack: (trackId: string) => string | null;
   removeTrack: (trackId: string) => void;
   /** Reorder tracks by supplying the new ordered array of track IDs. */
   reorderTracks: (orderedIds: string[]) => void;
@@ -569,6 +586,20 @@ function partializedEqual(
  * avoid a needless allocation + subscriber re-render. Unchanged elements keep
  * their object identity (only the matched element is re-created).
  */
+/**
+ * Insert `track` at `atIndex` (clamped) and renumber `index` on every track so
+ * it always matches array position, as `reorderTracks` does.
+ */
+function insertTrackAt(
+  tracks: readonly TimelineTrack[],
+  track: TimelineTrack,
+  atIndex: number
+): TimelineTrack[] {
+  const at = Math.max(0, Math.min(atIndex, tracks.length));
+  const next = [...tracks.slice(0, at), track, ...tracks.slice(at)];
+  return next.map((t, index) => (t.index === index ? t : { ...t, index }));
+}
+
 function patchById<T extends { id: string }>(
   items: T[],
   id: string,
@@ -974,15 +1005,47 @@ export const createTimelineStore = (
 
         // ── Tracks ──────────────────────────────────────────────────────────
 
-        addTrack: (type, name) =>
-          set((state) => {
-            const track = makeTrack({
-              type,
-              name: name ?? `${type} ${state.tracks.length + 1}`,
-              index: state.tracks.length
-            });
-            return { tracks: [...state.tracks, track] };
-          }),
+        addTrack: (type, name) => {
+          get().insertTrack(type, get().tracks.length, name);
+        },
+
+        insertTrack: (type, atIndex, name) => {
+          const track = makeTrack({
+            type,
+            name: name ?? `${type} ${get().tracks.length + 1}`
+          });
+          set((state) => ({
+            tracks: insertTrackAt(state.tracks, track, atIndex)
+          }));
+          return track.id;
+        },
+
+        duplicateTrack: (trackId) => {
+          const state = get();
+          const sourceIndex = state.tracks.findIndex((t) => t.id === trackId);
+          if (sourceIndex === -1) {
+            return null;
+          }
+          const source = state.tracks[sourceIndex];
+          const copy = makeTrack({
+            ...structuredClone(source),
+            id: createTimeOrderedUuid(),
+            name: `${source.name} copy`,
+            effects: source.effects?.map((e) => ({
+              ...structuredClone(e),
+              id: createTimeOrderedUuid()
+            }))
+          });
+          const copiedClips = cloneClipsToTrack(
+            state.clips.filter((c) => c.trackId === trackId),
+            copy.id
+          );
+          set((s) => ({
+            tracks: insertTrackAt(s.tracks, copy, sourceIndex + 1),
+            clips: [...s.clips, ...copiedClips]
+          }));
+          return copy.id;
+        },
 
         getOrCreateAudioTrack: (range) => {
           const audioTracks = get().tracks.filter((t) => t.type === "audio");

--- a/web/src/stores/timeline/TimelineUIStore.ts
+++ b/web/src/stores/timeline/TimelineUIStore.ts
@@ -7,6 +7,7 @@
  *   - horizontal scroll position (scrollLeftPx)
  *   - hover state
  *   - fullscreen flag
+ *   - drag/trim gesture feedback (snap guide, geometry readout)
  *
  * Kept separate from TimelineStore so clip-geometry mutations (move, trim)
  * never force the selection panel to re-render and vice versa.
@@ -25,6 +26,21 @@ export interface TimelineRubberBand {
   top: number;
   width: number;
   height: number;
+}
+
+/** Which clip edge a pointer gesture is moving. */
+export type GestureKind = "move" | "trim-start" | "trim-end";
+
+/**
+ * Live geometry of the clip under a pointer gesture, for the readout pill.
+ * `inPointMs` is the source in-point (0 when the clip has none).
+ */
+export interface GestureReadout {
+  clipId: string;
+  kind: GestureKind;
+  startMs: number;
+  durationMs: number;
+  inPointMs: number;
 }
 
 /** A reference to one transcript word: its clip and the word index within it. */
@@ -96,6 +112,20 @@ export interface TimelineUIState {
   rubberBand: TimelineRubberBand | null;
   /** Set (or clear, with null) the rubber-band rect. */
   setRubberBand: (rect: TimelineRubberBand | null) => void;
+
+  // ── Gesture feedback ─────────────────────────────────────────────────────
+
+  /**
+   * Timeline position (ms) the active drag/trim gesture is snapped to, or
+   * null when no snap is engaged. Drawn as a vertical guide over the lanes.
+   */
+  snapGuideMs: number | null;
+  /** Set (or clear, with null) the snap guide position. */
+  setSnapGuide: (ms: number | null) => void;
+  /** Geometry of the clip under an active drag/trim gesture, or null. */
+  gestureReadout: GestureReadout | null;
+  /** Set (or clear, with null) the gesture readout. */
+  setGestureReadout: (readout: GestureReadout | null) => void;
 
   // ── Transcript word selection ──────────────────────────────────────────────
 
@@ -205,6 +235,14 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
   rubberBand: null,
 
   setRubberBand: (rect) => set({ rubberBand: rect }),
+
+  snapGuideMs: null,
+
+  setSnapGuide: (ms) => set({ snapGuideMs: ms }),
+
+  gestureReadout: null,
+
+  setGestureReadout: (readout) => set({ gestureReadout: readout }),
 
   wordSelection: null,
 

--- a/web/src/stores/timeline/__tests__/TimelineStore.tracks.test.ts
+++ b/web/src/stores/timeline/__tests__/TimelineStore.tracks.test.ts
@@ -1,0 +1,165 @@
+/**
+ * insertTrack / duplicateTrack — the track actions behind the header's
+ * context menu. Each case checks the invariant the UI relies on: `index`
+ * equals array position after every insert, and a duplicated track's clips
+ * are new clips on the new track, not the originals re-homed.
+ */
+import { describe, it, expect } from "@jest/globals";
+import { makeClip, makeTrackEffect } from "@nodetool-ai/timeline";
+import { createTimelineStore } from "../TimelineStore";
+
+function indices(store: ReturnType<typeof createTimelineStore>): number[] {
+  return store.getState().tracks.map((t) => t.index);
+}
+
+describe("TimelineStore.insertTrack", () => {
+  it("inserts at the given position and renumbers every track", () => {
+    const store = createTimelineStore();
+    store.getState().addTrack("video", "V1");
+    store.getState().addTrack("video", "V2");
+    const [v1, v2] = store.getState().tracks.map((t) => t.id);
+
+    const inserted = store.getState().insertTrack("audio", 1, "A1");
+
+    expect(store.getState().tracks.map((t) => t.id)).toEqual([v1, inserted, v2]);
+    expect(indices(store)).toEqual([0, 1, 2]);
+    expect(store.getState().tracks[1]).toMatchObject({
+      type: "audio",
+      name: "A1",
+      visible: true,
+      locked: false
+    });
+  });
+
+  it("clamps the position to the ends", () => {
+    const store = createTimelineStore();
+    store.getState().addTrack("video", "V1");
+    const first = store.getState().insertTrack("video", -5, "front");
+    const last = store.getState().insertTrack("video", 99, "back");
+    const ids = store.getState().tracks.map((t) => t.id);
+    expect(ids[0]).toBe(first);
+    expect(ids[ids.length - 1]).toBe(last);
+    expect(indices(store)).toEqual([0, 1, 2]);
+  });
+
+  it("addTrack appends through insertTrack with the same auto-name", () => {
+    const store = createTimelineStore();
+    store.getState().addTrack("audio");
+    store.getState().addTrack("video");
+    expect(store.getState().tracks.map((t) => t.name)).toEqual([
+      "audio 1",
+      "video 2"
+    ]);
+    expect(indices(store)).toEqual([0, 1]);
+  });
+});
+
+describe("TimelineStore.duplicateTrack", () => {
+  function storeWithClips() {
+    const store = createTimelineStore();
+    store.getState().addTrack("video", "Video 1");
+    store.getState().addTrack("audio", "Audio 1");
+    const [videoId, audioId] = store.getState().tracks.map((t) => t.id);
+    store.setState({
+      clips: [
+        makeClip({ id: "a", trackId: videoId, startMs: 0, durationMs: 1000 }),
+        makeClip({ id: "b", trackId: videoId, startMs: 2000, durationMs: 500 }),
+        makeClip({ id: "c", trackId: audioId, startMs: 0, durationMs: 1000 })
+      ]
+    });
+    return { store, videoId, audioId };
+  }
+
+  it("inserts the copy right after the source and renumbers", () => {
+    const { store, videoId, audioId } = storeWithClips();
+    const copyId = store.getState().duplicateTrack(videoId);
+
+    expect(copyId).not.toBeNull();
+    expect(copyId).not.toBe(videoId);
+    expect(store.getState().tracks.map((t) => t.id)).toEqual([
+      videoId,
+      copyId,
+      audioId
+    ]);
+    expect(indices(store)).toEqual([0, 1, 2]);
+  });
+
+  it("copies name, type and settings, with fresh effect ids", () => {
+    const { store, videoId } = storeWithClips();
+    const effect = makeTrackEffect("videoBlur");
+    store.setState({
+      tracks: store.getState().tracks.map((t) =>
+        t.id === videoId
+          ? { ...t, heightPx: 120, locked: true, effects: [effect] }
+          : t
+      )
+    });
+
+    const copyId = store.getState().duplicateTrack(videoId);
+    const copy = store.getState().tracks.find((t) => t.id === copyId)!;
+
+    expect(copy).toMatchObject({
+      name: "Video 1 copy",
+      type: "video",
+      heightPx: 120,
+      locked: true
+    });
+    expect(copy.effects).toHaveLength(1);
+    expect(copy.effects![0]).toMatchObject({ type: "videoBlur", enabled: true });
+    expect(copy.effects![0].id).not.toBe(effect.id);
+    // The copy owns its effect list: mutating it must not reach the source.
+    expect(copy.effects).not.toBe(
+      store.getState().tracks.find((t) => t.id === videoId)!.effects
+    );
+  });
+
+  it("copies every clip on the track under new ids onto the new track", () => {
+    const { store, videoId } = storeWithClips();
+    const copyId = store.getState().duplicateTrack(videoId)!;
+    const clips = store.getState().clips;
+
+    expect(clips).toHaveLength(5);
+    const originals = clips.filter((c) => c.trackId === videoId);
+    const copies = clips.filter((c) => c.trackId === copyId);
+    expect(originals.map((c) => c.id).sort()).toEqual(["a", "b"]);
+    expect(copies).toHaveLength(2);
+    for (const c of copies) {
+      expect(["a", "b", "c"]).not.toContain(c.id);
+    }
+    expect(copies.map((c) => [c.startMs, c.durationMs]).sort()).toEqual([
+      [0, 1000],
+      [2000, 500]
+    ]);
+  });
+
+  it("drops a linkId whose partner lives on another track, keeps a same-track link under a fresh id", () => {
+    const { store, videoId, audioId } = storeWithClips();
+    store.setState({
+      clips: [
+        makeClip({ id: "v", trackId: videoId, startMs: 0, durationMs: 1000, linkId: "cross" }),
+        makeClip({ id: "a", trackId: audioId, startMs: 0, durationMs: 1000, linkId: "cross" }),
+        makeClip({ id: "p", trackId: videoId, startMs: 3000, durationMs: 100, linkId: "same" }),
+        makeClip({ id: "q", trackId: videoId, startMs: 4000, durationMs: 100, linkId: "same" })
+      ]
+    });
+
+    const copyId = store.getState().duplicateTrack(videoId)!;
+    const copies = store.getState().clips.filter((c) => c.trackId === copyId);
+    const crossCopy = copies.find((c) => c.startMs === 0)!;
+    const sameCopies = copies.filter((c) => c.startMs >= 3000);
+
+    expect(crossCopy.linkId).toBeUndefined();
+    expect(sameCopies).toHaveLength(2);
+    expect(sameCopies[0].linkId).toBeDefined();
+    expect(sameCopies[0].linkId).toBe(sameCopies[1].linkId);
+    expect(sameCopies[0].linkId).not.toBe("same");
+  });
+
+  it("returns null and changes nothing for an unknown track", () => {
+    const { store } = storeWithClips();
+    const before = store.getState();
+    expect(store.getState().duplicateTrack("nope")).toBeNull();
+    expect(store.getState().tracks).toBe(before.tracks);
+    expect(store.getState().clips).toBe(before.clips);
+  });
+});

--- a/web/src/stores/timeline/__tests__/clipLookup.test.ts
+++ b/web/src/stores/timeline/__tests__/clipLookup.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { clipsById, findClipById } from "../clipLookup";
+import { clipIdsByTrack, clipsById, findClipById } from "../clipLookup";
 import { stub } from "../../../test-utils/doubles";
 import type { TimelineClip } from "@nodetool-ai/timeline";
 
@@ -79,5 +79,32 @@ describe("clipLookup", () => {
       // Verify caching: same array reference produces same Map
       expect(clipsById(clips)).toBe(clipsById(clips));
     });
+  });
+});
+
+describe("clipIdsByTrack", () => {
+  const onTrack = (id: string, trackId: string): TimelineClip => ({
+    ...makeClip(id),
+    trackId
+  });
+
+  it("groups ids by track in clips order", () => {
+    const clips = [onTrack("a", "t1"), onTrack("b", "t2"), onTrack("c", "t1")];
+    const index = clipIdsByTrack(clips);
+    expect(index.get("t1")).toEqual(["a", "c"]);
+    expect(index.get("t2")).toEqual(["b"]);
+    expect(index.get("t3")).toBeUndefined();
+  });
+
+  it("returns the same Map (and arrays) for the same clips reference", () => {
+    const clips = [onTrack("a", "t1")];
+    expect(clipIdsByTrack(clips)).toBe(clipIdsByTrack(clips));
+    expect(clipIdsByTrack(clips).get("t1")).toBe(clipIdsByTrack(clips).get("t1"));
+  });
+
+  it("rebuilds for a new clips reference", () => {
+    const first = [onTrack("a", "t1")];
+    const second = [...first];
+    expect(clipIdsByTrack(first)).not.toBe(clipIdsByTrack(second));
   });
 });

--- a/web/src/stores/timeline/__tests__/historyBatching.test.ts
+++ b/web/src/stores/timeline/__tests__/historyBatching.test.ts
@@ -33,7 +33,7 @@ function seed() {
   return clip.id;
 }
 
-/** Drive one trim-start gesture exactly the way Clip.tsx wires the hook. */
+/** Drive one trim-start gesture exactly the way useClipTrim wires the hook. */
 function runTrimStartGesture(
   history: ReturnType<typeof useTimelineHistoryBatch>,
   clipId: string,
@@ -41,7 +41,7 @@ function runTrimStartGesture(
 ) {
   history.begin();
   for (const d of deltasMs) {
-    // Clip.tsx calls trimClipStart(clip.id, -deltaMs) then history.mark().
+    // useClipTrim calls trimClipStart(clip.id, -deltaMs) then history.mark().
     useTimelineStore.getState().trimClipStart(clipId, -d);
     history.mark();
   }

--- a/web/src/stores/timeline/clipLookup.ts
+++ b/web/src/stores/timeline/clipLookup.ts
@@ -32,3 +32,29 @@ export function findClipById(
 ): TimelineClip | undefined {
   return clipsById(clips).get(clipId);
 }
+
+const byTrackCache = new WeakMap<readonly TimelineClip[], Map<string, string[]>>();
+
+/**
+ * Clip ids grouped by track, in `clips` order. Cached per `clips` array
+ * identity so every TrackLane's selector shares one pass over the array per
+ * store publish instead of filtering the whole list once per lane.
+ */
+export function clipIdsByTrack(
+  clips: readonly TimelineClip[]
+): Map<string, string[]> {
+  let index = byTrackCache.get(clips);
+  if (!index) {
+    index = new Map();
+    for (const c of clips) {
+      const ids = index.get(c.trackId);
+      if (ids) {
+        ids.push(c.id);
+      } else {
+        index.set(c.trackId, [c.id]);
+      }
+    }
+    byTrackCache.set(clips, index);
+  }
+  return index;
+}

--- a/web/src/stores/timeline/clipboardOps.ts
+++ b/web/src/stores/timeline/clipboardOps.ts
@@ -71,3 +71,39 @@ export function buildPastedClips(
   }
   return pasted;
 }
+
+/**
+ * Copies of `clips` re-homed onto `trackId`, each under a fresh id and at its
+ * original time. A link group whose members are all in `clips` keeps a link
+ * under a fresh shared id, so the copies form their own group; a lone half of
+ * a link (its partner lives on another track) is copied unlinked.
+ */
+export function cloneClipsToTrack(
+  clips: readonly TimelineClip[],
+  trackId: string
+): TimelineClip[] {
+  const groupCount = new Map<string, number>();
+  for (const c of clips) {
+    if (c.linkId !== undefined) {
+      groupCount.set(c.linkId, (groupCount.get(c.linkId) ?? 0) + 1);
+    }
+  }
+  const freshLinkByGroup = new Map<string, string>();
+  return clips.map((c) => {
+    let linkId: string | undefined;
+    if (c.linkId !== undefined && (groupCount.get(c.linkId) ?? 0) >= 2) {
+      let fresh = freshLinkByGroup.get(c.linkId);
+      if (fresh === undefined) {
+        fresh = createTimeOrderedUuid();
+        freshLinkByGroup.set(c.linkId, fresh);
+      }
+      linkId = fresh;
+    }
+    return makeClip({
+      ...structuredClone(c),
+      id: createTimeOrderedUuid(),
+      trackId,
+      linkId
+    });
+  });
+}

--- a/web/src/test-utils/timelineClipHarness.tsx
+++ b/web/src/test-utils/timelineClipHarness.tsx
@@ -1,0 +1,208 @@
+/**
+ * Shared fixtures for clip-gesture suites that drive the real TrackLane/Clip
+ * tree against the default timeline store instance.
+ *
+ * Each suite still declares its own `jest.mock` calls (they are hoisted per
+ * test file); this module only holds the pure builders and pointer drivers.
+ */
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+
+import type { TimelineClip, TimelineTrack } from "@nodetool-ai/timeline";
+import mockTheme from "../__mocks__/themeMock";
+import { installGlobal } from "./doubles";
+import { TrackLane } from "../components/timeline/Tracks/TrackLane";
+import { useTimelineStore } from "../stores/timeline/TimelineStore";
+import { useTimelineUIStore } from "../stores/timeline/TimelineUIStore";
+import { useTimelinePlaybackStore } from "../stores/timeline/TimelinePlaybackStore";
+
+/** Polyfill PointerEvent for jsdom, which does not implement it. */
+export function installPointerEvent(): void {
+  if (typeof window !== "undefined" && !window.PointerEvent) {
+    installGlobal(
+      "PointerEvent",
+      class PointerEvent extends MouseEvent {
+        readonly pointerId: number;
+        readonly pointerType: string;
+        readonly isPrimary: boolean;
+
+        constructor(
+          type: string,
+          params: PointerEventInit & MouseEventInit = {}
+        ) {
+          super(type, params);
+          this.pointerId = params.pointerId ?? 0;
+          this.pointerType = params.pointerType ?? "";
+          this.isPrimary = params.isPrimary ?? false;
+        }
+      }
+    );
+  }
+  // jsdom does not implement pointer capture.
+  HTMLElement.prototype.setPointerCapture = jest.fn();
+  HTMLElement.prototype.releasePointerCapture = jest.fn();
+}
+
+export const makeTrack = (
+  id: string,
+  index: number,
+  locked = false
+): TimelineTrack => ({
+  id,
+  name: `Video ${index + 1}`,
+  type: "video",
+  index,
+  visible: true,
+  locked
+});
+
+export const makeClip = (
+  id: string,
+  trackId: string,
+  startMs: number,
+  durationMs: number,
+  overrides: Partial<TimelineClip> = {}
+): TimelineClip => ({
+  id,
+  trackId,
+  name: id,
+  startMs,
+  durationMs,
+  mediaType: "video",
+  sourceType: "imported",
+  status: "draft",
+  locked: false,
+  versions: [],
+  ...overrides
+});
+
+/** 10 ms per px: the 8 px snap threshold is 80 ms. */
+export const MS_PER_PX = 10;
+
+export const clipState = (id: string) => {
+  const clip = useTimelineStore.getState().clips.find((c) => c.id === id);
+  if (!clip) {
+    throw new Error(`clip ${id} missing`);
+  }
+  return {
+    trackId: clip.trackId,
+    startMs: clip.startMs,
+    durationMs: clip.durationMs
+  };
+};
+
+export const seedTimeline = (
+  tracks: TimelineTrack[],
+  clips: TimelineClip[],
+  durationMs = 12_000
+): void => {
+  useTimelineStore.setState({ tracks, clips, durationMs });
+  useTimelineUIStore.setState({
+    msPerPx: MS_PER_PX,
+    scrollLeftPx: 0,
+    activeTool: "select",
+    selectedClipIds: new Set<string>(),
+    rubberBand: null,
+    snapGuideMs: null,
+    gestureReadout: null
+  });
+  useTimelinePlaybackStore.setState({ currentTimeMs: 0 });
+};
+
+/**
+ * Render every seeded track's lane. `wrap` lets a suite put the lanes inside
+ * its own scroll container.
+ */
+export const renderLanes = (
+  wrap: (lanes: React.ReactNode) => React.ReactNode = (lanes) => lanes
+) => {
+  const { tracks } = useTimelineStore.getState();
+  return render(
+    <ThemeProvider theme={mockTheme}>
+      {wrap(
+        <div data-timeline-lanes="true">
+          {tracks.map((t) => (
+            <TrackLane key={t.id} track={t} />
+          ))}
+        </div>
+      )}
+    </ThemeProvider>
+  );
+};
+
+interface PointerOptions {
+  altKey?: boolean;
+}
+
+/** Drag moves arrive through window listeners (the clip may re-parent). */
+export const pressClip = (clipId: string, x: number) => {
+  fireEvent.pointerDown(screen.getByTestId(`clip-${clipId}`), {
+    button: 0,
+    buttons: 1,
+    clientX: x,
+    clientY: 20,
+    pointerId: 1
+  });
+};
+
+export const moveClipPointer = (x: number, { altKey = false }: PointerOptions = {}) => {
+  fireEvent.pointerMove(window, {
+    buttons: 1,
+    clientX: x,
+    clientY: 20,
+    pointerId: 1,
+    altKey
+  });
+};
+
+export const releaseClipPointer = () => {
+  fireEvent.pointerUp(window, { pointerId: 1 });
+};
+
+export const dragClip = (
+  clipId: string,
+  fromX: number,
+  toX: number,
+  options: PointerOptions = {}
+) => {
+  pressClip(clipId, fromX);
+  moveClipPointer(toX, options);
+  releaseClipPointer();
+};
+
+/** Trim moves are React handlers on the handle itself. */
+export const pressHandle = (
+  clipId: string,
+  edge: "start" | "end",
+  x: number
+) => {
+  const el = screen.getByTestId(`clip-trim-${edge}-${clipId}`);
+  fireEvent.pointerDown(el, { button: 0, buttons: 1, clientX: x, pointerId: 1 });
+  return el;
+};
+
+export const moveHandle = (
+  el: HTMLElement,
+  x: number,
+  { altKey = false }: PointerOptions = {}
+) => {
+  fireEvent.pointerMove(el, { buttons: 1, clientX: x, pointerId: 1, altKey });
+};
+
+export const releaseHandle = (el: HTMLElement) => {
+  fireEvent.pointerUp(el, { pointerId: 1 });
+};
+
+export const dragHandle = (
+  clipId: string,
+  edge: "start" | "end",
+  fromX: number,
+  toX: number,
+  options: PointerOptions = {}
+) => {
+  const el = pressHandle(clipId, edge, fromX);
+  moveHandle(el, toX, options);
+  releaseHandle(el);
+};


### PR DESCRIPTION
## What changed

The timeline's clips and tracks editor gains the feedback and affordances an editor expects, and fixes two interaction bugs. Drag and trim now refuse on a locked track, not only a locked clip, and a multi-selection drag can move the primary clip to another track. Snapping resolves in the gesture hooks for both edges of a move and for the trim handles, draws a vertical snap guide, and shows a live start / duration / in-point readout; Alt bypasses it and the shortcut sheet says so. Dragging near the scroller edge auto-scrolls and re-applies the move. Video clips get the trim-end source cap audio already had, through a cached duration probe. Clip bodies draw fade ramps, an incoming-transition wedge with its type, a filmstrip sampled over the clip's in/out window, and a striped region where a clip runs past its source; trim grips appear on hover, selection, or touch and hide under 24px. Track headers get a right-click or touch-hold menu with rename, duplicate track, insert a same-type track above or below, and remove, backed by new `insertTrack` and `duplicateTrack` store actions. `Clip.tsx` is split into `useClipDrag`, `useClipTrim`, `useAssetUrl`, and `useClipSourceDuration`, the cross-track hit test uses `data-track-lane-id`, and lanes read their clip ids from a per-array index instead of filtering every clip per lane per publish.

## Verification

- [x] `npm run test:affected`: 255 suites, 2241 tests passed
- [x] `npm run typecheck`: web and electron pass; mobile fails only on missing `expo` / `react-native` modules in the sandbox
- [x] `npm run lint`: clean
- [x] `npm run dev:nodetool -- harness gate --base main`: 3/3 selfchecks, 5/5 Ring 0 reliability journeys passed

Every new test was inverted once and observed red before restoring. Examples: reverting the track-lock guard and the multi-drag `toTrackId` turned 4 of 11 gesture tests red; disabling snap turned 7 snap tests red; ignoring the in-point turned the filmstrip test red; moving "insert above" to `positionOf() + 1` turned the header menu test red.

## Agent capabilities

No capability added or changed.

## New checks

No check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nz1HzdUr6XM33Xc6GTS2zx