### PR TITLE
docs(marketing): align creative AI workspace positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@
 
 **Open-source creative AI workspace**
 
-Create and edit images, video, audio, and text with agents that work alongside you.
-Let them build and revise workflows, then inspect and edit the results yourself. Your
-project keeps the brief, assets, and edits together.
+Create and edit AI images, video, audio, and text in NodeTool, an open-source
+creative studio. Describe what you want and the agent builds it. What comes
+back is a project, not a render: open it in the workflow canvas, storyboard, or
+timeline and re-roll one shot, re-voice one line, re-cut the ending.
 
 **[Download NodeTool Studio](https://github.com/nodetool-ai/nodetool/releases/latest)** ·
 **[Quick start](#first-run-in-studio)** ·
@@ -20,22 +21,36 @@ project keeps the brief, assets, and edits together.
 
 ![NodeTool: one sentence becomes a storyboard, rendered stills and clips, a cut on the timeline, and a finished film](marketing/public/hero-project-poster.webp)
 
+## Every model you need, on your own keys
+
+Route a shot through GPT-5.6, Claude Opus 5, Gemini, or Grok for text; FLUX,
+Nano Banana, Seedream, or Ideogram for stills; Sora 2, Veo 3.1, Kling, Wan, or
+Seedance for motion; ElevenLabs, Suno, or Whisper for sound. Switch between
+them in one click, or run open weights locally through Ollama, vLLM, LM Studio,
+or llama.cpp.
+
+You connect the provider and NodeTool calls it with your key, so you pay that
+provider directly at their published price. There is no NodeTool billing unit
+in between, and a price the provider drops is a price you get the same day.
+[Models and Providers](docs/models-and-providers.md) lists what runs where.
+
 ## Why NodeTool
 
-- Inspect intermediate results, swap a model, and rerun the changed part of a
-  workflow. Agents can wire the graph, run it, and repair failures within the
-  limits you set.
-- Keep the graph, inputs, assets, and edits together in your project. Export
-  `.nodetool` bundles to reopen in another NodeTool installation.
-- Run repeatable workflows from the studio, CLI, or an external agent through
+- Agents drive the real editors, not a transcript. They wire the graph, run it,
+  and repair failures within the limits you set, and you take the wheel at any
+  point.
+- Inspect intermediate results, swap a model, and rerun only the part that
+  changed.
+- The graph, inputs, assets, and edits stay together in your project. Export a
+  `.nodetool` bundle and reopen it in any NodeTool installation.
+- Run the same workflow from the studio, the CLI, or an external agent over
   [MCP](#mcp).
 
-Studio is free and runs on macOS, Windows, and Linux. Cloud model requests go
-to the provider you connect, billed to your account at provider rates. Local
-models run through supported engines such as Ollama, MLX, and llama.cpp, with
-hardware requirements that depend on the model. Offline work requires local
-models and assets. [NodeTool Cloud](https://nodetool.ai/cloud) is in alpha and uses
-hosted storage and cloud providers rather than your machine's local models.
+Studio is free and runs on macOS, Windows, and Linux. Local models have
+hardware requirements that depend on the model, and working offline needs both
+the models and the assets on your machine.
+[NodeTool Cloud](https://nodetool.ai/cloud) is in alpha; it runs on hosted
+storage and cloud providers rather than your machine's local models.
 
 ## First run in Studio
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE.txt)
 [![Powered by Atlas Cloud](https://www.atlascloud.ai/oss-program/powered-by-atlas-cloud.svg)](https://www.atlascloud.ai/?ref=PW9AD2)
 
-**You are the director. The agent is your crew.**
+**Open-source creative AI workspace**
 
-Create and edit AI images, video, audio, and text in NodeTool, an open-source
-creative studio. Let agents build and revise your work, then inspect and edit
-it yourself in the workflow canvas, storyboard, or timeline.
+Create and edit images, video, audio, and text with agents that work alongside you.
+Let them build and revise workflows, then inspect and edit the results yourself. Your
+project keeps the brief, assets, and edits together.
 
 **[Download NodeTool Studio](https://github.com/nodetool-ai/nodetool/releases/latest)** ·
 **[Quick start](#first-run-in-studio)** ·

--- a/docs/BRAND.md
+++ b/docs/BRAND.md
@@ -22,18 +22,22 @@ change.
 
 - **Mission.** Give creators and developers control over multi-modal AI
   orchestration without platform lock-in, credit markups, or lost context.
-- **Elevator pitch.** NodeTool is the open canvas for multi-modal AI. It
-  connects image, video, audio, and language models into repeatable workflows
-  that run in the cloud, locally on your own hardware, or headless over MCP.
+- **Primary tagline.** Open-source creative AI workspace.
+- **Intro.** Create and edit images, video, audio, and text with agents that
+  work alongside you. Let them build and revise workflows, then inspect and
+  edit the results yourself. Your project keeps the brief, assets, and edits
+  together.
+- **Agent-first.** Use this in supporting copy to explain that agents operate
+  the same editable workflows and documents as the creator. Keep AI in the
+  primary category label.
 - **What we are against.** The closed AI studio: a model list they picked,
   priced in their credits, saved in a project only their app opens. Five
   browser tabs, lost context and markups are symptoms of it, not the enemy.
 
 The pitch above is the general-purpose one — README, docs, conference blurb,
-app store listing. The marketing homepage runs a narrower, filmmaker-first
-line; [marketing/NARRATIVE.md](../marketing/NARRATIVE.md) owns that hero and
-wins on nodetool.ai. The two must not contradict each other: both say the
-creator directs and keeps the project file.
+app store listing. The marketing homepage uses the same tagline and intro;
+[marketing/NARRATIVE.md](../marketing/NARRATIVE.md) owns the page narrative.
+Both describe editable agent work and persistent project context.
 
 ## 2. Voice
 
@@ -100,7 +104,8 @@ Vocabulary: MCP server, headless execution, API endpoints, CLI, spec-driven.
 
 | Term | Means |
 |---|---|
-| Studio | The product. Not "workspace", "platform", or "tool". |
+| Workspace | The product category: shared project context, agents, and editors. |
+| Studio | The desktop edition of NodeTool. |
 | Canvas | The surface where the work happens, inside the studio. |
 | Orchestrate / wire | Connecting models and steps. |
 | Pipeline / workflow | The repeatable system the user builds. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,15 @@
 ---
 layout: home
-description: "NodeTool — the open creative AI workspace. Ask an agent to build the workflow, then take the controls. Image, video, audio, and LLM models on one canvas, with your own keys or local models."
+description: "Open-source creative AI workspace. Create images, video, audio, and text with agents, then inspect and edit their work. Keep your project context together."
 ---
 
 <section class="home-hero">
-  <p class="eyebrow">A free and open AI workspace</p>
-  <h1>Tell the AI what to make. Then you take control.</h1>
+  <p class="eyebrow">NodeTool documentation</p>
+  <h1>Open-source creative AI workspace</h1>
   <p class="lead">
-   Tell NodeTool what you need, and its agent will build it for you. It can create workflows, images, videos, or simple apps. Everything it makes appears on a canvas where you can easily view and edit it yourself. You can use your own accounts or your own computer. It is open source and free to use (AGPL-3.0).
+    Create and edit images, video, audio, and text with agents that work alongside
+    you. Let them build and revise workflows, then inspect and edit the results
+    yourself. Your project keeps the brief, assets, and edits together.
   </p>
   <img src="{{ '/assets/home.png' | relative_url }}" alt="NodeTool canvas" class="home-screenshot">
   <div class="cta-row">

--- a/marketing/NARRATIVE.md
+++ b/marketing/NARRATIVE.md
@@ -9,10 +9,8 @@ copy and this file disagree, one of them is wrong — fix both in the same chang
 The page is edited more often than this file, so when in doubt the page is the
 newer of the two: bring the doc up to it, then fix the page.
 
-This file is the homepage's narrower cut of `BRAND.md`, not a second standard.
-The positioning line below wins on nodetool.ai; `BRAND.md`'s elevator pitch
-covers everywhere else (README, docs, listings). Both say the same thing: the
-creator directs and keeps the project file.
+The homepage, README, and docs share the primary tagline and intro in
+`BRAND.md`. Film production is a showcase of the broader workspace.
 
 ## The register
 
@@ -34,29 +32,19 @@ NodeTool can make.
 
 ## Positioning line
 
-**You are the director. The agent is your crew.**
+**Open-source creative AI workspace**
 
-Two beats, declarative, no mechanism. It names who does what: the agent handles
-the tedious stretch between a blank page and a rough cut — script, board,
-footage, sound, cut — and the creator stays the director throughout. "You direct
-the vision. The agent builds the film." is the same claim in prose form and stays
-in the meta descriptions and OG images; the hero uses the shorter line.
+Create and edit images, video, audio, and text with agents that work alongside
+you. Let them build and revise workflows, then inspect and edit the results
+yourself. Your project keeps the brief, assets, and edits together.
 
-The subhead carries the one claim a closed studio cannot make: what the agent
-makes stays open. The board, the script with its takes, and the multi-track cut
-come back as a project you can re-roll, re-voice, and re-cut. Other agents also
-build a film. Nobody else hands the project back. That claim goes in the hero,
-not one and a half screens down.
+Use "agent-first" in supporting copy to explain how agents build and revise
+workflows and documents that creators can inspect and edit. Keep the primary
+headline and metadata category-led. Studio and Cloud use the same headline,
+with edition details in their badges and introductions.
 
-Under the CTA sits the trust line: free, open source, AGPL-3.0, and the three
-platforms it runs on. It is our version of "Used by 60M+ users globally" — the
-facts we actually have, stated once, without adjectives. When a user or install
-count is worth printing, it replaces the platform list rather than joining it.
-
-"The agent-first creative workspace" stays as the category descriptor in
-`<title>`, meta descriptions, and schema. On the page itself the reader needs a
-category they already know, so the hero badge says **open-source AI film
-studio**. Nobody searches for a coined label.
+Keep the trust line under the CTA: free, open source, AGPL-3.0, and the
+supported desktop platforms.
 
 ## Message hierarchy
 

--- a/marketing/POSITIONING_PLAN.md
+++ b/marketing/POSITIONING_PLAN.md
@@ -44,13 +44,12 @@ production combined with programmable, deterministic workflow automation**.
 
 ### Category anchor and pitch
 
-- **Category:** the open-source, agent-first creative studio — a programmable
-  multimodal workspace.
+- **Category:** the open-source creative AI workspace.
 - **Elevator pitch:** NodeTool is the open-source platform where creative
   teams, developers, and marketers orchestrate generative AI models,
   deterministic media editors (timelines, sketches, scripts, 3D), and web
   automations into reproducible workflows and standalone mini-apps.
-- **Headline (outcome-first):** *"From prompt to final cut on one canvas."*
+- **Primary headline:** *"Open-source creative AI workspace."*
 
 Audience-specific taglines:
 
@@ -192,7 +191,7 @@ Comparison-page punchlines:
 The order below is the one [NARRATIVE.md § Order of the page](NARRATIVE.md#order-of-the-page)
 pins; that file wins when the two drift.
 
-1. **Hero** — "You are the director. The agent is your crew." + the project
+1. **Hero** — "Open-source creative AI workspace" + the project
    reel + download CTA. The subhead carries the project-not-render claim.
 2. **The enemy** — the closed AI studio, once, briefly: their models, their
    credits, their locked project.
@@ -214,22 +213,21 @@ pins; that file wins when the two drift.
 ### Hero section
 
 - **Badge:** `Open Source (AGPL-3.0) · Local-First · BYOK Direct Pricing`
-- **Headline:** **You are the director. The agent is your crew.**
+- **Headline:** **Open-source creative AI workspace**
   ([NARRATIVE.md](NARRATIVE.md) pins the line, and the homepage H1 carries it.
-  "From prompt to final cut on one canvas" was the earlier line.)
-- **Subhead:** *Stop juggling Midjourney, Runway, ElevenLabs, and Premiere.
-  NodeTool combines visual AI models, a multi-track timeline, layered
-  sketching, and scripts into one open-source workspace you drive manually or
-  through autonomous agents.*
+  Keep "agent-first" in supporting explanations.)
+- **Subhead:** Create and edit images, video, audio, and text with agents that
+  work alongside you. Let them build and revise workflows, then inspect and
+  edit the results yourself. Your project keeps the brief, assets, and edits
+  together.
 - **CTAs:** `Download NodeTool Studio (Free)` / `Try Instant Cloud Alpha`
 - **Visual:** interactive or looping 3-state demo — brief prompt → agent
   builds storyboard, casts voices, places clips on the timeline → finished
   video playback with captions.
 
-Rationale: "The agent-first creative workspace" is abstract for first-time
-visitors — lead with the outcome and let "agent-first" be shown, not asserted.
-It stays as the category descriptor in `<title>`, meta descriptions, schema,
-and body copy, per NARRATIVE.md.
+Rationale: "Creative AI workspace" names the category. Explain agent-first
+through editable workflows and persistent project context. Use the same
+category in titles, metadata, and schema, per NARRATIVE.md.
 
 ### The five surfaces (tab copy, condensed)
 

--- a/marketing/public/index.md
+++ b/marketing/public/index.md
@@ -1,13 +1,13 @@
 ---
 title: "NodeTool"
-description: "The open-source, agent-first creative workspace."
+description: "Open-source creative AI workspace."
 canonical: https://nodetool.ai/
 markdown: https://nodetool.ai/index.md
 product: NodeTool
 ---
 # NodeTool
 
-NodeTool is an open-source, agent-first visual workspace for building and running AI workflows. Every editor is exposed to [agents](https://nodetool.ai/agents.md) as tools: an agent can build the workflow, run it, and repair what fails. The canvas connects image, video, audio, language, agent, and data models on a node-based graph.
+NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Let them build and revise workflows, then inspect and edit the results yourself. Your project keeps the brief, assets, and edits together. Every editor is exposed to [agents](https://nodetool.ai/agents.md) as tools: an agent can build the workflow, run it, and repair what fails. The canvas connects image, video, audio, language, agent, and data models on a node-based graph.
 
 ## Editions
 

--- a/marketing/public/llms.txt
+++ b/marketing/public/llms.txt
@@ -1,6 +1,6 @@
 # NodeTool
 
-> NodeTool is the open-source, agent-first creative workspace: every editor — a node-based canvas, sketch pad, storyboard, video timeline, script editor, 3D scene, and app builder — is exposed to agents as tools. An agent builds workflows that wire image, video, audio, and text models from every major provider, runs them, and repairs what fails. Bring your own API keys. Runs as a free desktop app (Studio) or in the browser (Cloud). Licensed AGPL-3.0.
+> NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Let them build and revise workflows, then inspect and edit the results yourself. Your project keeps the brief, assets, and edits together. Studio is the free desktop edition; Cloud is the hosted browser edition, in alpha. Use supported local models in Studio or connect cloud providers with your own keys. Licensed AGPL-3.0.
 
 ## What NodeTool is
 

--- a/marketing/scripts/generate-llms-txt.mjs
+++ b/marketing/scripts/generate-llms-txt.mjs
@@ -29,7 +29,7 @@ const BASE_URL = "https://nodetool.ai";
 // --- Preamble prose (hand-written; edit here) --------------------------------
 const PREAMBLE = `# NodeTool
 
-> NodeTool is the open-source, agent-first creative workspace: every editor — a node-based canvas, sketch pad, storyboard, video timeline, script editor, 3D scene, and app builder — is exposed to agents as tools. An agent builds workflows that wire image, video, audio, and text models from every major provider, runs them, and repairs what fails. Bring your own API keys. Runs as a free desktop app (Studio) or in the browser (Cloud). Licensed AGPL-3.0.
+> NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Let them build and revise workflows, then inspect and edit the results yourself. Your project keeps the brief, assets, and edits together. Studio is the free desktop edition; Cloud is the hosted browser edition, in alpha. Use supported local models in Studio or connect cloud providers with your own keys. Licensed AGPL-3.0.
 
 ## What NodeTool is
 
@@ -97,8 +97,8 @@ function markdownPath(route) {
 const MARKDOWN_PAGES = {
   "index.md": {
     title: "NodeTool",
-    description: "The open-source, agent-first creative workspace.",
-    body: `NodeTool is an open-source, agent-first visual workspace for building and running AI workflows. Every editor is exposed to [agents](${BASE_URL}/agents.md) as tools: an agent can build the workflow, run it, and repair what fails. The canvas connects image, video, audio, language, agent, and data models on a node-based graph.
+    description: "Open-source creative AI workspace.",
+    body: `NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Let them build and revise workflows, then inspect and edit the results yourself. Your project keeps the brief, assets, and edits together. Every editor is exposed to [agents](${BASE_URL}/agents.md) as tools: an agent can build the workflow, run it, and repair what fails. The canvas connects image, video, audio, language, agent, and data models on a node-based graph.
 
 ## Editions
 

--- a/marketing/src/app/cloud/layout.tsx
+++ b/marketing/src/app/cloud/layout.tsx
@@ -1,9 +1,9 @@
 import JsonLd from "../../components/JsonLd";
 import type { Metadata } from "next";
 
-const TITLE = "The Agent-First Workspace in Your Browser — NodeTool Cloud (Alpha)";
+const TITLE = "NodeTool Cloud | Open-source creative AI workspace (Alpha)";
 const DESCRIPTION =
-  "The agent-first studio in your browser — no install, no GPU required. Pitch your idea and the agent drafts the script, boards the scenes, generates the footage, and cuts a timeline you can still edit. NodeTool Cloud is the hosted, browser-based edition of the open-source NodeTool platform, currently in alpha (not yet generally available). Bring your own API keys for OpenAI, Anthropic, Gemini, Replicate, and more. AGPL-3.0.";
+  "Open-source creative AI workspace. Create images, video, audio, and text with agents, then inspect and edit their work. Keep your project context together. Cloud is the hosted browser edition, in alpha. Use hosted storage and your own provider keys; no local model support.";
 
 export const metadata: Metadata = {
   title: TITLE,
@@ -54,7 +54,7 @@ export default function CloudLayout({
           "@type": "SoftwareApplication",
           name: "NodeTool Cloud",
           description:
-            "Hosted, browser-based edition of the open-source, agent-first NodeTool platform (alpha). Tell the agent what you want and it builds and runs the workflow — no install, no GPU, bringing your own API keys for OpenAI, Anthropic, Gemini, Replicate, and more.",
+            "Open-source creative AI workspace. Create images, video, audio, and text with agents, then inspect and edit their work. Keep your project context together. Cloud is the hosted browser edition, in alpha. Use hosted storage and your own provider keys; no local model support.",
           applicationCategory: "MultimediaApplication",
           operatingSystem: "Web browser",
           url: "https://nodetool.ai/cloud",

--- a/marketing/src/app/cloud/opengraph-image.tsx
+++ b/marketing/src/app/cloud/opengraph-image.tsx
@@ -1,13 +1,13 @@
 import { ogImage, ogSize, ogContentType } from "../../lib/og";
 
-export const alt = "NodeTool Cloud";
+export const alt = "NodeTool | Open-source creative AI workspace";
 export const size = ogSize;
 export const contentType = ogContentType;
 
 export default function Image() {
   return ogImage(
-    "The agent-first studio in your browser",
-    "Zero setup, no GPU. Bring your own keys, no token markups.",
+    "Open-source creative AI workspace",
+    "Agents build and revise. You inspect and edit. Cloud is in alpha.",
     { image: "screen_chat.png", accent: "cyan", eyebrow: "Cloud — Alpha" }
   );
 }

--- a/marketing/src/app/cloud/page.tsx
+++ b/marketing/src/app/cloud/page.tsx
@@ -174,28 +174,23 @@ export default function CloudPage() {
                     Alpha — not generally available
                   </span>
                 </div>
-                {/* Sized a step below the landing hero's 3.25rem cap: this
-                    headline carries an extra clause, and at that cap it wrapped
-                    to five lines in the 5/12 column and pushed the demo out of
-                    line with the copy. text-balance is off for the same reason
-                    — it broke the short first line to equalise against the
-                    much longer second one. */}
                 <h1
                   id="cloud-hero-title"
                   className="mt-6 text-[clamp(2rem,7vw,2.75rem)] font-bold leading-[1.1] tracking-tight text-white lg:text-[clamp(2rem,3.1vw,2.75rem)]"
                 >
-                  You are the director.
+                  Open-source
                   <br />
                   <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-300 to-cyan-300 pb-[0.12em]">
-                    The agent is your crew — in your browser.
+                    creative AI workspace
                   </span>
                 </h1>
                 <p className="mt-6 text-lg text-slate-300 leading-relaxed max-w-xl">
-                  Describe your idea. The agent writes the script, storyboards
-                  every scene, generates the footage, and cuts the timeline —
-                  all of it in the hosted version of the same open-source
-                  studio. Nothing to install, no hardware to set up, and your
-                  own API keys for whichever providers you want to use.
+                  Create and edit images, video, audio, and text with agents that
+                  work alongside you. Let them build and revise workflows, then
+                  inspect and edit the results yourself. Your project keeps the
+                  brief, assets, and edits together. Cloud brings the workspace to
+                  your browser with hosted storage and your own provider keys. Cloud
+                  is in alpha.
                 </p>
                 <div className="mt-6 rounded-lg border border-amber-500/30 bg-amber-500/[0.06] p-4 text-sm text-amber-100/90 max-w-xl">
                   <strong className="text-amber-200">Heads up:</strong> Cloud is

--- a/marketing/src/app/download/page.tsx
+++ b/marketing/src/app/download/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Download NodeTool Studio",
     description:
-      "The free, open-source AI film studio for macOS, Windows and Linux.",
+      "The free, open-source creative AI workspace for macOS, Windows and Linux.",
     url: `${BASE_URL}/download`,
     type: "website",
   },

--- a/marketing/src/app/faq/page.tsx
+++ b/marketing/src/app/faq/page.tsx
@@ -60,7 +60,7 @@ export default function FaqHubPage() {
             Frequently asked questions
           </h1>
           <p className="mt-5 text-lg leading-relaxed text-slate-300">
-            NodeTool is the open-source, agent-first creative workspace: one
+            NodeTool is the open-source creative AI workspace: one
             canvas for image, video, audio, and text, where every editor is a
             tool an agent can drive. You bring your own API keys and pay each
             provider directly. Studio runs on your machine; Cloud runs the same

--- a/marketing/src/app/layout.tsx
+++ b/marketing/src/app/layout.tsx
@@ -22,9 +22,9 @@ const jetBrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "NodeTool — The agent-first creative workspace",
+  title: "NodeTool | Open-source creative AI workspace",
   description:
-    "You direct the vision. The agent builds the film. Describe your idea and NodeTool's agent writes the script, boards every scene, generates the footage, and cuts a multi-track timeline you can still edit — the open-source, agent-first creative workspace. Run open weights locally or bring your own API keys. No credits, no markups, no lock-in.",
+    "Open-source creative AI workspace. Create images, video, audio, and text with agents, then inspect and edit their work. Keep your project context together.",
   metadataBase: new URL("https://nodetool.ai"),
   alternates: {
     canonical: "/",
@@ -57,15 +57,15 @@ export const metadata: Metadata = {
     other: [{ rel: "manifest", url: "/site.webmanifest" }],
   },
   openGraph: {
-    title: "NodeTool — The agent-first creative workspace",
+    title: "NodeTool | Open-source creative AI workspace",
     description:
-      "Describe your idea. The agent writes the script, boards every scene, generates the footage, and cuts the timeline — and hands you an editable multi-track project, not a flat render. Open source, your own keys, provider prices.",
+      "Open-source creative AI workspace. Create images, video, audio, and text with agents, then inspect and edit their work. Keep your project context together.",
     url: "https://nodetool.ai",
     siteName: "NodeTool",
     images: [
       {
         url: "/preview.png",
-        alt: "NodeTool — the open, agent-first creative workspace",
+        alt: "NodeTool | Open-source creative AI workspace",
       },
     ],
     locale: "en_US",
@@ -73,9 +73,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "NodeTool — The agent-first creative workspace",
+    title: "NodeTool | Open-source creative AI workspace",
     description:
-      "You direct the vision. The agent builds the film. Open-source AI film production on a real multi-track timeline — your keys, your models, your files.",
+      "Open-source creative AI workspace. Create images, video, audio, and text with agents, then inspect and edit their work. Keep your project context together.",
     images: ["/preview.png"],
   },
 };

--- a/marketing/src/app/opengraph-image.tsx
+++ b/marketing/src/app/opengraph-image.tsx
@@ -1,13 +1,13 @@
 import { ogImage, ogSize, ogContentType } from "../lib/og";
 
-export const alt = "NodeTool — the open creative AI workspace";
+export const alt = "NodeTool | Open-source creative AI workspace";
 export const size = ogSize;
 export const contentType = ogContentType;
 
 export default function Image() {
   return ogImage(
-    "You direct the vision. The agent builds the film.",
-    "Every model. Your keys. A timeline you can still edit.",
+    "Open-source creative AI workspace",
+    "Agents build and revise. You inspect and edit.",
     { image: "screen_canvas.png", accent: "blue" }
   );
 }

--- a/marketing/src/app/studio/layout.tsx
+++ b/marketing/src/app/studio/layout.tsx
@@ -1,9 +1,9 @@
 import JsonLd from "../../components/JsonLd";
 import type { Metadata } from "next";
 
-const TITLE = "NodeTool Studio — Agent-first creative workspace, offline";
+const TITLE = "NodeTool Studio | Open-source creative AI workspace";
 const DESCRIPTION =
-  "You direct the vision. The agent builds the film — on your own hardware. Describe your idea and NodeTool Studio's agent writes the script, boards every scene, generates the footage, and cuts a multi-track timeline you can still edit. Run open weights locally through Ollama, MLX, and GGUF, or bring your own API keys and pay provider prices. No credits, no markups, no lock-in. Offline, files on disk. macOS, Windows, Linux. AGPL-3.0.";
+  "Open-source creative AI workspace. Create images, video, audio, and text with agents, then inspect and edit their work. Keep your project context together. Studio runs on macOS, Windows, and Linux. Use supported local models or your own provider keys.";
 
 export const metadata: Metadata = {
   title: TITLE,
@@ -54,7 +54,7 @@ export default function StudioLayout({
           "@type": "SoftwareApplication",
           name: "NodeTool Studio",
           description:
-            "Open-source, agent-first creative workspace for the desktop. Describe an idea and the agent writes the script, boards the scenes, generates the footage, and cuts the timeline — on Ollama, MLX, and GGUF models running locally, or on your own API keys at provider prices. Works offline, files stay on disk.",
+            "Open-source creative AI workspace. Create images, video, audio, and text with agents, then inspect and edit their work. Keep your project context together. Studio runs on macOS, Windows, and Linux. Use supported local models or your own provider keys.",
           applicationCategory: "MultimediaApplication",
           operatingSystem: "macOS, Windows, Linux",
           url: "https://nodetool.ai/studio",

--- a/marketing/src/app/studio/opengraph-image.tsx
+++ b/marketing/src/app/studio/opengraph-image.tsx
@@ -1,13 +1,13 @@
 import { ogImage, ogSize, ogContentType } from "../../lib/og";
 
-export const alt = "NodeTool Studio — the agent builds the film on your hardware";
+export const alt = "NodeTool | Open-source creative AI workspace";
 export const size = ogSize;
 export const contentType = ogContentType;
 
 export default function Image() {
   return ogImage(
-    "You direct the vision. The agent builds the film on your hardware.",
-    "Open weights via Ollama and MLX, offline. Your keys. A timeline you can still edit.",
+    "Open-source creative AI workspace",
+    "Agents build and revise. You inspect and edit.",
     { image: "screen_assets.png", accent: "emerald", eyebrow: "Studio" }
   );
 }

--- a/marketing/src/app/studio/page.tsx
+++ b/marketing/src/app/studio/page.tsx
@@ -172,28 +172,23 @@ export default function StudioPage() {
                   <Cpu className="h-3.5 w-3.5" />
                   Studio · Desktop · Open source
                 </span>
-                {/* Sized a step below the landing hero's 3.25rem cap: this
-                    headline carries an extra clause, and at that cap it wrapped
-                    to five lines in the 5/12 column and pushed the demo out of
-                    line with the copy. text-balance is off for the same reason
-                    — it broke the short first line to equalise against the
-                    much longer second one. */}
                 <h1
                   id="studio-hero-title"
                   className="mt-6 text-[clamp(2rem,7vw,2.75rem)] font-bold leading-[1.1] tracking-tight text-white lg:text-[clamp(2rem,3.1vw,2.75rem)]"
                 >
-                  You are the director.
+                  Open-source
                   <br />
                   <span className="text-transparent bg-clip-text bg-gradient-to-r from-amber-300 to-orange-300 pb-[0.12em]">
-                    The agent is your crew — on your hardware.
+                    creative AI workspace
                   </span>
                 </h1>
                 <p className="mt-6 text-lg text-slate-300 leading-relaxed max-w-xl">
-                  Describe your idea. The agent writes the script, storyboards
-                  every scene, generates the footage, and cuts the timeline —
-                  all of it on your own machine, on open weights through Ollama
-                  and MLX, or on your own API keys when a cloud model is the
-                  right call.
+                  Create and edit images, video, audio, and text with agents that
+                  work alongside you. Let them build and revise workflows, then
+                  inspect and edit the results yourself. Your project keeps the
+                  brief, assets, and edits together. Run supported local models
+                  through Ollama or MLX, or connect cloud providers with your own API
+                  keys.
                 </p>
                 <div className="mt-8 flex flex-col gap-3">
                   <SmartDownloadButton

--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -18,7 +18,7 @@ export default function NodeToolHero() {
         <div className="hero-rise lg:col-span-5">
           <span className="inline-flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-blue-300">
             <span className="h-1.5 w-1.5 rounded-full bg-blue-400" />
-            Open-source AI film studio
+            Agents build. You edit.
           </span>
 
           {/*
@@ -34,17 +34,17 @@ export default function NodeToolHero() {
             id="hero-title"
             className="mt-5 text-balance text-[clamp(2rem,7.5vw,3.25rem)] font-bold leading-[1.1] tracking-tight text-white lg:text-[clamp(2.25rem,3.6vw,3.25rem)]"
           >
-            <span className="block">You are the director.</span>
+            <span className="block">Open-source</span>
             <span className="block bg-gradient-to-r from-rose-400 via-fuchsia-400 to-amber-300 bg-clip-text pb-[0.12em] text-transparent">
-              The agent is your crew.
+              creative AI workspace
             </span>
           </h1>
 
           <p className="mt-5 max-w-lg text-lg leading-relaxed text-slate-300">
-            Describe your idea. The agent writes the script, storyboards every
-            scene, generates the footage, and cuts the timeline. What comes back
-            is a project, not a render: re-roll one shot, re-voice one line,
-            re-cut the ending.
+            Create and edit images, video, audio, and text with agents that work
+            alongside you. Let them build and revise workflows, then inspect and edit
+            the results yourself. Your project keeps the brief, assets, and edits
+            together.
           </p>
 
           <div className="mt-7 flex">

--- a/marketing/src/components/agents/AgentsGraphHero.tsx
+++ b/marketing/src/components/agents/AgentsGraphHero.tsx
@@ -26,7 +26,7 @@ export default function AgentsGraphHero() {
                         <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-rose-500/10 border border-rose-500/20 mb-6">
                             <Sparkles className="w-4 h-4 text-rose-300" />
                             <span className="text-sm font-medium text-rose-200">
-                                An agent-first creative workspace
+                                Open-source creative AI workspace
                             </span>
                         </div>
 

--- a/marketing/src/data/faqEntries.ts
+++ b/marketing/src/data/faqEntries.ts
@@ -85,7 +85,7 @@ const seeds: FaqSeed[] = [
     slug: "what-is-nodetool",
     question: "What is NodeTool?",
     answerMd:
-      "NodeTool is the open AI production studio. You direct the vision and the agent builds the film: it drafts the script, boards every scene, generates the footage, and cuts a multi-track timeline you can still edit. Every major model from every major provider, including FAL, KIE, OpenAI, Anthropic, Gemini, and Replicate, sits on one visual canvas that you run on your own machine or in the browser.",
+      "NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Let them build and revise workflows, then inspect and edit the results yourself. Your project keeps the brief, assets, and edits together. Use supported local models or connect cloud providers with your own keys.",
     category: "general",
     relatedRoute: "/",
     surfaces: ["landing", "agents", "comparison"],

--- a/marketing/src/data/staticEntries.ts
+++ b/marketing/src/data/staticEntries.ts
@@ -15,7 +15,7 @@ import type { PageEntry } from "./types";
 export const staticEntries: PageEntry[] = [
   { route: "/", title: "NodeTool", description: "The open creative AI workspace.", priority: 1.0, changeFrequency: "weekly", indexable: true },
   { route: "/download", title: "Download NodeTool", description: "Installers for macOS, Windows and Linux, with what the app needs and how to open it.", priority: 0.9, changeFrequency: "weekly", indexable: true },
-  { route: "/studio", title: "NodeTool Studio", description: "You direct the vision. The agent builds the film on your own machine.", priority: 0.9, changeFrequency: "weekly", indexable: true },
+  { route: "/studio", title: "NodeTool Studio", description: "Open-source creative AI workspace for your desktop. Agents build and revise; you inspect and edit.", priority: 0.9, changeFrequency: "weekly", indexable: true },
   { route: "/cloud", title: "NodeTool Cloud", description: "Run NodeTool workflows in the cloud.", priority: 0.9, changeFrequency: "weekly", indexable: true },
   { route: "/pricing", title: "Pricing", description: "Free Studio, your own keys, pay providers directly.", priority: 0.8, changeFrequency: "weekly", indexable: true },
   // The entity page for the "node based ai" / "ai node editor" cluster — the

--- a/marketing/src/lib/siteSchema.ts
+++ b/marketing/src/lib/siteSchema.ts
@@ -14,7 +14,7 @@ export const softwareApplicationSchema: JsonLdObject = {
   "@type": "SoftwareApplication",
   name: "NodeTool",
   description:
-    "NodeTool is the open-source, agent-first creative workspace for film production. Every editor — the node canvas, sketch pad, storyboard, video timeline, script editor, 3D scene, and app builder — is exposed to agents as tools, around 120 in all: pitch your concept and the agent drafts the script, casts the voices, boards the scenes, generates the footage, and cuts a multi-track timeline you can still edit, running on every major model from every major provider with your own keys. It runs as a desktop app on macOS, Windows, and Linux, or in the browser with NodeTool Cloud.",
+    "NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Let them build and revise workflows, then inspect and edit the results yourself. Your project keeps the brief, assets, and edits together. Studio runs on macOS, Windows, and Linux. Cloud is the hosted browser edition, in alpha.",
   applicationCategory: "MultimediaApplication",
   applicationSubCategory: "Creative AI Workspace",
   operatingSystem: "macOS, Windows, Linux",
@@ -68,14 +68,14 @@ export const organizationSchema: JsonLdObject = {
     "https://discord.gg/WmQTWZRcYE",
   ],
   description:
-    "NodeTool builds the open, agent-first creative workspace: every editor is exposed to agents as tools, connecting every major model from every major provider using the creator's own keys, available as a desktop app and as a hosted browser edition.",
+    "NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Let them build and revise workflows, then inspect and edit the results yourself. Your project keeps the brief, assets, and edits together. Studio runs on macOS, Windows, and Linux. Cloud is the hosted browser edition, in alpha.",
 };
 
 /** The demo video on the home page. Emitted by the page that shows it. */
 export const demoVideoSchema: JsonLdObject = {
   "@context": "https://schema.org",
   "@type": "VideoObject",
-  name: "NodeTool — the open, agent-first creative workspace (demo)",
+  name: "NodeTool | Open-source creative AI workspace (demo)",
   description:
     "A trailer built end to end in NodeTool: the agent drafts the script, boards the shots, generates the footage, and cuts the timeline — on one canvas, with your own keys.",
   thumbnailUrl: "https://nodetool.ai/preview.png",


### PR DESCRIPTION
## Summary

The filmmaker tagline and agent-first category label obscure NodeTool's broader scope for new visitors. Lead with the agreed category, "Open-source creative AI workspace", and explain agent behavior through editable work and persistent project context.

- Update the README, docs index, homepage, Studio and Cloud heroes, and supporting FAQ/download/agents copy. Keep edition-specific local-model and Cloud alpha details.
- Align page titles, descriptions, social image text, structured data, and generated machine-readable summaries.
- Update brand and narrative guidance so future copy uses the same tagline and intro. Keep agent-first in supporting feature explanations.

## Test plan

- `git diff --check` passed.
- Parsed and transpiled all 15 changed TypeScript/TSX files with esbuild successfully.
- Regenerated machine-readable pages using the checked-in generator; its `--check` passed (run via Node's tsx loader).
- `npm run test:affected` could not run: marketing files select the repository-wide fallback, which stops because `vitest` is not installed in this checkout.
- Full application typechecking/build and interactive browser verification were not run. Changes are copy and documentation only; no runtime logic or styling changed.

Follow-up to merged #5606.

## Adaptation after #5614

Preserve #5614's README intro, model/provider section, ownership bullets, and platform notes. Relative to that merged README, only the primary tagline changes. The marketing and docs-index positioning changes remain. The marquee test is untouched and its fix stays on main.

README three-way merge and whitespace checks passed; the generated-docs freshness check passed again. GitHub reports no merge conflicts. No rebase or force push was used.