### PR TITLE
docs(system-skills): link the shipped skills into one routed set

### DIFF
--- a/packages/agents/tests/motion-graphics-skill-names.test.ts
+++ b/packages/agents/tests/motion-graphics-skill-names.test.ts
@@ -37,7 +37,8 @@ const SKILL_NAMES = [
   "logo-reveal",
   "motion-background",
   "motion-curves",
-  "caption-titles"
+  "caption-titles",
+  "video-audio-continuity"
 ] as const;
 
 function skillPath(name: string): string {

--- a/packages/system-skills/README.md
+++ b/packages/system-skills/README.md
@@ -57,18 +57,46 @@ the capability registry. A new line means a directory here plus a row there.
 `motion-graphics` carries the mechanics and the other motion skills carry the
 craft. A craft skill quotes calls rather than teaching them, so
 `packages/agents/tests/motion-graphics-skill-names.test.ts` checks every
-snake_case call in all ten against the capability registry and
-`edit_timeline`'s op list — a renamed tool fails there rather than in a model's
-hands. Add a skill to `SKILL_NAMES` in that test in the same change. The board
-skills stay out of it: the test knows `edit_timeline`'s ops and not
-`edit_storyboard`'s, and four of them name `set_entities` in order to say the
-op does not exist, which that check cannot tell from a typo.
+snake_case call in the skills its `SKILL_NAMES` lists against the capability
+registry and `edit_timeline`'s op list — a renamed tool fails there rather than
+in a model's hands. Add a skill to `SKILL_NAMES` in that test in the same
+change. The board skills stay out of it: the test knows `edit_timeline`'s ops
+and not `edit_storyboard`'s, so `set_board` and `add_shot` would read as
+unregistered calls.
 
-Every skill states where the rest of the set picks up. A craft skill opens by
-pointing back at `motion-graphics` for the op contract and sideways at the
-neighbours that decide its numbers; a board skill points forward at the motion
-skills at the step where a board becomes a cut, so an agent asked to animate a
-finished board loads the craft file instead of improvising against the op list.
+## How the set routes
+
+One job crosses the whole set in a fixed order, and each skill hands off at
+the same seams:
+
+1. **Brief → board.** A board skill (`commercial-beat-sheet`,
+   `launch-commercial`, `explainer-storyboard`, `music-video-treatment`,
+   `trailer-template`) resolves entities, writes the beats and stores them
+   with `create_storyboard` / `edit_storyboard`. The storyboard and entity call
+   shapes — return fields, the five ops, what `set_board` accepts, which
+   entities a shot's prompt receives, what text the generator actually reads —
+   live once, in `commercial-beat-sheet` § Tool contract, and the other four
+   point there.
+2. **Board → model.** Before the shot text is written, `find_model` picks the
+   image and video lines, `set_board {image_model, video_model}` makes them the
+   render defaults, and the `prompting_skill` on each result names the
+   `*-prompting` guide that decides how `action` and `motion` are worded.
+3. **Sound, before the first render.** `video-audio-continuity` decides whether
+   a multi-scene piece is one native-audio generation or separate clips under
+   a track of your own; the audio guides (`elevenlabs-audio-prompting`,
+   `stable-audio-prompting`) write that track.
+4. **Render → cut.** `assemble_storyboard_timeline` turns the board into the
+   document `motion-graphics` edits; `beat-sync-editing` sits the cuts on the
+   bed, `caption-titles` adds every word on screen (never a render prompt),
+   `logo-reveal` the mark, `color-motion` the grade, `motion-direction` the one
+   motion language, and the rest of the craft skills the numbers.
+
+Every skill states where the rest of the set picks up along that path. A craft
+skill opens by pointing back at `motion-graphics` for the op contract and
+sideways at the neighbours that decide its numbers; a board skill points
+forward at the motion skills at the step where a board becomes a cut, so an
+agent asked to animate a finished board loads the craft file instead of
+improvising against the op list.
 
 ## Credit
 

--- a/packages/system-skills/beat-sync-editing/SKILL.md
+++ b/packages/system-skills/beat-sync-editing/SKILL.md
@@ -16,6 +16,13 @@ scene.
 
 ## Get the grid from the audio, not from arithmetic
 
+When the bed does not exist yet, generate it with the grid in mind: a Stable
+Audio prompt states its BPM (`stable-audio-prompting`), and an ElevenLabs
+`composition_plan` pins each section's length in milliseconds
+(`elevenlabs-audio-prompting`), so the drop lands where the plan says instead
+of where the model felt like putting it. Then measure it anyway — the
+generated file, not the prompt, is the grid.
+
 `detect_audio_events` on the music clip reports onsets and a tempo.
 
 - `onsets.times` are in **seconds**. Every timeline op takes milliseconds, so

--- a/packages/system-skills/caption-titles/SKILL.md
+++ b/packages/system-skills/caption-titles/SKILL.md
@@ -7,15 +7,25 @@ description: Add a consistent, timed text layer to an existing picture-locked No
 
 Work directly with timeline capabilities and open-timeline tools. Do not build a workflow, fabricate a cut, or render video.
 
-`motion-graphics` carries the op contract for every call named here. `motion-principles` gives the entry and exit durations and easing behind each tier's presets, `frame-composition` fixes the safe inset and where a tier sits, and `logo-reveal` owns the brand mark at the head or tail.
+`motion-graphics` carries the op contract for every call named here. `motion-principles` gives the entry and exit durations and easing behind each tier's presets, `frame-composition` fixes the safe inset and where a tier sits, `color-motion` the scrim and contrast fixes when type does not read, and `logo-reveal` owns the brand mark at the head or tail.
+
+## Type is post, never a render prompt
+
+Every board skill and every video prompting skill sends its on-screen copy here. A title card, a super, a lyric or a CTA is a text clip on the timeline, not words in a `generate_video` or `generate_image` prompt: generators letter unreliably, and copy baked into pixels cannot be corrected, translated or re-timed. When a board's shot `action` carries `Text: …`, that is the caption map's input, and the render prompt should not have asked for it.
 
 ## Hard gate
 
 List and read the selected timeline first. It must contain picture clips. If it is missing or empty, stop and ask for a real cut; route users to storyboard or script-to-timeline work instead. Snapshot the timeline before editing with `create_timeline_version`.
 
+Read `fps`, `width` and `height` off `get_timeline` before setting a size: `fontSizePx` is authored against the sequence resolution, and the tiers below are fractions of `height`.
+
 ## Lock one type system before adding text
 
 Resolve type family and tier weights, five size tiers as fractions of frame height, text/accent/scrim palette, safe inset and maximum width, and per-tier motion presets. Prefer a supplied brand kit, then existing text on the timeline, then a platform-safe system. Keep these tiers consistent: T1 title/end card, T2 lower-third, T3 captions, T4 callouts, T5 CTA.
+
+The family is one NodeTool ships — `Inter`, `Space Grotesk`, `Bebas Neue`, `Playfair Display`, `Lora`, `JetBrains Mono` — or every host resolves it against its own installed fonts, the editor and the render disagree on line widths, and `validate_timeline` reports `font_not_portable`. Sizes below 2.5% of frame height report `text_illegible`; body copy sits at 2.5–4%. `motion-direction` holds the same rule for the whole piece, so when a motion language already exists, take its type family rather than picking a second one.
+
+Motion per tier follows `motion-principles`: `fade` or `slide` in at 300–500ms, out at 200–300ms, role-default easing. Stagger only on a T1 or a kinetic T3 line of five words or fewer, and work out the span (`durationMs + offsetMs × (words − 1)`) against the clip — a span that does not fit is compressed silently and only `stagger_compressed` says so.
 
 Each tier has a shipped composition. Insert it with `{"op": "insert_composition", "composition_id": "<id>", ...}` and override its `params` rather than building the rig from bare clips — the timing and motion inside it are already balanced.
 
@@ -37,4 +47,8 @@ Write the timed map before editing: tier, exact text, start/end, position, and s
 
 ## Build and verify
 
-Add separate overlay and subtitle tracks. For each map item, add scrim before text, apply the locked tier style, then animate it with that tier’s entry and exit preset. No hard cut-on. Use stagger only for tone-appropriate kinetic captions. Keep all text within safe margins and clear of faces and product moments. Re-read timeline state and verify timing, reading floors, scrim ordering, single CTA at the end, and structural timeline validation. Stop after authoring the text layer unless rendering is requested.
+Add separate overlay and subtitle tracks. For each map item, add scrim before text, apply the locked tier style, then animate it with that tier’s entry and exit preset. No hard cut-on. Use stagger only for tone-appropriate kinetic captions. Keep all text within safe margins and clear of faces and product moments.
+
+Two facts about stacking decide whether the text is seen at all. The lowest track `index` draws on top, so the scrim's track index sits between the picture's and the text's — picture, scrim, text, in descending index. And word-level captions generated from a voiceover clip composite above every real track regardless of where that clip sits, so no title can cover them: time a T1 around the narration rather than over it.
+
+Verify in two passes, and they answer different questions. `validate_timeline` reads the document: `text_illegible` (size, or under 3:1 contrast against the text's own `background` plate or a full-frame shape behind it), `font_not_portable`, `stagger_compressed`, `animation_exceeds_clip`, overlaps, and clips shorter than a frame. Its contrast check refuses to guess — a translucent scrim, gradient type or a plate it cannot prove is behind the text produces no finding — so a silent pass is not a pass. Then `preview_timeline_frame` at each item's entry midpoint, a held moment, and its exit: that is where text over a busy plate, a scrim covering a face, or a caption still finishing when its clip ends shows up. Re-read the map against the frames: timing, reading floors, scrim ordering, one CTA at the end. Stop after authoring the text layer unless rendering is requested.

--- a/packages/system-skills/commercial-beat-sheet/SKILL.md
+++ b/packages/system-skills/commercial-beat-sheet/SKILL.md
@@ -30,6 +30,28 @@ Never generate a storyboard before the roster is resolved. Without entities, bea
 
 **Ids.** `create_entity` returns `{entity}`; an entity's id **is the asset id you passed in**. Do not read `.id` off the result.
 
+**Which entities a shot's prompt receives.** The render does not send the whole roster to every shot. Per shot it applies the style and location entities always, plus every character and prop whose **name appears in the shot's text** (`action`, `motion`, `dialogue`, `narration`, `slug`, case-insensitive). That is why the shot text names entities in plain words — `[Protagonist]` works because the word is there, `@Protagonist` or a pronoun does not. To override the match, `add_shot` / `update_shot` take an explicit `entity_ids` list for that shot, and then only those apply.
+
+---
+
+## Tool contract (shared by every board skill)
+
+`explainer-storyboard`, `music-video-treatment`, `trailer-template` and `launch-commercial` build the same board with the same calls and point here for the shapes. Every line below is checked against the capability code, not remembered.
+
+| Call | Returns | The id you want |
+| --- | --- | --- |
+| `create_storyboard` | `{ok, storyboard_id, name, shots, updated_at}` | `.storyboard_id`, never `.id` |
+| `create_entity` | `{entity: {...}}` | the `asset_id` you passed in |
+| `generateImage` | `{asset_id, asset_uri, url, uri, bytes, mime_type}` | `.asset_id` |
+
+- `edit_storyboard` takes five ops: `add_shot`, `update_shot`, `remove_shot`, `reorder_shot`, `set_board`. `set_entities` is accepted only as an alias that resolves to `set_board`.
+- `set_board` takes `{brief?, style?, aspect_ratio?, entity_ids?, image_model?, video_model?}`. Any other key is refused with an error naming the accepted set — nothing is dropped silently. `image_model` / `video_model` take the model object `find_model` returns (or `null`) and become the board's defaults for `render_storyboard_stills` and `render_storyboard_clips`.
+- `add_shot` / `update_shot` take `{action, slug?, camera?, motion?, dialogue?, narration?, duration_seconds?, duration_source?, render_mode?, entity_ids?, location_id?, notes?, index?}`. `target` on an update is a shot id, its 0-based index, or its slug.
+- The render calls take `provider` + `model` and fall back to the board's model. With neither, the call fails and says so — it never picks one. Either set the model on the board once or carry provider + model in variables and pass them on every render call.
+- `render_storyboard_clips` has no duration override. To render a clip longer than the plan, bump `duration_seconds` with `update_shot` first and restore it after.
+- **What the model actually reads.** A still's prompt is `action`, then `<framing> shot`, then the board `style`, comma-joined, with the matched entities' descriptors and one reference image each attached. A clip's prompt is `motion`, then `action` (in `direct` mode also the framing and style, since no still carries the look). Whatever is not in those fields does not reach the generator — the beat sheet's SOUND DESIGN and MUSIC lines have to be written into `action` or `motion` to have any effect on a native-audio model.
+- **The chosen model line has its own prompting skill.** `find_model` returns `prompting_skill` on a route it covers; `load_skill` it before writing `action` and `motion`, because the same beat is worded differently for Seedance (verbs and a sound brief), Kling (a shot list, tagged elements), Hailuo (beats in order, no negatives) or Veo (150–300 characters). The image line for the stills has one too.
+
 ---
 
 ## Brief (collect from the user, never invent)
@@ -228,18 +250,23 @@ const board = await create_storyboard({
 const boardId = board.storyboard_id;   // NOT board.id
 ```
 
-### 7. Attach the roster
+### 7. Attach the roster and the models
 
-`edit_storyboard` takes exactly five ops: `add_shot`, `update_shot`, `remove_shot`, `reorder_shot`, `set_board`. **There is no `set_entities`** — the roster goes on `set_board`, which accepts `{brief?, style?, aspect_ratio?, entity_ids?}` and drops anything else silently.
+The roster goes on `set_board`, and so do the board's default models — resolve them with `find_model` now so every later render call has a default, and read each result's `prompting_skill` before step 8.
 
 ```js
+const stills = await find_model({ capability: "text_to_image" });
+const clips = await find_model({ capability: "image_to_video" });
+// .ref is {type, provider, id, name} — the object the board and the render read.
+// .prompting_skill names the guide to load before writing shot text.
 await edit_storyboard({
   storyboard_id: boardId,
-  ops: [{ op: "set_board", entity_ids: roster }]
+  ops: [{ op: "set_board", entity_ids: roster,
+          image_model: stills.ref, video_model: clips.ref }]
 });
 ```
 
-The render pipeline reads that list and applies the relevant descriptors per shot, so you do not pass them again.
+The render pipeline reads that list and applies, per shot, the style and location entities plus every entity named in the shot's text (see the tool contract above), so you do not pass them again.
 
 ### 8. Add one shot per beat
 
@@ -261,6 +288,10 @@ await edit_storyboard({
 ```
 HOOK (0:00–0:01.5): In media res failure. ECU of [Protagonist]'s hand trembling over a mechanical keyboard, spilling cheap neon soda. Text: YOUR ENERGY IS BROKEN.
 ```
+
+Write `action` and `motion` the way the chosen model line's prompting skill says (the `prompting_skill` that `find_model` returned in step 7): the still prompt is this text plus the framing and the board style, and the clip prompt is `motion` then `action`, so the generator sees nothing you did not put in these two fields. Put the beat's sound design into `motion` when the video line writes native audio.
+
+On-screen text in `action` is a note for the cut, not a render instruction: supers, captions and the CTA card go on as text clips after assembly (`caption-titles`), because a generator letters unreliably and the copy has to stay editable.
 
 Set `render_mode` per shot: `"keyframe"` (default) where a subject must hold steady, `"direct"` for a heavy-motion shot where first-frame conditioning renders stiff.
 
@@ -289,7 +320,7 @@ import { render_storyboard_stills, render_storyboard_clips } from "@nodetool-ai/
 await render_storyboard_stills({ storyboard_id: boardId, provider, model });
 ```
 
-**Pass `provider` and `model` on every render call.** The board has `image_model` / `video_model` fields, and if this build's `set_board` cannot write them, an unset board fails the render outright — never silently picks something.
+`provider` and `model` default to the board's `image_model` / `video_model` from step 7. With neither set nor passed, the render fails and says so — it never silently picks something. Pass them explicitly when one shot needs a different line than the board default.
 
 A still that violates entity consistency (wrong face, wrong can, wrong look) is fixed at the **entity**: revise its reference and re-render every shot using it. Never paper over drift in one shot's prompt. A clip wrong where its keyframe was right is a **motion** problem: one `revise_storyboard_clip`.
 

--- a/packages/system-skills/elevenlabs-audio-prompting/SKILL.md
+++ b/packages/system-skills/elevenlabs-audio-prompting/SKILL.md
@@ -130,6 +130,18 @@ Check the result with `analyze_audio` and `detect_audio_events` rather than
 listening through it, and `transcribe_audio` when you need to prove the words
 landed as written.
 
+## Where it lands
+
+A voice or a bed from here is the "track of your own" build in
+`video-audio-continuity`: it goes on its own audio track and the generated
+clips are muted under it, which is what lets a multi-scene piece keep one
+continuous mix. For a storyboard's script, `voice_script_lines` voices every
+line in one call, each with its own voice, instead of one `generate_speech`
+per line. A bed built from a `composition_plan` has sections of known length,
+which is the grid `beat-sync-editing` cuts to; a sound-effect hit is what
+`logo-reveal` times a sting against. `motion-graphics` carries the timeline ops
+that lay the clip down.
+
 Adapted from the ElevenLabs prompting documentation for Eleven v3, sound
 effects and music:
 https://elevenlabs.io/docs/best-practices/prompting/eleven-v3

--- a/packages/system-skills/explainer-storyboard/SKILL.md
+++ b/packages/system-skills/explainer-storyboard/SKILL.md
@@ -44,11 +44,17 @@ For every beat include timecode, teaching job, framing, visual, action, visible 
 
 ## Persist the board
 
-Create the storyboard with `create_storyboard({ name, brief, style, aspect_ratio })`. Use `board.storyboard_id`. Put the complete brief, chosen direction, and entity roster into `brief` so the project can be reconstructed later.
+Create the storyboard with `create_storyboard({ name, brief, style, aspect_ratio })`. Use `board.storyboard_id`, never `.id`. Put the complete brief, chosen direction, and entity roster into `brief` so the project can be reconstructed later. The exact call shapes and return fields — entity id equals the asset id you passed in, the five `edit_storyboard` ops, what `set_board` accepts — are in `commercial-beat-sheet` § Tool contract; every board skill builds against that one section.
 
-Attach roster ids with `edit_storyboard({ storyboard_id, ops: [{ op: "set_board", entity_ids }] })`. `set_board` is the entity operation; `set_entities` does not exist. Add one shot per beat with `edit_storyboard` and an `add_shot` op. The dense `action` field names the teaching job, visible entity names in brackets, on-screen text, and UI demonstration. Every named entity must exist, and every external generation prompt must apply the ids for every entity visible in that shot.
+Attach roster ids with `edit_storyboard({ storyboard_id, ops: [{ op: "set_board", entity_ids }] })` (`set_entities` is only an alias for `set_board`). Resolve the render models in the same op: `find_model` for `text_to_image` and `image_to_video`, each result's `.ref` on `image_model` / `video_model`, and each result's `prompting_skill` loaded before the shot text is written — the shot `action` is the prompt the still model reads, with the framing and board style appended.
+
+Add one shot per beat with `edit_storyboard` and an `add_shot` op. The dense `action` field names the teaching job, visible entity names in brackets, on-screen text, and UI demonstration. The render attaches a persona or prop entity to a shot only when its name appears in that shot's text (style and location always apply), so every visible entity must be named in `action` or `motion`, or listed on the shot's own `entity_ids`. On-screen text in `action` is a note for the cut: it goes on as a text clip after assembly (`caption-titles`), not into the render prompt.
 
 Stop after the planned board unless the user explicitly requests rendering or a cut. Report the directions, chosen board, and entity roster.
+
+## Render (only on request)
+
+Stills first with `render_storyboard_stills` — they cost cents, and you look at every one with `view_image` asking what is wrong, then `score_image_adherence` against the shot text. A persona or UI mock that drifts is fixed at the entity (descriptor or reference), then every shot using it re-renders; a shot that fails on composition is fixed in its `action`. Clips with `render_storyboard_clips`; a clip wrong where its still was right is one `revise_storyboard_clip`. Then `assemble_storyboard_timeline`.
 
 ## When the board becomes motion
 

--- a/packages/system-skills/flux-2-klein-prompting/SKILL.md
+++ b/packages/system-skills/flux-2-klein-prompting/SKILL.md
@@ -59,6 +59,9 @@ portrait for social and mobile, square for profiles and balanced compositions.
 - **Text renders well when specified.** Give the copy, the font class, the
   colour, the placement and the capitalisation: "a white coffee mug with the
   text 'GOOD MORNING' in bold sans-serif black letters, centred on the mug".
+  Copy that belongs to the design, in other words — a title or a super on a
+  still headed for a timeline goes on as a text clip afterwards
+  (`caption-titles`), not into the render.
 - **Multi-reference conditioning is the family's edge.** "The subject from the
   first image wearing the jacket from the second image, photographed in the
   environment from the third image."

--- a/packages/system-skills/gpt-image-2-prompting/SKILL.md
+++ b/packages/system-skills/gpt-image-2-prompting/SKILL.md
@@ -132,7 +132,9 @@ reference, and it guesses wrong.
   believable UI spacing" does the layout work; remove those clauses and the HUD
   collapses into noise.
 - **Text in image.** Give the copy verbatim, then typography, then layout, then
-  "render the text verbatim / no extra words / no duplicate text".
+  "render the text verbatim / no extra words / no duplicate text". For a still
+  that will sit on a timeline or seed a video clip, leave the copy off and add
+  it as a text clip afterwards (`caption-titles`) so it stays editable.
 - **Style transfer.** "Same style" is not enough. Name the parts: chunky pixel
   forms, limited arcade palette, bright glow accents, clean silhouette edges.
 - **Drawing to photo.** Say whether the drawing is a suggestion or a contract:

--- a/packages/system-skills/launch-commercial/SKILL.md
+++ b/packages/system-skills/launch-commercial/SKILL.md
@@ -49,11 +49,11 @@ These are the exact shapes. Getting them wrong cost a previous run six failed ac
 
 Never write `result.id || result.asset_id` and proceed. If an id is `undefined`, stop and read it back with `list_*` — do not pass it onward.
 
-**`edit_storyboard` ops are exactly five:** `add_shot`, `update_shot`, `remove_shot`, `reorder_shot`, `set_board`. There is no `set_entities`. `set_board` takes `{brief?, style?, aspect_ratio?, entity_ids?}` — **and nothing else**. Keys it does not know are dropped silently.
+**`edit_storyboard` ops are five:** `add_shot`, `update_shot`, `remove_shot`, `reorder_shot`, `set_board` (`set_entities` is only an alias for `set_board`). `set_board` takes `{brief?, style?, aspect_ratio?, entity_ids?, image_model?, video_model?}` and refuses any other key with an error — nothing is dropped silently. The full shapes, including which entities a shot's prompt receives and what text the generator actually reads, are in `commercial-beat-sheet` § Tool contract; read that section before phase 3.
 
-**The board cannot hold a model.** `set_board` has no `image_model` / `video_model`, so passing them appears to work and leaves the board's fields null. **Pass `provider` + `model` explicitly to every `render_storyboard_stills` and `render_storyboard_clips` call.** Do not rely on a board default; there isn't one.
+**The board holds the default models.** `image_model` / `video_model` on `set_board` take the `.ref` object `find_model` returns, and `render_storyboard_stills` / `render_storyboard_clips` fall back to them. With no board model and no `provider` + `model` on the call, the render fails and says so — it never picks one. Set them on the board once in phase 3 and pass `provider` + `model` only for a shot that needs a different line.
 
-**`image.*` cannot read an `asset://` uri here.** `image.info` / `image.resize` on a stored PNG fails with "could not decode the image (png) — Invalid SVG image". So: no contact sheets, and **no programmatic dimension check**. You grade frames with `view_image` and `score_image_adherence`, and you standardize aspect at assembly rather than measuring it now.
+**`image.*` cannot read an `asset://` uri here.** `image.info` / `image.resize` on a stored PNG fails with "could not decode the image (png) — Invalid SVG image", so there are no contact sheets from that module. **Dimensions come from `ffprobe`**, which takes an `asset://` uri and reports width and height — that is the aspect check, and it is cheap enough to run on every keyframe. You grade the picture itself with `view_image` and `score_image_adherence`.
 
 **`take_screenshot` needs a configured remote browser.** Without `BROWSER_URL` it fails with a message saying exactly that. Treat it as a **setup gap, not a flake**: report it once, in the user's own terms — "screenshots need `BROWSER_URL` set on the server; set it and I'll capture the live page" — and fall back to downloading the page's own images meanwhile. Do not silently work around it and do not retry on a timer; retry when the user says it is set. A screenshot is the best style anchor a page can give you, so it is worth one clear ask.
 
@@ -145,7 +145,7 @@ for (const shot of shots) {
 
 Set `render_mode` per shot: `"keyframe"` where the product or a face must hold steady, `"direct"` for the one or two heavy-motion shots. A launch spot usually has exactly one direct shot.
 
-Resolve the model slate now with `nodetool.models.pick` / `find_model`, name what you picked, and **carry provider+model in variables** — you will pass them to every render call.
+Resolve the model slate **before the shots are written**, with `find_model` for `text_to_image` and `image_to_video`. Name what you picked, put each result's `.ref` on the board with `set_board {image_model, video_model}`, and `load_skill` the `prompting_skill` each result names: the shot `action` and `motion` you are about to write are the prompt, and each model line wants them shaped differently. On-screen copy stays out of the prompt and goes on as a text layer in phase 7.
 
 ---
 
@@ -154,11 +154,7 @@ Resolve the model slate now with `nodetool.models.pick` / `find_model`, name wha
 ```js
 import { render_storyboard_stills, get_storyboard } from "@nodetool-ai/sandbox-nodetool/storyboards";
 
-await render_storyboard_stills({
-  storyboard_id: boardId,
-  provider,                   // required — the board holds no model
-  model
-});
+await render_storyboard_stills({ storyboard_id: boardId });   // uses the board's image_model
 ```
 
 Then grade. **This is the step most likely to fail, and it fails as flattery.** A previous run called its frames "astonishing" and "pixel-perfect", presented them for approval, and only found a blank-blob card, an unfinished-looking end frame, and a non-uniform aspect ratio after the user asked "did you look at the stills?".
@@ -169,7 +165,7 @@ The discipline:
 2. **Score adherence** with `score_image_adherence({image, prompt})` where the shot prompt is specific enough to score against.
 3. **Compare frames to each other**, not just to their prompts. The defect that killed two frames in the real run was only visible next to a third that got it right.
 4. **Report per frame: keep, or the specific defect.** Banned words in a grade: stunning, astonishing, gorgeous, perfect, night-and-day. If you cannot name a defect, write "checked: card fidelity, baked text, palette, framing — none found".
-5. **Never claim a property you did not verify.** You cannot measure dimensions (`image.info` fails on `asset://`), so do not state the aspect ratio. Say it is unverified and will be standardized at assembly.
+5. **Never claim a property you did not verify.** Measure the aspect ratio with `ffprobe` on each keyframe's `asset://` uri rather than eyeballing it; a plate that came back in the wrong ratio is a defect to name at G2, and it is still standardized at assembly.
 
 Two failure classes, two different fixes — never confuse them:
 
@@ -183,10 +179,10 @@ Present all keyframes at G2 with the per-clip cost of phase 5.
 ## Phase 5 — Clips
 
 ```js
-await render_storyboard_clips({ storyboard_id: boardId, provider, model });
+await render_storyboard_clips({ storyboard_id: boardId });   // uses the board's video_model
 ```
 
-A clip wrong where its keyframe was right is a **motion** problem: one `revise_storyboard_clip`, never a board-wide re-render. Cap at one revision per shot before flagging.
+A clip wrong where its keyframe was right is a **motion** problem: one `revise_storyboard_clip`, never a board-wide re-render. Cap at one revision per shot before flagging. Video models overshoot the requested length and can ignore a 9:16 source: `analyze_video` on each clip reports duration and frame before you assemble (`video-audio-continuity` § Check what came back).
 
 ---
 

--- a/packages/system-skills/logo-reveal/SKILL.md
+++ b/packages/system-skills/logo-reveal/SKILL.md
@@ -110,9 +110,13 @@ clearspace — a support element sliding through the mark's margin cheapens it.
 
 ## Landing on a sound logo
 
-Decide the audio first. `detect_audio_events` on the sting reports
-`onsets.times` in **seconds**; multiply by 1000. Time the reveal so the mark
-reaches full opacity and scale on that millisecond:
+Decide the audio first. A sound logo that does not exist yet is a 1–3 s
+effects brief — source, action, space — on ElevenLabs sound effects
+(`elevenlabs-audio-prompting`) or a `TrackType: SFX` prompt on Stable Audio
+(`stable-audio-prompting`); a 30-second request for a hit is a hit followed by
+room tone. Then `detect_audio_events` on the sting reports `onsets.times` in
+**seconds**; multiply by 1000. Time the reveal so the mark reaches full opacity
+and scale on that millisecond:
 
 `delayMs` on the `in` animation = onset ms − the clip's `startMs` −
 `durationMs`. Then add the accent on the hit itself, as a separate emphasis:

--- a/packages/system-skills/motion-background/SKILL.md
+++ b/packages/system-skills/motion-background/SKILL.md
@@ -86,9 +86,14 @@ a screensaver, and text in front of it becomes hard to hold.
 
 For organic motion nothing on the timeline can draw — smoke, ink, particles,
 clouds — generate it. `find_model` with `text_to_video`, then `generate_video`,
-then `add_media_clip` with the returned `asset://` reference. Prompt for slow,
-even motion with no cuts and no subject; a bed with an event in it is a shot, not
-a bed.
+then `add_media_clip` with the returned `asset://` reference. The `find_model`
+result names a `prompting_skill` for the line it picked; load it, because each
+line wants the prompt shaped differently. Whatever the line, prompt for slow,
+even motion with no cuts and no subject; a bed with an event in it is a shot,
+not a bed. On a line that writes native audio (Seedance 2, Veo 3, MiniMax H3,
+Kling 2.6 and later) the bed arrives with a soundtrack: either brief it as room
+tone and keep it, or mute the clip under the track you meant to use —
+`video-audio-continuity` is the rule for which.
 
 A generated clip does not loop. Cover a longer sequence by duplicating it and
 crossfading the joins: overlap the copies by 800–1500ms on one track, which

--- a/packages/system-skills/motion-graphics/SKILL.md
+++ b/packages/system-skills/motion-graphics/SKILL.md
@@ -26,10 +26,18 @@ job is about, and come back here for argument shapes.
 | A logo sting, an end card, a splash | `logo-reveal` |
 | An ambient bed behind the content | `motion-background` |
 
-Two are neighbours rather than layers: `caption-titles` decides what text says
-and when it appears, and the board skills (`explainer-storyboard`,
-`commercial-beat-sheet`, `launch-commercial`, `music-video-treatment`) decide
-the shots before there is a timeline to animate.
+Three are neighbours rather than layers. `caption-titles` decides what text
+says and when it appears. `video-audio-continuity` decides, before the first
+clip renders, whether a multi-scene piece's sound comes from one generated clip
+or from a track of your own — a decision this file's ops cannot undo. The
+board skills (`explainer-storyboard`, `commercial-beat-sheet`,
+`launch-commercial`, `music-video-treatment`, `trailer-template`) decide the
+shots before there is a timeline to animate; `assemble_storyboard_timeline` is
+where their board becomes this file's document.
+
+Anything generated for the timeline — a bed, a sting, a voice, a clip — has a
+model line with its own guide. `find_model` returns `prompting_skill` on a
+route it covers; `load_skill` it before writing that prompt.
 
 ## Read before you animate
 

--- a/packages/system-skills/music-video-treatment/SKILL.md
+++ b/packages/system-skills/music-video-treatment/SKILL.md
@@ -23,9 +23,17 @@ For each section, provide timecode and bar range, musical and visual jobs, frami
 
 ## Persist the board
 
-Create a storyboard with `create_storyboard({ name, brief, style, aspect_ratio })`, using `storyboard_id` from its result. Put the full brief, lyrics, section map, bar grid, and roster in `brief`. Attach entity ids with `edit_storyboard({ storyboard_id, ops: [{ op: "set_board", entity_ids }] })`; `set_entities` does not exist. Add one `add_shot` op per section. Each action names visible entities in brackets, includes its sync point, and uses the section duration rounded to 0.5 seconds.
+Create a storyboard with `create_storyboard({ name, brief, style, aspect_ratio })`, using `storyboard_id` from its result, never `.id`. Put the full brief, lyrics, section map, bar grid, and roster in `brief`. The call shapes every board skill shares — entity id equals the asset id you passed in, the five `edit_storyboard` ops, what `set_board` accepts, what text the generator actually reads — are in `commercial-beat-sheet` § Tool contract.
+
+Attach entity ids with `edit_storyboard({ storyboard_id, ops: [{ op: "set_board", entity_ids, image_model, video_model }] })` (`set_entities` is only an alias). The two models are the `.ref` of a `find_model` call each, for `text_to_image` and `image_to_video`; load the `prompting_skill` each one names before writing shot text, since `motion` then `action` is the clip prompt verbatim and a performance section is worded differently for Kling's shot list, Hailuo's ordered beats or Seedance's sound brief.
+
+Add one `add_shot` op per section. Each action names visible entities in brackets, includes its sync point, and uses the section duration rounded to 0.5 seconds. The render attaches the artist or a prop to a shot only when its name appears in that shot's text (style and location always apply), so the artist's name goes in every performance shot, or on that shot's own `entity_ids`. Lyric text on screen is a note for the cut and goes on as a text clip after assembly (`caption-titles`), not into the render prompt.
 
 Stop at the planned board unless asked to render. Report the directions, selected treatment, and entity roster.
+
+## Render (only on request)
+
+Stills first with `render_storyboard_stills`; look at each with `view_image` asking what is wrong, and fix a drifting artist at the entity, never in one shot's prompt. Clips with `render_storyboard_clips`; ask for longer clips than the section needs (bump `duration_seconds` with `update_shot`, restore after) so the cut has frames to choose from on the beat. A clip wrong where its still was right is one `revise_storyboard_clip`. Then `assemble_storyboard_timeline`.
 
 ## When the treatment becomes a cut
 

--- a/packages/system-skills/nano-banana-pro-prompting/SKILL.md
+++ b/packages/system-skills/nano-banana-pro-prompting/SKILL.md
@@ -82,7 +82,10 @@ which one broke the image. Re-state the lock list on every pass.
 - Name the real thing. If the shot needs a boarding pass, the words "boarding
   pass" beat any amount of mood language.
 - Wrap on-image text in quotes and call out the typeface and its position. When
-  the model keeps dropping a letter, spell the word out.
+  the model keeps dropping a letter, spell the word out. That is for a poster or
+  a mockup that ships as an image; a still headed for a timeline, or a
+  storyboard keyframe, keeps its copy off the picture and gets it as a text clip
+  afterwards (`caption-titles`), where it stays editable.
 
 The contrast is the whole lesson. "A gorgeous hyper-detailed photo of a potter,
 masterpiece, cinematic, 8k" gives the model nothing to decide against. "A

--- a/packages/system-skills/qwen-image-prompting/SKILL.md
+++ b/packages/system-skills/qwen-image-prompting/SKILL.md
@@ -37,6 +37,11 @@ Three habits that make it land:
 - **Close with "no other text".** Left to itself, the model fills empty margins
   with invented lettering.
 
+This is the model for copy that is part of the image — a poster, a label, a
+sign in the scene. A title or a super on a still headed for a timeline is not:
+that goes on as a text clip afterwards (`caption-titles`), where it can be
+corrected and re-timed.
+
 ## Turn prompt expansion off for typography
 
 On the hosted tiers — Qwen-Image-2, Max and 3 — `enable_prompt_expansion`

--- a/packages/system-skills/seedream-prompting/SKILL.md
+++ b/packages/system-skills/seedream-prompting/SKILL.md
@@ -52,7 +52,10 @@ describe rather than quote, the model writes for you.
 > palette. No other text.
 
 Closing with "no other text" is what stops the model filling the margins with
-invented lettering.
+invented lettering. Quote copy only when it belongs to the deliverable itself;
+a keyframe for a timeline or a video clip keeps its titles and supers off the
+image and gets them as text clips afterwards (`caption-titles`), where they
+stay editable.
 
 ## Editing: pin before you change
 

--- a/packages/system-skills/stable-audio-prompting/SKILL.md
+++ b/packages/system-skills/stable-audio-prompting/SKILL.md
@@ -110,6 +110,15 @@ Check the result with `analyze_audio`, `analyze_audio_spectrum` and
 `detect_audio_events` rather than listening for it — a missing instrument or a
 clipped peak shows up there faster than by ear.
 
+## Where it lands
+
+A bed from here is the "track of your own" build in `video-audio-continuity`:
+one clip on its own audio track for the whole runtime, with the generated shots
+muted under it. Because the prompt states the BPM, `beat-sync-editing` starts
+with a grid it can predict and then confirms with `detect_audio_events` on the
+file. A `TrackType: SFX` hit of 1–3 s is what `logo-reveal` lands a mark on.
+`motion-graphics` carries the timeline ops that lay the clip down.
+
 Adapted from Stability's Stable Audio 2.5 prompt guide and the Stable Audio 3
 prompting guide:
 https://stability.ai/implementations/stable-audio-25-prompt-guide

--- a/packages/system-skills/trailer-template/SKILL.md
+++ b/packages/system-skills/trailer-template/SKILL.md
@@ -184,7 +184,7 @@ await create_entity({
 const entityId = still.asset_id;   // the entity IS its asset
 ```
 
-The descriptor is the face. Name entities in plain text in a shot's `action` or `motion` — "Mara turns from the window", never `@Mara` — and do not re-describe them in shot text. Show the roster before drafting beats.
+The descriptor is the face. Name entities in plain text in a shot's `action` or `motion` — "Mara turns from the window", never `@Mara` — and do not re-describe them in shot text. The render attaches a character or prop entity to a shot only when its name appears in that shot's text (style and location entities always apply), so a reception shot that says "she" instead of "Mara" renders a stranger. Show the roster before drafting beats.
 
 ---
 
@@ -206,14 +206,19 @@ const boardId = board.storyboard_id;   // NOT board.id
 
 ### 2. Roster and models
 
-`edit_storyboard` takes five ops: `add_shot`, `update_shot`, `remove_shot`, `reorder_shot`, `set_board`. `set_board` accepts `{brief?, style?, aspect_ratio?, entity_ids?, image_model?, video_model?}`. Models come from `find_model` — there is no default, and an unset model fails the render.
+`edit_storyboard` takes five ops: `add_shot`, `update_shot`, `remove_shot`, `reorder_shot`, `set_board`. `set_board` accepts `{brief?, style?, aspect_ratio?, entity_ids?, image_model?, video_model?}` and refuses anything else. Models come from `find_model` — pass each result's `.ref`; there is no default, and an unset model fails the render. The full contract, including which entities each shot's prompt receives, is in `commercial-beat-sheet` § Tool contract.
 
 ```js
+const stills = await find_model({ capability: "text_to_image" });
+const clips = await find_model({ capability: "image_to_video" });
 await edit_storyboard({
   storyboard_id: boardId,
-  ops: [{ op: "set_board", entity_ids: roster, image_model, video_model }]
+  ops: [{ op: "set_board", entity_ids: roster,
+          image_model: stills.ref, video_model: clips.ref }]
 });
 ```
+
+Each result also names a `prompting_skill`. Load it before step 3: the shot `action` and `motion` are the prompt the generator reads (`motion` first, then `action`, for a clip), and a trailer's receptions and its drop are worded differently for a line that wants beats in order (Hailuo), a shot list (Kling) or a sound brief (Seedance).
 
 ### 3. One shot per row
 
@@ -272,7 +277,7 @@ Run before showing anyone. Every line must be true of the board, not the plan.
 
 **Stills first.** `render_storyboard_stills` costs cents and you look at them. A wrong face is fixed at the entity, never in one shot's prompt.
 
-**Generate every clip long.** Ask the video model for 4–5s per shot even where the plan says 1.5s — you want frames to choose from — and trim in the timeline. Set `duration_seconds` to the plan length and pass the longer value on the render call, or bump it on `update_shot` before `render_storyboard_clips` and restore it after. Shots render individually and mute their own audio.
+**Generate every clip long.** Ask the video model for 4–5s per shot even where the plan says 1.5s — you want frames to choose from — and trim in the timeline. `render_storyboard_clips` has no duration override, so bump `duration_seconds` on `update_shot` before the render and restore it after. Shots render individually and mute their own audio; `analyze_video` on each clip gives the real length before you trim, because the model honours the request loosely.
 
 **The bed is one clip.** After `assemble_storyboard_timeline`:
 

--- a/packages/system-skills/video-audio-continuity/SKILL.md
+++ b/packages/system-skills/video-audio-continuity/SKILL.md
@@ -29,13 +29,24 @@ Separate per-shot clips are right in two cases:
 
 - the piece is silent, or
 - the continuity comes from a track you add yourself — narration from
-  `generate_speech`, a bed from `generate_music` — on its own timeline track.
-  Then the visual beds can be separate and the shots are muted under it.
+  `generate_speech` (or `voice_script_lines`, which voices every line of a
+  board's script in one call), a bed from `generate_music` — on its own
+  timeline track. Then the visual beds can be separate and the shots are muted
+  under it. `elevenlabs-audio-prompting` directs the voice and the music plan,
+  `stable-audio-prompting` the bed and any effects; a bed generated with a
+  stated BPM is a bed whose grid `beat-sync-editing` already knows.
+
+Two video lines force the second build: Wan 2.6 takes an audio file as input
+but writes none, and Hailuo has no native audio at all, so a piece on either
+gets its sound from a track of your own.
 
 On a storyboard this means one shot, not seven. A board whose shots each render
 their own native-audio clip cannot be assembled into a continuous mix; decide
 which of the two builds you are doing before the first render, because the fix
-afterwards is a re-render.
+afterwards is a re-render. The board skills (`commercial-beat-sheet`,
+`trailer-template`, `explainer-storyboard`, `music-video-treatment`) each say
+which build they default to; the sound brief itself goes into the shot's
+`motion` and `action`, the only fields the clip prompt is built from.
 
 ## A sound brief that is not refused
 
@@ -73,4 +84,5 @@ and the model-line skill says how to write them.
 
 `motion-graphics` carries the timeline op contract for laying the bed and muting
 shot audio under a narration track. `beat-sync-editing` sits the cuts on that
-bed once it exists.
+bed once it exists, and `caption-titles` times the type to it — a title card is
+never rendered into the clip, whichever build you chose.


### PR DESCRIPTION
## What changed

The 29 shipped skills in `packages/system-skills` taught the same job in isolation and, in two places, taught a contract the code no longer has. `commercial-beat-sheet` and `launch-commercial` said `set_board` takes four keys and drops the rest silently and that "the board cannot hold a model"; `set_board` now accepts `image_model` / `video_model` (the `.ref` from `find_model`), refuses unknown keys with an error, and `set_entities` resolves as an alias. No skill said which entities a shot's prompt receives (`entitiesForShot`: style and location always, a character or prop only when its name appears in the shot text, or an explicit per-shot `entity_ids`), nor what text the still and clip prompts are built from. That contract now lives once, in `commercial-beat-sheet` § Tool contract, and the other four board skills point at it instead of restating or omitting it.

The rest is routing so the set hands off at the same seams: board skills load the model line's `prompting_skill` before writing shot text; `motion-graphics` names `video-audio-continuity` and `trailer-template`, which it had left out; `video-audio-continuity` names the audio guides for the own-track build and the two video lines that force it; `motion-background`, `beat-sync-editing` and `logo-reveal` point at the prompting skills for a generated bed, a BPM-pinned track and a sound logo; the two audio guides say where their output lands; every "type goes in post" rule points at `caption-titles`, which now carries the validator codes, bundled font list, stagger span and stacking facts it lacked. Two factual fixes ride along: `render_storyboard_clips` has no duration override (`trailer-template` said to pass one), and `ffprobe` reads an `asset://` still's dimensions (`launch-commercial` said no programmatic check existed). `video-audio-continuity` is added to the tool-name test so a renamed capability fails there. README gains a "How the set routes" section.

## Verification

- [x] `npm run test:affected` — packages, web and electron suites. One red: `packages/cli/tests/run-dsl.test.ts` timed out at 30 s while turbo ran eighteen package suites in parallel; it passes 10/10 in isolation and the diff touches nothing it imports.
- [x] `npm run typecheck` — web and electron pass; mobile fails on missing `expo-*` modules because `mobile/node_modules` is not installed in this container, unrelated to a Markdown diff.
- [x] `npm run lint`
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — 1/1 selfchecks passed
- [x] `packages/agents` `motion-graphics-skill-names`, `model-prompting-skills`, `system-skills` suites: 131/131

## Agent capabilities

Skipped: no capability added and no contract changed.

## New checks

- [x] The new `video-audio-continuity` pin was inverted once by appending a bogus `detect_video_cadence` call to the skill:
  ```
  × video-audio-continuity names only capabilities and edit_timeline ops that exist
  AssertionError: named in the skill but registered nowhere: expected [ 'detect_video_cadence' ] to deeply equal []
  ```
  Restored, the suite passes.
- [x] The existing test already asserts it read calls out of every listed skill (`named.length > 0`), so it cannot pass by matching nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB5NV29444yGK8HmH7HaEP

---
_Generated by [Claude Code](https://claude.ai/code/session_01EB5NV29444yGK8HmH7HaEP)_