### PR TITLE
feat(storyboard): drag-to-reorder, arrow keys, retry, add shot

### DIFF
--- a/web/src/components/storyboard/ShotCard.tsx
+++ b/web/src/components/storyboard/ShotCard.tsx
@@ -17,7 +17,9 @@ import {
   Box,
   Card,
   Caption,
+  EditorButton,
   FlexColumn,
+  FlexRow,
   ProgressBar,
   Text,
   ToolbarIconButton,
@@ -28,11 +30,9 @@ import {
 } from "../ui_primitives";
 import ImageRefPreview from "../node/ImageRefPreview";
 import ShotMediaViewer from "./ShotMediaViewer";
-import ShotStatusPill, {
-  CLIP_COLOR,
-  isShotGenerating
-} from "./ShotStatusPill";
+import ShotStatusPill, { CLIP_COLOR, isShotGenerating } from "./ShotStatusPill";
 import { useStoryboardGenerationStore } from "../../stores/storyboard/StoryboardGenerationStore";
+import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
 import { useShotDuration } from "../../hooks/storyboard/useShotDuration";
 import { useResolvedMediaUri } from "../../hooks/useResolvedMediaUri";
 
@@ -43,6 +43,17 @@ interface ShotCardProps {
   selected?: boolean;
   /** Selects (or, on the selected card, deselects) this shot. */
   onSelect?: (shotId: string) => void;
+  /** Hide the per-shot actions (Retry) on a board that cannot be edited. */
+  readOnly?: boolean;
+  /** When set, the card can be dragged onto another card to reorder shots. */
+  draggable?: boolean;
+  /** True while another card is being dragged over this one. */
+  dropTarget?: boolean;
+  onDragStart?: (shotId: string) => void;
+  onDragEnter?: (shotId: string) => void;
+  onDragEnd?: () => void;
+  /** Fired on the card a drag was released on. */
+  onDrop?: (shotId: string) => void;
 }
 
 /** The thumbnail: a fixed 16:9 media area every card in the grid shares. */
@@ -85,7 +96,14 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
   boardId,
   shot,
   selected,
-  onSelect
+  onSelect,
+  readOnly,
+  draggable,
+  dropTarget,
+  onDragStart,
+  onDragEnter,
+  onDragEnd,
+  onDrop
 }) => {
   const theme = useTheme();
   // The still or clip the fullscreen viewer shows; null when it is closed.
@@ -99,9 +117,15 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
     const job = state.shotJobs[shot.id];
     return job?.status === "failed" ? job.errorMessage : undefined;
   });
+  // Which step failed, so Retry re-runs that one rather than guessing.
+  const failedKind = useStoryboardGenerationStore((state) => {
+    const job = state.shotJobs[shot.id];
+    return job?.status === "failed" ? job.kind : undefined;
+  });
   const progress = useStoryboardGenerationStore(
     (state) => state.shotJobs[shot.id]?.progress
   );
+  const { generateKeyframe, generateClip } = useGenerateShot();
 
   const failed = shot.status === "failed";
   const isGenerating = isShotGenerating(shot);
@@ -131,6 +155,50 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
     onSelect?.(shot.id);
   }, [onSelect, shot.id]);
 
+  // A start that throws records its reason on the shot's job state, which is
+  // the line this button sits under — so the rejection is already shown.
+  const handleRetry = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      const retryClip =
+        failedKind === "clip" || (!failedKind && !!shot.keyframe);
+      const run = retryClip ? generateClip : generateKeyframe;
+      void run(boardId, shot).catch(() => undefined);
+    },
+    [failedKind, shot, generateClip, generateKeyframe, boardId]
+  );
+
+  const handleDragStart = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.setData("text/plain", shot.id);
+      onDragStart?.(shot.id);
+    },
+    [onDragStart, shot.id]
+  );
+  const handleDragEnter = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      onDragEnter?.(shot.id);
+    },
+    [onDragEnter, shot.id]
+  );
+  // Without preventDefault on dragover the browser refuses the drop.
+  const handleDragOver = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "move";
+    },
+    []
+  );
+  const handleDrop = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      onDrop?.(shot.id);
+    },
+    [onDrop, shot.id]
+  );
+
   return (
     <Card
       variant="outlined"
@@ -143,29 +211,46 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
       data-shot-id={shot.id}
       data-generating={isGenerating ? "true" : undefined}
       data-selected={selected ? "true" : undefined}
+      data-drop-target={dropTarget ? "true" : undefined}
+      draggable={draggable || undefined}
+      onDragStart={draggable ? handleDragStart : undefined}
+      onDragEnter={draggable ? handleDragEnter : undefined}
+      onDragOver={draggable ? handleDragOver : undefined}
+      onDragEnd={draggable ? onDragEnd : undefined}
+      onDrop={draggable ? handleDrop : undefined}
       sx={{
         overflow: "hidden",
         borderRadius: BORDER_RADIUS.lg,
-        borderColor: isGenerating
-          ? CLIP_COLOR
-          : selected
+        borderColor:
+          dropTarget || selected
             ? "primary.main"
-            : "divider",
-        boxShadow: isGenerating
-          ? `0 0 0 1px ${CLIP_COLOR}`
-          : selected
-            ? `0 0 0 1px ${theme.palette.primary.main}`
-            : undefined
+            : isGenerating
+              ? CLIP_COLOR
+              : "divider",
+        boxShadow: dropTarget
+          ? `0 0 0 2px ${theme.palette.primary.main}`
+          : isGenerating
+            ? `0 0 0 1px ${CLIP_COLOR}`
+            : selected
+              ? `0 0 0 1px ${theme.palette.primary.main}`
+              : undefined,
+        cursor: draggable ? "grab" : undefined
       }}
     >
-      <Box sx={mediaSx} onDoubleClick={previewMedia ? handleOpenViewer : undefined}>
+      <Box
+        sx={mediaSx}
+        onDoubleClick={previewMedia ? handleOpenViewer : undefined}
+      >
         {clipUri ? (
           <VideoPlayer locator={shot.clip} />
         ) : (
           <ImageRefPreview
             value={shot.keyframe}
             placeholder={
-              <Caption color="muted" sx={{ textAlign: "center", p: SPACING.md }}>
+              <Caption
+                color="muted"
+                sx={{ textAlign: "center", p: SPACING.md }}
+              >
                 No still yet
               </Caption>
             }
@@ -180,7 +265,9 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
           <ToolbarIconButton
             icon={<FullscreenIcon sx={{ fontSize: "1em" }} />}
             tooltip="View fullscreen (double-click)"
-            ariaLabel={clipUri ? "View clip fullscreen" : "View still fullscreen"}
+            ariaLabel={
+              clipUri ? "View clip fullscreen" : "View still fullscreen"
+            }
             onClick={handleOpenViewer}
             sx={{
               position: "absolute",
@@ -207,7 +294,9 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
           <Box sx={{ position: "absolute", left: 0, right: 0, bottom: 0 }}>
             <ProgressBar
               value={progress ?? 0}
-              progressVariant={progress == null ? "indeterminate" : "determinate"}
+              progressVariant={
+                progress == null ? "indeterminate" : "determinate"
+              }
               showValue={false}
               sx={{
                 height: RENDER_BAR_HEIGHT,
@@ -221,13 +310,25 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
 
       <FlexColumn gap={SPACING.xs} sx={{ p: SPACING.lg, minWidth: 0 }}>
         {failed && (
-          <Caption
-            role="alert"
-            data-testid="shot-render-error"
-            sx={{ color: "error.main" }}
-          >
-            {renderError ?? "The render failed. Try again."}
-          </Caption>
+          <FlexRow align="center" justify="space-between" gap={SPACING.sm}>
+            <Caption
+              role="alert"
+              data-testid="shot-render-error"
+              sx={{ color: "error.main", minWidth: 0 }}
+            >
+              {renderError ?? "The render failed. Try again."}
+            </Caption>
+            {!readOnly && (
+              <EditorButton
+                size="small"
+                variant="outlined"
+                onClick={handleRetry}
+                sx={{ flexShrink: 0 }}
+              >
+                Retry
+              </EditorButton>
+            )}
+          </FlexRow>
         )}
         <Text size="small" weight={400} lineClamp={2} sx={{ lineHeight: 1.45 }}>
           {shot.action}

--- a/web/src/components/storyboard/ShotInspector.tsx
+++ b/web/src/components/storyboard/ShotInspector.tsx
@@ -3,7 +3,8 @@
  *
  * The selected shot's detail, docked under the shot grid. Its top bar is the
  * selection footer — which shot is selected, where it appears in the
- * project's sibling documents, and the two actions that re-render it. Below
+ * project's sibling documents, and the render actions, with the step the shot
+ * has not taken yet (a still before a clip) as the one filled button. Below
  * that sits everything the grid card no longer shows: the action line, the
  * camera and cost meta, the cast chips, the takes browser, the script lines
  * the shot covers, and the reorder/delete controls.
@@ -357,6 +358,9 @@ const ShotInspectorInner: React.FC<ShotInspectorProps> = ({
 
   const meta = STATUS_META[shot.status];
   const isGenerating = isShotGenerating(shot);
+  // The clip is animated from a still, so a shot without one (and not set to
+  // render straight from its prompt) has the still as its next step.
+  const needsStill = !shot.keyframe && shotRenderMode(shot) !== "direct";
   const camera = cameraLine(shot);
   const shotName = `${shot.index + 1}. ${shot.slug ?? "Untitled shot"}`;
   const shotNumber = `SH ${String(shot.index + 1).padStart(2, "0")}`;
@@ -671,13 +675,25 @@ const ShotInspectorInner: React.FC<ShotInspectorProps> = ({
               Revise take
             </EditorButton>
             <EditorButton
-              variant="contained"
-              color="primary"
-              onClick={handleGenerateClip}
-              disabled={
-                isGenerating ||
-                (!shot.keyframe && shotRenderMode(shot) !== "direct")
+              variant={needsStill ? "contained" : "text"}
+              color={needsStill ? "primary" : undefined}
+              onClick={handleGenerateStill}
+              disabled={isGenerating}
+              sx={needsStill ? undefined : quietActionSx}
+              title={
+                shot.keyframe
+                  ? "Generate another still for this shot"
+                  : "Generate the still the clip is animated from"
               }
+            >
+              {shot.keyframe ? "New still" : "Generate still"}
+            </EditorButton>
+            <EditorButton
+              variant={needsStill ? "text" : "contained"}
+              color={needsStill ? undefined : "primary"}
+              onClick={handleGenerateClip}
+              disabled={isGenerating || needsStill}
+              sx={needsStill ? quietActionSx : undefined}
               title={
                 shot.keyframe
                   ? "Animate the selected still into a clip"
@@ -688,6 +704,15 @@ const ShotInspectorInner: React.FC<ShotInspectorProps> = ({
             >
               {shot.clip ? "Re-render clip" : "Render clip"}
             </EditorButton>
+            {(shot.keyframe || shot.clip) && (
+              <ToolbarIconButton
+                icon={<MoreHorizIcon sx={{ fontSize: "1em" }} />}
+                tooltip="More actions"
+                ariaLabel="More shot actions"
+                onClick={handleOpenMenu}
+                disabled={isGenerating}
+              />
+            )}
           </>
         )}
         {onClose && (
@@ -862,10 +887,7 @@ const ShotInspectorInner: React.FC<ShotInspectorProps> = ({
                 onClick={handleToggleDurationSource}
               />
             )}
-            <ShotCostLine
-              estimate={costEstimate}
-              sx={{ mb: SPACING.micro }}
-            />
+            <ShotCostLine estimate={costEstimate} sx={{ mb: SPACING.micro }} />
           </FlexRow>
         )}
 
@@ -906,27 +928,6 @@ const ShotInspectorInner: React.FC<ShotInspectorProps> = ({
         <ShotTakesGallery boardId={boardId} shot={shot} readOnly={readOnly} />
 
         <ShotScriptPanel boardId={boardId} shot={shot} readOnly={readOnly} />
-
-        {!readOnly && (
-          <FlexRow gap={SPACING.xs} align="center" wrap>
-            <EditorButton
-              onClick={handleGenerateStill}
-              disabled={isGenerating}
-              sx={shot.keyframe ? quietActionSx : undefined}
-            >
-              {shot.keyframe ? "New still" : "Generate still"}
-            </EditorButton>
-            {(shot.keyframe || shot.clip) && (
-              <ToolbarIconButton
-                icon={<MoreHorizIcon sx={{ fontSize: "1em" }} />}
-                tooltip="More actions"
-                ariaLabel="More shot actions"
-                onClick={handleOpenMenu}
-                disabled={isGenerating}
-              />
-            )}
-          </FlexRow>
-        )}
       </FlexColumn>
 
       <EditorMenu

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -6,11 +6,21 @@
  * forward (render stills, render clips, assemble the timeline); the
  * Screenplay/Direction form — including *Direct* — folds into a collapsible
  * section behind *Board settings*, open by default while the board has no
- * shots. Selecting a card opens {@link ShotInspector} under the grid.
+ * shots. Selecting a card opens {@link ShotInspector} under the grid and
+ * scrolls it into view; the arrow keys walk the selection along the grid, and
+ * dragging one card onto another reorders the shots.
  */
 
-import React, { memo, useCallback, useMemo, useState } from "react";
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
 import { shotRenderMode } from "@nodetool-ai/protocol";
+import AddIcon from "@mui/icons-material/Add";
 import TuneIcon from "@mui/icons-material/Tune";
 
 import {
@@ -68,6 +78,7 @@ import ScriptLinkControl from "./ScriptLinkControl";
 import ShotCard from "./ShotCard";
 import ShotInspector from "./ShotInspector";
 import StoryboardEntitiesField from "./StoryboardEntitiesField";
+import { dropShotOrder, isShotNavigationKey, navigateShots } from "./shotOrder";
 
 // The preview mounts the timeline compositor; keep it out of the board bundle.
 const LazyStoryboardPreview = React.lazy(() => import("./StoryboardPreview"));
@@ -236,10 +247,14 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   const setBrief = useStoryboardStore((state) => state.setBrief);
   const setStyle = useStoryboardStore((state) => state.setStyle);
   const setAspectRatio = useStoryboardStore((state) => state.setAspectRatio);
-  const setDirectorModel = useStoryboardStore((state) => state.setDirectorModel);
+  const setDirectorModel = useStoryboardStore(
+    (state) => state.setDirectorModel
+  );
   const setImageModel = useStoryboardStore((state) => state.setImageModel);
   const setVideoModel = useStoryboardStore((state) => state.setVideoModel);
   const selectShot = useStoryboardStore((state) => state.selectShot);
+  const addShot = useStoryboardStore((state) => state.addShot);
+  const reorderShots = useStoryboardStore((state) => state.reorderShots);
   const undo = useStoryboardStore((state) => state.undo);
   const redo = useStoryboardStore((state) => state.redo);
   const canUndo = useStoryboardCanUndo(boardId);
@@ -263,12 +278,34 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
     []
   );
 
+  // The inspector docks under the grid, so on a board of more than a row or
+  // two it opens below the fold. A selection the user makes here scrolls it
+  // into view; one made from another document (useStoryboardShotFocus) does
+  // not, because that already centres the card.
+  const gridRef = useRef<HTMLDivElement>(null);
+  const inspectorRef = useRef<HTMLDivElement>(null);
+  const revealInspector = useRef(false);
+  useEffect(() => {
+    if (!revealInspector.current) {
+      return;
+    }
+    revealInspector.current = false;
+    // `scrollIntoView` is absent under jsdom, so the call is guarded.
+    inspectorRef.current?.scrollIntoView?.({
+      block: "nearest",
+      behavior: "smooth"
+    });
+  }, [activeShotId]);
+
   // Clicking the selected card deselects it (the card's aria-pressed
   // contract); the store's selectShot stays idempotent for programmatic
   // callers.
   const handleSelectShot = useCallback(
-    (shotId: string) =>
-      selectShot(boardId, shotId === activeShotId ? null : shotId),
+    (shotId: string) => {
+      const next = shotId === activeShotId ? null : shotId;
+      revealInspector.current = next !== null;
+      selectShot(boardId, next);
+    },
     [selectShot, boardId, activeShotId]
   );
   const clearSelection = useCallback(
@@ -277,6 +314,89 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   );
   const activeShotIndex = shots.findIndex((s) => s.id === activeShotId);
   const activeShot = activeShotIndex >= 0 ? shots[activeShotIndex] : undefined;
+
+  // Arrow keys walk the selection along the grid and move focus with it;
+  // Escape clears it. A card's fullscreen viewer is a portal whose key events
+  // still bubble here in React, so only keys from the grid's own DOM count,
+  // and none typed into a field.
+  const handleGridKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const target = event.target as HTMLElement;
+      if (
+        !gridRef.current?.contains(target) ||
+        target.closest("input, textarea, [contenteditable=true]")
+      ) {
+        return;
+      }
+      if (event.key === "Escape") {
+        if (activeShotId) {
+          event.preventDefault();
+          selectShot(boardId, null);
+        }
+        return;
+      }
+      if (!isShotNavigationKey(event.key)) {
+        return;
+      }
+      const next = navigateShots(
+        shots.map((s) => s.id),
+        activeShotId,
+        event.key
+      );
+      if (!next) {
+        return;
+      }
+      event.preventDefault();
+      if (next !== activeShotId) {
+        revealInspector.current = true;
+        selectShot(boardId, next);
+      }
+      gridRef.current
+        ?.querySelector<HTMLElement>(`[data-shot-id="${next}"]`)
+        ?.focus();
+    },
+    [shots, activeShotId, selectShot, boardId]
+  );
+
+  // Drag one card onto another: the dragged shot takes the target's slot.
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [dropTargetId, setDropTargetId] = useState<string | null>(null);
+  const handleDragStart = useCallback((shotId: string) => {
+    setDraggingId(shotId);
+  }, []);
+  const handleDragEnter = useCallback(
+    (shotId: string) => {
+      setDropTargetId(shotId === draggingId ? null : shotId);
+    },
+    [draggingId]
+  );
+  const handleDragEnd = useCallback(() => {
+    setDraggingId(null);
+    setDropTargetId(null);
+  }, []);
+  const handleDrop = useCallback(
+    (targetId: string) => {
+      if (draggingId && draggingId !== targetId) {
+        reorderShots(
+          boardId,
+          dropShotOrder(
+            shots.map((s) => s.id),
+            draggingId,
+            targetId
+          )
+        );
+      }
+      setDraggingId(null);
+      setDropTargetId(null);
+    },
+    [draggingId, reorderShots, boardId, shots]
+  );
+
+  // A shot added by hand opens in the inspector, blank, ready to describe.
+  const handleAddShot = useCallback(() => {
+    revealInspector.current = true;
+    addShot(boardId);
+  }, [addShot, boardId]);
 
   // Entity reference images only reach generation through an editing model;
   // warn when entities are attached but the still model can't take them.
@@ -371,7 +491,11 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   }, [pendingClips, generateClip, boardId]);
 
   // What each batch button is about to spend, over exactly the shots it loops.
-  const stillsCost = useRenderBatchCostEstimate(boardId, pendingStills, "still");
+  const stillsCost = useRenderBatchCostEstimate(
+    boardId,
+    pendingStills,
+    "still"
+  );
   const clipsCost = useRenderBatchCostEstimate(boardId, pendingClips, "clip");
 
   // The archive is packed server-side from the saved board, so a download
@@ -420,6 +544,14 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
                 redoTooltip="Redo (⌘⇧Z)"
               />
               <ScriptLinkControl boardId={boardId} disabled={directing} />
+              <EditorButton
+                variant="outlined"
+                startIcon={<AddIcon fontSize="small" />}
+                onClick={handleAddShot}
+                disabled={directing}
+              >
+                Add shot
+              </EditorButton>
               <EditorButton
                 variant="outlined"
                 onClick={togglePreview}
@@ -652,7 +784,13 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
             }
           />
         ) : (
-          <Box sx={shotGridSx}>
+          <Box
+            ref={gridRef}
+            role="group"
+            aria-label="Shots"
+            onKeyDown={handleGridKeyDown}
+            sx={shotGridSx}
+          >
             {shots.map((shot) => (
               <ShotCard
                 key={shot.id}
@@ -660,21 +798,30 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
                 shot={shot}
                 selected={shot.id === activeShotId}
                 onSelect={handleSelectShot}
+                readOnly={readOnly}
+                draggable={!readOnly && !directing}
+                dropTarget={shot.id === dropTargetId}
+                onDragStart={handleDragStart}
+                onDragEnter={handleDragEnter}
+                onDragEnd={handleDragEnd}
+                onDrop={handleDrop}
               />
             ))}
           </Box>
         )}
 
         {activeShot && (
-          <ShotInspector
-            key={activeShot.id}
-            boardId={boardId}
-            shot={activeShot}
-            readOnly={readOnly}
-            isFirst={activeShotIndex === 0}
-            isLast={activeShotIndex === shots.length - 1}
-            onClose={clearSelection}
-          />
+          <Box ref={inspectorRef}>
+            <ShotInspector
+              key={activeShot.id}
+              boardId={boardId}
+              shot={activeShot}
+              readOnly={readOnly}
+              isFirst={activeShotIndex === 0}
+              isLast={activeShotIndex === shots.length - 1}
+              onClose={clearSelection}
+            />
+          </Box>
         )}
       </FlexColumn>
     </ScrollArea>

--- a/web/src/components/storyboard/__tests__/ShotCard.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotCard.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 import type { Shot, ShotStatus } from "@nodetool-ai/protocol";
@@ -50,6 +50,15 @@ jest.mock("../../node/ImageRefPreview", () => ({
   )
 }));
 
+const generateKeyframeMock = jest.fn(async () => undefined);
+const generateClipMock = jest.fn(async () => undefined);
+jest.mock("../../../hooks/storyboard/useGenerateShot", () => ({
+  useGenerateShot: () => ({
+    generateKeyframe: generateKeyframeMock,
+    generateClip: generateClipMock
+  })
+}));
+
 import ShotCard from "../ShotCard";
 import { useStoryboardGenerationStore } from "../../../stores/storyboard/StoryboardGenerationStore";
 
@@ -72,6 +81,100 @@ const renderCard = (
       <ShotCard boardId="board-1" shot={shot} {...props} />
     </ThemeProvider>
   );
+
+describe("ShotCard retry", () => {
+  beforeEach(() => {
+    generateKeyframeMock.mockClear();
+    generateClipMock.mockClear();
+    act(() => useStoryboardGenerationStore.setState({ shotJobs: {} }));
+  });
+
+  it("re-runs the failed step from the card without selecting it", async () => {
+    const onSelect = jest.fn();
+    const shot = makeShot({ status: "failed" });
+    act(() => {
+      useStoryboardGenerationStore.setState({
+        shotJobs: {
+          [shot.id]: {
+            shotId: shot.id,
+            boardId: "board-1",
+            jobId: "job-1",
+            kind: "clip",
+            status: "failed",
+            errorMessage: "Provider rejected the request"
+          }
+        }
+      });
+    });
+    renderCard(shot, { onSelect });
+
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(generateClipMock).toHaveBeenCalledWith("board-1", shot);
+    expect(generateKeyframeMock).not.toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("retries the still when no job state says which step failed", async () => {
+    const shot = makeShot({ status: "failed" });
+    renderCard(shot);
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(generateKeyframeMock).toHaveBeenCalledWith("board-1", shot);
+  });
+
+  it("offers no retry on a read-only board", () => {
+    renderCard(makeShot({ status: "failed" }), { readOnly: true });
+    expect(
+      screen.queryByRole("button", { name: "Retry" })
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("ShotCard drag to reorder", () => {
+  it("reports drag start, hover and drop by shot id when draggable", () => {
+    const onDragStart = jest.fn();
+    const onDragEnter = jest.fn();
+    const onDrop = jest.fn();
+    renderCard(makeShot(), {
+      onSelect: jest.fn(),
+      draggable: true,
+      onDragStart,
+      onDragEnter,
+      onDrop
+    });
+    const card = screen.getByRole("button", { name: "1. Opening" });
+    expect(card).toHaveAttribute("draggable", "true");
+
+    const dataTransfer = {
+      setData: jest.fn(),
+      effectAllowed: "",
+      dropEffect: ""
+    };
+    fireEvent.dragStart(card, { dataTransfer });
+    fireEvent.dragEnter(card, { dataTransfer });
+    fireEvent.dragOver(card, { dataTransfer });
+    fireEvent.drop(card, { dataTransfer });
+
+    expect(onDragStart).toHaveBeenCalledWith("shot-1");
+    expect(onDragEnter).toHaveBeenCalledWith("shot-1");
+    expect(onDrop).toHaveBeenCalledWith("shot-1");
+    expect(dataTransfer.dropEffect).toBe("move");
+  });
+
+  it("is not draggable by default", () => {
+    renderCard(makeShot(), { onSelect: jest.fn() });
+    expect(
+      screen.getByRole("button", { name: "1. Opening" })
+    ).not.toHaveAttribute("draggable");
+  });
+
+  it("marks the card a drop target", () => {
+    renderCard(makeShot(), { onSelect: jest.fn(), dropTarget: true });
+    expect(screen.getByRole("button", { name: "1. Opening" })).toHaveAttribute(
+      "data-drop-target",
+      "true"
+    );
+  });
+});
 
 describe("ShotCard", () => {
   it("shows the shot number, its length, and the action line", () => {

--- a/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
+++ b/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 import type { Shot } from "@nodetool-ai/protocol";
@@ -21,6 +21,9 @@ jest.mock("../../../utils/modelUnitPricing", () => ({
   getModelUnitPrice: (model: unknown, params: PriceParams) =>
     mockPrice(model, params)
 }));
+const mockSelectShot = jest.fn();
+const mockAddShot = jest.fn();
+const mockReorderShots = jest.fn();
 jest.mock("../../../stores/storyboard/StoryboardStore", () => ({
   useBoard: () => ({
     title: "My film",
@@ -49,6 +52,8 @@ jest.mock("../../../stores/storyboard/StoryboardStore", () => ({
       undo: jest.Mock;
       redo: jest.Mock;
       selectShot: jest.Mock;
+      addShot: jest.Mock;
+      reorderShots: jest.Mock;
     }) => T
   ) =>
     selector({
@@ -62,7 +67,9 @@ jest.mock("../../../stores/storyboard/StoryboardStore", () => ({
       setVideoModel: jest.fn(),
       undo: jest.fn(),
       redo: jest.fn(),
-      selectShot: jest.fn()
+      selectShot: mockSelectShot,
+      addShot: mockAddShot,
+      reorderShots: mockReorderShots
     }),
   useStoryboardCanUndo: () => false,
   useStoryboardCanRedo: () => false
@@ -111,7 +118,46 @@ const stub = (name: string) => ({
 jest.mock("../../properties/LanguageModelSelect", () => stub("lang-model"));
 jest.mock("../../properties/ImageModelSelect", () => stub("image-model"));
 jest.mock("../../properties/VideoModelSelect", () => stub("video-model"));
-jest.mock("../ShotCard", () => stub("shot-card"));
+// The card's own behaviour has its own suite (ShotCard.test.tsx); this stub
+// keeps the contract the board drives — the shot id hook the keyboard
+// navigation focuses, selection on click, and the drag callbacks.
+jest.mock("../ShotCard", () => ({
+  __esModule: true,
+  default: ({
+    shot,
+    selected,
+    onSelect,
+    draggable,
+    dropTarget,
+    onDragStart,
+    onDragEnter,
+    onDrop
+  }: {
+    shot: Shot;
+    selected?: boolean;
+    onSelect?: (id: string) => void;
+    draggable?: boolean;
+    dropTarget?: boolean;
+    onDragStart?: (id: string) => void;
+    onDragEnter?: (id: string) => void;
+    onDrop?: (id: string) => void;
+  }) => (
+    <div
+      data-testid="shot-card"
+      data-shot-id={shot.id}
+      data-draggable={draggable ? "true" : undefined}
+      data-drop-target={dropTarget ? "true" : undefined}
+      role="button"
+      tabIndex={0}
+      aria-pressed={!!selected}
+      aria-label={shot.id}
+      onClick={() => onSelect?.(shot.id)}
+      onDragStart={() => onDragStart?.(shot.id)}
+      onDragEnter={() => onDragEnter?.(shot.id)}
+      onDrop={() => onDrop?.(shot.id)}
+    />
+  )
+}));
 // The inspector reads the real store, the entity library and the linked
 // script; it has its own suite (ShotInspector.test.tsx).
 jest.mock("../ShotInspector", () => stub("shot-inspector"));
@@ -330,6 +376,125 @@ describe("StoryboardBoard toolbar", () => {
     boardModels = { imageModel: null, videoModel: null };
     mockPrice.mockReset();
     mockPrice.mockReturnValue(null);
+  });
+});
+
+describe("StoryboardBoard add shot", () => {
+  it("appends a shot through the store", async () => {
+    mockShots = [makeShot("s1")];
+    mockAddShot.mockClear();
+    renderBoard(jest.fn());
+    await userEvent.click(screen.getByRole("button", { name: "Add shot" }));
+    expect(mockAddShot).toHaveBeenCalledWith("board-1");
+  });
+
+  it("is hidden on a read-only board", () => {
+    mockShots = [makeShot("s1")];
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <StoryboardBoard boardId="board-1" readOnly />
+      </ThemeProvider>
+    );
+    expect(
+      screen.queryByRole("button", { name: "Add shot" })
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("StoryboardBoard keyboard navigation", () => {
+  beforeEach(() => {
+    mockShots = [makeShot("s1"), makeShot("s2"), makeShot("s3")];
+    mockSelectShot.mockClear();
+  });
+  afterEach(() => {
+    activeShot = null;
+  });
+
+  it("moves the selection to the next shot and focuses its card", () => {
+    activeShot = "s1";
+    renderBoard(jest.fn());
+    const grid = screen.getByRole("group", { name: "Shots" });
+    screen.getByRole("button", { name: "s1" }).focus();
+
+    fireEvent.keyDown(grid, { key: "ArrowRight" });
+    expect(mockSelectShot).toHaveBeenCalledWith("board-1", "s2");
+    expect(screen.getByRole("button", { name: "s2" })).toHaveFocus();
+  });
+
+  it("stops at the last shot rather than wrapping", () => {
+    activeShot = "s3";
+    renderBoard(jest.fn());
+    fireEvent.keyDown(screen.getByRole("group", { name: "Shots" }), {
+      key: "ArrowRight"
+    });
+    expect(mockSelectShot).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "s3" })).toHaveFocus();
+  });
+
+  it("jumps to the ends with Home and End", () => {
+    activeShot = "s2";
+    renderBoard(jest.fn());
+    const grid = screen.getByRole("group", { name: "Shots" });
+    fireEvent.keyDown(grid, { key: "End" });
+    expect(mockSelectShot).toHaveBeenLastCalledWith("board-1", "s3");
+    fireEvent.keyDown(grid, { key: "Home" });
+    expect(mockSelectShot).toHaveBeenLastCalledWith("board-1", "s1");
+  });
+
+  it("clears the selection on Escape", () => {
+    activeShot = "s2";
+    renderBoard(jest.fn());
+    fireEvent.keyDown(screen.getByRole("group", { name: "Shots" }), {
+      key: "Escape"
+    });
+    expect(mockSelectShot).toHaveBeenCalledWith("board-1", null);
+  });
+});
+
+describe("StoryboardBoard drag to reorder", () => {
+  beforeEach(() => {
+    mockShots = [makeShot("s1"), makeShot("s2"), makeShot("s3")];
+    mockReorderShots.mockClear();
+  });
+
+  it("drops the dragged shot into the target's slot", () => {
+    renderBoard(jest.fn());
+    const first = screen.getByRole("button", { name: "s1" });
+    const third = screen.getByRole("button", { name: "s3" });
+    expect(first).toHaveAttribute("data-draggable", "true");
+
+    fireEvent.dragStart(first);
+    fireEvent.dragEnter(third);
+    expect(third).toHaveAttribute("data-drop-target", "true");
+    fireEvent.drop(third);
+
+    expect(mockReorderShots).toHaveBeenCalledWith("board-1", [
+      "s2",
+      "s3",
+      "s1"
+    ]);
+    expect(third).not.toHaveAttribute("data-drop-target");
+  });
+
+  it("ignores a drop on the dragged card itself", () => {
+    renderBoard(jest.fn());
+    const first = screen.getByRole("button", { name: "s1" });
+    fireEvent.dragStart(first);
+    fireEvent.dragEnter(first);
+    expect(first).not.toHaveAttribute("data-drop-target");
+    fireEvent.drop(first);
+    expect(mockReorderShots).not.toHaveBeenCalled();
+  });
+
+  it("does not make cards draggable on a read-only board", () => {
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <StoryboardBoard boardId="board-1" readOnly />
+      </ThemeProvider>
+    );
+    expect(screen.getByRole("button", { name: "s1" })).not.toHaveAttribute(
+      "data-draggable"
+    );
   });
 });
 

--- a/web/src/components/storyboard/__tests__/shotOrder.test.ts
+++ b/web/src/components/storyboard/__tests__/shotOrder.test.ts
@@ -1,0 +1,48 @@
+import { dropShotOrder, navigateShots } from "../shotOrder";
+
+const IDS = ["a", "b", "c", "d"];
+
+describe("dropShotOrder", () => {
+  it("moves a shot forward into the target's slot", () => {
+    expect(dropShotOrder(IDS, "a", "c")).toEqual(["b", "c", "a", "d"]);
+  });
+
+  it("moves a shot backward into the target's slot", () => {
+    expect(dropShotOrder(IDS, "d", "b")).toEqual(["a", "d", "b", "c"]);
+  });
+
+  it("leaves the order alone for a drop on itself or an unknown id", () => {
+    expect(dropShotOrder(IDS, "b", "b")).toEqual(IDS);
+    expect(dropShotOrder(IDS, "zz", "b")).toEqual(IDS);
+    expect(dropShotOrder(IDS, "b", "zz")).toEqual(IDS);
+  });
+
+  it("does not mutate its input", () => {
+    const input = [...IDS];
+    dropShotOrder(input, "a", "d");
+    expect(input).toEqual(IDS);
+  });
+});
+
+describe("navigateShots", () => {
+  it("steps to the neighbour and stops at the ends", () => {
+    expect(navigateShots(IDS, "b", "ArrowRight")).toBe("c");
+    expect(navigateShots(IDS, "b", "ArrowLeft")).toBe("a");
+    expect(navigateShots(IDS, "d", "ArrowRight")).toBe("d");
+    expect(navigateShots(IDS, "a", "ArrowLeft")).toBe("a");
+  });
+
+  it("jumps to the first and last shot with Home and End", () => {
+    expect(navigateShots(IDS, "c", "Home")).toBe("a");
+    expect(navigateShots(IDS, "b", "End")).toBe("d");
+  });
+
+  it("picks the first shot when nothing is selected", () => {
+    expect(navigateShots(IDS, null, "ArrowRight")).toBe("a");
+    expect(navigateShots(IDS, "gone", "ArrowLeft")).toBe("a");
+  });
+
+  it("returns null on an empty board", () => {
+    expect(navigateShots([], null, "End")).toBeNull();
+  });
+});

--- a/web/src/components/storyboard/shotOrder.ts
+++ b/web/src/components/storyboard/shotOrder.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure helpers behind the shot grid's drag-to-reorder and arrow-key
+ * navigation. Both take the board's shot ids in display order and return
+ * what the store should be told; neither reads the DOM.
+ */
+
+/**
+ * The order after dropping `draggedId` onto `targetId`: the dragged shot
+ * takes the target's slot, so dropping on an earlier card lands before it and
+ * dropping on a later card lands after it. Unknown ids and a drop on itself
+ * return the input untouched.
+ */
+export const dropShotOrder = (
+  ids: readonly string[],
+  draggedId: string,
+  targetId: string
+): string[] => {
+  const from = ids.indexOf(draggedId);
+  const to = ids.indexOf(targetId);
+  if (from === -1 || to === -1 || from === to) {
+    return [...ids];
+  }
+  const next = [...ids];
+  next.splice(from, 1);
+  next.splice(to, 0, draggedId);
+  return next;
+};
+
+export type ShotNavigationKey = "ArrowLeft" | "ArrowRight" | "Home" | "End";
+
+export const isShotNavigationKey = (key: string): key is ShotNavigationKey =>
+  key === "ArrowLeft" ||
+  key === "ArrowRight" ||
+  key === "Home" ||
+  key === "End";
+
+/**
+ * The shot an arrow or Home/End key lands on from `activeId`. With nothing
+ * selected, any key picks the first shot; the arrows stop at the ends rather
+ * than wrapping, so holding one parks on the last card. Null on an empty board.
+ */
+export const navigateShots = (
+  ids: readonly string[],
+  activeId: string | null,
+  key: ShotNavigationKey
+): string | null => {
+  if (ids.length === 0) {
+    return null;
+  }
+  const current = activeId ? ids.indexOf(activeId) : -1;
+  if (key === "Home" || current === -1) {
+    return ids[0];
+  }
+  if (key === "End") {
+    return ids[ids.length - 1];
+  }
+  const step = key === "ArrowLeft" ? -1 : 1;
+  const next = Math.min(ids.length - 1, Math.max(0, current + step));
+  return ids[next];
+};

--- a/web/src/stores/storyboard/StoryboardStore.ts
+++ b/web/src/stores/storyboard/StoryboardStore.ts
@@ -168,7 +168,11 @@ interface StoryboardStoreState {
   /** Patch fields on a single shot. No-op when the shot is gone. */
   updateShot: (boardId: string, shotId: string, patch: Partial<Shot>) => void;
   setShotStatus: (boardId: string, shotId: string, status: ShotStatus) => void;
-  setShotKeyframe: (boardId: string, shotId: string, keyframe: ImageRef) => void;
+  setShotKeyframe: (
+    boardId: string,
+    shotId: string,
+    keyframe: ImageRef
+  ) => void;
   setShotClip: (boardId: string, shotId: string, clip: VideoRef) => void;
   /** Make one of the shot's preserved stills the selected keyframe. */
   selectKeyframeVersion: (
@@ -206,6 +210,11 @@ interface StoryboardStoreState {
     versionIndex: number
   ) => void;
   removeShot: (boardId: string, shotId: string) => void;
+  /**
+   * Append a blank planned shot and select it, so the inspector opens on it.
+   * Returns the new shot's id, or null when the board is not in the store.
+   */
+  addShot: (boardId: string) => string | null;
   /** Reorder shots to match `orderedIds`; re-stamps each shot's `index`. */
   reorderShots: (boardId: string, orderedIds: string[]) => void;
   /**
@@ -269,7 +278,13 @@ const withBoard = (
     boards: { ...state.boards, [boardId]: { ...next, updatedAt: now } }
   };
   if (track !== false) {
-    patch.history = pushHistory(state.history, boardId, board, track.coalesceKey ?? null, now);
+    patch.history = pushHistory(
+      state.history,
+      boardId,
+      board,
+      track.coalesceKey ?? null,
+      now
+    );
   }
   return patch;
 };
@@ -301,8 +316,7 @@ const withLiveTransient = (
 export const sameMediaRef = (
   a: { asset_id?: string | null; uri?: string },
   b: { asset_id?: string | null; uri?: string }
-): boolean =>
-  b.asset_id ? a.asset_id === b.asset_id : a.uri === b.uri;
+): boolean => (b.asset_id ? a.asset_id === b.asset_id : a.uri === b.uri);
 
 /** Patch the single shot with `shotId`; returns the same board on a no-op. */
 /**
@@ -402,13 +416,7 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
         boards: { ...state.boards, [id]: next }
       };
       if (options?.checkpoint && prev) {
-        patch.history = pushHistory(
-          state.history,
-          id,
-          prev,
-          null,
-          Date.now()
-        );
+        patch.history = pushHistory(state.history, id, prev, null, Date.now());
       }
       return patch;
     }),
@@ -489,7 +497,13 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
       // A (re-)direct that replaces an existing board is undoable; the first
       // screenplay on an empty board has nothing to step back to.
       if (prev) {
-        patch.history = pushHistory(state.history, boardId, prev, null, Date.now());
+        patch.history = pushHistory(
+          state.history,
+          boardId,
+          prev,
+          null,
+          Date.now()
+        );
       }
       return patch;
     }),
@@ -693,7 +707,8 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
         }
         // Preserve every still; the new render becomes the selected keyframe.
         const versions =
-          target.keyframe_versions ?? (target.keyframe ? [target.keyframe] : []);
+          target.keyframe_versions ??
+          (target.keyframe ? [target.keyframe] : []);
         const exists = versions.some((v) => sameMediaRef(v, keyframe));
         return patchShot(b, shotId, {
           keyframe,
@@ -710,7 +725,8 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
           return b;
         }
         // Preserve every take; the new render becomes the selected clip.
-        const versions = target.clip_versions ?? (target.clip ? [target.clip] : []);
+        const versions =
+          target.clip_versions ?? (target.clip ? [target.clip] : []);
         const exists = versions.some((v) => sameMediaRef(v, clip));
         return patchShot(b, shotId, {
           clip,
@@ -819,9 +835,7 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
         }
         const remaining = versions.filter((_, i) => i !== versionIndex);
         const selectedIndex = target.clip
-          ? versions.findIndex((v) =>
-              sameMediaRef(v, target.clip as VideoRef)
-            )
+          ? versions.findIndex((v) => sameMediaRef(v, target.clip as VideoRef))
           : -1;
         const removedSelected = selectedIndex === versionIndex;
         let nextClip: VideoRef | null | undefined;
@@ -863,6 +877,30 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
         };
       })
     ),
+
+  addShot: (boardId) => {
+    if (!get().boards[boardId]) {
+      return null;
+    }
+    const id = crypto.randomUUID();
+    set((state) =>
+      withBoard(state, boardId, (b) => ({
+        ...b,
+        shots: [
+          ...b.shots,
+          {
+            type: "shot",
+            id,
+            index: b.shots.length,
+            action: "",
+            status: "planned"
+          }
+        ],
+        activeShotId: id
+      }))
+    );
+    return id;
+  },
 
   reorderShots: (boardId, orderedIds) =>
     set((state) =>
@@ -915,7 +953,8 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
         // click-to-deselect toggle lives in the click handler, so
         // programmatic callers (focus jumps, the agent bridge) can
         // re-select safely.
-        (b) => (b.activeShotId === shotId ? null : { ...b, activeShotId: shotId }),
+        (b) =>
+          b.activeShotId === shotId ? null : { ...b, activeShotId: shotId },
         // Selection is transient UI state, not an authoring edit.
         false
       )

--- a/web/src/stores/storyboard/__tests__/StoryboardStore.test.ts
+++ b/web/src/stores/storyboard/__tests__/StoryboardStore.test.ts
@@ -144,6 +144,37 @@ describe("moveShot", () => {
   });
 });
 
+describe("addShot", () => {
+  it("appends a blank planned shot at the end and selects it", () => {
+    seed();
+    const id = useStoryboardStore.getState().addShot(BOARD);
+
+    const board = useStoryboardStore.getState().boards[BOARD];
+    expect(id).not.toBeNull();
+    expect(board?.shots.map((s) => s.id)).toEqual([SHOT, id]);
+    expect(board?.shots[1]).toMatchObject({
+      index: 1,
+      action: "",
+      status: "planned"
+    });
+    expect(board?.activeShotId).toBe(id);
+  });
+
+  it("returns null for a board the store does not carry", () => {
+    expect(useStoryboardStore.getState().addShot("no-such-board")).toBeNull();
+  });
+
+  it("is one undo step", () => {
+    seed();
+    const store = useStoryboardStore.getState();
+    store.addShot(BOARD);
+    store.undo(BOARD);
+    expect(
+      useStoryboardStore.getState().boards[BOARD]?.shots.map((s) => s.id)
+    ).toEqual([SHOT]);
+  });
+});
+
 describe("setShotClip / selectClipVersion", () => {
   it("accumulates takes and switches between them", () => {
     seed();
@@ -263,7 +294,9 @@ describe("removeBoard cleanup", () => {
     expect(useStoryboardStore.getState().serverRevisions[BOARD]).toBe("rev-1");
 
     store.removeBoard(BOARD);
-    expect(useStoryboardStore.getState().serverRevisions[BOARD]).toBeUndefined();
+    expect(
+      useStoryboardStore.getState().serverRevisions[BOARD]
+    ).toBeUndefined();
   });
 });
 
@@ -280,7 +313,9 @@ describe("undo selection safety", () => {
       status: "planned"
     });
     store.selectShot(BOARD, "s0");
-    expect(useStoryboardStore.getState().boards[BOARD]?.activeShotId).toBe("s0");
+    expect(useStoryboardStore.getState().boards[BOARD]?.activeShotId).toBe(
+      "s0"
+    );
 
     // Undo the creation of the selected shot: the selection must not dangle.
     store.undo(BOARD);


### PR DESCRIPTION
## What changed

Five gaps in the storyboard editor, all in the shot grid and its inspector. Cards can now be dragged onto each other to reorder shots (the dragged shot takes the target's slot, via the store's existing `reorderShots`), where before the only path was one step at a time from the inspector's arrows. The arrow keys, Home and End walk the selection along the grid and move focus with it, and Escape clears it. The inspector's one filled button is now the step the shot actually needs next: "Generate still" for a shot without a still, "Render clip" once it has one; the still action used to sit at the very bottom of the inspector under a disabled "Render clip". Picking a card scrolls the inspector into view, since on a board of more than a row or two it opens below the fold. A failed card carries a Retry that re-runs the step that failed (read from the shot's job state). The toolbar gains "Add shot", backed by a new `addShot` store action that appends a blank planned shot and selects it, so the inspector opens on it ready to describe.

The reorder and navigation math lives in `web/src/components/storyboard/shotOrder.ts` as pure functions with their own suite.

## Verification

- [x] `npm run test:affected` — all affected suites passed (storyboard component and store suites: 208 tests)
- [x] `npm run typecheck` — web and electron pass; mobile fails only on missing `expo`/`react-native` modules because its separate dependency tree is not installed in this container
- [x] `npm run lint` — exit 0, no findings in touched files
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — 2/2 selfchecks passed, 261/261 graphs validate

## Agent capabilities

No capability added or changed.

## New checks

No check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWiXVX1i4npKWBuwdCXqs4

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWiXVX1i4npKWBuwdCXqs4)_