### PR TITLE
fix(storyboard): assemble the timeline at each clip's rendered length

### DIFF
--- a/.claude/skills/storyboard-core/references/tool-contract.md
+++ b/.claude/skills/storyboard-core/references/tool-contract.md
@@ -78,8 +78,8 @@ shot of the run, then tell the board which slice each sibling uses:
 The covered shot then reads `has_clip: true` with `status: "rendered"`, is skipped by
 `render_storyboard_clips` (so it is never generated twice), and
 `assemble_storyboard_timeline` lays it down as that window of the covering clip
-instead of skipping it. Without `end_seconds` it runs to the end of the covering clip,
-capped at its own `duration_seconds`.
+instead of skipping it, and the covering shot ends where the first covered shot takes
+over. Without `end_seconds` the covered shot runs to the end of the covering clip.
 
 One hop only: `shot_id` must name a shot that owns its clip, not another covered shot.
 Removing the covering shot clears the coverage and reports which shots it uncovered.
@@ -179,6 +179,14 @@ do not pre-season shot text with it.
 board and shot id, and gives every shot clip an **audio twin on a "Shot Audio" track**
 (each surface mutes video elements and mixes audio clips only). Board narration and
 music become draft clips on their own tracks.
+
+**Each shot is as long as its render**, not as long as its `duration_seconds` — a shot
+directed at 1.5s that came back at 5.184s occupies 5.184s of the cut. Shots that came
+back off their directed length are returned in `retimed_shots` and warned about, so a
+cut that runs longer than planned is visible without playing it. `duration_seconds`
+only decides a shot whose footage has no measurable length. A board linked to a script
+is the exception: there the words decide, and `trimmed_shots` names the shots whose
+footage does not fill the slot its lines gave it.
 
 `edit_timeline {timeline_id, ops[]}` ops: `get_state`, `add_track`, `add_media_clip`,
 `add_text_clip`, `add_shape_clip`, `split_clip`, `trim_clip`, `move_clip`,

--- a/packages/agents/src/capabilities/storyboards.ts
+++ b/packages/agents/src/capabilities/storyboards.ts
@@ -1081,9 +1081,25 @@ const assembleStoryboardTimeline: CapabilityExport = {
     const skippedLineIds =
       "skippedLineIds" in assembled ? assembled.skippedLineIds : [];
     // A model returns the length it returns: shots directed at 1.5s come back
-    // at 5.2s, and the cut then shows each shot's head. Saying which shots
-    // that happened to, and by how much, is what turns a silent mismatch into
-    // a decision the caller can make.
+    // at 5.2s, and the cut plays all of it. Saying which shots came back off
+    // the length they were directed at turns a film longer than the caller
+    // planned into a decision they can make.
+    if (assembled.retimedShots.length > 0) {
+      const worst = assembled.retimedShots.reduce((a, b) =>
+        Math.abs(b.directedMs - b.usedMs) > Math.abs(a.directedMs - a.usedMs)
+          ? b
+          : a
+      );
+      warnings.push(
+        `${assembled.retimedShots.length} shot(s) run at their rendered length, not the length they were directed at — ` +
+          `the largest difference is ${Math.round(Math.abs(worst.directedMs - worst.usedMs))}ms on shot ${worst.shotId} ` +
+          `(${worst.usedMs}ms in the cut, ${worst.directedMs}ms directed). ` +
+          `Re-render with a duration the model honours, or trim the clips in the timeline.`
+      );
+    }
+    // A jointly assembled cut takes its lengths from the words, so a shot can
+    // sit in a slot its footage does not fill: black under the voiceover, or a
+    // render the cut never reaches the end of.
     if (assembled.trimmedShots.length > 0) {
       const worst = assembled.trimmedShots.reduce((a, b) =>
         Math.abs(b.sourceMs - b.usedMs) > Math.abs(a.sourceMs - a.usedMs)
@@ -1094,7 +1110,7 @@ const assembleStoryboardTimeline: CapabilityExport = {
         `${assembled.trimmedShots.length} shot(s) do not match their rendered footage — ` +
           `the longest gap is ${Math.round(Math.abs(worst.sourceMs - worst.usedMs))}ms on shot ${worst.shotId} ` +
           `(${worst.usedMs}ms in the cut, ${worst.sourceMs}ms rendered). ` +
-          `Re-time the clips, or set each shot's duration_seconds to the length its model produces.`
+          `Re-render those shots at the length their lines need.`
       );
     }
     if (assembled.clips.length === 0) {
@@ -1162,7 +1178,8 @@ const assembleStoryboardTimeline: CapabilityExport = {
         script_id: script ? scriptId : null,
         skipped_shot_ids: assembled.skippedShotIds,
         skipped_line_ids: skippedLineIds,
-        trimmed_shots: assembled.trimmedShots
+        trimmed_shots: assembled.trimmedShots,
+        retimed_shots: assembled.retimedShots
       };
       if (warnings.length) {
         created.warnings = warnings;
@@ -1246,7 +1263,8 @@ const assembleStoryboardTimeline: CapabilityExport = {
         script_id: script ? scriptId : null,
         skipped_shot_ids: assembled.skippedShotIds,
         skipped_line_ids: skippedLineIds,
-        trimmed_shots: assembled.trimmedShots
+        trimmed_shots: assembled.trimmedShots,
+        retimed_shots: assembled.retimedShots
       };
       if (warnings.length) {
         result.warnings = warnings;

--- a/packages/agents/tests/capabilities-storyboards.test.ts
+++ b/packages/agents/tests/capabilities-storyboards.test.ts
@@ -709,6 +709,45 @@ describe("storyboards capability behaviour", () => {
     });
   });
 
+  it("cuts each shot at its rendered length and says which came back off plan", async () => {
+    // A video model returns the length it returns: a shot directed at 1.5s
+    // comes back at 5.184s. The cut plays all of it, and the caller is told
+    // rather than left to discover a film three times the length they planned.
+    const board = await makeBoard([
+      shot({
+        id: "s1",
+        index: 0,
+        status: "rendered",
+        duration_seconds: 1.5,
+        clip: { type: "video", asset_id: "clip-s1", duration: 5.184 }
+      })
+    ]);
+
+    const assembled = (await run(ctx()).invoke(
+      "assemble_storyboard_timeline",
+      { storyboard_id: board.id }
+    )) as {
+      timeline_id: string;
+      duration_ms: number;
+      retimed_shots: Array<{ shotId: string; usedMs: number; directedMs: number }>;
+      warnings?: string[];
+    };
+
+    expect(assembled.duration_ms).toBe(5184);
+    expect(assembled.retimed_shots).toEqual([
+      { shotId: "s1", usedMs: 5184, directedMs: 1500 }
+    ]);
+    expect(assembled.warnings?.join(" ")).toContain("rendered length");
+
+    const document = (await sequenceOf(assembled.timeline_id)).toDocument();
+    expect(
+      document.clips.map((c) => [c.mediaType, c.durationMs])
+    ).toEqual([
+      ["video", 5184],
+      ["audio", 5184]
+    ]);
+  });
+
   it("cuts a linked board against the script's takes", async () => {
     const script = await makeVoicedScript();
     const board = await makeBoard(

--- a/packages/timeline/src/linked.ts
+++ b/packages/timeline/src/linked.ts
@@ -4,10 +4,11 @@
  * The two documents keep their jobs — the board owns the picture, the script
  * owns the words — and this is where they meet. Shots lay out end to end as in
  * `buildStoryboardTimeline`, but each one is as long as the takes it covers
- * (`linkedShotDurationMs`), and every voiced line gets its own clip on the
- * voiceover track, parked where its words fall inside the shot. Each shot also
- * keeps the sound of its own rendered clip, on the shot-audio track
- * `buildStoryboardTimeline` uses. The whole-cut narration draft clip is gone:
+ * (`linkedShotDurationMs`) — falling back to its own footage, as an unlinked
+ * cut does, when the words say nothing about it — and every voiced line gets
+ * its own clip on the voiceover track, parked where its words fall inside the
+ * shot. Each shot also keeps the sound of its own rendered clip, on the
+ * shot-audio track `buildStoryboardTimeline` uses. The whole-cut narration draft clip is gone:
  * the script says the words now, so a prompt spanning the cut would be a
  * second, competing answer.
  *
@@ -38,8 +39,7 @@ import {
   SHOT_AUDIO_TRACK_NAME,
   shotAudioClip,
   shotDurationMs,
-  shotSource,
-  shotsById,
+  shotSources,
   type AssembledTimeline,
   type TrimmedShot
 } from "./storyboard.js";
@@ -83,12 +83,12 @@ export function buildLinkedTimeline(
       ? input.script.cast.find((s) => s.id === speakerId)?.name
       : undefined;
 
-  const byId = shotsById(input.shots);
+  const sources = shotSources(input.shots);
   let cursorMs = 0;
   const trimmedShots: TrimmedShot[] = [];
   for (const shot of ordered) {
     const lineIds = shot.script_line_ids ?? [];
-    const source = shotSource(shot, byId);
+    const source = sources.get(shot.id) ?? null;
     if (!source) {
       skippedShotIds.push(shot.id);
       skippedLineIds.push(...lineIds);
@@ -101,8 +101,12 @@ export function buildLinkedTimeline(
     // imposed. A shot whose render is shorter than its lines still shows up in
     // `trimmedShots` with a negative headroom of its own kind: `sourceMs`
     // under `usedMs` is the caller's cue that the picture runs out first.
+    // A shot the words say nothing about falls back to its footage, as an
+    // unlinked cut does, and only then to the length it was directed at.
     const durationMs =
-      linkedShotDurationMs(shot, linesById) ?? shotDurationMs(shot);
+      linkedShotDurationMs(shot, linesById) ??
+      source.availableMs ??
+      shotDurationMs(shot);
     const sourceMs = source.availableMs;
     if (sourceMs !== null && sourceMs !== durationMs) {
       trimmedShots.push({ shotId: shot.id, usedMs: durationMs, sourceMs });
@@ -198,6 +202,9 @@ export function buildLinkedTimeline(
     durationMs: cursorMs,
     skippedShotIds,
     skippedLineIds,
-    trimmedShots
+    trimmedShots,
+    // Nothing is reported as retimed: a linked shot is meant to run as long
+    // as its lines, so differing from `duration_seconds` is the point.
+    retimedShots: []
   };
 }

--- a/packages/timeline/src/storyboard.ts
+++ b/packages/timeline/src/storyboard.ts
@@ -7,12 +7,13 @@
  * the same cut the editor would have produced.
  *
  * Rendered shots become imported, asset-backed video clips laid end to end in
- * shot order, each stamped with `storyboardBoardId`/`storyboardShotId` so a
- * later shot revision can round-trip into the cut. Every shot clip also gets an
- * audio twin on its own track (`shotAudioClip`), because the preview and the
- * export mute video elements and take sound only from audio clips. Narration
- * and music become draft text-to-audio clips on their own tracks — the
- * timeline's generation machinery renders them on demand.
+ * shot order, each as long as the footage it holds, and each stamped with
+ * `storyboardBoardId`/`storyboardShotId` so a later shot revision can
+ * round-trip into the cut. Every shot clip also gets an audio twin on its own
+ * track (`shotAudioClip`), because the preview and the export mute video
+ * elements and take sound only from audio clips. Narration and music become
+ * draft text-to-audio clips on their own tracks — the timeline's generation
+ * machinery renders them on demand.
  *
  * `buildStoryboardPreviewTimeline` is the same mapping for the in-editor
  * player, where a board that is only half rendered still has to play.
@@ -101,21 +102,37 @@ export interface AssembledTimeline {
   /** Shots skipped because they have no persisted clip asset. */
   skippedShotIds: string[];
   /**
-   * Shots whose render is longer than the direction asked for, and by how
-   * much. The cut takes the head of each and leaves the rest; saying so is
-   * what lets a caller re-time on purpose instead of discovering it in
-   * playback.
+   * Shots whose place in the cut is not the length of the footage they hold.
+   * Empty for a plain storyboard cut, which lays every shot down at its
+   * rendered length; a jointly assembled cut fills it, because there the
+   * words decide how long a shot runs.
    */
   trimmedShots: TrimmedShot[];
+  /**
+   * Shots laid down at a length other than the one they were directed at, and
+   * what each was directed at. A model returns the length it returns: saying
+   * which shots came back off-plan is what lets a caller re-render or re-time
+   * on purpose instead of discovering it in playback.
+   */
+  retimedShots: RetimedShot[];
 }
 
-/** A shot whose source footage outruns its place in the cut. */
+/** A shot whose source footage does not match its place in the cut. */
 export interface TrimmedShot {
   shotId: string;
   /** Length used on the timeline. */
   usedMs: number;
   /** Length of the rendered source. */
   sourceMs: number;
+}
+
+/** A shot whose length in the cut is not the length it was directed at. */
+export interface RetimedShot {
+  shotId: string;
+  /** Length used on the timeline. */
+  usedMs: number;
+  /** Length `duration_seconds` asked for, or the default. */
+  directedMs: number;
 }
 
 /** A shot is assemblable when its clip landed as a persisted asset. */
@@ -168,7 +185,11 @@ export interface ShotSource {
    * unknown and no coverage window pins it.
    */
   availableMs: number | null;
-  /** Length the coverage window fixes, when it names an end. */
+  /**
+   * Length somebody's window fixes rather than the direction: the coverage
+   * window when this shot is covered, the point another shot cuts into this
+   * one's clip when it is not. Null when nothing but the shot itself decides.
+   */
   windowMs: number | null;
 }
 
@@ -179,6 +200,50 @@ export interface ShotSourceOptions {
    * board is still working, and its own tests pin that.
    */
   requireRendered?: boolean;
+  /**
+   * Where another shot cuts into each clip, from {@link coverageClaims}. A
+   * shot that owns a fused generation plays only up to the first slice
+   * somebody else took out of it.
+   */
+  claims?: ReadonlyMap<string, number>;
+}
+
+/** Whether a shot has a clip of its own to play, under a caller's bar. */
+const playableShot = (shot: Shot, options?: ShotSourceOptions): boolean =>
+  options?.requireRendered === false
+    ? assetIdOf(shot.clip) !== undefined
+    : isAssemblableShot(shot);
+
+/**
+ * The earliest point another shot cuts into each shot's clip.
+ *
+ * A fused generation lands on the first shot of the run and the rest name it
+ * in `covered_by`. Its owner holds the whole asset, so a cut that laid it down
+ * at its full length would play the whole run and then play the covered slices
+ * again after it. The claim is where the owner's own picture ends.
+ */
+export function coverageClaims(
+  shots: readonly Shot[],
+  options?: ShotSourceOptions
+): Map<string, number> {
+  const claims = new Map<string, number>();
+  for (const shot of shots) {
+    const coveringId = shot.covered_by?.shot_id;
+    // A shot with a clip of its own plays it and never reaches its coverage,
+    // so it takes nothing out of the covering shot.
+    if (!coveringId || coveringId === shot.id || playableShot(shot, options)) {
+      continue;
+    }
+    const startMs = Math.max(
+      0,
+      Math.round((shot.covered_by?.start_seconds ?? 0) * 1000)
+    );
+    const claimed = claims.get(coveringId);
+    if (claimed === undefined || startMs < claimed) {
+      claims.set(coveringId, startMs);
+    }
+  }
+  return claims;
 }
 
 /**
@@ -193,16 +258,22 @@ export function shotSource(
   options?: ShotSourceOptions
 ): ShotSource | null {
   const playable = (candidate: Shot): boolean =>
-    options?.requireRendered === false
-      ? assetIdOf(candidate.clip) !== undefined
-      : isAssemblableShot(candidate);
+    playableShot(candidate, options);
   if (playable(shot)) {
+    const sourceMs = shotSourceDurationMs(shot);
+    // The head of the clip, when other shots cover the rest of it.
+    const claimMs = options?.claims?.get(shot.id) ?? null;
     return {
       assetId: shot.clip!.asset_id as string,
       sourceShotId: shot.id,
       inPointMs: 0,
-      availableMs: shotSourceDurationMs(shot),
-      windowMs: null
+      availableMs:
+        claimMs === null
+          ? sourceMs
+          : sourceMs === null
+            ? claimMs
+            : Math.min(sourceMs, claimMs),
+      windowMs: claimMs
     };
   }
   const coverage = shot.covered_by;
@@ -234,58 +305,73 @@ export function shotSource(
   };
 }
 
+/**
+ * Every shot's picture in one pass: the coverage claims are computed once and
+ * shared, so resolving a board is linear in the number of shots.
+ */
+export function shotSources(
+  shots: readonly Shot[],
+  options?: ShotSourceOptions
+): Map<string, ShotSource | null> {
+  const byId = shotsById(shots);
+  const resolveOptions: ShotSourceOptions = {
+    ...options,
+    claims: coverageClaims(shots, options)
+  };
+  return new Map(
+    shots.map((shot) => [shot.id, shotSource(shot, byId, resolveOptions)])
+  );
+}
+
 /** Whether a shot's picture is a window into another shot's clip. */
 export const isCoveredShot = (shot: Shot): boolean =>
   !isAssemblableShot(shot) && !!shot.covered_by?.shot_id;
 
-/** How a shot's laid-down length was decided, and what it cost. */
+/** How a shot's laid-down length was decided. */
 export interface ShotLayout {
   /** Length on the timeline. */
   durationMs: number;
   /** Explicit source window, set whenever the source length is known. */
   inPointMs?: number;
   outPointMs?: number;
-  /** Footage the cut leaves unused, in ms. Zero when nothing was discarded. */
-  unusedSourceMs: number;
+  /** Length the shot was directed at: `duration_seconds`, or the default. */
+  directedMs: number;
 }
 
 /**
- * Fit a shot's directed length to the footage that came back.
+ * Lay a shot down at the length of the footage that came back.
  *
- * A video model returns what it returns: eight shots directed at 1.0–3.5s all
- * rendered as 5.184s. Assembly used to write the directed length and nothing
- * else, so each clip played its source's head and dropped the remainder with
- * no in/out point to show for it — the cut said 1.5s, the media was 5.2s, and
- * the two never met. Now the window is explicit: a shot keeps its directed
- * length, capped at the footage that exists, and reports what it left on the
- * floor so a caller can re-time deliberately.
+ * A video model returns what it returns: eight shots directed at 1.0-3.5s all
+ * rendered as 5.184s. Assembly used to cut each clip down to its directed
+ * length, so most of every render was discarded before anyone saw it. The
+ * render is the picture, so it is the clip: a shot whose source length is
+ * known plays all of it, and `duration_seconds` only decides the length of a
+ * shot whose footage cannot be measured.
  *
  * A covered shot is cut out of the middle of someone else's clip, so its
- * window — not its `duration_seconds` — is what the cut uses when the coverage
- * names an end. That is the whole point of fusing: the run was directed as one
- * generation and split at timecodes the caller chose.
+ * coverage window is the footage it has — `shotSource` already folds the
+ * window into `availableMs` — and that window is what it plays.
  */
 export function layoutShot(shot: Shot, source?: ShotSource | null): ShotLayout {
   const resolved = source === undefined ? shotSource(shot) : source;
-  const intended = resolved?.windowMs ?? shotDurationMs(shot);
   const available = resolved?.availableMs ?? null;
   const inPointMs = resolved?.inPointMs ?? 0;
+  const directedMs = shotDurationMs(shot);
   if (available === null) {
-    // No source length to fit to. The window is still written when the shot
+    // No source length to lay down. The window is still written when the shot
     // starts inside someone else's clip, or it would play that clip's head.
-    const layout: ShotLayout = { durationMs: intended, unusedSourceMs: 0 };
+    const layout: ShotLayout = { durationMs: directedMs, directedMs };
     if (inPointMs > 0) {
       layout.inPointMs = inPointMs;
-      layout.outPointMs = inPointMs + intended;
+      layout.outPointMs = inPointMs + directedMs;
     }
     return layout;
   }
-  const durationMs = Math.min(intended, available);
   return {
-    durationMs,
+    durationMs: available,
     inPointMs,
-    outPointMs: inPointMs + durationMs,
-    unusedSourceMs: available - durationMs
+    outPointMs: inPointMs + available,
+    directedMs
   };
 }
 
@@ -293,10 +379,7 @@ export function buildStoryboardTimeline(
   input: StoryboardAssemblyInput
 ): AssembledTimeline {
   const ordered = [...input.shots].sort((a, b) => a.index - b.index);
-  const byId = shotsById(input.shots);
-  const sources = new Map(
-    ordered.map((shot) => [shot.id, shotSource(shot, byId)] as const)
-  );
+  const sources = shotSources(input.shots);
   const assemblable = ordered.filter((s) => sources.get(s.id) != null);
   const skippedShotIds = ordered
     .filter((s) => sources.get(s.id) == null)
@@ -312,16 +395,19 @@ export function buildStoryboardTimeline(
   const clips: TimelineClip[] = [];
 
   let cursorMs = 0;
-  const trimmedShots: TrimmedShot[] = [];
+  const retimedShots: RetimedShot[] = [];
   for (const shot of assemblable) {
     const source = sources.get(shot.id) ?? null;
     const layout = layoutShot(shot, source);
     const durationMs = layout.durationMs;
-    if (layout.unusedSourceMs > 0) {
-      trimmedShots.push({
+    // A shot cut to a coverage window is exactly as long as the caller asked
+    // for when they split the generation; only a shot playing a clip of its
+    // own can come back off the length it was directed at.
+    if (source?.windowMs === null && durationMs !== layout.directedMs) {
+      retimedShots.push({
         shotId: shot.id,
         usedMs: durationMs,
-        sourceMs: durationMs + layout.unusedSourceMs
+        directedMs: layout.directedMs
       });
     }
     const videoClip = makeClip({
@@ -399,7 +485,16 @@ export function buildStoryboardTimeline(
     );
   }
 
-  return { tracks, clips, durationMs: cursorMs, skippedShotIds, trimmedShots };
+  return {
+    tracks,
+    clips,
+    durationMs: cursorMs,
+    skippedShotIds,
+    // Nothing is trimmed: every shot is laid down at the length of the
+    // footage it holds, so no clip leaves any of its render unplayed.
+    trimmedShots: [],
+    retimedShots
+  };
 }
 
 export interface StoryboardPreviewInput {
@@ -448,10 +543,10 @@ export function buildStoryboardPreviewTimeline(
   const stillShotIds: string[] = [];
   let hasShotAudio = false;
 
-  const byId = shotsById(input.shots);
+  const sources = shotSources(input.shots, { requireRendered: false });
   let cursorMs = 0;
   for (const shot of ordered) {
-    const source = shotSource(shot, byId, { requireRendered: false });
+    const source = sources.get(shot.id) ?? null;
     const clipAssetId = source?.assetId;
     const stillAssetId = clipAssetId ? undefined : assetIdOf(shot.keyframe);
     const assetId = clipAssetId ?? stillAssetId;
@@ -465,9 +560,10 @@ export function buildStoryboardPreviewTimeline(
 
     // A held keyframe is a still with no source length of its own; only a
     // real clip gets fitted to its footage.
+    const directedMs = shotDurationMs(shot);
     const layout: ShotLayout = clipAssetId
       ? layoutShot(shot, source)
-      : { durationMs: shotDurationMs(shot), unusedSourceMs: 0 };
+      : { durationMs: directedMs, directedMs };
     const durationMs = layout.durationMs;
     const shotClip = makeClip({
       trackId: shotTrack.id,

--- a/packages/timeline/tests/storyboard.test.ts
+++ b/packages/timeline/tests/storyboard.test.ts
@@ -345,9 +345,9 @@ describe("buildStoryboardPreviewTimeline", () => {
 // ── rendered length vs directed length ────────────────────────────────
 //
 // Reproduction of the shipped failure: eight shots directed at 1.0–3.5s all
-// came back from the model at 5.184s, and assembly laid down the directed
-// length with no in/out point — so every clip played its source's head and
-// discarded the rest without saying so.
+// came back from the model at 5.184s, and assembly cut every clip down to the
+// directed length — so the cut played each render's head and discarded the
+// rest. The footage that came back is the picture, so it is the clip.
 
 describe("assembly against the footage that came back", () => {
   const renderedShot = (
@@ -367,17 +367,19 @@ describe("assembly against the footage that came back", () => {
           : { type: "video", asset_id: `asset-${id}`, duration: sourceSeconds }
     });
 
-  it("writes an explicit source window and reports the unused footage", () => {
+  it("plays the whole render of a shot that came back long", () => {
     const result = buildStoryboardTimeline({
       boardId: "board-1",
       shots: [renderedShot("a", 0, 1.5, 5.184)]
     });
     const [picture] = pictureClips(result.clips);
-    expect(picture.durationMs).toBe(1500);
+    expect(picture.durationMs).toBe(5184);
     expect(picture.inPointMs).toBe(0);
-    expect(picture.outPointMs).toBe(1500);
-    expect(result.trimmedShots).toEqual([
-      { shotId: "a", usedMs: 1500, sourceMs: 5184 }
+    expect(picture.outPointMs).toBe(5184);
+    expect(result.durationMs).toBe(5184);
+    expect(result.trimmedShots).toEqual([]);
+    expect(result.retimedShots).toEqual([
+      { shotId: "a", usedMs: 5184, directedMs: 1500 }
     ]);
   });
 
@@ -389,10 +391,21 @@ describe("assembly against the footage that came back", () => {
     const [picture] = pictureClips(result.clips);
     expect(picture.durationMs).toBe(5184);
     expect(result.durationMs).toBe(5184);
-    expect(result.trimmedShots).toEqual([]);
+    expect(result.retimedShots).toEqual([
+      { shotId: "a", usedMs: 5184, directedMs: 8000 }
+    ]);
   });
 
-  it("leaves a shot whose source length is unknown exactly as before", () => {
+  it("says nothing about a render that matches its direction", () => {
+    const result = buildStoryboardTimeline({
+      boardId: "board-1",
+      shots: [renderedShot("a", 0, 5.184, 5.184)]
+    });
+    expect(pictureClips(result.clips)[0].durationMs).toBe(5184);
+    expect(result.retimedShots).toEqual([]);
+  });
+
+  it("falls back to the directed length when the source length is unknown", () => {
     const result = buildStoryboardTimeline({
       boardId: "board-1",
       shots: [renderedShot("a", 0, 1.5)]
@@ -400,7 +413,7 @@ describe("assembly against the footage that came back", () => {
     const [picture] = pictureClips(result.clips);
     expect(picture.durationMs).toBe(1500);
     expect(picture.inPointMs).toBeUndefined();
-    expect(result.trimmedShots).toEqual([]);
+    expect(result.retimedShots).toEqual([]);
   });
 
   it("keeps the audio twin on the same window as its picture", () => {
@@ -410,7 +423,7 @@ describe("assembly against the footage that came back", () => {
     });
     const audio = result.clips.filter((c) => c.mediaType === "audio");
     expect(audio).toHaveLength(1);
-    expect(audio[0].durationMs).toBe(1500);
+    expect(audio[0].durationMs).toBe(5184);
   });
 
   it("lays the whole board end to end without gaps or overlaps", () => {
@@ -418,22 +431,22 @@ describe("assembly against the footage that came back", () => {
       boardId: "board-1",
       shots: [
         renderedShot("a", 0, 1.5, 5.184),
-        renderedShot("b", 1, 1.0, 5.184),
-        renderedShot("c", 2, 2.0, 5.184)
+        renderedShot("b", 1, 1.0, 2.0),
+        renderedShot("c", 2, 2.0, 3.5)
       ]
     });
     expect(pictureClips(result.clips).map((c) => [c.startMs, c.durationMs])).toEqual(
       [
-        [0, 1500],
-        [1500, 1000],
-        [2500, 2000]
+        [0, 5184],
+        [5184, 2000],
+        [7184, 3500]
       ]
     );
-    expect(result.durationMs).toBe(4500);
-    expect(result.trimmedShots).toHaveLength(3);
+    expect(result.durationMs).toBe(10684);
+    expect(result.retimedShots).toHaveLength(3);
   });
 
-  it("fits a preview clip to its footage too, and leaves stills alone", () => {
+  it("plays a preview clip at its footage length, and leaves stills alone", () => {
     const result = buildStoryboardPreviewTimeline({
       boardId: "board-1",
       shots: [
@@ -497,6 +510,28 @@ describe("covered shots", () => {
       outPointMs: 5184
     });
     expect(result.durationMs).toBe(5184);
+  });
+
+  it("ends the covering shot where the covered one takes over", () => {
+    // The claim decides, not the direction: the owner holds the whole fused
+    // asset, so laying it down at its rendered length would play the run
+    // once and then play the covered slices again after it.
+    const shots = fused();
+    shots[0].duration_seconds = 1;
+    const result = buildStoryboardTimeline({ boardId: "b", shots });
+    const picture = pictureClips(result.clips);
+
+    expect(picture[0]).toMatchObject({
+      startMs: 0,
+      durationMs: 2500,
+      inPointMs: 0,
+      outPointMs: 2500
+    });
+    expect(picture[1]).toMatchObject({ startMs: 2500, durationMs: 2684 });
+    expect(result.durationMs).toBe(5184);
+    // Neither shot's length came from `duration_seconds`, so neither is a
+    // shot that came back off the length it was directed at.
+    expect(result.retimedShots).toEqual([]);
   });
 
   it("runs to the end of the covering clip when no end is named", () => {


### PR DESCRIPTION
## What changed

Storyboard assembly cut every clip down to the shot's `duration_seconds`, so a shot directed at 1.5s that a video model returned at 5.184s played only its first 1.5s and the rest of the render was discarded. `layoutShot` now lays a shot down at the length of the footage it holds whenever that length is known; `duration_seconds` only decides a shot whose footage cannot be measured. Shots that came back off their directed length are reported as `retimedShots` (`retimed_shots` on `assemble_storyboard_timeline`) and warned about, so a cut that runs longer than planned is visible without playing it. That change needed a matching cap for fused generations: the shot that owns a fused clip now ends where the first covered shot takes over (`coverageClaims`), instead of playing the whole run and then playing the covered slices again after it — `shotSources` resolves a board in one pass so those claims are computed once rather than per shot. A board linked to a script is unchanged (the words still decide shot length), except that a shot the words say nothing about now falls back to its footage before its directed length.

## Verification

- [x] `npm run test:affected` — passes except two failures that reproduce on a clean tree in this container: `@nodetool-ai/document-nodes` (entry not resolvable until its own dist is built) and `@nodetool-ai/video-nodes#timeline-time-remap-decode` (no ffmpeg on PATH here). Both verified by stashing the diff and re-running. The directly affected suites are green: `@nodetool-ai/timeline` 704 passed, `@nodetool-ai/agents` 4240 passed, `@nodetool-ai/execution` 442 passed, plus the web storyboard suites (255 passed).
- [x] `npm run typecheck` — web and electron pass; the mobile leg fails on missing `mobile/node_modules` (`react-native`, `expo`), which predates this diff.
- [x] `npm run lint` — 0 errors on the changed files (12 pre-existing unused-var warnings in `packages/agents/src/capabilities/storyboards.ts`).
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — `Gate: 4/4 selfchecks passed`.

New assertions were inverted to prove they can fail: with `coverageClaims` stubbed to an empty map, `packages/timeline/tests/storyboard.test.ts` reports

```
× cuts the covered shot out of the covering shot's clip
× ends the covering shot where the covered one takes over
Tests  2 failed | 25 passed (27)
```

and restoring it returns 27 passed.

## Agent capabilities

`assemble_storyboard_timeline` keeps its name, description, input schema and permission category. Its result gains `retimed_shots` alongside `trimmed_shots`, covered by a new case in `packages/agents/tests/capabilities-storyboards.test.ts` ("cuts each shot at its rendered length and says which came back off plan"), which asserts the clip lengths in the persisted sequence, the `retimed_shots` rows and the warning.

## New checks

No new check, rule, or audit — the added tests pin behavior rather than gate a diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HweELL4ARPmMaLMeWBU5Yo

---
_Generated by [Claude Code](https://claude.ai/code/session_01HweELL4ARPmMaLMeWBU5Yo)_