### PR TITLE
feat(assets): keep the prompt and generation settings on generated assets

### DIFF
--- a/packages/kernel/src/actor.ts
+++ b/packages/kernel/src/actor.ts
@@ -186,12 +186,32 @@ export interface ActorResult {
 }
 
 /**
- * Pick the scalar input properties (string/number/boolean) from a resolved
- * input dict. Drops nested objects, arrays, and binary refs so the
- * `generation_complete` event stays small and carries only persistable
- * generation params (prompt, seed, model, …). Reserved keys (`_control_context`
- * and other `_`-prefixed internals) are stripped. Returns `null` when nothing
- * scalar remains.
+ * A resolved model property (`{type: "image_model", id, name, provider}`),
+ * reduced to the fields that identify it. Which model ran is the one
+ * generation setting that is never a scalar, and without it a saved asset
+ * cannot say what produced it.
+ */
+function modelReference(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const ref = value as Record<string, unknown>;
+  if (!isString(ref.type) || !ref.type.endsWith("_model")) return null;
+  if (!isString(ref.id) || ref.id.length === 0) return null;
+  const out: Record<string, unknown> = { type: ref.type, id: ref.id };
+  if (isString(ref.name)) out.name = ref.name;
+  if (isString(ref.provider)) out.provider = ref.provider;
+  return out;
+}
+
+/**
+ * Pick the persistable input properties from a resolved input dict: scalars
+ * (string/number/boolean) plus model references, reduced by
+ * {@link modelReference}. Drops every other nested object, array and binary
+ * ref so the `generation_complete` event stays small and carries only
+ * generation params (prompt, seed, model, …). Reserved keys
+ * (`_control_context` and other `_`-prefixed internals) are stripped. Returns
+ * `null` when nothing remains.
  */
 function scalarInputProperties(
   inputs: Record<string, unknown>
@@ -205,7 +225,10 @@ function scalarInputProperties(
       isBoolean(value)
     ) {
       out[key] = value;
+      continue;
     }
+    const model = modelReference(value);
+    if (model) out[key] = model;
   }
   return Object.keys(out).length > 0 ? out : null;
 }
@@ -2059,9 +2082,10 @@ export class NodeActor {
       node_name: this.node.name ?? this.node.type,
       node_type: this.node.type,
       outputs,
-      // Resolved scalar inputs (prompt, seed, model, …) ride along so the relay
-      // can persist them into auto-saved asset metadata. Filtered to scalars to
-      // keep the event small — binary refs and nested objects are dropped.
+      // Resolved inputs (prompt, seed, model, …) ride along so the relay can
+      // persist them into auto-saved asset metadata. Filtered to scalars plus
+      // model references to keep the event small — binary refs and every other
+      // nested object are dropped.
       properties: inputs ? scalarInputProperties(inputs) : null
       // NO job_id, NO index — the runner relay stamps them downstream.
     });

--- a/packages/kernel/tests/actor-mutation-kills.test.ts
+++ b/packages/kernel/tests/actor-mutation-kills.test.ts
@@ -170,6 +170,42 @@ describe("generation_complete properties — scalar filter", () => {
     });
   });
 
+  it("carries the model reference, reduced to what identifies it", async () => {
+    // Which model ran is the one generation setting that is never a scalar,
+    // and the auto-save stamps it onto the asset so a variant can re-run it.
+    const node = makeNode({
+      properties: {
+        prompt: "a red fox",
+        model: {
+          type: "image_model",
+          id: "fal-ai/flux/dev",
+          name: "FLUX.1 [dev]",
+          provider: "fal",
+          supported_tasks: ["text_to_image"]
+        },
+        image: { type: "image", uri: "asset://x" },
+        folder: { type: "folder", id: "f-1" }
+      }
+    });
+    const { actor, messages } = createActor(node, new NodeInbox(), {
+      async process() {
+        return { image: "bytes" };
+      }
+    });
+
+    await actor.run();
+
+    expect(generationCompletes(messages)[0].properties).toEqual({
+      prompt: "a red fox",
+      model: {
+        type: "image_model",
+        id: "fal-ai/flux/dev",
+        name: "FLUX.1 [dev]",
+        provider: "fal"
+      }
+    });
+  });
+
   it("reports null (not an empty object) when no input is scalar", async () => {
     // Arrange
     const node = makeNode({

--- a/packages/protocol/src/asset-generation.ts
+++ b/packages/protocol/src/asset-generation.ts
@@ -1,0 +1,185 @@
+/**
+ * What produced a generated asset, kept on the asset row itself.
+ *
+ * An asset that came out of a model is only reproducible if the prompt and the
+ * settings travel with it: the ledger row that recorded the call is a separate
+ * table with its own retention, and a workflow can be edited after the run. So
+ * both write paths — the generation seam in `runtime` and the workflow
+ * auto-save in `websocket` — stamp the same shape here, and the asset viewer
+ * reads it back to show the prompt and to seed a variant.
+ */
+
+/** Char cap for the prompt stored on an asset. */
+export const ASSET_PROMPT_MAX_CHARS = 8_000;
+
+/** Char cap for any one string setting. */
+export const ASSET_PARAM_MAX_CHARS = 1_000;
+
+/** How many settings are kept; the rest are dropped. */
+export const ASSET_PARAM_MAX_KEYS = 40;
+
+/** Settings that are plumbing, not generation parameters. */
+const IGNORED_PARAM_KEYS = new Set([
+  "prompt",
+  "background",
+  "output_file",
+  "input_file",
+  "reference_files",
+  "signal"
+]);
+
+/** The model and settings one generation ran with. */
+export interface AssetGenerationSettings {
+  /** Provider id that ran the call ("fal", "openai", …). */
+  provider?: string;
+  /** Model id passed to the provider. */
+  model?: string;
+  /** Display name of the model, when the caller had one. */
+  model_name?: string;
+  /** Provider capability the call used ("text_to_image", …). */
+  capability?: string;
+  /** Node type that produced the asset, for a workflow run. */
+  node_type?: string;
+  /** Remaining settings: seed, resolution, guidance, voice, … */
+  params?: Record<string, string | number | boolean | Array<string | number | boolean>>;
+}
+
+/** The asset-metadata fields this feature owns. */
+export interface AssetGenerationMetadata {
+  /** The prompt, capped at {@link ASSET_PROMPT_MAX_CHARS}. */
+  prompt?: string;
+  generation?: AssetGenerationSettings;
+}
+
+type ParamValue = string | number | boolean | Array<string | number | boolean>;
+
+function isText(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isBool(value: unknown): value is boolean {
+  return typeof value === "boolean";
+}
+
+function isScalar(value: unknown): value is string | number | boolean {
+  return isBool(value) || isText(value) || isFiniteNumber(value);
+}
+
+function isScalarArray(
+  value: unknown
+): value is Array<string | number | boolean> {
+  return Array.isArray(value) && value.length > 0 && value.every(isScalar);
+}
+
+function capString(value: string, max: number): string {
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+/**
+ * Keep a setting only if it survives a round trip through the asset row: a
+ * scalar, or an array of them. Bytes, streams, abort signals and nested
+ * request objects are not settings and are dropped rather than truncated.
+ */
+function paramValue(value: unknown): ParamValue | null {
+  if (isText(value)) return text(value) ?? null;
+  if (isBool(value)) return value;
+  if (isFiniteNumber(value)) return value;
+  if (isScalarArray(value)) {
+    return value.map((item) =>
+      isText(item) ? capString(item, ASSET_PARAM_MAX_CHARS) : item
+    );
+  }
+  return null;
+}
+
+/** Non-empty trimmed string, capped; undefined when there is nothing to keep. */
+function text(value: unknown, max = ASSET_PARAM_MAX_CHARS): string | undefined {
+  if (!isText(value)) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? capString(trimmed, max) : undefined;
+}
+
+export interface AssetGenerationInput {
+  prompt?: unknown;
+  provider?: unknown;
+  model?: unknown;
+  modelName?: unknown;
+  capability?: unknown;
+  nodeType?: unknown;
+  params?: Record<string, unknown> | null;
+}
+
+/**
+ * Build the metadata fragment for one generated asset. Returns `{}` when
+ * nothing worth keeping was passed, so a caller can spread it unconditionally.
+ */
+export function buildAssetGenerationMetadata(
+  input: AssetGenerationInput
+): AssetGenerationMetadata {
+  const settings: AssetGenerationSettings = {};
+  const provider = text(input.provider);
+  const model = text(input.model);
+  const modelName = text(input.modelName);
+  const capability = text(input.capability);
+  const nodeType = text(input.nodeType);
+  if (provider) settings.provider = provider;
+  if (model) settings.model = model;
+  if (modelName && modelName !== model) settings.model_name = modelName;
+  if (capability) settings.capability = capability;
+  if (nodeType) settings.node_type = nodeType;
+
+  const params: Record<string, ParamValue> = {};
+  for (const [key, raw] of Object.entries(input.params ?? {})) {
+    if (key.startsWith("_") || IGNORED_PARAM_KEYS.has(key)) continue;
+    if (Object.keys(params).length >= ASSET_PARAM_MAX_KEYS) break;
+    const value = paramValue(raw);
+    if (value !== null) params[key] = value;
+  }
+  if (Object.keys(params).length > 0) settings.params = params;
+
+  const out: AssetGenerationMetadata = {};
+  const prompt = text(input.prompt, ASSET_PROMPT_MAX_CHARS);
+  if (prompt) out.prompt = prompt;
+  if (Object.keys(settings).length > 0) out.generation = settings;
+  return out;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Read the prompt and settings back off an asset's metadata bag. Everything is
+ * re-validated: the row is JSON written by an older build or by a caller that
+ * put its own keys there.
+ */
+export function readAssetGenerationMetadata(
+  metadata: unknown
+): AssetGenerationMetadata {
+  if (!isRecord(metadata)) return {};
+  const out: AssetGenerationMetadata = {};
+  const prompt = text(metadata.prompt, ASSET_PROMPT_MAX_CHARS);
+  if (prompt) out.prompt = prompt;
+
+  const generation = metadata.generation;
+  if (!isRecord(generation)) return out;
+  const settings: AssetGenerationSettings = {};
+  for (const key of ["provider", "model", "model_name", "capability", "node_type"] as const) {
+    const value = text(generation[key]);
+    if (value) settings[key] = value;
+  }
+  if (isRecord(generation.params)) {
+    const params: Record<string, ParamValue> = {};
+    for (const [key, raw] of Object.entries(generation.params)) {
+      const value = paramValue(raw);
+      if (value !== null) params[key] = value;
+    }
+    if (Object.keys(params).length > 0) settings.params = params;
+  }
+  if (Object.keys(settings).length > 0) out.generation = settings;
+  return out;
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -40,6 +40,7 @@ export * from "./skill-document.js";
 export * from "./wasm-binary.js";
 export * from "./resource-id.js";
 export * from "./game-assets.js";
+export * from "./asset-generation.js";
 export {
   type Platform,
   type NodeEffect,

--- a/packages/protocol/tests/asset-generation.test.ts
+++ b/packages/protocol/tests/asset-generation.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The prompt and settings a generated asset carries. Both write paths (the
+ * runtime generation seam, the workflow auto-save) build the fragment here, so
+ * what one writes the asset viewer reads back unchanged.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  ASSET_PARAM_MAX_CHARS,
+  ASSET_PARAM_MAX_KEYS,
+  ASSET_PROMPT_MAX_CHARS,
+  buildAssetGenerationMetadata,
+  readAssetGenerationMetadata
+} from "../src/asset-generation.js";
+
+describe("buildAssetGenerationMetadata", () => {
+  it("keeps the prompt, the model and the scalar settings", () => {
+    expect(
+      buildAssetGenerationMetadata({
+        prompt: "  a fox in snow  ",
+        provider: "fal",
+        model: "fal-ai/flux/dev",
+        modelName: "FLUX.1 [dev]",
+        capability: "text_to_image",
+        params: {
+          prompt: "a fox in snow",
+          width: 1024,
+          height: 1024,
+          seed: 42,
+          raw: true,
+          loras: ["a", "b"]
+        }
+      })
+    ).toEqual({
+      prompt: "a fox in snow",
+      generation: {
+        provider: "fal",
+        model: "fal-ai/flux/dev",
+        model_name: "FLUX.1 [dev]",
+        capability: "text_to_image",
+        params: {
+          width: 1024,
+          height: 1024,
+          seed: 42,
+          raw: true,
+          loras: ["a", "b"]
+        }
+      }
+    });
+  });
+
+  it("drops what cannot be re-run: bytes, nested objects, internals, plumbing", () => {
+    const { generation } = buildAssetGenerationMetadata({
+      provider: "fal",
+      model: "m",
+      params: {
+        images: [new Uint8Array([1, 2, 3])],
+        image: { bytes: 40 },
+        signal: new AbortController().signal,
+        _tool_call_id: "call-1",
+        output_file: "out.png",
+        background: true,
+        empty: "   ",
+        nan: Number.NaN,
+        steps: 30
+      }
+    });
+    expect(generation?.params).toEqual({ steps: 30 });
+  });
+
+  it("caps the prompt, each string setting, and the number of settings", () => {
+    const params: Record<string, unknown> = {
+      style: "s".repeat(ASSET_PARAM_MAX_CHARS + 100)
+    };
+    for (let i = 0; i < ASSET_PARAM_MAX_KEYS + 10; i += 1) {
+      params[`k${i}`] = i;
+    }
+    const meta = buildAssetGenerationMetadata({
+      prompt: "p".repeat(ASSET_PROMPT_MAX_CHARS + 100),
+      params
+    });
+    expect(meta.prompt).toHaveLength(ASSET_PROMPT_MAX_CHARS);
+    expect(meta.generation?.params?.style).toHaveLength(ASSET_PARAM_MAX_CHARS);
+    expect(Object.keys(meta.generation?.params ?? {})).toHaveLength(
+      ASSET_PARAM_MAX_KEYS
+    );
+  });
+
+  it("omits the model name when it repeats the id, and answers {} with nothing to keep", () => {
+    expect(
+      buildAssetGenerationMetadata({ model: "m", modelName: "m" }).generation
+    ).toEqual({ model: "m" });
+    expect(buildAssetGenerationMetadata({ prompt: "  ", params: {} })).toEqual({});
+    expect(buildAssetGenerationMetadata({ prompt: 42, params: null })).toEqual({});
+  });
+});
+
+describe("readAssetGenerationMetadata", () => {
+  it("round-trips what the builder wrote", () => {
+    const built = buildAssetGenerationMetadata({
+      prompt: "a fox",
+      provider: "fal",
+      model: "m",
+      nodeType: "nodetool.image.TextToImage",
+      params: { seed: 7 }
+    });
+    expect(readAssetGenerationMetadata(built)).toEqual(built);
+  });
+
+  it("ignores unrelated metadata and re-validates a hand-written row", () => {
+    expect(
+      readAssetGenerationMetadata({
+        generation_id: "g-1",
+        generation_index: 3,
+        prompt: "a fox"
+      })
+    ).toEqual({ prompt: "a fox" });
+
+    expect(
+      readAssetGenerationMetadata({
+        generation: { model: 42, provider: "fal", params: { bad: { a: 1 }, seed: 7 } }
+      })
+    ).toEqual({ generation: { provider: "fal", params: { seed: 7 } } });
+
+    for (const value of [null, undefined, "x", 5, ["a"]]) {
+      expect(readAssetGenerationMetadata(value)).toEqual({});
+    }
+  });
+});

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -18,6 +18,7 @@ import type {
   ProviderCost
 } from "@nodetool-ai/protocol";
 import {
+  buildAssetGenerationMetadata,
   isShortResourceId,
   packageAssetHttpPath,
   parsePackageAssetUri
@@ -3718,6 +3719,17 @@ export class ProcessingContext {
   ): Promise<AssetRef[]> {
     if (!this.hasModelInterface("createAsset")) return [];
     const assets: AssetRef[] = [];
+    // The prompt and settings ride on the asset, not only on the ledger row:
+    // the row has its own retention and lives in another table, while the
+    // asset is what somebody opens weeks later to make a variant.
+    const provenance = buildAssetGenerationMetadata({
+      prompt: req.params?.prompt,
+      provider: req.provider,
+      model: req.model,
+      capability: req.capability,
+      params: req.params
+    });
+    const metadata = { generation_id: id, ...provenance };
     for (const [index, bytes] of buffers.entries()) {
       const mime =
         req.persist?.mime ?? mimeOverride ?? generationMime(req.capability, bytes);
@@ -3733,7 +3745,7 @@ export class ProcessingContext {
           content: bytes,
           parentId: req.persist?.parentId ?? null,
           nodeId: req.nodeId ?? null,
-          metadata: { generation_id: id }
+          metadata: { ...metadata }
         });
         const assetId =
           isRecord(created) && typeof created.id === "string"
@@ -3744,7 +3756,7 @@ export class ProcessingContext {
           type: assetRefType(mime),
           uri: `asset://${assetId}.${ext}`,
           asset_id: assetId,
-          metadata: { generation_id: id }
+          metadata: { ...metadata }
         });
       } catch (error) {
         // The generation happened and was billed; a failed save must not turn

--- a/packages/runtime/tests/generation-seam.test.ts
+++ b/packages/runtime/tests/generation-seam.test.ts
@@ -126,16 +126,61 @@ describe("runGeneration", () => {
     expect(created).toHaveLength(1);
     expect(created[0].name).toBe("fox.png");
     expect(created[0].contentType).toBe("image/png");
-    expect(created[0].metadata).toEqual({ generation_id: result.id });
+    expect(created[0].metadata).toEqual({
+      generation_id: result.id,
+      prompt: "x",
+      generation: { provider: "fake", model: "m", capability: "text_to_image" }
+    });
     expect(result.assets).toEqual([
       {
         type: "image",
         uri: "asset://asset-1.png",
         asset_id: "asset-1",
-        metadata: { generation_id: result.id }
+        metadata: {
+          generation_id: result.id,
+          prompt: "x",
+          generation: { provider: "fake", model: "m", capability: "text_to_image" }
+        }
       }
     ]);
     expect(predictions(ctx)[1].asset_ids).toEqual(["asset-1"]);
+  });
+
+  it("keeps the prompt and settings on the asset, without the input bytes", async () => {
+    const ctx = new ProcessingContext({ jobId: "job-1" });
+    const created: Array<Record<string, unknown>> = [];
+    ctx.setModelInterfaces({
+      createAsset: async (args) => {
+        created.push({ ...args });
+        return { id: "asset-1", content_type: args.contentType };
+      }
+    });
+    ctx.registerProvider("fake", new ImageProvider(async () => PNG));
+    await ctx.runGeneration({
+      provider: "fake",
+      capability: "text_to_image",
+      model: "flux-dev",
+      params: {
+        prompt: "  a fox in snow  ",
+        negative_prompt: "blurry",
+        width: 1024,
+        seed: 42,
+        images: [new Uint8Array(40)]
+      },
+      persist: { name: "fox.png" }
+    });
+    // What it takes to ask for another one like this, and nothing that cannot
+    // be re-run: the conditioning bytes are not a setting.
+    expect(created[0].metadata).toEqual({
+      generation_id: expect.any(String),
+      prompt: "a fox in snow",
+      generation: {
+        provider: "fake",
+        model: "flux-dev",
+        capability: "text_to_image",
+        params: { negative_prompt: "blurry", width: 1024, seed: 42 }
+      }
+    });
   });
 
   it("tracks a local generation without resolving a provider", async () => {

--- a/packages/websocket/src/session/asset-autosave.ts
+++ b/packages/websocket/src/session/asset-autosave.ts
@@ -4,7 +4,10 @@ import {
 } from "@nodetool-ai/execution";
 import { createLogger, getDefaultAssetsPath } from "@nodetool-ai/config";
 import { Asset } from "@nodetool-ai/models";
-import { isRawRgbaImage } from "@nodetool-ai/protocol";
+import {
+  buildAssetGenerationMetadata,
+  isRawRgbaImage
+} from "@nodetool-ai/protocol";
 import { encodeRawRgbaToPng, fetchExternalMedia } from "@nodetool-ai/runtime";
 import { getAssetFileName } from "../lib/asset-paths.js";
 import { storeAssetWithThumbnail } from "../lib/thumbnail.js";
@@ -30,28 +33,41 @@ const ASSET_MEDIA_TYPES = new Set(["image", "audio", "video"]);
 /** Byte cap for inline-preview text stored in a text generation's asset metadata. */
 const TEXT_GENERATION_PREVIEW_CAP = 200_000;
 
-/** Char cap for the prompt stored in a media asset's metadata. */
-const PROMPT_METADATA_CAP = 8_000;
+/**
+ * The model property a generative node ran with, as the actor forwards it:
+ * `{type: "image_model", id, name, provider}`. Which key holds it varies by
+ * node, so the first model-shaped property wins.
+ */
+function modelProperty(
+  properties: Record<string, unknown> | undefined
+): { id?: unknown; name?: unknown; provider?: unknown } | null {
+  for (const value of Object.values(properties ?? {})) {
+    if (!isRecord(value)) continue;
+    if (isString(value.type) && value.type.endsWith("_model") && isString(value.id)) {
+      return value;
+    }
+  }
+  return null;
+}
 
 /**
- * Lift the prompt out of a generation's scalar input properties into asset
- * metadata. Returns `{ prompt }` when a non-empty `prompt` string is present
- * (capped), else an empty object. Other generation params are intentionally
- * left out — the prompt is the field the asset viewer surfaces.
+ * Lift the prompt and the generation settings out of a generation's input
+ * properties into asset metadata, so the asset says what produced it and can
+ * seed a variant later. Returns `{}` when nothing worth keeping is present.
  */
-function promptMetadata(
-  properties: Record<string, unknown> | undefined
+function generationMetadata(
+  properties: Record<string, unknown> | undefined,
+  nodeType: string | undefined
 ) {
-  const prompt = properties?.prompt;
-  if (!isString(prompt)) return {};
-  const trimmed = prompt.trim();
-  if (trimmed.length === 0) return {};
-  return {
-    prompt:
-      trimmed.length > PROMPT_METADATA_CAP
-        ? trimmed.slice(0, PROMPT_METADATA_CAP)
-        : trimmed
-  };
+  const model = modelProperty(properties);
+  return buildAssetGenerationMetadata({
+    prompt: properties?.prompt,
+    provider: model?.provider,
+    model: model?.id,
+    modelName: model?.name,
+    nodeType,
+    params: properties ?? null
+  });
 }
 
 /**
@@ -290,17 +306,20 @@ export async function autoSaveAssets(
      */
     generationIndex?: number;
     /**
-     * Scalar input properties from the `generation_complete` event (the actor's
-     * resolved declared/dynamic/edge inputs, filtered to scalars). The `prompt`
-     * is persisted into each saved media asset's `metadata.prompt` so the asset
-     * viewer can show what produced the image/audio/video.
+     * Input properties from the `generation_complete` event (the actor's
+     * resolved declared/dynamic/edge inputs, filtered to scalars and model
+     * refs). The prompt and the settings are persisted into each saved media
+     * asset's metadata so the asset viewer can show what produced the
+     * image/audio/video, and so the same settings can seed a variant.
      */
     properties?: Record<string, unknown>;
+    /** Node type that produced the result, recorded alongside the settings. */
+    nodeType?: string;
   }
 ): Promise<void> {
-  // Generation params lifted into each media asset's metadata. Just the prompt
-  // today — the field the asset viewer surfaces as "what produced this".
-  const promptMeta = promptMetadata(opts.properties);
+  // Prompt + settings lifted into each media asset's metadata: what produced
+  // this, and what to re-run to get another one like it.
+  const generationMeta = generationMetadata(opts.properties, opts.nodeType);
   // Generations the seam opened for this node that no asset names yet: the
   // node returned an inline ref, so the link is made here, on save
   // (docs/media-generation-tracking-design.md § 8, S3).
@@ -376,7 +395,7 @@ export async function autoSaveAssets(
       content_type: contentType,
       parent_id: null
     });
-    const mediaMeta: Record<string, unknown> = { ...promptMeta };
+    const mediaMeta: Record<string, unknown> = { ...generationMeta };
     if (opts.generationIndex != null) {
       mediaMeta.generation_index = opts.generationIndex;
     }

--- a/packages/websocket/src/session/job-execution.ts
+++ b/packages/websocket/src/session/job-execution.ts
@@ -1945,7 +1945,10 @@ export class JobExecutionManager {
                         (outbound.properties as Record<
                           string,
                           unknown
-                        > | null) ?? undefined
+                        > | null) ?? undefined,
+                      nodeType: isString(outbound.node_type)
+                        ? outbound.node_type
+                        : undefined
                     }
                   );
                 } catch (err) {

--- a/packages/websocket/tests/asset-autosave-edges.test.ts
+++ b/packages/websocket/tests/asset-autosave-edges.test.ts
@@ -48,6 +48,7 @@ const saveOpts = (
     textOutputName: string;
     generationIndex: number;
     properties: Record<string, unknown>;
+    nodeType: string;
   }> = {}
 ) => ({
   userId: "1",
@@ -257,6 +258,38 @@ describe("autoSaveAssets", () => {
     expect(row?.metadata).toEqual({
       prompt: "a fox in snow",
       generation_index: 3
+    });
+  });
+
+  it("keeps the model and the settings the node ran with", async () => {
+    const image: Record<string, unknown> = { type: "image", data: PNG_B64 };
+    await autoSaveAssets(
+      { image },
+      saveOpts({
+        nodeType: "nodetool.image.TextToImage",
+        properties: {
+          prompt: "a fox in snow",
+          model: {
+            type: "image_model",
+            id: "fal-ai/flux/dev",
+            name: "FLUX.1 [dev]",
+            provider: "fal"
+          },
+          width: 1024,
+          seed: 42
+        }
+      })
+    );
+    const row = await Asset.find("1", image.asset_id as string);
+    expect(row?.metadata).toEqual({
+      prompt: "a fox in snow",
+      generation: {
+        provider: "fal",
+        model: "fal-ai/flux/dev",
+        model_name: "FLUX.1 [dev]",
+        node_type: "nodetool.image.TextToImage",
+        params: { width: 1024, seed: 42 }
+      }
     });
   });
 

--- a/web/src/components/context_menus/AssetInfoPanel.tsx
+++ b/web/src/components/context_menus/AssetInfoPanel.tsx
@@ -1,9 +1,18 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 import { memo, useMemo } from "react";
-import { Text, Box, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
+import {
+  Text,
+  Box,
+  CopyButton,
+  FlexRow,
+  BORDER_RADIUS,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
+import { readAssetGenerationMetadata } from "@nodetool-ai/protocol";
 import type { Asset } from "../../stores/ApiTypes";
 import {
   formatContentType,
@@ -13,6 +22,9 @@ import {
 import { secondsToHMS } from "../../utils/formatDateAndTime";
 import { useAssetGridStore } from "../../stores/AssetGridStore";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
+
+/** Metadata keys rendered by their own section, not by the raw dump. */
+const RENDERED_METADATA_KEYS = new Set(["prompt", "generation"]);
 
 const styles = (theme: Theme) =>
   css({
@@ -50,11 +62,47 @@ const styles = (theme: Theme) =>
       borderTop: `1px solid ${theme.vars.palette.grey[700]}`,
       marginTop: "0.35em",
       paddingTop: "0.35em"
+    },
+    "& .info-section-title": {
+      fontSize: theme.fontSizeSmaller,
+      color: theme.vars.palette.grey[400]
+    },
+    "& .info-prompt": {
+      fontSize: theme.fontSizeSmaller,
+      color: theme.vars.palette.grey[100],
+      whiteSpace: "pre-wrap",
+      wordBreak: "break-word",
+      maxHeight: "12em",
+      overflowY: "auto"
     }
   });
 
 interface AssetInfoPanelProps {
   asset: Asset;
+}
+
+/** Render one setting value; arrays join, so no `[object Object]` reaches the UI. */
+function formatSetting(value: string | number | boolean | Array<string | number | boolean>) {
+  return Array.isArray(value) ? value.join(", ") : String(value);
+}
+
+/** A metadata value the sections above do not own; objects stay readable. */
+function formatMetadataValue(value: unknown) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return null;
+    }
+  }
+  return String(value);
+}
+
+/** `negative_prompt` → `Negative prompt`. */
+function settingLabel(key: string) {
+  const words = key.replace(/_/g, " ");
+  return words.charAt(0).toUpperCase() + words.slice(1);
 }
 
 const AssetInfoPanel: React.FC<AssetInfoPanelProps> = ({ asset }) => {
@@ -84,6 +132,21 @@ const AssetInfoPanel: React.FC<AssetInfoPanelProps> = ({ asset }) => {
   const thumbSrc = asset.thumb_url || (isImage ? asset.get_url : null);
   const metadata = asset.metadata;
 
+  // The prompt and settings the asset was generated with — kept on the asset so
+  // the same recipe is at hand when someone wants another variant of it.
+  const { prompt, generation } = useMemo(
+    () => readAssetGenerationMetadata(metadata),
+    [metadata]
+  );
+  const settings = generation?.params;
+  const otherMetadata = useMemo(
+    () =>
+      Object.entries(metadata ?? {}).filter(
+        ([key]) => !RENDERED_METADATA_KEYS.has(key)
+      ),
+    [metadata]
+  );
+
   return (
     <Box css={styles(theme)}>
       {thumbSrc && (
@@ -110,14 +173,45 @@ const AssetInfoPanel: React.FC<AssetInfoPanelProps> = ({ asset }) => {
         </div>
       )}
 
+      {prompt && (
+        <div className="info-section">
+          <FlexRow align="center" justify="space-between">
+            <Text className="info-section-title" component="span">
+              Prompt
+            </Text>
+            <CopyButton value={prompt} tooltip="Copy prompt" buttonSize="small" />
+          </FlexRow>
+          <Text className="info-prompt" component="p">
+            {prompt}
+          </Text>
+        </div>
+      )}
+
+      {generation && (
+        <div className="info-section">
+          <InfoRow label="Model" value={generation.model_name ?? generation.model} />
+          <InfoRow label="Provider" value={generation.provider} />
+          <InfoRow label="Node" value={generation.node_type} />
+          <InfoRow label="Task" value={generation.capability} />
+          {settings &&
+            Object.entries(settings).map(([key, value]) => (
+              <InfoRow
+                key={key}
+                label={settingLabel(key)}
+                value={formatSetting(value)}
+              />
+            ))}
+        </div>
+      )}
+
       <div className="info-section">
         <InfoRow label="ID" value={asset.id} />
       </div>
 
-      {metadata && Object.keys(metadata).length > 0 && (
+      {otherMetadata.length > 0 && (
         <div className="info-section">
-          {Object.entries(metadata).map(([key, val]) => (
-            <InfoRow key={key} label={key} value={String(val)} />
+          {otherMetadata.map(([key, val]) => (
+            <InfoRow key={key} label={key} value={formatMetadataValue(val)} />
           ))}
         </div>
       )}

--- a/web/src/components/context_menus/__tests__/AssetInfoPanel.test.tsx
+++ b/web/src/components/context_menus/__tests__/AssetInfoPanel.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * The info panel is where a generated asset says what produced it: the prompt,
+ * the model, and the settings, so the same recipe is at hand for a variant.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+
+import mockTheme from "../../../__mocks__/themeMock";
+
+jest.mock("../../../stores/AssetGridStore", () => ({
+  useAssetGridStore: <T,>(selector: (s: { currentFolder: null }) => T) =>
+    selector({ currentFolder: null })
+}));
+
+jest.mock("../../../contexts/WorkflowManagerContext", () => ({
+  useWorkflowManager: <T,>(selector: (s: { getWorkflow: () => null }) => T) =>
+    selector({ getWorkflow: () => null })
+}));
+
+import AssetInfoPanel from "../AssetInfoPanel";
+import type { Asset } from "../../../stores/ApiTypes";
+
+const asset = (metadata: Record<string, unknown> | null): Asset =>
+  ({
+    id: "asset-1",
+    user_id: "1",
+    parent_id: null,
+    name: "fox.png",
+    content_type: "image/png",
+    workflow_id: null,
+    created_at: "2026-01-02T03:04:05Z",
+    get_url: null,
+    thumb_url: null,
+    metadata
+  }) as Asset;
+
+const renderPanel = (metadata: Record<string, unknown> | null) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <AssetInfoPanel asset={asset(metadata)} />
+    </ThemeProvider>
+  );
+
+describe("AssetInfoPanel generation settings", () => {
+  it("shows the prompt, the model and each setting", () => {
+    renderPanel({
+      generation_id: "gen-1",
+      prompt: "a fox in snow",
+      generation: {
+        provider: "fal",
+        model: "fal-ai/flux/dev",
+        model_name: "FLUX.1 [dev]",
+        params: { seed: 42, negative_prompt: "blurry", loras: ["a", "b"] }
+      }
+    });
+
+    expect(screen.getByText("a fox in snow")).toBeInTheDocument();
+    expect(screen.getByText("FLUX.1 [dev]")).toBeInTheDocument();
+    expect(screen.getByText("fal")).toBeInTheDocument();
+    expect(screen.getByText("Negative prompt")).toBeInTheDocument();
+    expect(screen.getByText("blurry")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("a, b")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /copy prompt/i })
+    ).toBeInTheDocument();
+    // The raw dump still carries the keys the sections do not render.
+    expect(screen.getByText("gen-1")).toBeInTheDocument();
+  });
+
+  it("renders nothing generation-shaped for an uploaded asset", () => {
+    renderPanel(null);
+    expect(screen.queryByText("Prompt")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /copy prompt/i })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("fox.png")).toBeInTheDocument();
+  });
+
+  it("never renders an object as [object Object]", () => {
+    const { container } = renderPanel({
+      generation: { model: "m", params: { seed: 1 } }
+    });
+    expect(container.textContent).not.toContain("[object Object]");
+  });
+});


### PR DESCRIPTION
## What changed

A generated asset was only reproducible by joining to the ledger row that recorded the call — a separate table with its own retention — or by reading a workflow that may have been edited since. The workflow auto-save kept the prompt and nothing else; the generation seam kept only a `generation_id`. Both write paths now stamp the same fragment, built by `buildAssetGenerationMetadata` in `packages/protocol/src/asset-generation.ts`: the prompt plus provider, model, capability or node type, and the scalar settings (seed, resolution, guidance, voice). Values that cannot be re-run — conditioning bytes, streams, abort signals, nested request objects — are dropped rather than truncated, and the prompt, each string setting and the number of settings are capped. Which model ran is the one setting that is never a scalar, so the actor's `generation_complete` properties filter now carries a model reference through, reduced to `type`/`id`/`name`/`provider`. The asset info panel reads the fragment back with `readAssetGenerationMetadata`: the prompt with a copy button, then the model and each setting, so the recipe is at hand when someone wants another variant.

## Verification

- [x] `npm run test:affected` — the stale `origin/main` ref in this container selects every workspace, so the touched suites were run directly instead: `@nodetool-ai/protocol` (61 files), `@nodetool-ai/kernel` (70 files), `@nodetool-ai/websocket` (256 files, 2914 tests) all pass; `@nodetool-ai/runtime` passes 176/177, the one failure being `tests/providers/video-frame-fallback.test.ts` → `Error: spawn ffmpeg ENOENT`, which reproduces identically with the changes stashed. `web` was covered by `npx jest --findRelatedTests src/components/context_menus/AssetInfoPanel.tsx` — 212 suites, 1814 tests, all passing.
- [x] `npm run typecheck` — `typecheck:web` and `typecheck:electron` pass. `typecheck:mobile` fails on missing modules (`react-native`, `expo-*`): `mobile/node_modules` is absent in this container and `mobile/` is not a root workspace. No mobile file is touched by this diff.
- [x] `npm run lint`
- [x] `npm run dev:nodetool -- harness gate` — 4/4 selfchecks passed (workflow-execution, api-server, web-editor surfaces).

Both new checks were inverted once and observed failing:

```
# protocol: dropped the ignored-param filter in buildAssetGenerationMetadata
Tests  2 failed | 4 passed (6)

# web: stopped rendering the settings rows in AssetInfoPanel
✕ shows the prompt, the model and each setting (113 ms)
Tests  1 failed, 2 passed, 3 total
```

## Agent capabilities

No capability is added and no capability's declared contract changes.

## New checks

The diff adds tests, not a rule or an audit.

- [x] Both new suites were inverted once and observed failing; the failing output is in **Verification** above
- [x] Not applicable — no audit that scans files was added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDBkBTEfqEXbrfLWomkmVu

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDBkBTEfqEXbrfLWomkmVu)_