### PR TITLE
feat(chat): open the welcome screen with the studio's own jobs

### DIFF
--- a/web/src/components/chat/containers/WelcomePlaceholder.tsx
+++ b/web/src/components/chat/containers/WelcomePlaceholder.tsx
@@ -86,12 +86,15 @@ const styles = (theme: Theme) =>
  * to finish. Each leads with the outcome and names only what the user is about
  * to supply — never an attachment the thread does not have.
  */
+// Each chip is the start of a brief the user finishes in the composer, one
+// per job the studio is built for: a product spot, a creator-style cut, a
+// narrated explainer, a whole campaign, and the pipeline that repeats it.
 const SUGGESTIONS = [
-  "Summarize the document I attach",
-  "Generate an image of …",
-  "Write a script for a 30-second ad about …",
-  "Build a workflow that …",
-  "Explain this code: …"
+  "Storyboard a 30-second ad for …",
+  "Direct a UGC-style testimonial for …",
+  "Narrate a 60-second explainer about …",
+  "Turn this brief into a launch campaign: …",
+  "Build a workflow that renders an ad for every …"
 ];
 
 // Cloud LLM providers we point first-time users at. Each maps to an API key

--- a/web/src/components/chat/containers/__tests__/WelcomePlaceholder.test.tsx
+++ b/web/src/components/chat/containers/__tests__/WelcomePlaceholder.test.tsx
@@ -80,14 +80,18 @@ describe("WelcomePlaceholder", () => {
       screen.queryByText("Connect an AI provider to get started")
     ).not.toBeInTheDocument();
 
-    // Every opener either names what the user is about to attach or trails off
-    // for them to finish — none of them commands a run on its own.
-    expect(screen.getByText("Generate an image of …")).toBeInTheDocument();
-    expect(screen.getByText("Build a workflow that …")).toBeInTheDocument();
+    // Every opener names a job the studio is built for and trails off for the
+    // user to finish — none of them commands a run on its own.
+    expect(
+      screen.getByText("Direct a UGC-style testimonial for …")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Build a workflow that renders an ad for every …")
+    ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("Summarize the document I attach"));
+    fireEvent.click(screen.getByText("Storyboard a 30-second ad for …"));
     expect(onSuggestionClick).toHaveBeenCalledWith(
-      "Summarize the document I attach"
+      "Storyboard a 30-second ad for …"
     );
   });
 


### PR DESCRIPTION
## What changed

The five welcome-screen openers were generic assistant fare ("Summarize the document I attach", "Explain this code"). Each now starts a brief for a job NodeTool is built for, in the brand voice of outcome before mechanism: "Storyboard a 30-second ad for …", "Direct a UGC-style testimonial for …", "Narrate a 60-second explainer about …", "Turn this brief into a launch campaign: …", "Build a workflow that renders an ad for every …". They still seed the composer (through `ChatDraftStore`, as of #5585) for the user to finish rather than sending. The `WelcomePlaceholder` test asserts the new strings.

## Verification

- [x] `npm run test:affected`: all affected suites passed (6 tests).
- [x] `npm run typecheck`: `tsc --noEmit` in `web` exits 0 on this head.
- [x] `npm run lint`: oxlint clean on the two changed files.
- [ ] `npm run dev:nodetool -- harness gate --base main`: not re-run; the diff touches only copy and its test.

The updated test was inverted once (asserting the old opener) and observed failing before the strings were swapped back.

## Agent capabilities

Skipped: the diff adds no capability and changes no capability's declared contract.

## New checks

Skipped: the diff adds no check, rule, or audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PxAHRE4g2ZdV1q5vksRCA