### PR TITLE
fix(capabilities): close the contract gaps a 30s teaser run hit

### DIFF
--- a/.claude/skills/storyboard-core/SKILL.md
+++ b/.claude/skills/storyboard-core/SKILL.md
@@ -118,6 +118,38 @@ message*; it never becomes shot text.
   before rendering: either the whole piece is one shot carrying the cuts, or the
   continuity comes from a narration or music track and the shot audio is muted.
 
+## Where the models will not do what the cut wants
+
+Four constraints that are not bugs and have no tool to fix them. Each has a working
+shape.
+
+**A video model returns a fixed length.** It ignores `duration_seconds` — the same
+model gives 5.184s whether the shot was directed at 1.5s or 5s. For a fast cut,
+render one generation per *run* of short beats with bracketed timecodes in the prompt
+and record the split with `covered_by`. `references/tool-contract.md` § Fusing shots
+has the call.
+
+**Moderation reads the words, not the story.** A prompt naming institutional force —
+police grabbing someone, a raid, restraint — trips a safety filter that a shot of the
+same threat does not. Reframe with non-trigger vocabulary and keep the stakes:
+"two uniformed city officials approaching with a clipboard and caution tape" passes
+where "two aggressive police officers grabbing her arms" does not. Reframe once; do
+not retry the rejected prompt.
+
+**A music model cannot leave a hole.** Ask for 1.5s of silence at 00:19.5 and the
+decoder fills it with reverb tail and room tone — there is no envelope gate in the
+prompt. Cut the silence on the timeline instead: generate the score in two parts,
+lay them as two clips with the gap between them, and fade the first out (~300ms) and
+the second in (~100ms) so the edges are not clicks.
+
+**Speech does not fit a 1.5s shot.** An expressive take of a line runs 4s, and
+compressing it to the picture beat makes it sound processed. Let the words cross the
+cut: keep the voiceover clip on its own track and start it under the previous shot
+(J-cut) or run it past the cut into the next (L-cut). The picture cuts on the beat;
+the line finishes where it finishes. On a script-linked board that is automatic —
+each shot runs as long as the lines it covers — so use this on an unlinked board or
+where the picture has to stay on the beat.
+
 ## Gating and spend
 
 Permission mode decides what runs without asking. `read` tools always run.

--- a/.claude/skills/storyboard-core/references/tool-contract.md
+++ b/.claude/skills/storyboard-core/references/tool-contract.md
@@ -11,7 +11,7 @@ Work with no editor open. Shot `target` = shot id, 0-based index as a string, or
 |---|---|
 | `list_storyboards` | `limit?` → id, name, shots, with_keyframe, with_clip, timeline_id, updated_at |
 | `create_storyboard` | `name` (required), `brief?`, `style?`, `aspect_ratio?` (default `16:9`), `project_id?`, `id?` |
-| `get_storyboard` | `storyboard_id` → brief, style, aspect ratio, narration, music_prompt, image_model, video_model, script link, and every shot with id/index/slug/action/camera/motion/duration/status/has_keyframe/has_clip |
+| `get_storyboard` | `storyboard_id` → brief, style, aspect ratio, narration, music_prompt, image_model, video_model, script link, and every shot with id/index/slug/action/camera/motion/duration/status/has_keyframe/has_clip/covered_by |
 | `edit_storyboard` | `storyboard_id`, `ops[]` — see below |
 | `render_storyboard_stills` | `storyboard_id`, `targets?`, `provider?`, `model?`, `style?`, `concurrency?` |
 | `render_storyboard_clips` | `storyboard_id`, `targets?`, `provider?`, `model?`, `resolution?`, `mode?` (`keyframe`\|`direct`), `concurrency?` |
@@ -24,7 +24,8 @@ Render limits: **24 shots per call**, `concurrency` default 3, max 8.
 
 Omitting `targets` selects every shot that still needs that step. For stills that is
 every shot with no keyframe that is not set to render directly; for clips, every shot
-with no clip. A `keyframe`-mode shot that reaches `render_storyboard_clips` with no
+with no picture — its own or one it is covered by (§ Fusing shots). A `keyframe`-mode
+shot that reaches `render_storyboard_clips` with no
 still is reported in the results, not rendered — render its still first, or set its
 `render_mode` to `direct`. Each render appends to `keyframe_versions` /
 `clip_versions` and makes the new one selected.
@@ -36,22 +37,52 @@ still is reported in the results, not rendered — render its still first, or se
 
 Shot fields (add and update both): `action`, `slug`, `camera`, `motion`, `dialogue`,
 `narration`, `notes`, `duration_seconds`, `duration_source` (`audio`\|`manual`),
-`render_mode` (`keyframe`\|`direct`), `entity_ids`, `location_id`, `index`.
+`render_mode` (`keyframe`\|`direct`), `entity_ids`, `location_id`, `covered_by`, `index`.
 
 `camera` is `{framing?, lens?, angle?, movement?}`.
+
+`covered_by` is `{shot_id, start_seconds?, end_seconds?}` — this shot's picture is a
+window into another shot's clip. See § Fusing shots below. `null` undoes it.
 
 Board fields (`set_board` only): `brief`, `style`, `aspect_ratio`, `entity_ids`,
 `image_model`, `video_model`. The two model fields take a model **object** from
 `find_model`, or null.
 
 **An edit cannot set `keyframe`, `clip` or `status`.** Those belong to the render
-tools; passing them raises an error naming the right tool.
+tools; passing them raises an error naming the right tool. `covered_by` is the one
+exception: coverage is a picture that arrived without a render, so setting it marks
+the shot `rendered` and clearing it puts the shot back to `keyframe_ready`/`planned`.
 
 **An edit cannot set `title`, `logline`, `style_bible`, `narration` or `music_prompt`
 at the board level.** Those live on the screenplay, which only
 `ui_storyboard_set_screenplay` writes. Per-*shot* `narration` is an ordinary shot
 field and works fine headlessly. Board narration and music matter because
 `assemble_storyboard_timeline` turns them into draft audio clips.
+
+### Fusing shots
+
+A video model returns a fixed window — 5.184s, 6s, 8s — whatever length the shot was
+directed at. A cut whose beats run 1.5-2.5s is therefore cheaper to render as one
+generation covering a run of shots and split afterwards, than as one generation per
+shot: fifteen 1.5-2.5s beats bought one at a time is ~77s of footage for a 30s cut.
+
+Direct the run as one prompt with bracketed timecodes
+(`[00:00 to 00:02.5] Event … [00:02.5 to 00:05.2] Reception`), render it on the first
+shot of the run, then tell the board which slice each sibling uses:
+
+```json
+{"op": "update_shot", "target": "06",
+ "covered_by": {"shot_id": "05", "start_seconds": 2.5, "end_seconds": 5.184}}
+```
+
+The covered shot then reads `has_clip: true` with `status: "rendered"`, is skipped by
+`render_storyboard_clips` (so it is never generated twice), and
+`assemble_storyboard_timeline` lays it down as that window of the covering clip
+instead of skipping it. Without `end_seconds` it runs to the end of the covering clip,
+capped at its own `duration_seconds`.
+
+One hop only: `shot_id` must name a shot that owns its clip, not another covered shot.
+Removing the covering shot clears the coverage and reports which shots it uncovered.
 
 ## Storyboard — browser (`ui_storyboard_*`)
 
@@ -160,6 +191,26 @@ clips with `muted: true`, or `volumeDb: -18`. `set_clip_params` also takes `name
 `opacity`, `speedMultiplier`, `fadeInMs`, `fadeOutMs`, `blendMode`, `borderRadius`,
 `hidden`, `locked`, `textStyle`, `shapeStyle`.
 
+Every field goes on the op itself. A `params` / `props` wrapper is unwrapped, but the
+flat form is the contract:
+
+```json
+{"op": "set_clip_params", "target": "clip_1",
+ "textStyle": {"fontFamily": "Space Grotesk", "fontWeight": 800}}
+```
+
+`textStyle` is **merged** over the clip's own, so send only what you are changing —
+re-sending the whole object is how the fields you did not mean to touch get
+overwritten. `fontWeight` is a number, and the CSS keywords (`bold`, `semibold`,
+`extrabold`) are accepted and stored as one.
+
+**Set a bundled family or none at all.** `sans-serif`, `serif`, `system-ui` and the
+other CSS generics are refused where the clip is authored: they name no typeface, so
+the editor preview, the render and `preview_timeline_frame` each pick a different one.
+NodeTool ships Inter (the default), Space Grotesk, Bebas Neue, Playfair Display, Lora
+and JetBrains Mono. A named system font is still allowed and `validate_timeline`
+reports it as `font_not_portable`.
+
 `validate_timeline {timeline_id | document, fps?}` after every edit pass. It catches
 overlaps, fades longer than their clip, unknown presets and incomplete bindings.
 
@@ -175,7 +226,21 @@ line ids it covers, and from then on the script owns the words. `derive_storyboa
 goes the other way, one shot per line, optionally with a director pass over the scaffold.
 
 `voice_script_lines` synthesizes each line with its cast voice; `assemble_script_timeline`
-lays the takes end to end. On a linked board, `assemble_storyboard_timeline` cuts words
+lays the takes end to end.
+
+**Give the cast their voices first, then voice with no override.** A voice is the
+triple `{provider, model, voice}` where `voice` is the voice's own name (`Aoede`,
+`Charon`, `alloy`) — a provider and a model alone do not pick one, so
+`voice_script_lines {provider, model}` is refused. Set each speaker once:
+
+```json
+{"op": "set_speaker_voice", "target": "MOM",
+ "provider": "gemini", "model": "tts-hd", "voice": "Aoede"}
+```
+
+The three keys sit on the op, though a `voice: {provider, model, voice_id}` object —
+the shape `get_script` reports a voice in — is flattened onto it. Then call
+`voice_script_lines {script_id}` with no override and every speaker resolves its own. On a linked board, `assemble_storyboard_timeline` cuts words
 and picture together: each shot runs as long as the takes it covers and every voiced
 line gets its own voiceover clip.
 

--- a/packages/agents/src/capabilities/scripts.ts
+++ b/packages/agents/src/capabilities/scripts.ts
@@ -553,8 +553,9 @@ const getScript: CapabilityExport = {
 
 /** The call-level voice override, or null when the lines' own voices apply. */
 function voiceOverrideFrom(
-  params: Record<string, unknown>
+  rawParams: Record<string, unknown>
 ): ScriptVoiceBinding | null | ToolError {
+  const params = flattenVoiceArg(rawParams);
   const provider = params["provider"];
   const model = params["model"];
   const voice = params["voice"];
@@ -565,9 +566,18 @@ function voiceOverrideFrom(
     !isNonEmptyString(model) ||
     !isNonEmptyString(voice)
   ) {
+    // A provider and a model with no voice is the shape a caller sends when
+    // it means "use this TTS endpoint for the whole script" — there is no
+    // such thing here, because the endpoint does not pick a voice. Naming the
+    // op that does say it saves the round trip the refusal used to cost.
     return {
       error:
-        "A voice override needs all three of provider, model, and voice (use find_model with capability=text_to_speech). Omit all three to use each line's own voice."
+        "A voice override needs all three of provider, model, and voice — " +
+        "`voice` is the voice's own name (e.g. \"Aoede\"), which find_model " +
+        "with capability=text_to_speech lists per model. To give the whole " +
+        'script one model, set each speaker\'s voice once with edit_script ' +
+        '{"op": "set_speaker_voice", "target": "<speaker>", "provider", ' +
+        '"model", "voice"} and call this with no override at all.'
     };
   }
   return { provider, model, voice };
@@ -1166,18 +1176,65 @@ function mintId(prefix: string, used: Set<string>): string {
   return `${prefix}_${n}`;
 }
 
+/**
+ * How the voice's own name is spelled inside a nested voice object, depending
+ * on which surface printed it. All five mean the same field.
+ */
+const VOICE_NAME_KEYS = ["voice", "voice_id", "voiceId", "id", "name"] as const;
+
+/**
+ * Flatten a voice sent as an object under `voice`.
+ *
+ * The binding is three sibling keys, but `get_script` *reports* a speaker's
+ * voice as one object, so `{op: "set_speaker_voice", target, voice: {provider,
+ * model, voice_id}}` is what a caller writes after reading the cast back — and
+ * it used to land as a `voice` that was not a string, fail the triple check,
+ * and be refused with a message listing the three keys it had just supplied.
+ */
+function flattenVoiceArg(
+  args: Record<string, unknown>
+): Record<string, unknown> {
+  const nested = args["voice"];
+  if (!isRecord(nested)) return args;
+  const { voice: _nested, ...rest } = args;
+  const flat: Record<string, unknown> = { ...rest };
+  for (const key of ["provider", "model", "settings"]) {
+    if (flat[key] === undefined && nested[key] !== undefined) {
+      flat[key] = nested[key];
+    }
+  }
+  const name = VOICE_NAME_KEYS.map((key) => nested[key]).find((v) =>
+    isString(v)
+  );
+  if (name !== undefined) flat["voice"] = name;
+  return flat;
+}
+
 /** A provider/model/voice triple, all three or none — never a half-guess. */
 function parseVoiceBinding(
-  args: Record<string, unknown>
+  raw: Record<string, unknown>
 ): ScriptVoiceBinding | null {
+  const args = flattenVoiceArg(raw);
   const provider = args["provider"];
   const model = args["model"];
   const voice = args["voice"];
   const given = [provider, model, voice].filter((v) => isString(v));
   if (given.length === 0) return null;
   if (given.length !== 3) {
+    const missing = (
+      [
+        ["provider", provider],
+        ["model", model],
+        ["voice", voice]
+      ] as const
+    )
+      .filter(([, value]) => !isString(value))
+      .map(([key]) => key);
     throw new Error(
-      "A voice needs provider, model and voice together (use find_model to pick one)."
+      `A voice needs provider, model and voice together; this one has no ${missing.join(" and no ")}. ` +
+        "`voice` is the voice's own name (e.g. \"Aoede\"), not a second model " +
+        "id — find_model with capability=text_to_speech lists the names a " +
+        "model takes."
     );
   }
   const binding: ScriptVoiceBinding = {

--- a/packages/agents/src/capabilities/storyboards.specs.ts
+++ b/packages/agents/src/capabilities/storyboards.specs.ts
@@ -177,11 +177,16 @@ export const EDIT_STORYBOARD_SCHEMA: JsonSchema = {
         'Operations in order. Each is {"op": <name>, ...arguments}: ' +
         "add_shot {action, slug?, camera?, motion?, dialogue?, narration?, " +
         "duration_seconds?, duration_source?, render_mode?, entity_ids?, " +
-        "location_id?, notes?, index?}, " +
+        "location_id?, covered_by?, notes?, index?}, " +
         "update_shot {target, ...same fields}, remove_shot {target}, " +
         "reorder_shot {target, index}, set_board {brief?, style?, " +
         "aspect_ratio?, entity_ids?, image_model?, video_model?}. " +
         "`target` is a shot id, its 0-based index, or its slug. " +
+        "covered_by {shot_id, start_seconds?, end_seconds?} says this shot's " +
+        "picture is a window into another shot's clip — how you record a " +
+        "generation whose fixed length covers several beats. The covered " +
+        "shot then reads as rendered, is skipped by the render selections, " +
+        "and assembles as that window. Pass null to undo it. " +
         "image_model/video_model take a model object from find_model and " +
         "become the board's defaults for render_storyboard_stills and " +
         "render_storyboard_clips.",
@@ -246,6 +251,8 @@ export const getStoryboardSpec: CapabilitySpec = {
     "Read one storyboard: brief, style, aspect ratio, the still/clip models it " +
     "renders with, and every shot with its id, index, slug, action, camera, " +
     "motion, duration, status, and whether it already has a still or a clip. " +
+    "`has_clip` counts a shot whose picture is a window into another shot's " +
+    "generation; `covered_by` says which shot and which window. " +
     "Call this before rendering — the other tools address shots by these ids.",
   inputSchema: GET_STORYBOARD_SCHEMA,
   category: "read",
@@ -282,7 +289,9 @@ export const renderStoryboardClipsSpec: CapabilitySpec = {
     "call. Each clip is saved as an asset and attached to its shot (previous " +
     "takes are kept as versions), leaving the shot 'rendered' and ready for " +
     "assemble_storyboard_timeline. Omit `targets` to render every shot that " +
-    "still needs a clip and can render one. A keyframe-mode shot with no " +
+    "still needs a clip and can render one — a shot covered by another " +
+    "shot's generation already has its picture and is skipped. " +
+    "A keyframe-mode shot with no " +
     "still is reported, not rendered — run render_storyboard_stills first, or " +
     "set its render_mode to 'direct'. This is the expensive step.",
   inputSchema: RENDER_CLIPS_SCHEMA,

--- a/packages/agents/src/capabilities/storyboards.ts
+++ b/packages/agents/src/capabilities/storyboards.ts
@@ -32,6 +32,7 @@ import type {
   Screenplay,
   ScriptLinkDocument,
   Shot,
+  ShotCoverage,
   VideoRef
 } from "@nodetool-ai/protocol";
 import type { ScriptAssemblyInput } from "@nodetool-ai/timeline";
@@ -226,6 +227,20 @@ function findShot(shots: Shot[], target: string): Shot | undefined {
   const slug = target.trim().toLowerCase();
   return shots.find((s) => (s.slug ?? "").trim().toLowerCase() === slug);
 }
+
+/**
+ * Whether a shot's picture already exists — its own clip, or a window into the
+ * clip of the shot that covers it.
+ *
+ * The render selections read this rather than `shot.clip`, so a shot fused
+ * into a sibling's generation is not offered up to be generated a second time.
+ */
+const shotHasPicture = (shot: Shot, shots: readonly Shot[]): boolean => {
+  if (shot.clip) return true;
+  const coverage = shot.covered_by;
+  if (!coverage) return false;
+  return shots.some((s) => s.id === coverage.shot_id && !!s.clip);
+};
 
 /**
  * The shots a render call acts on: the explicit `targets` when given, else
@@ -634,7 +649,8 @@ const getStoryboard: CapabilityExport = {
           duration_seconds: shot.duration_seconds,
           status: shot.status,
           has_keyframe: !!shot.keyframe,
-          has_clip: !!shot.clip,
+          has_clip: shotHasPicture(shot, doc.shots),
+          covered_by: shot.covered_by ?? null,
           render_mode: shot.render_mode ?? "keyframe",
           script_line_ids: shot.script_line_ids ?? [],
           duration_source: shot.duration_source,
@@ -662,7 +678,10 @@ const renderStoryboardStills: CapabilityExport = {
     const selected = selectShots(
       doc.shots,
       params["targets"],
-      (s) => !s.keyframe && shotRenderMode(s) !== "direct"
+      (s) =>
+        !s.keyframe &&
+        shotRenderMode(s) !== "direct" &&
+        !shotHasPicture(s, doc.shots)
     );
     if (isError(selected)) return selected;
     if (selected.length === 0) {
@@ -794,7 +813,9 @@ const renderStoryboardClips: CapabilityExport = {
     const selected = selectShots(
       doc.shots,
       params["targets"],
-      (s) => !s.clip && (modeOf(s) === "direct" || !!s.keyframe)
+      (s) =>
+        !shotHasPicture(s, doc.shots) &&
+        (modeOf(s) === "direct" || !!s.keyframe)
     );
     if (isError(selected)) return selected;
     if (selected.length === 0) {
@@ -1348,7 +1369,8 @@ const SHOT_EDIT_FIELDS = new Set([
   "duration_source",
   "render_mode",
   "entity_ids",
-  "location_id"
+  "location_id",
+  "covered_by"
 ]);
 
 /** Fields a caller reaches for to attach media, which an edit cannot set. */
@@ -1414,8 +1436,73 @@ function assertKnownBoardFields(args: Record<string, unknown>): void {
   );
 }
 
+/**
+ * Read `covered_by` on an edit: which shot's clip holds this shot's picture,
+ * and the window of it this shot uses.
+ *
+ * A model that renders a fixed 5.2s window covers several 1.5-2.2s beats in
+ * one generation, and the clip lands on one shot. Before this the siblings had
+ * no way to say so: they stayed `has_clip: false`, the board read as half
+ * unrendered when the cut was locked, and the default clip selection offered
+ * to generate them again. The covering shot must own its clip — a window
+ * measured against a window has no source length behind it.
+ */
+function parseShotCoverage(
+  shot: Shot,
+  shots: readonly Shot[],
+  value: unknown
+): ShotCoverage | null {
+  if (value === null) return null;
+  const raw = isString(value) ? { shot_id: value } : value;
+  if (!isRecord(raw)) {
+    throw new Error(
+      "covered_by must be {shot_id, start_seconds?, end_seconds?} or null. " +
+        "A bare shot id is accepted and means the whole clip."
+    );
+  }
+  const ref = raw["shot_id"] ?? raw["target"] ?? raw["shot"];
+  if (!isString(ref) || ref.trim() === "") {
+    throw new Error("covered_by needs a `shot_id` naming the covering shot.");
+  }
+  const cover = findShot([...shots], ref.trim());
+  if (!cover) throw new Error(`covered_by names no shot: "${ref}".`);
+  if (cover.id === shot.id) {
+    throw new Error("A shot cannot cover itself.");
+  }
+  if (cover.covered_by) {
+    throw new Error(
+      `Shot ${cover.id} is itself covered by ${cover.covered_by.shot_id}; ` +
+        "point at the shot that owns the clip."
+    );
+  }
+  const seconds = (key: "start_seconds" | "end_seconds"): number | undefined => {
+    const given = raw[key];
+    if (given === undefined || given === null) return undefined;
+    const n = Number(given);
+    if (!Number.isFinite(n) || n < 0) {
+      throw new Error(`covered_by.${key} must be a number of seconds >= 0.`);
+    }
+    return n;
+  };
+  const start = seconds("start_seconds");
+  const end = seconds("end_seconds");
+  if (start !== undefined && end !== undefined && end <= start) {
+    throw new Error(
+      `covered_by.end_seconds (${end}) must be after start_seconds (${start}).`
+    );
+  }
+  const coverage: ShotCoverage = { shot_id: cover.id };
+  if (start !== undefined) coverage.start_seconds = start;
+  if (end !== undefined) coverage.end_seconds = end;
+  return coverage;
+}
+
 /** The shot fields an edit may set. Media and status stay the render tools'. */
-function applyShotFields(shot: Shot, args: Record<string, unknown>): Shot {
+function applyShotFields(
+  shot: Shot,
+  args: Record<string, unknown>,
+  shots: readonly Shot[] = []
+): Shot {
   const next: Shot = { ...shot };
   if (args["action"] !== undefined) next.action = String(args["action"]);
   if (args["slug"] !== undefined) next.slug = String(args["slug"]);
@@ -1453,6 +1540,18 @@ function applyShotFields(shot: Shot, args: Record<string, unknown>): Shot {
   if (args["location_id"] !== undefined) {
     next.location_id = optionalString(args["location_id"]) ?? null;
   }
+  if (args["covered_by"] !== undefined) {
+    const coverage = parseShotCoverage(next, shots, args["covered_by"]);
+    next.covered_by = coverage;
+    // Status is the render tools' to write, with one exception: coverage is
+    // the only way a shot's picture arrives without a render, and a covered
+    // shot left at `keyframe_ready` is the drift this field exists to remove.
+    if (coverage) {
+      next.status = "rendered";
+    } else if (!next.clip) {
+      next.status = next.keyframe ? "keyframe_ready" : "planned";
+    }
+  }
   return next;
 }
 
@@ -1484,7 +1583,8 @@ function applyBoardOp(
           action: "",
           status: "planned"
         },
-        args
+        args,
+        doc.shots
       );
       const at =
         isNumber(args["index"])
@@ -1501,7 +1601,7 @@ function applyBoardOp(
       const target = String(args["target"] ?? "");
       const shot = findShot(doc.shots, target);
       if (!shot) throw new Error(`No shot matches "${target}".`);
-      const updated = applyShotFields(shot, args);
+      const updated = applyShotFields(shot, args, doc.shots);
       doc.shots = doc.shots.map((s) => (s.id === shot.id ? updated : s));
       return { id: updated.id, action: updated.action };
     }
@@ -1510,8 +1610,28 @@ function applyBoardOp(
       const target = String(args["target"] ?? "");
       const shot = findShot(doc.shots, target);
       if (!shot) throw new Error(`No shot matches "${target}".`);
-      doc.shots = renumberShots(doc.shots.filter((s) => s.id !== shot.id));
-      return { removed: shot.id };
+      // Coverage pointing at a shot that is gone would read as a picture that
+      // exists and assemble as nothing, so the dependents go back to needing
+      // their own render.
+      const uncovered = doc.shots
+        .filter((s) => s.covered_by?.shot_id === shot.id)
+        .map((s) => s.id);
+      doc.shots = renumberShots(
+        doc.shots
+          .filter((s) => s.id !== shot.id)
+          .map((s) =>
+            s.covered_by?.shot_id === shot.id
+              ? {
+                  ...s,
+                  covered_by: null,
+                  status: s.keyframe ? "keyframe_ready" : "planned"
+                }
+              : s
+          )
+      );
+      return uncovered.length > 0
+        ? { removed: shot.id, uncovered }
+        : { removed: shot.id };
     }
 
     case "reorder_shot": {

--- a/packages/agents/src/evals/surfaces/timeline.ts
+++ b/packages/agents/src/evals/surfaces/timeline.ts
@@ -38,6 +38,7 @@ import {
   DEFAULT_TEXT_CLIP_DURATION_MS,
   DEFAULT_MEDIA_CLIP_DURATION_MS,
   shapeStyleWithDefaults,
+  assertAuthorableFontFamily,
   textStyleWithDefaults,
   moveTrackOrder,
   mediaTypeForContentType,
@@ -101,6 +102,7 @@ import {
   trackTargetParam,
   resolveShapeArg,
   targetParam,
+  textStylePatchParams,
   textStyleParams,
   transitionParams
 } from "@nodetool-ai/protocol/api-schemas/timeline-tool-params.js";
@@ -472,6 +474,61 @@ const CLIP_PARAM_KEYS = [
   "shapeStyle",
   "captionStyle"
 ];
+
+/**
+ * Keys a caller wraps the whole patch in.
+ *
+ * `set_clip_params` reads its fields off the op itself — `{op, target,
+ * textStyle}` — but a REST-shaped guess sends `{op, target, params: {…}}`, and
+ * that used to be refused as an unknown key with the real fields hidden one
+ * level down inside it. The wrapper says nothing the op does not already know,
+ * so it is unwrapped rather than argued with.
+ */
+const CLIP_PARAM_WRAPPERS = ["params", "patch", "props", "properties"];
+
+/** Lift a patch a caller nested under a wrapper key onto the op itself. */
+export function unwrapClipParams(
+  patch: Record<string, unknown>
+): Record<string, unknown> {
+  const wrapper = CLIP_PARAM_WRAPPERS.find((key) => isRecordValue(patch[key]));
+  if (!wrapper) return patch;
+  const { [wrapper]: nested, ...rest } = patch;
+  // The op's own keys win: a caller that sent both meant the one it spelled
+  // out, and silently preferring the wrapper would drop it.
+  return { ...(nested as Record<string, unknown>), ...rest };
+}
+
+const isRecordValue = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * A text style patch, merged over the clip's own and checked for a family that
+ * names no face.
+ *
+ * A clip that carries no text style yet still needs the three fields that make
+ * one drawable, so the merged result goes through the same schema the whole
+ * bag does rather than being stored half-built.
+ */
+function mergeTextStyle(
+  clip: TimelineClip,
+  patch: unknown
+): TimelineClip["textStyle"] {
+  const merged = { ...(clip.textStyle ?? {}), ...(patch as object) };
+  const parsed = textStyleParams.safeParse(merged);
+  if (!parsed.success) {
+    const missing = parsed.error.issues
+      .filter((issue) => issue.code === "invalid_type")
+      .map((issue) => issue.path.join("."));
+    throw new Error(
+      missing.length > 0
+        ? `Clip "${clip.name}" has no text style yet, so this patch cannot ` +
+          `stand on its own — it still needs ${missing.join(", ")}.`
+        : `textStyle: ${parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ")}`
+    );
+  }
+  assertAuthorableFontFamily(parsed.data.fontFamily);
+  return parsed.data as TimelineClip["textStyle"];
+}
 
 function rejectUnknownClipParams(patch: Record<string, unknown>): void {
   for (const key of Object.keys(patch)) {
@@ -1396,7 +1453,7 @@ export function createTimelineToolBridge(
 
     tool(
       "ui_timeline_set_clip_params",
-      "Change a clip's render/audio params: `name`, `opacity` (0..1), `speedMultiplier` (0.1..8), `volumeDb`, `fadeInMs`, `fadeOutMs`, `blendMode`, `borderRadius`, `hidden`, `muted`, `locked`, a text clip's `textStyle`, a shape clip's `shapeStyle`, or a caption clip's `captionStyle`. `fontSizePx` is shorthand for `textStyle.fontSizePx`. Timing is accepted too and applied as trim_clip/move_clip would: `durationMs`, `inPointMs`, `outPointMs`, `startMs`, `trackId`. A key this tool does not know is refused by name rather than ignored. Omit a field to leave it unchanged.",
+      "Change a clip's render/audio params: `name`, `opacity` (0..1), `speedMultiplier` (0.1..8), `volumeDb`, `fadeInMs`, `fadeOutMs`, `blendMode`, `borderRadius`, `hidden`, `muted`, `locked`, a text clip's `textStyle`, a shape clip's `shapeStyle`, or a caption clip's `captionStyle`. Fields go on the op itself, not inside a `params` wrapper. `textStyle` is merged over the clip's own, so send only what you are changing, and `fontWeight` takes the CSS keywords as well as the number. `fontSizePx` is shorthand for `textStyle.fontSizePx`. Timing is accepted too and applied as trim_clip/move_clip would: `durationMs`, `inPointMs`, `outPointMs`, `startMs`, `trackId`. A key this tool does not know is refused by name rather than ignored. Omit a field to leave it unchanged.",
       z.object({
         target: targetParam,
         startMs: z.number().optional(),
@@ -1416,14 +1473,15 @@ export function createTimelineToolBridge(
         hidden: z.boolean().optional(),
         muted: z.boolean().optional(),
         locked: z.boolean().optional(),
-        textStyle: textStyleParams.optional(),
+        textStyle: textStylePatchParams.optional(),
         shapeStyle: shapeStyleParams.optional(),
         captionStyle: captionStyleParams.optional()
         // A key the schema does not list is kept rather than stripped, so it
         // can be refused by name below: silently dropping `startMs` looked
         // like a successful call that changed nothing.
       }).catchall(z.unknown()),
-      async ({ target, ...patch }) => {
+      async ({ target, ...wrapped }) => {
+        const patch = unwrapClipParams(wrapped);
         let clip = resolveClip(target as string);
         rejectUnknownClipParams(patch);
         // Timing belongs to move_clip and trim_clip, but a caller sending it
@@ -1438,6 +1496,12 @@ export function createTimelineToolBridge(
           startMs: patch.startMs as number | undefined,
           trackId: patch.trackId as string | undefined
         });
+        // The style is a patch over what the clip already carries: changing one
+        // field used to mean re-sending the whole bag, and re-sending it is how
+        // the four fields the caller did not mean to touch get overwritten.
+        if (patch.textStyle !== undefined) {
+          patch.textStyle = mergeTextStyle(clip, patch.textStyle);
+        }
         if (patch.fontSizePx !== undefined) {
           // Shorthand for the one text field callers reach for by name.
           const size = patch.fontSizePx as number;

--- a/packages/agents/tests/capabilities-scripts.test.ts
+++ b/packages/agents/tests/capabilities-scripts.test.ts
@@ -479,4 +479,70 @@ describe("scripts capability behaviour", () => {
     expect(result.note).toContain("set_speaker_voice");
     expect(result.note).not.toContain("already up to date");
   });
+
+  // `get_script` reports a speaker's voice as one object, so a caller that
+  // reads the cast back and writes it straight into `set_speaker_voice` sends
+  // that object — and used to be refused with a message listing the three keys
+  // it had just supplied, one level down.
+  describe("a voice sent as an object", () => {
+    it("flattens it onto the speaker, whichever key names the voice", async () => {
+      const row = await makeScript(
+        [line({ id: "l1", speakerId: "sp1" })],
+        [{ id: "sp1", name: "MOM", voice: null }] as never
+      );
+      const result = (await run(ctx().context).invoke("edit_script", {
+        script_id: row.id,
+        ops: [
+          {
+            op: "set_speaker_voice",
+            target: "MOM",
+            voice: { provider: "gemini", model: "tts-hd", voice_id: "Aoede" }
+          }
+        ]
+      })) as { applied: number; failed: number; ops: Array<{ error?: string }> };
+      expect(result).toMatchObject({ applied: 1, failed: 0 });
+
+      const read = (await run(ctx().context).invoke("get_script", {
+        script_id: row.id
+      })) as { cast: Array<{ name: string; voice: unknown }> };
+      expect(read.cast[0].voice).toEqual({
+        provider: "gemini",
+        model: "tts-hd",
+        voice: "Aoede"
+      });
+    });
+
+    it("still refuses one that names no voice, and says which key is missing", async () => {
+      const row = await makeScript(
+        [line({ id: "l1", speakerId: "sp1" })],
+        [{ id: "sp1", name: "MOM", voice: null }] as never
+      );
+      const result = (await run(ctx().context).invoke("edit_script", {
+        script_id: row.id,
+        ops: [
+          {
+            op: "set_speaker_voice",
+            target: "MOM",
+            voice: { provider: "gemini", model: "tts-hd" }
+          }
+        ]
+      })) as { failed: number; ops: Array<{ error?: string }> };
+      expect(result.failed).toBe(1);
+      expect(result.ops[0].error).toContain("has no voice");
+    });
+  });
+
+  // A provider and a model with no voice is the shape a caller sends meaning
+  // "use this endpoint for the whole script". The refusal used to list the
+  // three keys without saying what `voice` is or where to set it once.
+  it("points a half-specified voice override at set_speaker_voice", async () => {
+    const row = await makeScript([line({ id: "l1", speakerId: "sp1" })]);
+    const result = (await run(ctx().context).invoke("voice_script_lines", {
+      script_id: row.id,
+      provider: "gemini",
+      model: "tts-hd"
+    })) as { error?: string };
+    expect(result.error).toContain("set_speaker_voice");
+    expect(result.error).toContain("the voice's own name");
+  });
 });

--- a/packages/agents/tests/capabilities-storyboards.test.ts
+++ b/packages/agents/tests/capabilities-storyboards.test.ts
@@ -875,4 +875,159 @@ describe("storyboards capability behaviour", () => {
     expect(result.ops[2].error).toContain('No shot matches "nope"');
     expect(result.shots[0].slug).toBe("wide");
   });
+
+  // A model that renders a fixed 5.184s window covers several 1.5-2.2s beats
+  // in one generation. The clip lands on the first shot of the run; before
+  // `covered_by` the siblings stayed `has_clip: false` for the rest of the
+  // session, so the board read as half unrendered when the cut was locked and
+  // the default clip selection offered to generate them again.
+  describe("fused shots", () => {
+    const fusedBoard = () =>
+      makeBoard([
+        shot({
+          id: "event",
+          index: 0,
+          status: "rendered",
+          duration_seconds: 2.5,
+          clip: { type: "video", asset_id: "clip-fused", duration: 5.184 }
+        }),
+        shot({
+          id: "reception",
+          index: 1,
+          status: "keyframe_ready",
+          keyframe: { type: "image", asset_id: "still-reception" }
+        })
+      ]);
+
+    const cover = async (context: ProcessingContext, boardId: string) =>
+      (await run(context).invoke("edit_storyboard", {
+        storyboard_id: boardId,
+        ops: [
+          {
+            op: "update_shot",
+            target: "reception",
+            covered_by: {
+              shot_id: "event",
+              start_seconds: 2.5,
+              end_seconds: 5.184
+            }
+          }
+        ]
+      })) as { applied: number; failed: number; ops: Array<{ error?: string }> };
+
+    it("reads a covered shot back as rendered, with its window", async () => {
+      const board = await fusedBoard();
+      const context = ctx();
+      expect(await cover(context, board.id)).toMatchObject({
+        applied: 1,
+        failed: 0
+      });
+
+      const read = (await run(context).invoke("get_storyboard", {
+        storyboard_id: board.id
+      })) as {
+        shots: Array<{
+          id: string;
+          status: string;
+          has_clip: boolean;
+          covered_by: { shot_id: string; start_seconds?: number } | null;
+        }>;
+      };
+      expect(read.shots[1]).toMatchObject({
+        id: "reception",
+        status: "rendered",
+        has_clip: true,
+        covered_by: {
+          shot_id: "event",
+          start_seconds: 2.5,
+          end_seconds: 5.184
+        }
+      });
+      expect(read.shots[0].covered_by).toBeNull();
+    });
+
+    it("does not offer a covered shot up for another render", async () => {
+      const board = await fusedBoard();
+      const context = ctx();
+      await cover(context, board.id);
+
+      // Nothing is selected at all — not "selected and then failed", which is
+      // what the old `!s.clip` predicate produced on a shot whose picture had
+      // already been generated into its sibling.
+      const clips = (await run(context).invoke("render_storyboard_clips", {
+        storyboard_id: board.id
+      })) as { rendered: number; results: unknown[]; note?: string };
+      expect(clips).toMatchObject({ rendered: 0, results: [] });
+      expect(clips.note).toContain("No shot is ready for a clip");
+    });
+
+    it("assembles the covered shot as a slice of the covering clip", async () => {
+      const board = await fusedBoard();
+      const context = ctx();
+      await cover(context, board.id);
+
+      const assembled = (await run(context).invoke(
+        "assemble_storyboard_timeline",
+        { storyboard_id: board.id }
+      )) as { timeline_id: string };
+      const sequence = await sequenceOf(assembled.timeline_id);
+      const picture = sequence
+        .toDocument()
+        .clips.filter((c) => c.mediaType !== "audio");
+
+      expect(picture).toHaveLength(2);
+      expect(picture[1]).toMatchObject({
+        currentAssetId: "clip-fused",
+        startMs: 2500,
+        inPointMs: 2500,
+        outPointMs: 5184
+      });
+    });
+
+    it("refuses coverage that names a shot, itself, or another window", async () => {
+      const board = await fusedBoard();
+      const context = ctx();
+      const refused = (await run(context).invoke("edit_storyboard", {
+        storyboard_id: board.id,
+        ops: [
+          { op: "update_shot", target: "reception", covered_by: "ghost" },
+          { op: "update_shot", target: "event", covered_by: "event" },
+          {
+            op: "update_shot",
+            target: "reception",
+            covered_by: { shot_id: "event", start_seconds: 3, end_seconds: 1 }
+          }
+        ]
+      })) as { failed: number; ops: Array<{ error?: string }> };
+      expect(refused.failed).toBe(3);
+      expect(refused.ops[0].error).toContain('covered_by names no shot: "ghost"');
+      expect(refused.ops[1].error).toContain("cannot cover itself");
+      expect(refused.ops[2].error).toContain("must be after start_seconds");
+    });
+
+    it("uncovers the dependents when the covering shot is removed", async () => {
+      const board = await fusedBoard();
+      const context = ctx();
+      await cover(context, board.id);
+
+      const removed = (await run(context).invoke("edit_storyboard", {
+        storyboard_id: board.id,
+        ops: [{ op: "remove_shot", target: "event" }]
+      })) as { ops: Array<{ result?: { uncovered?: string[] } }> };
+      expect(removed.ops[0].result?.uncovered).toEqual(["reception"]);
+
+      const read = (await run(context).invoke("get_storyboard", {
+        storyboard_id: board.id
+      })) as {
+        shots: Array<{ id: string; status: string; has_clip: boolean }>;
+      };
+      expect(read.shots).toEqual([
+        expect.objectContaining({
+          id: "reception",
+          status: "keyframe_ready",
+          has_clip: false
+        })
+      ]);
+    });
+  });
 });

--- a/packages/agents/tests/timeline-op-ergonomics.test.ts
+++ b/packages/agents/tests/timeline-op-ergonomics.test.ts
@@ -109,6 +109,81 @@ describe("ui_timeline_set_clip_params", () => {
     ).toBe(140);
   });
 
+  /**
+   * `{op, target, params: {...}}` is the REST-shaped guess. The fields were
+   * refused as one unknown key called `params`, with the real ones hidden a
+   * level down inside it.
+   */
+  it("lifts a patch the caller nested under `params`", async () => {
+    const { b, byName } = bridge();
+    await byName["ui_timeline_set_clip_params"].execute({
+      target: "shot",
+      params: { opacity: 0.4, durationMs: 3000 }
+    });
+    expect(b.finalState().documentClips[0]).toMatchObject({
+      opacity: 0.4,
+      durationMs: 3000
+    });
+  });
+
+  it("lets a key on the op itself win over the wrapper's copy", async () => {
+    const { b, byName } = bridge();
+    await byName["ui_timeline_set_clip_params"].execute({
+      target: "shot",
+      opacity: 0.9,
+      params: { opacity: 0.1 }
+    });
+    expect(b.finalState().documentClips[0].opacity).toBe(0.9);
+  });
+
+  /**
+   * A finished title needed one field changed. `textStyle` required the whole
+   * bag — text, fontSizePx and color — so a partial failed Zod validation, and
+   * re-sending the whole object to get past that is how the fields the caller
+   * did not mean to touch get overwritten.
+   */
+  it("merges a partial textStyle over the one the clip carries", async () => {
+    const { byName } = bridge();
+    await byName["ui_timeline_add_text_clip"].execute({
+      text: "MY MOM IS HOMELESS",
+      fontSizePx: 64,
+      color: "#ffffff"
+    });
+    const result = await byName["ui_timeline_set_clip_params"].execute({
+      target: "selected",
+      textStyle: { fontFamily: "Space Grotesk", fontWeight: 800 }
+    });
+    expect(clipOf(result).textStyle).toMatchObject({
+      text: "MY MOM IS HOMELESS",
+      fontSizePx: 64,
+      color: "#ffffff",
+      fontFamily: "Space Grotesk",
+      fontWeight: 800
+    });
+  });
+
+  it("takes a CSS weight keyword and stores the number the renderer draws", async () => {
+    const { byName } = bridge();
+    await byName["ui_timeline_add_text_clip"].execute({ text: "TITLE" });
+    const result = await byName["ui_timeline_set_clip_params"].execute({
+      target: "selected",
+      textStyle: { fontWeight: "extrabold" }
+    });
+    expect(
+      (clipOf(result).textStyle as Record<string, unknown>).fontWeight
+    ).toBe(800);
+  });
+
+  it("says what a patch is still missing on a clip with no text style", async () => {
+    const { byName } = bridge();
+    await expect(
+      byName["ui_timeline_set_clip_params"].execute({
+        target: "shot",
+        textStyle: { fontFamily: "Space Grotesk" }
+      })
+    ).rejects.toThrow(/still needs .*(text|color|fontSizePx)/);
+  });
+
   it("refuses a key it does not know, naming the op that does the job", async () => {
     const { byName } = bridge();
     await expect(
@@ -123,6 +198,47 @@ describe("ui_timeline_set_clip_params", () => {
         wobble: 3
       })
     ).rejects.toThrow(/no `wobble` param/);
+  });
+});
+
+/**
+ * `sans-serif` names no typeface: it is whatever the machine drawing the frame
+ * calls its default, so the editor preview, the render and the frame preview
+ * each pick their own. It used to be stored and reported afterwards as a
+ * `font_not_portable` validator warning — one round trip after the title was
+ * already authored.
+ */
+describe("generic font families", () => {
+  it("refuses one on the clip that is being authored", async () => {
+    const { byName } = bridge();
+    await expect(
+      byName["ui_timeline_add_text_clip"].execute({
+        text: "TITLE",
+        fontFamily: "sans-serif"
+      })
+    ).rejects.toThrow(/names no typeface[\s\S]*Space Grotesk/);
+  });
+
+  it("refuses one on a set_clip_params patch as well", async () => {
+    const { byName } = bridge();
+    await byName["ui_timeline_add_text_clip"].execute({ text: "TITLE" });
+    await expect(
+      byName["ui_timeline_set_clip_params"].execute({
+        target: "selected",
+        textStyle: { fontFamily: "system-ui" }
+      })
+    ).rejects.toThrow(/names no typeface/);
+  });
+
+  it("still takes a named system font, which the validator reports instead", async () => {
+    const { byName } = bridge();
+    const result = await byName["ui_timeline_add_text_clip"].execute({
+      text: "TITLE",
+      fontFamily: "Helvetica Neue"
+    });
+    expect(
+      (clipOf(result).textStyle as Record<string, unknown>).fontFamily
+    ).toBe("Helvetica Neue");
   });
 });
 

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -2286,7 +2286,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "get_storyboard",
     module: "storyboards",
     impl: "packages/agents/src/capabilities/storyboards.ts",
-    contract: "a9792020b14a",
+    contract: "23b366075a94",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-storyboards.test.ts",
@@ -2318,7 +2318,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "render_storyboard_clips",
     module: "storyboards",
     impl: "packages/agents/src/capabilities/storyboards.ts",
-    contract: "7cfc44e9c9d6",
+    contract: "63dfa003d0f1",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-storyboards.test.ts",
@@ -2360,7 +2360,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "edit_storyboard",
     module: "storyboards",
     impl: "packages/agents/src/capabilities/storyboards.ts",
-    contract: "9b3c1f3f93a1",
+    contract: "e0a1059b33ed",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-storyboards.test.ts",

--- a/packages/protocol/src/api-schemas/timeline-tool-params.ts
+++ b/packages/protocol/src/api-schemas/timeline-tool-params.ts
@@ -269,6 +269,57 @@ const textBackgroundParams = z
   })
   .strict();
 
+/**
+ * CSS weight keywords, as the number the rasterizer draws with.
+ *
+ * `fontWeight` is a number on the document because that is what a canvas font
+ * shorthand takes, but every caller writes CSS, and `"bold"` came back as a
+ * Zod type error on a title that was otherwise complete. The keywords are
+ * unambiguous, so translating them costs nothing; a weight that is neither a
+ * number nor a keyword is still refused.
+ */
+const FONT_WEIGHT_KEYWORDS: Readonly<Record<string, number>> = {
+  thin: 100,
+  hairline: 100,
+  extralight: 200,
+  ultralight: 200,
+  light: 300,
+  normal: 400,
+  regular: 400,
+  book: 400,
+  medium: 500,
+  semibold: 600,
+  demibold: 600,
+  bold: 700,
+  extrabold: 800,
+  ultrabold: 800,
+  black: 900,
+  heavy: 900
+};
+
+/** A weight written as a word (or a quoted number), as its number. */
+const writtenFontWeight = z
+  .string()
+  .transform((raw) => raw.trim().toLowerCase().replace(/[\s_-]/g, ""))
+  .refine(
+    (key) => FONT_WEIGHT_KEYWORDS[key] !== undefined || isFiniteWeight(key),
+    {
+      message: `not a weight — use a number, or one of: ${Object.keys(FONT_WEIGHT_KEYWORDS).join(", ")}`
+    }
+  )
+  .transform((key) => FONT_WEIGHT_KEYWORDS[key] ?? Number(key));
+
+const isFiniteWeight = (key: string): boolean =>
+  key !== "" && Number.isFinite(Number(key));
+
+/** `fontWeight`, accepting the CSS keyword spellings as well as the number. */
+export const fontWeightParam = z
+  .union([z.number(), writtenFontWeight])
+  .describe(
+    "Numeric weight (400 regular, 600 semibold, 800 extrabold). The CSS " +
+      'keywords ("bold", "semibold", …) are accepted and stored as their number.'
+  );
+
 /** A text clip's whole authored look, as `set_clip_params` replaces it. */
 export const textStyleParams = withFieldNotes(clipTextStyle, {
   fontSizePx: "Font size in sequence pixels, not CSS pixels.",
@@ -295,6 +346,7 @@ export const textStyleParams = withFieldNotes(clipTextStyle, {
    * Only the authoring surface is strict. Widening the document schema would
    * make an already-saved sequence carrying `"center"` fail to save.
    */
+  fontWeight: fontWeightParam.optional(),
   verticalAlign: z
     .enum(["top", "middle", "bottom"])
     .optional()
@@ -355,6 +407,20 @@ export function withTextClipRemedies<TSchema extends z.ZodType>(
 export const partialTextStyleParams = textStyleParams
   .omit({ text: true })
   .partial();
+
+/**
+ * The look as `set_clip_params` takes it: every field optional, merged over
+ * what the clip already carries.
+ *
+ * Changing one field used to mean re-sending the whole style, because
+ * `textStyleParams` requires `text`, `fontSizePx` and `color` — so
+ * `{textStyle: {fontFamily: "Space Grotesk"}}` on a finished title failed
+ * validation, and re-sending the whole object to get past it is how a caller
+ * overwrites the four fields it did not mean to touch. The op merges instead,
+ * and a clip with no text style yet still needs the three required fields
+ * before it draws anything.
+ */
+export const textStylePatchParams = textStyleParams.partial();
 
 /** A shape clip's geometry and fill. */
 export const shapeStyleParams = withFieldNotes(clipShapeStyle, {

--- a/packages/protocol/src/creative.ts
+++ b/packages/protocol/src/creative.ts
@@ -237,7 +237,46 @@ export interface Shot {
    * `"keyframe"`.
    */
   render_mode?: ShotRenderMode;
+  /**
+   * The clip this shot's picture is cut out of, when one generation covers
+   * several shots. Null or absent means the shot renders its own.
+   */
+  covered_by?: ShotCoverage | null;
 }
+
+/**
+ * A shot whose picture is a slice of another shot's clip.
+ *
+ * Video models return a fixed window — one returns 5.184s whatever the shot
+ * was directed at — so a cut whose beats run 1.5-2.2s is rendered as one
+ * generation spanning several of them and split on the timeline. The
+ * generation attaches to the first shot of the run; each of the others names
+ * it here with the window it uses. Without this the siblings sat at
+ * `has_clip: false` for the rest of the session and read as unrendered, and
+ * the default `render_storyboard_clips` selection offered to generate them
+ * again.
+ *
+ * One level only: the shot named by {@link shot_id} must own its clip. A chain
+ * would let a window be measured against a window, and the second hop has no
+ * source length of its own to measure against.
+ */
+export interface ShotCoverage {
+  /** The shot whose `clip` holds this shot's picture. */
+  shot_id: string;
+  /** Where this shot begins inside that clip, in seconds. Defaults to 0. */
+  start_seconds?: number;
+  /**
+   * Where it ends, in seconds. When set it is the shot's length on the
+   * timeline; without it the shot takes its own `duration_seconds`, capped at
+   * what is left of the covering clip.
+   */
+  end_seconds?: number;
+}
+
+/** A shot's coverage, or null when it renders its own picture. */
+export const shotCoverage = (
+  shot: Pick<Shot, "covered_by">
+): ShotCoverage | null => shot.covered_by ?? null;
 
 /** Whether a shot's length follows its linked audio or a pinned user value. */
 export type ShotDurationSource = "audio" | "manual";

--- a/packages/timeline/src/authoredStyles.ts
+++ b/packages/timeline/src/authoredStyles.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_TEXT_CLIP_COLOR,
   DEFAULT_TEXT_CLIP_FONT_SIZE_PX
 } from "./defaults.js";
+import { assertAuthorableFontFamily } from "./fonts/catalog.js";
 import type { ClipShapeStyle, ClipTextStyle } from "./types.js";
 
 /**
@@ -39,6 +40,10 @@ export function textStyleWithDefaults(
   text: string,
   style?: Partial<Omit<ClipTextStyle, "text">>
 ): ClipTextStyle {
+  // A generic CSS family is refused here rather than stored and reported by
+  // the validator afterwards: it names no face, so there is no version of it
+  // that renders the same twice.
+  assertAuthorableFontFamily(style?.fontFamily);
   return {
     ...style,
     text,

--- a/packages/timeline/src/fonts/catalog.ts
+++ b/packages/timeline/src/fonts/catalog.ts
@@ -210,6 +210,60 @@ export interface ResolvedFontFamily {
 }
 
 /**
+ * Generic CSS families: names that select no typeface at all.
+ *
+ * `sans-serif` is not a font, it is "whatever this machine calls its default
+ * sans" — so a title set in it draws in one face in the editor preview,
+ * another in a server render, and a third on the reviewer's laptop. Unlike a
+ * named system font, there is no version of it that is right, which is why
+ * these are refused where a clip is authored rather than reported afterwards
+ * as `font_not_portable`.
+ */
+const GENERIC_FONT_FAMILIES = new Set([
+  "sans-serif",
+  "serif",
+  "monospace",
+  "cursive",
+  "fantasy",
+  "system-ui",
+  "ui-sans-serif",
+  "ui-serif",
+  "ui-monospace",
+  "ui-rounded",
+  "math",
+  "emoji",
+  "fangsong",
+  "-apple-system",
+  "blinkmacsystemfont"
+]);
+
+/**
+ * Why a `fontFamily` cannot be authored as written, or null when it can.
+ *
+ * Only the generics are refused. A named system font stays authorable and is
+ * reported by the timeline validator as `font_not_portable` (D8) — the family
+ * exists somewhere, and pinning it may be exactly what the caller wants.
+ */
+export function fontFamilyRefusal(family: string | undefined): string | null {
+  if (family === undefined) return null;
+  const head = primaryFamilyOf(family);
+  if (!GENERIC_FONT_FAMILIES.has(head.toLowerCase())) return null;
+  return (
+    `"${head}" names no typeface — it is whatever the machine drawing the ` +
+    "frame calls its default, so the editor preview, the render and the " +
+    "agent's frame preview each pick their own. Set a family NodeTool ships: " +
+    `${BUNDLED_FONT_FAMILIES.join(", ")}. Omit fontFamily to get ` +
+    `${DEFAULT_FONT_FAMILY}.`
+  );
+}
+
+/** Throw {@link fontFamilyRefusal} when a family cannot be authored. */
+export function assertAuthorableFontFamily(family: string | undefined): void {
+  const refusal = fontFamilyRefusal(family);
+  if (refusal !== null) throw new Error(refusal);
+}
+
+/**
  * Turn a document's `fontFamily` into the family list every host draws with.
  *
  * A bundled family resolves to itself plus its generic; anything else keeps

--- a/packages/timeline/src/linked.ts
+++ b/packages/timeline/src/linked.ts
@@ -36,10 +36,10 @@ import {
 } from "./script-link.js";
 import {
   SHOT_AUDIO_TRACK_NAME,
-  isAssemblableShot,
   shotAudioClip,
   shotDurationMs,
-  shotSourceDurationMs,
+  shotSource,
+  shotsById,
   type AssembledTimeline,
   type TrimmedShot
 } from "./storyboard.js";
@@ -83,11 +83,13 @@ export function buildLinkedTimeline(
       ? input.script.cast.find((s) => s.id === speakerId)?.name
       : undefined;
 
+  const byId = shotsById(input.shots);
   let cursorMs = 0;
   const trimmedShots: TrimmedShot[] = [];
   for (const shot of ordered) {
     const lineIds = shot.script_line_ids ?? [];
-    if (!isAssemblableShot(shot)) {
+    const source = shotSource(shot, byId);
+    if (!source) {
       skippedShotIds.push(shot.id);
       skippedLineIds.push(...lineIds);
       continue;
@@ -101,7 +103,7 @@ export function buildLinkedTimeline(
     // under `usedMs` is the caller's cue that the picture runs out first.
     const durationMs =
       linkedShotDurationMs(shot, linesById) ?? shotDurationMs(shot);
-    const sourceMs = shotSourceDurationMs(shot);
+    const sourceMs = source.availableMs;
     if (sourceMs !== null && sourceMs !== durationMs) {
       trimmedShots.push({ shotId: shot.id, usedMs: durationMs, sourceMs });
     }
@@ -113,12 +115,19 @@ export function buildLinkedTimeline(
       mediaType: "video",
       sourceType: "imported",
       status: "generated",
-      currentAssetId: shot.clip?.asset_id ?? undefined,
+      currentAssetId: source.assetId,
       linkId: createTimeOrderedUuid(),
       storyboardBoardId: input.boardId,
       storyboardShotId: shot.id,
       versions: []
     });
+    // A covered shot is a slice out of the middle of someone else's
+    // generation, so it needs its window written; a shot playing its own clip
+    // starts at the head and is left exactly as it was.
+    if (source.sourceShotId !== shot.id) {
+      videoClip.inPointMs = source.inPointMs;
+      videoClip.outPointMs = source.inPointMs + durationMs;
+    }
     clips.push(videoClip, shotAudioClip(videoClip, shotAudioTrack.id));
     cursorMs += durationMs;
 

--- a/packages/timeline/src/storyboard.ts
+++ b/packages/timeline/src/storyboard.ts
@@ -145,6 +145,99 @@ export const shotSourceDurationMs = (shot: Shot): number | null => {
     : null;
 };
 
+/** Shots by id, for resolving {@link Shot.covered_by}. */
+export const shotsById = (shots: readonly Shot[]): Map<string, Shot> =>
+  new Map(shots.map((shot) => [shot.id, shot]));
+
+/**
+ * Where a shot's picture comes from: its own clip, or a window into another's.
+ *
+ * Assembly used to read `shot.clip` directly, so a shot covered by a fused
+ * generation had no picture at all and was skipped — the run that hit this
+ * trimmed the fused clips onto the track by hand and the board never caught up.
+ */
+export interface ShotSource {
+  /** The asset the clip plays. */
+  assetId: string;
+  /** The shot that owns it — this shot, unless it is covered. */
+  sourceShotId: string;
+  /** Where this shot starts inside that asset, in ms. */
+  inPointMs: number;
+  /**
+   * Footage available from `inPointMs` on, or null when the asset's length is
+   * unknown and no coverage window pins it.
+   */
+  availableMs: number | null;
+  /** Length the coverage window fixes, when it names an end. */
+  windowMs: number | null;
+}
+
+export interface ShotSourceOptions {
+  /**
+   * Require the shot's lifecycle status to be `rendered`, as assembly does.
+   * The in-editor preview passes false: it plays a selected take while the
+   * board is still working, and its own tests pin that.
+   */
+  requireRendered?: boolean;
+}
+
+/**
+ * Resolve a shot's picture, following {@link Shot.covered_by} one hop.
+ *
+ * Returns null for a shot that has neither its own clip nor a covering shot
+ * that has one — the same shots assembly skipped before.
+ */
+export function shotSource(
+  shot: Shot,
+  byId?: ReadonlyMap<string, Shot>,
+  options?: ShotSourceOptions
+): ShotSource | null {
+  const playable = (candidate: Shot): boolean =>
+    options?.requireRendered === false
+      ? assetIdOf(candidate.clip) !== undefined
+      : isAssemblableShot(candidate);
+  if (playable(shot)) {
+    return {
+      assetId: shot.clip!.asset_id as string,
+      sourceShotId: shot.id,
+      inPointMs: 0,
+      availableMs: shotSourceDurationMs(shot),
+      windowMs: null
+    };
+  }
+  const coverage = shot.covered_by;
+  if (!coverage || !byId) return null;
+  const cover = byId.get(coverage.shot_id);
+  // One hop: a covering shot that is itself covered has no source length to
+  // measure a window against.
+  if (!cover || !playable(cover)) return null;
+  const inPointMs = Math.max(0, Math.round((coverage.start_seconds ?? 0) * 1000));
+  const windowMs =
+    typeof coverage.end_seconds === "number" && coverage.end_seconds > 0
+      ? Math.max(0, Math.round(coverage.end_seconds * 1000) - inPointMs)
+      : null;
+  const coverSourceMs = shotSourceDurationMs(cover);
+  const remainingMs =
+    coverSourceMs === null ? null : Math.max(0, coverSourceMs - inPointMs);
+  const availableMs =
+    windowMs === null
+      ? remainingMs
+      : remainingMs === null
+        ? windowMs
+        : Math.min(windowMs, remainingMs);
+  return {
+    assetId: cover.clip!.asset_id as string,
+    sourceShotId: cover.id,
+    inPointMs,
+    availableMs,
+    windowMs
+  };
+}
+
+/** Whether a shot's picture is a window into another shot's clip. */
+export const isCoveredShot = (shot: Shot): boolean =>
+  !isAssemblableShot(shot) && !!shot.covered_by?.shot_id;
+
 /** How a shot's laid-down length was decided, and what it cost. */
 export interface ShotLayout {
   /** Length on the timeline. */
@@ -166,19 +259,33 @@ export interface ShotLayout {
  * the two never met. Now the window is explicit: a shot keeps its directed
  * length, capped at the footage that exists, and reports what it left on the
  * floor so a caller can re-time deliberately.
+ *
+ * A covered shot is cut out of the middle of someone else's clip, so its
+ * window — not its `duration_seconds` — is what the cut uses when the coverage
+ * names an end. That is the whole point of fusing: the run was directed as one
+ * generation and split at timecodes the caller chose.
  */
-export function layoutShot(shot: Shot): ShotLayout {
-  const intended = shotDurationMs(shot);
-  const source = shotSourceDurationMs(shot);
-  if (source === null) {
-    return { durationMs: intended, unusedSourceMs: 0 };
+export function layoutShot(shot: Shot, source?: ShotSource | null): ShotLayout {
+  const resolved = source === undefined ? shotSource(shot) : source;
+  const intended = resolved?.windowMs ?? shotDurationMs(shot);
+  const available = resolved?.availableMs ?? null;
+  const inPointMs = resolved?.inPointMs ?? 0;
+  if (available === null) {
+    // No source length to fit to. The window is still written when the shot
+    // starts inside someone else's clip, or it would play that clip's head.
+    const layout: ShotLayout = { durationMs: intended, unusedSourceMs: 0 };
+    if (inPointMs > 0) {
+      layout.inPointMs = inPointMs;
+      layout.outPointMs = inPointMs + intended;
+    }
+    return layout;
   }
-  const durationMs = Math.min(intended, source);
+  const durationMs = Math.min(intended, available);
   return {
     durationMs,
-    inPointMs: 0,
-    outPointMs: durationMs,
-    unusedSourceMs: source - durationMs
+    inPointMs,
+    outPointMs: inPointMs + durationMs,
+    unusedSourceMs: available - durationMs
   };
 }
 
@@ -186,9 +293,13 @@ export function buildStoryboardTimeline(
   input: StoryboardAssemblyInput
 ): AssembledTimeline {
   const ordered = [...input.shots].sort((a, b) => a.index - b.index);
-  const assemblable = ordered.filter(isAssemblableShot);
+  const byId = shotsById(input.shots);
+  const sources = new Map(
+    ordered.map((shot) => [shot.id, shotSource(shot, byId)] as const)
+  );
+  const assemblable = ordered.filter((s) => sources.get(s.id) != null);
   const skippedShotIds = ordered
-    .filter((s) => !isAssemblableShot(s))
+    .filter((s) => sources.get(s.id) == null)
     .map((s) => s.id);
 
   const shotTrack = makeTrack({ type: "video", name: "Shots", index: 0 });
@@ -203,7 +314,8 @@ export function buildStoryboardTimeline(
   let cursorMs = 0;
   const trimmedShots: TrimmedShot[] = [];
   for (const shot of assemblable) {
-    const layout = layoutShot(shot);
+    const source = sources.get(shot.id) ?? null;
+    const layout = layoutShot(shot, source);
     const durationMs = layout.durationMs;
     if (layout.unusedSourceMs > 0) {
       trimmedShots.push({
@@ -220,7 +332,7 @@ export function buildStoryboardTimeline(
       mediaType: "video",
       sourceType: "imported",
       status: "generated",
-      currentAssetId: shot.clip?.asset_id ?? undefined,
+      currentAssetId: source?.assetId,
       linkId: createTimeOrderedUuid(),
       storyboardBoardId: input.boardId,
       storyboardShotId: shot.id,
@@ -336,9 +448,11 @@ export function buildStoryboardPreviewTimeline(
   const stillShotIds: string[] = [];
   let hasShotAudio = false;
 
+  const byId = shotsById(input.shots);
   let cursorMs = 0;
   for (const shot of ordered) {
-    const clipAssetId = assetIdOf(shot.clip);
+    const source = shotSource(shot, byId, { requireRendered: false });
+    const clipAssetId = source?.assetId;
     const stillAssetId = clipAssetId ? undefined : assetIdOf(shot.keyframe);
     const assetId = clipAssetId ?? stillAssetId;
     if (!assetId) {
@@ -352,7 +466,7 @@ export function buildStoryboardPreviewTimeline(
     // A held keyframe is a still with no source length of its own; only a
     // real clip gets fitted to its footage.
     const layout: ShotLayout = clipAssetId
-      ? layoutShot(shot)
+      ? layoutShot(shot, source)
       : { durationMs: shotDurationMs(shot), unusedSourceMs: 0 };
     const durationMs = layout.durationMs;
     const shotClip = makeClip({

--- a/packages/timeline/tests/storyboard.test.ts
+++ b/packages/timeline/tests/storyboard.test.ts
@@ -453,3 +453,106 @@ describe("assembly against the footage that came back", () => {
     expect(still.inPointMs).toBeUndefined();
   });
 });
+
+// ── Fused shots (Shot.covered_by) ─────────────────────────────────────
+//
+// A model that renders a fixed 5.184s window covers several 1.5-2.2s beats in
+// one generation. The clip lands on the first shot of the run; the rest name
+// it in `covered_by` with the slice they use. Before this they assembled as
+// nothing and had to be trimmed onto the track by hand.
+
+describe("covered shots", () => {
+  const fused = (): Shot[] => [
+    makeShot({
+      id: "event",
+      index: 0,
+      status: "rendered",
+      duration_seconds: 2.5,
+      clip: { type: "video", asset_id: "fused", duration: 5.184 }
+    }),
+    makeShot({
+      id: "reception",
+      index: 1,
+      status: "rendered",
+      covered_by: { shot_id: "event", start_seconds: 2.5, end_seconds: 5.184 }
+    })
+  ];
+
+  it("cuts the covered shot out of the covering shot's clip", () => {
+    const result = buildStoryboardTimeline({ boardId: "b", shots: fused() });
+    const picture = pictureClips(result.clips);
+
+    expect(result.skippedShotIds).toEqual([]);
+    expect(picture.map((c) => c.currentAssetId)).toEqual(["fused", "fused"]);
+    expect(picture[0]).toMatchObject({
+      startMs: 0,
+      durationMs: 2500,
+      inPointMs: 0,
+      outPointMs: 2500
+    });
+    expect(picture[1]).toMatchObject({
+      startMs: 2500,
+      durationMs: 2684,
+      inPointMs: 2500,
+      outPointMs: 5184
+    });
+    expect(result.durationMs).toBe(5184);
+  });
+
+  it("runs to the end of the covering clip when no end is named", () => {
+    const shots = fused();
+    shots[1].covered_by = { shot_id: "event", start_seconds: 2.5 };
+    shots[1].duration_seconds = 10;
+    const picture = pictureClips(
+      buildStoryboardTimeline({ boardId: "b", shots }).clips
+    );
+
+    // 10s was asked for and 2.684s of footage is left: the window caps it.
+    expect(picture[1]).toMatchObject({
+      durationMs: 2684,
+      inPointMs: 2500,
+      outPointMs: 5184
+    });
+  });
+
+  it("skips a shot whose covering shot never rendered", () => {
+    const shots = fused();
+    delete shots[0].clip;
+    shots[0].status = "keyframe_ready";
+    const result = buildStoryboardTimeline({ boardId: "b", shots });
+
+    expect(result.skippedShotIds).toEqual(["event", "reception"]);
+    expect(pictureClips(result.clips)).toHaveLength(0);
+  });
+
+  it("refuses to follow a second hop", () => {
+    const shots = fused();
+    shots.push(
+      makeShot({
+        id: "third",
+        index: 2,
+        status: "rendered",
+        covered_by: { shot_id: "reception", start_seconds: 0 }
+      })
+    );
+    const result = buildStoryboardTimeline({ boardId: "b", shots });
+
+    expect(result.skippedShotIds).toEqual(["third"]);
+  });
+
+  it("plays the covered shot in the editor preview too", () => {
+    const result = buildStoryboardPreviewTimeline({
+      boardId: "b",
+      shots: fused()
+    });
+    const picture = pictureClips(result.clips);
+
+    expect(result.skippedShotIds).toEqual([]);
+    expect(picture).toHaveLength(2);
+    expect(picture[1]).toMatchObject({
+      mediaType: "video",
+      currentAssetId: "fused",
+      inPointMs: 2500
+    });
+  });
+});

--- a/web/src/components/storyboard/ShotStatusPill.tsx
+++ b/web/src/components/storyboard/ShotStatusPill.tsx
@@ -55,6 +55,11 @@ export const shotPill = (
   if (shot.clip) {
     return null;
   }
+  // A shot fused into a sibling's generation has its picture but no clip of
+  // its own, and a card that says "still" reads as a shot nobody has rendered.
+  if (shot.covered_by) {
+    return { tone: "neutral", label: "covered" };
+  }
   if (shot.keyframe) {
     const clipQueued = jobStatus === "queued" || jobStatus === "running";
     return clipQueued

--- a/web/src/components/storyboard/__tests__/ShotStatusPill.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotStatusPill.test.tsx
@@ -60,6 +60,31 @@ describe("shotPill", () => {
       label: "still"
     });
   });
+
+  // A shot fused into a sibling's generation has its picture but no clip of
+  // its own. "still" reads as a shot nobody has rendered yet, which is what
+  // sent a finished cut back round for a second render.
+  it("says a shot is covered rather than still waiting on a clip", () => {
+    expect(
+      shotPill(
+        makeShot({
+          status: "rendered",
+          covered_by: { shot_id: "shot-0", start_seconds: 2.5 }
+        })
+      )
+    ).toEqual({ tone: "neutral", label: "covered" });
+  });
+
+  it("says nothing for a shot that has its own clip, covered or not", () => {
+    expect(
+      shotPill(
+        makeShot({
+          status: "rendered",
+          clip: { type: "video", uri: "http://example.com/clip.mp4" }
+        })
+      )
+    ).toBeNull();
+  });
 });
 
 describe("ShotStatusPill", () => {

--- a/web/src/components/timeline/timelineAgentBridge.ts
+++ b/web/src/components/timeline/timelineAgentBridge.ts
@@ -220,7 +220,8 @@ interface TimelineClipParamsPatch {
   hidden?: boolean;
   muted?: boolean;
   locked?: boolean;
-  textStyle?: TimelineTextStyle;
+  /** Merged over the clip's own style — a partial patch, not a replacement. */
+  textStyle?: Partial<TimelineTextStyle>;
   shapeStyle?: TimelineShapeStyle;
   captionStyle?: TimelineCaptionStyle;
 }

--- a/web/src/hooks/timeline/useTimelineAgentBridge.ts
+++ b/web/src/hooks/timeline/useTimelineAgentBridge.ts
@@ -700,7 +700,14 @@ export const useTimelineAgentBridge = (sequenceId: string | null): void => {
         if (patch.hidden !== undefined) next.hidden = patch.hidden;
         if (patch.muted !== undefined) next.muted = patch.muted;
         if (patch.locked !== undefined) next.locked = patch.locked;
-        if (patch.textStyle !== undefined) next.textStyle = patch.textStyle;
+        if (patch.textStyle !== undefined) {
+          // A patch over the clip's own style, so changing one field does not
+          // mean re-sending (and overwriting) the whole bag.
+          next.textStyle = textStyleWithDefaults(
+            patch.textStyle.text ?? clip.textStyle?.text ?? clip.name,
+            { ...clip.textStyle, ...patch.textStyle }
+          );
+        }
         if (patch.shapeStyle !== undefined) {
           next.shapeStyle = shapeStyleWithDefaults(patch.shapeStyle);
         }

--- a/web/src/lib/tools/builtin/timeline.ts
+++ b/web/src/lib/tools/builtin/timeline.ts
@@ -35,7 +35,7 @@ import {
   setTimeRemapParams,
   shapeStyleParams,
   targetParam,
-  textStyleParams,
+  textStylePatchParams,
   transitionParams
 } from "@nodetool-ai/protocol/api-schemas/timeline-tool-params.js";
 import { FrontendToolRegistry } from "../frontendTools";
@@ -417,7 +417,7 @@ FrontendToolRegistry.register({
 FrontendToolRegistry.register({
   name: "ui_timeline_set_clip_params",
   description:
-    "Change a clip's render/audio params: `name`, `opacity` (0..1), `speedMultiplier` (0.1..8), `volumeDb`, `fadeInMs`, `fadeOutMs`, `blendMode`, `borderRadius`, `hidden`, `muted`, `locked`, a text clip's `textStyle`, a shape clip's `shapeStyle`, or a caption clip's `captionStyle`. Omit a field to leave it unchanged.",
+    "Change a clip's render/audio params: `name`, `opacity` (0..1), `speedMultiplier` (0.1..8), `volumeDb`, `fadeInMs`, `fadeOutMs`, `blendMode`, `borderRadius`, `hidden`, `muted`, `locked`, a text clip's `textStyle`, a shape clip's `shapeStyle`, or a caption clip's `captionStyle`. `textStyle` is merged over the clip's own, so send only the fields you are changing. Omit a field to leave it unchanged.",
   parameters: z.object({
     timeline_id: timelineIdParam,
     target: targetParam,
@@ -432,7 +432,7 @@ FrontendToolRegistry.register({
     hidden: z.boolean().optional(),
     muted: z.boolean().optional(),
     locked: z.boolean().optional(),
-    textStyle: textStyleParams.optional(),
+    textStyle: textStylePatchParams.optional(),
     shapeStyle: shapeStyleParams.optional(),
     captionStyle: captionStyleParams.optional()
   }),


### PR DESCRIPTION
## What changed

Four capability surfaces refused, dropped, or obscured a call that meant something real during a 30s teaser build, each costing a round trip or a second render. **Storyboard fused shots**: a video model returns a fixed window (5.184s) whatever the shot was directed at, so a cut whose beats run 1.5–2.5s gets rendered as one generation covering a run of shots — the clip lands on one shot and the siblings had no way to say so, sitting at `has_clip: false`, assembling as nothing, and being offered up for a second render. `Shot.covered_by {shot_id, start_seconds?, end_seconds?}` records the split, so the covered shot reads as rendered, both render selections skip it, and assembly lays it down as that window of the covering clip. **Script voices**: `get_script` reports a speaker's voice as one object, so writing it back into `set_speaker_voice` sent that object and was refused with a message listing the three keys it had just supplied — it is flattened now, and a half-specified `voice_script_lines` override says what `voice` is and where to set it once. **`set_clip_params`**: a patch nested under `params` is lifted onto the op, `textStyle` merges over the clip's own instead of demanding the whole bag, and `fontWeight` takes the CSS keywords. **Generic font families**: `sans-serif` names no typeface, so it used to be stored and reported one round trip later as `font_not_portable`; it is refused where the clip is authored, naming the bundled families. The four constraints with no tool fix — quantized clip length, moderation on institutional violence, hard silence in a score, speech that outruns its picture beat — are written up in the `storyboard-core` skill.

## Verification

```
npm run test:affected      # only failure: @nodetool-ai/image-nodes (no Vulkan ICD in
                           # this container, per AGENTS.md § dev-environment)
npm run typecheck          # web + electron clean; mobile fails on missing
                           # mobile/node_modules, identical on the base commit
npm run lint               # 0 errors
npm run dev:nodetool -- harness gate --base origin/main   # Gate: 8/8 selfchecks passed
```

Package suites run in full: `packages/timeline` 666 passed, `packages/agents` 4210 passed, `packages/protocol` 1083 passed, `packages/execution` 442 passed. Web: 173 passed across the 10 suites related to the changed files.

Four package suites fail in this container and fail identically on the base commit — `image-nodes` and `base-nodes` need a Vulkan driver for the WebGPU shader nodes, `runtime` and `video-nodes` need `ffmpeg`. Confirmed pre-existing by stashing the diff and re-running `packages/runtime/tests/providers/video-frame-fallback.test.ts` (`Error: spawn ffmpeg ENOENT` either way).

New tests inverted and observed failing:

- Inverting `shotHasPicture` back to `!!shot.clip` fails `reads a covered shot back as rendered, with its window` and `does not offer a covered shot up for another render` (2 failed / 32 passed). The second assertion was sharpened after the first inversion showed it passing: it now asserts nothing is *selected* (`results: []` plus the "No shot is ready for a clip" note) rather than that nothing was rendered, since a selected-then-failed render also reports `rendered: 0`.

## Agent capabilities

- [x] `npm run capabilities:check` passes — `npm run capabilities:sync` regenerated the contract hashes for `get_storyboard`, `render_storyboard_clips` and `edit_storyboard`, whose declared input schemas and descriptions changed.
- [x] All three already name `capability-suites` and the `packages/agents/tests/capabilities-storyboards.test.ts` suite, which this PR extends with the five fused-shot cases.

## New checks

The one new refusal is `assertAuthorableFontFamily`, which rejects a generic CSS family where a text clip is authored. It is covered three ways in `packages/agents/tests/timeline-op-ergonomics.test.ts`: it refuses on `add_text_clip`, refuses on a `set_clip_params` patch, and — the case that proves it is not matching everything — still *accepts* a named system font (`Helvetica Neue`), which stays authorable and is reported by the timeline validator as `font_not_portable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017L8c1snkJEcfr669Nev4so

---
_Generated by [Claude Code](https://claude.ai/code/session_017L8c1snkJEcfr669Nev4so)_