### PR TITLE
feat(agents): short resource ids at the CodeAct boundary

### DIFF
--- a/packages/agents/src/capabilities/dispatcher.ts
+++ b/packages/agents/src/capabilities/dispatcher.ts
@@ -28,6 +28,7 @@ import {
   type SandboxCapabilityModuleSpec
 } from "@nodetool-ai/protocol";
 
+import { compactResourceIds } from "../codeact/compact-ids.js";
 import { extractErrorPayload, toTransferable } from "../codeact/tool-api.js";
 import { coerceCapabilityArgs } from "./args.js";
 import { listCapabilityModules, loadCapabilityModule } from "./registry.js";
@@ -127,7 +128,9 @@ export function createCapabilityDispatcher(
       if (failure !== null) {
         throw new SandboxCapabilityError(`${found.spec.name}: ${failure}`);
       }
-      return value;
+      // Short ids from here on: the guest, and so the observation, reads the
+      // 12-char form that every capability accepts back.
+      return toTransferable(compactResourceIds(value));
     }
   };
 }

--- a/packages/agents/src/codeact/compact-ids.ts
+++ b/packages/agents/src/codeact/compact-ids.ts
@@ -1,0 +1,77 @@
+/**
+ * Shorten resource ids in what the model reads.
+ *
+ * A capability answers with full 32-hex row ids — `id`, `workflow_id`,
+ * `asset://<id>.png` — and each costs the model about 30 tokens to read and
+ * again to write back. `DBModel.get` accepts the 12-char prefix
+ * (`resource-id.ts` in protocol), so what the model sees can be the short form
+ * without any capability changing what it accepts.
+ *
+ * Rewriting is keyed by field name, never by shape alone: an md5 etag or a
+ * content hash is also 32 hex, and truncating one would corrupt it. `id`,
+ * `*_id`, `*_ids`, and `asset://` uris under `uri` / `*_uri` / `uris` are the
+ * places an id lives. `user_id` is dropped outright: it is always the caller.
+ *
+ * Applied where host values enter the guest (the capability dispatcher and
+ * the belt bridge), so guest variables and the observation agree, and where
+ * host text enters the prompt directly (direct tool results, the memory
+ * block).
+ */
+
+import { isFullResourceId, shortResourceId } from "@nodetool-ai/protocol";
+import { isRecord, isString } from "../utils/type-guards.js";
+
+const ASSET_URI = /asset:\/\/([0-9a-f]{32})(?=[./?#]|$)/g;
+
+/** Every `asset://<full id>` in a string, shortened; the rest untouched. */
+export function compactAssetUris(text: string): string {
+  return text.replace(ASSET_URI, (_, id: string) => `asset://${shortResourceId(id)}`);
+}
+
+function isIdKey(key: string): boolean {
+  return key === "id" || key.endsWith("_id");
+}
+
+function isIdListKey(key: string): boolean {
+  return key === "ids" || key.endsWith("_ids");
+}
+
+function isUriKey(key: string): boolean {
+  return key === "uri" || key.endsWith("_uri") || key === "uris";
+}
+
+function compactIdValue(value: unknown): unknown {
+  return isString(value) && isFullResourceId(value)
+    ? shortResourceId(value)
+    : value;
+}
+
+function compactUriValue(value: unknown): unknown {
+  if (isString(value)) return compactAssetUris(value);
+  if (Array.isArray(value)) return value.map(compactUriValue);
+  return value;
+}
+
+/**
+ * The value with every resource id in an id-named field shortened and
+ * `user_id` removed, recursively. Arrays and nested records are walked;
+ * strings outside id fields are not touched.
+ */
+export function compactResourceIds(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(compactResourceIds);
+  if (!isRecord(value)) return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === "user_id") continue;
+    if (isIdKey(key)) {
+      out[key] = compactIdValue(entry);
+    } else if (isIdListKey(key) && Array.isArray(entry)) {
+      out[key] = entry.map(compactIdValue);
+    } else if (isUriKey(key)) {
+      out[key] = compactUriValue(entry);
+    } else {
+      out[key] = compactResourceIds(entry);
+    }
+  }
+  return out;
+}

--- a/packages/agents/src/codeact/prompt.ts
+++ b/packages/agents/src/codeact/prompt.ts
@@ -116,6 +116,9 @@ Rules:
   along in the same observation, costs nothing, and turns a wrong guess into
   something you can fix inside the same program instead of a probe action.
 - A failed tool call throws; use try/catch when partial failure is acceptable.
+- Resource ids (\`id\`, \`workflow_id\`, \`asset://…\`) arrive as 12-character
+  prefixes of the stored id. Pass them back as they are: every capability
+  accepts the prefix or the full id.
 - Top-level \`await\` and \`return\` work.`;
 
 const actionContractStep = (

--- a/packages/agents/src/codeact/tool-api.ts
+++ b/packages/agents/src/codeact/tool-api.ts
@@ -27,6 +27,7 @@ import {
   stripImagePayload
 } from "../tools/image-injection.js";
 import type { JsonValue } from "../utils/json-parser.js";
+import { compactResourceIds } from "./compact-ids.js";
 import { GRAPH_MODEL_GLOBALS } from "./graph-model.js";
 import { NODETOOL_API_GLOBALS } from "./nodetool-api.js";
 import { TOOLS_PRELUDE } from "./tools-prelude.js";
@@ -214,7 +215,7 @@ export function buildToolBridge(options: ToolBridgeOptions): ToolBridge {
         });
         return { ok: false, error: `tools.${name}: ${errorPayload}` };
       }
-      const transferable = toTransferable(result);
+      const transferable = toTransferable(compactResourceIds(result));
       options.onToolResult?.({
         name,
         toolCallId,

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -392,6 +392,7 @@ export {
   NODETOOL_PRELUDE
 } from "./sandbox-toolbelt.js";
 export type { ToolSignatureSource } from "./codeact/tool-api.js";
+export { compactResourceIds, compactAssetUris } from "./codeact/compact-ids.js";
 export { createChatCodeActSession } from "./codeact/chat-codeact.js";
 export type {
   ChatCodeActSession,

--- a/packages/agents/tests/capabilities-dispatcher.test.ts
+++ b/packages/agents/tests/capabilities-dispatcher.test.ts
@@ -17,6 +17,7 @@ import {
   SANDBOX_CAPABILITY_PACK
 } from "@nodetool-ai/protocol";
 import { createCapabilityDispatcher } from "../src/capabilities/dispatcher.js";
+import { compactResourceIds } from "../src/codeact/compact-ids.js";
 import { UNGATED, createCapabilityRun } from "../src/capabilities/index.js";
 import type { CapabilityRun } from "../src/capabilities/types.js";
 import { createChatCodeActSession } from "../src/codeact/chat-codeact.js";
@@ -165,7 +166,9 @@ describe("the import path in the sandbox", () => {
     const direct = await run.invoke("list_workflows", {});
 
     expect(imported.ok).toBe(true);
-    expect(imported.result).toEqual(direct);
+    // Both guest paths shorten resource ids on the way in; the host-side
+    // invoke answers full ids. Same value past that one boundary.
+    expect(imported.result).toEqual(compactResourceIds(direct));
     const names = (
       (imported.result as { workflows: { name: string }[] }).workflows ?? []
     ).map((w) => w.name);

--- a/packages/agents/tests/compact-ids.test.ts
+++ b/packages/agents/tests/compact-ids.test.ts
@@ -1,0 +1,109 @@
+/**
+ * What the model reads carries short resource ids; what it never needed
+ * (`user_id`) is gone; and nothing that merely looks like an id is touched.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { Workflow, initTestDb } from "@nodetool-ai/models";
+import {
+  sandboxCapabilitySpecifier,
+  shortResourceId
+} from "@nodetool-ai/protocol";
+import {
+  compactAssetUris,
+  compactResourceIds
+} from "../src/codeact/compact-ids.js";
+import { createCapabilityDispatcher } from "../src/capabilities/dispatcher.js";
+import { UNGATED, createCapabilityRun } from "../src/capabilities/index.js";
+
+const FULL = "0192a7f3c4e5b6d7a8f9e0c1b2d3e4f5";
+const SHORT = FULL.slice(0, 12);
+
+describe("compactResourceIds", () => {
+  it("shortens ids in id-named fields, nested and in lists", () => {
+    const out = compactResourceIds({
+      id: FULL,
+      workflow_id: FULL,
+      asset_ids: [FULL, "not-an-id"],
+      nested: [{ job_id: FULL }],
+      uri: `asset://${FULL}.png`,
+      uris: [`asset://${FULL}`]
+    });
+    expect(out).toEqual({
+      id: SHORT,
+      workflow_id: SHORT,
+      asset_ids: [SHORT, "not-an-id"],
+      nested: [{ job_id: SHORT }],
+      uri: `asset://${SHORT}.png`,
+      uris: [`asset://${SHORT}`]
+    });
+  });
+
+  it("drops user_id and leaves 32-hex values outside id fields alone", () => {
+    const etag = "9e107d9d372bb6826bd81d3542a419d6";
+    const out = compactResourceIds({
+      user_id: FULL,
+      etag,
+      content: FULL,
+      source: FULL
+    });
+    expect(out).toEqual({ etag, content: FULL, source: FULL });
+  });
+
+  it("leaves values that are not a full id alone", () => {
+    const out = compactResourceIds({
+      id: "example/hello",
+      _tool_call_id: "codeact_3",
+      thread_id: null,
+      uri: "https://example.com/x.png"
+    });
+    expect(out).toEqual({
+      id: "example/hello",
+      _tool_call_id: "codeact_3",
+      thread_id: null,
+      uri: "https://example.com/x.png"
+    });
+  });
+
+  it("rewrites only asset:// uris in free text", () => {
+    const text = `clip: asset://${FULL}.mp4 hash ${FULL} also asset://${FULL}`;
+    expect(compactAssetUris(text)).toBe(
+      `clip: asset://${SHORT}.mp4 hash ${FULL} also asset://${SHORT}`
+    );
+  });
+});
+
+describe("a capability round trip", () => {
+  const USER = "user-short-id";
+  const ctx = { userId: USER } as unknown as ProcessingContext;
+  const WORKFLOWS = sandboxCapabilitySpecifier("workflows");
+
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("lists short ids and resolves one back to the same row", async () => {
+    const created = await Workflow.create<Workflow>({
+      user_id: USER,
+      name: "round trip",
+      graph: { nodes: [], edges: [] }
+    });
+    const run = createCapabilityRun({ context: ctx, gate: UNGATED });
+    const dispatcher = createCapabilityDispatcher(run, ["workflows"]);
+
+    const listed = (await dispatcher.call(WORKFLOWS, "list_workflows", [
+      {}
+    ])) as { workflows: Array<{ id: string; user_id?: string }> };
+    const row = listed.workflows.find(
+      (entry) => entry.id === shortResourceId(created.id)
+    );
+    expect(row).toBeDefined();
+    expect(row).not.toHaveProperty("user_id");
+
+    const fetched = (await dispatcher.call(WORKFLOWS, "get_workflow", [
+      { workflow_id: row!.id }
+    ])) as { id: string; name: string };
+    expect(fetched.name).toBe("round trip");
+    expect(fetched.id).toBe(shortResourceId(created.id));
+  });
+});

--- a/packages/models/src/base-model.ts
+++ b/packages/models/src/base-model.ts
@@ -8,7 +8,8 @@
 import { randomUUID } from "node:crypto";
 import { createHash } from "node:crypto";
 import { createLogger } from "@nodetool-ai/config";
-import { Column, eq, getTableColumns, Table } from "drizzle-orm";
+import { Column, eq, getTableColumns, like, Table } from "drizzle-orm";
+import { isShortResourceId } from "@nodetool-ai/protocol";
 import { getDb } from "./db.js";
 
 const log = createLogger("nodetool.models");
@@ -191,8 +192,30 @@ export abstract class DBModel {
     const pkCol = getTableColumn(table, this.primaryKey);
     const rows = await db.select().from(table).where(eq(pkCol, key)).limit(1);
     const row = rows[0];
-    if (!row) return null;
-    return new this(row as Record<string, unknown>) as T;
+    if (row) return new this(row as Record<string, unknown>) as T;
+    // A short resource id (`resource-id.ts` in protocol) resolves by prefix.
+    // Only the `id` column, only the exact short length, and only after the
+    // exact lookup missed: a numeric key or a table keyed by something else
+    // never reaches this query. Two matches is an error, not a guess.
+    if (
+      this.primaryKey !== "id" ||
+      typeof key !== "string" ||
+      !isShortResourceId(key)
+    ) {
+      return null;
+    }
+    const matches = await db
+      .select()
+      .from(table)
+      .where(like(pkCol, `${key}%`))
+      .limit(2);
+    if (matches.length > 1) {
+      throw new Error(
+        `short id "${key}" matches more than one row; use the full id`
+      );
+    }
+    const match = matches[0];
+    return match ? (new this(match as Record<string, unknown>) as T) : null;
   }
 
   beforeSave(): void {}

--- a/packages/models/tests/short-id.test.ts
+++ b/packages/models/tests/short-id.test.ts
@@ -1,0 +1,65 @@
+/**
+ * `DBModel.get` resolves a 12-char short id (`resource-id.ts` in protocol) by
+ * prefix, and only then: the exact key still wins, an ambiguous prefix is an
+ * error, and a key that is not the short form never reaches the prefix query.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { shortResourceId } from "@nodetool-ai/protocol";
+import { ModelObserver } from "../src/base-model.js";
+import { initTestDb } from "../src/db.js";
+import { Asset } from "../src/asset.js";
+import { Workflow } from "../src/workflow.js";
+
+describe("DBModel.get with a short resource id", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+  afterEach(() => ModelObserver.clear());
+
+  it("resolves the 12-char prefix to the one row it names", async () => {
+    const asset = await Asset.create<Asset>({
+      user_id: "u1",
+      name: "hero.png",
+      content_type: "image/png"
+    });
+    const short = shortResourceId(asset.id);
+    expect(short).toHaveLength(12);
+    const found = await Asset.find("u1", short);
+    expect(found?.id).toBe(asset.id);
+    expect(await Asset.find("u2", short)).toBeNull();
+  });
+
+  it("refuses a prefix that matches more than one row", async () => {
+    const shared = "0123456789ab";
+    await Asset.create<Asset>({
+      id: `${shared}cdef0123456789abcdef`,
+      user_id: "u1",
+      name: "a.png",
+      content_type: "image/png"
+    });
+    await Asset.create<Asset>({
+      id: `${shared}fedcba9876543210fedc`,
+      user_id: "u1",
+      name: "b.png",
+      content_type: "image/png"
+    });
+    await expect(Asset.get<Asset>(shared)).rejects.toThrow(
+      /matches more than one row/
+    );
+  });
+
+  it("does not prefix-match a key that is not the short form", async () => {
+    const wf = await Workflow.create<Workflow>({
+      user_id: "u1",
+      name: "wf",
+      graph: { nodes: [], edges: [] }
+    });
+    // 11 and 13 chars, and uppercase: none is a short id.
+    expect(await Workflow.get<Workflow>(wf.id.slice(0, 11))).toBeNull();
+    expect(await Workflow.get<Workflow>(wf.id.slice(0, 13))).toBeNull();
+    expect(
+      await Workflow.get<Workflow>(wf.id.slice(0, 12).toUpperCase())
+    ).toBeNull();
+    expect(await Workflow.get<Workflow>("nonexistent-id")).toBeNull();
+  });
+});

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -38,6 +38,7 @@ export * from "./sandbox-package.js";
 export * from "./sandbox-wasm.js";
 export * from "./skill-document.js";
 export * from "./wasm-binary.js";
+export * from "./resource-id.js";
 export {
   type Platform,
   type NodeEffect,

--- a/packages/protocol/src/resource-id.ts
+++ b/packages/protocol/src/resource-id.ts
@@ -1,0 +1,36 @@
+/**
+ * Short resource ids: the first {@link SHORT_RESOURCE_ID_LENGTH} hex chars of
+ * a 32-hex row id.
+ *
+ * A full row id costs about 30 tokens every time a model reads or writes it,
+ * and a list result carries several per row. The short form is stateless — no
+ * alias table, the same string in every thread, in memory, over REST and
+ * after a restart — and at 48 bits a per-user collision is not a practical
+ * concern. Resolution is one indexed prefix query in `DBModel.get`, which
+ * refuses an ambiguous prefix rather than guessing.
+ *
+ * Both forms are accepted everywhere a row is loaded; only what the model
+ * sees is shortened, at the sandbox and prompt boundaries.
+ */
+
+export const SHORT_RESOURCE_ID_LENGTH = 12;
+
+const FULL_ID = /^[0-9a-f]{32}$/;
+const SHORT_ID = new RegExp(`^[0-9a-f]{${SHORT_RESOURCE_ID_LENGTH}}$`);
+
+/** A 32-hex row id as the models generate them. */
+export function isFullResourceId(value: string): boolean {
+  return FULL_ID.test(value);
+}
+
+/** Exactly the short form — a prefix, never a full id or a shorter string. */
+export function isShortResourceId(value: string): boolean {
+  return SHORT_ID.test(value);
+}
+
+/** The short form of a full id; anything else comes back unchanged. */
+export function shortResourceId(value: string): string {
+  return isFullResourceId(value)
+    ? value.slice(0, SHORT_RESOURCE_ID_LENGTH)
+    : value;
+}

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -18,6 +18,7 @@ import type {
   ProviderCost
 } from "@nodetool-ai/protocol";
 import {
+  isShortResourceId,
   packageAssetHttpPath,
   parsePackageAssetUri
 } from "@nodetool-ai/protocol";
@@ -2887,14 +2888,17 @@ export class ProcessingContext {
           try {
             const listing = await adapter.list(prefix);
             const bareEndsWithThumb = bareId.endsWith("_thumb");
+            // A short resource id is a prefix of the stored id, so the key
+            // continues with more hex before its extension; a full id is
+            // followed by the extension itself.
+            const needle = isShortResourceId(bareId) ? bareId : `${bareId}.`;
             const match = listing.entries.find((entry) => {
               const key = entry.key;
               const lastSegment = key.split("/").pop() ?? "";
               // A hierarchical id (`user-1/image`) lives in the full key, a flat
               // id in the last segment — match against whichever form fits.
               const matches =
-                key.startsWith(`${bareId}.`) ||
-                lastSegment.startsWith(`${bareId}.`);
+                key.startsWith(needle) || lastSegment.startsWith(needle);
               if (!matches) {
                 return false;
               }

--- a/packages/runtime/tests/context.test.ts
+++ b/packages/runtime/tests/context.test.ts
@@ -1157,6 +1157,17 @@ describe("ProcessingContext.resolveAssetBytes", () => {
     expect(Uint8Array.from(bytes ?? [])).toEqual(new Uint8Array([4, 5, 6]));
   });
 
+  it("resolves a 12-char short id to the stored full id under the owner prefix", async () => {
+    const full = "0192a7f3c4e5b6d7a8f9e0c1b2d3e4f5";
+    const storage = new InMemoryStorageAdapter();
+    await storage.store(`user-7/${full}.png`, new Uint8Array([3, 1, 4]), "image/png");
+    await storage.store(`user-7/${full}_thumb.png`, new Uint8Array([9]), "image/png");
+    const ctx = new ProcessingContext({ jobId: "j1", userId: "user-7", storage });
+
+    const { bytes } = await ctx.resolveAssetBytes(`asset://${full.slice(0, 12)}.png`);
+    expect(Uint8Array.from(bytes ?? [])).toEqual(new Uint8Array([3, 1, 4]));
+  });
+
   it("resolves the owner-prefixed key by exact lookup, without listing", async () => {
     // Regression: assets are written under `<userId>/<id>.<ext>`, but only the
     // flat and `assets/` candidates were probed. Every reference missed all

--- a/packages/websocket/src/session/chat-turn.ts
+++ b/packages/websocket/src/session/chat-turn.ts
@@ -87,7 +87,7 @@ import type {
   ProcessingMessage
 } from "@nodetool-ai/protocol";
 import type { UiContext } from "@nodetool-ai/protocol";
-import { Tool } from "@nodetool-ai/agents";
+import { Tool, compactAssetUris, compactResourceIds } from "@nodetool-ai/agents";
 import {
   createChatCodeActSession,
   createSandboxClock,
@@ -824,13 +824,16 @@ export class ChatTurnHandler {
       const mine = recent.filter((memory) => memory.thread_id === threadId);
       const elsewhere = recent.length - mine.length;
       if (mine.length === 0 && elsewhere === 0) return "";
+      // Stored with full ids; shown with short ones, which every capability
+      // accepts back. Free text is only rewritten where the scheme types the
+      // id (`asset://…`), so a hash in a note stays intact.
       const rendered = mine.slice(0, MEMORY_BLOCK_LIMIT).map((memory) => ({
         kind: memory.kind,
         title: memory.title,
-        content: memory.content,
-        resources: (Array.isArray(memory.resources)
-          ? memory.resources
-          : []) as MemoryResource[]
+        content: compactAssetUris(memory.content),
+        resources: compactResourceIds(
+          Array.isArray(memory.resources) ? memory.resources : []
+        ) as MemoryResource[]
       }));
       return formatMemoriesForPrompt(rendered, elsewhere);
     } catch (err) {
@@ -1937,7 +1940,9 @@ export class ChatTurnHandler {
       // handle and calls view_image when it wants to look.
       toolResult = await this.materializeToolResultImages(toolResult, ctx);
 
-      const processed = await this.processToolResult(toolResult, ctx);
+      const processed = compactResourceIds(
+        await this.processToolResult(toolResult, ctx)
+      );
       return isString(processed) ? processed : JSON.stringify(processed);
     };
 


### PR DESCRIPTION
## What changed

A 32-hex row id costs the model about 30 tokens every time it reads or writes one, and a list result carries several per row (an asset row was 185 tokens, of which ids and `user_id` were most). This diff shortens what the model sees to the 12-char prefix of the stored id and makes every lookup accept it. `DBModel.get` resolves the prefix after the exact lookup misses, on the `id` column only, and throws on an ambiguous match instead of guessing. The asset-bytes listing fallback accepts the prefix so `asset://<short>.png` still reaches its storage key. A new `compactResourceIds` pass rewrites ids by field name (`id`, `*_id`, `*_ids`, `asset://` under `uri`/`*_uri`) so an md5 etag is never truncated, and drops `user_id` since it is always the caller. It runs where host values enter the guest (capability dispatcher, belt bridge) and where host text enters the prompt (direct tool results, memory block). The short form is stateless: same string in every thread, in memory, over REST, and after a restart, so no alias table is needed. One sentence in the action contract tells the model both forms are accepted.

## Verification

- [x] `npm run test:affected` maps to the full pass because `protocol` changed. Ran the suites the change reaches instead: `protocol` (1083 passed), `models` (987 passed), `runtime` (3335 passed, 1 file failed at load with `spawn ffmpeg ENOENT`, a missing binary in the container, unrelated to the diff), `agents` (4196 passed), `websocket` (2897 passed)
- [x] `npm run typecheck`: web and electron exit 0; mobile fails on missing Expo modules in this container, unrelated
- [x] `npm run lint`: exit 0
- [x] `npm run dev:nodetool -- harness gate --base origin/main`: 7/7 selfchecks passed

The existing dispatcher parity test (`capabilities-dispatcher.test.ts`, "answers what the capability itself answers") failed after the change with the id shortened on the import path and full on the host-side `invoke`; it now compares against `compactResourceIds(direct)`, which is the invariant past the one boundary.

## Agent capabilities

No capability added and no declared contract changed.

## New checks

New tests, each pinning a refusal or a non-rewrite: an ambiguous prefix throws (`models/tests/short-id.test.ts`), 11/13-char and uppercase keys never prefix-match, an md5 etag and 32-hex values outside id fields are untouched (`agents/tests/compact-ids.test.ts`), and a short `asset://` uri resolves through the owner-prefixed listing without picking the thumbnail (`runtime/tests/context.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115ssP5rDfyYkkHWaEEXzRY

---
_Generated by [Claude Code](https://claude.ai/code/session_0115ssP5rDfyYkkHWaEEXzRY)_