### PR TITLE
fix(chat): stop the conversation panning sideways on a phone

### DIFF
--- a/web/src/components/chat/containers/WelcomePlaceholder.tsx
+++ b/web/src/components/chat/containers/WelcomePlaceholder.tsx
@@ -12,6 +12,7 @@ import {
   BORDER_RADIUS,
   MOTION,
   SPACING,
+  SPACING_PX,
   getSpacingPx
 } from "../../ui_primitives";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
@@ -31,6 +32,9 @@ const styles = (theme: Theme) =>
     minHeight: 0,
     width: "100%",
     overflowY: "auto",
+    // `overflowY` alone leaves the other axis at `auto`, which lets a phone
+    // pan the welcome screen sideways.
+    overflowX: "hidden",
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
@@ -77,7 +81,26 @@ const styles = (theme: Theme) =>
       flexWrap: "wrap",
       justifyContent: "center",
       gap: getSpacingPx(SPACING.md),
-      marginTop: getSpacingPx(SPACING.xs)
+      marginTop: getSpacingPx(SPACING.xs),
+      // A chip's label does not wrap, so on a phone the longest opener is
+      // wider than the column and pushes the whole screen sideways.
+      maxWidth: "100%"
+    },
+
+    // Rather than ellipsing the opener away on a narrow screen, let it run
+    // onto a second line.
+    ".suggestions .MuiChip-root": {
+      height: "auto",
+      minHeight: `${SPACING_PX.xxxl}px`,
+      maxWidth: "100%"
+    },
+
+    ".suggestions .MuiChip-label": {
+      whiteSpace: "normal",
+      overflow: "visible",
+      textOverflow: "clip",
+      paddingTop: getSpacingPx(SPACING.xs),
+      paddingBottom: getSpacingPx(SPACING.xs)
     }
   });
 
@@ -155,7 +178,7 @@ const WelcomePlaceholder: React.FC<WelcomePlaceholderProps> = ({
   const noProvider = !isLoading && !error && providers.length === 0;
 
   return (
-    <div css={cssStyles}>
+    <div css={cssStyles} className="chat-welcome">
       <div className="welcome-inner">
         {noProvider ? (
           <FlexColumn align="center" gap={SPACING.sm} sx={{ textAlign: "center" }}>

--- a/web/src/components/chat/thread/ChatThreadView.styles.ts
+++ b/web/src/components/chat/thread/ChatThreadView.styles.ts
@@ -36,6 +36,11 @@ export const createStyles = (theme: Theme) => ({
     justifyContent: "flex-start",
     alignItems: "center",
     overflowY: "auto",
+    // Without this the axis computes to `auto` alongside `overflowY`, and a
+    // single wide turn lets a phone pan the whole conversation sideways.
+    // Content that genuinely needs the width (code blocks, tables, JSON
+    // dumps) scrolls inside its own box.
+    overflowX: "hidden",
     overflowAnchor: "none",
     padding: theme.spacing(2, 0),
     marginTop: 0,
@@ -78,6 +83,15 @@ export const createStyles = (theme: Theme) => ({
       flexDirection: "column",
       alignItems: "flex-start",
       gap: theme.spacing(1)
+    },
+    // The turn's body. `.chat-message` aligns its children to the start, so
+    // without a width this box takes its content's min-content size — an
+    // unbreakable URL or a wide table then makes the turn wider than the
+    // column instead of wrapping or scrolling inside it.
+    ".message-body": {
+      width: "100%",
+      minWidth: 0,
+      maxWidth: "100%"
     },
     ".chat-message.assistant": {
       padding: theme.spacing(3, 4),

--- a/web/tests/journeys/mobile-chat.spec.ts
+++ b/web/tests/journeys/mobile-chat.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Journey: the chat on a phone.
+ *
+ * A conversation scrolls up and down, never sideways. Content that genuinely
+ * needs the width — a code block, a table, a JSON dump — scrolls inside its
+ * own box; the thread itself stays put. Both checks drive the real surface at
+ * phone width and try to pan it, so a layout regression that widens a turn
+ * fails here rather than on someone's phone.
+ */
+
+import { test, expect, FIXTURES } from "./fixtures";
+import { ChatPage } from "./pages";
+
+test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
+
+/** What a real answer puts in a turn: an unbreakable URL, a wide table, a long command. */
+const WIDE_MARKDOWN = [
+  "https://example.com/a/very/long/path/that/never/breaks/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "",
+  "| column one | column two | column three | column four | column five | column six |",
+  "| --- | --- | --- | --- | --- | --- |",
+  "| aaaaaaaaaa | bbbbbbbbbb | cccccccccc | dddddddddd | eeeeeeeeee | ffffffffff |",
+  "",
+  "```sh",
+  "docker run --rm -it --name nodetool --network host -e NODETOOL_API_URL=https://api.example.com/v1/endpoint ghcr.io/example/nodetool:latest",
+  "```"
+].join("\\n");
+
+/** Text in the seeded assistant turn this suite rewrites into `WIDE_MARKDOWN`. */
+const SEEDED_TAIL = "That night, they dreamed together.";
+
+/** Try to pan `selector` right; report where it actually ended up. */
+async function pan(page: import("@playwright/test").Page, selector: string) {
+  return page.evaluate((sel) => {
+    const el = document.querySelector(sel) as HTMLElement | null;
+    if (!el) {
+      throw new Error(`no element for ${sel}`);
+    }
+    el.scrollLeft = 500;
+    return {
+      scrollLeft: el.scrollLeft,
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth
+    };
+  }, selector);
+}
+
+test.describe("Chat on a phone", () => {
+  test("a turn wider than the column does not pan the conversation", async ({
+    page
+  }) => {
+    // The fixture backend has no model configured, so the wide turn is
+    // injected into the seeded history rather than sent.
+    await page.route("**/trpc/**", async (route) => {
+      const response = await route.fetch();
+      const body = await response.text();
+      return route.fulfill({
+        response,
+        body: body.includes(SEEDED_TAIL)
+          ? body.replace(SEEDED_TAIL, WIDE_MARKDOWN)
+          : body
+      });
+    });
+
+    const chat = new ChatPage(page);
+    await page.goto(`/chat/${FIXTURES.thread}`, {
+      waitUntil: "domcontentloaded"
+    });
+    await chat.waitForMessage("column three");
+    // The fenced block is the last thing in the injected turn — once it is on
+    // screen the turn has finished laying out and the widths are stable.
+    await page
+      .locator(".code-block-content")
+      .waitFor({ state: "visible", timeout: 30_000 });
+
+    const thread = await pan(page, ".scrollable-message-wrapper");
+    expect(thread.scrollLeft, "the conversation panned sideways").toBe(0);
+    expect(thread.scrollWidth).toBeLessThanOrEqual(thread.clientWidth);
+
+    // The code block keeps its own horizontal scroll — locking the thread
+    // must not make wide content unreachable.
+    const code = await pan(page, ".code-block-content");
+    expect(code.scrollWidth).toBeGreaterThan(code.clientWidth);
+    expect(code.scrollLeft).toBeGreaterThan(0);
+  });
+
+  // 320px is the narrowest phone still in use; the longest opener chip is
+  // wider than the column there, which is where the screen used to pan.
+  test("the welcome screen does not pan sideways", async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 780 });
+    await page.goto("/chat/thread-mobile-welcome", {
+      waitUntil: "domcontentloaded"
+    });
+    const welcome = page.locator(".chat-welcome");
+    await welcome.waitFor({ state: "visible", timeout: 30_000 });
+
+    const screen = await pan(page, ".chat-welcome");
+    expect(screen.scrollLeft, "the welcome screen panned sideways").toBe(0);
+    expect(screen.scrollWidth).toBeLessThanOrEqual(screen.clientWidth);
+  });
+});


### PR DESCRIPTION
## What changed

At phone width the chat thread could be dragged sideways. Two causes, both in the chat rework. `.message-body` — the wrapper now around every turn — carries no style rule, so as a flex item of `.chat-message` (`align-items: flex-start`) it takes its content's min-content size: one unbreakable URL made the turn 673px wide inside a 325px column, and the thread's scroller then panned 360px. It now fills the column and clamps to it, which also lets the URL wrap instead of widening the turn. Separately, `.scrollable-message-wrapper` set only `overflowY: auto`, which leaves the other axis at `auto` — so any overflow at all became a horizontal pan. Locking it costs nothing, because code blocks, tables and JSON dumps each scroll inside their own box. The welcome screen had the same pair: its longest opener chip does not wrap, and at 320px it overran the column and panned the screen 32px, so the chip label now wraps and that screen's axis is locked too.

`web/tests/journeys/mobile-chat.spec.ts` drives both surfaces at phone width, injects a turn with a long URL, a wide table and a long command, and tries to pan them.

## Verification

- [x] `npm run test:affected` — 205 suites, 1795 passed, 3 skipped
- [x] `npm run typecheck` — web and electron clean; mobile fails on missing `mobile/node_modules` (no mobile files touched, pre-existing in this environment)
- [x] `npm run lint` — 0 errors
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — 3 files touch `web-editor`, 0 selfchecks to run
- [x] `npx playwright test -c playwright.journeys.config.ts mobile-chat` — 2 passed

New check inverted against the pre-fix code (`git stash` of both source files):

```
✘  Chat on a phone › a turn wider than the column does not pan the conversation
   Error: the conversation panned sideways
   Expected: 0
   Received: 360
```

The welcome check's condition, measured on the same pre-fix tree at 320px: `{"scrollLeft":32,"scrollWidth":304,"clientWidth":272}`.

## Agent capabilities

No capability added or re-declared.

## New checks

- [x] The check was inverted once and observed failing; the failing output is above
- [x] Not an audit — it asserts on measured geometry from the real surface, and throws if the element it measures is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBuThTiVLayPtrzoxwfU2b

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBuThTiVLayPtrzoxwfU2b)_