### PR TITLE
test(marketing): fix the marquee test left red by #5611, and bring the README up to the new positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@
 **You are the director. The agent is your crew.**
 
 Create and edit AI images, video, audio, and text in NodeTool, an open-source
-creative studio. Let agents build and revise your work, then inspect and edit
-it yourself in the workflow canvas, storyboard, or timeline.
+creative studio. Describe what you want and the agent builds it. What comes
+back is a project, not a render: open it in the workflow canvas, storyboard, or
+timeline and re-roll one shot, re-voice one line, re-cut the ending.
 
 **[Download NodeTool Studio](https://github.com/nodetool-ai/nodetool/releases/latest)** ·
 **[Quick start](#first-run-in-studio)** ·
@@ -20,22 +21,36 @@ it yourself in the workflow canvas, storyboard, or timeline.
 
 ![NodeTool: one sentence becomes a storyboard, rendered stills and clips, a cut on the timeline, and a finished film](marketing/public/hero-project-poster.webp)
 
+## Every model you need, on your own keys
+
+Route a shot through GPT-5.6, Claude Opus 5, Gemini, or Grok for text; FLUX,
+Nano Banana, Seedream, or Ideogram for stills; Sora 2, Veo 3.1, Kling, Wan, or
+Seedance for motion; ElevenLabs, Suno, or Whisper for sound. Switch between
+them in one click, or run open weights locally through Ollama, vLLM, LM Studio,
+or llama.cpp.
+
+You connect the provider and NodeTool calls it with your key, so you pay that
+provider directly at their published price. There is no NodeTool billing unit
+in between, and a price the provider drops is a price you get the same day.
+[Models and Providers](docs/models-and-providers.md) lists what runs where.
+
 ## Why NodeTool
 
-- Inspect intermediate results, swap a model, and rerun the changed part of a
-  workflow. Agents can wire the graph, run it, and repair failures within the
-  limits you set.
-- Keep the graph, inputs, assets, and edits together in your project. Export
-  `.nodetool` bundles to reopen in another NodeTool installation.
-- Run repeatable workflows from the studio, CLI, or an external agent through
+- Agents drive the real editors, not a transcript. They wire the graph, run it,
+  and repair failures within the limits you set, and you take the wheel at any
+  point.
+- Inspect intermediate results, swap a model, and rerun only the part that
+  changed.
+- The graph, inputs, assets, and edits stay together in your project. Export a
+  `.nodetool` bundle and reopen it in any NodeTool installation.
+- Run the same workflow from the studio, the CLI, or an external agent over
   [MCP](#mcp).
 
-Studio is free and runs on macOS, Windows, and Linux. Cloud model requests go
-to the provider you connect, billed to your account at provider rates. Local
-models run through supported engines such as Ollama, MLX, and llama.cpp, with
-hardware requirements that depend on the model. Offline work requires local
-models and assets. [NodeTool Cloud](https://nodetool.ai/cloud) is in alpha and uses
-hosted storage and cloud providers rather than your machine's local models.
+Studio is free and runs on macOS, Windows, and Linux. Local models have
+hardware requirements that depend on the model, and working offline needs both
+the models and the assets on your machine.
+[NodeTool Cloud](https://nodetool.ai/cloud) is in alpha; it runs on hosted
+storage and cloud providers rather than your machine's local models.
 
 ## First run in Studio
 

--- a/marketing/tests/e2e/mobile-menu.spec.ts
+++ b/marketing/tests/e2e/mobile-menu.spec.ts
@@ -63,20 +63,21 @@ test.describe("landing page on a phone", () => {
 
     const track = page.locator(".animate-marquee").first();
     await expect(track).toHaveCount(1);
+    const playState = () =>
+      track.evaluate((el) => getComputedStyle(el).animationPlayState);
 
-    // Top of the page: the model section is far below, so nothing should run.
-    await expect
-      .poll(() =>
-        track.evaluate((el) => getComputedStyle(el).animationPlayState)
-      )
-      .toBe("paused");
+    // Scroll the section away rather than trusting it to start off screen:
+    // the model wall sits directly under the hero (NARRATIVE.md § Order of the
+    // page), and this test guards the IntersectionObserver, not the page order.
+    // It read "paused" for free while the section happened to be tenth, which
+    // is how it passed without ever proving the observer pauses on scroll-away.
+    await page.evaluate(() =>
+      window.scrollTo(0, document.body.scrollHeight)
+    );
+    await expect.poll(playState).toBe("paused");
 
     await track.scrollIntoViewIfNeeded();
-    await expect
-      .poll(() =>
-        track.evaluate((el) => getComputedStyle(el).animationPlayState)
-      )
-      .toBe("running");
+    await expect.poll(playState).toBe("running");
   });
 
   test("the menu opens with the page's JavaScript blocked", async ({ page }) => {


### PR DESCRIPTION
## What changed

Two things, both fallout from #5611.

**1. `main` is red and this fixes it.** `mobile-menu.spec.ts` → "the model marquees stay paused while their section is off screen". #5611 moved the model wall from tenth on the homepage to directly under the hero, and that test asserted `paused` immediately after load on the assumption that the section starts far below the fold. It now reads `running`, correctly. The fix was pushed to the branch seconds after #5611 was merged, so it missed the merge; this carries it over onto the new `main`.

Worth noting what the test was actually doing before: the `paused` half was free. It passed because the section had simply never been scrolled to, not because the `IntersectionObserver` had paused anything — so the pause-on-scroll-away path it claims to guard was never exercised. This scrolls to the bottom of the document first, asserts `paused`, then scrolls back and asserts `running`, exercising both directions of the observer and making the test independent of where the section sits. No source change: the observer (`setOnScreen(entry.isIntersecting)` in `ModelSupportSection.tsx`) toggles both ways and was never broken.

**2. The README now matches the repositioned narrative.** #5611 made model breadth the beat directly under the hero and put ownership in the same headline. The README had no model beat at all — providers appeared only as a billing caveat halfway down a paragraph about operating systems. Adds "Every model you need, on your own keys" as the second section, naming the model families (per `NARRATIVE.md`'s rule that abundance is a number or a name, never an adjective) and stating the BYOK economics once. The platform paragraph is trimmed to what it alone says, since it had come to repeat the billing and local-engine facts. The subhead and the "Why NodeTool" bullets now lead with what the agent leaves behind — a project you can reopen and revise, not a render.

## Verification

- [x] Reproduced the CI failure locally: ran the pre-fix test against the new page order and got the same `Expected: "paused" / Received: "running"` at line 72 that [the CI job](https://github.com/nodetool-ai/nodetool/actions/runs/33979837063/job/101342968421) reported.
- [x] `npx playwright test tests/e2e/mobile-menu.spec.ts` against the current `main` (post-#5611 page order) — 4 passed.
- [x] Rest of the marketing e2e suite green on the same tree: smoke 354, cls/idle-animation/models 10 — 368 total, matching CI's count.
- [x] Every model, provider, and local-engine name added to the README checked against `docs/models-and-providers.md` rather than written from memory; the one link added resolves.
- [ ] `npm run typecheck` / `npm run lint` — not run; the diff is one Playwright spec and one Markdown file, neither of which either check reaches.
- [ ] `npm run dev:nodetool -- harness gate` — the harness registry maps no entry to `marketing/` or to the README.

Same Playwright browser-pin workaround as before: `@playwright/test` pins `chromium_headless_shell-1228` and this container ships `chromium-1194`, so the runs went through a throwaway config setting `launchOptions.executablePath`. That config is deleted and not in the diff.

## Agent capabilities

No capability added or re-declared.

## New checks

No check added. The existing check was made able to fail — it previously could not detect a broken observer, and now can.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnSQFbczUtTWqvEijS5eDw