### PR TITLE
feat(projects): read the starter off the prompt and fold the skill pills

### DIFF
--- a/web/src/components/chat/composer/useTextareaSkillMention.tsx
+++ b/web/src/components/chat/composer/useTextareaSkillMention.tsx
@@ -139,8 +139,6 @@ interface UseTextareaSkillMentionOptions {
   textareaRef: React.RefObject<HTMLTextAreaElement | null>;
   value: string;
   setValue: (next: string) => void;
-  /** Called with the picked skill after its `/name` has been written in. */
-  onSelect?: (skill: Skill) => void;
 }
 
 interface UseTextareaSkillMention {
@@ -154,8 +152,7 @@ interface UseTextareaSkillMention {
 export const useTextareaSkillMention = ({
   textareaRef,
   value,
-  setValue,
-  onSelect
+  setValue
 }: UseTextareaSkillMentionOptions): UseTextareaSkillMention => {
   // The shipped skills answer to `/name` in a turn exactly as a user's own row
   // does, so the menu that completes that name offers both.
@@ -279,10 +276,9 @@ export const useTextareaSkillMention = ({
           value.slice(0, trigger.start) + inserted + value.slice(trigger.end)
         );
       }
-      onSelect?.(skill);
       close();
     },
-    [close, onSelect, setValue, trigger, value]
+    [close, setValue, trigger, value]
   );
 
   const selectIndex = useCallback(

--- a/web/src/components/projects/NewProjectSurface.tsx
+++ b/web/src/components/projects/NewProjectSurface.tsx
@@ -5,21 +5,30 @@
  * box takes the chat composer's triggers: `/` completes a skill and `@` picks
  * an asset or a library entity, so the opening turn is written the same way
  * every other turn is. A starter is one of the user's skills — their own or one
- * NodeTool ships — picked from a chip or from `/`, and it prefixes the opening
- * turn with `/<name>` so the agent reads that skill's instructions before it
- * plans anything. The picked skill is stored as the project's kind, which is
- * what its spend history is read back by. Blank documents keep their place at
- * the foot of the view, opening loose tabs the way the `+ New` menu always
- * did.
+ * NodeTool ships — and the prompt is the one record of which was picked: a
+ * pill writes `/<name>` into the prompt, `/` completes it, and a hand-typed one
+ * counts the same, so the pills light up from the text and can never disagree
+ * with what the agent is handed. The picked skill is stored as the project's
+ * kind, which is what its spend history is read back by. Blank documents keep
+ * their place at the foot of the view, opening loose tabs the way the `+ New`
+ * menu always did.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
 import { isModelSelected, type Entity } from "@nodetool-ai/protocol";
 
 import {
   BORDER_RADIUS,
   Box,
   Caption,
+  Chip,
   CloseButton,
   Divider,
   EditorButton,
@@ -33,6 +42,7 @@ import {
   SPACING,
   Text,
   TextInput,
+  Tooltip,
   TYPOGRAPHY
 } from "../ui_primitives";
 import type { Asset, MessageContent } from "../../stores/ApiTypes";
@@ -76,13 +86,32 @@ import {
   composeFirstTurn,
   estimateFromHistory,
   formatEstimate,
+  invokedStarter,
   projectNameFromPrompt,
-  starterLabel
+  rankStarters,
+  starterLabel,
+  toggleStarterInPrompt,
+  VISIBLE_STARTERS
 } from "./projectStarters";
 import { useSkills } from "../../hooks/skills/useSkills";
 
 /** Width of the centered column, per the new-project mockup. */
 const COLUMN_WIDTH = 860;
+
+/** A starter pill at rest: outlined, quiet, the project's colour on hover. */
+const starterPillSx = {
+  borderRadius: BORDER_RADIUS.pill,
+  color: "text.secondary",
+  "&:hover": { borderColor: PROJECT_COLOR, color: "text.primary" }
+} as const;
+
+/** The picked starter: drawn in the project colour on a tint of it. */
+const activeStarterPillSx = {
+  color: PROJECT_COLOR,
+  borderColor: PROJECT_COLOR,
+  backgroundColor: "rgba(var(--palette-info-lightChannel) / 0.12)",
+  "&:hover": { backgroundColor: "rgba(var(--palette-info-lightChannel) / 0.2)" }
+} as const;
 
 interface SubmenuAnchor {
   kind: NewDocumentSubmenu;
@@ -92,9 +121,8 @@ interface SubmenuAnchor {
 
 const NewProjectSurface = () => {
   const [prompt, setPrompt] = useState("");
-  // The skill this project starts from, by name. Null is a bare start, where
-  // the prompt is the whole ask.
-  const [starterName, setStarterName] = useState<string | null>(null);
+  // The starter row folds past `VISIBLE_STARTERS` until asked to show the rest.
+  const [showAllStarters, setShowAllStarters] = useState(false);
   const [entityIds, setEntityIds] = useState<string[]>([]);
   const [entityAnchor, setEntityAnchor] = useState<HTMLElement | null>(null);
   const [submenu, setSubmenu] = useState<SubmenuAnchor | null>(null);
@@ -107,6 +135,9 @@ const NewProjectSurface = () => {
   const refInputRef = useRef<HTMLInputElement>(null);
   const modelButtonRef = useRef<HTMLButtonElement>(null);
   const promptRef = useRef<HTMLTextAreaElement>(null);
+  // Where the caret goes once a pill has rewritten the prompt: back in the
+  // box, at the end, so the user keeps typing without a click.
+  const pendingCaretRef = useRef<number | null>(null);
 
   const { droppedFiles, addFiles, addDroppedFiles, removeFile, getFileContents } =
     useFileHandling();
@@ -156,15 +187,55 @@ const NewProjectSurface = () => {
     [entities, entityIds]
   );
 
-  const starters = useMemo(() => skills ?? [], [skills]);
-
-  // A starter the list no longer carries (a skill renamed or deleted while
-  // this tab sat open) is no starter at all, rather than a `/name` the agent
-  // would fail to resolve.
-  const starter = useMemo(
-    () => starters.find((entry) => entry.name === starterName) ?? null,
-    [starterName, starters]
+  const starters = useMemo(
+    () => rankStarters(skills ?? [], summaries.data ?? []),
+    [skills, summaries.data]
   );
+
+  // Read off the prompt, so a `/name` typed by hand lights its pill and a
+  // deleted one goes dark. A skill the catalog no longer carries is no
+  // starter at all, rather than a `/name` the agent would fail to resolve.
+  const starter = useMemo(
+    () => invokedStarter(prompt, starters),
+    [prompt, starters]
+  );
+
+  // The folded row still shows the picked starter, wherever it ranks, so the
+  // pill that is lit is never one that is hidden.
+  const visibleStarters = useMemo(() => {
+    if (showAllStarters || starters.length <= VISIBLE_STARTERS) {
+      return starters;
+    }
+    const head = starters.slice(0, VISIBLE_STARTERS);
+    return starter && !head.includes(starter) ? [...head, starter] : head;
+  }, [showAllStarters, starter, starters]);
+  const hiddenStarterCount = starters.length - visibleStarters.length;
+
+  const handleToggleStarter = useCallback(
+    (name: string) => {
+      const next = toggleStarterInPrompt(
+        prompt,
+        starter?.name ?? null,
+        starter?.name === name ? null : name
+      );
+      pendingCaretRef.current = next.length;
+      setPrompt(next);
+    },
+    [prompt, starter]
+  );
+
+  useLayoutEffect(() => {
+    const caret = pendingCaretRef.current;
+    if (caret === null) {
+      return;
+    }
+    pendingCaretRef.current = null;
+    const element = promptRef.current;
+    if (element) {
+      element.focus();
+      element.setSelectionRange(caret, caret);
+    }
+  }, [prompt]);
 
   const estimate = useMemo(
     () => estimateFromHistory(summaries.data ?? [], starter?.name ?? ""),
@@ -208,31 +279,15 @@ const NewProjectSurface = () => {
       includeEntities: true
     });
 
-  // A skill picked from `/` is the project's starter too — it is what the
-  // project's kind is stored as, and what its spend estimate reads back. The
-  // `/name` stays in the prompt where the user typed it; `composeFirstTurn`
-  // knows not to write a second one.
+  // A skill picked from `/` is written into the prompt as `/name`, which is
+  // all it takes to make it the starter: the pills and the project's kind
+  // both read the prompt.
   const { skillMenu, handleKeyDown: handleSkillKeyDown } =
     useTextareaSkillMention({
       textareaRef: promptRef,
       value: prompt,
-      setValue: setPrompt,
-      onSelect: (skill) => setStarterName(skill.name)
+      setValue: setPrompt
     });
-
-  // The handler rides the field wrapper, where MUI puts unknown props, and the
-  // keydown reaches it by bubbling from the textarea. Both pickers only read
-  // `key` and call `preventDefault`, so the retype is safe.
-  const handlePromptKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
-      const keyEvent = event as unknown as React.KeyboardEvent<HTMLTextAreaElement>;
-      if (handleSkillKeyDown(keyEvent)) {
-        return;
-      }
-      handleMentionKeyDown(keyEvent);
-    },
-    [handleMentionKeyDown, handleSkillKeyDown]
-  );
 
   const handleRefImages = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -343,6 +398,28 @@ const NewProjectSurface = () => {
     void resumeProject.current();
   }, [pendingStart, hasConfiguredProvider]);
 
+  // The handler rides the field wrapper, where MUI puts unknown props, and the
+  // keydown reaches it by bubbling from the textarea. Both pickers only read
+  // `key` and call `preventDefault`, so the retype is safe. Enter keeps its
+  // newline — a project brief runs to more than one line — and Ctrl/⌘+Enter
+  // starts, the way a multi-line composer submits everywhere else.
+  const handlePromptKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const keyEvent = event as unknown as React.KeyboardEvent<HTMLTextAreaElement>;
+      if (handleSkillKeyDown(keyEvent)) {
+        return;
+      }
+      if (handleMentionKeyDown(keyEvent)) {
+        return;
+      }
+      if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        void handleStart();
+      }
+    },
+    [handleMentionKeyDown, handleSkillKeyDown, handleStart]
+  );
+
   const handleConnectProvider = useCallback(() => {
     openProviderOnboarding();
   }, []);
@@ -391,7 +468,7 @@ const NewProjectSurface = () => {
               label="Project prompt"
               hideLabel
               inputRef={promptRef}
-              placeholder="A 30-second launch spot for our desk lamp — warm, minimal, night-time mood. Type / for a skill, @ for an asset or entity."
+              placeholder="A 30-second launch spot for our desk lamp — warm, minimal, night-time mood. Type / for a skill, @ for an asset or entity. Ctrl+Enter starts."
               onChange={(event) => setPrompt(event.target.value)}
               onKeyDown={handlePromptKeyDown}
             />
@@ -480,53 +557,60 @@ const NewProjectSurface = () => {
 
           {starters.length > 0 && (
             <FlexColumn gap={SPACING.md} align="center">
-              <FlexRow justify="center" gap={SPACING.md} wrap>
-                {starters.map((entry) => {
+              <FlexRow
+                justify="center"
+                gap={SPACING.sm}
+                wrap
+                role="group"
+                aria-label="Start from a skill"
+              >
+                {visibleStarters.map((entry) => {
                   const active = entry.name === starter?.name;
                   return (
-                    <Box
+                    <Tooltip
                       key={entry.name}
-                      component="button"
-                      type="button"
-                      aria-pressed={active}
-                      // What the skill does, before it is picked; the picked
-                      // one says it in full below the row.
                       title={entry.description}
-                      onClick={() =>
-                        setStarterName(active ? null : entry.name)
-                      }
-                      sx={{
-                        height: "28px",
-                        px: SPACING.lg,
-                        cursor: "pointer",
-                        borderRadius: BORDER_RADIUS.pill,
-                        border: "1px solid",
-                        borderColor: active ? PROJECT_COLOR : "divider",
-                        color: active ? PROJECT_COLOR : "text.secondary",
-                        bgcolor: "transparent",
-                        ...TYPOGRAPHY.sans.body
-                      }}
+                      placement="bottom"
+                      // Described by, not named by: the pill's name stays the
+                      // skill's label.
+                      describeChild
                     >
-                      {starterLabel(entry.name)}
-                    </Box>
+                      <Chip
+                        clickable
+                        variant="outlined"
+                        label={starterLabel(entry.name)}
+                        aria-pressed={active}
+                        onClick={() => handleToggleStarter(entry.name)}
+                        sx={{
+                          ...starterPillSx,
+                          ...(active && activeStarterPillSx)
+                        }}
+                      />
+                    </Tooltip>
                   );
                 })}
+                {(hiddenStarterCount > 0 || showAllStarters) && (
+                  <Chip
+                    clickable
+                    variant="outlined"
+                    aria-expanded={showAllStarters}
+                    label={
+                      showAllStarters
+                        ? "Show fewer"
+                        : `${hiddenStarterCount} more`
+                    }
+                    onClick={() => setShowAllStarters((shown) => !shown)}
+                    sx={{ ...starterPillSx, borderStyle: "dashed" }}
+                  />
+                )}
               </FlexRow>
               {starter ? (
-                <FlexColumn gap={SPACING.xs} align="center">
-                  <Box
-                    component="span"
-                    sx={{ ...TYPOGRAPHY.mono.caption, color: PROJECT_COLOR }}
-                  >
-                    {`/${starter.name}`}
-                  </Box>
-                  <Caption
-                    color="secondary"
-                    sx={{ maxWidth: "620px", textAlign: "center" }}
-                  >
-                    {starter.description}
-                  </Caption>
-                </FlexColumn>
+                <Caption
+                  color="secondary"
+                  sx={{ maxWidth: "620px", textAlign: "center" }}
+                >
+                  {starter.description}
+                </Caption>
               ) : (
                 <Caption color="muted">
                   Pick a skill to start from, or just describe what you want.

--- a/web/src/components/projects/__tests__/NewProjectSurface.test.tsx
+++ b/web/src/components/projects/__tests__/NewProjectSurface.test.tsx
@@ -254,25 +254,101 @@ describe("NewProjectSurface", () => {
     ).toBeInTheDocument();
   });
 
-  it("names the picked starter's slash command and what it does", async () => {
+  // A pill is a shortcut for typing the command: the prompt stays the one
+  // record of what the agent is handed.
+  it("writes the picked starter into the prompt, and says what it does", async () => {
     renderSurface();
+    const prompt = screen.getByPlaceholderText(/30-second launch spot/);
     expect(
       screen.getByText(/Pick a skill to start from/)
     ).toBeInTheDocument();
 
-    await userEvent.click(
-      screen.getByRole("button", { name: "Launch commercial" })
-    );
-    expect(screen.getByText("/launch-commercial")).toBeInTheDocument();
+    await userEvent.type(prompt, "A spot for our desk lamp");
+    const pill = screen.getByRole("button", { name: "Launch commercial" });
+    await userEvent.click(pill);
+    expect(prompt).toHaveValue("/launch-commercial A spot for our desk lamp");
+    expect(pill).toHaveAttribute("aria-pressed", "true");
     expect(
       screen.getByText("Turn a product page into a finished launch commercial.")
     ).toBeInTheDocument();
+    // The caret is back in the box, so the user keeps typing.
+    expect(prompt).toHaveFocus();
 
-    // Pressing the picked starter again starts the project from nothing.
+    // Pressing the picked starter again takes the command out.
+    await userEvent.click(pill);
+    expect(prompt).toHaveValue("A spot for our desk lamp");
+    expect(pill).toHaveAttribute("aria-pressed", "false");
+    expect(
+      screen.getByText(/Pick a skill to start from/)
+    ).toBeInTheDocument();
+  });
+
+  it("swaps one starter for another in place", async () => {
+    renderSurface();
+    const prompt = screen.getByPlaceholderText(/30-second launch spot/);
     await userEvent.click(
       screen.getByRole("button", { name: "Launch commercial" })
     );
-    expect(screen.queryByText("/launch-commercial")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "House style" }));
+    expect(prompt).toHaveValue("/house-style ");
+    expect(
+      screen.getByRole("button", { name: "Launch commercial" })
+    ).toHaveAttribute("aria-pressed", "false");
+    expect(
+      screen.getByRole("button", { name: "House style" })
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  // BUG: a starter picked from `/` stayed the project's kind after its command
+  // was deleted from the prompt, and a hand-typed one never counted at all.
+  it("lights the pill for a hand-typed command and clears it when deleted", async () => {
+    renderSurface();
+    const prompt = screen.getByPlaceholderText(/30-second launch spot/);
+    await userEvent.type(prompt, "/house-style{Escape} our lamp");
+    expect(
+      screen.getByRole("button", { name: "House style" })
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.getByText("Our house grade and typography.")
+    ).toBeInTheDocument();
+
+    await userEvent.clear(prompt);
+    await userEvent.type(prompt, "our lamp");
+    expect(
+      screen.getByRole("button", { name: "House style" })
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("folds the row past eight starters, keeping the picked one in view", async () => {
+    skills = Array.from({ length: 12 }, (_, index) => ({
+      id: `s${index}`,
+      name: `skill-${String.fromCharCode(97 + index)}`,
+      description: `Skill ${index}.`,
+      updatedAt: "",
+      system: true
+    }));
+    renderSurface();
+    const row = screen.getByRole("group", { name: "Start from a skill" });
+    expect(within(row).getAllByRole("button")).toHaveLength(9);
+    expect(
+      within(row).queryByRole("button", { name: "Skill l" })
+    ).not.toBeInTheDocument();
+
+    // Typed from `/`, a hidden starter is shown lit rather than left folded.
+    await userEvent.type(
+      screen.getByPlaceholderText(/30-second launch spot/),
+      "/skill-l{Escape} our lamp"
+    );
+    expect(
+      within(row).getByRole("button", { name: "Skill l" })
+    ).toHaveAttribute("aria-pressed", "true");
+
+    await userEvent.click(within(row).getByRole("button", { name: "3 more" }));
+    expect(within(row).getAllByRole("button")).toHaveLength(13);
+    await userEvent.click(
+      within(row).getByRole("button", { name: "Show fewer" })
+    );
+    expect(within(row).getAllByRole("button")).toHaveLength(10);
   });
 
   it("shows no starter row when there are no skills", () => {
@@ -300,12 +376,12 @@ describe("NewProjectSurface", () => {
 
   it("creates the project, stages its first turn, and opens its group", async () => {
     renderSurface();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Launch commercial" })
+    );
     await userEvent.type(
       screen.getByPlaceholderText(/30-second launch spot/),
       "A spot for our desk lamp"
-    );
-    await userEvent.click(
-      screen.getByRole("button", { name: "Launch commercial" })
     );
     await userEvent.click(screen.getByRole("button", { name: "Entities · none" }));
     await userEvent.click(screen.getByText("Aurora lamp"));
@@ -327,13 +403,30 @@ describe("NewProjectSurface", () => {
     );
     expect(closeTab).toHaveBeenCalledWith("project-new:new");
 
-    // The staged turn triggers the skill the way a typed `/name` does.
+    // The staged turn is the prompt as written, command and all, plus the
+    // entities picked from the button.
     const staged = takeProjectFirstTurn("p9");
     expect(staged).not.toBeNull();
     const text = staged?.[0].type === "text" ? staged[0].text : "";
     expect(text).toBe(
-      "/launch-commercial\n\nA spot for our desk lamp\n\n" +
+      "/launch-commercial A spot for our desk lamp\n\n" +
         "Use these entities: Aurora lamp."
+    );
+  });
+
+  it("starts on Ctrl+Enter, and keeps Enter for a new line", async () => {
+    renderSurface();
+    const prompt = screen.getByPlaceholderText(/30-second launch spot/);
+    await userEvent.type(prompt, "A spot for our desk lamp{Enter}warm");
+    expect(createProject).not.toHaveBeenCalled();
+    expect(prompt).toHaveValue("A spot for our desk lamp\nwarm");
+
+    await userEvent.keyboard("{Control>}{Enter}{/Control}");
+    await waitFor(() =>
+      expect(createProject).toHaveBeenCalledWith({
+        name: "A spot for our desk lamp",
+        kind: ""
+      })
     );
   });
 

--- a/web/src/components/projects/__tests__/projectStarters.test.ts
+++ b/web/src/components/projects/__tests__/projectStarters.test.ts
@@ -7,8 +7,11 @@ import {
   composeFirstTurn,
   estimateFromHistory,
   formatEstimate,
+  invokedStarter,
   projectNameFromPrompt,
+  rankStarters,
   starterLabel,
+  toggleStarterInPrompt,
   type ProjectStarter
 } from "../projectStarters";
 import type { ProjectDetail } from "../projectStatus";
@@ -61,6 +64,23 @@ describe("projectNameFromPrompt", () => {
     const name = projectNameFromPrompt("word ".repeat(30), launch);
     expect(name.length).toBeLessThanOrEqual(61);
     expect(name.endsWith("…")).toBe(true);
+  });
+
+  // The command is for the agent; a tab named "/launch-commercial A spot…"
+  // would read as a mistake.
+  it("leaves the starter's slash command out of the name", () => {
+    expect(
+      projectNameFromPrompt("/launch-commercial A spot for our desk lamp", launch)
+    ).toBe("A spot for our desk lamp");
+    expect(
+      projectNameFromPrompt("A spot /launch-commercial for our lamp", launch)
+    ).toBe("A spot for our lamp");
+  });
+
+  it("names a prompt that is only the command after the starter", () => {
+    expect(projectNameFromPrompt("/launch-commercial ", launch)).toBe(
+      "Launch commercial"
+    );
   });
 
   it("falls back to the starter when the prompt says nothing", () => {
@@ -124,6 +144,122 @@ describe("composeFirstTurn", () => {
         entityNames: []
       })
     ).toBe("Whatever I want");
+  });
+});
+
+const houseStyle: ProjectStarter = {
+  name: "house-style",
+  description: "Our house grade and typography.",
+  system: false
+};
+
+describe("invokedStarter", () => {
+  const starters = [launch, houseStyle];
+
+  it("reads the starter off a `/name` anywhere in the prompt", () => {
+    expect(invokedStarter("/launch-commercial A spot", starters)).toBe(launch);
+    expect(invokedStarter("A spot, /house-style please", starters)).toBe(
+      houseStyle
+    );
+  });
+
+  it("is null when no skill is invoked, or only a prefix of one is", () => {
+    expect(invokedStarter("A spot for our lamp", starters)).toBeNull();
+    expect(invokedStarter("/launch A spot", starters)).toBeNull();
+    expect(invokedStarter("/launch-commercial-v2 A spot", starters)).toBeNull();
+    // A slash inside a word is a path or a fraction, not a command.
+    expect(invokedStarter("see docs/launch-commercial", starters)).toBeNull();
+  });
+
+  it("takes the first command written when the prompt names two", () => {
+    expect(
+      invokedStarter("/house-style then /launch-commercial", starters)
+    ).toBe(houseStyle);
+  });
+});
+
+describe("toggleStarterInPrompt", () => {
+  it("writes a picked starter in front of the ask", () => {
+    expect(toggleStarterInPrompt("A spot", null, "launch-commercial")).toBe(
+      "/launch-commercial A spot"
+    );
+    expect(toggleStarterInPrompt("", null, "launch-commercial")).toBe(
+      "/launch-commercial "
+    );
+  });
+
+  it("swaps the starter in place when the prompt already carries one", () => {
+    expect(
+      toggleStarterInPrompt(
+        "A spot /house-style please",
+        "house-style",
+        "launch-commercial"
+      )
+    ).toBe("A spot /launch-commercial please");
+  });
+
+  it("takes the command out when the starter is let go", () => {
+    expect(
+      toggleStarterInPrompt("/launch-commercial A spot", "launch-commercial", null)
+    ).toBe("A spot");
+    expect(
+      toggleStarterInPrompt("A spot /launch-commercial lit", "launch-commercial", null)
+    ).toBe("A spot lit");
+    expect(
+      toggleStarterInPrompt("/launch-commercial ", "launch-commercial", null)
+    ).toBe("");
+  });
+
+  it("leaves the prompt alone when there is nothing to let go", () => {
+    expect(toggleStarterInPrompt("A spot", null, null)).toBe("A spot");
+  });
+});
+
+describe("rankStarters", () => {
+  const cut: ProjectStarter = {
+    name: "beat-sync-editing",
+    description: "Cut to music.",
+    system: true
+  };
+  const at = (kind: string, updatedAt: string): ProjectDetail =>
+    ({
+      ...summary(kind, 3),
+      project: { ...summary(kind, 3).project, updatedAt }
+    }) as ProjectDetail;
+
+  it("puts starters used before first, the most recent ahead", () => {
+    expect(
+      rankStarters(
+        [houseStyle, cut, launch],
+        [at("launch-commercial", "2026-01-01"), at("beat-sync-editing", "2026-03-01")]
+      ).map((starter) => starter.name)
+    ).toEqual(["beat-sync-editing", "launch-commercial", "house-style"]);
+  });
+
+  it("keeps the catalog's order when nothing was started before", () => {
+    expect(
+      rankStarters([houseStyle, cut, launch], [at("", "2026-03-01")]).map(
+        (starter) => starter.name
+      )
+    ).toEqual(["house-style", "beat-sync-editing", "launch-commercial"]);
+  });
+
+  // A guide to prompting one model line is loaded by the agent mid-run, not
+  // started from; it goes to the back unless this user did start from it.
+  it("ranks the model-line prompting guides last", () => {
+    const veo: ProjectStarter = {
+      name: "veo-3-prompting",
+      description: "Prompt Veo 3.",
+      system: true
+    };
+    expect(
+      rankStarters([veo, houseStyle, launch], []).map((starter) => starter.name)
+    ).toEqual(["house-style", "launch-commercial", "veo-3-prompting"]);
+    expect(
+      rankStarters([veo, houseStyle, launch], [at("veo-3-prompting", "2026-03-01")]).map(
+        (starter) => starter.name
+      )
+    ).toEqual(["veo-3-prompting", "house-style", "launch-commercial"]);
   });
 });
 

--- a/web/src/components/projects/projectStarters.ts
+++ b/web/src/components/projects/projectStarters.ts
@@ -32,19 +32,130 @@ export const starterLabel = (name: string): string => {
   return words.length === 0 ? name : words[0].toUpperCase() + words.slice(1);
 };
 
+const escapeRegExp = (text: string): string =>
+  text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/** `/name` as a whitespace-delimited word, which is what the host matches. */
+const invocationPattern = (name: string): RegExp =>
+  new RegExp(`(^|\\s)/${escapeRegExp(name)}(?=\\s|$)`, "g");
+
+/** True when the prompt already invokes `/name` as a whitespace-delimited word. */
+export const invokesStarter = (prompt: string, name: string): boolean =>
+  invocationPattern(name).test(prompt);
+
+/**
+ * The starter the prompt invokes, or null. The prompt is the one record of
+ * what the agent will be handed, so this is read off it rather than kept
+ * beside it: a `/name` typed by hand counts, and a `/name` deleted stops
+ * counting. A prompt naming several skills starts from the one written first.
+ */
+export const invokedStarter = <T extends { name: string }>(
+  prompt: string,
+  starters: readonly T[]
+): T | null => {
+  let found: T | null = null;
+  let foundAt = Infinity;
+  for (const starter of starters) {
+    const match = invocationPattern(starter.name).exec(prompt);
+    if (match && match.index < foundAt) {
+      found = starter;
+      foundAt = match.index;
+    }
+  }
+  return found;
+};
+
+/** The prompt with every `/name` of the given starter taken out, one space with it. */
+const withoutStarter = (prompt: string, name: string): string =>
+  prompt.replace(
+    new RegExp(`(^|\\s)/${escapeRegExp(name)}(?:\\s|$)`, "g"),
+    "$1"
+  );
+
+/**
+ * The prompt after the starter pills' toggle: `next` picked, `current` let go.
+ * A picked starter replaces the one the prompt already carries, in place, so a
+ * command typed mid-sentence stays where it was; a prompt carrying none gets
+ * `/next` in front of it, which is where the agent reads it first. Letting go
+ * takes the command out and leaves the ask as it was.
+ */
+export const toggleStarterInPrompt = (
+  prompt: string,
+  current: string | null,
+  next: string | null
+): string => {
+  if (next === null) {
+    return current === null ? prompt : withoutStarter(prompt, current);
+  }
+  if (current !== null && invokesStarter(prompt, current)) {
+    return prompt.replace(invocationPattern(current), `$1/${next}`);
+  }
+  return prompt.length === 0 ? `/${next} ` : `/${next} ${prompt}`;
+};
+
+/**
+ * How many starter pills the row shows before the rest fold behind a count.
+ * NodeTool ships more skills than fit a glance; the rest are one click away,
+ * and every one of them still answers to `/` in the prompt.
+ */
+export const VISIBLE_STARTERS = 8;
+
+/**
+ * A shipped guide to prompting one model line. The agent loads these mid-run,
+ * when `find_model` names one for the model it picked; nobody starts a project
+ * from "Veo 3 prompting", so they rank behind everything else.
+ */
+const isPromptingGuide = (name: string): boolean => name.endsWith("-prompting");
+
+/**
+ * Starters in the order the row shows them: the ones this user's past projects
+ * started from, most recently used first, then the rest as the catalog lists
+ * them — the user's own skills, then the shipped ones — with the model-line
+ * prompting guides last. What someone has started before is the best guess at
+ * what they will start next.
+ */
+export const rankStarters = <T extends { name: string }>(
+  starters: readonly T[],
+  summaries: readonly ProjectDetail[]
+): T[] => {
+  const lastUsed = new Map<string, string>();
+  for (const { project } of summaries) {
+    if (project.kind.length === 0) {
+      continue;
+    }
+    const seen = lastUsed.get(project.kind);
+    if (seen === undefined || project.updatedAt > seen) {
+      lastUsed.set(project.kind, project.updatedAt);
+    }
+  }
+  const used = starters
+    .filter((starter) => lastUsed.has(starter.name))
+    .sort((a, b) =>
+      (lastUsed.get(b.name) ?? "").localeCompare(lastUsed.get(a.name) ?? "")
+    );
+  const rest = starters.filter((starter) => !lastUsed.has(starter.name));
+  return [
+    ...used,
+    ...rest.filter((starter) => !isPromptingGuide(starter.name)),
+    ...rest.filter((starter) => isPromptingGuide(starter.name))
+  ];
+};
+
 /** How long a name derived from the prompt may run before it is cut short. */
 const NAME_LIMIT = 60;
 
 /**
  * The project's name, taken from the prompt's first line. A name is what the
  * tab and the card carry, so it is trimmed to a phrase rather than left as a
- * paragraph; an empty prompt falls back to the starter's label.
+ * paragraph, and the starter's own `/name` is left out of it: the command is
+ * for the agent, not a title. An empty prompt falls back to the starter's label.
  */
 export const projectNameFromPrompt = (
   prompt: string,
   starter: ProjectStarter | null
 ): string => {
-  const firstLine = prompt.trim().split("\n")[0]?.trim() ?? "";
+  const ask = starter ? withoutStarter(prompt, starter.name) : prompt;
+  const firstLine = ask.trim().split("\n")[0]?.trim() ?? "";
   if (firstLine.length === 0) {
     return starter ? starterLabel(starter.name) : "New project";
   }
@@ -63,12 +174,6 @@ interface FirstTurnInput {
   /** Entity names picked from the library, injected by name downstream. */
   entityNames: readonly string[];
 }
-
-/** True when the prompt already invokes `/name` as a whitespace-delimited word. */
-const invokesStarter = (prompt: string, name: string): boolean => {
-  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`(^|\\s)/${escaped}(\\s|$)`).test(prompt);
-};
 
 /**
  * The first thing the project's agent reads: the starter it was given, what


### PR DESCRIPTION
## What changed

The new-project surface listed every shipped skill as an equal starter pill, so the row ran to thirty pills with model-prompting guides beside the real starters, and the picked starter lived in state beside the prompt: a pill pick was never written into the text, a hand-typed `/name` lit nothing, and a `/name` deleted from the prompt stayed the project's kind. The prompt is now the one record of the starter. A pill writes `/<name>` into the prompt (or takes it out, or swaps it in place) and puts the caret back in the box; the pills light up from the text; the project's name leaves the command out. The row ranks starters this user's past projects used first, then the catalog's order with the model-line prompting guides last, and folds past eight behind a "N more" pill that keeps the lit one in view. Pills are the `Chip` primitive with a tooltip for the description. Ctrl/⌘+Enter starts the project; Enter keeps its newline. The skill-mention hook loses its `onSelect` option, whose only caller was this surface.

## Verification

- [x] `npm run test:affected` — 202 suites, 1772 passed, 3 skipped
- [x] `npm run typecheck` — web `tsc --noEmit`: no errors in touched files (the remaining errors are unbuilt package `dist` folders in this container)
- [x] `npm run lint` — `oxlint` on touched paths, `lint:anti-slop:enforced`, `lint:design --workspace=web`: all clean
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — maps to `web-editor`, 0 selfchecks to run
- Rendered the surface against the dev server with Playwright: folded row of 8 + "20 more", picked pill in the project colour with the description below, tooltip on hover, `/launch-commercial` written into the prompt.

## Agent capabilities

No capability added or changed.

## New checks

No check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gyw2Nia4opYasjRYNy8kRJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gyw2Nia4opYasjRYNy8kRJ)_