### PR TITLE
feat(timeline): Premiere and Final Cut editing model (ripple, drop modes, edit points, presets, transitions, keyframes, source viewer)

### DIFF
--- a/packages/timeline/AGENTS.md
+++ b/packages/timeline/AGENTS.md
@@ -58,6 +58,25 @@
   to both sides so the sequence length never changes; either side running out
   of source throws and the store leaves the document alone.
 
+## Drop modes, transitions, keyframes
+
+- **A drop settles once, on release** (`src/dropResolve.ts`). During a drag
+  the store lets a clip overlap; `resolveDrop` then overwrites (trims, splits
+  or removes what the mover covers on its track), inserts (cuts a straddler
+  on the mover's track and shifts every later clip on unlocked tracks by the
+  moved span) or leaves the overlap for the renderer. Linked siblings of a
+  mover are never its victims.
+- **A transition needs two pictures** (`src/transitionAtCut.ts`). The document
+  keeps `transitionIn` on the incoming clip; `applyTransitionAtCut` also
+  extends the abutting predecessor under it by the transition length, so a
+  hard cut becomes a dissolve rather than a fade from transparent. It never
+  exceeds the shorter of the two clips.
+- **Hand-set keyframes are one custom animation** (`src/keyframes.ts`):
+  `preset: "custom"`, role `emphasis`, `params.keyframed`, duration equal to
+  the clip's, one curve per property. The sampler plays it like any custom
+  animation. Times are `t` over the clip, so a trim stretches its keyframes;
+  a caller that needs absolute times converts through `keyframeTimesMs`.
+
 ## Snapping & placement
 
 - **Generate snap-point ticks as `i * interval`, never `t += interval`** —

--- a/packages/timeline/AGENTS.md
+++ b/packages/timeline/AGENTS.md
@@ -41,6 +41,23 @@
   straddling word) and **rebase** the moved side's local timings
   (`startMs - splitMs`), not copy the whole `words` array to both.
 
+## Ripple and roll (`src/rippleEdit.ts`)
+
+- **A ripple moves every unlocked track, not just the edited one.** A voiceover
+  or caption sits against a shot; a ripple that only closed the video track
+  would pull them out of sync. `shiftClipsFrom` is the one shift, and every
+  ripple (`rippleTrim`, `rippleDelete`, `closeGap`) is a trim or removal
+  followed by it, so the "what moves" rule lives in one place.
+- **A ripple head-trim keeps the clip parked.** `rippleTrim(..., "start", d)`
+  moves the in-point and the duration and puts `startMs` back; the downstream
+  shift is measured from the clip's *old* end. The web trim gesture
+  (`useClipTrim`) measures a head-trim against the duration at pointerdown for
+  the same reason.
+- **A roll is two trims that sum to zero.** `rollEdit` finds the neighbour
+  across the cut (`findRollNeighbour`, 1 ms tolerance) and applies `trimClip`
+  to both sides so the sequence length never changes; either side running out
+  of source throws and the store leaves the document alone.
+
 ## Snapping & placement
 
 - **Generate snap-point ticks as `i * interval`, never `t += interval`** —

--- a/packages/timeline/src/dropResolve.ts
+++ b/packages/timeline/src/dropResolve.ts
@@ -1,0 +1,158 @@
+/**
+ * Drop resolution: what happens to the clips a moved clip lands on.
+ *
+ * During a drag the store lets a clip sit on top of whatever is under it, so
+ * the picture follows the pointer. On release the editor picks one of three
+ * outcomes, the same three Premiere and Final Cut offer:
+ *
+ * - **overwrite** — the moved clip replaces what it covers on its track. A
+ *   clip fully under it goes, a clip it partly covers is trimmed back, and a
+ *   clip that spans it is cut in two around it.
+ * - **insert** — the moved clip pushes everything from its start onward to
+ *   the right by its length, on every unlocked track, cutting a clip on its
+ *   own track that straddles the insert point.
+ * - **overlap** — nothing else moves; the renderer composites the later clip
+ *   on top and cross-fades across the overlap. This was the only behaviour
+ *   before drop modes existed and stays available for that reason.
+ *
+ * Pure over the clip array so the store, the agent bridge and a test agree.
+ */
+
+import { shiftClipsFrom, type RippleOptions } from "./rippleEdit.js";
+import { splitClip } from "./splitClip.js";
+import { trimClip } from "./trimClip.js";
+import type { TimelineClip } from "./types.js";
+
+export const DROP_MODES = ["overwrite", "insert", "overlap"] as const;
+export type DropMode = (typeof DROP_MODES)[number];
+
+const clipEndMs = (c: TimelineClip): number => c.startMs + c.durationMs;
+
+/** Ids of every moved clip plus the members of their link groups. */
+function movedAndLinked(
+  clips: readonly TimelineClip[],
+  movedIds: ReadonlySet<string>
+): Set<string> {
+  const linkIds = new Set<string>();
+  for (const c of clips) {
+    if (movedIds.has(c.id) && c.linkId !== undefined) linkIds.add(c.linkId);
+  }
+  const out = new Set(movedIds);
+  for (const c of clips) {
+    if (c.linkId !== undefined && linkIds.has(c.linkId)) out.add(c.id);
+  }
+  return out;
+}
+
+/**
+ * Cut back, split or remove the clips that `movedIds` now cover on their own
+ * tracks. Linked siblings of a moved clip are never victims (they moved
+ * too), and a clip that refuses a trim or split (a time-remapped one) is
+ * left where it is rather than half-edited.
+ */
+export function resolveOverwrite(
+  clips: readonly TimelineClip[],
+  movedIds: ReadonlySet<string>
+): TimelineClip[] {
+  const movers = clips.filter((c) => movedIds.has(c.id));
+  if (movers.length === 0) return [...clips];
+  const protectedIds = movedAndLinked(clips, movedIds);
+
+  let next: TimelineClip[] = [...clips];
+  for (const m of movers) {
+    const mStart = m.startMs;
+    const mEnd = clipEndMs(m);
+    const out: TimelineClip[] = [];
+    for (const c of next) {
+      if (protectedIds.has(c.id) || c.trackId !== m.trackId) {
+        out.push(c);
+        continue;
+      }
+      const cStart = c.startMs;
+      const cEnd = clipEndMs(c);
+      if (cEnd <= mStart || cStart >= mEnd) {
+        out.push(c);
+        continue;
+      }
+      try {
+        if (cStart >= mStart && cEnd <= mEnd) {
+          // Fully covered: gone.
+          continue;
+        }
+        if (cStart < mStart && cEnd > mEnd) {
+          // Spans the mover: keep the head and the tail.
+          const [head, rest] = splitClip(c, mStart);
+          const [, tail] = splitClip(rest, mEnd);
+          out.push(head, tail);
+          continue;
+        }
+        if (cStart < mStart) {
+          // Overlaps the mover's head: cut the victim's tail back.
+          out.push(trimClip(c, "end", mStart - cEnd));
+          continue;
+        }
+        // Overlaps the mover's tail: advance the victim's head.
+        out.push(trimClip(c, "start", -(mEnd - cStart)));
+      } catch {
+        out.push(c);
+      }
+    }
+    next = out;
+  }
+  return next;
+}
+
+/**
+ * Make room for `movedIds`: every clip on an unlocked track that starts at or
+ * after the earliest moved start shifts right by the moved span, and a clip on
+ * a moved clip's own track that straddles that point is cut there first so
+ * its second half can move. The moved clips themselves stay put.
+ */
+export function resolveInsert(
+  clips: readonly TimelineClip[],
+  movedIds: ReadonlySet<string>,
+  options: RippleOptions = {}
+): TimelineClip[] {
+  const movers = clips.filter((c) => movedIds.has(c.id));
+  if (movers.length === 0) return [...clips];
+  const protectedIds = movedAndLinked(clips, movedIds);
+  const insertMs = Math.min(...movers.map((c) => c.startMs));
+  const spanMs = Math.max(...movers.map(clipEndMs)) - insertMs;
+  const moverTracks = new Set(movers.map((c) => c.trackId));
+
+  const cut: TimelineClip[] = [];
+  for (const c of clips) {
+    if (
+      !protectedIds.has(c.id) &&
+      moverTracks.has(c.trackId) &&
+      c.startMs < insertMs &&
+      clipEndMs(c) > insertMs
+    ) {
+      try {
+        cut.push(...splitClip(c, insertMs));
+        continue;
+      } catch {
+        // A clip that cannot be split stays whole and does not move.
+      }
+    }
+    cut.push(c);
+  }
+  return shiftClipsFrom(cut, insertMs, spanMs, protectedIds, options);
+}
+
+/** Apply `mode` to a finished drop. */
+export function resolveDrop(
+  clips: readonly TimelineClip[],
+  movedIds: ReadonlySet<string>,
+  mode: DropMode,
+  options: RippleOptions = {}
+): TimelineClip[] {
+  switch (mode) {
+    case "overwrite":
+      return resolveOverwrite(clips, movedIds);
+    case "insert":
+      return resolveInsert(clips, movedIds, options);
+    case "overlap":
+      return [...clips];
+  }
+}

--- a/packages/timeline/src/index.ts
+++ b/packages/timeline/src/index.ts
@@ -19,6 +19,7 @@ export * from "./group.js";
 export * from "./composition.js";
 export * from "./splitClip.js";
 export * from "./trimClip.js";
+export * from "./rippleEdit.js";
 export * from "./sourceRate.js";
 export * from "./timeRemap.js";
 export * from "./snap.js";

--- a/packages/timeline/src/index.ts
+++ b/packages/timeline/src/index.ts
@@ -20,6 +20,7 @@ export * from "./composition.js";
 export * from "./splitClip.js";
 export * from "./trimClip.js";
 export * from "./rippleEdit.js";
+export * from "./dropResolve.js";
 export * from "./sourceRate.js";
 export * from "./timeRemap.js";
 export * from "./snap.js";

--- a/packages/timeline/src/index.ts
+++ b/packages/timeline/src/index.ts
@@ -22,6 +22,7 @@ export * from "./trimClip.js";
 export * from "./rippleEdit.js";
 export * from "./dropResolve.js";
 export * from "./transitionAtCut.js";
+export * from "./keyframes.js";
 export * from "./sourceRate.js";
 export * from "./timeRemap.js";
 export * from "./snap.js";

--- a/packages/timeline/src/index.ts
+++ b/packages/timeline/src/index.ts
@@ -21,6 +21,7 @@ export * from "./splitClip.js";
 export * from "./trimClip.js";
 export * from "./rippleEdit.js";
 export * from "./dropResolve.js";
+export * from "./transitionAtCut.js";
 export * from "./sourceRate.js";
 export * from "./timeRemap.js";
 export * from "./snap.js";

--- a/packages/timeline/src/keyframes.ts
+++ b/packages/timeline/src/keyframes.ts
@@ -1,0 +1,180 @@
+/**
+ * Per-property keyframes on a clip.
+ *
+ * A clip's hand-set keyframes live in one custom animation that spans the
+ * whole clip: `preset: "custom"`, `role: "emphasis"`, no delay, duration equal
+ * to the clip's, one curve per property. The sampler already knows how to
+ * play such a curve (`animation/compile.ts`), so a keyframe set here renders
+ * everywhere a preset does. Keyframe times are stored as `t` in 0..1 over the
+ * clip, so trimming the clip stretches its keyframes with it.
+ *
+ * These are pure functions over one clip; the store wraps them.
+ */
+
+import type { ClipAnimation, CustomClipAnimation } from "./animation/types.js";
+import { ANIMATED_PROPERTY_FOLD, type AnimatedProperty } from "./animation/types.js";
+import { createTimeOrderedUuid } from "./defaults.js";
+import type { TimelineClip } from "./types.js";
+
+/** The properties the keyframe inspector offers, with their identity value. */
+export const KEYFRAME_PROPERTIES = [
+  "opacity",
+  "scale",
+  "offsetX",
+  "offsetY",
+  "rotation"
+] as const satisfies readonly AnimatedProperty[];
+export type KeyframeProperty = (typeof KEYFRAME_PROPERTIES)[number];
+
+/** The value that changes nothing for a property, by how it folds. */
+export function keyframeIdentity(property: AnimatedProperty): number {
+  const fold = ANIMATED_PROPERTY_FOLD[property];
+  return fold === "multiply" ? 1 : 0;
+}
+
+export const KEYFRAME_ANIMATION_PRESET = "custom";
+/** Two keyframes closer than this (in `t`) are the same keyframe. */
+const T_EPSILON = 1e-4;
+
+export function isKeyframeAnimation(animation: ClipAnimation): boolean {
+  return (
+    animation.preset === KEYFRAME_ANIMATION_PRESET &&
+    animation.role === "emphasis" &&
+    (animation.delayMs ?? 0) === 0 &&
+    animation.params?.keyframed === true
+  );
+}
+
+export function findKeyframeAnimation(
+  clip: Pick<TimelineClip, "animations">
+): ClipAnimation | undefined {
+  return clip.animations?.find(isKeyframeAnimation);
+}
+
+function toT(clip: Pick<TimelineClip, "durationMs">, atMs: number): number {
+  if (clip.durationMs <= 0) return 0;
+  return Math.max(0, Math.min(1, atMs / clip.durationMs));
+}
+
+/** Every keyframe time (clip-relative ms) across all properties, sorted. */
+export function keyframeTimesMs(
+  clip: Pick<TimelineClip, "animations" | "durationMs">
+): number[] {
+  const animation = findKeyframeAnimation(clip);
+  if (!animation?.custom) return [];
+  const times = new Set<number>();
+  for (const curve of animation.custom.curves) {
+    for (const kf of curve.keyframes) {
+      times.add(Math.round(kf.t * clip.durationMs));
+    }
+  }
+  return [...times].sort((a, b) => a - b);
+}
+
+/** Linear sample of one property's curve at `atMs`; identity without one. */
+export function keyframeValueAt(
+  clip: Pick<TimelineClip, "animations" | "durationMs">,
+  property: AnimatedProperty,
+  atMs: number
+): number {
+  const curve = findKeyframeAnimation(clip)?.custom?.curves.find(
+    (c) => c.property === property
+  );
+  if (!curve || curve.keyframes.length === 0) return keyframeIdentity(property);
+  const t = toT(clip, atMs);
+  const kfs = [...curve.keyframes].sort((a, b) => a.t - b.t);
+  if (t <= kfs[0].t) return kfs[0].value;
+  const last = kfs[kfs.length - 1];
+  if (t >= last.t) return last.value;
+  for (let i = 1; i < kfs.length; i++) {
+    if (t <= kfs[i].t) {
+      const a = kfs[i - 1];
+      const b = kfs[i];
+      const span = b.t - a.t;
+      const f = span <= 0 ? 1 : (t - a.t) / span;
+      return a.value + (b.value - a.value) * f;
+    }
+  }
+  return last.value;
+}
+
+/** Whether `property` has a keyframe at `atMs` (within a frame's rounding). */
+export function hasKeyframeAt(
+  clip: Pick<TimelineClip, "animations" | "durationMs">,
+  property: AnimatedProperty,
+  atMs: number
+): boolean {
+  const curve = findKeyframeAnimation(clip)?.custom?.curves.find(
+    (c) => c.property === property
+  );
+  if (!curve) return false;
+  const t = toT(clip, atMs);
+  return curve.keyframes.some((kf) => Math.abs(kf.t - t) < T_EPSILON);
+}
+
+function withCurves(
+  clip: TimelineClip,
+  update: (curves: CustomClipAnimation["curves"]) => CustomClipAnimation["curves"]
+): ClipAnimation[] {
+  const animations = clip.animations ?? [];
+  const existing = findKeyframeAnimation(clip);
+  const curves = update(existing?.custom?.curves ?? []);
+  const live = curves.filter((c) => c.keyframes.length > 0);
+  if (live.length === 0) {
+    return animations.filter((a) => a !== existing);
+  }
+  const next: ClipAnimation = {
+    id: existing?.id ?? createTimeOrderedUuid(),
+    role: "emphasis",
+    preset: KEYFRAME_ANIMATION_PRESET,
+    durationMs: clip.durationMs,
+    delayMs: 0,
+    enabled: true,
+    params: { keyframed: true },
+    custom: { ...(existing?.custom ?? {}), curves: live }
+  };
+  return existing
+    ? animations.map((a) => (a === existing ? next : a))
+    : [...animations, next];
+}
+
+/**
+ * Set `property` to `value` at `atMs`, adding a keyframe or updating the one
+ * already there. Returns the clip's new animation list.
+ */
+export function setKeyframe(
+  clip: TimelineClip,
+  property: AnimatedProperty,
+  atMs: number,
+  value: number
+): ClipAnimation[] {
+  const t = toT(clip, atMs);
+  return withCurves(clip, (curves) => {
+    const others = curves.filter((c) => c.property !== property);
+    const curve = curves.find((c) => c.property === property);
+    const kept = (curve?.keyframes ?? []).filter(
+      (kf) => Math.abs(kf.t - t) >= T_EPSILON
+    );
+    const keyframes = [...kept, { t, value }].sort((a, b) => a.t - b.t);
+    return [...others, { property, keyframes }];
+  });
+}
+
+/** Remove `property`'s keyframe at `atMs`, if any. */
+export function removeKeyframe(
+  clip: TimelineClip,
+  property: AnimatedProperty,
+  atMs: number
+): ClipAnimation[] {
+  const t = toT(clip, atMs);
+  return withCurves(clip, (curves) =>
+    curves.map((c) =>
+      c.property === property
+        ? {
+            ...c,
+            keyframes: c.keyframes.filter((kf) => Math.abs(kf.t - t) >= T_EPSILON)
+          }
+        : c
+    )
+  );
+}

--- a/packages/timeline/src/rippleEdit.ts
+++ b/packages/timeline/src/rippleEdit.ts
@@ -1,0 +1,243 @@
+/**
+ * Ripple and roll edits: the trims and deletes that keep a cut gap-free.
+ *
+ * A plain trim moves one edge and leaves everything else where it was, so
+ * shortening a clip opens a hole. The operations here close it the way
+ * Premiere and Final Cut do: a ripple moves every later clip by the amount the
+ * edit added or removed, a roll moves a cut between two neighbours without
+ * changing anything downstream, and a ripple delete or close-gap pulls the
+ * rest of the sequence left.
+ *
+ * Every function is pure over the clip array so the web store, the agent
+ * bridge and a test all get the same answer. Downstream means every clip on an
+ * unlocked track that starts at or after the edit point, on every track: the
+ * timeline is a multi-track document where a voiceover and a caption sit
+ * against a shot, and a ripple that only moved one track would pull them out
+ * of sync.
+ */
+
+import { trimClip } from "./trimClip.js";
+import type { TimelineClip } from "./types.js";
+
+export interface RippleOptions {
+  /** Tracks whose clips never move. */
+  lockedTrackIds?: ReadonlySet<string>;
+}
+
+const clipEndMs = (c: TimelineClip): number => c.startMs + c.durationMs;
+
+/** Every clip sharing `clip`'s link group, the clip itself included. */
+function linkGroupIds(
+  clips: readonly TimelineClip[],
+  clip: TimelineClip
+): Set<string> {
+  const ids = new Set([clip.id]);
+  if (clip.linkId !== undefined) {
+    for (const c of clips) {
+      if (c.linkId === clip.linkId) ids.add(c.id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Move every clip that starts at or after `fromMs` by `deltaMs`, skipping
+ * `excludeIds` and clips on locked tracks. A negative delta never pushes a
+ * clip before zero. Children of a group carry their own `startMs`, so a
+ * group and its children each shift on their own start.
+ */
+export function shiftClipsFrom(
+  clips: readonly TimelineClip[],
+  fromMs: number,
+  deltaMs: number,
+  excludeIds: ReadonlySet<string> = new Set(),
+  options: RippleOptions = {}
+): TimelineClip[] {
+  if (deltaMs === 0) return [...clips];
+  const locked = options.lockedTrackIds;
+  return clips.map((c) => {
+    if (excludeIds.has(c.id) || locked?.has(c.trackId)) return c;
+    if (c.startMs < fromMs) return c;
+    return { ...c, startMs: Math.max(0, c.startMs + deltaMs) };
+  });
+}
+
+/**
+ * Trim one edge of `clip` (and its linked siblings) with `trimClip`'s delta
+ * convention, then ripple: everything that started at or after the clip's old
+ * end moves by the change in its duration. Trimming the start edge keeps the
+ * clip parked at its `startMs` (the in-point moves, the picture on the
+ * timeline does not), which is what ripple-trimming a head means in every
+ * editor. Throws when the trim itself is invalid.
+ */
+export function rippleTrim(
+  clips: readonly TimelineClip[],
+  clipId: string,
+  edge: "start" | "end",
+  deltaMs: number,
+  options: RippleOptions & { maxSourceDurationMs?: number } = {}
+): TimelineClip[] {
+  const clip = clips.find((c) => c.id === clipId);
+  if (!clip) throw new Error(`rippleTrim: clip ${clipId} not found`);
+  const group = linkGroupIds(clips, clip);
+  const oldEndMs = clipEndMs(clip);
+
+  const trimmed = new Map<string, TimelineClip>();
+  for (const c of clips) {
+    if (!group.has(c.id)) continue;
+    const next = trimClip(
+      c,
+      edge,
+      deltaMs,
+      c.id === clipId ? options.maxSourceDurationMs : undefined
+    );
+    trimmed.set(c.id, edge === "start" ? { ...next, startMs: c.startMs } : next);
+  }
+
+  const applied = trimmed.get(clipId)!.durationMs - clip.durationMs;
+  const withTrim = clips.map((c) => trimmed.get(c.id) ?? c);
+  return shiftClipsFrom(withTrim, oldEndMs, applied, group, options);
+}
+
+/**
+ * The clip on `clip`'s track that abuts the given edge: the one starting where
+ * `clip` ends, or ending where it starts. A cut is a shared timestamp, with a
+ * 1 ms tolerance for rounding.
+ */
+export function findRollNeighbour(
+  clips: readonly TimelineClip[],
+  clip: TimelineClip,
+  edge: "start" | "end"
+): TimelineClip | undefined {
+  const cutMs = edge === "end" ? clipEndMs(clip) : clip.startMs;
+  return clips.find(
+    (c) =>
+      c.id !== clip.id &&
+      c.trackId === clip.trackId &&
+      Math.abs((edge === "end" ? c.startMs : clipEndMs(c)) - cutMs) <= 1
+  );
+}
+
+/**
+ * Roll the cut on `edge` of `clip` by `deltaMs` (positive = later). The clip
+ * on one side grows by what the other loses, so the sequence length and every
+ * other clip stay put. Linked siblings of both clips follow. Throws when
+ * either side cannot give up or reveal that much source, or when the edge has
+ * no neighbour to roll against.
+ */
+export function rollEdit(
+  clips: readonly TimelineClip[],
+  clipId: string,
+  edge: "start" | "end",
+  deltaMs: number
+): TimelineClip[] {
+  const clip = clips.find((c) => c.id === clipId);
+  if (!clip) throw new Error(`rollEdit: clip ${clipId} not found`);
+  const neighbour = findRollNeighbour(clips, clip, edge);
+  if (!neighbour) throw new Error("rollEdit: no clip on the other side of the cut");
+
+  const left = edge === "end" ? clip : neighbour;
+  const right = edge === "end" ? neighbour : clip;
+  const leftIds = linkGroupIds(clips, left);
+  const rightIds = linkGroupIds(clips, right);
+
+  const next = new Map<string, TimelineClip>();
+  for (const c of clips) {
+    if (leftIds.has(c.id)) next.set(c.id, trimClip(c, "end", deltaMs));
+    else if (rightIds.has(c.id)) next.set(c.id, trimClip(c, "start", -deltaMs));
+  }
+  return clips.map((c) => next.get(c.id) ?? c);
+}
+
+/** Merge overlapping or touching [start, end) ranges into disjoint ones. */
+function mergeRanges(
+  ranges: { startMs: number; endMs: number }[]
+): { startMs: number; endMs: number }[] {
+  const sorted = [...ranges].sort((a, b) => a.startMs - b.startMs);
+  const out: { startMs: number; endMs: number }[] = [];
+  for (const r of sorted) {
+    const last = out[out.length - 1];
+    if (last && r.startMs <= last.endMs) {
+      last.endMs = Math.max(last.endMs, r.endMs);
+    } else {
+      out.push({ ...r });
+    }
+  }
+  return out;
+}
+
+/**
+ * Remove `ids` and close the time they covered: for each span the removed
+ * clips occupied (overlapping spans merged), every remaining clip that started
+ * at or after the span's end moves left by its length. Spans are closed from
+ * the right so an earlier shift never changes what a later one measures.
+ * A surviving clip that straddles a span is left alone.
+ */
+export function rippleDelete(
+  clips: readonly TimelineClip[],
+  ids: ReadonlySet<string>,
+  options: RippleOptions = {}
+): TimelineClip[] {
+  const removed = clips.filter((c) => ids.has(c.id));
+  if (removed.length === 0) return [...clips];
+  let next: TimelineClip[] = clips.filter((c) => !ids.has(c.id));
+  const spans = mergeRanges(
+    removed.map((c) => ({ startMs: c.startMs, endMs: clipEndMs(c) }))
+  ).reverse();
+  for (const span of spans) {
+    next = shiftClipsFrom(
+      next,
+      span.endMs,
+      span.startMs - span.endMs,
+      new Set(),
+      options
+    );
+  }
+  return next;
+}
+
+/**
+ * The empty stretch on `trackId` containing `atMs`, or null when a clip covers
+ * that time. The gap runs from the end of the last clip before `atMs` (or 0)
+ * to the start of the first clip after it; with no clip after there is nothing
+ * to pull in, so that is null too.
+ */
+export function findGap(
+  clips: readonly TimelineClip[],
+  trackId: string,
+  atMs: number
+): { startMs: number; endMs: number } | null {
+  let prevEnd = 0;
+  let nextStart = Infinity;
+  for (const c of clips) {
+    if (c.trackId !== trackId) continue;
+    const end = clipEndMs(c);
+    if (c.startMs <= atMs && end > atMs) return null;
+    if (end <= atMs) prevEnd = Math.max(prevEnd, end);
+    else nextStart = Math.min(nextStart, c.startMs);
+  }
+  if (nextStart === Infinity || nextStart <= prevEnd) return null;
+  return { startMs: prevEnd, endMs: nextStart };
+}
+
+/**
+ * Close the gap on `trackId` at `atMs`: everything on an unlocked track that
+ * starts at or after the gap's end moves left by the gap's length. Returns the
+ * input array unchanged when there is no gap there.
+ */
+export function closeGap(
+  clips: readonly TimelineClip[],
+  trackId: string,
+  atMs: number,
+  options: RippleOptions = {}
+): TimelineClip[] {
+  const gap = findGap(clips, trackId, atMs);
+  if (!gap) return [...clips];
+  return shiftClipsFrom(
+    clips,
+    gap.endMs,
+    gap.startMs - gap.endMs,
+    new Set(),
+    options
+  );
+}

--- a/packages/timeline/src/rippleEdit.ts
+++ b/packages/timeline/src/rippleEdit.ts
@@ -22,6 +22,8 @@ import type { TimelineClip } from "./types.js";
 export interface RippleOptions {
   /** Tracks whose clips never move. */
   lockedTrackIds?: ReadonlySet<string>;
+  /** Linked siblings follow the edited clip (default). Off, only it moves. */
+  followLinks?: boolean;
 }
 
 const clipEndMs = (c: TimelineClip): number => c.startMs + c.durationMs;
@@ -29,10 +31,11 @@ const clipEndMs = (c: TimelineClip): number => c.startMs + c.durationMs;
 /** Every clip sharing `clip`'s link group, the clip itself included. */
 function linkGroupIds(
   clips: readonly TimelineClip[],
-  clip: TimelineClip
+  clip: TimelineClip,
+  followLinks = true
 ): Set<string> {
   const ids = new Set([clip.id]);
-  if (clip.linkId !== undefined) {
+  if (followLinks && clip.linkId !== undefined) {
     for (const c of clips) {
       if (c.linkId === clip.linkId) ids.add(c.id);
     }
@@ -79,7 +82,7 @@ export function rippleTrim(
 ): TimelineClip[] {
   const clip = clips.find((c) => c.id === clipId);
   if (!clip) throw new Error(`rippleTrim: clip ${clipId} not found`);
-  const group = linkGroupIds(clips, clip);
+  const group = linkGroupIds(clips, clip, options.followLinks);
   const oldEndMs = clipEndMs(clip);
 
   const trimmed = new Map<string, TimelineClip>();
@@ -129,7 +132,8 @@ export function rollEdit(
   clips: readonly TimelineClip[],
   clipId: string,
   edge: "start" | "end",
-  deltaMs: number
+  deltaMs: number,
+  options: Pick<RippleOptions, "followLinks"> = {}
 ): TimelineClip[] {
   const clip = clips.find((c) => c.id === clipId);
   if (!clip) throw new Error(`rollEdit: clip ${clipId} not found`);
@@ -138,8 +142,8 @@ export function rollEdit(
 
   const left = edge === "end" ? clip : neighbour;
   const right = edge === "end" ? neighbour : clip;
-  const leftIds = linkGroupIds(clips, left);
-  const rightIds = linkGroupIds(clips, right);
+  const leftIds = linkGroupIds(clips, left, options.followLinks);
+  const rightIds = linkGroupIds(clips, right, options.followLinks);
 
   const next = new Map<string, TimelineClip>();
   for (const c of clips) {

--- a/packages/timeline/src/transitionAtCut.ts
+++ b/packages/timeline/src/transitionAtCut.ts
@@ -1,0 +1,104 @@
+/**
+ * Transitions on a cut.
+ *
+ * The document keeps a transition on the incoming clip (`transitionIn`), and
+ * the renderer cross-fades that clip in over the window while whatever sits
+ * under it on the same track keeps playing. On a hard cut nothing sits under
+ * it, so a dissolve needs the outgoing clip to keep going for the length of
+ * the transition: that is what Premiere and Final Cut do with the outgoing
+ * clip's handle. `applyTransitionAtCut` extends the abutting predecessor by
+ * the transition length and sets the incoming clip's `transitionIn`, in one
+ * step, so a default-transition key or a context-menu item produces a real
+ * dissolve. A predecessor that cannot grow (time-remapped) is left alone and
+ * the incoming clip fades from transparent instead.
+ */
+
+import { trimClip } from "./trimClip.js";
+import type { ClipTransition, TimelineClip } from "./types.js";
+
+export const DEFAULT_TRANSITION_MS = 500;
+
+const clipEndMs = (c: TimelineClip): number => c.startMs + c.durationMs;
+
+/**
+ * The clip on `clip`'s track that ends at (±1 ms) or already overlaps its
+ * start: the one a transition into `clip` plays over.
+ */
+export function transitionPredecessor(
+  clips: readonly TimelineClip[],
+  clip: TimelineClip
+): TimelineClip | undefined {
+  let best: TimelineClip | undefined;
+  for (const c of clips) {
+    if (c.id === clip.id || c.trackId !== clip.trackId) continue;
+    if (c.startMs >= clip.startMs) continue;
+    const end = clipEndMs(c);
+    if (end < clip.startMs - 1) continue;
+    if (!best || end > clipEndMs(best)) best = c;
+  }
+  return best;
+}
+
+/** Longest transition `clip` can carry: no more than itself or its predecessor. */
+export function maxTransitionMs(
+  clips: readonly TimelineClip[],
+  clip: TimelineClip
+): number {
+  const prev = transitionPredecessor(clips, clip);
+  return prev ? Math.min(clip.durationMs, prev.durationMs) : clip.durationMs;
+}
+
+/**
+ * Give `clipId` a transition of `durationMs`, extending an abutting
+ * predecessor under it so the two overlap for that long. A predecessor that
+ * already overlaps is grown only by what the transition still lacks. The
+ * transition type is kept when the clip already has one, else `type`.
+ */
+export function applyTransitionAtCut(
+  clips: readonly TimelineClip[],
+  clipId: string,
+  durationMs: number,
+  type: ClipTransition["type"] = "crossfade"
+): TimelineClip[] {
+  const clip = clips.find((c) => c.id === clipId);
+  if (!clip) throw new Error(`applyTransitionAtCut: clip ${clipId} not found`);
+  const wanted = Math.max(0, Math.min(durationMs, maxTransitionMs(clips, clip)));
+  const prev = transitionPredecessor(clips, clip);
+
+  let grownPrev: TimelineClip | undefined;
+  if (prev && wanted > 0) {
+    const overlap = clipEndMs(prev) - clip.startMs;
+    const missing = wanted - Math.max(0, overlap);
+    if (missing > 0) {
+      try {
+        grownPrev = trimClip(prev, "end", missing);
+      } catch {
+        // The predecessor cannot grow; the incoming clip fades in on its own.
+      }
+    }
+  }
+
+  const existing = clip.transitionIn;
+  const transitionIn: ClipTransition =
+    existing && existing.durationMs > 0
+      ? { ...existing, durationMs: wanted }
+      : ({ type, durationMs: wanted } as ClipTransition);
+
+  return clips.map((c) => {
+    if (c.id === clipId) return { ...c, transitionIn };
+    if (grownPrev && c.id === grownPrev.id) return grownPrev;
+    return c;
+  });
+}
+
+/** Drop `clipId`'s transition; the predecessor keeps whatever length it has. */
+export function removeTransitionAtCut(
+  clips: readonly TimelineClip[],
+  clipId: string
+): TimelineClip[] {
+  return clips.map((c) => {
+    if (c.id !== clipId || c.transitionIn === undefined) return c;
+    const { transitionIn: _dropped, ...rest } = c;
+    return rest;
+  });
+}

--- a/packages/timeline/tests/dropResolve.test.ts
+++ b/packages/timeline/tests/dropResolve.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { resolveInsert, resolveOverwrite, resolveDrop } from "../src/dropResolve.js";
+import type { TimelineClip } from "../src/types.js";
+
+function clip(
+  id: string,
+  startMs: number,
+  durationMs: number,
+  extra: Partial<TimelineClip> = {}
+): TimelineClip {
+  return {
+    id,
+    trackId: "v1",
+    name: id,
+    startMs,
+    durationMs,
+    inPointMs: 0,
+    outPointMs: durationMs,
+    mediaType: "video",
+    sourceType: "imported",
+    status: "generated",
+    locked: false,
+    versions: [],
+    ...extra
+  };
+}
+const byId = (clips: TimelineClip[], id: string) => clips.find((c) => c.id === id);
+
+describe("resolveOverwrite", () => {
+  it("removes a clip the mover fully covers", () => {
+    const out = resolveOverwrite(
+      [clip("a", 1000, 500), clip("m", 800, 1000)],
+      new Set(["m"])
+    );
+    expect(out.map((c) => c.id)).toEqual(["m"]);
+  });
+
+  it("trims a clip the mover's head lands on, and one its tail lands on", () => {
+    const out = resolveOverwrite(
+      [clip("a", 0, 1000), clip("b", 1000, 1000), clip("m", 700, 600)],
+      new Set(["m"])
+    );
+    expect(byId(out, "a")!.durationMs).toBe(700);
+    expect(byId(out, "b")!.startMs).toBe(1300);
+    expect(byId(out, "b")!.inPointMs).toBe(300);
+    expect(byId(out, "b")!.durationMs).toBe(700);
+  });
+
+  it("cuts a clip that spans the mover into a head and a tail", () => {
+    const out = resolveOverwrite(
+      [clip("big", 0, 3000), clip("m", 1000, 500)],
+      new Set(["m"])
+    );
+    const others = out.filter((c) => c.id !== "m");
+    expect(others).toHaveLength(2);
+    expect(others[0].startMs).toBe(0);
+    expect(others[0].durationMs).toBe(1000);
+    expect(others[1].startMs).toBe(1500);
+    expect(others[1].durationMs).toBe(1500);
+    expect(others[1].inPointMs).toBe(1500);
+  });
+
+  it("ignores other tracks and the mover's linked sibling", () => {
+    const out = resolveOverwrite(
+      [
+        clip("m", 0, 1000, { linkId: "L" }),
+        clip("ma", 0, 1000, { trackId: "a1", linkId: "L" }),
+        clip("vo", 200, 300, { trackId: "a2" })
+      ],
+      new Set(["m"])
+    );
+    expect(out).toHaveLength(3);
+  });
+});
+
+describe("resolveInsert", () => {
+  it("pushes later clips right by the mover's length and cuts a straddler", () => {
+    const out = resolveInsert(
+      [
+        clip("a", 0, 2000),
+        clip("b", 2000, 1000),
+        clip("vo", 1500, 200, { trackId: "a1" }),
+        clip("m", 1000, 500)
+      ],
+      new Set(["m"])
+    );
+    const aParts = out.filter((c) => c.id !== "m" && c.trackId === "v1" && c.startMs < 2500);
+    expect(aParts.map((c) => [c.startMs, c.durationMs])).toEqual([
+      [0, 1000],
+      [1500, 1000]
+    ]);
+    expect(byId(out, "b")!.startMs).toBe(2500);
+    expect(byId(out, "vo")!.startMs).toBe(2000);
+    expect(byId(out, "m")!.startMs).toBe(1000);
+  });
+
+  it("leaves a locked track alone", () => {
+    const out = resolveInsert(
+      [clip("vo", 1500, 200, { trackId: "a1" }), clip("m", 1000, 500)],
+      new Set(["m"]),
+      { lockedTrackIds: new Set(["a1"]) }
+    );
+    expect(byId(out, "vo")!.startMs).toBe(1500);
+  });
+});
+
+describe("resolveDrop", () => {
+  it("overlap keeps everything", () => {
+    const input = [clip("a", 0, 1000), clip("m", 500, 1000)];
+    expect(resolveDrop(input, new Set(["m"]), "overlap")).toEqual(input);
+  });
+});

--- a/packages/timeline/tests/keyframes.test.ts
+++ b/packages/timeline/tests/keyframes.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  findKeyframeAnimation,
+  hasKeyframeAt,
+  keyframeTimesMs,
+  keyframeValueAt,
+  removeKeyframe,
+  setKeyframe
+} from "../src/keyframes.js";
+import { compileClipAnimations } from "../src/animation/compile.js";
+import type { TimelineClip } from "../src/types.js";
+
+function clip(extra: Partial<TimelineClip> = {}): TimelineClip {
+  return {
+    id: "c",
+    trackId: "v1",
+    name: "c",
+    startMs: 1000,
+    durationMs: 2000,
+    mediaType: "video",
+    sourceType: "imported",
+    status: "generated",
+    locked: false,
+    versions: [],
+    ...extra
+  };
+}
+
+describe("keyframes", () => {
+  it("adds, updates and reads back a keyframe", () => {
+    let c = clip();
+    c = { ...c, animations: setKeyframe(c, "opacity", 500, 0.2) };
+    c = { ...c, animations: setKeyframe(c, "opacity", 1500, 0.8) };
+    expect(keyframeTimesMs(c)).toEqual([500, 1500]);
+    expect(keyframeValueAt(c, "opacity", 1000)).toBeCloseTo(0.5);
+    expect(keyframeValueAt(c, "opacity", 0)).toBe(0.2);
+    expect(hasKeyframeAt(c, "opacity", 500)).toBe(true);
+    expect(hasKeyframeAt(c, "opacity", 600)).toBe(false);
+
+    c = { ...c, animations: setKeyframe(c, "opacity", 500, 0.4) };
+    expect(keyframeTimesMs(c)).toEqual([500, 1500]);
+    expect(keyframeValueAt(c, "opacity", 500)).toBe(0.4);
+  });
+
+  it("keeps one animation for every property and spans the clip", () => {
+    let c = clip();
+    c = { ...c, animations: setKeyframe(c, "opacity", 0, 1) };
+    c = { ...c, animations: setKeyframe(c, "scale", 2000, 1.5) };
+    expect(c.animations).toHaveLength(1);
+    const a = findKeyframeAnimation(c)!;
+    expect(a.durationMs).toBe(2000);
+    expect(a.custom?.curves.map((x) => x.property).sort()).toEqual(["opacity", "scale"]);
+  });
+
+  it("reads identity where nothing is keyframed", () => {
+    expect(keyframeValueAt(clip(), "opacity", 100)).toBe(1);
+    expect(keyframeValueAt(clip(), "offsetX", 100)).toBe(0);
+  });
+
+  it("removing the last keyframe drops the animation, other animations survive", () => {
+    const other = {
+      id: "fade",
+      role: "in" as const,
+      preset: "fade",
+      durationMs: 300,
+      enabled: true
+    };
+    let c = clip({ animations: [other] });
+    c = { ...c, animations: setKeyframe(c, "rotation", 1000, 45) };
+    expect(c.animations).toHaveLength(2);
+    c = { ...c, animations: removeKeyframe(c, "rotation", 1000) };
+    expect(c.animations).toEqual([other]);
+  });
+
+  it("compiles like any other custom animation", () => {
+    let c = clip();
+    c = { ...c, animations: setKeyframe(c, "opacity", 0, 0) };
+    c = { ...c, animations: setKeyframe(c, "opacity", 2000, 1) };
+    const compiled = compileClipAnimations(c.animations, c.durationMs, {
+      width: 1920,
+      height: 1080
+    });
+    expect(compiled.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/timeline/tests/rippleEdit.test.ts
+++ b/packages/timeline/tests/rippleEdit.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import {
+  closeGap,
+  findGap,
+  findRollNeighbour,
+  rippleDelete,
+  rippleTrim,
+  rollEdit,
+  shiftClipsFrom
+} from "../src/rippleEdit.js";
+import type { TimelineClip } from "../src/types.js";
+
+function clip(
+  id: string,
+  startMs: number,
+  durationMs: number,
+  extra: Partial<TimelineClip> = {}
+): TimelineClip {
+  return {
+    id,
+    trackId: "v1",
+    name: id,
+    startMs,
+    durationMs,
+    inPointMs: 0,
+    outPointMs: durationMs,
+    mediaType: "video",
+    sourceType: "imported",
+    status: "generated",
+    locked: false,
+    versions: [],
+    ...extra
+  };
+}
+
+const byId = (clips: TimelineClip[], id: string) =>
+  clips.find((c) => c.id === id)!;
+
+describe("shiftClipsFrom", () => {
+  it("moves clips at or after the point and leaves earlier ones", () => {
+    const clips = [clip("a", 0, 1000), clip("b", 1000, 1000), clip("c", 2000, 500)];
+    const out = shiftClipsFrom(clips, 1000, -300);
+    expect(byId(out, "a").startMs).toBe(0);
+    expect(byId(out, "b").startMs).toBe(700);
+    expect(byId(out, "c").startMs).toBe(1700);
+  });
+
+  it("skips excluded clips and locked tracks, and never goes below zero", () => {
+    const clips = [
+      clip("a", 100, 500),
+      clip("b", 100, 500, { trackId: "a1" }),
+      clip("c", 100, 500, { trackId: "v2" })
+    ];
+    const out = shiftClipsFrom(clips, 0, -400, new Set(["b"]), {
+      lockedTrackIds: new Set(["v2"])
+    });
+    expect(byId(out, "a").startMs).toBe(0);
+    expect(byId(out, "b").startMs).toBe(100);
+    expect(byId(out, "c").startMs).toBe(100);
+  });
+});
+
+describe("rippleTrim", () => {
+  const clips = () => [
+    clip("a", 0, 1000, { inPointMs: 200, outPointMs: 1200 }),
+    clip("b", 1000, 1000),
+    clip("c", 2000, 1000, { trackId: "a1" })
+  ];
+
+  it("shortening the end pulls every later clip on every track left", () => {
+    const out = rippleTrim(clips(), "a", "end", -400);
+    expect(byId(out, "a").durationMs).toBe(600);
+    expect(byId(out, "b").startMs).toBe(600);
+    expect(byId(out, "c").startMs).toBe(1600);
+  });
+
+  it("extending the end pushes later clips right", () => {
+    const out = rippleTrim(clips(), "a", "end", 300);
+    expect(byId(out, "b").startMs).toBe(1300);
+    expect(byId(out, "c").startMs).toBe(2300);
+  });
+
+  it("trimming the head moves the in-point but keeps the clip parked", () => {
+    const out = rippleTrim(clips(), "a", "start", -250);
+    const a = byId(out, "a");
+    expect(a.startMs).toBe(0);
+    expect(a.inPointMs).toBe(450);
+    expect(a.durationMs).toBe(750);
+    expect(byId(out, "b").startMs).toBe(750);
+  });
+
+  it("moves linked siblings with the clip and does not ripple them twice", () => {
+    const linked = [
+      clip("v", 0, 1000, { linkId: "L" }),
+      clip("a", 0, 1000, { trackId: "a1", linkId: "L" }),
+      clip("next", 1000, 500)
+    ];
+    const out = rippleTrim(linked, "v", "end", -200);
+    expect(byId(out, "v").durationMs).toBe(800);
+    expect(byId(out, "a").durationMs).toBe(800);
+    expect(byId(out, "a").startMs).toBe(0);
+    expect(byId(out, "next").startMs).toBe(800);
+  });
+
+  it("rejects a trim that empties the clip and leaves the input alone", () => {
+    const input = clips();
+    expect(() => rippleTrim(input, "a", "end", -1000)).toThrow();
+    expect(byId(input, "b").startMs).toBe(1000);
+  });
+});
+
+describe("rollEdit", () => {
+  const pair = () => [
+    clip("a", 0, 1000, { inPointMs: 0, outPointMs: 1000 }),
+    clip("b", 1000, 1000, { inPointMs: 500, outPointMs: 1500 }),
+    clip("c", 2000, 500)
+  ];
+
+  it("finds the neighbour across a cut", () => {
+    const clips = pair();
+    expect(findRollNeighbour(clips, clips[0], "end")?.id).toBe("b");
+    expect(findRollNeighbour(clips, clips[1], "start")?.id).toBe("a");
+    expect(findRollNeighbour(clips, clips[1], "end")?.id).toBe("c");
+    expect(findRollNeighbour(clips, clips[0], "start")).toBeUndefined();
+  });
+
+  it("moves the cut later: left grows, right loses its head, nothing else moves", () => {
+    const out = rollEdit(pair(), "a", "end", 300);
+    expect(byId(out, "a").durationMs).toBe(1300);
+    expect(byId(out, "b").startMs).toBe(1300);
+    expect(byId(out, "b").durationMs).toBe(700);
+    expect(byId(out, "b").inPointMs).toBe(800);
+    expect(byId(out, "c").startMs).toBe(2000);
+  });
+
+  it("rolling from the right clip's start edge is the same edit", () => {
+    const out = rollEdit(pair(), "b", "start", -200);
+    expect(byId(out, "a").durationMs).toBe(800);
+    expect(byId(out, "b").startMs).toBe(800);
+    expect(byId(out, "b").durationMs).toBe(1200);
+  });
+
+  it("refuses when the right clip has no more head to reveal", () => {
+    expect(() => rollEdit(pair(), "a", "end", -600)).toThrow();
+  });
+
+  it("refuses without a neighbour", () => {
+    expect(() => rollEdit(pair(), "c", "end", 100)).toThrow();
+  });
+});
+
+describe("rippleDelete", () => {
+  it("removes the clip and closes its span on every unlocked track", () => {
+    const clips = [
+      clip("a", 0, 1000),
+      clip("b", 1000, 1000),
+      clip("c", 2000, 1000),
+      clip("vo", 2500, 500, { trackId: "a1" })
+    ];
+    const out = rippleDelete(clips, new Set(["b"]));
+    expect(out.map((c) => c.id)).toEqual(["a", "c", "vo"]);
+    expect(byId(out, "c").startMs).toBe(1000);
+    expect(byId(out, "vo").startMs).toBe(1500);
+  });
+
+  it("merges overlapping spans and closes several at once", () => {
+    const clips = [
+      clip("a", 0, 1000),
+      clip("b", 1000, 1000),
+      clip("b2", 1500, 1000, { trackId: "v2" }),
+      clip("c", 3000, 1000),
+      clip("d", 4000, 1000),
+      clip("e", 5000, 1000)
+    ];
+    const out = rippleDelete(clips, new Set(["b", "b2", "d"]));
+    expect(byId(out, "c").startMs).toBe(1500);
+    expect(byId(out, "e").startMs).toBe(2500);
+  });
+
+  it("leaves a straddling clip on another track where it is", () => {
+    const clips = [
+      clip("a", 0, 1000),
+      clip("b", 1000, 1000),
+      clip("music", 500, 3000, { trackId: "a1" }),
+      clip("c", 2000, 1000)
+    ];
+    const out = rippleDelete(clips, new Set(["b"]));
+    expect(byId(out, "music").startMs).toBe(500);
+    expect(byId(out, "c").startMs).toBe(1000);
+  });
+});
+
+describe("closeGap", () => {
+  const clips = () => [
+    clip("a", 0, 1000),
+    clip("b", 1500, 1000),
+    clip("vo", 1600, 200, { trackId: "a1" })
+  ];
+
+  it("finds the gap around a time and null inside a clip", () => {
+    expect(findGap(clips(), "v1", 1200)).toEqual({ startMs: 1000, endMs: 1500 });
+    expect(findGap(clips(), "v1", 500)).toBeNull();
+    expect(findGap(clips(), "v1", 4000)).toBeNull();
+    expect(findGap(clips(), "a1", 100)).toEqual({ startMs: 0, endMs: 1600 });
+  });
+
+  it("pulls everything after the gap left by its length", () => {
+    const out = closeGap(clips(), "v1", 1200);
+    expect(byId(out, "b").startMs).toBe(1000);
+    expect(byId(out, "vo").startMs).toBe(1100);
+  });
+
+  it("is a no-op at a time with no gap", () => {
+    const input = clips();
+    expect(closeGap(input, "v1", 500)).toEqual(input);
+  });
+});

--- a/packages/timeline/tests/transitionAtCut.test.ts
+++ b/packages/timeline/tests/transitionAtCut.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyTransitionAtCut,
+  maxTransitionMs,
+  removeTransitionAtCut,
+  transitionPredecessor
+} from "../src/transitionAtCut.js";
+import type { TimelineClip } from "../src/types.js";
+
+function clip(
+  id: string,
+  startMs: number,
+  durationMs: number,
+  extra: Partial<TimelineClip> = {}
+): TimelineClip {
+  return {
+    id,
+    trackId: "v1",
+    name: id,
+    startMs,
+    durationMs,
+    inPointMs: 0,
+    outPointMs: durationMs,
+    mediaType: "video",
+    sourceType: "imported",
+    status: "generated",
+    locked: false,
+    versions: [],
+    ...extra
+  };
+}
+const byId = (clips: TimelineClip[], id: string) => clips.find((c) => c.id === id)!;
+
+describe("transitionPredecessor", () => {
+  it("finds the abutting or overlapping clip before, not one on another track", () => {
+    const clips = [clip("a", 0, 1000), clip("b", 1000, 1000), clip("x", 0, 1500, { trackId: "v2" })];
+    expect(transitionPredecessor(clips, clips[1])?.id).toBe("a");
+    expect(transitionPredecessor(clips, clips[0])).toBeUndefined();
+  });
+});
+
+describe("applyTransitionAtCut", () => {
+  it("extends the predecessor under the incoming clip and sets a cross-fade", () => {
+    const out = applyTransitionAtCut([clip("a", 0, 1000), clip("b", 1000, 1000)], "b", 400);
+    expect(byId(out, "a").durationMs).toBe(1400);
+    expect(byId(out, "a").outPointMs).toBe(1400);
+    expect(byId(out, "b").transitionIn).toEqual({ type: "crossfade", durationMs: 400 });
+    expect(byId(out, "b").startMs).toBe(1000);
+  });
+
+  it("grows an existing overlap only by what is missing, and keeps the type", () => {
+    const out = applyTransitionAtCut(
+      [
+        clip("a", 0, 1200),
+        clip("b", 1000, 1000, { transitionIn: { type: "wipe", durationMs: 200, direction: "left" } as never })
+      ],
+      "b",
+      500
+    );
+    expect(byId(out, "a").durationMs).toBe(1500);
+    expect(byId(out, "b").transitionIn?.type).toBe("wipe");
+    expect(byId(out, "b").transitionIn?.durationMs).toBe(500);
+  });
+
+  it("caps at the shorter of the two clips", () => {
+    const clips = [clip("a", 0, 300), clip("b", 300, 1000)];
+    expect(maxTransitionMs(clips, clips[1])).toBe(300);
+    const out = applyTransitionAtCut(clips, "b", 900);
+    expect(byId(out, "b").transitionIn?.durationMs).toBe(300);
+  });
+
+  it("with no predecessor the clip fades in on its own", () => {
+    const out = applyTransitionAtCut([clip("a", 0, 1000)], "a", 250);
+    expect(byId(out, "a").transitionIn?.durationMs).toBe(250);
+  });
+});
+
+describe("removeTransitionAtCut", () => {
+  it("drops the field and leaves other clips untouched", () => {
+    const clips = [clip("a", 0, 1000), clip("b", 1000, 1000, { transitionIn: { type: "crossfade", durationMs: 100 } })];
+    const out = removeTransitionAtCut(clips, "b");
+    expect("transitionIn" in byId(out, "b")).toBe(false);
+    expect(byId(out, "a")).toBe(clips[0]);
+  });
+});

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -27,6 +27,7 @@ import { useShallow } from "zustand/react/shallow";
 import AssetGrid from "../assets/AssetGrid";
 import {
   AssetGridStoreProvider,
+  ASSETS_ASSET_GRID_STORE_KEY,
   LIBRARY_ASSET_GRID_STORE_KEY
 } from "../../stores/AssetGridStore";
 import WorkflowList from "../workflows/WorkflowList";
@@ -455,7 +456,7 @@ const PanelContent = memo(function PanelContent({
               }
             />
           )}
-          <AssetGridStoreProvider persistKey="asset-grid-storage:assets">
+          <AssetGridStoreProvider persistKey={ASSETS_ASSET_GRID_STORE_KEY}>
             <AssetGrid maxItemSize={5} isMobile={isMobile} />
           </AssetGridStoreProvider>
         </FlexColumn>

--- a/web/src/components/timeline/Inspector/ClipKeyframes.tsx
+++ b/web/src/components/timeline/Inspector/ClipKeyframes.tsx
@@ -1,0 +1,155 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * ClipKeyframes — per-property keyframes at the playhead, the way a stopwatch
+ * row works in Premiere's Effect Controls or Final Cut's Video inspector.
+ *
+ * One row per property: a diamond that adds or removes a keyframe at the
+ * playhead, and the value there. Typing a value keyframes it at the playhead.
+ * The clip shows its keyframes as diamonds along its bottom edge.
+ */
+import React, { memo, useCallback } from "react";
+import DiamondOutlinedIcon from "@mui/icons-material/DiamondOutlined";
+import DiamondIcon from "@mui/icons-material/Diamond";
+import TimelineOutlinedIcon from "@mui/icons-material/TimelineOutlined";
+
+import {
+  KEYFRAME_PROPERTIES,
+  hasKeyframeAt,
+  keyframeTimesMs,
+  keyframeValueAt,
+  type KeyframeProperty,
+  type TimelineClip
+} from "@nodetool-ai/timeline";
+import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
+import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
+import {
+  Caption,
+  CollapsibleSection,
+  FlexColumn,
+  FlexRow,
+  SPACING,
+  StateIconButton
+} from "../../ui_primitives";
+import {
+  InspectorDivider,
+  InspectorPillInput,
+  InspectorRow,
+  InspectorSectionTitle
+} from "./InspectorPrimitives";
+import { usePersistedFold } from "./usePersistedFold";
+
+const PROPERTY_LABELS: Record<KeyframeProperty, { label: string; unit?: string; step: number }> = {
+  opacity: { label: "Opacity", step: 0.05 },
+  scale: { label: "Scale", unit: "×", step: 0.05 },
+  offsetX: { label: "Position X", unit: "px", step: 1 },
+  offsetY: { label: "Position Y", unit: "px", step: 1 },
+  rotation: { label: "Rotation", unit: "°", step: 1 }
+};
+
+interface ClipKeyframesProps {
+  clip: TimelineClip;
+}
+
+const KeyframeRow: React.FC<{
+  clip: TimelineClip;
+  property: KeyframeProperty;
+  atMs: number;
+}> = memo(({ clip, property, atMs }) => {
+  const setClipKeyframe = useTimelineStore((s) => s.setClipKeyframe);
+  const removeClipKeyframe = useTimelineStore((s) => s.removeClipKeyframe);
+  const keyframeProperty = useTimelineUIStore((s) => s.keyframeProperty);
+  const setKeyframeProperty = useTimelineUIStore((s) => s.setKeyframeProperty);
+  const meta = PROPERTY_LABELS[property];
+  const value = keyframeValueAt(clip, property, atMs);
+  const keyed = hasKeyframeAt(clip, property, atMs);
+  const armed = keyframeProperty === property;
+
+  const toggle = useCallback(() => {
+    if (keyed) removeClipKeyframe(clip.id, property, atMs);
+    else setClipKeyframe(clip.id, property, atMs, value);
+    setKeyframeProperty(property);
+  }, [keyed, removeClipKeyframe, setClipKeyframe, setKeyframeProperty, clip.id, property, atMs, value]);
+
+  const commit = useCallback(
+    (raw: string) => {
+      const next = Number.parseFloat(raw);
+      if (!Number.isFinite(next)) return;
+      setClipKeyframe(clip.id, property, atMs, next);
+      setKeyframeProperty(property);
+    },
+    [setClipKeyframe, setKeyframeProperty, clip.id, property, atMs]
+  );
+
+  return (
+    <InspectorRow
+      label={
+        <FlexRow align="center" gap={SPACING.xs}>
+          <StateIconButton
+            size="small"
+            onClick={toggle}
+            isActive={keyed}
+            icon={<DiamondOutlinedIcon fontSize="inherit" />}
+            activeIcon={<DiamondIcon fontSize="inherit" />}
+            tooltip={
+              keyed
+                ? "Remove keyframe at playhead"
+                : `Add keyframe at playhead${armed ? " (Alt+K)" : ""}`
+            }
+            aria-label={`${keyed ? "Remove" : "Add"} ${meta.label} keyframe`}
+          />
+          <span>{meta.label}</span>
+        </FlexRow>
+      }
+    >
+      <InspectorPillInput
+        value={String(Math.round(value * 100) / 100)}
+        onCommit={commit}
+        unit={meta.unit}
+        ariaLabel={`${meta.label} at playhead`}
+        scrub={{ step: meta.step }}
+      />
+    </InspectorRow>
+  );
+});
+KeyframeRow.displayName = "KeyframeRow";
+
+export const ClipKeyframes: React.FC<ClipKeyframesProps> = memo(({ clip }) => {
+  const [open, setOpen] = usePersistedFold("keyframes");
+  const currentTimeMs = useTimelinePlaybackStore((s) => s.currentTimeMs);
+  const atMs = Math.max(
+    0,
+    Math.min(clip.durationMs, currentTimeMs - clip.startMs)
+  );
+  const inside = currentTimeMs >= clip.startMs && currentTimeMs <= clip.startMs + clip.durationMs;
+  const count = keyframeTimesMs(clip).length;
+
+  return (
+    <>
+      <InspectorDivider />
+      <CollapsibleSection
+        title={
+          <InspectorSectionTitle
+            title={count > 0 ? `Keyframes (${count})` : "Keyframes"}
+            icon={<TimelineOutlinedIcon />}
+          />
+        }
+        open={open}
+        onToggle={setOpen}
+        unmountOnExit
+      >
+        <FlexColumn gap={SPACING.sm} sx={{ py: SPACING.xs }}>
+          {!inside && (
+            <Caption sx={{ opacity: 0.7 }}>
+              Move the playhead over the clip to set keyframes.
+            </Caption>
+          )}
+          {KEYFRAME_PROPERTIES.map((property) => (
+            <KeyframeRow key={property} clip={clip} property={property} atMs={atMs} />
+          ))}
+        </FlexColumn>
+      </CollapsibleSection>
+    </>
+  );
+});
+ClipKeyframes.displayName = "ClipKeyframes";

--- a/web/src/components/timeline/Inspector/InspectorPrimitives.helpers.ts
+++ b/web/src/components/timeline/Inspector/InspectorPrimitives.helpers.ts
@@ -1,7 +1,8 @@
 /** Formats ms as HH:MM:SS:FF (frames) — used for the Start field. */
 export function formatTimecode(ms: number, fps: number): string {
+  const actualFps = Math.max(1, fps);
   const safeFps = Math.max(1, Math.round(fps));
-  const totalFrames = Math.max(0, Math.round((ms / 1000) * safeFps));
+  const totalFrames = Math.max(0, Math.round((ms / 1000) * actualFps));
   const ff = totalFrames % safeFps;
   const totalSec = Math.floor(totalFrames / safeFps);
   const ss = totalSec % 60;
@@ -15,6 +16,7 @@ export function formatTimecode(ms: number, fps: number): string {
 export function parseTimecode(input: string, fps: number): number | null {
   const trimmed = input.trim();
   if (trimmed === "") return null;
+  const actualFps = Math.max(1, fps);
   const safeFps = Math.max(1, Math.round(fps));
   if (/^\d+(\.\d+)?$/.test(trimmed)) {
     const n = Number(trimmed);
@@ -41,7 +43,12 @@ export function parseTimecode(input: string, fps: number): number | null {
     return null;
   }
   const totalSec = hh * 3600 + mm * 60 + ss;
-  return Math.round(totalSec * 1000 + (ff * 1000) / safeFps);
+  if (nums.length === 4) {
+    // The displayed seconds/frames use the nominal integer FPS as their
+    // timecode base, while the source timestamp uses the actual FPS.
+    return Math.round(((totalSec * safeFps + ff) * 1000) / actualFps);
+  }
+  return Math.round(totalSec * 1000 + (ff * 1000) / actualFps);
 }
 
 /** "4.60s" → 4.6 seconds, returns ms. */

--- a/web/src/components/timeline/Inspector/TimelineInspector.tsx
+++ b/web/src/components/timeline/Inspector/TimelineInspector.tsx
@@ -47,6 +47,7 @@ import { ClipAdjustments } from "./ClipAdjustments";
 import { ClipCaptionStyle } from "./ClipCaptionStyle";
 import { ClipStoryboardLink } from "./ClipStoryboardLink";
 import { ClipAnimations } from "./ClipAnimations";
+import { ClipKeyframes } from "./ClipKeyframes";
 import { ClipShapeSection } from "./ClipShapeSection";
 import { ClipTextStyleSection } from "./ClipTextStyleSection";
 import { GeneratedClipPanel } from "./GeneratedClipPanel";
@@ -408,6 +409,8 @@ export const TimelineInspector: React.FC = memo(() => {
       <ClipAdjustments clip={clip} />
 
       <ClipAnimations clip={clip} />
+
+      <ClipKeyframes clip={clip} />
     </Panel>
   );
 });

--- a/web/src/components/timeline/Inspector/__tests__/InspectorPrimitives.helpers.test.ts
+++ b/web/src/components/timeline/Inspector/__tests__/InspectorPrimitives.helpers.test.ts
@@ -44,9 +44,15 @@ describe("formatTimecode", () => {
     expect(formatTimecode(-100, 30)).toBe("00:00:00:00");
   });
 
-  it("handles fractional fps by rounding", () => {
-    // 29.97fps → 30fps
+  it("uses the actual fractional fps for elapsed frame math", () => {
     expect(formatTimecode(1000, 29.97)).toBe("00:00:01:00");
+    expect(formatTimecode(984, 29.97)).toBe("00:00:00:29");
+  });
+
+  it("round-trips a long fractional-fps timecode", () => {
+    // A frame-aligned timestamp is exactly representable in HH:MM:SS:FF.
+    const timeMs = 60_060;
+    expect(parseTimecode(formatTimecode(timeMs, 29.97), 29.97)).toBe(timeMs);
   });
 
   it("handles 0 fps by using 1", () => {

--- a/web/src/components/timeline/README.md
+++ b/web/src/components/timeline/README.md
@@ -4,6 +4,31 @@ The timeline editor (`/timeline/:sequenceId`) is a generation-aware media
 sequencing surface. Tracks hold imported or AI-generated clips; each clip
 remembers how it was made and can be re-generated, versioned, and exported.
 
+## Editing model
+
+The tracks region follows the editing habits of Premiere and Final Cut, on
+a keyboard layout the user picks in the shortcut sheet (`?`):
+`timelineKeymap.ts` holds the three layouts and the window handler in
+`TracksRegion` resolves every key through it.
+
+- **Ripple** (toolbar toggle): trims and Delete close the gap they would
+  leave, on every unlocked track. Shift+Delete ripple-deletes regardless.
+  Ctrl-drag on a clip edge rolls the cut with its neighbour. Close gap sits
+  in the empty-lane menu.
+- **Drop modes** (toolbar): Overwrite, Insert or Overlap decide what a
+  dropped clip does to the clips under it; Ctrl on release forces Insert.
+- **Edit points**: clicking a trim handle selects that edge. E extends it to
+  the playhead, Ctrl+Shift+arrows nudge it a frame.
+- **Transitions on the cut**: drag the wedge's right edge for length,
+  Ctrl+T cross-fades into the selected clips (the predecessor is extended
+  under them), the clip menu adds or removes one.
+- **Keyframes**: the inspector's Keyframes section keys a property at the
+  playhead; the clip draws them as diamonds. Alt+K keys the armed property.
+- **Source viewer** (Source tab): mark in and out on the explorer's selected
+  asset, then Append, Insert or Overwrite it at the playhead.
+- **Playback**: J/K/L shuttle, I/O mark a loop range shown on the ruler, M
+  adds a marker, Up/Down step between cuts.
+
 ## Phone layout
 
 Below the `sm` breakpoint (`useTimelineIsMobile`, matching `MobileClassProvider`

--- a/web/src/components/timeline/SourceViewerPanel.test.tsx
+++ b/web/src/components/timeline/SourceViewerPanel.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { SourceViewerPanel } from "./SourceViewerPanel";
+
+const mockSetSourceRange = jest.fn((range) => {
+  mockSourceRange = range;
+});
+let mockSourceRange: { inMs: number; outMs: number } | null = null;
+const mockPerformSourceEdit = jest.fn((_kind: unknown, _context: unknown) => "clip-1");
+const mockAsset = {
+  id: "beach",
+  name: "Beach scene",
+  content_type: "video/mp4",
+  duration: null
+};
+
+jest.mock("@mui/material/styles", () => ({ useTheme: () => ({ vars: { palette: { text: { primary: "#fff" }, c_scrim: "#000" } }, shape: { borderRadius: 4 } }) }));
+jest.mock("../../stores/PanelStore", () => ({ usePanelStore: (selector: (state: unknown) => unknown) => selector({ panel: { activeView: "assets" } }) }));
+jest.mock("../../stores/AssetGridStore", () => ({
+  useAssetsSelectedAsset: () => mockAsset,
+  useLibrarySelectedAsset: () => null
+}));
+jest.mock("../../stores/timeline/TimelineUIStore", () => ({
+  useTimelineUIStore: (selector: (state: unknown) => unknown) => selector({ sourceRange: mockSourceRange, setSourceRange: mockSetSourceRange }),
+  useTimelineUIStoreApi: () => ({ getState: () => ({ sourceRange: mockSourceRange, setSourceRange: mockSetSourceRange, selectClip: jest.fn() }) })
+}));
+jest.mock("../../stores/timeline/TimelineStore", () => ({ useTimelineStoreApi: () => ({ getState: () => ({}) }) }));
+jest.mock("../../stores/timeline/TimelinePlaybackStore", () => ({ useTimelinePlaybackStoreApi: () => ({ getState: () => ({ currentTimeMs: 0 }) }) }));
+jest.mock("../../stores/SettingsStore", () => ({ useSettingsStore: (selector: (state: unknown) => unknown) => selector({ settings: { timelineKeyboardPreset: "premiere" } }) }));
+jest.mock("./dnd/assetToClipAdapter", () => ({ assetMediaType: () => "video" }));
+jest.mock("./sourceEdit", () => ({
+  performSourceEdit: (kind: unknown, context: unknown) => mockPerformSourceEdit(kind, context),
+  sourceRangeFor: (asset: { duration: number | null }, range: { inMs: number; outMs: number } | null) => ({ inMs: range?.inMs ?? 1000, outMs: range?.outMs ?? (asset.duration ?? 5) * 1000 })
+}));
+jest.mock("../ui_primitives", () => ({
+  AudioPlayback: () => null,
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+  Caption: ({ children }: React.PropsWithChildren) => <span>{children}</span>,
+  FlexColumn: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  FlexRow: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  ResponsiveImage: () => null,
+  ShortcutHint: () => null,
+  Text: ({ children }: React.PropsWithChildren) => <span>{children}</span>,
+  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  TruncatedText: ({ children }: React.PropsWithChildren) => <span>{children}</span>,
+  VideoPlayer: ({ onDurationChange }: { onDurationChange?: (duration: number) => void }) => <button aria-label="Video player" onClick={() => onDurationChange?.(5)}>Video</button>,
+  SPACING: { md: 1, xs: 1, sm: 1 },
+  getSpacingPx: () => "1px"
+}));
+jest.mock("./Inspector/InspectorPrimitives", () => ({
+  InspectorPillInput: ({ ariaLabel, value, onCommit }: { ariaLabel: string; value: string; onCommit: (value: string) => void }) => <input aria-label={ariaLabel} defaultValue={value} onBlur={(event) => onCommit(event.currentTarget.value)} />,
+  InspectorRow: ({ children }: React.PropsWithChildren) => <div>{children}</div>
+}));
+jest.mock("./Inspector/InspectorPrimitives.helpers", () => ({ parseSeconds: (value: string) => Math.round(Number(value) * 1000) }));
+jest.mock("./timelineKeymap", () => ({ TIMELINE_KEYMAPS: { premiere: { sourceAppend: ["A"], sourceInsert: ["I"], sourceOverwrite: ["O"] } }, bindingKeys: () => "A" }));
+
+describe("SourceViewerPanel", () => {
+  beforeEach(() => {
+    mockSourceRange = null;
+    mockSetSourceRange.mockClear();
+    mockPerformSourceEdit.mockClear();
+  });
+
+  it("passes entered seconds to Append as milliseconds", () => {
+    mockSourceRange = { inMs: 1000, outMs: 5000 };
+    const view = render(<SourceViewerPanel />);
+    fireEvent.change(screen.getByLabelText("Source in point"), { target: { value: "1" } });
+    fireEvent.blur(screen.getByLabelText("Source in point"));
+    view.rerender(<SourceViewerPanel />);
+    fireEvent.change(screen.getByLabelText("Source in point"), { target: { value: "1" } });
+    fireEvent.blur(screen.getByLabelText("Source in point"));
+    view.rerender(<SourceViewerPanel />);
+    fireEvent.change(screen.getByLabelText("Source out point"), { target: { value: "2" } });
+    fireEvent.blur(screen.getByLabelText("Source out point"));
+    view.rerender(<SourceViewerPanel />);
+    fireEvent.click(screen.getByRole("button", { name: "Append" }));
+    expect(mockPerformSourceEdit).toHaveBeenCalledWith("append", expect.objectContaining({ ui: expect.objectContaining({ sourceRange: { inMs: 1000, outMs: 2000 } }) }));
+  });
+});

--- a/web/src/components/timeline/SourceViewerPanel.tsx
+++ b/web/src/components/timeline/SourceViewerPanel.tsx
@@ -1,0 +1,196 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * SourceViewerPanel — the source monitor: the asset selected in the explorer,
+ * an in and out point on it, and Append / Insert / Overwrite into the
+ * sequence at the playhead. Three-point editing, the Premiere source monitor
+ * and the Final Cut browser range in one panel.
+ */
+import React, { memo, useCallback, useEffect, useRef, useState } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import PlaylistAddOutlinedIcon from "@mui/icons-material/PlaylistAddOutlined";
+import KeyboardTabOutlinedIcon from "@mui/icons-material/KeyboardTabOutlined";
+import FlipToFrontOutlinedIcon from "@mui/icons-material/FlipToFrontOutlined";
+
+import { useAssetGridStore } from "../../stores/AssetGridStore";
+import { useTimelineStoreApi } from "../../stores/timeline/TimelineStore";
+import { useTimelineUIStore, useTimelineUIStoreApi } from "../../stores/timeline/TimelineUIStore";
+import { useTimelinePlaybackStoreApi } from "../../stores/timeline/TimelinePlaybackStore";
+import {
+  AudioPlayback,
+  Button,
+  Caption,
+  FlexColumn,
+  FlexRow,
+  ResponsiveImage,
+  ShortcutHint,
+  SPACING,
+  Text,
+  Tooltip,
+  TruncatedText,
+  VideoPlayer,
+  getSpacingPx
+} from "../ui_primitives";
+import { InspectorPillInput, InspectorRow } from "./Inspector/InspectorPrimitives";
+import { parseSeconds } from "./Inspector/InspectorPrimitives.helpers";
+import { assetMediaType } from "./dnd/assetToClipAdapter";
+import { performSourceEdit, sourceRangeFor, type SourceEditKind } from "./sourceEdit";
+import { TIMELINE_KEYMAPS, bindingKeys } from "./timelineKeymap";
+import { useSettingsStore } from "../../stores/SettingsStore";
+
+const panelStyles = (theme: Theme) =>
+  css({
+    padding: getSpacingPx(SPACING.md),
+    overflowY: "auto",
+    color: theme.vars.palette.text.primary
+  });
+
+const mediaBoxStyles = (theme: Theme) =>
+  css({
+    background: theme.vars.palette.c_scrim,
+    borderRadius: theme.shape.borderRadius,
+    overflow: "hidden",
+    "& video": { width: "100%", display: "block" }
+  });
+
+const formatSeconds = (ms: number): string => (ms / 1000).toFixed(2);
+
+export const SourceViewerPanel: React.FC = memo(() => {
+  const theme = useTheme();
+  const asset = useAssetGridStore((s) => s.selectedAssets.at(-1));
+  const sourceRange = useTimelineUIStore((s) => s.sourceRange);
+  const setSourceRange = useTimelineUIStore((s) => s.setSourceRange);
+  const docApi = useTimelineStoreApi();
+  const uiApi = useTimelineUIStoreApi();
+  const playbackApi = useTimelinePlaybackStoreApi();
+  const preset = useSettingsStore((s) => s.settings.timelineKeyboardPreset);
+
+  // The player's own time, so "mark in/out here" reads where it is parked.
+  const playerTimeRef = useRef(0);
+  const [playerTimeMs, setPlayerTimeMs] = useState(0);
+  const onTimeUpdate = useCallback((sec: number) => {
+    playerTimeRef.current = Math.round(sec * 1000);
+    setPlayerTimeMs(playerTimeRef.current);
+  }, []);
+
+  // A new asset starts with no range.
+  const assetId = asset?.id;
+  useEffect(() => {
+    setSourceRange(null);
+    setPlayerTimeMs(0);
+    playerTimeRef.current = 0;
+  }, [assetId, setSourceRange]);
+
+  const run = useCallback(
+    (kind: SourceEditKind) => {
+      const id = performSourceEdit(kind, {
+        doc: docApi.getState(),
+        ui: uiApi.getState(),
+        playheadMs: playbackApi.getState().currentTimeMs,
+        asset
+      });
+      if (id) uiApi.getState().selectClip(id);
+    },
+    [asset, docApi, uiApi, playbackApi]
+  );
+
+  if (!asset) {
+    return (
+      <div css={panelStyles(theme)}>
+        <Text size="small">
+          Select an asset in the explorer to preview it here and mark the part
+          to use.
+        </Text>
+      </div>
+    );
+  }
+
+  const mediaType = assetMediaType(asset.content_type);
+  const range = sourceRangeFor(asset, sourceRange);
+  const locator = `asset://${asset.id}`;
+  const keys = (action: "sourceAppend" | "sourceInsert" | "sourceOverwrite") =>
+    bindingKeys(TIMELINE_KEYMAPS[preset][action][0]);
+
+  return (
+    <div css={panelStyles(theme)} data-testid="source-viewer">
+      <FlexColumn gap={SPACING.md}>
+        <TruncatedText variant="body2" sx={{ fontWeight: 500 }} showTooltip>
+          {asset.name}
+        </TruncatedText>
+        <div css={mediaBoxStyles(theme)}>
+          {mediaType === "video" && (
+            <VideoPlayer locator={locator} label={asset.name} onTimeUpdate={onTimeUpdate} />
+          )}
+          {mediaType === "audio" && <AudioPlayback locator={locator} label={asset.name} />}
+          {mediaType === "image" && (
+            <ResponsiveImage locator={locator} alt={asset.name} fit="contain" />
+          )}
+          {!mediaType && <Caption>This asset type cannot go on the timeline.</Caption>}
+        </div>
+
+        <InspectorRow label="In">
+          <FlexRow gap={SPACING.xs} align="center">
+            <InspectorPillInput
+              value={formatSeconds(range.inMs)}
+              unit="s"
+              ariaLabel="Source in point"
+              onCommit={(raw) => {
+                const sec = parseSeconds(raw);
+                if (sec !== null) setSourceRange({ inMs: Math.round(sec * 1000), outMs: range.outMs });
+              }}
+            />
+            {mediaType === "video" && (
+              <Button size="small" variant="text" onClick={() => setSourceRange({ inMs: playerTimeMs, outMs: range.outMs })}>
+                Mark here
+              </Button>
+            )}
+          </FlexRow>
+        </InspectorRow>
+        <InspectorRow label="Out">
+          <FlexRow gap={SPACING.xs} align="center">
+            <InspectorPillInput
+              value={formatSeconds(range.outMs)}
+              unit="s"
+              ariaLabel="Source out point"
+              onCommit={(raw) => {
+                const sec = parseSeconds(raw);
+                if (sec !== null) setSourceRange({ inMs: range.inMs, outMs: Math.round(sec * 1000) });
+              }}
+            />
+            {mediaType === "video" && (
+              <Button size="small" variant="text" onClick={() => setSourceRange({ inMs: range.inMs, outMs: playerTimeMs })}>
+                Mark here
+              </Button>
+            )}
+          </FlexRow>
+        </InspectorRow>
+        <Caption sx={{ opacity: 0.7 }}>
+          Range {formatSeconds(range.outMs - range.inMs)} s. Insert and Overwrite
+          land at the playhead on the first unlocked track that fits the media.
+        </Caption>
+
+        <FlexRow gap={SPACING.sm} sx={{ flexWrap: "wrap" }}>
+          <Tooltip title={<ShortcutHint shortcut={keys("sourceAppend")} />}>
+            <Button size="small" variant="outlined" startIcon={<PlaylistAddOutlinedIcon />} onClick={() => run("append")} disabled={!mediaType}>
+              Append
+            </Button>
+          </Tooltip>
+          <Tooltip title={<ShortcutHint shortcut={keys("sourceInsert")} />}>
+            <Button size="small" variant="outlined" startIcon={<KeyboardTabOutlinedIcon />} onClick={() => run("insert")} disabled={!mediaType}>
+              Insert
+            </Button>
+          </Tooltip>
+          <Tooltip title={<ShortcutHint shortcut={keys("sourceOverwrite")} />}>
+            <Button size="small" variant="outlined" startIcon={<FlipToFrontOutlinedIcon />} onClick={() => run("overwrite")} disabled={!mediaType}>
+              Overwrite
+            </Button>
+          </Tooltip>
+        </FlexRow>
+      </FlexColumn>
+    </div>
+  );
+});
+SourceViewerPanel.displayName = "SourceViewerPanel";
+
+export default SourceViewerPanel;

--- a/web/src/components/timeline/SourceViewerPanel.tsx
+++ b/web/src/components/timeline/SourceViewerPanel.tsx
@@ -13,7 +13,11 @@ import PlaylistAddOutlinedIcon from "@mui/icons-material/PlaylistAddOutlined";
 import KeyboardTabOutlinedIcon from "@mui/icons-material/KeyboardTabOutlined";
 import FlipToFrontOutlinedIcon from "@mui/icons-material/FlipToFrontOutlined";
 
-import { useAssetGridStore } from "../../stores/AssetGridStore";
+import {
+  useAssetsSelectedAsset,
+  useLibrarySelectedAsset
+} from "../../stores/AssetGridStore";
+import { usePanelStore } from "../../stores/PanelStore";
 import { useTimelineStoreApi } from "../../stores/timeline/TimelineStore";
 import { useTimelineUIStore, useTimelineUIStoreApi } from "../../stores/timeline/TimelineUIStore";
 import { useTimelinePlaybackStoreApi } from "../../stores/timeline/TimelinePlaybackStore";
@@ -58,7 +62,14 @@ const formatSeconds = (ms: number): string => (ms / 1000).toFixed(2);
 
 export const SourceViewerPanel: React.FC = memo(() => {
   const theme = useTheme();
-  const asset = useAssetGridStore((s) => s.selectedAssets.at(-1));
+  const activeExplorer = usePanelStore((s) =>
+    s.panel.activeView === "library" || s.panel.activeView === "assets"
+      ? s.panel.activeView
+      : null
+  );
+  const assetsAsset = useAssetsSelectedAsset();
+  const libraryAsset = useLibrarySelectedAsset();
+  const asset = activeExplorer === "library" ? libraryAsset : activeExplorer === "assets" ? assetsAsset : null;
   const sourceRange = useTimelineUIStore((s) => s.sourceRange);
   const setSourceRange = useTimelineUIStore((s) => s.setSourceRange);
   const docApi = useTimelineStoreApi();
@@ -69,6 +80,17 @@ export const SourceViewerPanel: React.FC = memo(() => {
   // The player's own time, so "mark in/out here" reads where it is parked.
   const playerTimeRef = useRef(0);
   const [playerTimeMs, setPlayerTimeMs] = useState(0);
+  const [sourceDurationMs, setSourceDurationMs] = useState<number | null>(null);
+  const onDurationChange = useCallback(
+    (seconds: number) => {
+      const durationMs = Math.round(seconds * 1000);
+      setSourceDurationMs(durationMs);
+      if (durationMs > 0 && sourceRange === null) {
+        setSourceRange({ inMs: 0, outMs: durationMs });
+      }
+    },
+    [setSourceRange, sourceRange]
+  );
   const onTimeUpdate = useCallback((sec: number) => {
     playerTimeRef.current = Math.round(sec * 1000);
     setPlayerTimeMs(playerTimeRef.current);
@@ -78,6 +100,7 @@ export const SourceViewerPanel: React.FC = memo(() => {
   const assetId = asset?.id;
   useEffect(() => {
     setSourceRange(null);
+    setSourceDurationMs(null);
     setPlayerTimeMs(0);
     playerTimeRef.current = 0;
   }, [assetId, setSourceRange]);
@@ -88,7 +111,7 @@ export const SourceViewerPanel: React.FC = memo(() => {
         doc: docApi.getState(),
         ui: uiApi.getState(),
         playheadMs: playbackApi.getState().currentTimeMs,
-        asset
+        asset: asset ?? undefined
       });
       if (id) uiApi.getState().selectClip(id);
     },
@@ -120,7 +143,12 @@ export const SourceViewerPanel: React.FC = memo(() => {
         </TruncatedText>
         <div css={mediaBoxStyles(theme)}>
           {mediaType === "video" && (
-            <VideoPlayer locator={locator} label={asset.name} onTimeUpdate={onTimeUpdate} />
+            <VideoPlayer
+              locator={locator}
+              label={asset.name}
+              onTimeUpdate={onTimeUpdate}
+              onDurationChange={onDurationChange}
+            />
           )}
           {mediaType === "audio" && <AudioPlayback locator={locator} label={asset.name} />}
           {mediaType === "image" && (
@@ -136,8 +164,11 @@ export const SourceViewerPanel: React.FC = memo(() => {
               unit="s"
               ariaLabel="Source in point"
               onCommit={(raw) => {
-                const sec = parseSeconds(raw);
-                if (sec !== null) setSourceRange({ inMs: Math.round(sec * 1000), outMs: range.outMs });
+                const inMs = parseSeconds(raw);
+                if (inMs !== null) {
+                  const boundedInMs = Math.min(inMs, sourceDurationMs ?? Number.POSITIVE_INFINITY);
+                  setSourceRange({ inMs: Math.min(boundedInMs, range.outMs), outMs: range.outMs });
+                }
               }}
             />
             {mediaType === "video" && (
@@ -154,8 +185,11 @@ export const SourceViewerPanel: React.FC = memo(() => {
               unit="s"
               ariaLabel="Source out point"
               onCommit={(raw) => {
-                const sec = parseSeconds(raw);
-                if (sec !== null) setSourceRange({ inMs: range.inMs, outMs: Math.round(sec * 1000) });
+                const outMs = parseSeconds(raw);
+                if (outMs !== null) {
+                  const boundedOutMs = Math.min(outMs, sourceDurationMs ?? Number.POSITIVE_INFINITY);
+                  setSourceRange({ inMs: range.inMs, outMs: Math.max(range.inMs, boundedOutMs) });
+                }
               }}
             />
             {mediaType === "video" && (

--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -71,6 +71,8 @@ import { useTimelineStore } from "../../stores/timeline/TimelineStore";
 import { TimelineProvider } from "../../stores/timeline/TimelineInstance";
 import { PreviewArea } from "./preview/PreviewArea";
 import { TimelineInspector } from "./Inspector/TimelineInspector";
+import { SourceViewerPanel } from "./SourceViewerPanel";
+import MovieFilterOutlinedIcon from "@mui/icons-material/MovieFilterOutlined";
 import TimelineAgentPanel from "./TimelineAgentPanel";
 import ResizableSideDock from "../chat/assistant/ResizableSideDock";
 import TimelineVersionHistoryPanel from "./TimelineVersionHistoryPanel";
@@ -291,10 +293,11 @@ const PreviewRegion: React.FC<{
 });
 PreviewRegion.displayName = "PreviewRegion";
 
-type InspectorTab = "inspector" | "agent" | "history" | "script";
+type InspectorTab = "inspector" | "source" | "agent" | "history" | "script";
 
 const INSPECTOR_TABS = [
   { value: "inspector", label: "Inspector", icon: <TuneOutlinedIcon /> },
+  { value: "source", label: "Source", icon: <MovieFilterOutlinedIcon /> },
   { value: "agent", label: "Assistant", icon: <AutoAwesomeIcon /> },
   { value: "history", label: "History", icon: <HistoryOutlinedIcon /> }
 ];
@@ -333,6 +336,8 @@ const InspectorRegion: React.FC<{ sequenceId: string | undefined }> = memo(
         <FlexColumn fullWidth sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
           {tab === "inspector" ? (
             <TimelineInspector />
+          ) : tab === "source" ? (
+            <SourceViewerPanel />
           ) : tab === "agent" ? (
             <TimelineAgentPanel />
           ) : (

--- a/web/src/components/timeline/TimelineShortcutsDialog.tsx
+++ b/web/src/components/timeline/TimelineShortcutsDialog.tsx
@@ -76,7 +76,8 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
     shortcuts: [
       { keys: ["←"], action: "Nudge one frame", alt: ["→"] },
       { keys: ["Shift", "←"], action: "Nudge one second", alt: ["Shift", "→"] },
-      { keys: ["Alt", "drag"], action: "Disable snapping while moving or trimming" }
+      { keys: ["Alt", "drag"], action: "Disable snapping while moving or trimming" },
+      { keys: ["Ctrl", "drag clip"], action: "Insert on drop (push later clips right)" }
     ]
   },
   {

--- a/web/src/components/timeline/TimelineShortcutsDialog.tsx
+++ b/web/src/components/timeline/TimelineShortcutsDialog.tsx
@@ -54,7 +54,10 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
     title: "Editing",
     shortcuts: [
       { keys: ["S"], action: "Split selected clips at playhead" },
+      { keys: ["Ctrl", "K"], action: "Cut all tracks at playhead" },
       { keys: ["Delete"], action: "Delete selected clips", alt: ["Backspace"] },
+      { keys: ["Shift", "Delete"], action: "Ripple delete (close the gap)" },
+      { keys: ["Ctrl", "drag edge"], action: "Roll the cut with its neighbour" },
       { keys: ["Ctrl", "D"], action: "Duplicate (after each source)" },
       { keys: ["Ctrl", "Shift", "D"], action: "Duplicate with a 1 s gap" },
       { keys: ["Ctrl", "A"], action: "Select all clips" }
@@ -74,6 +77,20 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: ["←"], action: "Nudge one frame", alt: ["→"] },
       { keys: ["Shift", "←"], action: "Nudge one second", alt: ["Shift", "→"] },
       { keys: ["Alt", "drag"], action: "Disable snapping while moving or trimming" }
+    ]
+  },
+  {
+    title: "Playback",
+    shortcuts: [
+      { keys: ["Space"], action: "Play / pause" },
+      { keys: ["J"], action: "Shuttle backwards (again: faster)" },
+      { keys: ["K"], action: "Stop shuttle" },
+      { keys: ["L"], action: "Shuttle forwards (again: faster)" },
+      { keys: ["I"], action: "Mark in", alt: ["O"] },
+      { keys: ["Ctrl", "Shift", "X"], action: "Clear in and out" },
+      { keys: ["↑"], action: "Previous cut", alt: ["↓"] },
+      { keys: ["M"], action: "Add marker at playhead" },
+      { keys: ["Shift", "M"], action: "Next marker", alt: ["Ctrl", "Shift", "M"] }
     ]
   },
   {

--- a/web/src/components/timeline/TimelineShortcutsDialog.tsx
+++ b/web/src/components/timeline/TimelineShortcutsDialog.tsx
@@ -1,13 +1,15 @@
 /** @jsxImportSource @emotion/react */
 /**
  * TimelineShortcutsDialog — a reference sheet for every timeline keyboard
- * shortcut, grouped by task. Opened with `?` (or the toolbar help button) and
- * closed with Escape / the close button.
+ * shortcut, grouped by task, with the keyboard-layout switch at the top.
+ * Opened with `?` (or the toolbar help button) and closed with Escape / the
+ * close button.
  *
- * The shortcut set is authored here to match the window-level handler in
- * TracksRegion; keep the two in sync when adding a shortcut.
+ * The keys come from `timelineKeymap.ts`, the same table the window handler
+ * in TracksRegion resolves against, so the sheet cannot drift from what the
+ * keys do. The labels here are the only copy.
  */
-import React, { memo } from "react";
+import React, { memo, useCallback } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -19,97 +21,124 @@ import {
   ShortcutHint,
   Text,
   Caption,
+  ToggleGroup,
+  ToggleOption,
   SPACING,
   getSpacingPx
 } from "../ui_primitives";
+import { useSettingsStore } from "../../stores/SettingsStore";
+import {
+  bindingKeys,
+  TIMELINE_KEYBOARD_PRESET_LABELS,
+  TIMELINE_KEYBOARD_PRESETS,
+  TIMELINE_KEYMAPS,
+  type TimelineAction,
+  type TimelineKeyboardPreset
+} from "./timelineKeymap";
 
-interface Shortcut {
-  keys: string[];
-  action: string;
-  /** Alternate binding shown after the primary one (e.g. "or Backspace"). */
-  alt?: string[];
+interface Row {
+  /** The action whose bindings fill the key column, or fixed keys for a
+   *  pointer gesture that has no keyboard binding. */
+  action?: TimelineAction;
+  keys?: string[];
+  label: string;
 }
 
-interface ShortcutGroup {
+interface Group {
   title: string;
-  shortcuts: Shortcut[];
+  rows: Row[];
 }
 
-/**
- * Mirrors the bindings registered in TracksRegion's window keydown handler,
- * which fire on `ctrlKey || metaKey`. We label those keys "Ctrl" — rendered
- * verbatim by ShortcutHint on every platform — since the sheet is shared
- * across macOS and Windows/Linux and a single label keeps it compact.
- */
-const SHORTCUT_GROUPS: ShortcutGroup[] = [
+const GROUPS: Group[] = [
   {
     title: "Tools",
-    shortcuts: [
-      { keys: ["V"], action: "Select tool" },
-      { keys: ["C"], action: "Cut (blade) tool" },
-      { keys: ["Esc"], action: "Clear selection · back to Select" }
+    rows: [
+      { action: "selectTool", label: "Select tool" },
+      { action: "cutTool", label: "Cut (blade) tool" },
+      { action: "toggleSnap", label: "Toggle snapping" },
+      { action: "escape", label: "Clear selection · back to Select" }
     ]
   },
   {
     title: "Editing",
-    shortcuts: [
-      { keys: ["S"], action: "Split selected clips at playhead" },
-      { keys: ["Ctrl", "K"], action: "Cut all tracks at playhead" },
-      { keys: ["Delete"], action: "Delete selected clips", alt: ["Backspace"] },
-      { keys: ["Shift", "Delete"], action: "Ripple delete (close the gap)" },
-      { keys: ["Ctrl", "drag edge"], action: "Roll the cut with its neighbour" },
-      { keys: ["click edge"], action: "Select the edit point" },
-      { keys: ["E"], action: "Extend the edit point to the playhead" },
-      { keys: ["Ctrl", "Shift", "←"], action: "Trim edit point one frame (Alt: ten)", alt: ["Ctrl", "Shift", "→"] },
-      { keys: ["Ctrl", "D"], action: "Duplicate (after each source)" },
-      { keys: ["Ctrl", "Shift", "D"], action: "Duplicate with a 1 s gap" },
-      { keys: ["Ctrl", "A"], action: "Select all clips" }
+    rows: [
+      { action: "splitAtPlayhead", label: "Split selected clips at playhead" },
+      { action: "cutAllTracks", label: "Cut all tracks at playhead" },
+      { action: "deleteSelected", label: "Delete selected clips" },
+      { action: "rippleDeleteSelected", label: "Ripple delete (close the gap)" },
+      { keys: ["Ctrl", "drag edge"], label: "Roll the cut with its neighbour" },
+      { keys: ["click edge"], label: "Select the edit point" },
+      { action: "extendEdit", label: "Extend the edit point to the playhead" },
+      { action: "trimEditLeft", label: "Trim edit point one frame back" },
+      { action: "trimEditRight", label: "Trim edit point one frame on" },
+      { action: "trimEditLeftLarge", label: "Trim edit point ten frames back" },
+      { action: "trimEditRightLarge", label: "Trim edit point ten frames on" },
+      { action: "duplicate", label: "Duplicate (after each source)" },
+      { action: "duplicateWithGap", label: "Duplicate with a 1 s gap" },
+      { action: "applyDefaultTransition", label: "Cross-fade into selected clips" },
+      { action: "selectAll", label: "Select all clips" }
     ]
   },
   {
     title: "Clipboard",
-    shortcuts: [
-      { keys: ["Ctrl", "C"], action: "Copy selected clips" },
-      { keys: ["Ctrl", "X"], action: "Cut selected clips" },
-      { keys: ["Ctrl", "V"], action: "Paste at playhead" }
+    rows: [
+      { action: "copy", label: "Copy selected clips" },
+      { action: "cut", label: "Cut selected clips" },
+      { action: "paste", label: "Paste at playhead" }
     ]
   },
   {
     title: "Move",
-    shortcuts: [
-      { keys: ["←"], action: "Nudge one frame", alt: ["→"] },
-      { keys: ["Shift", "←"], action: "Nudge one second", alt: ["Shift", "→"] },
-      { keys: ["Alt", "drag"], action: "Disable snapping while moving or trimming" },
-      { keys: ["Ctrl", "drag clip"], action: "Insert on drop (push later clips right)" }
+    rows: [
+      { action: "nudgeLeft", label: "Nudge one frame back" },
+      { action: "nudgeRight", label: "Nudge one frame on" },
+      { action: "nudgeLeftLarge", label: "Nudge one second back" },
+      { action: "nudgeRightLarge", label: "Nudge one second on" },
+      { keys: ["Alt", "drag"], label: "Disable snapping while moving or trimming" },
+      { keys: ["Ctrl", "drag clip"], label: "Insert on drop (push later clips right)" }
     ]
   },
   {
     title: "Playback",
-    shortcuts: [
-      { keys: ["Space"], action: "Play / pause" },
-      { keys: ["J"], action: "Shuttle backwards (again: faster)" },
-      { keys: ["K"], action: "Stop shuttle" },
-      { keys: ["L"], action: "Shuttle forwards (again: faster)" },
-      { keys: ["I"], action: "Mark in", alt: ["O"] },
-      { keys: ["Ctrl", "Shift", "X"], action: "Clear in and out" },
-      { keys: ["↑"], action: "Previous cut", alt: ["↓"] },
-      { keys: ["M"], action: "Add marker at playhead" },
-      { keys: ["Shift", "M"], action: "Next marker", alt: ["Ctrl", "Shift", "M"] }
+    rows: [
+      { keys: ["Space"], label: "Play / pause" },
+      { action: "shuttleBack", label: "Shuttle backwards (again: faster)" },
+      { action: "shuttleStop", label: "Stop shuttle" },
+      { action: "shuttleForward", label: "Shuttle forwards (again: faster)" },
+      { action: "markIn", label: "Mark in" },
+      { action: "markOut", label: "Mark out" },
+      { action: "clearRange", label: "Clear in and out" },
+      { action: "prevCut", label: "Previous cut" },
+      { action: "nextCut", label: "Next cut" },
+      { action: "addMarker", label: "Add marker at playhead" },
+      { action: "nextMarker", label: "Next marker" },
+      { action: "prevMarker", label: "Previous marker" }
+    ]
+  },
+  {
+    title: "Keyframes & source",
+    rows: [
+      { action: "addKeyframe", label: "Keyframe the selected clip at the playhead" },
+      { action: "nextKeyframe", label: "Next keyframe" },
+      { action: "prevKeyframe", label: "Previous keyframe" },
+      { action: "sourceAppend", label: "Append source range to the end" },
+      { action: "sourceInsert", label: "Insert source range at playhead" },
+      { action: "sourceOverwrite", label: "Overwrite with source range at playhead" }
     ]
   },
   {
     title: "Zoom & view",
-    shortcuts: [
-      { keys: ["+"], action: "Zoom in", alt: ["="] },
-      { keys: ["-"], action: "Zoom out", alt: ["_"] },
-      { keys: ["Shift", "Z"], action: "Zoom to fit content" }
+    rows: [
+      { action: "zoomIn", label: "Zoom in" },
+      { action: "zoomOut", label: "Zoom out" },
+      { action: "zoomFit", label: "Zoom to fit content" }
     ]
   },
   {
     title: "History",
-    shortcuts: [
-      { keys: ["Ctrl", "Z"], action: "Undo" },
-      { keys: ["Ctrl", "Shift", "Z"], action: "Redo", alt: ["Ctrl", "Y"] }
+    rows: [
+      { action: "undo", label: "Undo" },
+      { action: "redo", label: "Redo" }
     ]
   }
 ];
@@ -143,21 +172,28 @@ const keysCellStyles = css({
   flexShrink: 0
 });
 
-const ShortcutRow: React.FC<{ shortcut: Shortcut }> = ({ shortcut }) => {
+const ShortcutRow: React.FC<{ row: Row; preset: TimelineKeyboardPreset }> = ({
+  row,
+  preset
+}) => {
   const theme = useTheme();
+  const combos: string[][] = row.action
+    ? TIMELINE_KEYMAPS[preset][row.action].map(bindingKeys)
+    : row.keys
+      ? [row.keys]
+      : [];
   return (
     <div css={rowStyles(theme)}>
       <Text size="small" sx={{ minWidth: 0 }}>
-        {shortcut.action}
+        {row.label}
       </Text>
       <div css={keysCellStyles}>
-        <ShortcutHint shortcut={shortcut.keys} />
-        {shortcut.alt ? (
-          <>
-            <Caption sx={{ opacity: 0.6 }}>or</Caption>
-            <ShortcutHint shortcut={shortcut.alt} />
-          </>
-        ) : null}
+        {combos.map((keys, i) => (
+          <React.Fragment key={keys.join("+")}>
+            {i > 0 && <Caption sx={{ opacity: 0.6 }}>or</Caption>}
+            <ShortcutHint shortcut={keys} />
+          </React.Fragment>
+        ))}
       </div>
     </div>
   );
@@ -172,6 +208,20 @@ interface TimelineShortcutsDialogProps {
 export const TimelineShortcutsDialog: React.FC<TimelineShortcutsDialogProps> =
   memo(({ open, onClose }) => {
     const theme = useTheme();
+    const preset = useSettingsStore(
+      (s) => s.settings.timelineKeyboardPreset
+    );
+    const updateSettings = useSettingsStore((s) => s.updateSettings);
+    const handlePreset = useCallback(
+      (_e: React.MouseEvent<HTMLElement>, value: string | null) => {
+        if (value && (TIMELINE_KEYBOARD_PRESETS as readonly string[]).includes(value)) {
+          updateSettings({
+            timelineKeyboardPreset: value as TimelineKeyboardPreset
+          });
+        }
+      },
+      [updateSettings]
+    );
     return (
       <Dialog
         open={open}
@@ -179,6 +229,22 @@ export const TimelineShortcutsDialog: React.FC<TimelineShortcutsDialogProps> =
         title="Keyboard shortcuts"
         minWidth="min(680px, 100vw - 32px)"
       >
+        <FlexRow align="center" gap={1} sx={{ pb: 1 }}>
+          <Caption sx={groupTitleSx}>Layout</Caption>
+          <ToggleGroup
+            value={preset}
+            exclusive
+            onChange={handlePreset}
+            compact
+            aria-label="Keyboard layout"
+          >
+            {TIMELINE_KEYBOARD_PRESETS.map((p) => (
+              <ToggleOption key={p} value={p}>
+                {TIMELINE_KEYBOARD_PRESET_LABELS[p]}
+              </ToggleOption>
+            ))}
+          </ToggleGroup>
+        </FlexRow>
         <div
           css={css({
             display: "grid",
@@ -188,11 +254,11 @@ export const TimelineShortcutsDialog: React.FC<TimelineShortcutsDialogProps> =
             "@media (max-width: 560px)": { gridTemplateColumns: "1fr" }
           })}
         >
-          {SHORTCUT_GROUPS.map((group) => (
+          {GROUPS.map((group) => (
             <FlexColumn key={group.title} gap={0.5} css={groupStyles}>
               <Caption sx={groupTitleSx}>{group.title}</Caption>
-              {group.shortcuts.map((shortcut) => (
-                <ShortcutRow key={shortcut.action} shortcut={shortcut} />
+              {group.rows.map((row) => (
+                <ShortcutRow key={row.label} row={row} preset={preset} />
               ))}
             </FlexColumn>
           ))}

--- a/web/src/components/timeline/TimelineShortcutsDialog.tsx
+++ b/web/src/components/timeline/TimelineShortcutsDialog.tsx
@@ -58,6 +58,9 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: ["Delete"], action: "Delete selected clips", alt: ["Backspace"] },
       { keys: ["Shift", "Delete"], action: "Ripple delete (close the gap)" },
       { keys: ["Ctrl", "drag edge"], action: "Roll the cut with its neighbour" },
+      { keys: ["click edge"], action: "Select the edit point" },
+      { keys: ["E"], action: "Extend the edit point to the playhead" },
+      { keys: ["Ctrl", "Shift", "←"], action: "Trim edit point one frame (Alt: ten)", alt: ["Ctrl", "Shift", "→"] },
       { keys: ["Ctrl", "D"], action: "Duplicate (after each source)" },
       { keys: ["Ctrl", "Shift", "D"], action: "Duplicate with a 1 s gap" },
       { keys: ["Ctrl", "A"], action: "Select all clips" }

--- a/web/src/components/timeline/ToolToggle.tsx
+++ b/web/src/components/timeline/ToolToggle.tsx
@@ -16,6 +16,10 @@ import SwapHorizOutlinedIcon from "@mui/icons-material/SwapHorizOutlined";
 import LayersOutlinedIcon from "@mui/icons-material/LayersOutlined";
 import KeyboardTabOutlinedIcon from "@mui/icons-material/KeyboardTabOutlined";
 import FlipToFrontOutlinedIcon from "@mui/icons-material/FlipToFrontOutlined";
+import LinkOutlinedIcon from "@mui/icons-material/LinkOutlined";
+import LinkOffOutlinedIcon from "@mui/icons-material/LinkOffOutlined";
+import GridGoldenratioOutlinedIcon from "@mui/icons-material/GridGoldenratioOutlined";
+import { useTimelineStore } from "../../stores/timeline/TimelineStore";
 
 import {
   FlexRow,
@@ -135,6 +139,10 @@ export const ToolToggle: React.FC<ToolToggleProps> = memo(({ compact = false }) 
   const toggleRippleMode = useTimelineUIStore((s) => s.toggleRippleMode);
   const dropMode = useTimelineUIStore((s) => s.dropMode);
   const setDropMode = useTimelineUIStore((s) => s.setDropMode);
+  const snapEnabled = useTimelineUIStore((s) => s.snapEnabled);
+  const toggleSnap = useTimelineUIStore((s) => s.toggleSnap);
+  const linkedSelection = useTimelineStore((s) => s.linkedSelection);
+  const setLinkedSelection = useTimelineStore((s) => s.setLinkedSelection);
   return (
     <FlexRow gap={0.5} align="center">
       <ToolButton
@@ -191,6 +199,25 @@ export const ToolToggle: React.FC<ToolToggleProps> = memo(({ compact = false }) 
         onClick={() => setDropMode("overlap")}
       >
         <LayersOutlinedIcon />
+      </ToolButton>
+      <span css={dividerStyles} aria-hidden />
+      <ToolButton
+        label="Snap"
+        shortcut="N · Alt-drag bypasses"
+        active={snapEnabled}
+        compact={compact}
+        onClick={toggleSnap}
+      >
+        <GridGoldenratioOutlinedIcon />
+      </ToolButton>
+      <ToolButton
+        label="Linked"
+        shortcut="video and its audio move together"
+        active={linkedSelection}
+        compact={compact}
+        onClick={() => setLinkedSelection(!linkedSelection)}
+      >
+        {linkedSelection ? <LinkOutlinedIcon /> : <LinkOffOutlinedIcon />}
       </ToolButton>
     </FlexRow>
   );

--- a/web/src/components/timeline/ToolToggle.tsx
+++ b/web/src/components/timeline/ToolToggle.tsx
@@ -13,8 +13,18 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ContentCutOutlinedIcon from "@mui/icons-material/ContentCutOutlined";
 import SwapHorizOutlinedIcon from "@mui/icons-material/SwapHorizOutlined";
+import LayersOutlinedIcon from "@mui/icons-material/LayersOutlined";
+import KeyboardTabOutlinedIcon from "@mui/icons-material/KeyboardTabOutlined";
+import FlipToFrontOutlinedIcon from "@mui/icons-material/FlipToFrontOutlined";
 
-import { FlexRow, Tooltip, MOTION, BORDER_RADIUS } from "../ui_primitives";
+import {
+  FlexRow,
+  Tooltip,
+  MOTION,
+  BORDER_RADIUS,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
 import { useTimelineUIStore } from "../../stores/timeline/TimelineUIStore";
 
 /** Custom pointer cursor — monoline, 1.6px stroke. */
@@ -71,6 +81,14 @@ const buttonStyles = (theme: Theme, active: boolean, compact: boolean) =>
     }
   });
 
+const dividerStyles = css({
+  width: 1,
+  height: 16,
+  margin: `0 ${getSpacingPx(SPACING.xs)}`,
+  background: "currentColor",
+  opacity: 0.2
+});
+
 interface ToolButtonProps {
   label: string;
   shortcut: string;
@@ -115,6 +133,8 @@ export const ToolToggle: React.FC<ToolToggleProps> = memo(({ compact = false }) 
   const setActiveTool = useTimelineUIStore((s) => s.setActiveTool);
   const rippleMode = useTimelineUIStore((s) => s.rippleMode);
   const toggleRippleMode = useTimelineUIStore((s) => s.toggleRippleMode);
+  const dropMode = useTimelineUIStore((s) => s.dropMode);
+  const setDropMode = useTimelineUIStore((s) => s.setDropMode);
   return (
     <FlexRow gap={0.5} align="center">
       <ToolButton
@@ -143,6 +163,34 @@ export const ToolToggle: React.FC<ToolToggleProps> = memo(({ compact = false }) 
         onClick={toggleRippleMode}
       >
         <SwapHorizOutlinedIcon />
+      </ToolButton>
+      <span css={dividerStyles} aria-hidden />
+      <ToolButton
+        label="Overwrite"
+        shortcut="drop replaces what it covers"
+        active={dropMode === "overwrite"}
+        compact={compact}
+        onClick={() => setDropMode("overwrite")}
+      >
+        <FlipToFrontOutlinedIcon />
+      </ToolButton>
+      <ToolButton
+        label="Insert"
+        shortcut="drop pushes later clips right · Ctrl+drag"
+        active={dropMode === "insert"}
+        compact={compact}
+        onClick={() => setDropMode("insert")}
+      >
+        <KeyboardTabOutlinedIcon />
+      </ToolButton>
+      <ToolButton
+        label="Overlap"
+        shortcut="drop stacks and cross-fades"
+        active={dropMode === "overlap"}
+        compact={compact}
+        onClick={() => setDropMode("overlap")}
+      >
+        <LayersOutlinedIcon />
       </ToolButton>
     </FlexRow>
   );

--- a/web/src/components/timeline/ToolToggle.tsx
+++ b/web/src/components/timeline/ToolToggle.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 /**
- * ToolToggle — Select / Cut tool buttons for the timeline editor.
+ * ToolToggle — Select / Cut tool buttons plus the Ripple toggle for the
+ * timeline editor.
  *
  * Labeled ghost buttons (icon + text). The active button picks up the
  * primary accent + subtle filled background; tooltip carries the shortcut.
@@ -11,6 +12,7 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ContentCutOutlinedIcon from "@mui/icons-material/ContentCutOutlined";
+import SwapHorizOutlinedIcon from "@mui/icons-material/SwapHorizOutlined";
 
 import { FlexRow, Tooltip, MOTION, BORDER_RADIUS } from "../ui_primitives";
 import { useTimelineUIStore } from "../../stores/timeline/TimelineUIStore";
@@ -111,6 +113,8 @@ interface ToolToggleProps {
 export const ToolToggle: React.FC<ToolToggleProps> = memo(({ compact = false }) => {
   const activeTool = useTimelineUIStore((s) => s.activeTool);
   const setActiveTool = useTimelineUIStore((s) => s.setActiveTool);
+  const rippleMode = useTimelineUIStore((s) => s.rippleMode);
+  const toggleRippleMode = useTimelineUIStore((s) => s.toggleRippleMode);
   return (
     <FlexRow gap={0.5} align="center">
       <ToolButton
@@ -130,6 +134,15 @@ export const ToolToggle: React.FC<ToolToggleProps> = memo(({ compact = false }) 
         onClick={() => setActiveTool("cut")}
       >
         <ContentCutOutlinedIcon />
+      </ToolButton>
+      <ToolButton
+        label="Ripple"
+        shortcut="trims and deletes close the gap"
+        active={rippleMode}
+        compact={compact}
+        onClick={toggleRippleMode}
+      >
+        <SwapHorizOutlinedIcon />
       </ToolButton>
     </FlexRow>
   );

--- a/web/src/components/timeline/TopBar.tsx
+++ b/web/src/components/timeline/TopBar.tsx
@@ -11,7 +11,7 @@
  * (see `TopBarPrompt`'s `compact` layout).
  */
 
-import React, { memo, useCallback, useState } from "react";
+import React, { memo, useCallback, useEffect, useState } from "react";
 import { useTheme } from "@mui/material/styles";
 import { css } from "@emotion/react";
 import type { Theme } from "@mui/material/styles";
@@ -80,10 +80,30 @@ export const TopBar: React.FC<TopBarProps> = memo(
   }) => {
     const theme = useTheme();
     const isMobile = useTimelineIsMobile();
+    const [isNarrow, setIsNarrow] = useState(false);
+    const isCompact = isMobile || isNarrow;
+    const barRef = React.useRef<HTMLDivElement>(null);
     const [overflowAnchor, setOverflowAnchor] = useState<HTMLElement | null>(
       null
     );
     const closeOverflow = useCallback(() => setOverflowAnchor(null), []);
+
+    useEffect(() => {
+      const element = barRef.current;
+      if (!element) return;
+      // The prompt's model/settings rail and the four labelled actions need
+      // roughly 1,200px together. Collapse the actions before flexbox starts
+      // shrinking controls into one another, so this remains safe when a
+      // sidebar reduces the editor to an intermediate width.
+      const update = () => {
+        if (element.clientWidth === 0) return;
+        setIsNarrow(element.clientWidth < 1200);
+      };
+      update();
+      const observer = new ResizeObserver(update);
+      observer.observe(element);
+      return () => observer.disconnect();
+    }, []);
 
     // "Save as Asset" anchors a folder popover to whatever element was clicked.
     // From the overflow menu that element is the menu item, which unmounts on
@@ -97,11 +117,17 @@ export const TopBar: React.FC<TopBarProps> = memo(
       [closeOverflow]
     );
 
-    if (isMobile) {
+    if (isCompact) {
       const hasActions =
         !!onOpenSettings || !!onSave || !!onSaveToAssets || !!onExportVideo;
       return (
-        <FlexRow align="flex-start" gap={SPACING.sm} fullWidth css={styles(theme, true)}>
+        <FlexRow
+          ref={barRef}
+          align="flex-start"
+          gap={SPACING.sm}
+          fullWidth
+          css={styles(theme, true)}
+        >
           <TopBarPrompt compact />
           {activitySlot}
           {hasActions && (
@@ -163,6 +189,7 @@ export const TopBar: React.FC<TopBarProps> = memo(
 
     return (
       <FlexRow
+        ref={barRef}
         align="center"
         gap={SPACING.xs}
         fullWidth

--- a/web/src/components/timeline/Tracks/Clip.tsx
+++ b/web/src/components/timeline/Tracks/Clip.tsx
@@ -32,6 +32,7 @@ import type { ClipErrorState } from "../status/clipStatusReducer";
 import { useClipSourceDuration } from "./useClipSourceDuration";
 import { useClipDrag } from "./useClipDrag";
 import { useClipTrim } from "./useClipTrim";
+import { useTransitionHandle } from "./useTransitionHandle";
 import { ClipBody, CLIP_STATUS_MAP, MIN_CLIP_WIDTH_PX } from "./ClipBody";
 import { ClipContextMenu } from "./ClipContextMenu";
 import { ReplaceOutputDialog } from "./ReplaceOutputDialog";
@@ -152,6 +153,12 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
     sourceDurationMs
   });
 
+  const {
+    handleTransitionPointerDown,
+    handleTransitionPointerMove,
+    handleTransitionPointerEnd
+  } = useTransitionHandle(clip, msPerPx, interactionLocked);
+
   const handleContextMenu = useCallback(
     (e: React.MouseEvent) => {
       if (!clip) {
@@ -240,6 +247,9 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
         handleTrimPointerEnd={handleTrimPointerEnd}
         cutMode={activeTool === "cut"}
         selectedEdge={selectedEdge}
+        handleTransitionPointerDown={handleTransitionPointerDown}
+        handleTransitionPointerMove={handleTransitionPointerMove}
+        handleTransitionPointerEnd={handleTransitionPointerEnd}
         interactionLocked={interactionLocked}
       />
       {contextMenuPos && (

--- a/web/src/components/timeline/Tracks/Clip.tsx
+++ b/web/src/components/timeline/Tracks/Clip.tsx
@@ -33,6 +33,8 @@ import { useClipSourceDuration } from "./useClipSourceDuration";
 import { useClipDrag } from "./useClipDrag";
 import { useClipTrim } from "./useClipTrim";
 import { useTransitionHandle } from "./useTransitionHandle";
+import { keyframeTimesMs as deriveKeyframeTimes } from "@nodetool-ai/timeline";
+import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
 import { ClipBody, CLIP_STATUS_MAP, MIN_CLIP_WIDTH_PX } from "./ClipBody";
 import { ClipContextMenu } from "./ClipContextMenu";
 import { ReplaceOutputDialog } from "./ReplaceOutputDialog";
@@ -159,6 +161,18 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
     handleTransitionPointerEnd
   } = useTransitionHandle(clip, msPerPx, interactionLocked);
 
+  const keyframeTimes = useMemo(
+    () => (clip ? deriveKeyframeTimes(clip) : []),
+    [clip]
+  );
+  const seek = useTimelinePlaybackStore((s) => s.seek);
+  const handleKeyframeClick = useCallback(
+    (relMs: number) => {
+      if (clip) seek(clip.startMs + relMs);
+    },
+    [clip, seek]
+  );
+
   const handleContextMenu = useCallback(
     (e: React.MouseEvent) => {
       if (!clip) {
@@ -250,6 +264,8 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
         handleTransitionPointerDown={handleTransitionPointerDown}
         handleTransitionPointerMove={handleTransitionPointerMove}
         handleTransitionPointerEnd={handleTransitionPointerEnd}
+        keyframeTimesMs={keyframeTimes}
+        onKeyframeClick={handleKeyframeClick}
         interactionLocked={interactionLocked}
       />
       {contextMenuPos && (

--- a/web/src/components/timeline/Tracks/Clip.tsx
+++ b/web/src/components/timeline/Tracks/Clip.tsx
@@ -57,6 +57,9 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
   const isSelected = useIsClipSelected(clipId);
   const msPerPx = useTimelineUIStore((s) => s.msPerPx);
   const activeTool = useTimelineUIStore((s) => s.activeTool);
+  const selectedEdge = useTimelineUIStore((s) =>
+    s.selectedEdit?.clipId === clipId ? s.selectedEdit.edge : null
+  );
 
   const selectClip = useTimelineUIStore((s) => s.selectClip);
   const addToSelection = useTimelineUIStore((s) => s.addToSelection);
@@ -236,6 +239,7 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
         handleTrimEndPointerMove={handleTrimEndPointerMove}
         handleTrimPointerEnd={handleTrimPointerEnd}
         cutMode={activeTool === "cut"}
+        selectedEdge={selectedEdge}
         interactionLocked={interactionLocked}
       />
       {contextMenuPos && (

--- a/web/src/components/timeline/Tracks/ClipBody.tsx
+++ b/web/src/components/timeline/Tracks/ClipBody.tsx
@@ -393,6 +393,18 @@ const transitionWedgeStyles = (theme: Theme, tint: string, accent: string) =>
     }
   });
 
+/** The draggable right edge of the transition wedge. */
+const transitionHandleStyles = css({
+  position: "absolute",
+  top: 0,
+  bottom: 0,
+  right: -3,
+  width: TRIM_HANDLE_WIDTH_PX,
+  cursor: "ew-resize",
+  pointerEvents: "auto",
+  zIndex: Z_INDEX.base + 3
+});
+
 /** Applied to both grips when the clip is too narrow to host them. */
 const HIDDEN_TRIM_HANDLE_STYLE: React.CSSProperties = {
   display: "none",
@@ -519,6 +531,9 @@ export interface ClipBodyProps {
   cutMode: boolean;
   /** The edge picked as the edit point (E, Ctrl+Shift+arrows), if this clip's. */
   selectedEdge: "start" | "end" | null;
+  handleTransitionPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handleTransitionPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handleTransitionPointerEnd: () => void;
   /** clip.locked OR the clip's track is locked: drives the not-allowed cursor.
    *  The lock badge below stays tied to clip.locked alone. */
   interactionLocked: boolean;
@@ -544,6 +559,9 @@ export const ClipBody: React.FC<ClipBodyProps> = memo(
     handleTrimPointerEnd,
     cutMode,
     selectedEdge,
+    handleTransitionPointerDown,
+    handleTransitionPointerMove,
+    handleTransitionPointerEnd,
     interactionLocked
   }) => {
     const theme = useTheme();
@@ -775,12 +793,20 @@ export const ClipBody: React.FC<ClipBodyProps> = memo(
           <div
             css={transitionCss}
             style={{ width: fadeMarkers.transitionIn.widthPx }}
-            aria-hidden
             data-testid={`clip-transition-in-${clipId}`}
           >
             {fadeMarkers.transitionIn.widthPx >= TRANSITION_LABEL_MIN_PX && (
-              <span>{fadeMarkers.transitionIn.type}</span>
+              <span aria-hidden>{fadeMarkers.transitionIn.type}</span>
             )}
+            <div
+              css={transitionHandleStyles}
+              onPointerDown={handleTransitionPointerDown}
+              onPointerMove={handleTransitionPointerMove}
+              onPointerUp={handleTransitionPointerEnd}
+              onPointerCancel={handleTransitionPointerEnd}
+              aria-label="Transition length"
+              data-testid={`clip-transition-handle-${clipId}`}
+            />
           </div>
         )}
 

--- a/web/src/components/timeline/Tracks/ClipBody.tsx
+++ b/web/src/components/timeline/Tracks/ClipBody.tsx
@@ -393,6 +393,22 @@ const transitionWedgeStyles = (theme: Theme, tint: string, accent: string) =>
     }
   });
 
+/** A hand-set keyframe, drawn as a diamond on the clip's bottom edge. */
+const keyframeDiamondStyles = (theme: Theme) =>
+  css({
+    position: "absolute",
+    bottom: 2,
+    width: 7,
+    height: 7,
+    marginLeft: -3.5,
+    transform: "rotate(45deg)",
+    background: theme.vars.palette.primary.main,
+    border: `1px solid ${theme.vars.palette.background.paper}`,
+    cursor: "pointer",
+    padding: 0,
+    zIndex: Z_INDEX.base + 3
+  });
+
 /** The draggable right edge of the transition wedge. */
 const transitionHandleStyles = css({
   position: "absolute",
@@ -534,6 +550,9 @@ export interface ClipBodyProps {
   handleTransitionPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
   handleTransitionPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
   handleTransitionPointerEnd: () => void;
+  /** Clip-relative times of hand-set keyframes, drawn as diamonds. */
+  keyframeTimesMs: readonly number[];
+  onKeyframeClick: (clipRelativeMs: number) => void;
   /** clip.locked OR the clip's track is locked: drives the not-allowed cursor.
    *  The lock badge below stays tied to clip.locked alone. */
   interactionLocked: boolean;
@@ -562,6 +581,8 @@ export const ClipBody: React.FC<ClipBodyProps> = memo(
     handleTransitionPointerDown,
     handleTransitionPointerMove,
     handleTransitionPointerEnd,
+    keyframeTimesMs,
+    onKeyframeClick,
     interactionLocked
   }) => {
     const theme = useTheme();
@@ -678,6 +699,10 @@ export const ClipBody: React.FC<ClipBodyProps> = memo(
     const dotCss = useMemo(() => clipDotStyles(accent), [accent]);
     const nameCss = useMemo(() => clipNameStyles(theme), [theme]);
     const durationCss = useMemo(() => clipDurationStyles(theme), [theme]);
+    const keyframeDiamondCss = useMemo(
+      () => keyframeDiamondStyles(theme),
+      [theme]
+    );
     const trimStartCss = useMemo(
       () =>
         trimHandleStyles(
@@ -687,7 +712,7 @@ export const ClipBody: React.FC<ClipBodyProps> = memo(
           isSelected,
           selectedEdge === "start"
         ),
-      [theme, interactionLocked, isSelected]
+      [theme, interactionLocked, isSelected, selectedEdge]
     );
     const trimEndCss = useMemo(
       () =>
@@ -698,7 +723,7 @@ export const ClipBody: React.FC<ClipBodyProps> = memo(
           isSelected,
           selectedEdge === "end"
         ),
-      [theme, interactionLocked, isSelected]
+      [theme, interactionLocked, isSelected, selectedEdge]
     );
     const transitionCss = useMemo(
       () =>
@@ -811,6 +836,22 @@ export const ClipBody: React.FC<ClipBodyProps> = memo(
         )}
 
         {imageUrl && <div css={filmstripStyles} style={imageStyle} />}
+
+        {keyframeTimesMs.map((t) => (
+          <button
+            key={t}
+            type="button"
+            css={keyframeDiamondCss}
+            style={{ left: t / msPerPx }}
+            aria-label={`Keyframe at ${formatClipDuration(t)}`}
+            data-testid={`clip-keyframe-${clipId}`}
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onKeyframeClick(t);
+            }}
+          />
+        ))}
 
         {clip.mediaType === "group" && (
           <GroupBracket

--- a/web/src/components/timeline/Tracks/ClipBody.tsx
+++ b/web/src/components/timeline/Tracks/ClipBody.tsx
@@ -403,7 +403,8 @@ const trimHandleStyles = (
   theme: Theme,
   edge: "start" | "end",
   interactionLocked: boolean,
-  selected: boolean
+  selected: boolean,
+  editSelected: boolean
 ) =>
   css({
     position: "absolute",
@@ -412,10 +413,12 @@ const trimHandleStyles = (
     width: TRIM_HANDLE_WIDTH_PX,
     [edge === "start" ? "left" : "right"]: 0,
     cursor: interactionLocked ? "not-allowed" : "ew-resize",
-    backgroundColor: "var(--palette-c_overlay_strong)",
-    // Hidden until the clip is hovered (root selector), selected, or under a
-    // finger, where there is no hover to reveal it.
-    opacity: selected ? 1 : 0,
+    backgroundColor: editSelected
+      ? theme.vars.palette.primary.main
+      : "var(--palette-c_overlay_strong)",
+    // Hidden until the clip is hovered (root selector), selected, picked as
+    // the edit point, or under a finger, where there is no hover to reveal it.
+    opacity: selected || editSelected ? 1 : 0,
     transition: `opacity ${MOTION.fast}, background-color ${MOTION.fast}`,
     "&:hover": {
       backgroundColor: interactionLocked
@@ -514,6 +517,8 @@ export interface ClipBodyProps {
   handleTrimEndPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
   handleTrimPointerEnd: () => void;
   cutMode: boolean;
+  /** The edge picked as the edit point (E, Ctrl+Shift+arrows), if this clip's. */
+  selectedEdge: "start" | "end" | null;
   /** clip.locked OR the clip's track is locked: drives the not-allowed cursor.
    *  The lock badge below stays tied to clip.locked alone. */
   interactionLocked: boolean;
@@ -538,6 +543,7 @@ export const ClipBody: React.FC<ClipBodyProps> = memo(
     handleTrimEndPointerMove,
     handleTrimPointerEnd,
     cutMode,
+    selectedEdge,
     interactionLocked
   }) => {
     const theme = useTheme();
@@ -655,11 +661,25 @@ export const ClipBody: React.FC<ClipBodyProps> = memo(
     const nameCss = useMemo(() => clipNameStyles(theme), [theme]);
     const durationCss = useMemo(() => clipDurationStyles(theme), [theme]);
     const trimStartCss = useMemo(
-      () => trimHandleStyles(theme, "start", interactionLocked, isSelected),
+      () =>
+        trimHandleStyles(
+          theme,
+          "start",
+          interactionLocked,
+          isSelected,
+          selectedEdge === "start"
+        ),
       [theme, interactionLocked, isSelected]
     );
     const trimEndCss = useMemo(
-      () => trimHandleStyles(theme, "end", interactionLocked, isSelected),
+      () =>
+        trimHandleStyles(
+          theme,
+          "end",
+          interactionLocked,
+          isSelected,
+          selectedEdge === "end"
+        ),
       [theme, interactionLocked, isSelected]
     );
     const transitionCss = useMemo(

--- a/web/src/components/timeline/Tracks/ClipContextMenu.tsx
+++ b/web/src/components/timeline/Tracks/ClipContextMenu.tsx
@@ -7,6 +7,9 @@ import ImageIcon from "@mui/icons-material/Image";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import LinkOffIcon from "@mui/icons-material/LinkOff";
 import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
+import GradientOutlinedIcon from "@mui/icons-material/GradientOutlined";
+import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { findClipById } from "../../../stores/timeline/clipLookup";
 
 import { ContextMenu, MenuItemPrimitive } from "../../ui_primitives";
 import {
@@ -40,6 +43,11 @@ export function ClipContextMenu({
   onError
 }: ClipContextMenuProps) {
   const actions = useClipMenuActions(clipId, { onRequestReplace, onError });
+  const hasTransition = useTimelineStore(
+    (s) => (findClipById(s.clips, clipId)?.transitionIn?.durationMs ?? 0) > 0
+  );
+  const applyDefaultTransition = useTimelineStore((s) => s.applyDefaultTransition);
+  const removeTransition = useTimelineStore((s) => s.removeTransition);
 
   const run = (fn: () => void) => () => {
     fn();
@@ -59,6 +67,16 @@ export function ClipContextMenu({
         icon={<ContentCopyIcon fontSize="small" />}
         compact
         onClick={run(actions.duplicate)}
+      />
+      <MenuItemPrimitive
+        label={hasTransition ? "Remove transition" : "Cross-fade in"}
+        icon={<GradientOutlinedIcon fontSize="small" />}
+        compact
+        onClick={run(() =>
+          hasTransition
+            ? removeTransition(clipId)
+            : applyDefaultTransition(new Set([clipId]))
+        )}
       />
       {actions.isGenerated && (
         <MenuItemPrimitive

--- a/web/src/components/timeline/Tracks/TimeRuler.tsx
+++ b/web/src/components/timeline/Tracks/TimeRuler.tsx
@@ -6,7 +6,8 @@
  * - Major ticks every 5 s, minor every 1 s by default.
  * - Tick density adapts to msPerPx zoom level.
  * - Click → set playhead; drag → scrub (live update).
- * - Timecode format: M:SS (e.g. 0:05, 1:30).
+ * - Timecode format: M:SS (e.g. 0:05, 1:30); M:SS:FF once ticks go sub-second.
+ * - In/out range (I / O) drawn as a band behind the ticks.
  */
 
 import React, {
@@ -240,16 +241,31 @@ function computeTickIntervals(msPerPx: number) {
 }
 
 /**
- * Formats ms into M:SS (e.g. 0:05, 1:30), gaining decimals once the tick
- * interval is sub-second — otherwise zooming past 1 s/tick prints the same
- * label on every tick ("0:02  0:02  0:02") and the ruler stops saying where
- * anything is.
+ * Formats ms into M:SS (e.g. 0:05, 1:30). Once the tick interval is
+ * sub-second the label has to say more or every tick reads the same
+ * ("0:02  0:02  0:02"): with an `fps` it gains a frame field (M:SS:FF, the
+ * non-drop-frame timecode editors count in), without one it gains decimals.
  */
-export function formatTimecode(ms: number, majorMs = 1000): string {
+export function formatTimecode(
+  ms: number,
+  majorMs = 1000,
+  fps?: number
+): string {
   const totalSec = ms / 1000;
   const min = Math.floor(totalSec / 60);
   const sec = totalSec - min * 60;
-  const decimals = majorMs >= 1000 ? 0 : majorMs >= 500 ? 1 : 2;
+  if (majorMs >= 1000) {
+    return `${min}:${sec < 10 ? "0" : ""}${sec.toFixed(0)}`;
+  }
+  if (fps !== undefined && fps > 0) {
+    const fpsInt = Math.max(1, Math.round(fps));
+    const totalFrames = Math.round((ms / 1000) * fps);
+    const frame = totalFrames % fpsInt;
+    const wholeSec = Math.floor(totalFrames / fpsInt) % 60;
+    const pad = (n: number) => (n < 10 ? `0${n}` : `${n}`);
+    return `${min}:${pad(wholeSec)}:${pad(frame)}`;
+  }
+  const decimals = majorMs >= 500 ? 1 : 2;
   const secText = sec.toFixed(decimals);
   return `${min}:${sec < 10 ? "0" : ""}${secText}`;
 }
@@ -276,6 +292,9 @@ export const TimeRuler: React.FC<TimeRulerProps> = memo(
     const playbackStoreApi = useTimelinePlaybackStoreApi();
     const markers = useTimelineStore((s) => s.markers);
     const removeScene = useTimelineStore((s) => s.removeScene);
+    const fps = useTimelineStore((s) => s.fps);
+    const rangeInMs = useTimelinePlaybackStore((s) => s.rangeInMs);
+    const rangeOutMs = useTimelinePlaybackStore((s) => s.rangeOutMs);
 
     // Resize → redraw.
     // The canvas backing store is sized from offsetWidth/offsetHeight inside
@@ -336,9 +355,21 @@ export const TimeRuler: React.FC<TimeRulerProps> = memo(
       scrollLeftPx,
       theme,
       activeMode,
-      markers
+      markers,
+      fps,
+      rangeInMs,
+      rangeOutMs
     });
-    drawInputsRef.current = { msPerPx, scrollLeftPx, theme, activeMode, markers };
+    drawInputsRef.current = {
+      msPerPx,
+      scrollLeftPx,
+      theme,
+      activeMode,
+      markers,
+      fps,
+      rangeInMs,
+      rangeOutMs
+    };
 
     const rafIdRef = useRef<number | null>(null);
 
@@ -353,7 +384,10 @@ export const TimeRuler: React.FC<TimeRulerProps> = memo(
         scrollLeftPx: scrollLeft,
         theme: th,
         activeMode: mode,
-        markers: marks
+        markers: marks,
+        fps: frameRate,
+        rangeInMs: rangeIn,
+        rangeOutMs: rangeOut
       } = drawInputsRef.current;
 
       const dpr = window.devicePixelRatio || 1;
@@ -383,6 +417,27 @@ export const TimeRuler: React.FC<TimeRulerProps> = memo(
       const tickColor = colors.tick;
 
       const { majorMs, minorMs } = computeTickIntervals(mpp);
+
+      // In/out range: a translucent band from the in point (or 0) to the out
+      // point (or the right edge), with a solid edge line at each set point.
+      if (rangeIn !== null || rangeOut !== null) {
+        const inPx = rangeIn === null ? 0 : rangeIn / mpp - scrollLeft;
+        const outPx = rangeOut === null ? w : rangeOut / mpp - scrollLeft;
+        ctx.save();
+        ctx.globalAlpha = 0.18;
+        ctx.fillStyle = colors.marker;
+        ctx.fillRect(Math.max(0, inPx), 0, Math.min(w, outPx) - Math.max(0, inPx), h);
+        ctx.restore();
+        ctx.strokeStyle = colors.marker;
+        ctx.lineWidth = 2;
+        for (const px of [rangeIn === null ? null : inPx, rangeOut === null ? null : outPx]) {
+          if (px === null || px < 0 || px > w) continue;
+          ctx.beginPath();
+          ctx.moveTo(px, 0);
+          ctx.lineTo(px, h);
+          ctx.stroke();
+        }
+      }
 
       // The canvas is already offset by the CSS paddingLeft (headerWidthPx),
       // so its x=0 aligns with the scrollable lanes' left edge. We work in the
@@ -419,7 +474,7 @@ export const TimeRuler: React.FC<TimeRulerProps> = memo(
 
         if (isMajor) {
           ctx.fillStyle = textColor;
-          ctx.fillText(formatTimecode(tMs, majorMs), px + 3, 3);
+          ctx.fillText(formatTimecode(tMs, majorMs, frameRate), px + 3, 3);
         }
       }
 
@@ -465,6 +520,9 @@ export const TimeRuler: React.FC<TimeRulerProps> = memo(
       headerWidthPx,
       activeMode,
       markers,
+      fps,
+      rangeInMs,
+      rangeOutMs,
       resizeTick,
       scheduleDraw
     ]);

--- a/web/src/components/timeline/Tracks/TrackLane.tsx
+++ b/web/src/components/timeline/Tracks/TrackLane.tsx
@@ -124,6 +124,7 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
   const addImportedClip = useTimelineStore((s) => s.addImportedClip);
   const addClip = useTimelineStore((s) => s.addClip);
   const closeGapAt = useTimelineStore((s) => s.closeGapAt);
+  const resolveDropInStore = useTimelineStore((s) => s.resolveDrop);
   const importVideoWithAudio = useVideoAudioImport();
 
   const heightPx = track.heightPx ?? DEFAULT_TRACK_HEIGHT_PX;
@@ -307,7 +308,8 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
       if (mediaType === "video" && track.type === "video") {
         void importVideoWithAudio(asset, track.id, startMs);
       } else {
-        addImportedClip(asset, track.id, startMs);
+        const newId = addImportedClip(asset, track.id, startMs);
+        resolveDropInStore(new Set([newId]), useTimelineUIStore.getState().dropMode);
       }
     },
     [
@@ -316,6 +318,7 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
       track.id,
       msPerPx,
       addImportedClip,
+      resolveDropInStore,
       importVideoWithAudio,
       showWarning
     ]

--- a/web/src/components/timeline/Tracks/TrackLane.tsx
+++ b/web/src/components/timeline/Tracks/TrackLane.tsx
@@ -28,6 +28,8 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
 import AddIcon from "@mui/icons-material/Add";
+import CompressOutlinedIcon from "@mui/icons-material/CompressOutlined";
+import { findGap } from "@nodetool-ai/timeline";
 import TitleIcon from "@mui/icons-material/Title";
 
 import {
@@ -121,6 +123,7 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
   const setRubberBand = useTimelineUIStore((s) => s.setRubberBand);
   const addImportedClip = useTimelineStore((s) => s.addImportedClip);
   const addClip = useTimelineStore((s) => s.addClip);
+  const closeGapAt = useTimelineStore((s) => s.closeGapAt);
   const importVideoWithAudio = useVideoAudioImport();
 
   const heightPx = track.heightPx ?? DEFAULT_TRACK_HEIGHT_PX;
@@ -546,6 +549,21 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
     [track.locked, openLaneMenuAt]
   );
 
+  // Read once per menu open, not subscribed: the lane must not re-render on
+  // every clip mutation for a menu that is closed almost all the time.
+  const menuGap =
+    contextMenuPos === null
+      ? null
+      : findGap(timelineStore.getState().clips, track.id, contextMenuPos.startMs);
+
+  const handleCloseGap = useCallback(() => {
+    if (!contextMenuPos) {
+      return;
+    }
+    closeGapAt(track.id, contextMenuPos.startMs);
+    setContextMenuPos(null);
+  }, [closeGapAt, contextMenuPos, track.id]);
+
   const handleAddClipFromMenu = useCallback(() => {
     if (!contextMenuPos) {
       return;
@@ -648,6 +666,14 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
           onClick={handleAddClipFromMenu}
           compact
         />
+        {menuGap && (
+          <MenuItemPrimitive
+            label="Close gap"
+            icon={<CompressOutlinedIcon fontSize="small" />}
+            onClick={handleCloseGap}
+            compact
+          />
+        )}
       </ContextMenu>
 
       {/* Invisible anchor for AddClipMenu, positioned at click location */}

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -981,6 +981,11 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
             return;
 
           case "applyDefaultTransition":
+            if (selectedClipIds.size === 0) return;
+            e.preventDefault();
+            doc.applyDefaultTransition(selectedClipIds);
+            return;
+
           case "addKeyframe":
           case "nextKeyframe":
           case "prevKeyframe":

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -732,6 +732,53 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         const playback = playbackStore.getState();
         const liveMs = playback.getTimeMs();
 
+        // Keyboard trims act on the selected edit point (a clicked clip edge).
+        // E extends it to the playhead; Ctrl+Shift+←/→ nudges it a frame
+        // (Alt: ten). Ripple mode decides whether later clips follow.
+        const trimEdit = (edgeTargetMs: number) => {
+          const edit = uiStoreApi.getState().selectedEdit;
+          if (!edit) return false;
+          const doc = docStore.getState();
+          const target = doc.clips.find((c) => c.id === edit.clipId);
+          if (!target) return false;
+          const ripple = uiStoreApi.getState().rippleMode;
+          if (edit.edge === "start") {
+            const delta = target.startMs - edgeTargetMs;
+            if (ripple) doc.rippleTrimClipStart(target.id, delta);
+            else doc.trimClipStart(target.id, delta);
+          } else {
+            const delta = edgeTargetMs - (target.startMs + target.durationMs);
+            if (ripple) doc.rippleTrimClipEnd(target.id, delta);
+            else doc.trimClipEnd(target.id, delta);
+          }
+          return true;
+        };
+        if (plain && e.key === "e") {
+          if (trimEdit(liveMs)) e.preventDefault();
+          return;
+        }
+        if (
+          isCtrl &&
+          e.shiftKey &&
+          (e.key === "ArrowLeft" || e.key === "ArrowRight")
+        ) {
+          const edit = uiStoreApi.getState().selectedEdit;
+          const target = edit
+            ? docStore.getState().clips.find((c) => c.id === edit.clipId)
+            : undefined;
+          if (edit && target) {
+            e.preventDefault();
+            const frameMs = 1000 / Math.max(1, docStore.getState().fps);
+            const stepMs = Math.round(frameMs * (e.altKey ? 10 : 1));
+            const edgeMs =
+              edit.edge === "start"
+                ? target.startMs
+                : target.startMs + target.durationMs;
+            trimEdit(edgeMs + (e.key === "ArrowLeft" ? -stepMs : stepMs));
+          }
+          return;
+        }
+
         // I / O → mark in and out; Ctrl+Shift+X clears both.
         if (plain && (e.key === "i" || e.key === "o")) {
           e.preventDefault();
@@ -814,7 +861,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         // Escape → clear selection and drop back to the select tool. No
         // preventDefault so Escape still closes any open menu/dialog.
         if (e.key === "Escape") {
-          if (selectedClipIds.size > 0) {
+          if (selectedClipIds.size > 0 || uiStoreApi.getState().selectedEdit) {
             setSelection([]);
           }
           if (uiStoreApi.getState().activeTool !== "select") {

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -102,6 +102,13 @@ import { assetMediaType } from "../dnd/assetToClipAdapter";
 import { buildTypedIndexMap } from "./trackVisuals";
 import { partitionTimelineWheel, normalizeWheelDeltaPx } from "./timelineWheel";
 import { resolveTimelineAction } from "../timelineKeymap";
+import { performSourceEdit } from "../sourceEdit";
+import { useAssetGridStore } from "../../../stores/AssetGridStore";
+import {
+  hasKeyframeAt,
+  keyframeTimesMs,
+  keyframeValueAt
+} from "@nodetool-ai/timeline";
 import { useSettingsStore } from "../../../stores/SettingsStore";
 
 const DEFAULT_TRACK_HEIGHT_PX = 64;
@@ -988,13 +995,57 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
 
           case "addKeyframe":
           case "nextKeyframe":
-          case "prevKeyframe":
+          case "prevKeyframe": {
+            // The selected clip (one) and the inspector's armed property.
+            if (selectedClipIds.size !== 1) return;
+            const clipId: string = selectedClipIds.values().next().value!;
+            const target = doc.clips.find((c) => c.id === clipId);
+            if (!target) return;
+            e.preventDefault();
+            const relMs = liveMs - target.startMs;
+            if (action === "addKeyframe") {
+              if (relMs < 0 || relMs > target.durationMs) return;
+              const property = ui.keyframeProperty;
+              if (hasKeyframeAt(target, property, relMs)) {
+                doc.removeClipKeyframe(clipId, property, relMs);
+              } else {
+                doc.setClipKeyframe(
+                  clipId,
+                  property,
+                  relMs,
+                  keyframeValueAt(target, property, relMs)
+                );
+              }
+              return;
+            }
+            seekToNeighbour(
+              keyframeTimesMs(target).map((t) => target.startMs + t),
+              action === "nextKeyframe"
+            );
+            return;
+          }
+
           case "sourceAppend":
           case "sourceInsert":
-          case "sourceOverwrite":
-            // Handled by the surfaces that own them (transition, keyframe
-            // and source-viewer actions); nothing here yet.
+          case "sourceOverwrite": {
+            const kind =
+              action === "sourceAppend"
+                ? "append"
+                : action === "sourceInsert"
+                  ? "insert"
+                  : "overwrite";
+            const id = performSourceEdit(kind, {
+              doc,
+              ui,
+              playheadMs: playback.currentTimeMs,
+              asset: useAssetGridStore.getState().selectedAssets.at(-1)
+            });
+            if (id) {
+              e.preventDefault();
+              setSelection([id]);
+            }
             return;
+          }
         }
       };
 

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -103,7 +103,12 @@ import { buildTypedIndexMap } from "./trackVisuals";
 import { partitionTimelineWheel, normalizeWheelDeltaPx } from "./timelineWheel";
 import { resolveTimelineAction } from "../timelineKeymap";
 import { performSourceEdit } from "../sourceEdit";
-import { useAssetGridStore } from "../../../stores/AssetGridStore";
+import {
+  getSelectedAssetForExplorer,
+  useAssetsSelectedAsset,
+  useLibrarySelectedAsset
+} from "../../../stores/AssetGridStore";
+import { usePanelStore } from "../../../stores/PanelStore";
 import {
   hasKeyframeAt,
   keyframeTimesMs,
@@ -228,6 +233,18 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
   ({ heightPx }) => {
     const theme = useTheme();
     const isMobile = useTimelineIsMobile();
+    const activeExplorer = usePanelStore((s) =>
+      s.panel.activeView === "library" || s.panel.activeView === "assets"
+        ? s.panel.activeView
+        : null
+    );
+    const assetsAsset = useAssetsSelectedAsset();
+    const libraryAsset = useLibrarySelectedAsset();
+    const activeAssetId = activeExplorer === "library"
+      ? libraryAsset?.id ?? null
+      : activeExplorer === "assets"
+        ? assetsAsset?.id ?? null
+        : null;
     const headerWidthPx = isMobile
       ? MOBILE_TRACK_HEADER_WIDTH_PX
       : TRACK_HEADER_WIDTH_PX;
@@ -285,6 +302,13 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
     const docStore = useTimelineStoreApi();
     const playbackStore = useTimelinePlaybackStoreApi();
     const uiStoreApi = useTimelineUIStoreApi();
+    const previousSourceAssetId = useRef<string | null>(null);
+    useEffect(() => {
+      if (previousSourceAssetId.current !== activeAssetId) {
+        uiStoreApi.getState().setSourceRange(null);
+        previousSourceAssetId.current = activeAssetId;
+      }
+    }, [activeAssetId, uiStoreApi]);
 
     const addTrack = useTimelineStore((s) => s.addTrack);
     const addImportedClip = useTimelineStore((s) => s.addImportedClip);
@@ -293,6 +317,26 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
 
     const scrollableRef = useRef<HTMLDivElement>(null);
     const headerColumnRef = useRef<HTMLDivElement>(null);
+    const toolbarRef = useRef<HTMLDivElement>(null);
+    const [toolbarNarrow, setToolbarNarrow] = useState(false);
+
+    useEffect(() => {
+      const element = toolbarRef.current;
+      if (!element) return;
+      // The labelled tool group is wider than the editor once the inspector
+      // or asset panel is open. Switch to the compact controls before the
+      // right-side actions are forced outside the toolbar.
+      const update = () => {
+        if (element.clientWidth === 0) return;
+        setToolbarNarrow(element.clientWidth < 1100);
+      };
+      update();
+      const observer = new ResizeObserver(update);
+      observer.observe(element);
+      return () => observer.disconnect();
+    }, []);
+
+    const toolbarCompact = isMobile || toolbarNarrow;
 
     // Keyboard-shortcut reference sheet (opened with `?` or the toolbar button).
     const [shortcutsOpen, setShortcutsOpen] = useState(false);
@@ -1038,7 +1082,9 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
               doc,
               ui,
               playheadMs: playback.currentTimeMs,
-              asset: useAssetGridStore.getState().selectedAssets.at(-1)
+              asset: activeExplorer
+                ? getSelectedAssetForExplorer(activeExplorer) ?? undefined
+                : undefined
             });
             if (id) {
               e.preventDefault();
@@ -1081,7 +1127,8 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
       // listener doesn't re-attach every render.
       arrowNudgeHistory.begin,
       arrowNudgeHistory.mark,
-      arrowNudgeHistory.end
+      arrowNudgeHistory.end,
+      activeExplorer
     ]);
 
     const expandedFxTrackId = useTimelineUIStore(
@@ -1133,15 +1180,16 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
       >
         {/* ── Tool toolbar (above the ruler) ──────────────────────────── */}
         <FlexRow
+          ref={toolbarRef}
           align="center"
-          gap={0.5}
-          css={toolbarStyles(theme, isMobile)}
+          gap={SPACING.micro}
+          css={toolbarStyles(theme, toolbarCompact)}
           data-testid="timeline-toolbar"
         >
-          <ToolToggle compact={isMobile} />
+          <ToolToggle compact={toolbarCompact} />
           <div style={{ flex: "1 1 auto" }} />
-          <ScriptToggleButton compact={isMobile} />
-          <AddTrackButton compact={isMobile} />
+          <ScriptToggleButton compact={toolbarCompact} />
+          <AddTrackButton compact={toolbarCompact} />
           {/* The shortcut sheet documents keyboard bindings — nothing a phone
               can act on, and the row has no width to spare. */}
           {!isMobile && (

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -101,6 +101,8 @@ import { deserializeDragData } from "../../../lib/dragdrop";
 import { assetMediaType } from "../dnd/assetToClipAdapter";
 import { buildTypedIndexMap } from "./trackVisuals";
 import { partitionTimelineWheel, normalizeWheelDeltaPx } from "./timelineWheel";
+import { resolveTimelineAction } from "../timelineKeymap";
+import { useSettingsStore } from "../../../stores/SettingsStore";
 
 const DEFAULT_TRACK_HEIGHT_PX = 64;
 const ZOOM_SENSITIVITY = 0.001;
@@ -681,210 +683,58 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
           return;
         }
 
-        const isCtrl = e.ctrlKey || e.metaKey;
-
-        // ? → toggle the keyboard-shortcut reference sheet. Match the resolved
-        // character, not the modifier state: some layouts produce "?" via AltGr
-        // (reported as ctrlKey+altKey), so gating on modifiers would hide the
-        // shortcut there. Editable targets are already excluded above.
-        if (e.key === "?") {
-          e.preventDefault();
-          // Ignore auto-repeat so holding the key doesn't flip the dialog
-          // open/closed every repeat tick and land on an unpredictable state.
-          if (!e.repeat) setShortcutsOpen((open) => !open);
+        const preset =
+          useSettingsStore.getState().settings.timelineKeyboardPreset;
+        const action = resolveTimelineAction(e, preset);
+        if (action === null) {
           return;
         }
 
         // Read on demand instead of subscribing reactively — subscribing
         // would re-render the region and re-attach this listener on every
         // selection change (e.g. every rubber-band drag tick).
-        const { selectedClipIds } = uiStoreApi.getState();
-
-        // Delete / Backspace → delete selected. Shift, or ripple mode,
-        // closes the gap the clips leave (Premiere's Ripple Delete, FCP's
-        // default Delete).
-        if (
-          (e.key === "Delete" || e.key === "Backspace") &&
-          selectedClipIds.size > 0
-        ) {
-          e.preventDefault();
-          if (e.shiftKey || uiStoreApi.getState().rippleMode) {
-            docStore.getState().rippleDeleteSelected(selectedClipIds);
-          } else {
-            deleteSelected(selectedClipIds);
-          }
-          return;
-        }
-
-        // Ctrl+K → cut every unlocked clip under the playhead, on every
-        // track (Premiere's Add Edit to all tracks, FCP's Blade All).
-        if (isCtrl && (e.key === "k" || e.key === "K")) {
-          e.preventDefault();
-          splitSelectedAtPlayhead(
-            playbackStore.getState().currentTimeMs,
-            new Set()
-          );
-          return;
-        }
-
-        // Unmodified single keys the rest of this handler shares.
-        const plain = !isCtrl && !e.altKey && !e.shiftKey;
+        const ui = uiStoreApi.getState();
+        const { selectedClipIds } = ui;
+        const doc = docStore.getState();
         const playback = playbackStore.getState();
         const liveMs = playback.getTimeMs();
+        const frameMs = 1000 / Math.max(1, doc.fps);
 
         // Keyboard trims act on the selected edit point (a clicked clip edge).
-        // E extends it to the playhead; Ctrl+Shift+←/→ nudges it a frame
-        // (Alt: ten). Ripple mode decides whether later clips follow.
-        const trimEdit = (edgeTargetMs: number) => {
-          const edit = uiStoreApi.getState().selectedEdit;
+        // Ripple mode decides whether later clips follow.
+        const trimEdit = (edgeTargetMs: number): boolean => {
+          const edit = ui.selectedEdit;
           if (!edit) return false;
-          const doc = docStore.getState();
           const target = doc.clips.find((c) => c.id === edit.clipId);
           if (!target) return false;
-          const ripple = uiStoreApi.getState().rippleMode;
           if (edit.edge === "start") {
             const delta = target.startMs - edgeTargetMs;
-            if (ripple) doc.rippleTrimClipStart(target.id, delta);
+            if (ui.rippleMode) doc.rippleTrimClipStart(target.id, delta);
             else doc.trimClipStart(target.id, delta);
           } else {
             const delta = edgeTargetMs - (target.startMs + target.durationMs);
-            if (ripple) doc.rippleTrimClipEnd(target.id, delta);
+            if (ui.rippleMode) doc.rippleTrimClipEnd(target.id, delta);
             else doc.trimClipEnd(target.id, delta);
           }
           return true;
         };
-        if (plain && e.key === "e") {
-          if (trimEdit(liveMs)) e.preventDefault();
-          return;
-        }
-        if (
-          isCtrl &&
-          e.shiftKey &&
-          (e.key === "ArrowLeft" || e.key === "ArrowRight")
-        ) {
-          const edit = uiStoreApi.getState().selectedEdit;
+        const trimEditBy = (deltaMs: number): boolean => {
+          const edit = ui.selectedEdit;
           const target = edit
-            ? docStore.getState().clips.find((c) => c.id === edit.clipId)
+            ? doc.clips.find((c) => c.id === edit.clipId)
             : undefined;
-          if (edit && target) {
-            e.preventDefault();
-            const frameMs = 1000 / Math.max(1, docStore.getState().fps);
-            const stepMs = Math.round(frameMs * (e.altKey ? 10 : 1));
-            const edgeMs =
-              edit.edge === "start"
-                ? target.startMs
-                : target.startMs + target.durationMs;
-            trimEdit(edgeMs + (e.key === "ArrowLeft" ? -stepMs : stepMs));
-          }
-          return;
-        }
-
-        // I / O → mark in and out; Ctrl+Shift+X clears both.
-        if (plain && (e.key === "i" || e.key === "o")) {
-          e.preventDefault();
-          if (e.key === "i") playback.setRangeIn(liveMs);
-          else playback.setRangeOut(liveMs);
-          return;
-        }
-        if (isCtrl && e.shiftKey && e.key === "X") {
-          e.preventDefault();
-          playback.clearRange();
-          return;
-        }
-
-        // J / K / L → shuttle. J plays backwards, L forwards, each press
-        // doubles the speed; K stops and puts the speed back to 1.
-        if (plain && (e.key === "j" || e.key === "l")) {
-          e.preventDefault();
-          const dir = e.key === "j" ? -1 : 1;
-          const cur = playback.rate;
-          const sameDir = playback.isPlaying && Math.sign(cur) === dir;
-          const next = sameDir ? Math.sign(cur) * Math.min(8, Math.abs(cur) * 2) : dir;
-          playback.setRate(next);
-          if (!playback.isPlaying) {
-            playback.play();
-          }
-          // A seek while playing restarts the clock and audio at the new
-          // rate; see PreviewArea's seek-restart effect.
-          playback.seek(liveMs);
-          return;
-        }
-        if (plain && e.key === "k") {
-          e.preventDefault();
-          if (playback.isPlaying) playback.pause();
-          playback.setRate(1);
-          return;
-        }
-
-        // M → marker at the playhead. Shift+M / Ctrl+Shift+M → next / previous.
-        if ((e.key === "m" || e.key === "M") && !e.altKey) {
-          e.preventDefault();
-          const { markers, addMarker } = docStore.getState();
-          if (!e.shiftKey) {
-            if (!isCtrl) {
-              addMarker({ timeMs: liveMs, label: `Marker ${markers.length + 1}` });
-            }
-            return;
-          }
-          const times = markers.map((m) => m.timeMs).sort((a, b) => a - b);
-          const target = isCtrl
-            ? times.filter((t) => t < liveMs - 1).at(-1)
-            : times.find((t) => t > liveMs + 1);
-          if (target !== undefined) playback.seek(target);
-          return;
-        }
-
-        // ↑ / ↓ → previous / next cut (every clip edge on every track).
-        if (plain && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
-          e.preventDefault();
-          const pts = new Set<number>([0]);
-          for (const c of docStore.getState().clips) {
-            pts.add(c.startMs);
-            pts.add(c.startMs + c.durationMs);
-          }
-          const sorted = [...pts].sort((a, b) => a - b);
-          const target =
-            e.key === "ArrowUp"
-              ? sorted.filter((t) => t < liveMs - 1).at(-1)
-              : sorted.find((t) => t > liveMs + 1);
-          if (target !== undefined) playback.seek(target);
-          return;
-        }
-
-        // Ctrl/Cmd+A → select every clip
-        if (isCtrl && (e.key === "a" || e.key === "A")) {
-          e.preventDefault();
-          setSelection(docStore.getState().clips.map((c) => c.id));
-          return;
-        }
-
-        // Escape → clear selection and drop back to the select tool. No
-        // preventDefault so Escape still closes any open menu/dialog.
-        if (e.key === "Escape") {
-          if (selectedClipIds.size > 0 || uiStoreApi.getState().selectedEdit) {
-            setSelection([]);
-          }
-          if (uiStoreApi.getState().activeTool !== "select") {
-            setActiveTool("select");
-          }
-          return;
-        }
-
-        // ←/→ → nudge selected clips by one frame (Shift: 1 s)
-        if (
-          (e.key === "ArrowLeft" || e.key === "ArrowRight") &&
-          !isCtrl &&
-          !e.altKey &&
-          selectedClipIds.size > 0
-        ) {
-          e.preventDefault();
+          if (!edit || !target) return false;
+          const edgeMs =
+            edit.edge === "start"
+              ? target.startMs
+              : target.startMs + target.durationMs;
+          return trimEdit(edgeMs + deltaMs);
+        };
+        const nudge = (deltaMs: number) => {
           if (!arrowNudgeOpen) {
             arrowNudgeOpen = true;
             arrowNudgeHistory.begin();
           }
-          const fps = docStore.getState().fps;
-          const stepMs = e.shiftKey ? 1000 : Math.round(1000 / Math.max(1, fps));
-          const deltaMs = e.key === "ArrowLeft" ? -stepMs : stepMs;
           const primaryId: string = selectedClipIds.values().next().value!;
           moveSelectedClips(primaryId, selectedClipIds, deltaMs);
           arrowNudgeHistory.mark();
@@ -892,98 +742,223 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
             clearTimeout(arrowNudgeTimeoutId);
           }
           arrowNudgeTimeoutId = setTimeout(endArrowNudgeBatch, 400);
-          return;
-        }
-
-        // Ctrl+C / Ctrl+X → copy (cut) selected clips
-        if (isCtrl && (e.key === "c" || e.key === "x") && selectedClipIds.size > 0) {
-          e.preventDefault();
-          const clips = docStore
-            .getState()
-            .clips.filter((c) => selectedClipIds.has(c.id));
-          copyClipsToClipboard(clips);
-          if (e.key === "x") {
-            deleteSelected(selectedClipIds);
+        };
+        const seekToNeighbour = (times: number[], forward: boolean) => {
+          const sorted = [...times].sort((a, b) => a - b);
+          const target = forward
+            ? sorted.find((t) => t > liveMs + 1)
+            : sorted.filter((t) => t < liveMs - 1).at(-1);
+          if (target !== undefined) playback.seek(target);
+        };
+        const shuttle = (dir: 1 | -1) => {
+          const cur = playback.rate;
+          const sameDir = playback.isPlaying && Math.sign(cur) === dir;
+          const next = sameDir
+            ? Math.sign(cur) * Math.min(8, Math.abs(cur) * 2)
+            : dir;
+          playback.setRate(next);
+          if (!playback.isPlaying) {
+            playback.play();
           }
-          return;
-        }
+          // A seek while playing restarts the clock and audio at the new
+          // rate; see PreviewArea's seek-restart effect.
+          playback.seek(liveMs);
+        };
 
-        // Ctrl+V → paste at playhead (earliest clip lands on the playhead,
-        // the rest keep their relative offsets)
-        if (isCtrl && e.key === "v" && hasClipboardClips()) {
-          e.preventDefault();
-          const pasted = buildPastedClips(
-            docStore.getState().tracks,
-            playbackStore.getState().currentTimeMs
-          );
-          if (pasted.length > 0) {
-            addClips(pasted);
-            setSelection(pasted.map((c) => c.id));
+        switch (action) {
+          case "toggleShortcuts":
+            e.preventDefault();
+            // Ignore auto-repeat so holding the key doesn't flip the dialog
+            // open/closed every repeat tick.
+            if (!e.repeat) setShortcutsOpen((open) => !open);
+            return;
+
+          case "deleteSelected":
+          case "rippleDeleteSelected":
+            if (selectedClipIds.size === 0) return;
+            e.preventDefault();
+            if (action === "rippleDeleteSelected" || ui.rippleMode) {
+              doc.rippleDeleteSelected(selectedClipIds);
+            } else {
+              deleteSelected(selectedClipIds);
+            }
+            return;
+
+          case "splitAtPlayhead":
+            e.preventDefault();
+            splitSelectedAtPlayhead(playback.currentTimeMs, selectedClipIds);
+            return;
+
+          case "cutAllTracks":
+            e.preventDefault();
+            splitSelectedAtPlayhead(playback.currentTimeMs, new Set());
+            return;
+
+          case "extendEdit":
+            if (trimEdit(liveMs)) e.preventDefault();
+            return;
+          case "trimEditLeft":
+            if (trimEditBy(-Math.round(frameMs))) e.preventDefault();
+            return;
+          case "trimEditRight":
+            if (trimEditBy(Math.round(frameMs))) e.preventDefault();
+            return;
+          case "trimEditLeftLarge":
+            if (trimEditBy(-Math.round(frameMs * 10))) e.preventDefault();
+            return;
+          case "trimEditRightLarge":
+            if (trimEditBy(Math.round(frameMs * 10))) e.preventDefault();
+            return;
+
+          case "markIn":
+            e.preventDefault();
+            playback.setRangeIn(liveMs);
+            return;
+          case "markOut":
+            e.preventDefault();
+            playback.setRangeOut(liveMs);
+            return;
+          case "clearRange":
+            e.preventDefault();
+            playback.clearRange();
+            return;
+
+          case "shuttleBack":
+            e.preventDefault();
+            shuttle(-1);
+            return;
+          case "shuttleForward":
+            e.preventDefault();
+            shuttle(1);
+            return;
+          case "shuttleStop":
+            e.preventDefault();
+            if (playback.isPlaying) playback.pause();
+            playback.setRate(1);
+            return;
+
+          case "addMarker":
+            e.preventDefault();
+            doc.addMarker({
+              timeMs: liveMs,
+              label: `Marker ${doc.markers.length + 1}`
+            });
+            return;
+          case "nextMarker":
+          case "prevMarker":
+            e.preventDefault();
+            seekToNeighbour(
+              doc.markers.map((m) => m.timeMs),
+              action === "nextMarker"
+            );
+            return;
+
+          case "prevCut":
+          case "nextCut": {
+            e.preventDefault();
+            const pts = new Set<number>([0]);
+            for (const c of doc.clips) {
+              pts.add(c.startMs);
+              pts.add(c.startMs + c.durationMs);
+            }
+            seekToNeighbour([...pts], action === "nextCut");
+            return;
           }
-          return;
-        }
 
-        // Ctrl+D → duplicate selected (placed right after each source)
-        if (isCtrl && e.key === "d" && !e.shiftKey) {
-          e.preventDefault();
-          const newIds = duplicateSelected(selectedClipIds);
-          if (newIds.length > 0) setSelection(newIds);
-          return;
-        }
+          case "selectAll":
+            e.preventDefault();
+            setSelection(doc.clips.map((c) => c.id));
+            return;
 
-        // Ctrl+Shift+D → duplicate with an extra 1 s gap after each source
-        if (isCtrl && e.shiftKey && e.key === "D") {
-          e.preventDefault();
-          const newIds = duplicateSelected(selectedClipIds, DUPLICATE_OFFSET_MS);
-          if (newIds.length > 0) setSelection(newIds);
-          return;
-        }
+          case "escape":
+            // No preventDefault so Escape still closes any open menu/dialog.
+            if (selectedClipIds.size > 0 || ui.selectedEdit) {
+              setSelection([]);
+            }
+            if (ui.activeTool !== "select") {
+              setActiveTool("select");
+            }
+            return;
 
-        // S → split at playhead (no modifier; avoid hijacking browser Ctrl+S)
-        if (e.key === "s" && !isCtrl && !e.shiftKey && !e.altKey) {
-          e.preventDefault();
-          splitSelectedAtPlayhead(
-            playbackStore.getState().currentTimeMs,
-            selectedClipIds
-          );
-          return;
-        }
+          case "nudgeLeft":
+          case "nudgeRight":
+          case "nudgeLeftLarge":
+          case "nudgeRightLarge": {
+            if (selectedClipIds.size === 0) return;
+            e.preventDefault();
+            const large = action.endsWith("Large");
+            const stepMs = large ? 1000 : Math.round(frameMs);
+            nudge(action.startsWith("nudgeLeft") ? -stepMs : stepMs);
+            return;
+          }
 
-        // V → select tool, C → cut tool (FCP-style)
-        if (
-          (e.key === "v" || e.key === "c") &&
-          !isCtrl &&
-          !e.shiftKey &&
-          !e.altKey
-        ) {
-          e.preventDefault();
-          setActiveTool(e.key === "v" ? "select" : "cut");
-          return;
-        }
+          case "copy":
+          case "cut": {
+            if (selectedClipIds.size === 0) return;
+            e.preventDefault();
+            copyClipsToClipboard(
+              doc.clips.filter((c) => selectedClipIds.has(c.id))
+            );
+            if (action === "cut") {
+              deleteSelected(selectedClipIds);
+            }
+            return;
+          }
 
-        // +/= → zoom in, -/_ → zoom out. setZoom triggers the scale-change
-        // layout effect above, which keeps the playhead pinned to the same
-        // viewport x as the lanes rescale.
-        if (!isCtrl && !e.altKey && (e.key === "+" || e.key === "=")) {
-          e.preventDefault();
-          const cur = uiStoreApi.getState().msPerPx;
-          uiStoreApi.getState().setZoom(cur * ZOOM_IN_FACTOR);
-          return;
-        }
-        if (!isCtrl && !e.altKey && (e.key === "-" || e.key === "_")) {
-          e.preventDefault();
-          const cur = uiStoreApi.getState().msPerPx;
-          uiStoreApi.getState().setZoom(cur * ZOOM_OUT_FACTOR);
-          return;
-        }
+          case "paste": {
+            if (!hasClipboardClips()) return;
+            e.preventDefault();
+            // The earliest clip lands on the playhead, the rest keep their
+            // relative offsets.
+            const pasted = buildPastedClips(doc.tracks, playback.currentTimeMs);
+            if (pasted.length > 0) {
+              addClips(pasted);
+              setSelection(pasted.map((c) => c.id));
+            }
+            return;
+          }
 
-        // Shift+Z → zoom so the whole content fits the visible lane width.
-        if (!isCtrl && e.shiftKey && (e.key === "z" || e.key === "Z")) {
-          e.preventDefault();
-          const el = scrollableRef.current;
-          if (el) {
-            let end = docStore.getState().durationMs || 0;
-            for (const c of docStore.getState().clips) {
+          case "duplicate":
+          case "duplicateWithGap": {
+            e.preventDefault();
+            const newIds = duplicateSelected(
+              selectedClipIds,
+              action === "duplicateWithGap" ? DUPLICATE_OFFSET_MS : 0
+            );
+            if (newIds.length > 0) setSelection(newIds);
+            return;
+          }
+
+          case "selectTool":
+            e.preventDefault();
+            setActiveTool("select");
+            return;
+          case "cutTool":
+            e.preventDefault();
+            setActiveTool("cut");
+            return;
+          case "toggleSnap":
+            e.preventDefault();
+            ui.toggleSnap();
+            return;
+
+          // setZoom triggers the scale-change layout effect above, which
+          // keeps the playhead pinned to the same viewport x as the lanes
+          // rescale.
+          case "zoomIn":
+            e.preventDefault();
+            ui.setZoom(ui.msPerPx * ZOOM_IN_FACTOR);
+            return;
+          case "zoomOut":
+            e.preventDefault();
+            ui.setZoom(ui.msPerPx * ZOOM_OUT_FACTOR);
+            return;
+          case "zoomFit": {
+            e.preventDefault();
+            const el = scrollableRef.current;
+            if (!el) return;
+            let end = doc.durationMs || 0;
+            for (const c of doc.clips) {
               end = Math.max(end, c.startMs + c.durationMs);
             }
             const viewport = el.clientWidth - ZOOM_FIT_PADDING_PX;
@@ -991,26 +966,30 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
               // Pin the content start to the left edge as the lanes rescale,
               // reusing the cursor-zoom anchor path (see the layout effect).
               zoomAnchorRef.current = { timeMs: 0, cursorPx: 0 };
-              uiStoreApi.getState().setZoom(end / viewport);
+              ui.setZoom(end / viewport);
             }
+            return;
           }
-          return;
-        }
 
-        // Ctrl+Z → undo
-        if (isCtrl && !e.shiftKey && e.key === "z") {
-          e.preventDefault();
-          getTimelineTemporal().undo();
-          return;
-        }
+          case "undo":
+            e.preventDefault();
+            getTimelineTemporal().undo();
+            return;
+          case "redo":
+            e.preventDefault();
+            getTimelineTemporal().redo();
+            return;
 
-        // Ctrl+Shift+Z / Ctrl+Y → redo
-        if (
-          (isCtrl && e.shiftKey && e.key === "Z") ||
-          (isCtrl && e.key === "y")
-        ) {
-          e.preventDefault();
-          getTimelineTemporal().redo();
+          case "applyDefaultTransition":
+          case "addKeyframe":
+          case "nextKeyframe":
+          case "prevKeyframe":
+          case "sourceAppend":
+          case "sourceInsert":
+          case "sourceOverwrite":
+            // Handled by the surfaces that own them (transition, keyframe
+            // and source-viewer actions); nothing here yet.
+            return;
         }
       };
 

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -700,13 +700,107 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         // selection change (e.g. every rubber-band drag tick).
         const { selectedClipIds } = uiStoreApi.getState();
 
-        // Delete / Backspace → delete selected
+        // Delete / Backspace → delete selected. Shift, or ripple mode,
+        // closes the gap the clips leave (Premiere's Ripple Delete, FCP's
+        // default Delete).
         if (
           (e.key === "Delete" || e.key === "Backspace") &&
           selectedClipIds.size > 0
         ) {
           e.preventDefault();
-          deleteSelected(selectedClipIds);
+          if (e.shiftKey || uiStoreApi.getState().rippleMode) {
+            docStore.getState().rippleDeleteSelected(selectedClipIds);
+          } else {
+            deleteSelected(selectedClipIds);
+          }
+          return;
+        }
+
+        // Ctrl+K → cut every unlocked clip under the playhead, on every
+        // track (Premiere's Add Edit to all tracks, FCP's Blade All).
+        if (isCtrl && (e.key === "k" || e.key === "K")) {
+          e.preventDefault();
+          splitSelectedAtPlayhead(
+            playbackStore.getState().currentTimeMs,
+            new Set()
+          );
+          return;
+        }
+
+        // Unmodified single keys the rest of this handler shares.
+        const plain = !isCtrl && !e.altKey && !e.shiftKey;
+        const playback = playbackStore.getState();
+        const liveMs = playback.getTimeMs();
+
+        // I / O → mark in and out; Ctrl+Shift+X clears both.
+        if (plain && (e.key === "i" || e.key === "o")) {
+          e.preventDefault();
+          if (e.key === "i") playback.setRangeIn(liveMs);
+          else playback.setRangeOut(liveMs);
+          return;
+        }
+        if (isCtrl && e.shiftKey && e.key === "X") {
+          e.preventDefault();
+          playback.clearRange();
+          return;
+        }
+
+        // J / K / L → shuttle. J plays backwards, L forwards, each press
+        // doubles the speed; K stops and puts the speed back to 1.
+        if (plain && (e.key === "j" || e.key === "l")) {
+          e.preventDefault();
+          const dir = e.key === "j" ? -1 : 1;
+          const cur = playback.rate;
+          const sameDir = playback.isPlaying && Math.sign(cur) === dir;
+          const next = sameDir ? Math.sign(cur) * Math.min(8, Math.abs(cur) * 2) : dir;
+          playback.setRate(next);
+          if (!playback.isPlaying) {
+            playback.play();
+          }
+          // A seek while playing restarts the clock and audio at the new
+          // rate; see PreviewArea's seek-restart effect.
+          playback.seek(liveMs);
+          return;
+        }
+        if (plain && e.key === "k") {
+          e.preventDefault();
+          if (playback.isPlaying) playback.pause();
+          playback.setRate(1);
+          return;
+        }
+
+        // M → marker at the playhead. Shift+M / Ctrl+Shift+M → next / previous.
+        if ((e.key === "m" || e.key === "M") && !e.altKey) {
+          e.preventDefault();
+          const { markers, addMarker } = docStore.getState();
+          if (!e.shiftKey) {
+            if (!isCtrl) {
+              addMarker({ timeMs: liveMs, label: `Marker ${markers.length + 1}` });
+            }
+            return;
+          }
+          const times = markers.map((m) => m.timeMs).sort((a, b) => a - b);
+          const target = isCtrl
+            ? times.filter((t) => t < liveMs - 1).at(-1)
+            : times.find((t) => t > liveMs + 1);
+          if (target !== undefined) playback.seek(target);
+          return;
+        }
+
+        // ↑ / ↓ → previous / next cut (every clip edge on every track).
+        if (plain && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
+          e.preventDefault();
+          const pts = new Set<number>([0]);
+          for (const c of docStore.getState().clips) {
+            pts.add(c.startMs);
+            pts.add(c.startMs + c.durationMs);
+          }
+          const sorted = [...pts].sort((a, b) => a - b);
+          const target =
+            e.key === "ArrowUp"
+              ? sorted.filter((t) => t < liveMs - 1).at(-1)
+              : sorted.find((t) => t > liveMs + 1);
+          if (target !== undefined) playback.seek(target);
           return;
         }
 

--- a/web/src/components/timeline/Tracks/__tests__/ClipBody.render.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/ClipBody.render.test.tsx
@@ -66,6 +66,8 @@ const renderBody = (
         handleTransitionPointerDown={jest.fn()}
         handleTransitionPointerMove={jest.fn()}
         handleTransitionPointerEnd={jest.fn()}
+        keyframeTimesMs={[]}
+        onKeyframeClick={jest.fn()}
         interactionLocked={false}
       />
     </ThemeProvider>

--- a/web/src/components/timeline/Tracks/__tests__/ClipBody.render.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/ClipBody.render.test.tsx
@@ -62,6 +62,7 @@ const renderBody = (
         handleTrimEndPointerMove={jest.fn()}
         handleTrimPointerEnd={jest.fn()}
         cutMode={false}
+        selectedEdge={null}
         interactionLocked={false}
       />
     </ThemeProvider>

--- a/web/src/components/timeline/Tracks/__tests__/ClipBody.render.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/ClipBody.render.test.tsx
@@ -63,6 +63,9 @@ const renderBody = (
         handleTrimPointerEnd={jest.fn()}
         cutMode={false}
         selectedEdge={null}
+        handleTransitionPointerDown={jest.fn()}
+        handleTransitionPointerMove={jest.fn()}
+        handleTransitionPointerEnd={jest.fn()}
         interactionLocked={false}
       />
     </ThemeProvider>

--- a/web/src/components/timeline/Tracks/__tests__/formatTimecode.test.ts
+++ b/web/src/components/timeline/Tracks/__tests__/formatTimecode.test.ts
@@ -33,6 +33,17 @@ describe("formatTimecode", () => {
     expect(formatTimecode(2200, 200)).toBe("0:02.20");
   });
 
+  it("counts frames instead of decimals when the sequence fps is known", () => {
+    expect(formatTimecode(2000, 500, 30)).toBe("0:02:00");
+    expect(formatTimecode(2500, 500, 30)).toBe("0:02:15");
+    expect(formatTimecode(2080, 100, 25)).toBe("0:02:02");
+    expect(formatTimecode(61_500, 500, 24)).toBe("1:01:12");
+  });
+
+  it("keeps whole seconds at coarse intervals even with an fps", () => {
+    expect(formatTimecode(5000, 1000, 30)).toBe("0:05");
+  });
+
   it("pads seconds under ten and rolls over past a minute", () => {
     expect(formatTimecode(9900, 100)).toBe("0:09.90");
     expect(formatTimecode(61_500, 500)).toBe("1:01.5");

--- a/web/src/components/timeline/Tracks/useClipDrag.ts
+++ b/web/src/components/timeline/Tracks/useClipDrag.ts
@@ -115,6 +115,7 @@ export function useClipDrag({
 }: UseClipDragOptions): ClipDragHandlers {
   const moveClip = useTimelineStore((s) => s.moveClip);
   const moveSelectedClips = useTimelineStore((s) => s.moveSelectedClips);
+  const resolveDrop = useTimelineStore((s) => s.resolveDrop);
   const splitClipAtTime = useTimelineStore((s) => s.splitClipAtTime);
 
   // Undo batching: the gesture mutates the store on every pointermove. begin()
@@ -354,7 +355,7 @@ export function useClipDrag({
         }
       };
 
-      const onUpOrCancel = () => {
+      const onUpOrCancel = (ev?: PointerEvent) => {
         longPress.cancel();
         window.removeEventListener("pointermove", onMove);
         window.removeEventListener("pointerup", onUpOrCancel);
@@ -365,6 +366,20 @@ export function useClipDrag({
         }
         stopAutoScroll();
         clearGestureFeedback(useTimelineUIStore.getState());
+        if (isDraggingRef.current && ev?.type === "pointerup") {
+          // The drop settles inside the gesture's undo entry. Ctrl/Cmd on
+          // release forces insert; otherwise the toolbar's drop mode applies.
+          const ui = useTimelineUIStore.getState();
+          const moved =
+            ui.selectedClipIds.has(clipId) && ui.selectedClipIds.size > 1
+              ? new Set(ui.selectedClipIds)
+              : new Set([clipId]);
+          resolveDrop(
+            moved,
+            ev.ctrlKey || ev.metaKey ? "insert" : ui.dropMode
+          );
+          history.mark();
+        }
         history.end();
         // Defer dragging flag reset so the synthetic click that follows
         // pointerup is still suppressed by handleClick.
@@ -392,6 +407,7 @@ export function useClipDrag({
       splitClipAtTime,
       moveClip,
       moveSelectedClips,
+      resolveDrop,
       history
     ]
   );

--- a/web/src/components/timeline/Tracks/useClipDrag.ts
+++ b/web/src/components/timeline/Tracks/useClipDrag.ts
@@ -254,7 +254,8 @@ export function useClipDrag({
           0,
           dragStartMsRef.current + deltaPx * msPerPx
         );
-        const { startMs: targetStartMs, guideMs } = lastPointer.altKey
+        const { startMs: targetStartMs, guideMs } =
+          lastPointer.altKey || !useTimelineUIStore.getState().snapEnabled
           ? { startMs: rawStartMs, guideMs: null }
           : snapClipWindow(
               rawStartMs,

--- a/web/src/components/timeline/Tracks/useClipTrim.ts
+++ b/web/src/components/timeline/Tracks/useClipTrim.ts
@@ -80,7 +80,7 @@ function targetEdge(
   msPerPx: number
 ) {
   const rawMs = gesture.edgeMsAtStart + (e.clientX - gesture.startX) * msPerPx;
-  if (e.altKey) {
+  if (e.altKey || !useTimelineUIStore.getState().snapEnabled) {
     return { valueMs: rawMs, guideMs: null };
   }
   return snapEdge(rawMs, gesture.candidates, msPerPx);

--- a/web/src/components/timeline/Tracks/useClipTrim.ts
+++ b/web/src/components/timeline/Tracks/useClipTrim.ts
@@ -68,6 +68,9 @@ interface TrimGesture {
   durationMsAtStart: number;
   /** Edit mode locked in at pointerdown so it cannot flip mid-gesture. */
   mode: "trim" | "ripple" | "roll";
+  /** Set once the pointer has travelled; a press that never moves selects
+   *  the edge as the edit point instead of trimming. */
+  moved: boolean;
 }
 
 /** The snapped edge the pointer is asking for, and the guide to show. */
@@ -111,7 +114,8 @@ export function useClipTrim({
     edgeMsAtStart: 0,
     candidates: [],
     durationMsAtStart: 0,
-    mode: "trim"
+    mode: "trim",
+    moved: false
   });
 
   const beginGesture = useCallback(
@@ -140,7 +144,8 @@ export function useClipTrim({
           new Set([clip.id])
         ),
         durationMsAtStart: clip.durationMs,
-        mode
+        mode,
+        moved: false
       };
       history.begin();
     },
@@ -178,6 +183,7 @@ export function useClipTrim({
         return;
       }
       const gesture = gestureRef.current;
+      gesture.moved = true;
       const { valueMs, guideMs } = targetEdge(gesture, e, msPerPx);
       // trimClip(edge="start", deltaMs) convention (packages/timeline/src/trimClip.ts):
       //   nextStartMs    = clip.startMs    - deltaMs  (positive = move start left = grow)
@@ -257,6 +263,7 @@ export function useClipTrim({
       if (!fresh) {
         return;
       }
+      gestureRef.current.moved = true;
       const { valueMs, guideMs } = targetEdge(gestureRef.current, e, msPerPx);
       // trimClip(edge="end", deltaMs): nextDurationMs = durationMs + deltaMs,
       // so the delta that lands the end edge on `valueMs` is value - end.
@@ -297,11 +304,22 @@ export function useClipTrim({
   );
 
   const handleTrimPointerEnd = useCallback(() => {
+    const edge = isTrimmingStartRef.current
+      ? "start"
+      : isTrimmingEndRef.current
+        ? "end"
+        : null;
     isTrimmingStartRef.current = false;
     isTrimmingEndRef.current = false;
-    clearGestureFeedback(useTimelineUIStore.getState());
+    const ui = useTimelineUIStore.getState();
+    clearGestureFeedback(ui);
     history.end();
-  }, [history]);
+    // The edge just handled becomes the edit point for E and the keyboard
+    // trims, whether the press dragged it or only clicked it.
+    if (edge && clip) {
+      ui.setSelectedEdit({ clipId: clip.id, edge });
+    }
+  }, [history, clip]);
 
   return {
     handleTrimStartPointerDown,

--- a/web/src/components/timeline/Tracks/useClipTrim.ts
+++ b/web/src/components/timeline/Tracks/useClipTrim.ts
@@ -5,6 +5,11 @@
  * clip's in-point (startMs and durationMs change together); the end handle
  * changes durationMs only, capped at the source length when one is known.
  *
+ * Three edit modes share the gesture: a plain trim leaves the rest of the
+ * sequence alone; with ripple mode on (toolbar toggle) the clips after the
+ * edit follow it so no gap opens; holding Ctrl/Cmd rolls the cut instead,
+ * so the neighbour across it gives up what this clip gains.
+ *
  * The moving edge is targeted absolutely from the pointer (edge at
  * pointerdown + pointer travel), snapped against a candidate set snapshotted
  * at pointerdown unless Alt is held, and converted to the delta the store's
@@ -59,6 +64,10 @@ interface TrimGesture {
   edgeMsAtStart: number;
   /** Snap candidates snapshotted at pointerdown. */
   candidates: number[];
+  /** Clip length at pointerdown; a ripple head-trim measures against it. */
+  durationMsAtStart: number;
+  /** Edit mode locked in at pointerdown so it cannot flip mid-gesture. */
+  mode: "trim" | "ripple" | "roll";
 }
 
 /** The snapped edge the pointer is asking for, and the guide to show. */
@@ -83,6 +92,9 @@ export function useClipTrim({
 }: UseClipTrimOptions): ClipTrimHandlers {
   const trimClipStart = useTimelineStore((s) => s.trimClipStart);
   const trimClipEnd = useTimelineStore((s) => s.trimClipEnd);
+  const rippleTrimClipStart = useTimelineStore((s) => s.rippleTrimClipStart);
+  const rippleTrimClipEnd = useTimelineStore((s) => s.rippleTrimClipEnd);
+  const rollClipEdge = useTimelineStore((s) => s.rollClipEdge);
 
   // One undo entry per trim gesture; see useTimelineHistoryBatch.
   const history = useTimelineHistoryBatch();
@@ -97,7 +109,9 @@ export function useClipTrim({
   const gestureRef = useRef<TrimGesture>({
     startX: 0,
     edgeMsAtStart: 0,
-    candidates: []
+    candidates: [],
+    durationMsAtStart: 0,
+    mode: "trim"
   });
 
   const beginGesture = useCallback(
@@ -109,6 +123,12 @@ export function useClipTrim({
       e.stopPropagation();
       e.currentTarget.setPointerCapture(e.pointerId);
       const state = useTimelineStore.getState();
+      const mode =
+        e.ctrlKey || e.metaKey
+          ? "roll"
+          : useTimelineUIStore.getState().rippleMode
+            ? "ripple"
+            : "trim";
       gestureRef.current = {
         startX: e.clientX,
         edgeMsAtStart:
@@ -118,7 +138,9 @@ export function useClipTrim({
           state.durationMs,
           useTimelinePlaybackStore.getState().getTimeMs(),
           new Set([clip.id])
-        )
+        ),
+        durationMsAtStart: clip.durationMs,
+        mode
       };
       history.begin();
     },
@@ -155,25 +177,54 @@ export function useClipTrim({
       if (!fresh) {
         return;
       }
-      const { valueMs, guideMs } = targetEdge(gestureRef.current, e, msPerPx);
+      const gesture = gestureRef.current;
+      const { valueMs, guideMs } = targetEdge(gesture, e, msPerPx);
       // trimClip(edge="start", deltaMs) convention (packages/timeline/src/trimClip.ts):
       //   nextStartMs    = clip.startMs    - deltaMs  (positive = move start left = grow)
       //   nextDurationMs = clip.durationMs + deltaMs
       // so the delta that lands the start edge on `valueMs` is start - value.
-      trimClipStart(clip.id, fresh.startMs - valueMs);
+      let landed: boolean;
+      if (gesture.mode === "ripple") {
+        // A ripple head-trim keeps the clip parked, so the pointer's travel
+        // from the original edge is the total to take off (or add back), and
+        // the duration says how much of that is already applied.
+        const wantedMs = gesture.edgeMsAtStart - valueMs;
+        const appliedMs = fresh.durationMs - gesture.durationMsAtStart;
+        rippleTrimClipStart(clip.id, wantedMs - appliedMs);
+        landed =
+          findClipById(useTimelineStore.getState().clips, clip.id)
+            ?.durationMs === gesture.durationMsAtStart + wantedMs;
+      } else {
+        const deltaMs = fresh.startMs - valueMs;
+        if (gesture.mode === "roll") {
+          rollClipEdge(clip.id, "start", -deltaMs);
+        } else {
+          trimClipStart(clip.id, deltaMs);
+        }
+        landed =
+          findClipById(useTimelineStore.getState().clips, clip.id)?.startMs ===
+          valueMs;
+      }
       history.mark();
       const trimmed = findClipById(useTimelineStore.getState().clips, clip.id);
       if (trimmed) {
         // An invalid trim leaves the clip alone; then the snap did not land.
-        const applied = trimmed.startMs === valueMs ? guideMs : null;
         publishGestureFeedback(
           useTimelineUIStore.getState(),
-          applied,
+          landed ? guideMs : null,
           readoutFor(trimmed, "trim-start")
         );
       }
     },
-    [clip, interactionLocked, msPerPx, trimClipStart, history]
+    [
+      clip,
+      interactionLocked,
+      msPerPx,
+      trimClipStart,
+      rippleTrimClipStart,
+      rollClipEdge,
+      history
+    ]
   );
 
   const handleTrimEndPointerDown = useCallback<TrimPointerHandler>(
@@ -210,7 +261,15 @@ export function useClipTrim({
       // trimClip(edge="end", deltaMs): nextDurationMs = durationMs + deltaMs,
       // so the delta that lands the end edge on `valueMs` is value - end.
       const currentEndMs = fresh.startMs + fresh.durationMs;
-      trimClipEnd(clip.id, valueMs - currentEndMs, sourceDurationMs);
+      const deltaMs = valueMs - currentEndMs;
+      const mode = gestureRef.current.mode;
+      if (mode === "roll") {
+        rollClipEdge(clip.id, "end", deltaMs);
+      } else if (mode === "ripple") {
+        rippleTrimClipEnd(clip.id, deltaMs, sourceDurationMs);
+      } else {
+        trimClipEnd(clip.id, deltaMs, sourceDurationMs);
+      }
       history.mark();
       const trimmed = findClipById(useTimelineStore.getState().clips, clip.id);
       if (trimmed) {
@@ -225,7 +284,16 @@ export function useClipTrim({
         );
       }
     },
-    [clip, interactionLocked, msPerPx, trimClipEnd, sourceDurationMs, history]
+    [
+      clip,
+      interactionLocked,
+      msPerPx,
+      trimClipEnd,
+      rippleTrimClipEnd,
+      rollClipEdge,
+      sourceDurationMs,
+      history
+    ]
   );
 
   const handleTrimPointerEnd = useCallback(() => {

--- a/web/src/components/timeline/Tracks/useTransitionHandle.ts
+++ b/web/src/components/timeline/Tracks/useTransitionHandle.ts
@@ -1,0 +1,78 @@
+/**
+ * useTransitionHandle
+ *
+ * Drag the right edge of a clip's incoming-transition wedge to change how
+ * long the dissolve runs. The store grows the predecessor under the clip as
+ * the window grows (see `applyTransitionAtCut`), so the wedge is the whole
+ * transition, the way a transition object sits on a cut in other editors.
+ * One undo entry per gesture.
+ */
+
+import { useCallback, useRef } from "react";
+import type React from "react";
+
+import type { TimelineClip } from "@nodetool-ai/timeline";
+import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { useTimelineHistoryBatch } from "../../../stores/timeline/useTimelineHistoryBatch";
+
+type Handler = (e: React.PointerEvent<HTMLDivElement>) => void;
+
+export interface TransitionHandleHandlers {
+  handleTransitionPointerDown: Handler;
+  handleTransitionPointerMove: Handler;
+  handleTransitionPointerEnd: () => void;
+}
+
+export function useTransitionHandle(
+  clip: TimelineClip | undefined,
+  msPerPx: number,
+  interactionLocked: boolean
+): TransitionHandleHandlers {
+  const setTransitionDuration = useTimelineStore((s) => s.setTransitionDuration);
+  const history = useTimelineHistoryBatch();
+  const gestureRef = useRef<{ startX: number; startMs: number } | null>(null);
+
+  const handleTransitionPointerDown = useCallback<Handler>(
+    (e) => {
+      if (!clip || interactionLocked) return;
+      e.preventDefault();
+      e.stopPropagation();
+      e.currentTarget.setPointerCapture(e.pointerId);
+      gestureRef.current = {
+        startX: e.clientX,
+        startMs: clip.transitionIn?.durationMs ?? 0
+      };
+      history.begin();
+    },
+    [clip, interactionLocked, history]
+  );
+
+  const handleTransitionPointerMove = useCallback<Handler>(
+    (e) => {
+      const gesture = gestureRef.current;
+      if (!gesture || !clip || e.buttons !== 1) return;
+      e.stopPropagation();
+      const fps = useTimelineStore.getState().fps;
+      const minMs = Math.round(1000 / Math.max(1, fps));
+      const wanted = Math.max(
+        minMs,
+        Math.round(gesture.startMs + (e.clientX - gesture.startX) * msPerPx)
+      );
+      setTransitionDuration(clip.id, wanted);
+      history.mark();
+    },
+    [clip, msPerPx, setTransitionDuration, history]
+  );
+
+  const handleTransitionPointerEnd = useCallback(() => {
+    if (!gestureRef.current) return;
+    gestureRef.current = null;
+    history.end();
+  }, [history]);
+
+  return {
+    handleTransitionPointerDown,
+    handleTransitionPointerMove,
+    handleTransitionPointerEnd
+  };
+}

--- a/web/src/components/timeline/__tests__/sourceEdit.test.ts
+++ b/web/src/components/timeline/__tests__/sourceEdit.test.ts
@@ -1,0 +1,76 @@
+import { createTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { createTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
+import type { Asset } from "../../../stores/ApiTypes";
+import { performSourceEdit, sourceRangeFor, sourceTargetTrackId } from "../sourceEdit";
+import { makeClip } from "@nodetool-ai/timeline";
+
+const videoAsset = {
+  id: "asset-1",
+  name: "shot.mp4",
+  content_type: "video/mp4",
+  duration: 10,
+  metadata: null
+} as unknown as Asset;
+
+function setup() {
+  const doc = createTimelineStore();
+  const ui = createTimelineUIStore();
+  doc.getState().addTrack("video", "V1");
+  doc.getState().addTrack("audio", "A1");
+  const v1 = doc.getState().tracks[0].id;
+  doc.getState().addClips([
+    makeClip({ trackId: v1, mediaType: "video", startMs: 0, durationMs: 4000, status: "generated" }),
+    makeClip({ trackId: v1, mediaType: "video", startMs: 4000, durationMs: 2000, status: "generated" })
+  ]);
+  return { doc, ui, v1 };
+}
+
+describe("sourceRangeFor", () => {
+  it("defaults to the whole asset and clamps a reversed range", () => {
+    expect(sourceRangeFor(videoAsset, null)).toEqual({ inMs: 0, outMs: 10000 });
+    expect(sourceRangeFor(videoAsset, { inMs: 3000, outMs: 1000 })).toEqual({ inMs: 3000, outMs: 3000 });
+  });
+});
+
+describe("performSourceEdit", () => {
+  it("append lands after the last clip on the first compatible unlocked track", () => {
+    const { doc, ui, v1 } = setup();
+    ui.getState().setSourceRange({ inMs: 1000, outMs: 3500 });
+    const id = performSourceEdit("append", { doc: doc.getState(), ui: ui.getState(), playheadMs: 500, asset: videoAsset });
+    const clip = doc.getState().clips.find((c) => c.id === id)!;
+    expect(sourceTargetTrackId(doc.getState(), videoAsset)).toBe(v1);
+    expect(clip.trackId).toBe(v1);
+    expect(clip.startMs).toBe(6000);
+    expect(clip.inPointMs).toBe(1000);
+    expect(clip.outPointMs).toBe(3500);
+    expect(clip.durationMs).toBe(2500);
+  });
+
+  it("insert at the playhead pushes later clips right", () => {
+    const { doc, ui } = setup();
+    ui.getState().setSourceRange({ inMs: 0, outMs: 1000 });
+    const id = performSourceEdit("insert", { doc: doc.getState(), ui: ui.getState(), playheadMs: 4000, asset: videoAsset });
+    const clips = doc.getState().clips;
+    expect(clips.find((c) => c.id === id)!.startMs).toBe(4000);
+    expect(clips.find((c) => c.startMs === 5000)!.durationMs).toBe(2000);
+  });
+
+  it("overwrite at the playhead trims what it covers", () => {
+    const { doc, ui } = setup();
+    ui.getState().setSourceRange({ inMs: 0, outMs: 1000 });
+    performSourceEdit("overwrite", { doc: doc.getState(), ui: ui.getState(), playheadMs: 3500, asset: videoAsset });
+    const clips = doc.getState().clips.sort((a, b) => a.startMs - b.startMs);
+    expect(clips.map((c) => [c.startMs, c.durationMs])).toEqual([
+      [0, 3500],
+      [3500, 1000],
+      [4500, 1500]
+    ]);
+  });
+
+  it("returns null without an asset or a track", () => {
+    const { doc, ui } = setup();
+    expect(performSourceEdit("append", { doc: doc.getState(), ui: ui.getState(), playheadMs: 0, asset: undefined })).toBeNull();
+    doc.getState().setTrackLocked(doc.getState().tracks[0].id, true);
+    expect(performSourceEdit("append", { doc: doc.getState(), ui: ui.getState(), playheadMs: 0, asset: videoAsset })).toBeNull();
+  });
+});

--- a/web/src/components/timeline/__tests__/timelineKeymap.test.ts
+++ b/web/src/components/timeline/__tests__/timelineKeymap.test.ts
@@ -1,0 +1,101 @@
+import {
+  bindingKeys,
+  resolveTimelineAction,
+  TIMELINE_KEYMAPS,
+  TIMELINE_KEYBOARD_PRESETS,
+  type KeyEventLike
+} from "../timelineKeymap";
+
+const ev = (key: string, mods: Partial<KeyEventLike> = {}): KeyEventLike => ({
+  key,
+  ctrlKey: false,
+  metaKey: false,
+  shiftKey: false,
+  altKey: false,
+  ...mods
+});
+
+describe("resolveTimelineAction", () => {
+  it("resolves the NodeTool layout", () => {
+    expect(resolveTimelineAction(ev("s"), "nodetool")).toBe("splitAtPlayhead");
+    expect(resolveTimelineAction(ev("k", { ctrlKey: true }), "nodetool")).toBe("cutAllTracks");
+    expect(resolveTimelineAction(ev("Delete", { shiftKey: true }), "nodetool")).toBe(
+      "rippleDeleteSelected"
+    );
+    expect(resolveTimelineAction(ev("ArrowLeft"), "nodetool")).toBe("nudgeLeft");
+    expect(resolveTimelineAction(ev("ArrowLeft", { shiftKey: true }), "nodetool")).toBe(
+      "nudgeLeftLarge"
+    );
+  });
+
+  it("resolves the Premiere layout", () => {
+    expect(resolveTimelineAction(ev("s"), "premiere")).toBe("toggleSnap");
+    expect(resolveTimelineAction(ev("k", { metaKey: true }), "premiere")).toBe(
+      "splitAtPlayhead"
+    );
+    expect(resolveTimelineAction(ev("\\"), "premiere")).toBe("zoomFit");
+    expect(resolveTimelineAction(ev("d", { ctrlKey: true }), "premiere")).toBe(
+      "applyDefaultTransition"
+    );
+  });
+
+  it("resolves the Final Cut layout, where Delete ripples", () => {
+    expect(resolveTimelineAction(ev("Delete"), "fcp")).toBe("rippleDeleteSelected");
+    expect(resolveTimelineAction(ev("Delete", { shiftKey: true }), "fcp")).toBe(
+      "deleteSelected"
+    );
+    expect(resolveTimelineAction(ev("a"), "fcp")).toBe("selectTool");
+    expect(resolveTimelineAction(ev("e"), "fcp")).toBe("sourceAppend");
+    expect(resolveTimelineAction(ev("X", { shiftKey: true }), "fcp")).toBe("extendEdit");
+  });
+
+  it("prefers the binding with more modifiers", () => {
+    expect(resolveTimelineAction(ev("z", { ctrlKey: true }), "nodetool")).toBe("undo");
+    expect(
+      resolveTimelineAction(ev("Z", { ctrlKey: true, shiftKey: true }), "nodetool")
+    ).toBe("redo");
+  });
+
+  it("matches ? whatever modifiers the layout needed", () => {
+    expect(
+      resolveTimelineAction(ev("?", { ctrlKey: true, altKey: true }), "premiere")
+    ).toBe("toggleShortcuts");
+  });
+
+  it("returns null for an unbound key", () => {
+    expect(resolveTimelineAction(ev("q"), "nodetool")).toBeNull();
+  });
+
+  it("binds every action in every preset", () => {
+    const actions = Object.keys(TIMELINE_KEYMAPS.nodetool);
+    for (const preset of TIMELINE_KEYBOARD_PRESETS) {
+      for (const action of actions) {
+        expect(TIMELINE_KEYMAPS[preset][action as keyof typeof TIMELINE_KEYMAPS.nodetool].length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("no two actions share a binding inside a preset", () => {
+    for (const preset of TIMELINE_KEYBOARD_PRESETS) {
+      const seen = new Map<string, string>();
+      for (const [action, bindings] of Object.entries(TIMELINE_KEYMAPS[preset])) {
+        for (const b of bindings) {
+          const sig = `${b.key}|${b.ctrl ? 1 : 0}${b.shift ? 1 : 0}${b.alt ? 1 : 0}`;
+          expect(seen.get(sig) ?? action).toBe(action);
+          seen.set(sig, action);
+        }
+      }
+    }
+  });
+});
+
+describe("bindingKeys", () => {
+  it("spells modifiers and arrows for the sheet", () => {
+    expect(bindingKeys({ key: "ArrowLeft", ctrl: true, shift: true })).toEqual([
+      "Ctrl",
+      "Shift",
+      "←"
+    ]);
+    expect(bindingKeys({ key: "z", shift: true })).toEqual(["Shift", "Z"]);
+  });
+});

--- a/web/src/components/timeline/preview/PlaybackClock.ts
+++ b/web/src/components/timeline/preview/PlaybackClock.ts
@@ -22,18 +22,29 @@ export class PlaybackClock {
   private audioStartTimeSec = 0;
   private rate = 1;
   private durationMs = Infinity;
+  private floorMs = 0;
+  private onReachEnd: (() => void) | null = null;
 
+  /**
+   * Run from `positionMs` at `rate` (negative plays backwards) until the
+   * position leaves [`floorMs`, `durationMs`]. Reaching the end calls
+   * `onReachEnd` when given (a loop restarts from there) and pauses
+   * otherwise; reaching the floor always pauses.
+   */
   start(
     positionMs: number,
     rate = 1,
     audioContext: BaseAudioContext | null = null,
-    durationMs = Infinity
+    durationMs = Infinity,
+    options: { floorMs?: number; onReachEnd?: () => void } = {}
   ): void {
     this.stop();
     this.startPositionMs = positionMs;
     this.startWallMs = performance.now();
     this.rate = rate;
     this.durationMs = durationMs;
+    this.floorMs = options.floorMs ?? 0;
+    this.onReachEnd = options.onReachEnd ?? null;
     this.audioContext = audioContext;
     if (audioContext) {
       this.audioStartTimeSec = audioContext.currentTime;
@@ -74,8 +85,19 @@ export class PlaybackClock {
     // Clamp to sequence boundaries. On the boundary case we write the
     // *reactive* snapshot (setCurrentTimeMs) before pausing so subscribers
     // see the correct final position; pause() also syncs to the live value.
-    if (currentTimeMs >= this.durationMs) {
+    if (this.rate > 0 && currentTimeMs >= this.durationMs) {
+      this.rafId = null;
+      if (this.onReachEnd) {
+        setTimeMs(this.durationMs);
+        this.onReachEnd();
+        return;
+      }
       setCurrentTimeMs(this.durationMs);
+      pause();
+      return;
+    }
+    if (this.rate < 0 && currentTimeMs <= this.floorMs) {
+      setCurrentTimeMs(this.floorMs);
       pause();
       this.rafId = null;
       return;

--- a/web/src/components/timeline/preview/PreviewArea.tsx
+++ b/web/src/components/timeline/preview/PreviewArea.tsx
@@ -47,22 +47,7 @@ import { AudioGraph } from "./AudioGraph";
 import { PreviewCompositor } from "./PreviewCompositor";
 import { getAssetUrl } from "../../../utils/assetHelpers";
 import { useCombo } from "../../../stores/KeyPressedStore";
-
-function formatTimecode(timeMs: number, fps: number): string {
-  // Integer frame math: fractional rates (29.97, 23.976) would otherwise
-  // leak fractions into the frame field. Non-drop-frame timecode.
-  const fpsInt = Math.max(1, Math.round(fps));
-  const totalFrames = Math.floor((timeMs / 1000) * fps);
-  const framePart = totalFrames % fpsInt;
-  const totalSeconds = Math.floor(totalFrames / fpsInt);
-  const seconds = totalSeconds % 60;
-  const totalMinutes = Math.floor(totalSeconds / 60);
-  const minutes = totalMinutes % 60;
-  const hours = Math.floor(totalMinutes / 60);
-
-  const pad2 = (n: number) => String(n).padStart(2, "0");
-  return `${pad2(hours)}:${pad2(minutes)}:${pad2(seconds)}:${pad2(framePart)}`;
-}
+import { formatTimecode } from "../Inspector/InspectorPrimitives.helpers";
 
 function frameDeltaMs(fps: number): number {
   return 1000 / Math.max(1, fps);
@@ -243,21 +228,21 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
     // subscription: it feeds the `graph.updateTracks` effect below so DSP/
     // gain/solo/mute changes are audible immediately.
     const tracks = useTimelineStore((s) => s.tracks);
-    const durationMs = useTimelineStore((s) => s.durationMs);
-
     // `durationMs` is set only on load and is NOT recomputed when clips are
     // added/moved (see TracksRegion, which derives its own content extent).
     // For a new/unsaved sequence it stays 0, which would pin the scrubber's
     // range to [0, 1] (max ≤ step → every drag snaps to the end). Derive the
-    // max from the actual clip extent, matching the ruler. Returning a
+    // max from the actual clip extent, matching the ruler. When a sequence is
+    // empty, retain its stored duration so an intentional blank sequence still
+    // has a usable range. Returning a
     // primitive means the default equality skips re-renders for edits that
     // don't move the content boundary (e.g. an opacity slider drag).
     const contentEndMs = useTimelineStore((s) => {
-      let end = s.durationMs || 0;
+      let end = 0;
       for (const c of s.clips) {
         end = Math.max(end, c.startMs + c.durationMs);
       }
-      return end;
+      return s.clips.length > 0 ? end : s.durationMs || 0;
     });
 
     /** All unique clip boundary timestamps (start + end), sorted ascending.
@@ -273,7 +258,7 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
           pts.add(c.startMs);
           pts.add(c.startMs + c.durationMs);
         }
-        if (s.durationMs) {
+        if (s.clips.length === 0 && s.durationMs) {
           pts.add(s.durationMs);
         }
         return Array.from(pts).sort((a, b) => a - b);
@@ -633,11 +618,11 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
         const delta = frameDeltaMs(fps) * direction;
         const next = Math.max(
           0,
-          Math.min(durationMs || Infinity, currentTimeMs + delta)
+          Math.min(contentEndMs || Infinity, currentTimeMs + delta)
         );
         setCurrentTimeMs(next);
       },
-      [isPlaying, fps, durationMs, currentTimeMs, setCurrentTimeMs]
+      [isPlaying, fps, contentEndMs, currentTimeMs, setCurrentTimeMs]
     );
 
     const stepBack = useCallback(() => stepFrame(-1), [stepFrame]);
@@ -773,7 +758,7 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
             if (isPlaying) {
               handleStop();
             }
-            setCurrentTimeMs(durationMs || 0);
+            setCurrentTimeMs(contentEndMs || 0);
             break;
           default:
             break;
@@ -787,12 +772,12 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
         isPlaying,
         handleStop,
         setCurrentTimeMs,
-        durationMs
+        contentEndMs
       ]
     );
 
     const timecode = formatTimecode(currentTimeMs, fps);
-    const durationTimecode = formatTimecode(durationMs || 0, fps);
+    const durationTimecode = formatTimecode(contentEndMs, fps);
 
     // Playback no longer re-renders the bar (see above), but a scrub still
     // does, once per discrete `currentTimeMs` write.

--- a/web/src/components/timeline/preview/PreviewArea.tsx
+++ b/web/src/components/timeline/preview/PreviewArea.tsx
@@ -410,6 +410,10 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       [getAsset, getTimeMs, playbackApi, timelineApi]
     );
 
+    /** The rate the running clock was started with; the rate-change restart
+     *  effect compares against it so a same-rate re-render is not a restart. */
+    const startedRateRef = useRef(1);
+
     const handlePlay = useCallback(async () => {
       const generation = ++playGenRef.current;
       const isStale = () => playGenRef.current !== generation;
@@ -427,12 +431,18 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
 
       // Read fresh to avoid stale closure when the user scrubs before pressing play.
       let startMs = playbackApi.getState().currentTimeMs;
-      // Pressing Play while parked at the end restarts from the top. Uses the
-      // live content end (contentEndMs), not the stale store `durationMs`,
-      // which is only set on load and never recomputed as clips change.
-      if (contentEndMs > 0 && startMs >= contentEndMs - frameDeltaMs(fps)) {
-        startMs = 0;
-        setCurrentTimeMs(0);
+      // An out point bounds playback and loops it back to the in point (or
+      // the top); without one the live content end stops it. The store
+      // `durationMs` is only set on load and never recomputed as clips change.
+      const { rangeInMs: rangeIn, rangeOutMs: rangeOut } =
+        playbackApi.getState();
+      const loopStartMs = rangeIn ?? 0;
+      const endMs = rangeOut ?? contentEndMs;
+      // Pressing Play while parked at the end restarts from the top (or the
+      // in point).
+      if (endMs > 0 && startMs >= endMs - frameDeltaMs(fps)) {
+        startMs = loopStartMs;
+        setCurrentTimeMs(loopStartMs);
       }
 
       play();
@@ -441,14 +451,24 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       // (and the live rate-change restart below) takes effect. Feeds both the
       // clock and audio scheduling so the visual clock and audio stay locked.
       const globalRate = playbackApi.getState().rate;
+      startedRateRef.current = globalRate;
+      const clockOptions = {
+        floorMs: loopStartMs,
+        // Only a marked out point loops; the content end still parks.
+        onReachEnd:
+          rangeOut !== null ? () => playbackApi.getState().seek(loopStartMs) : undefined
+      };
 
       // Read fresh rather than closing over the reactive `clips` value so
       // this component never needs to subscribe to (and re-render on) the
       // clips array itself.
       const clipsNow = timelineApi.getState().clips;
-      const remainingAudioClips = clipsNow.filter((c) =>
-        isPendingAudioClip(c, startMs)
-      );
+      // Backwards playback (J) is picture only: the audio graph schedules
+      // forward from a source position.
+      const remainingAudioClips =
+        globalRate < 0
+          ? []
+          : clipsNow.filter((c) => isPendingAudioClip(c, startMs));
 
       if (remainingAudioClips.length === 0) {
         // Nothing left to play — e.g. a seek landed past the last audio
@@ -456,7 +476,7 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
         // AudioContext creation/resume entirely rather than paying the
         // autoplay-policy round trip for silence.
         graph.stopAll();
-        clock.start(startMs, globalRate, null, contentEndMs || Infinity);
+        clock.start(startMs, globalRate, null, endMs || Infinity, clockOptions);
         return;
       }
 
@@ -503,7 +523,7 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
         scheduledClipIdsRef.current.add(clip.id);
       }
 
-      clock.start(startMs, globalRate, ctx, contentEndMs || Infinity);
+      clock.start(startMs, globalRate, ctx, endMs || Infinity, clockOptions);
 
       topUpIntervalRef.current = setInterval(() => {
         void topUpAudio(isStale);
@@ -588,19 +608,22 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
     // rate. Guarded on isPlaying so a rate set while paused just applies on the
     // next play.
     useEffect(() => {
-      if (!isPlaying) return;
+      if (!isPlaying || rate === startedRateRef.current) return;
       seek(getTimeMs());
       // Only restart on an actual rate change, not on play/pause transitions.
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [rate]);
 
+    // Space always plays at normal speed; a J/L shuttle speed does not
+    // outlive the pause that ended it.
     const handlePlayPauseToggle = useCallback(() => {
       if (isPlaying) {
         handlePause();
       } else {
+        playbackApi.getState().setRate(1);
         void handlePlay();
       }
-    }, [isPlaying, handlePlay, handlePause]);
+    }, [isPlaying, handlePlay, handlePause, playbackApi]);
 
     const stepFrame = useCallback(
       (direction: 1 | -1) => {

--- a/web/src/components/timeline/preview/__tests__/PreviewArea.test.tsx
+++ b/web/src/components/timeline/preview/__tests__/PreviewArea.test.tsx
@@ -44,6 +44,8 @@ const mockSubscribeTime = jest.fn(() => () => {});
 
 let mockCurrentTimeMs = 0;
 let mockIsPlaying = false;
+let mockDurationMs = 60_000;
+let mockClips: unknown[] = [];
 
 jest.mock("../../../../stores/timeline/TimelinePlaybackStore", () => {
   const getState = () => ({
@@ -74,9 +76,9 @@ jest.mock("../../../../stores/timeline/TimelinePlaybackStore", () => {
 
 jest.mock("../../../../stores/timeline/TimelineStore", () => {
   const getState = () => ({
-    clips: [] as unknown[],
+    clips: mockClips,
     tracks: [] as unknown[],
-    durationMs: 60_000
+    durationMs: mockDurationMs
   });
   const useTimelineStore = <T,>(
     selector: (s: ReturnType<typeof getState>) => T
@@ -114,6 +116,8 @@ describe("PreviewArea", () => {
     jest.clearAllMocks();
     mockCurrentTimeMs = 0;
     mockIsPlaying = false;
+    mockDurationMs = 60_000;
+    mockClips = [];
   });
 
   describe("rendering", () => {
@@ -220,6 +224,16 @@ describe("PreviewArea", () => {
       const stepBack = screen.getByRole("button", { name: /step back one frame/i });
       expect(stepBack).not.toBeDisabled();
     });
+
+    it("does not navigate to a stale stored duration boundary", () => {
+      mockDurationMs = 60_000;
+      mockClips = [{ id: "clip", startMs: 0, durationMs: 10_000 }];
+      renderPreview();
+      fireEvent.click(
+        screen.getByRole("button", { name: "Next clip boundary" })
+      );
+      expect(mockSetCurrentTimeMs).toHaveBeenCalledWith(10_000);
+    });
   });
 
   describe("timecode formatting", () => {
@@ -234,6 +248,21 @@ describe("PreviewArea", () => {
       mockCurrentTimeMs = 60_000;
       renderPreview({ fps: 30 });
       expect(screen.getByText("00:01:00:00")).toBeInTheDocument();
+    });
+
+    it("shows the live clip extent when the stored duration is stale", () => {
+      mockDurationMs = 60_000;
+      mockClips = [
+        { id: "clip", startMs: 0, durationMs: 10_000 }
+      ];
+      renderPreview();
+      expect(screen.getByText("/00:00:10:00")).toBeInTheDocument();
+    });
+
+    it("uses the same rounded frame as the playhead at fractional frames", () => {
+      mockCurrentTimeMs = 4825;
+      renderPreview({ fps: 30 });
+      expect(screen.getByText("00:00:04:25")).toBeInTheDocument();
     });
   });
 });

--- a/web/src/components/timeline/sourceEdit.ts
+++ b/web/src/components/timeline/sourceEdit.ts
@@ -1,0 +1,77 @@
+/**
+ * Three-point editing from the source viewer: take the marked range of the
+ * asset selected in the explorer and append, insert or overwrite it into the
+ * sequence. Shared by the Source panel's buttons and the keyboard actions in
+ * TracksRegion, so both do exactly the same thing.
+ */
+
+import type { Asset } from "../../stores/ApiTypes";
+import type { TimelineStoreState } from "../../stores/timeline/TimelineStore";
+import type { TimelineUIState } from "../../stores/timeline/TimelineUIStore";
+import { assetMediaType, isCompatibleWithTrack } from "./dnd/assetToClipAdapter";
+
+export type SourceEditKind = "append" | "insert" | "overwrite";
+
+export interface SourceEditContext {
+  doc: TimelineStoreState;
+  ui: TimelineUIState;
+  playheadMs: number;
+  asset: Asset | undefined;
+}
+
+/** The asset's marked range, or its whole length when nothing is marked. */
+export function sourceRangeFor(
+  asset: Asset,
+  range: TimelineUIState["sourceRange"]
+): { inMs: number; outMs: number } {
+  const fullMs =
+    asset.duration !== null && asset.duration !== undefined
+      ? Math.round(asset.duration * 1000)
+      : 0;
+  const inMs = Math.max(0, range?.inMs ?? 0);
+  const outMs = range?.outMs ?? (fullMs > 0 ? fullMs : inMs);
+  return { inMs, outMs: Math.max(inMs, outMs) };
+}
+
+/** First unlocked track the asset can sit on, else null. */
+export function sourceTargetTrackId(
+  doc: TimelineStoreState,
+  asset: Asset
+): string | null {
+  const mediaType = assetMediaType(asset.content_type);
+  if (!mediaType) return null;
+  const track = [...doc.tracks]
+    .sort((a, b) => a.index - b.index)
+    .find((t) => !t.locked && isCompatibleWithTrack(mediaType, t.type));
+  return track?.id ?? null;
+}
+
+/**
+ * Perform the edit. Returns the new clip's id, or null when there is no
+ * asset, no usable range, or no track to put it on.
+ */
+export function performSourceEdit(
+  kind: SourceEditKind,
+  { doc, ui, playheadMs, asset }: SourceEditContext
+): string | null {
+  if (!asset) return null;
+  const { inMs, outMs } = sourceRangeFor(asset, ui.sourceRange);
+  const mediaType = assetMediaType(asset.content_type);
+  if (!mediaType) return null;
+  // An image has no length; the range is the clip length on the timeline.
+  if (mediaType !== "image" && outMs <= inMs) return null;
+
+  const trackId = sourceTargetTrackId(doc, asset);
+  if (!trackId) return null;
+
+  let startMs = playheadMs;
+  if (kind === "append") {
+    startMs = doc.clips
+      .filter((c) => c.trackId === trackId)
+      .reduce((end, c) => Math.max(end, c.startMs + c.durationMs), 0);
+  }
+  const id = doc.addSourceRange(asset, trackId, startMs, inMs, outMs);
+  if (kind === "insert") doc.resolveDrop(new Set([id]), "insert");
+  if (kind === "overwrite") doc.resolveDrop(new Set([id]), "overwrite");
+  return id;
+}

--- a/web/src/components/timeline/sourceEdit.ts
+++ b/web/src/components/timeline/sourceEdit.ts
@@ -28,9 +28,15 @@ export function sourceRangeFor(
     asset.duration !== null && asset.duration !== undefined
       ? Math.round(asset.duration * 1000)
       : 0;
-  const inMs = Math.max(0, range?.inMs ?? 0);
+  const inMs = Math.min(
+    fullMs || Number.POSITIVE_INFINITY,
+    Math.max(0, range?.inMs ?? 0)
+  );
   const outMs = range?.outMs ?? (fullMs > 0 ? fullMs : inMs);
-  return { inMs, outMs: Math.max(inMs, outMs) };
+  return {
+    inMs,
+    outMs: Math.min(fullMs || Number.POSITIVE_INFINITY, Math.max(inMs, outMs))
+  };
 }
 
 /** First unlocked track the asset can sit on, else null. */

--- a/web/src/components/timeline/timelineKeymap.ts
+++ b/web/src/components/timeline/timelineKeymap.ts
@@ -1,0 +1,277 @@
+/**
+ * Timeline keyboard map.
+ *
+ * Every keyboard action the tracks region performs has an id here, and each
+ * preset binds those ids to keys the way one editor's users expect: the
+ * NodeTool layout, Premiere's, or Final Cut's. The window handler in
+ * TracksRegion resolves an event to an action through `resolveTimelineAction`
+ * and never looks at `e.key` itself, and the shortcut sheet renders the same
+ * table, so the two cannot disagree.
+ *
+ * A binding names a key (`e.key`, letters lower-case) and the exact modifier
+ * state. Ctrl stands for Ctrl or Cmd. Shift is ignored for a symbol key, since
+ * the symbol already is the shifted character on most layouts ("?", "+").
+ */
+
+export const TIMELINE_KEYBOARD_PRESETS = ["nodetool", "premiere", "fcp"] as const;
+export type TimelineKeyboardPreset = (typeof TIMELINE_KEYBOARD_PRESETS)[number];
+
+export const TIMELINE_KEYBOARD_PRESET_LABELS: Record<TimelineKeyboardPreset, string> = {
+  nodetool: "NodeTool",
+  premiere: "Premiere Pro",
+  fcp: "Final Cut Pro"
+};
+
+export type TimelineAction =
+  | "toggleShortcuts"
+  | "selectTool"
+  | "cutTool"
+  | "splitAtPlayhead"
+  | "cutAllTracks"
+  | "deleteSelected"
+  | "rippleDeleteSelected"
+  | "duplicate"
+  | "duplicateWithGap"
+  | "selectAll"
+  | "escape"
+  | "copy"
+  | "cut"
+  | "paste"
+  | "nudgeLeft"
+  | "nudgeRight"
+  | "nudgeLeftLarge"
+  | "nudgeRightLarge"
+  | "extendEdit"
+  | "trimEditLeft"
+  | "trimEditRight"
+  | "trimEditLeftLarge"
+  | "trimEditRightLarge"
+  | "markIn"
+  | "markOut"
+  | "clearRange"
+  | "shuttleBack"
+  | "shuttleStop"
+  | "shuttleForward"
+  | "addMarker"
+  | "nextMarker"
+  | "prevMarker"
+  | "prevCut"
+  | "nextCut"
+  | "zoomIn"
+  | "zoomOut"
+  | "zoomFit"
+  | "undo"
+  | "redo"
+  | "toggleSnap"
+  | "applyDefaultTransition"
+  | "addKeyframe"
+  | "nextKeyframe"
+  | "prevKeyframe"
+  | "sourceAppend"
+  | "sourceInsert"
+  | "sourceOverwrite";
+
+export interface KeyBinding {
+  key: string;
+  ctrl?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+}
+
+type Keymap = Record<TimelineAction, KeyBinding[]>;
+
+const k = (key: string, mods: Omit<KeyBinding, "key"> = {}): KeyBinding => ({
+  key,
+  ...mods
+});
+
+/** Bindings every preset shares. */
+const COMMON: Partial<Keymap> = {
+  toggleShortcuts: [k("?")],
+  deleteSelected: [k("Delete"), k("Backspace")],
+  selectAll: [k("a", { ctrl: true })],
+  escape: [k("Escape")],
+  copy: [k("c", { ctrl: true })],
+  cut: [k("x", { ctrl: true })],
+  paste: [k("v", { ctrl: true })],
+  markIn: [k("i")],
+  markOut: [k("o")],
+  shuttleBack: [k("j")],
+  shuttleStop: [k("k")],
+  shuttleForward: [k("l")],
+  addMarker: [k("m")],
+  prevCut: [k("ArrowUp")],
+  nextCut: [k("ArrowDown")],
+  undo: [k("z", { ctrl: true })],
+  redo: [k("z", { ctrl: true, shift: true }), k("y", { ctrl: true })],
+  addKeyframe: [k("k", { alt: true })],
+  nextKeyframe: [k("k", { alt: true, shift: true })],
+  prevKeyframe: [k("k", { ctrl: true, alt: true, shift: true })]
+};
+
+const NODETOOL: Keymap = {
+  ...(COMMON as Keymap),
+  selectTool: [k("v")],
+  cutTool: [k("c")],
+  splitAtPlayhead: [k("s")],
+  cutAllTracks: [k("k", { ctrl: true })],
+  rippleDeleteSelected: [k("Delete", { shift: true }), k("Backspace", { shift: true })],
+  duplicate: [k("d", { ctrl: true })],
+  duplicateWithGap: [k("d", { ctrl: true, shift: true })],
+  nudgeLeft: [k("ArrowLeft")],
+  nudgeRight: [k("ArrowRight")],
+  nudgeLeftLarge: [k("ArrowLeft", { shift: true })],
+  nudgeRightLarge: [k("ArrowRight", { shift: true })],
+  extendEdit: [k("e")],
+  trimEditLeft: [k("ArrowLeft", { ctrl: true, shift: true })],
+  trimEditRight: [k("ArrowRight", { ctrl: true, shift: true })],
+  trimEditLeftLarge: [k("ArrowLeft", { ctrl: true, shift: true, alt: true })],
+  trimEditRightLarge: [k("ArrowRight", { ctrl: true, shift: true, alt: true })],
+  clearRange: [k("x", { ctrl: true, shift: true })],
+  nextMarker: [k("m", { shift: true })],
+  prevMarker: [k("m", { ctrl: true, shift: true })],
+  zoomIn: [k("+"), k("=")],
+  zoomOut: [k("-"), k("_")],
+  zoomFit: [k("z", { shift: true })],
+  toggleSnap: [k("n")],
+  applyDefaultTransition: [k("t", { ctrl: true })],
+  sourceAppend: [k("e", { shift: true })],
+  sourceInsert: [k("w")],
+  sourceOverwrite: [k("d")]
+};
+
+const PREMIERE: Keymap = {
+  ...(COMMON as Keymap),
+  selectTool: [k("v")],
+  cutTool: [k("c")],
+  splitAtPlayhead: [k("k", { ctrl: true })],
+  cutAllTracks: [k("k", { ctrl: true, shift: true })],
+  rippleDeleteSelected: [k("Delete", { shift: true }), k("Backspace", { shift: true })],
+  duplicate: [k("d", { alt: true })],
+  duplicateWithGap: [k("d", { alt: true, shift: true })],
+  nudgeLeft: [k("ArrowLeft", { alt: true })],
+  nudgeRight: [k("ArrowRight", { alt: true })],
+  nudgeLeftLarge: [k("ArrowLeft", { alt: true, shift: true })],
+  nudgeRightLarge: [k("ArrowRight", { alt: true, shift: true })],
+  extendEdit: [k("e")],
+  trimEditLeft: [k("ArrowLeft", { ctrl: true, alt: true })],
+  trimEditRight: [k("ArrowRight", { ctrl: true, alt: true })],
+  trimEditLeftLarge: [k("ArrowLeft", { ctrl: true, alt: true, shift: true })],
+  trimEditRightLarge: [k("ArrowRight", { ctrl: true, alt: true, shift: true })],
+  clearRange: [k("x", { ctrl: true, shift: true })],
+  nextMarker: [k("m", { shift: true })],
+  prevMarker: [k("m", { ctrl: true, shift: true })],
+  zoomIn: [k("=")],
+  zoomOut: [k("-")],
+  zoomFit: [k("\\")],
+  toggleSnap: [k("s")],
+  applyDefaultTransition: [k("d", { ctrl: true })],
+  sourceAppend: [k("e", { shift: true })],
+  sourceInsert: [k(",")],
+  sourceOverwrite: [k(".")]
+};
+
+const FCP: Keymap = {
+  ...(COMMON as Keymap),
+  selectTool: [k("a")],
+  cutTool: [k("b")],
+  splitAtPlayhead: [k("b", { ctrl: true })],
+  cutAllTracks: [k("b", { ctrl: true, shift: true })],
+  // Final Cut ripples on Delete; Shift+Delete lifts and leaves the gap.
+  deleteSelected: [k("Delete", { shift: true }), k("Backspace", { shift: true })],
+  rippleDeleteSelected: [k("Delete"), k("Backspace")],
+  duplicate: [k("d", { ctrl: true })],
+  duplicateWithGap: [k("d", { ctrl: true, shift: true })],
+  nudgeLeft: [k(",")],
+  nudgeRight: [k(".")],
+  nudgeLeftLarge: [k(",", { shift: true })],
+  nudgeRightLarge: [k(".", { shift: true })],
+  extendEdit: [k("x", { shift: true })],
+  trimEditLeft: [k(",", { alt: true })],
+  trimEditRight: [k(".", { alt: true })],
+  trimEditLeftLarge: [k(",", { alt: true, shift: true })],
+  trimEditRightLarge: [k(".", { alt: true, shift: true })],
+  clearRange: [k("x", { alt: true })],
+  nextMarker: [k("'", { ctrl: true })],
+  prevMarker: [k(";", { ctrl: true })],
+  zoomIn: [k("=", { ctrl: true }), k("+", { ctrl: true })],
+  zoomOut: [k("-", { ctrl: true })],
+  zoomFit: [k("z", { shift: true })],
+  toggleSnap: [k("n")],
+  applyDefaultTransition: [k("t", { ctrl: true })],
+  sourceAppend: [k("e")],
+  sourceInsert: [k("w")],
+  sourceOverwrite: [k("d")]
+};
+
+export const TIMELINE_KEYMAPS: Record<TimelineKeyboardPreset, Keymap> = {
+  nodetool: NODETOOL,
+  premiere: PREMIERE,
+  fcp: FCP
+};
+
+/** The subset of a KeyboardEvent a binding is matched against. */
+export interface KeyEventLike {
+  key: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+}
+
+const isLetter = (key: string): boolean => /^[a-z]$/i.test(key);
+
+function matches(binding: KeyBinding, e: KeyEventLike): boolean {
+  const ctrl = e.ctrlKey || e.metaKey;
+  const key = isLetter(e.key) ? e.key.toLowerCase() : e.key;
+  if (key !== binding.key) return false;
+  // "?" can arrive as AltGr on some layouts (ctrl+alt); match the character.
+  if (binding.key === "?") return true;
+  if (ctrl !== Boolean(binding.ctrl)) return false;
+  if (e.altKey !== Boolean(binding.alt)) return false;
+  const symbol = binding.key.length === 1 && !isLetter(binding.key);
+  if (!symbol && e.shiftKey !== Boolean(binding.shift)) return false;
+  if (symbol && binding.shift && !e.shiftKey) return false;
+  return true;
+}
+
+/**
+ * The action `e` triggers under `preset`, or null. Bindings with more
+ * modifiers are tried first so Ctrl+Shift+Z resolves to redo, not undo.
+ */
+export function resolveTimelineAction(
+  e: KeyEventLike,
+  preset: TimelineKeyboardPreset
+): TimelineAction | null {
+  const map = TIMELINE_KEYMAPS[preset];
+  let best: { action: TimelineAction; weight: number } | null = null;
+  for (const action of Object.keys(map) as TimelineAction[]) {
+    for (const binding of map[action]) {
+      if (!matches(binding, e)) continue;
+      const weight =
+        (binding.ctrl ? 1 : 0) + (binding.shift ? 1 : 0) + (binding.alt ? 1 : 0);
+      if (!best || weight > best.weight) best = { action, weight };
+    }
+  }
+  return best?.action ?? null;
+}
+
+const KEY_LABELS: Record<string, string> = {
+  ArrowLeft: "←",
+  ArrowRight: "→",
+  ArrowUp: "↑",
+  ArrowDown: "↓",
+  " ": "Space",
+  Escape: "Esc"
+};
+
+/** The key chips the shortcut sheet shows for one binding. */
+export function bindingKeys(binding: KeyBinding): string[] {
+  const parts: string[] = [];
+  if (binding.ctrl) parts.push("Ctrl");
+  if (binding.alt) parts.push("Alt");
+  if (binding.shift) parts.push("Shift");
+  const label = KEY_LABELS[binding.key] ?? binding.key.toUpperCase();
+  parts.push(label);
+  return parts;
+}

--- a/web/src/components/ui_primitives/VideoPlayer.tsx
+++ b/web/src/components/ui_primitives/VideoPlayer.tsx
@@ -169,6 +169,8 @@ export interface VideoPlayerProps {
   muted?: boolean;
   /** Called on every timeupdate with currentTime in seconds */
   onTimeUpdate?: (time: number) => void;
+  /** Called once media metadata provides the duration, in seconds. */
+  onDurationChange?: (duration: number) => void;
   /** Accessible name for the player. */
   label?: string;
   className?: string;
@@ -181,6 +183,7 @@ const ResolvedVideoPlayer: React.FC<Omit<VideoPlayerProps, "locator">> = ({
   loop = false,
   muted = false,
   onTimeUpdate,
+  onDurationChange,
   label = "Video player",
   className
 }) => {
@@ -229,8 +232,12 @@ const ResolvedVideoPlayer: React.FC<Omit<VideoPlayerProps, "locator">> = ({
   const handlePause = useCallback(() => setIsPlaying(false), []);
 
   const handleLoadedMetadata = useCallback(() => {
-    if (videoRef.current) {setDuration(videoRef.current.duration);}
-  }, []);
+    if (videoRef.current) {
+      const duration = videoRef.current.duration;
+      setDuration(duration);
+      onDurationChange?.(duration);
+    }
+  }, [onDurationChange]);
 
   const handleVideoTimeUpdate = useCallback(() => {
     const v = videoRef.current;

--- a/web/src/components/ui_primitives/__tests__/mediaLocatorPrimitives.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/mediaLocatorPrimitives.test.tsx
@@ -8,7 +8,7 @@
  * end up as.
  */
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 
 import mockTheme from "../../../__mocks__/themeMock";
@@ -52,6 +52,17 @@ describe("ResponsiveImage", () => {
       "src",
       "https://cdn.test/a.png"
     );
+  });
+
+  it("reports metadata duration to source monitors", () => {
+    const onDurationChange = jest.fn();
+    renderWithTheme(
+      <VideoPlayer src={HTTPS_URL} onDurationChange={onDurationChange} />
+    );
+    const video = screen.getByLabelText("Video player");
+    Object.defineProperty(video, "duration", { configurable: true, value: 4.25 });
+    fireEvent.loadedMetadata(video);
+    expect(onDurationChange).toHaveBeenCalledWith(4.25);
   });
 
   it("sets no src for a locator that resolves to nothing", () => {

--- a/web/src/stores/AssetGridStore.ts
+++ b/web/src/stores/AssetGridStore.ts
@@ -252,6 +252,28 @@ export const LIBRARY_ASSET_GRID_STORE_KEY = "asset-grid-storage:library";
 
 const libraryStore = getOrCreateStore(LIBRARY_ASSET_GRID_STORE_KEY);
 
+/** The two sidebar explorers have isolated stores, but timeline source edits
+ * need to follow whichever explorer is visible. Keep that choice explicit so
+ * source monitor UI and its keyboard actions use the same selection. */
+export const ASSETS_ASSET_GRID_STORE_KEY = "asset-grid-storage:assets";
+
+export const useAssetsSelectedAsset = (): Asset | null =>
+  useStore(getOrCreateStore(ASSETS_ASSET_GRID_STORE_KEY), (state) =>
+    state.selectedAssets.at(-1) ?? null
+  );
+
+export const useLibrarySelectedAsset = (): Asset | null =>
+  useStore(libraryStore, (state) => state.selectedAssets.at(-1) ?? null);
+
+export const getSelectedAssetForExplorer = (
+  explorer: "assets" | "library"
+): Asset | null => {
+  const store = getOrCreateStore(
+    explorer === "assets" ? ASSETS_ASSET_GRID_STORE_KEY : LIBRARY_ASSET_GRID_STORE_KEY
+  );
+  return store.getState().selectedAssets.at(-1) ?? null;
+};
+
 /** Reactive access to the Library panel's current folder, for cross-cutting
  * callers (e.g. canvas file-drop/paste) that need it without being inside
  * the panel's provider subtree. */

--- a/web/src/stores/SettingsStore.ts
+++ b/web/src/stores/SettingsStore.ts
@@ -65,6 +65,8 @@ export interface Settings {
    * load. Applies to live patches (Audio Out node).
    */
   audioBufferMs: number;
+  /** Which editor's keyboard layout the timeline follows. */
+  timelineKeyboardPreset: "nodetool" | "premiere" | "fcp";
   autosave: AutosaveSettings;
 }
 
@@ -113,6 +115,7 @@ export const defaultSettings: Settings = {
   confirmLargeRun: true,
   largeRunThreshold: 5,
   audioBufferMs: 100,
+  timelineKeyboardPreset: "nodetool",
   autosave: { ...defaultAutosaveSettings }
 };
 

--- a/web/src/stores/__tests__/AssetGridStore.test.tsx
+++ b/web/src/stores/__tests__/AssetGridStore.test.tsx
@@ -1,5 +1,11 @@
-import { act } from "@testing-library/react";
-import { useAssetGridStore } from "../AssetGridStore";
+import { act, render, waitFor } from "@testing-library/react";
+import {
+  AssetGridStoreProvider,
+  ASSETS_ASSET_GRID_STORE_KEY,
+  getSelectedAssetForExplorer,
+  useAssetGridStore
+} from "../AssetGridStore";
+import { useEffect } from "react";
 import { Asset } from "../ApiTypes";
 
 const createMockAsset = (id: string, name: string = `Asset ${id}`): Asset => ({
@@ -32,6 +38,28 @@ describe("AssetGridStore", () => {
     store.setAssetItemSize(2);
     store.setIsGlobalSearchMode(false);
     store.setGlobalSearchResults([]);
+  });
+
+  it("exposes the selected asset from the active scoped explorer", async () => {
+    const asset = createMockAsset("sidebar-video", "Beach scene");
+    const SelectionWriter = () => {
+      const setSelectedAssets = useAssetGridStore(
+        (state) => state.setSelectedAssets
+      );
+      useEffect(() => setSelectedAssets([asset]), [setSelectedAssets]);
+      return null;
+    };
+
+    render(
+      <AssetGridStoreProvider persistKey={ASSETS_ASSET_GRID_STORE_KEY}>
+        <SelectionWriter />
+      </AssetGridStoreProvider>
+    );
+
+    await waitFor(() => {
+      expect(getSelectedAssetForExplorer("assets")).toEqual(asset);
+    });
+    expect(getSelectedAssetForExplorer("library")).toBeNull();
   });
 
   describe("initial state", () => {

--- a/web/src/stores/timeline/TimelinePlaybackStore.ts
+++ b/web/src/stores/timeline/TimelinePlaybackStore.ts
@@ -42,6 +42,12 @@ export interface TimelinePlaybackState {
    *  clock at the new position. The playback clock itself does NOT bump this
    *  when advancing currentTimeMs frame-by-frame. */
   seekNonce: number;
+  /**
+   * In and out points (I / O). Playback runs inside the range and loops back
+   * to `rangeInMs` at `rangeOutMs`; null on either side leaves that end open.
+   */
+  rangeInMs: number | null;
+  rangeOutMs: number | null;
 
   setCurrentTimeMs: (timeMs: number) => void;
   /** Seek to a new position (bumps seekNonce). */
@@ -51,6 +57,11 @@ export interface TimelinePlaybackState {
   play: () => void;
   pause: () => void;
   stop: () => void;
+  /** Set the in point; an out point at or before it is dropped. */
+  setRangeIn: (timeMs: number | null) => void;
+  /** Set the out point; an in point at or after it is dropped. */
+  setRangeOut: (timeMs: number | null) => void;
+  clearRange: () => void;
 
   // ── Transient playhead channel (does NOT trigger React re-renders) ─────────
   /** Read the live playhead position. Updated ~60×/s during playback. */
@@ -81,6 +92,8 @@ export const createTimelinePlaybackStore = (): TimelinePlaybackStoreApi => {
     isPlaying: false,
     rate: 1,
     seekNonce: 0,
+    rangeInMs: null,
+    rangeOutMs: null,
 
     setCurrentTimeMs: (timeMs) => {
       liveTimeMs = timeMs;
@@ -103,6 +116,32 @@ export const createTimelinePlaybackStore = (): TimelinePlaybackStoreApi => {
       emitTime(0);
       set({ isPlaying: false, currentTimeMs: 0 });
     },
+
+    setRangeIn: (timeMs) =>
+      set((s) => {
+        if (timeMs === null) return { rangeInMs: null };
+        const rangeInMs = Math.max(0, timeMs);
+        return {
+          rangeInMs,
+          rangeOutMs:
+            s.rangeOutMs !== null && s.rangeOutMs <= rangeInMs
+              ? null
+              : s.rangeOutMs
+        };
+      }),
+    setRangeOut: (timeMs) =>
+      set((s) => {
+        if (timeMs === null) return { rangeOutMs: null };
+        const rangeOutMs = Math.max(0, timeMs);
+        return {
+          rangeOutMs,
+          rangeInMs:
+            s.rangeInMs !== null && s.rangeInMs >= rangeOutMs
+              ? null
+              : s.rangeInMs
+        };
+      }),
+    clearRange: () => set({ rangeInMs: null, rangeOutMs: null }),
 
     getTimeMs: () => liveTimeMs,
     setTimeMs: (timeMs) => {

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -39,6 +39,9 @@ import {
   rippleDelete,
   closeGap,
   resolveDrop,
+  applyTransitionAtCut,
+  removeTransitionAtCut,
+  DEFAULT_TRANSITION_MS,
   trimGroup,
   ungroup,
   snap,
@@ -298,6 +301,16 @@ export interface TimelineStoreState {
    * push everything right, or leave the overlap for the renderer.
    */
   resolveDrop: (movedIds: ReadonlySet<string>, mode: DropMode) => void;
+
+  /**
+   * Cross-fade into each clip: its abutting predecessor is extended under it
+   * by the transition length so the dissolve has two pictures. A clip that
+   * already carries a transition keeps its type. One undo step.
+   */
+  applyDefaultTransition: (clipIds: ReadonlySet<string>, durationMs?: number) => void;
+  /** Resize a clip's incoming transition, growing the predecessor as needed. */
+  setTransitionDuration: (clipId: string, durationMs: number) => void;
+  removeTransition: (clipId: string) => void;
 
   /** Split the clip at the given time. The clip must contain that time. */
   splitClipAtTime: (clipId: string, atMs: number) => void;
@@ -1639,6 +1652,25 @@ export const createTimelineStore = (
               })
             };
           }),
+
+        applyDefaultTransition: (clipIds, durationMs = DEFAULT_TRANSITION_MS) =>
+          set((state) => {
+            let clips: TimelineClip[] = state.clips;
+            for (const id of clipIds) {
+              if (!clips.some((c) => c.id === id)) continue;
+              clips = applyTransitionAtCut(clips, id, durationMs);
+            }
+            return clips === state.clips ? state : { clips };
+          }),
+
+        setTransitionDuration: (clipId, durationMs) =>
+          set((state) => {
+            if (!state.clips.some((c) => c.id === clipId)) return state;
+            return { clips: applyTransitionAtCut(state.clips, clipId, durationMs) };
+          }),
+
+        removeTransition: (clipId) =>
+          set((state) => ({ clips: removeTransitionAtCut(state.clips, clipId) })),
 
         splitClipAtTime: (clipId, atMs) =>
           set((state) => {

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -34,6 +34,10 @@ import {
   moveGroup,
   splitClip,
   trimClip,
+  rippleTrim,
+  rollEdit,
+  rippleDelete,
+  closeGap,
   trimGroup,
   ungroup,
   snap,
@@ -250,6 +254,36 @@ export interface TimelineStoreState {
     deltaMs: number,
     maxSourceDurationMs?: number
   ) => void;
+
+  /**
+   * Trim an edge and ripple: every clip on an unlocked track that started at
+   * or after the clip's old end moves by the change in duration. Same delta
+   * convention as trimClipStart/trimClipEnd. A start-edge ripple keeps the
+   * clip parked at its startMs. Invalid trims no-op.
+   */
+  rippleTrimClipStart: (clipId: string, deltaMs: number) => void;
+  rippleTrimClipEnd: (
+    clipId: string,
+    deltaMs: number,
+    maxSourceDurationMs?: number
+  ) => void;
+
+  /**
+   * Roll the cut on one edge of a clip: the neighbour across the cut gives up
+   * what this clip gains. Positive delta moves the cut later. No-ops when the
+   * edge has no neighbour or either side runs out of source.
+   */
+  rollClipEdge: (
+    clipId: string,
+    edge: "start" | "end",
+    deltaMs: number
+  ) => void;
+
+  /** Delete the selection and close the time it covered on unlocked tracks. */
+  rippleDeleteSelected: (selectedIds: Set<string>) => void;
+
+  /** Close the empty stretch on `trackId` containing `timeMs`. */
+  closeGapAt: (trackId: string, timeMs: number) => void;
 
   /** Split the clip at the given time. The clip must contain that time. */
   splitClipAtTime: (clipId: string, atMs: number) => void;
@@ -615,6 +649,50 @@ function patchById<T extends { id: string }>(
     return items;
   }
   return items.map((it) => (it.id === id ? { ...it, ...patch } : it));
+}
+
+/** Ids of the tracks a ripple must leave alone. */
+function lockedTrackIds(tracks: readonly TimelineTrack[]): Set<string> {
+  return new Set(tracks.filter((t) => t.locked).map((t) => t.id));
+}
+
+/**
+ * Remove `ids` from `clips`: a deleted group releases its children, and a
+ * link group left with one member drops its linkId.
+ */
+function removeClipsLinkAware(
+  clips: readonly TimelineClip[],
+  ids: ReadonlySet<string>
+): TimelineClip[] {
+  const affectedLinkIds = new Set<string>();
+  let remaining: TimelineClip[] = [...clips];
+  for (const c of clips) {
+    if (!ids.has(c.id)) continue;
+    if (c.linkId !== undefined) affectedLinkIds.add(c.linkId);
+    if (isGroupClip(c)) remaining = ungroup(remaining, c.id);
+  }
+  const next = remaining.filter((c) => !ids.has(c.id));
+
+  if (affectedLinkIds.size > 0) {
+    const linkCounts = new Map<string, number>();
+    const lastSeenLinkIndex = new Map<string, number>();
+    for (let j = 0; j < next.length; j++) {
+      const linkId = next[j].linkId;
+      if (linkId !== undefined && affectedLinkIds.has(linkId)) {
+        const count = (linkCounts.get(linkId) ?? 0) + 1;
+        linkCounts.set(linkId, count);
+        if (count === 1) {
+          lastSeenLinkIndex.set(linkId, j);
+        } else if (count === 2) {
+          lastSeenLinkIndex.delete(linkId);
+        }
+      }
+    }
+    for (const idx of lastSeenLinkIndex.values()) {
+      next[idx] = { ...next[idx], linkId: undefined };
+    }
+  }
+  return next;
 }
 
 // ── Scene split/merge helpers (pure) ───────────────────────────────────────
@@ -1465,6 +1543,67 @@ export const createTimelineStore = (
             };
           }),
 
+        rippleTrimClipStart: (clipId, deltaMs) =>
+          set((state) => {
+            try {
+              return {
+                clips: rippleTrim(state.clips, clipId, "start", deltaMs, {
+                  lockedTrackIds: lockedTrackIds(state.tracks)
+                })
+              };
+            } catch {
+              return state;
+            }
+          }),
+
+        rippleTrimClipEnd: (clipId, deltaMs, maxSourceDurationMs) =>
+          set((state) => {
+            try {
+              return {
+                clips: rippleTrim(state.clips, clipId, "end", deltaMs, {
+                  lockedTrackIds: lockedTrackIds(state.tracks),
+                  maxSourceDurationMs
+                })
+              };
+            } catch {
+              return state;
+            }
+          }),
+
+        rollClipEdge: (clipId, edge, deltaMs) =>
+          set((state) => {
+            try {
+              return { clips: rollEdit(state.clips, clipId, edge, deltaMs) };
+            } catch {
+              return state;
+            }
+          }),
+
+        rippleDeleteSelected: (selectedIds) =>
+          set((state) => {
+            // Which clips left and the spans they covered come from the
+            // pre-delete array; the shift runs over the survivors.
+            const removed = state.clips.filter((c) => selectedIds.has(c.id));
+            if (removed.length === 0) return state;
+            const survivors = removeClipsLinkAware(state.clips, selectedIds);
+            return {
+              clips: rippleDelete([...removed, ...survivors], selectedIds, {
+                lockedTrackIds: lockedTrackIds(state.tracks)
+              })
+            };
+          }),
+
+        closeGapAt: (trackId, timeMs) =>
+          set((state) => {
+            const next = closeGap(state.clips, trackId, timeMs, {
+              lockedTrackIds: lockedTrackIds(state.tracks)
+            });
+            return next.length === state.clips.length &&
+              next.every((c, i) => c === state.clips[i])
+              ? state
+              : { clips: next };
+          }),
+
         splitClipAtTime: (clipId, atMs) =>
           set((state) => {
             const next = splitClipsLinkAware(state.clips, atMs, [clipId]);
@@ -1534,44 +1673,9 @@ export const createTimelineStore = (
         },
 
         deleteSelected: (selectedIds) =>
-          set((state) => {
-            // Link ids touched by the removal — survivors that drop below two
-            // members are unlinked so they don't keep a dangling linkId.
-            const affectedLinkIds = new Set<string>();
-            let remaining = state.clips;
-            for (const c of state.clips) {
-              if (!selectedIds.has(c.id)) continue;
-              if (c.linkId !== undefined) affectedLinkIds.add(c.linkId);
-              // Same rule as `deleteClip`: a deleted group releases its
-              // children rather than taking them with it (D4).
-              if (isGroupClip(c)) remaining = ungroup(remaining, c.id);
-            }
-            let clips = remaining.filter((c) => !selectedIds.has(c.id));
-
-            if (affectedLinkIds.size > 0) {
-              const linkCounts = new Map<string, number>();
-              const lastSeenLinkIndex = new Map<string, number>();
-
-              for (let j = 0; j < clips.length; j++) {
-                const linkId = clips[j].linkId;
-                if (linkId !== undefined && affectedLinkIds.has(linkId)) {
-                  const count = (linkCounts.get(linkId) ?? 0) + 1;
-                  linkCounts.set(linkId, count);
-                  if (count === 1) {
-                    lastSeenLinkIndex.set(linkId, j);
-                  } else if (count === 2) {
-                    lastSeenLinkIndex.delete(linkId);
-                  }
-                }
-              }
-
-              for (const idx of lastSeenLinkIndex.values()) {
-                clips[idx] = { ...clips[idx], linkId: undefined };
-              }
-            }
-
-            return { clips };
-          }),
+          set((state) => ({
+            clips: removeClipsLinkAware(state.clips, selectedIds)
+          })),
 
         deleteClip: (clipId) =>
           set((state) => {

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -38,6 +38,7 @@ import {
   rollEdit,
   rippleDelete,
   closeGap,
+  resolveDrop,
   trimGroup,
   ungroup,
   snap,
@@ -47,6 +48,7 @@ import {
   makeTrackEffect,
   createTimeOrderedUuid
 } from "@nodetool-ai/timeline";
+import type { DropMode } from "@nodetool-ai/timeline";
 import type {
   TimelineSequence,
   TimelineTrack,
@@ -285,6 +287,12 @@ export interface TimelineStoreState {
   /** Close the empty stretch on `trackId` containing `timeMs`. */
   closeGapAt: (trackId: string, timeMs: number) => void;
 
+  /**
+   * Settle a finished drop: overwrite what the moved clips cover, insert and
+   * push everything right, or leave the overlap for the renderer.
+   */
+  resolveDrop: (movedIds: ReadonlySet<string>, mode: DropMode) => void;
+
   /** Split the clip at the given time. The clip must contain that time. */
   splitClipAtTime: (clipId: string, atMs: number) => void;
 
@@ -343,7 +351,7 @@ export interface TimelineStoreState {
    * The clip geometry is derived from the asset's content type and duration.
    * Use this action to add clips created by asset drag-and-drop.
    */
-  addImportedClip: (asset: Asset, trackId: string, startMs: number) => void;
+  addImportedClip: (asset: Asset, trackId: string, startMs: number) => string;
 
   /** Update an arbitrary subset of fields on a clip. */
   patchClip: (clipId: string, patch: Partial<TimelineClip>) => void;
@@ -1604,6 +1612,16 @@ export const createTimelineStore = (
               : { clips: next };
           }),
 
+        resolveDrop: (movedIds, mode) =>
+          set((state) => {
+            if (mode === "overlap") return state;
+            return {
+              clips: resolveDrop(state.clips, movedIds, mode, {
+                lockedTrackIds: lockedTrackIds(state.tracks)
+              })
+            };
+          }),
+
         splitClipAtTime: (clipId, atMs) =>
           set((state) => {
             const next = splitClipsLinkAware(state.clips, atMs, [clipId]);
@@ -1721,6 +1739,7 @@ export const createTimelineStore = (
         addImportedClip: (asset, trackId, startMs) => {
           const clip = assetToClip(asset, trackId, startMs);
           set((state) => ({ clips: [...state.clips, clip] }));
+          return clip.id;
         },
 
         unlinkClip: (clipId) =>

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -107,6 +107,11 @@ export interface TimelineStoreState {
    */
   scriptEnabled: boolean;
   /**
+   * Linked selection: a clip's linked siblings (a video and its extracted
+   * audio) move and trim with it. Editor state, not part of the document.
+   */
+  linkedSelection: boolean;
+  /**
    * The document as the editor last read or wrote it — the merge base for an
    * external change into a dirty draft. Refreshed by `loadSequence` and by
    * `setBaseUpdatedAt` (which only autosave calls after a landed write).
@@ -155,6 +160,7 @@ export interface TimelineStoreState {
   ) => void;
   /** Show or hide the script feature (non-destructive; does not touch clips). */
   setScriptEnabled: (enabled: boolean) => void;
+  setLinkedSelection: (on: boolean) => void;
 
   /**
    * Patch the project settings — canvas resolution (`width`/`height`) and frame
@@ -901,6 +907,7 @@ const emptyState = {
   markers: [],
   transcript: [],
   scriptEnabled: false,
+  linkedSelection: true,
   syncedDocument: null
 } satisfies {
   sequenceId: string | null;
@@ -914,6 +921,7 @@ const emptyState = {
   markers: TimelineMarker[];
   transcript: TranscriptLine[];
   scriptEnabled: boolean;
+  linkedSelection: boolean;
   syncedDocument: TimelineStoreState["syncedDocument"];
 };
 
@@ -1073,6 +1081,8 @@ export const createTimelineStore = (
           }),
 
         setScriptEnabled: (enabled) => set({ scriptEnabled: enabled }),
+
+        setLinkedSelection: (on) => set({ linkedSelection: on }),
 
         setProjectSettings: (patch) =>
           set((state) => {
@@ -1350,7 +1360,7 @@ export const createTimelineStore = (
             }
 
             const linkedIds =
-              clip.linkId !== undefined
+              state.linkedSelection && clip.linkId !== undefined
                 ? new Set(
                     state.clips
                       .filter(
@@ -1428,7 +1438,9 @@ export const createTimelineStore = (
             const carried = new Set<string>();
             for (const c of state.clips) {
               if (!selectedIds.has(c.id)) continue;
-              if (c.linkId !== undefined) selectedLinkIds.add(c.linkId);
+              if (state.linkedSelection && c.linkId !== undefined) {
+                selectedLinkIds.add(c.linkId);
+              }
               if (isGroupClip(c)) {
                 for (const id of groupDescendantIds(state.clips, c.id)) {
                   carried.add(id);
@@ -1485,7 +1497,7 @@ export const createTimelineStore = (
                 return state;
               }
             }
-            const linkId = clip.linkId;
+            const linkId = state.linkedSelection ? clip.linkId : undefined;
             // All-or-nothing: compute the primary AND every linked sibling
             // first. If any trim is invalid, abort so the link never desyncs.
             const trimmed = new Map<string, TimelineClip>();
@@ -1530,7 +1542,7 @@ export const createTimelineStore = (
                 return state;
               }
             }
-            const linkId = clip.linkId;
+            const linkId = state.linkedSelection ? clip.linkId : undefined;
             // All-or-nothing: compute the primary AND every linked sibling
             // first. If any trim is invalid, abort so the link never desyncs.
             const trimmed = new Map<string, TimelineClip>();
@@ -1556,7 +1568,8 @@ export const createTimelineStore = (
             try {
               return {
                 clips: rippleTrim(state.clips, clipId, "start", deltaMs, {
-                  lockedTrackIds: lockedTrackIds(state.tracks)
+                  lockedTrackIds: lockedTrackIds(state.tracks),
+                  followLinks: state.linkedSelection
                 })
               };
             } catch {
@@ -1570,6 +1583,7 @@ export const createTimelineStore = (
               return {
                 clips: rippleTrim(state.clips, clipId, "end", deltaMs, {
                   lockedTrackIds: lockedTrackIds(state.tracks),
+                  followLinks: state.linkedSelection,
                   maxSourceDurationMs
                 })
               };
@@ -1581,7 +1595,11 @@ export const createTimelineStore = (
         rollClipEdge: (clipId, edge, deltaMs) =>
           set((state) => {
             try {
-              return { clips: rollEdit(state.clips, clipId, edge, deltaMs) };
+              return {
+                clips: rollEdit(state.clips, clipId, edge, deltaMs, {
+                  followLinks: state.linkedSelection
+                })
+              };
             } catch {
               return state;
             }

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -42,6 +42,8 @@ import {
   applyTransitionAtCut,
   removeTransitionAtCut,
   DEFAULT_TRANSITION_MS,
+  setKeyframe,
+  removeKeyframe,
   trimGroup,
   ungroup,
   snap,
@@ -51,7 +53,7 @@ import {
   makeTrackEffect,
   createTimeOrderedUuid
 } from "@nodetool-ai/timeline";
-import type { DropMode } from "@nodetool-ai/timeline";
+import type { AnimatedProperty, DropMode } from "@nodetool-ai/timeline";
 import type {
   TimelineSequence,
   TimelineTrack,
@@ -311,6 +313,31 @@ export interface TimelineStoreState {
   /** Resize a clip's incoming transition, growing the predecessor as needed. */
   setTransitionDuration: (clipId: string, durationMs: number) => void;
   removeTransition: (clipId: string) => void;
+
+  /** Keyframe `property` at a clip-relative time (see `keyframes.ts`). */
+  setClipKeyframe: (
+    clipId: string,
+    property: AnimatedProperty,
+    atMs: number,
+    value: number
+  ) => void;
+  removeClipKeyframe: (
+    clipId: string,
+    property: AnimatedProperty,
+    atMs: number
+  ) => void;
+
+  /**
+   * Add the marked range of an asset as a clip (three-point editing from the
+   * source viewer). Returns the new clip's id.
+   */
+  addSourceRange: (
+    asset: Asset,
+    trackId: string,
+    startMs: number,
+    inMs: number,
+    outMs: number
+  ) => string;
 
   /** Split the clip at the given time. The clip must contain that time. */
   splitClipAtTime: (clipId: string, atMs: number) => void;
@@ -1671,6 +1698,45 @@ export const createTimelineStore = (
 
         removeTransition: (clipId) =>
           set((state) => ({ clips: removeTransitionAtCut(state.clips, clipId) })),
+
+        setClipKeyframe: (clipId, property, atMs, value) =>
+          set((state) => {
+            const clip = state.clips.find((c) => c.id === clipId);
+            if (!clip) return state;
+            const animations = setKeyframe(clip, property, atMs, value);
+            return {
+              clips: state.clips.map((c) =>
+                c.id === clipId ? { ...c, animations } : c
+              )
+            };
+          }),
+
+        removeClipKeyframe: (clipId, property, atMs) =>
+          set((state) => {
+            const clip = state.clips.find((c) => c.id === clipId);
+            if (!clip) return state;
+            const animations = removeKeyframe(clip, property, atMs);
+            return {
+              clips: state.clips.map((c) =>
+                c.id === clipId ? { ...c, animations } : c
+              )
+            };
+          }),
+
+        addSourceRange: (asset, trackId, startMs, inMs, outMs) => {
+          const base = assetToClip(asset, trackId, startMs);
+          const ranged: TimelineClip =
+            base.mediaType === "image"
+              ? { ...base, durationMs: Math.max(1, outMs - inMs) || base.durationMs }
+              : {
+                  ...base,
+                  inPointMs: inMs,
+                  outPointMs: outMs,
+                  durationMs: Math.max(1, outMs - inMs)
+                };
+          set((state) => ({ clips: [...state.clips, ranged] }));
+          return ranged.id;
+        },
 
         splitClipAtTime: (clipId, atMs) =>
           set((state) => {

--- a/web/src/stores/timeline/TimelineUIStore.ts
+++ b/web/src/stores/timeline/TimelineUIStore.ts
@@ -66,6 +66,12 @@ export interface TimelineUIState {
    */
   activeTool: TimelineTool;
   /**
+   * Ripple mode: trims and deletes close the gap they would otherwise open,
+   * pulling every later clip along (Premiere's ripple tools, FCP's default).
+   * Off, a trim or delete leaves the rest of the sequence where it is.
+   */
+  rippleMode: boolean;
+  /**
    * Milliseconds per pixel — the primary zoom metric.
    * Default 10 ms/px ≈ 100 px/s. Smaller = zoomed in.
    */
@@ -164,6 +170,8 @@ export interface TimelineUIState {
   // ── Tool ─────────────────────────────────────────────────────────────────
 
   setActiveTool: (tool: TimelineTool) => void;
+  setRippleMode: (on: boolean) => void;
+  toggleRippleMode: () => void;
 
   // ── FX panel ─────────────────────────────────────────────────────────────
 
@@ -198,6 +206,7 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
   selectedClipIds: new Set(),
   hoveredClipId: null,
   activeTool: "select",
+  rippleMode: false,
   msPerPx: 10,
   scrollLeftPx: 0,
   revealRequest: null,
@@ -272,6 +281,10 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
   toggleFullscreen: () => set((state) => ({ fullscreen: !state.fullscreen })),
 
   setActiveTool: (tool) => set({ activeTool: tool }),
+
+  setRippleMode: (on) => set({ rippleMode: on }),
+
+  toggleRippleMode: () => set((state) => ({ rippleMode: !state.rippleMode })),
 
   setExpandedFxTrackId: (trackId) => set({ expandedFxTrackId: trackId }),
 

--- a/web/src/stores/timeline/TimelineUIStore.ts
+++ b/web/src/stores/timeline/TimelineUIStore.ts
@@ -14,7 +14,7 @@
  */
 
 import { create, type StoreApi, type UseBoundStore } from "zustand";
-import type { DropMode } from "@nodetool-ai/timeline";
+import type { DropMode, KeyframeProperty } from "@nodetool-ai/timeline";
 
 export type TimelineTool = "select" | "cut";
 
@@ -90,6 +90,10 @@ export interface TimelineUIState {
   selectedEdit: SelectedEdit | null;
   /** Magnet: edges snap to clips, the playhead and the grid. Alt-drag bypasses. */
   snapEnabled: boolean;
+  /** The property Alt+K keyframes; the inspector's last-touched row. */
+  keyframeProperty: KeyframeProperty;
+  /** In and out on the source viewer's asset, clip-source milliseconds. */
+  sourceRange: { inMs: number; outMs: number } | null;
   /**
    * Milliseconds per pixel — the primary zoom metric.
    * Default 10 ms/px ≈ 100 px/s. Smaller = zoomed in.
@@ -194,6 +198,8 @@ export interface TimelineUIState {
   setDropMode: (mode: DropMode) => void;
   setSelectedEdit: (edit: SelectedEdit | null) => void;
   toggleSnap: () => void;
+  setKeyframeProperty: (property: KeyframeProperty) => void;
+  setSourceRange: (range: { inMs: number; outMs: number } | null) => void;
 
   // ── FX panel ─────────────────────────────────────────────────────────────
 
@@ -232,6 +238,8 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
   dropMode: "overwrite",
   selectedEdit: null,
   snapEnabled: true,
+  keyframeProperty: "opacity",
+  sourceRange: null,
   msPerPx: 10,
   scrollLeftPx: 0,
   revealRequest: null,
@@ -319,6 +327,10 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
   setSelectedEdit: (edit) => set({ selectedEdit: edit }),
 
   toggleSnap: () => set((state) => ({ snapEnabled: !state.snapEnabled })),
+
+  setKeyframeProperty: (property) => set({ keyframeProperty: property }),
+
+  setSourceRange: (range) => set({ sourceRange: range }),
 
   setExpandedFxTrackId: (trackId) => set({ expandedFxTrackId: trackId }),
 

--- a/web/src/stores/timeline/TimelineUIStore.ts
+++ b/web/src/stores/timeline/TimelineUIStore.ts
@@ -14,6 +14,7 @@
  */
 
 import { create, type StoreApi, type UseBoundStore } from "zustand";
+import type { DropMode } from "@nodetool-ai/timeline";
 
 export type TimelineTool = "select" | "cut";
 
@@ -71,6 +72,12 @@ export interface TimelineUIState {
    * Off, a trim or delete leaves the rest of the sequence where it is.
    */
   rippleMode: boolean;
+  /**
+   * What a dropped clip does to the clips under it: overwrite them
+   * (Premiere's default), insert and push them right, or overlap and let the
+   * renderer cross-fade. Ctrl/Cmd during a drag forces insert.
+   */
+  dropMode: DropMode;
   /**
    * Milliseconds per pixel — the primary zoom metric.
    * Default 10 ms/px ≈ 100 px/s. Smaller = zoomed in.
@@ -172,6 +179,7 @@ export interface TimelineUIState {
   setActiveTool: (tool: TimelineTool) => void;
   setRippleMode: (on: boolean) => void;
   toggleRippleMode: () => void;
+  setDropMode: (mode: DropMode) => void;
 
   // ── FX panel ─────────────────────────────────────────────────────────────
 
@@ -207,6 +215,7 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
   hoveredClipId: null,
   activeTool: "select",
   rippleMode: false,
+  dropMode: "overwrite",
   msPerPx: 10,
   scrollLeftPx: 0,
   revealRequest: null,
@@ -285,6 +294,8 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
   setRippleMode: (on) => set({ rippleMode: on }),
 
   toggleRippleMode: () => set((state) => ({ rippleMode: !state.rippleMode })),
+
+  setDropMode: (mode) => set({ dropMode: mode }),
 
   setExpandedFxTrackId: (trackId) => set({ expandedFxTrackId: trackId }),
 

--- a/web/src/stores/timeline/TimelineUIStore.ts
+++ b/web/src/stores/timeline/TimelineUIStore.ts
@@ -56,6 +56,11 @@ interface WordSelection {
   focus: WordRef;
 }
 
+export interface SelectedEdit {
+  clipId: string;
+  edge: "start" | "end";
+}
+
 export interface TimelineUIState {
   /** Set of selected clip IDs. */
   selectedClipIds: Set<string>;
@@ -78,6 +83,11 @@ export interface TimelineUIState {
    * renderer cross-fade. Ctrl/Cmd during a drag forces insert.
    */
   dropMode: DropMode;
+  /**
+   * The edit point the keyboard trims act on: one edge of one clip, picked by
+   * clicking a trim handle without dragging. Cleared with the clip selection.
+   */
+  selectedEdit: SelectedEdit | null;
   /**
    * Milliseconds per pixel — the primary zoom metric.
    * Default 10 ms/px ≈ 100 px/s. Smaller = zoomed in.
@@ -180,6 +190,7 @@ export interface TimelineUIState {
   setRippleMode: (on: boolean) => void;
   toggleRippleMode: () => void;
   setDropMode: (mode: DropMode) => void;
+  setSelectedEdit: (edit: SelectedEdit | null) => void;
 
   // ── FX panel ─────────────────────────────────────────────────────────────
 
@@ -216,6 +227,7 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
   activeTool: "select",
   rippleMode: false,
   dropMode: "overwrite",
+  selectedEdit: null,
   msPerPx: 10,
   scrollLeftPx: 0,
   revealRequest: null,
@@ -223,7 +235,8 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
   expandedFxTrackId: null,
   draggingTrackId: null,
   trackDropTarget: null,
-  selectClip: (id) => set({ selectedClipIds: new Set([id]) }),
+  selectClip: (id) =>
+    set({ selectedClipIds: new Set([id]), selectedEdit: null }),
 
   addToSelection: (id) =>
     set((state) => ({
@@ -246,9 +259,11 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
     }
   },
 
-  clearSelection: () => set({ selectedClipIds: new Set() }),
+  clearSelection: () =>
+    set({ selectedClipIds: new Set(), selectedEdit: null }),
 
-  setSelection: (ids) => set({ selectedClipIds: new Set(ids) }),
+  setSelection: (ids) =>
+    set({ selectedClipIds: new Set(ids), selectedEdit: null }),
 
   rubberBand: null,
 
@@ -296,6 +311,8 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
   toggleRippleMode: () => set((state) => ({ rippleMode: !state.rippleMode })),
 
   setDropMode: (mode) => set({ dropMode: mode }),
+
+  setSelectedEdit: (edit) => set({ selectedEdit: edit }),
 
   setExpandedFxTrackId: (trackId) => set({ expandedFxTrackId: trackId }),
 

--- a/web/src/stores/timeline/TimelineUIStore.ts
+++ b/web/src/stores/timeline/TimelineUIStore.ts
@@ -88,6 +88,8 @@ export interface TimelineUIState {
    * clicking a trim handle without dragging. Cleared with the clip selection.
    */
   selectedEdit: SelectedEdit | null;
+  /** Magnet: edges snap to clips, the playhead and the grid. Alt-drag bypasses. */
+  snapEnabled: boolean;
   /**
    * Milliseconds per pixel — the primary zoom metric.
    * Default 10 ms/px ≈ 100 px/s. Smaller = zoomed in.
@@ -191,6 +193,7 @@ export interface TimelineUIState {
   toggleRippleMode: () => void;
   setDropMode: (mode: DropMode) => void;
   setSelectedEdit: (edit: SelectedEdit | null) => void;
+  toggleSnap: () => void;
 
   // ── FX panel ─────────────────────────────────────────────────────────────
 
@@ -228,6 +231,7 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
   rippleMode: false,
   dropMode: "overwrite",
   selectedEdit: null,
+  snapEnabled: true,
   msPerPx: 10,
   scrollLeftPx: 0,
   revealRequest: null,
@@ -313,6 +317,8 @@ export const createTimelineUIStore = (): TimelineUIStoreApi =>
   setDropMode: (mode) => set({ dropMode: mode }),
 
   setSelectedEdit: (edit) => set({ selectedEdit: edit }),
+
+  toggleSnap: () => set((state) => ({ snapEnabled: !state.snapEnabled })),
 
   setExpandedFxTrackId: (trackId) => set({ expandedFxTrackId: trackId }),
 

--- a/web/src/stores/timeline/__tests__/TimelinePlaybackStore.range.test.ts
+++ b/web/src/stores/timeline/__tests__/TimelinePlaybackStore.range.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment node
+ */
+
+import { createTimelinePlaybackStore } from "../TimelinePlaybackStore";
+
+describe("TimelinePlaybackStore — in/out range", () => {
+  it("starts with no range", () => {
+    const store = createTimelinePlaybackStore();
+    expect(store.getState().rangeInMs).toBeNull();
+    expect(store.getState().rangeOutMs).toBeNull();
+  });
+
+  it("sets in and out and clears both", () => {
+    const store = createTimelinePlaybackStore();
+    store.getState().setRangeIn(1000);
+    store.getState().setRangeOut(4000);
+    expect(store.getState().rangeInMs).toBe(1000);
+    expect(store.getState().rangeOutMs).toBe(4000);
+    store.getState().clearRange();
+    expect(store.getState().rangeInMs).toBeNull();
+    expect(store.getState().rangeOutMs).toBeNull();
+  });
+
+  it("an in point at or past the out point drops the out point, and vice versa", () => {
+    const store = createTimelinePlaybackStore();
+    store.getState().setRangeIn(1000);
+    store.getState().setRangeOut(4000);
+    store.getState().setRangeIn(4000);
+    expect(store.getState().rangeOutMs).toBeNull();
+    store.getState().setRangeOut(500);
+    expect(store.getState().rangeInMs).toBeNull();
+    expect(store.getState().rangeOutMs).toBe(500);
+  });
+
+  it("clamps a negative in point to zero", () => {
+    const store = createTimelinePlaybackStore();
+    store.getState().setRangeIn(-50);
+    expect(store.getState().rangeInMs).toBe(0);
+  });
+});

--- a/web/src/stores/timeline/__tests__/TimelineStore.ripple.test.ts
+++ b/web/src/stores/timeline/__tests__/TimelineStore.ripple.test.ts
@@ -139,3 +139,42 @@ describe("closeGapAt", () => {
     expect(clip(c.id).startMs).toBe(2000);
   });
 });
+
+describe("resolveDrop", () => {
+  it("overwrite trims what the moved clip covers", () => {
+    const { store, a, b, clip } = storeWithCut();
+    store.getState().moveClip(b.id, -300);
+    store.getState().resolveDrop(new Set([b.id]), "overwrite");
+    expect(clip(a.id).durationMs).toBe(700);
+    expect(clip(b.id).startMs).toBe(700);
+  });
+
+  it("insert pushes later clips right on unlocked tracks", () => {
+    const { store, a, b, c, vo, clip } = storeWithCut();
+    store.getState().moveClip(c.id, -1500);
+    store.getState().resolveDrop(new Set([c.id]), "insert");
+    expect(clip(c.id).startMs).toBe(500);
+    // a straddled 500 and was cut into fresh halves; its tail and b moved
+    // right by c's length.
+    const v1Clips = store
+      .getState()
+      .clips.filter((x) => x.trackId === clip(c.id).trackId && x.id !== c.id)
+      .map((x) => [x.startMs, x.durationMs])
+      .sort((p, q) => p[0] - q[0]);
+    expect(v1Clips).toEqual([
+      [0, 500],
+      [1500, 500],
+      [2000, 1000]
+    ]);
+    expect(clip(vo.id).startMs).toBe(2200);
+  });
+
+  it("overlap leaves the document alone", () => {
+    const { store, b, clip } = storeWithCut();
+    store.getState().moveClip(b.id, -300);
+    const before = store.getState().clips;
+    store.getState().resolveDrop(new Set([b.id]), "overlap");
+    expect(store.getState().clips).toBe(before);
+    expect(clip(b.id).startMs).toBe(700);
+  });
+});

--- a/web/src/stores/timeline/__tests__/TimelineStore.ripple.test.ts
+++ b/web/src/stores/timeline/__tests__/TimelineStore.ripple.test.ts
@@ -214,3 +214,22 @@ describe("linkedSelection", () => {
     expect(clip(audio.id).startMs).toBe(5100);
   });
 });
+
+describe("transitions on the cut", () => {
+  it("applyDefaultTransition extends the predecessor and sets a cross-fade", () => {
+    const { store, a, b, clip } = storeWithCut();
+    store.getState().applyDefaultTransition(new Set([b.id]), 400);
+    expect(clip(a.id).durationMs).toBe(1400);
+    expect(clip(b.id).transitionIn).toEqual({ type: "crossfade", durationMs: 400 });
+  });
+
+  it("setTransitionDuration grows the window and removeTransition drops it", () => {
+    const { store, a, b, clip } = storeWithCut();
+    store.getState().applyDefaultTransition(new Set([b.id]), 200);
+    store.getState().setTransitionDuration(b.id, 600);
+    expect(clip(a.id).durationMs).toBe(1600);
+    expect(clip(b.id).transitionIn?.durationMs).toBe(600);
+    store.getState().removeTransition(b.id);
+    expect(clip(b.id).transitionIn).toBeUndefined();
+  });
+});

--- a/web/src/stores/timeline/__tests__/TimelineStore.ripple.test.ts
+++ b/web/src/stores/timeline/__tests__/TimelineStore.ripple.test.ts
@@ -233,3 +233,15 @@ describe("transitions on the cut", () => {
     expect(clip(b.id).transitionIn).toBeUndefined();
   });
 });
+
+describe("keyframes", () => {
+  it("setClipKeyframe and removeClipKeyframe round-trip through the store", () => {
+    const { store, b, clip } = storeWithCut();
+    store.getState().setClipKeyframe(b.id, "opacity", 500, 0.5);
+    expect(clip(b.id).animations?.[0].custom?.curves[0].keyframes).toEqual([
+      { t: 0.5, value: 0.5 }
+    ]);
+    store.getState().removeClipKeyframe(b.id, "opacity", 500);
+    expect(clip(b.id).animations).toEqual([]);
+  });
+});

--- a/web/src/stores/timeline/__tests__/TimelineStore.ripple.test.ts
+++ b/web/src/stores/timeline/__tests__/TimelineStore.ripple.test.ts
@@ -178,3 +178,39 @@ describe("resolveDrop", () => {
     expect(clip(b.id).startMs).toBe(700);
   });
 });
+
+describe("linkedSelection", () => {
+  it("off, a move and a trim leave the linked sibling alone", () => {
+    const { store, v1, a1, clip } = storeWithCut();
+    const video = makeClip({
+      trackId: v1,
+      mediaType: "video",
+      startMs: 5000,
+      durationMs: 1000,
+      inPointMs: 0,
+      outPointMs: 1000,
+      linkId: "L",
+      status: "generated"
+    });
+    const audio = makeClip({
+      trackId: a1,
+      mediaType: "audio",
+      startMs: 5000,
+      durationMs: 1000,
+      inPointMs: 0,
+      outPointMs: 1000,
+      linkId: "L",
+      status: "generated"
+    });
+    store.getState().addClips([video, audio]);
+    store.getState().setLinkedSelection(false);
+    store.getState().moveClip(video.id, 500);
+    store.getState().trimClipEnd(video.id, -200);
+    expect(clip(video.id).startMs).toBe(5500);
+    expect(clip(audio.id).startMs).toBe(5000);
+    expect(clip(audio.id).durationMs).toBe(1000);
+    store.getState().setLinkedSelection(true);
+    store.getState().moveClip(video.id, 100);
+    expect(clip(audio.id).startMs).toBe(5100);
+  });
+});

--- a/web/src/stores/timeline/__tests__/TimelineStore.ripple.test.ts
+++ b/web/src/stores/timeline/__tests__/TimelineStore.ripple.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "@jest/globals";
+import { createTimelineStore } from "../TimelineStore";
+import { timelineTemporalOf } from "../TimelineStore";
+import { makeClip } from "@nodetool-ai/timeline";
+
+/** V1: a | b | c back to back; A1: vo under b. */
+function storeWithCut() {
+  const store = createTimelineStore();
+  store.getState().addTrack("video", "Video 1");
+  store.getState().addTrack("audio", "Audio 1");
+  const [v1, a1] = store.getState().tracks.map((t) => t.id);
+  const mk = (
+    trackId: string,
+    startMs: number,
+    durationMs: number,
+    inPointMs = 0
+  ) =>
+    makeClip({
+      trackId,
+      mediaType: trackId === a1 ? "audio" : "video",
+      startMs,
+      durationMs,
+      inPointMs,
+      outPointMs: inPointMs + durationMs,
+      status: "generated"
+    });
+  const a = mk(v1, 0, 1000, 500);
+  const b = mk(v1, 1000, 1000, 500);
+  const c = mk(v1, 2000, 1000);
+  const vo = mk(a1, 1200, 400);
+  store.getState().addClips([a, b, c, vo]);
+  const clip = (id: string) => store.getState().clips.find((x) => x.id === id)!;
+  return { store, v1, a1, a, b, c, vo, clip };
+}
+
+describe("ripple trims", () => {
+  it("rippleTrimClipEnd moves later clips on every track", () => {
+    const { store, a, b, c, vo, clip } = storeWithCut();
+    store.getState().rippleTrimClipEnd(a.id, -300);
+    expect(clip(a.id).durationMs).toBe(700);
+    expect(clip(b.id).startMs).toBe(700);
+    expect(clip(c.id).startMs).toBe(1700);
+    expect(clip(vo.id).startMs).toBe(900);
+  });
+
+  it("rippleTrimClipStart keeps the clip parked and moves its in point", () => {
+    const { store, b, c, clip } = storeWithCut();
+    store.getState().rippleTrimClipStart(b.id, -200);
+    expect(clip(b.id).startMs).toBe(1000);
+    expect(clip(b.id).inPointMs).toBe(700);
+    expect(clip(b.id).durationMs).toBe(800);
+    expect(clip(c.id).startMs).toBe(1800);
+  });
+
+  it("leaves a locked track alone", () => {
+    const { store, a, a1, vo, c, clip } = storeWithCut();
+    store.getState().setTrackLocked(a1, true);
+    store.getState().rippleTrimClipEnd(a.id, -300);
+    expect(clip(vo.id).startMs).toBe(1200);
+    expect(clip(c.id).startMs).toBe(1700);
+  });
+
+  it("an invalid trim is a no-op", () => {
+    const { store, a, b, clip } = storeWithCut();
+    store.getState().rippleTrimClipEnd(a.id, -1000);
+    expect(clip(a.id).durationMs).toBe(1000);
+    expect(clip(b.id).startMs).toBe(1000);
+  });
+});
+
+describe("rollClipEdge", () => {
+  it("moves the cut and nothing downstream", () => {
+    const { store, a, b, c, clip } = storeWithCut();
+    store.getState().rollClipEdge(a.id, "end", 250);
+    expect(clip(a.id).durationMs).toBe(1250);
+    expect(clip(b.id).startMs).toBe(1250);
+    expect(clip(b.id).inPointMs).toBe(750);
+    expect(clip(b.id).durationMs).toBe(750);
+    expect(clip(c.id).startMs).toBe(2000);
+  });
+
+  it("no-ops without a neighbour", () => {
+    const { store, c, clip } = storeWithCut();
+    store.getState().rollClipEdge(c.id, "end", 250);
+    expect(clip(c.id).durationMs).toBe(1000);
+  });
+});
+
+describe("rippleDeleteSelected", () => {
+  it("removes the clips and closes their span in one undo step", () => {
+    const { store, b, c, vo, clip } = storeWithCut();
+    const before = store.getState().clips;
+    store.getState().rippleDeleteSelected(new Set([b.id]));
+    expect(store.getState().clips.find((x) => x.id === b.id)).toBeUndefined();
+    expect(clip(c.id).startMs).toBe(1000);
+    // vo started inside b's span, so it stays; only later starts move.
+    expect(clip(vo.id).startMs).toBe(1200);
+    timelineTemporalOf(store).undo();
+    expect(store.getState().clips).toEqual(before);
+  });
+
+  it("drops the surviving half of a link group's linkId", () => {
+    const { store, v1, a1 } = storeWithCut();
+    const video = makeClip({
+      trackId: v1,
+      mediaType: "video",
+      startMs: 5000,
+      durationMs: 500,
+      linkId: "L",
+      status: "generated"
+    });
+    const audio = makeClip({
+      trackId: a1,
+      mediaType: "audio",
+      startMs: 5000,
+      durationMs: 500,
+      linkId: "L",
+      status: "generated"
+    });
+    store.getState().addClips([video, audio]);
+    store.getState().rippleDeleteSelected(new Set([video.id]));
+    const survivor = store.getState().clips.find((x) => x.id === audio.id);
+    expect(survivor?.linkId).toBeUndefined();
+  });
+});
+
+describe("closeGapAt", () => {
+  it("pulls later clips left by the gap on the clicked track", () => {
+    const { store, b, c, vo, clip } = storeWithCut();
+    store.getState().deleteSelected(new Set([b.id]));
+    store.getState().closeGapAt(clip(c.id).trackId, 1500);
+    expect(clip(c.id).startMs).toBe(1000);
+    expect(clip(vo.id).startMs).toBe(1200);
+  });
+
+  it("is a no-op inside a clip", () => {
+    const { store, c, clip } = storeWithCut();
+    store.getState().closeGapAt(clip(c.id).trackId, 500);
+    expect(clip(c.id).startMs).toBe(2000);
+  });
+});


### PR DESCRIPTION
## What changed

Editors coming from Premiere or Final Cut reach for a ripple trim before anything else, and the timeline had none: every trim and delete left a gap. This PR adds that editing model, one commit per feature, all backed by pure functions in `@nodetool-ai/timeline` so the store, the agent bridge and a test agree.

1. **Ripple and roll** (`rippleEdit.ts`): ripple trim, roll edit, ripple delete and close gap, rippling every unlocked track so voiceover and captions stay against their shot. A Ripple toggle in the toolbar; Ctrl-drag on an edge rolls; Shift+Delete ripple-deletes. Ctrl+K cuts every track at the playhead. J/K/L shuttle, I/O loop range drawn on the ruler, M markers, Up/Down step between cuts, ruler labels count frames once ticks go sub-second.
2. **Drop modes** (`dropResolve.ts`): Overwrite (default), Insert (Ctrl on release forces it) or Overlap decide what a dropped clip does to what is under it, settled inside the drag's undo entry. An asset dropped from the explorer settles the same way.
3. **Edit points**: clicking a trim handle selects that edge; E extends it to the playhead, Ctrl+Shift+arrows nudge it a frame (Alt: ten).
4. **Keyboard presets** (`timelineKeymap.ts`): NodeTool, Premiere Pro and Final Cut Pro layouts, switched in the shortcut sheet and persisted in settings; the sheet renders from the same table the handler resolves against. Snapping toggle (N, or S under Premiere) and a Linked toggle so a video can move without its extracted audio.
5. **Transitions on the cut** (`transitionAtCut.ts`): drag the wedge's right edge for length, Ctrl+T (Ctrl+D under Premiere) cross-fades into the selected clips, the clip menu adds or removes one. Applying a transition extends the abutting predecessor under the incoming clip so a hard cut becomes a real dissolve.
6. **Keyframes** (`keyframes.ts`): an inspector section keys opacity, scale, position and rotation at the playhead, stored as one custom animation spanning the clip; the clip draws them as diamonds. Alt+K keys the armed property, Shift+Alt+K steps between keyframes.
7. **Source viewer**: a Source tab previews the asset selected in the explorer, takes an in and out point, and appends, inserts or overwrites the range at the playhead (three-point editing).

Known limits, called out in the package overlay: keyframe times are stored as `t` over the clip, so a trim stretches them; transitions align to the cut's start (the predecessor is extended under the incoming clip), not centered; backwards shuttle is picture only.

## Browser fixes and verification

Browser testing found and fixed source selection reading the wrong asset store, missing video duration metadata, source fields converting milliseconds twice, toolbar overlap with the asset sidebar open, stale sequence duration, and inconsistent frame timecodes.

- Browser-tested asset drag/drop, playback and scrubbing, ripple trim/delete with undo, Premiere and Final Cut shortcuts, transitions, keyframes, markers, source ranges and append, and save/reload. Verified In=1s and Out=2s appends a one-second clip. Checked toolbar layouts with the sidebar open at 1207px and 1450px.
- `npm run test:affected -- --base HEAD` before the fix commit: 432 suites passed, 3,575 tests passed, 3 skipped. The source-range component regression was verified red with the original conversion and green with the fix.
- `npm run typecheck` and `npm run lint` passed locally. Mobile used the built local protocol package.
- `npm run dev:nodetool -- harness gate --base origin/main` passed on a local integration merge with current main. No automated selfchecks selected for this diff.
- All GitHub checks passed on `06cb474c29db1d59d0224a0792024cf97d7a2a5b`, including app/package tests, browser E2E, page-load smoke, Docker, backend bundle, typecheck, lint, harness gate, and CodeQL.
- The broader local package run encountered a live-browser reliability failure under parallel load. That test passed independently. CI's complete package checks passed.

## Agent capabilities

No capability added or changed.

## New checks

No new check, rule, or audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAY2EXA24WZKVvbcQiv4gT