### PR TITLE
feat(examples): ship the recipe chains in the app

### DIFF
--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -911,9 +911,13 @@ copies the whole chain into the library. The site builds its `/recipes` pages
 and the downloadable `.nodetool` bundles from the same manifests
 (`marketing/scripts/generate-recipes.mjs`, with the sample renders and page
 order in `marketing/scripts/recipes.mjs`), so the page and the product name one
-list of workflows. `npm run validate:examples` checks every step, alternative
-and hero resolves; `scripts/verify-backend-bundle.mjs` checks the manifests and
-the examples they name were staged into the packaged bundle.
+list of workflows. The `recipes` harness is the gate on that: its selfcheck runs
+the resolver's suite (`packages/websocket/tests/example-recipes.test.ts`) and
+the site generator in `--check` mode, and it fires on any diff touching a
+manifest, the resolver, the Examples listing, or the recipe pages.
+`npm run validate:examples` also checks every step, alternative and hero
+resolves, and `scripts/verify-backend-bundle.mjs` checks the manifests and the
+examples they name were staged into the packaged bundle.
 
 ### 3D scene tools (no editor, no browser)
 

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -891,6 +891,30 @@ and the `edit_timeline` op `insert_composition`; the pure
 `instantiateComposition`/`extractComposition` live in
 `packages/timeline/src/composition.ts`.
 
+### Shipped recipes
+
+A recipe is a named outcome plus the ordered example workflows that reach it —
+"one packshot per SKU becomes the whole channel set", four to six shipped
+workflows deep. The manifests are
+`packages/base-nodes/nodetool/examples/recipes/<slug>.recipe.json` (the
+`recipes` sibling of the example workflows, where `exampleRecipesDir` looks by
+default in the monorepo, the packaged backend, and the server image). They hold
+no graphs: each step names a shipped example, and
+`listExampleRecipes` (`packages/websocket/src/lib/example-recipes.ts`) resolves
+those names against the examples the install actually ships, reading each
+step's node count, thumbnail and models out of the graph. A recipe with a step
+that no longer resolves is dropped from the listing rather than half-offered.
+
+`workflows.recipes` serves them; the web app shows them above the gallery on
+**Examples**, where a step opens that example as a workflow and "Add all"
+copies the whole chain into the library. The site builds its `/recipes` pages
+and the downloadable `.nodetool` bundles from the same manifests
+(`marketing/scripts/generate-recipes.mjs`, with the sample renders and page
+order in `marketing/scripts/recipes.mjs`), so the page and the product name one
+list of workflows. `npm run validate:examples` checks every step, alternative
+and hero resolves; `scripts/verify-backend-bundle.mjs` checks the manifests and
+the examples they name were staged into the packaged bundle.
+
 ### 3D scene tools (no editor, no browser)
 
 An agent builds and fixes a 3D model without an editor open:

--- a/electron/src/__tests__/verifyBackendBundle.test.ts
+++ b/electron/src/__tests__/verifyBackendBundle.test.ts
@@ -39,6 +39,11 @@ function writeValidBundle(dir: string): void {
     path.join(dir, "examples", "compositions", "hello.composition.json"),
     "{}"
   );
+  fs.mkdirSync(path.join(dir, "examples", "recipes"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "examples", "recipes", "hello.recipe.json"),
+    JSON.stringify(RECIPE_MANIFEST)
+  );
   fs.mkdirSync(path.join(dir, "assets", "nodetool-base", "storyboards", "hello"), {
     recursive: true,
   });
@@ -80,6 +85,15 @@ function writeValidBundle(dir: string): void {
     "export {};"
   );
 }
+
+/** One shipped recipe, naming the example workflow staged alongside it. */
+const RECIPE_MANIFEST = {
+  schemaVersion: 1,
+  slug: "hello",
+  name: "Hello",
+  hero: "hello",
+  steps: [{ example: "hello", role: "Say hello", handoff: "In: nothing." }],
+};
 
 /** One shipped board, naming the two media files staged alongside it. */
 const STORYBOARD_BUNDLE = {
@@ -262,6 +276,27 @@ describe("verify-backend-bundle", () => {
     const { status, output } = runVerify(tempDir);
     expect(output).toContain("example storyboard media not staged");
     expect(output).toContain("storyboards/hello/shot.mp4");
+    expect(status).toBe(1);
+  });
+
+  it("fails when a recipe names an example that was not staged", () => {
+    fs.writeFileSync(
+      path.join(tempDir, "examples", "recipes", "hello.recipe.json"),
+      JSON.stringify({
+        ...RECIPE_MANIFEST,
+        steps: [{ ...RECIPE_MANIFEST.steps[0], example: "renamed" }],
+      })
+    );
+    const { status, output } = runVerify(tempDir);
+    expect(output).toContain("recipe steps name examples that were not staged");
+    expect(output).toContain("hello.recipe.json: renamed");
+    expect(status).toBe(1);
+  });
+
+  it("fails when no recipe manifest is staged at all", () => {
+    fs.rmSync(path.join(tempDir, "examples", "recipes"), { recursive: true });
+    const { status, output } = runVerify(tempDir);
+    expect(output).toContain("examples/recipes/ is missing");
     expect(status).toBe(1);
   });
 

--- a/marketing/NARRATIVE.md
+++ b/marketing/NARRATIVE.md
@@ -139,12 +139,13 @@ ownership.
 
 The homepage shows the four recipes (`/recipes`) under the heading "How teams
 are using NodeTool", because each is a job with a buyer, a real run against live
-models, and a `.nodetool` bundle to download. The four use cases on `/use-cases`
+models, and a chain that ships inside Studio (Examples → Recipes; the site also
+packs each as a `.nodetool` bundle). The four use cases on `/use-cases`
 (trailer, teaser, product video, poster) are demos of a surface; they stay on
 their own pages.
 
-Each recipe card carries: what you end up holding, who it is for, the models
-the shipped chain calls, and the bundle. That is the proof the BYOK claim has
+Each recipe card carries: what you end up holding, who it is for, and the models
+the shipped chain calls. That is the proof the BYOK claim has
 today. The proof it still lacks is a real provider bill per recipe. Until a
 recorded run produces one, the card says "at provider list prices" and names
 the models. **Do not put an estimated dollar figure on a card.** A number that

--- a/marketing/scripts/generate-recipes.mjs
+++ b/marketing/scripts/generate-recipes.mjs
@@ -1,15 +1,19 @@
 // Generates marketing/src/data/recipeEntries.generated.ts and the downloadable
-// .nodetool bundles in marketing/public/recipes/ from the editorial specs in
-// scripts/recipes.mjs.
+// .nodetool bundles in marketing/public/recipes/ from the recipe manifests the
+// app ships (packages/base-nodes/nodetool/examples/recipes/*.recipe.json) plus
+// the site-only presentation in scripts/recipes.mjs.
 //
 // Regenerate: npm run gen:recipes        Verify: npm run gen:recipes -- --check
 //
 // The generated module is checked in, so the site builds without this script.
 // What the script adds is that a recipe cannot outlive its ingredients: every
-// step is resolved against the shipped example workflows, and a slug that stops
+// step is resolved against the shipped example workflows, and a name that stops
 // resolving throws here rather than shipping a page whose bundle is short a
 // workflow. The models and API keys each recipe lists are read out of the
 // graphs, never written by hand.
+//
+// The manifests are the app's: the same files the Examples page reads to offer
+// each chain, so the page and the product describe one list of workflows.
 //
 // The .nodetool bundles are NOT deterministic — packWorkflowsBundle stamps a
 // created_at and the running NodeTool version into the manifest — so --check
@@ -25,7 +29,7 @@ import { fileURLToPath } from "node:url";
 // Fastify server, and tsx would resolve the specifier to a stale `dist/`.
 // The codec itself only needs fflate and node:crypto.
 import { packWorkflowsBundle } from "../../packages/websocket/src/lib/workflow-bundle.ts";
-import { recipes } from "./recipes.mjs";
+import { recipePresentation } from "./recipes.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const MARKETING = path.resolve(__dirname, "..");
@@ -33,6 +37,10 @@ const REPO_ROOT = path.resolve(MARKETING, "..");
 const EXAMPLES_DIR = path.join(
   REPO_ROOT,
   "packages/base-nodes/nodetool/examples/nodetool-base",
+);
+const RECIPES_DIR = path.join(
+  REPO_ROOT,
+  "packages/base-nodes/nodetool/examples/recipes",
 );
 const TEMPLATE_ENTRIES = path.join(
   MARKETING,
@@ -44,6 +52,8 @@ const RENDER_MANIFEST = path.join(__dirname, "recipe-samples.manifest.json");
 const OUT_FILE = path.join(MARKETING, "src/data/recipeEntries.generated.ts");
 
 const CHECK = process.argv.includes("--check");
+
+const RECIPE_SUFFIX = ".recipe.json";
 
 /**
  * Stamped into each bundle manifest, matching what the CLI exporter writes.
@@ -162,17 +172,17 @@ function buildSample(spec) {
 }
 
 /**
- * A step's swap-in variant: another shipped template that reaches a different
+ * A step's swap-in variant: another shipped example that reaches a different
  * ending from the same inputs. Resolved the same way a step is, so a variant
- * cannot name a template that stopped shipping.
+ * cannot name an example that stopped shipping.
  */
-function buildAlternative(spec, step, byTemplateSlug) {
+function buildAlternative(spec, step, byExampleName) {
   if (!step.alternative) return null;
-  const entry = byTemplateSlug.get(step.alternative.template);
+  const entry = byExampleName.get(step.alternative.example);
   if (!entry) {
     fail(
-      `recipe "${spec.slug}" step "${step.template}" offers alternative ` +
-        `"${step.alternative.template}", which resolves to no shipped template.`,
+      `recipe "${spec.slug}" step "${step.example}" offers alternative ` +
+        `"${step.alternative.example}", which resolves to no shipped example.`,
     );
   }
   return {
@@ -184,15 +194,15 @@ function buildAlternative(spec, step, byTemplateSlug) {
   };
 }
 
-/** Resolve one recipe spec into the record the page renders. */
-function buildRecipe(spec, byTemplateSlug) {
+/** Resolve one recipe manifest into the record the page renders. */
+function buildRecipe(spec, byExampleName) {
   const steps = spec.steps.map((step) => {
-    const entry = byTemplateSlug.get(step.template);
+    const entry = byExampleName.get(step.example);
     if (!entry) {
       fail(
-        `recipe "${spec.slug}" step "${step.template}" resolves to no shipped ` +
-          "template. Run `npm run gen:templates` first; if the example was " +
-          "renamed, update scripts/recipes.mjs.",
+        `recipe "${spec.slug}" step "${step.example}" resolves to no shipped ` +
+          "example. Run `npm run gen:templates` first; if the example was " +
+          `renamed, update ${path.relative(REPO_ROOT, RECIPES_DIR)}/${spec.slug}.recipe.json.`,
       );
     }
     const file = path.join(EXAMPLES_DIR, `${entry.name}.json`);
@@ -212,15 +222,13 @@ function buildRecipe(spec, byTemplateSlug) {
         thumbnail: entry.thumbnail,
         nodeCount: entry.nodeCount,
         models: modelRefs(graph),
-        alternative: buildAlternative(spec, step, byTemplateSlug),
+        alternative: buildAlternative(spec, step, byExampleName),
       },
     };
   });
 
-  if (!steps.some((s) => s.entry.slug === spec.heroStep)) {
-    fail(
-      `recipe "${spec.slug}": heroStep "${spec.heroStep}" is not one of its steps`,
-    );
+  if (!steps.some((s) => s.entry.name === spec.hero)) {
+    fail(`recipe "${spec.slug}": hero "${spec.hero}" is not one of its steps`);
   }
 
   const providers = [
@@ -250,7 +258,7 @@ function buildRecipe(spec, byTemplateSlug) {
       audience: spec.audience,
       summary: spec.summary,
       caveats: spec.caveats,
-      heroThumbnail: steps.find((s) => s.entry.slug === spec.heroStep).step
+      heroThumbnail: steps.find((s) => s.entry.name === spec.hero).step
         .thumbnail,
       bundle: `/recipes/${spec.slug}.nodetool`,
       workflowCount: steps.length,
@@ -329,15 +337,56 @@ export const recipeEntries: RecipeEntry[] = ${JSON.stringify(records, null, 2)};
 `;
 }
 
-async function main() {
-  const byTemplateSlug = new Map(readTemplateEntries().map((t) => [t.slug, t]));
-  const slugs = new Set();
-  for (const spec of recipes) {
-    if (slugs.has(spec.slug)) fail(`duplicate recipe slug "${spec.slug}"`);
-    slugs.add(spec.slug);
+/**
+ * The shipped manifests, in page order: the order scripts/recipes.mjs lists,
+ * then anything else on disk by slug. Each carries the site-only sample block
+ * for its slug, so a manifest that ships without one still gets a page.
+ */
+function readManifests() {
+  let files;
+  try {
+    files = fs
+      .readdirSync(RECIPES_DIR)
+      .filter((file) => file.endsWith(RECIPE_SUFFIX))
+      .sort((a, b) => a.localeCompare(b));
+  } catch {
+    fail(`no recipe manifests at ${path.relative(REPO_ROOT, RECIPES_DIR)}`);
+  }
+  const bySlug = new Map();
+  for (const file of files) {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(RECIPES_DIR, file), "utf8"),
+    );
+    const slug = file.slice(0, -RECIPE_SUFFIX.length);
+    if (manifest.slug !== slug) {
+      fail(`${file} declares slug "${manifest.slug}" — rename one or the other`);
+    }
+    bySlug.set(slug, manifest);
   }
 
-  const built = recipes.map((spec) => buildRecipe(spec, byTemplateSlug));
+  const ordered = [];
+  for (const { slug, sample } of recipePresentation) {
+    const manifest = bySlug.get(slug);
+    if (!manifest) {
+      fail(
+        `scripts/recipes.mjs lists "${slug}", which has no manifest in ` +
+          `${path.relative(REPO_ROOT, RECIPES_DIR)}`,
+      );
+    }
+    ordered.push({ ...manifest, sample: sample ?? null });
+    bySlug.delete(slug);
+  }
+  for (const manifest of bySlug.values()) {
+    ordered.push({ ...manifest, sample: null });
+  }
+  return ordered;
+}
+
+async function main() {
+  const byExampleName = new Map(readTemplateEntries().map((t) => [t.name, t]));
+  const specs = readManifests();
+
+  const built = specs.map((spec) => buildRecipe(spec, byExampleName));
   const source = render(built.map((b) => b.record));
 
   if (CHECK) {

--- a/marketing/scripts/recipes.mjs
+++ b/marketing/scripts/recipes.mjs
@@ -1,21 +1,12 @@
-// The four launch recipes, as editorial content only.
+// How the site presents each recipe: the page order, and the sample render
+// that heads the page.
 //
-// A recipe is a named outcome plus the ordered shipped example workflows that
-// reach it. Everything mechanical — the models each step calls, the API keys
-// the chain needs, the node counts, the card art — is derived from those
-// workflows by generate-recipes.mjs, so this file cannot claim a model or a
-// key that the graph does not actually use.
-//
-// `template` is a slug in marketing/src/data/templateEntries.generated.ts.
-// The generator throws when one stops resolving, which is what keeps a renamed
-// example from silently shipping a broken recipe page and an empty bundle.
-
-/**
- * @typedef {object} RecipeStepSpec
- * @property {string} template  Template slug (must resolve).
- * @property {string} role      What this step is for, in the recipe's terms.
- * @property {string} handoff   What goes in and what comes back out.
- */
+// The recipes themselves — the outcome, the prose, the ordered workflows each
+// chain runs — ship with the app, one manifest per recipe in
+// `packages/base-nodes/nodetool/examples/recipes/`. generate-recipes.mjs reads
+// those, so a page and the chain the app offers cannot describe different
+// workflows. What stays here is what only the site has: the contact sheets and
+// clips in `public/recipes/samples/`, and the order the cards appear in.
 
 /**
  * @typedef {object} RecipeSample
@@ -24,61 +15,17 @@
  * @property {string} [poster]   Poster for the clip.
  * @property {boolean} [hasAudio] The clip carries sound, so it needs controls.
  * @property {string} caption    What the reader is looking at.
- * @property {string} [substitutions] Why the run differs from the shipped graph.
  */
 
 /**
- * @typedef {object} RecipeSpec
- * @property {string} slug
- * @property {string} name
- * @property {string} outcome    One sentence: what you end up holding.
- * @property {string} audience   Who runs this.
- * @property {string[]} summary  Intro paragraphs for the page.
- * @property {string} heroStep   Template slug whose card art heads the page.
- * @property {RecipeStepSpec[]} steps
- * @property {RecipeSample} [sample]  Real output, produced by running the chain.
- * @property {string[]} caveats  What this does not do, stated plainly.
+ * Recipe slugs in page order, each with its sample or null. A slug listed here
+ * must have a manifest; a manifest not listed here still ships a page, after
+ * these.
+ * @type {{slug: string, sample: RecipeSample | null}[]}
  */
-
-/** @type {RecipeSpec[]} */
-export const recipes = [
+export const recipePresentation = [
   {
     slug: "viral-video-ad-engine",
-    name: "Viral Video Ad Engine",
-    outcome:
-      "A vertical product ad, plus the hook lines and thumbnails to test it against.",
-    audience: "Performance and social teams shipping several ad variants a week.",
-    summary: [
-      "Four workflows, ordered cheapest first. The copy and the hook set are text and fast images, so you can throw most of them away; only the last two steps touch a video model, and by then you have already chosen the line and the frame.",
-      "That order is the whole point. Deciding register and hook after paying for footage is how an ad budget disappears into renders nobody posts.",
-    ],
-    heroStep: "hook-and-thumbnail-factory",
-    steps: [
-      {
-        template: "ad-copy-in-three-registers",
-        role: "Settle the register before anything renders",
-        handoff:
-          "In: the offer in a sentence. Out: the same offer written plain, playful and premium. One text call, so the argument about tone costs cents instead of a render queue.",
-      },
-      {
-        template: "hook-and-thumbnail-factory",
-        role: "Fan the winning line into a test set",
-        handoff:
-          "In: the video topic. Out: a stream of hook lines, each with its own color-graded thumbnail. The fan-out is the useful part — one hook stream drives the whole gallery in a single run.",
-      },
-      {
-        template: "ad-loop-from-a-product-photo",
-        role: "Put the product in motion",
-        handoff:
-          "In: the product photo. Out: a short hero loop. A prompt node writes the motion brief, the image-to-video model animates the still, and a speed pass slows it. This is the step that costs real money.",
-      },
-      {
-        template: "cut-a-landscape-clip-for-vertical",
-        role: "Cut it to the frame the channel wants",
-        handoff:
-          "In: the 16:9 loop. Out: a 1080×1920 file. Runs through ffmpeg on your own machine — no key, no per-run charge.",
-      },
-    ],
     sample: {
       image: "viral-video-ad-engine.jpg",
       video: "viral-video-ad-engine.mp4",
@@ -86,54 +33,9 @@ export const recipes = [
       caption:
         "One product photo and one line of copy, run through the whole chain: four hook lines with a thumbnail each, then the hero loop cut to 1080x1920. The fourth thumbnail went off-brief and is shown as it came back.",
     },
-    caveats: [
-      "The vertical step rescales rather than crops, so frame the loop with room to lose or add a crop node ahead of it.",
-      "Nothing here measures performance. The recipe produces variants to test; the testing happens in your ad platform.",
-    ],
   },
   {
     slug: "multilingual-video-dubber",
-    name: "Multilingual Video Dubber",
-    outcome:
-      "One presenter clip, spoken in a second language, with a lip-synced cut, subtitles, and a back-translation to check it.",
-    audience: "Anyone re-releasing a recorded talk, demo, or ad into another market.",
-    summary: [
-      "The spine is transcribe, translate, revoice. What makes it usable outside the languages your team reads is the third step: a back-translation printed next to the localised line, so the person approving the cut can see what was actually said.",
-      "The last two steps are a fork, not a sequence. A voice-over cut ends at the revoiced audio; an on-camera cut carries on into lip-sync so the presenter's mouth matches the new delivery.",
-    ],
-    heroStep: "ai-spokesperson",
-    steps: [
-      {
-        template: "transcribe-a-clip",
-        role: "Get the script back out of the footage",
-        handoff:
-          "In: the source clip. Out: the spoken words as text. The audio is extracted on your machine and only the audio is sent to a speech-to-text model.",
-      },
-      {
-        template: "localise-a-script-and-revoice-it",
-        role: "Translate and voice in one pass",
-        handoff:
-          "In: the transcript and a target language. Out: audio in that language. A translated document still leaves the recording to do, which is why this step ends in sound rather than text.",
-      },
-      {
-        template: "one-tagline-six-markets",
-        role: "Read back what you just shipped",
-        handoff:
-          "In: the lines that carry the message — the claim, the offer, the call to action. Out: each one in six languages with a back-translation beside it. This is the review gate for a language nobody in the room speaks.",
-      },
-      {
-        template: "ai-spokesperson",
-        role: "Make the mouth match, for an on-camera cut",
-        handoff:
-          "In: the presenter clip and the translated script — the script, not the audio from step two, because this workflow voices the line itself before it redrives the mouth. Out: a take that looks recorded in the new language.",
-      },
-      {
-        template: "subtitle-text-from-a-recording",
-        role: "Ship the version people read",
-        handoff:
-          "In: the localised audio. Out: transcript broken into subtitle-length lines. The line-length rule is what separates a subtitle file from a wall of text.",
-      },
-    ],
     sample: {
       image: "multilingual-video-dubber.jpg",
       video: "multilingual-video-dubber.mp4",
@@ -142,61 +44,9 @@ export const recipes = [
       caption:
         "The same take, before and after the lip-sync step, with the Spanish the translator produced. The presenter is generated too — the recipe assumes you bring your own footage, and this render had none to bring.",
     },
-    caveats: [
-      "Lip-sync redrives the mouth. It does not change gesture, gaze, or anything a presenter does with their hands, so a take with heavy pointing at on-screen text will still read as dubbed.",
-      "Timing is not stretched to match the original. A language that runs longer than the source will run longer in the cut.",
-      "The back-translation is a check on meaning, not on register. A native reviewer is still the last word before a paid campaign.",
-    ],
   },
   {
     slug: "ecommerce-sku-visual-factory",
-    name: "E-commerce SKU Visual Factory",
-    outcome:
-      "One packshot per SKU becomes the whole channel set: cutout, studio scene, seasonal relight, turntable clip, print master, and the listing copy.",
-    audience: "Catalogue and marketplace teams with more SKUs than shoot days.",
-    summary: [
-      "Every step after the first one starts from the cutout, so the product itself is never regenerated. That is the constraint that matters in a catalogue: the customer is buying the object in the photograph, and a model that redraws it has sold them something else.",
-      "Run the chain once per SKU. The upscale sits at the end on purpose — one call for the asset you actually print, rather than paying print resolution on every draft.",
-    ],
-    heroStep: "put-a-product-on-a-studio-backdrop",
-    steps: [
-      {
-        template: "cut-a-product-out-of-its-background",
-        role: "Isolate the product once",
-        handoff:
-          "In: the packshot. Out: the product on a real alpha channel rather than a white matte, so the edge survives compositing onto anything later.",
-      },
-      {
-        template: "put-a-product-on-a-studio-backdrop",
-        role: "Place it in a described setting",
-        handoff:
-          "In: the cutout and a scene description. Out: the product in that scene. An edit model told to change only the surroundings, rather than a strength setting on image-to-image, is what keeps the product unchanged.",
-      },
-      {
-        template: "relight-a-product-for-a-seasonal-campaign",
-        role: "Change the season without a reshoot",
-        handoff:
-          "In: the placed shot. Out: the same geometry and materials under different light. Relighting moves where the light comes from and nothing else.",
-      },
-      {
-        template: "spin-a-packshot-into-a-turntable-clip",
-        role: "Give the product page motion",
-        handoff:
-          "In: the still. Out: a short clip with a camera move. Image-to-video keeps the product identical, which a text-to-video model would not.",
-      },
-      {
-        template: "take-a-product-shot-to-print-resolution",
-        role: "Upscale only the keeper",
-        handoff:
-          "In: the approved web asset. Out: a print-resolution master. One call at the end of the pipeline instead of print resolution on every draft.",
-      },
-      {
-        template: "write-a-listing-from-the-product-photo",
-        role: "Write the copy from the photograph",
-        handoff:
-          "In: the image itself, not a description of it. Out: marketplace copy that catches finish, proportion, and what the thing sits next to — details a spec sheet leaves out.",
-      },
-    ],
     sample: {
       image: "ecommerce-sku-visual-factory.jpg",
       video: "ecommerce-sku-visual-factory.mp4",
@@ -204,54 +54,9 @@ export const recipes = [
       caption:
         "One generated packshot carried through the whole chain: cutout on a real alpha channel, placed on a concrete plinth, relit for winter sun, spun into a turntable clip, and mastered at 4096px. The product is the same object in all six.",
     },
-    caveats: [
-      "Background removal is a model, not a matte artist. Hair, mesh, glassware, and anything transparent need a look before they go live.",
-      "Relighting changes light, not colour management. A brand colour that has to match a printed swatch still needs a proofing step.",
-      "The listing copy is written from one photograph. It does not know your stock, sizing, or compliance wording.",
-    ],
   },
   {
     slug: "storyboard-to-trailer",
-    name: "Storyboard to Trailer",
-    outcome:
-      "A logline becomes a beat sheet, a numbered shot list, a cut teaser, and a score under it.",
-    audience: "Directors, agencies, and anyone pitching a film that does not exist yet.",
-    summary: [
-      "The two text steps come first because they are the ones you will rewrite. A beat sheet and a shot list are cheap to redo and expensive to skip — prose cannot be iterated over by a generation pipeline, numbered shots can.",
-      "Only the third step spends. It runs each shot through a video model metered per second, which is why the two documents in front of it are worth arguing over first.",
-    ],
-    heroStep: "movie-trailer-generator",
-    steps: [
-      {
-        template: "trailer-beats-from-a-premise",
-        role: "Write the structure before buying footage",
-        handoff:
-          "In: the premise. Out: hook, escalation, turn, title card. The shape a trailer needs, settled while it still costs one text call to change.",
-      },
-      {
-        template: "shot-list-from-a-synopsis",
-        role: "Turn prose into something a pipeline can walk",
-        handoff:
-          "In: the synopsis. Out: numbered shots with framing and duration. This is the document the next step iterates over.",
-      },
-      {
-        template: "movie-trailer-generator",
-        role: "Film it and cut it",
-        handoff:
-          "In: the logline. Out: a cut teaser. A Director node writes the storyboard and one style bible, each shot becomes an image prompt, and the frames are rendered, animated, and assembled. The per-second video model is the expensive step.",
-        alternative: {
-          template: "directed-film-to-timeline",
-          label: "Swap this step to keep editing",
-          why: "The same director-to-shots chain, ending on the timeline as an editable sequence rather than a finished file. Re-roll one shot or re-cut the ending without running the chain again.",
-        },
-      },
-      {
-        template: "score-a-silent-clip",
-        role: "Put music under it",
-        handoff:
-          "In: the cut and a mood. Out: a bed written to the clip's own length, mixed under the original audio. One audio generation per run.",
-      },
-    ],
     sample: {
       image: "storyboard-to-trailer.jpg",
       video: "storyboard-to-trailer.mp4",
@@ -260,9 +65,5 @@ export const recipes = [
       caption:
         "One logline — a lighthouse keeper finds a message in a bottle dated forty years from now — through steps three and four: five shots directed, rendered, animated, cut, and scored. The first two steps produce documents, so they are not in the picture; the style bible holding these five together is written in step three.",
     },
-    caveats: [
-      "Steps three and four both hold their own storyboard. Rewriting the beat sheet does not reach back into a teaser you already rendered — re-run the chain.",
-      "Continuity across shots comes from a shared style bible, not from a persistent character model. Faces drift over a long cut.",
-    ],
   },
 ];

--- a/marketing/src/app/recipes/[slug]/page.tsx
+++ b/marketing/src/app/recipes/[slug]/page.tsx
@@ -170,9 +170,9 @@ export default async function RecipePage({
               directly — NodeTool takes no cut and adds no markup.
             </p>
             <p className="mb-6 max-w-2xl text-sm leading-relaxed text-slate-400">
-              You need none of them to look. Downloading the bundle, importing
-              it, opening every graph, and reading what each node is set to
-              costs nothing and connects to nothing.
+              You need none of them to look. Opening every graph in the chain
+              and reading what each node is set to costs nothing and connects to
+              nothing.
               {firstSingleKeyStep && (
                 <>
                   {" "}
@@ -318,23 +318,19 @@ export default async function RecipePage({
             <h2 className="mb-8 text-2xl font-bold tracking-tight md:text-3xl">
               Running it
             </h2>
-            <ol className="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+            <ol className="grid gap-5 sm:grid-cols-3">
               {[
                 {
                   title: "Install Studio",
                   body: "The desktop app is free and runs on your own machine. No account, no sign-in, and no key is needed to open a workflow.",
                 },
                 {
-                  title: "Import the bundle",
-                  body: "Open the command menu and choose Import Workflow as Bundle. All the workflows in this recipe land in your library at once.",
+                  title: "Open it from Examples",
+                  body: `This recipe ships inside Studio. Open Examples, find ${entry.name} under Recipes, and add all ${entry.workflowCount} workflows to your library in one click.`,
                 },
                 {
-                  title: "Add your keys",
-                  body: "Paste each key above into Settings. Studio stores them in your OS keychain and sends them only to that provider.",
-                },
-                {
-                  title: "Run the chain",
-                  body: "Work down the list. Each step takes what the one before it produced, so you can stop and change your mind at any point.",
+                  title: "Add your keys and work down the chain",
+                  body: "Paste each key above into Settings. Studio keeps them in your OS keychain and sends them only to that provider. Each step takes what the one before it produced, so you can stop and change your mind at any point.",
                 },
               ].map((step, i) => (
                 <li
@@ -353,6 +349,16 @@ export default async function RecipePage({
                 </li>
               ))}
             </ol>
+            <p className="mt-6 max-w-2xl text-sm leading-relaxed text-slate-500">
+              Prefer a file? The same chain is packed as{" "}
+              <a
+                href={entry.bundle}
+                className="text-slate-300 underline decoration-slate-600 underline-offset-2 hover:text-amber-300"
+              >
+                one <code className="font-mono">.nodetool</code> bundle
+              </a>
+              , which imports from the command menu.
+            </p>
           </div>
         </section>
 

--- a/marketing/src/app/recipes/page.tsx
+++ b/marketing/src/app/recipes/page.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import Image from "next/image";
-import { ArrowRight, Download, Package } from "lucide-react";
+import { ArrowRight, Package } from "lucide-react";
 import SiteHeader from "@/components/SiteHeader";
 import SiteFooter from "@/components/SiteFooter";
 import JsonLd from "@/components/JsonLd";
@@ -13,7 +13,7 @@ const BASE_URL = "https://nodetool.ai";
 export const metadata: Metadata = {
   title: "AI Workflow Recipes — NodeTool",
   description:
-    "Multi-step NodeTool recipes for ad production, video dubbing, product catalogues, and trailers. Each one is the workflows to run, in order, as a single downloadable bundle.",
+    "Multi-step NodeTool recipes for ad production, video dubbing, product catalogues, and trailers. Each one is the workflows to run, in order, and each ships inside Studio.",
   alternates: { canonical: `${BASE_URL}/recipes` },
 };
 
@@ -47,8 +47,8 @@ export default function RecipesHub() {
             <p className="mt-5 max-w-2xl text-lg leading-relaxed text-slate-400">
               A template shows you a graph. A recipe gives you the finished job:
               which workflows to run, in what order, what each one hands the
-              next, and where the money goes. Download the chain as one file and
-              import it into Studio.
+              next, and where the money goes. Every recipe ships inside Studio,
+              on the Examples page.
             </p>
           </div>
         </section>
@@ -109,15 +109,14 @@ export default function RecipesHub() {
 
         <section className="relative pb-24">
           <div className="mx-auto max-w-3xl px-6 text-center">
-            <Download className="mx-auto h-8 w-8 text-amber-400" />
+            <Package className="mx-auto h-8 w-8 text-amber-400" />
             <h2 className="mt-5 text-3xl font-bold tracking-tight md:text-4xl">
-              Every recipe is one file
+              Every recipe is already installed
             </h2>
             <p className="mt-4 text-lg leading-relaxed text-slate-400">
-              A <code className="font-mono text-amber-300">.nodetool</code>{" "}
-              bundle carries every workflow in the chain. In Studio, open the
-              command menu and choose Import Workflow as Bundle — the whole
-              recipe lands in your library, editable node by node.
+              Studio ships these chains with its examples: open Examples, pick a
+              recipe, and add its workflows to your library in one click,
+              editable node by node. Nothing to download or import.
             </p>
             <a
               href="/templates"

--- a/marketing/src/app/templates/page.tsx
+++ b/marketing/src/app/templates/page.tsx
@@ -126,8 +126,8 @@ export default function TemplatesHub() {
               </h2>
               <p className="mt-3 max-w-2xl text-sm leading-relaxed text-slate-400">
                 A recipe chains several of these templates in order and ships
-                them as one downloadable bundle, with the keys each step needs
-                and where the money goes.
+                that chain inside Studio, with the keys each step needs and
+                where the money goes.
               </p>
               <ul className="mt-5 flex flex-wrap gap-2">
                 {recipeEntries.map((recipe) => (

--- a/marketing/src/components/RecipeShowcase.tsx
+++ b/marketing/src/components/RecipeShowcase.tsx
@@ -6,8 +6,8 @@ import { PROVIDER_DISPLAY } from "../data/providerDisplay";
 
 /**
  * The jobs on the homepage: the four recipes, because each is a job with a
- * buyer, a real run against live models, and a `.nodetool` bundle to
- * download. The demo use cases stay on /use-cases.
+ * buyer, a real run against live models, and a chain that ships inside Studio.
+ * The demo use cases stay on /use-cases.
  *
  * A card names the models the shipped chain calls and says "at provider list
  * prices". It never carries a dollar figure: no recorded run has produced one
@@ -58,10 +58,9 @@ export default function RecipeShowcase() {
           <p className="mt-4 text-lg text-slate-400 leading-relaxed">
             Four jobs that run every week, each a real run against live models:
             what you end up holding, who it is for, the models the chain calls,
-            and every workflow in it as one file you import into Studio.
-            Downloading a chain and reading every graph in it needs no key and no
-            account. Running it bills the providers you chose, at their list
-            prices.
+            and every workflow in it already installed with Studio. Opening a
+            chain and reading every graph in it needs no key and no account.
+            Running it bills the providers you chose, at their list prices.
           </p>
         </div>
 
@@ -106,7 +105,7 @@ export default function RecipeShowcase() {
                   {fidelity && (
                     <p className="mt-4 text-xs text-slate-500">
                       {fidelity.changed.length === 0
-                        ? "The picture above is this chain run exactly as the download ships it."
+                        ? "The picture above is this chain run exactly as Studio ships it."
                         : `The picture above is this chain run for real, with ${fidelity.changed.length} of ${fidelity.total} models reached another way — the recipe page names which, and why.`}
                     </p>
                   )}

--- a/marketing/src/data/recipes.ts
+++ b/marketing/src/data/recipes.ts
@@ -2,14 +2,17 @@
  * Recipe page-data contract, consumed by the `/recipes/*` routes.
  *
  * A recipe is a named outcome plus the ordered shipped example workflows that
- * reach it, downloadable as one `.nodetool` bundle. Where a template page
- * answers "what does this graph do", a recipe answers "what do I run, in what
- * order, and what does it cost me".
+ * reach it. Studio ships the same chains on its Examples page, and the site
+ * also packs each as one `.nodetool` bundle. Where a template page answers
+ * "what does this graph do", a recipe answers "what do I run, in what order,
+ * and what does it cost me".
  *
  * `recipeEntries.generated.ts` is written by
- * `marketing/scripts/generate-recipes.mjs` from the editorial specs in
- * `marketing/scripts/recipes.mjs` plus the shipped examples themselves. Do not
- * edit the generated file by hand — run `npm run gen:recipes`.
+ * `marketing/scripts/generate-recipes.mjs` from the recipe manifests the app
+ * ships (`packages/base-nodes/nodetool/examples/recipes/`), the site-only
+ * presentation in `marketing/scripts/recipes.mjs`, and the shipped examples
+ * themselves. Do not edit the generated file by hand — run
+ * `npm run gen:recipes`.
  */
 import type { PageEntry } from "./types";
 import { templateEntries } from "./templates";

--- a/marketing/src/data/staticEntries.ts
+++ b/marketing/src/data/staticEntries.ts
@@ -28,7 +28,7 @@ export const staticEntries: PageEntry[] = [
   { route: "/marketing", title: "For Marketing", description: "Produce campaign assets with AI workflows.", priority: 0.8, changeFrequency: "monthly", indexable: true },
   // /alternatives/* comes from the competitorEntries engine module.
   { route: "/templates", title: "AI Workflow Templates", description: "Browse ready-to-run NodeTool workflow templates by category.", priority: 0.8, changeFrequency: "weekly", indexable: true },
-  { route: "/recipes", title: "AI Workflow Recipes", description: "Multi-step NodeTool recipes: the workflows to run, in order, as one downloadable bundle.", priority: 0.8, changeFrequency: "monthly", indexable: true },
+  { route: "/recipes", title: "AI Workflow Recipes", description: "Multi-step NodeTool recipes: the workflows to run, in order, shipped inside Studio.", priority: 0.8, changeFrequency: "monthly", indexable: true },
   { route: "/apps", title: "AI Mini Apps", description: "Ready-to-use AI mini apps built with NodeTool's App Builder.", priority: 0.8, changeFrequency: "weekly", indexable: true },
   { route: "/use-cases/product-video", title: "Product Video", description: "Make product videos with AI workflows.", priority: 0.6, changeFrequency: "monthly", indexable: true },
   { route: "/use-cases/movie-poster", title: "Movie Poster", description: "Generate movie posters with AI workflows.", priority: 0.6, changeFrequency: "monthly", indexable: true },

--- a/packages/base-nodes/nodetool/examples/recipes/ecommerce-sku-visual-factory.recipe.json
+++ b/packages/base-nodes/nodetool/examples/recipes/ecommerce-sku-visual-factory.recipe.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "slug": "ecommerce-sku-visual-factory",
+  "name": "E-commerce SKU Visual Factory",
+  "outcome": "One packshot per SKU becomes the whole channel set: cutout, studio scene, seasonal relight, turntable clip, print master, and the listing copy.",
+  "audience": "Catalogue and marketplace teams with more SKUs than shoot days.",
+  "summary": [
+    "Every step after the first one starts from the cutout, so the product itself is never regenerated. That is the constraint that matters in a catalogue: the customer is buying the object in the photograph, and a model that redraws it has sold them something else.",
+    "Run the chain once per SKU. The upscale sits at the end on purpose — one call for the asset you actually print, rather than paying print resolution on every draft."
+  ],
+  "caveats": [
+    "Background removal is a model, not a matte artist. Hair, mesh, glassware, and anything transparent need a look before they go live.",
+    "Relighting changes light, not colour management. A brand colour that has to match a printed swatch still needs a proofing step.",
+    "The listing copy is written from one photograph. It does not know your stock, sizing, or compliance wording."
+  ],
+  "hero": "Put a Product on a Studio Backdrop",
+  "steps": [
+    {
+      "example": "Cut a Product Out of Its Background",
+      "role": "Isolate the product once",
+      "handoff": "In: the packshot. Out: the product on a real alpha channel rather than a white matte, so the edge survives compositing onto anything later."
+    },
+    {
+      "example": "Put a Product on a Studio Backdrop",
+      "role": "Place it in a described setting",
+      "handoff": "In: the cutout and a scene description. Out: the product in that scene. An edit model told to change only the surroundings, rather than a strength setting on image-to-image, is what keeps the product unchanged."
+    },
+    {
+      "example": "Relight a Product for a Seasonal Campaign",
+      "role": "Change the season without a reshoot",
+      "handoff": "In: the placed shot. Out: the same geometry and materials under different light. Relighting moves where the light comes from and nothing else."
+    },
+    {
+      "example": "Spin a Packshot into a Turntable Clip",
+      "role": "Give the product page motion",
+      "handoff": "In: the still. Out: a short clip with a camera move. Image-to-video keeps the product identical, which a text-to-video model would not."
+    },
+    {
+      "example": "Take a Product Shot to Print Resolution",
+      "role": "Upscale only the keeper",
+      "handoff": "In: the approved web asset. Out: a print-resolution master. One call at the end of the pipeline instead of print resolution on every draft."
+    },
+    {
+      "example": "Write a Listing from the Product Photo",
+      "role": "Write the copy from the photograph",
+      "handoff": "In: the image itself, not a description of it. Out: marketplace copy that catches finish, proportion, and what the thing sits next to — details a spec sheet leaves out."
+    }
+  ]
+}

--- a/packages/base-nodes/nodetool/examples/recipes/multilingual-video-dubber.recipe.json
+++ b/packages/base-nodes/nodetool/examples/recipes/multilingual-video-dubber.recipe.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": 1,
+  "slug": "multilingual-video-dubber",
+  "name": "Multilingual Video Dubber",
+  "outcome": "One presenter clip, spoken in a second language, with a lip-synced cut, subtitles, and a back-translation to check it.",
+  "audience": "Anyone re-releasing a recorded talk, demo, or ad into another market.",
+  "summary": [
+    "The spine is transcribe, translate, revoice. What makes it usable outside the languages your team reads is the third step: a back-translation printed next to the localised line, so the person approving the cut can see what was actually said.",
+    "The last two steps are a fork, not a sequence. A voice-over cut ends at the revoiced audio; an on-camera cut carries on into lip-sync so the presenter's mouth matches the new delivery."
+  ],
+  "caveats": [
+    "Lip-sync redrives the mouth. It does not change gesture, gaze, or anything a presenter does with their hands, so a take with heavy pointing at on-screen text will still read as dubbed.",
+    "Timing is not stretched to match the original. A language that runs longer than the source will run longer in the cut.",
+    "The back-translation is a check on meaning, not on register. A native reviewer is still the last word before a paid campaign."
+  ],
+  "hero": "AI Spokesperson",
+  "steps": [
+    {
+      "example": "Transcribe a Clip",
+      "role": "Get the script back out of the footage",
+      "handoff": "In: the source clip. Out: the spoken words as text. The audio is extracted on your machine and only the audio is sent to a speech-to-text model."
+    },
+    {
+      "example": "Localise a Script and Revoice It",
+      "role": "Translate and voice in one pass",
+      "handoff": "In: the transcript and a target language. Out: audio in that language. A translated document still leaves the recording to do, which is why this step ends in sound rather than text."
+    },
+    {
+      "example": "One Tagline, Six Markets",
+      "role": "Read back what you just shipped",
+      "handoff": "In: the lines that carry the message — the claim, the offer, the call to action. Out: each one in six languages with a back-translation beside it. This is the review gate for a language nobody in the room speaks."
+    },
+    {
+      "example": "AI Spokesperson",
+      "role": "Make the mouth match, for an on-camera cut",
+      "handoff": "In: the presenter clip and the translated script — the script, not the audio from step two, because this workflow voices the line itself before it redrives the mouth. Out: a take that looks recorded in the new language."
+    },
+    {
+      "example": "Subtitle Text from a Recording",
+      "role": "Ship the version people read",
+      "handoff": "In: the localised audio. Out: transcript broken into subtitle-length lines. The line-length rule is what separates a subtitle file from a wall of text."
+    }
+  ]
+}

--- a/packages/base-nodes/nodetool/examples/recipes/storyboard-to-trailer.recipe.json
+++ b/packages/base-nodes/nodetool/examples/recipes/storyboard-to-trailer.recipe.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": 1,
+  "slug": "storyboard-to-trailer",
+  "name": "Storyboard to Trailer",
+  "outcome": "A logline becomes a beat sheet, a numbered shot list, a cut teaser, and a score under it.",
+  "audience": "Directors, agencies, and anyone pitching a film that does not exist yet.",
+  "summary": [
+    "The two text steps come first because they are the ones you will rewrite. A beat sheet and a shot list are cheap to redo and expensive to skip — prose cannot be iterated over by a generation pipeline, numbered shots can.",
+    "Only the third step spends. It runs each shot through a video model metered per second, which is why the two documents in front of it are worth arguing over first."
+  ],
+  "caveats": [
+    "Steps three and four both hold their own storyboard. Rewriting the beat sheet does not reach back into a teaser you already rendered — re-run the chain.",
+    "Continuity across shots comes from a shared style bible, not from a persistent character model. Faces drift over a long cut."
+  ],
+  "hero": "Movie Trailer Generator",
+  "steps": [
+    {
+      "example": "Trailer Beats from a Premise",
+      "role": "Write the structure before buying footage",
+      "handoff": "In: the premise. Out: hook, escalation, turn, title card. The shape a trailer needs, settled while it still costs one text call to change."
+    },
+    {
+      "example": "Shot List from a Synopsis",
+      "role": "Turn prose into something a pipeline can walk",
+      "handoff": "In: the synopsis. Out: numbered shots with framing and duration. This is the document the next step iterates over."
+    },
+    {
+      "example": "Movie Trailer Generator",
+      "role": "Film it and cut it",
+      "handoff": "In: the logline. Out: a cut teaser. A Director node writes the storyboard and one style bible, each shot becomes an image prompt, and the frames are rendered, animated, and assembled. The per-second video model is the expensive step.",
+      "alternative": {
+        "example": "Directed Film to Timeline",
+        "label": "Swap this step to keep editing",
+        "why": "The same director-to-shots chain, ending on the timeline as an editable sequence rather than a finished file. Re-roll one shot or re-cut the ending without running the chain again."
+      }
+    },
+    {
+      "example": "Score a Silent Clip",
+      "role": "Put music under it",
+      "handoff": "In: the cut and a mood. Out: a bed written to the clip's own length, mixed under the original audio. One audio generation per run."
+    }
+  ]
+}

--- a/packages/base-nodes/nodetool/examples/recipes/viral-video-ad-engine.recipe.json
+++ b/packages/base-nodes/nodetool/examples/recipes/viral-video-ad-engine.recipe.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "slug": "viral-video-ad-engine",
+  "name": "Viral Video Ad Engine",
+  "outcome": "A vertical product ad, plus the hook lines and thumbnails to test it against.",
+  "audience": "Performance and social teams shipping several ad variants a week.",
+  "summary": [
+    "Four workflows, ordered cheapest first. The copy and the hook set are text and fast images, so you can throw most of them away; only the last two steps touch a video model, and by then you have already chosen the line and the frame.",
+    "That order is the whole point. Deciding register and hook after paying for footage is how an ad budget disappears into renders nobody posts."
+  ],
+  "caveats": [
+    "The vertical step rescales rather than crops, so frame the loop with room to lose or add a crop node ahead of it.",
+    "Nothing here measures performance. The recipe produces variants to test; the testing happens in your ad platform."
+  ],
+  "hero": "Hook & Thumbnail Factory",
+  "steps": [
+    {
+      "example": "Ad Copy in Three Registers",
+      "role": "Settle the register before anything renders",
+      "handoff": "In: the offer in a sentence. Out: the same offer written plain, playful and premium. One text call, so the argument about tone costs cents instead of a render queue."
+    },
+    {
+      "example": "Hook & Thumbnail Factory",
+      "role": "Fan the winning line into a test set",
+      "handoff": "In: the video topic. Out: a stream of hook lines, each with its own color-graded thumbnail. The fan-out is the useful part — one hook stream drives the whole gallery in a single run."
+    },
+    {
+      "example": "Ad Loop from a Product Photo",
+      "role": "Put the product in motion",
+      "handoff": "In: the product photo. Out: a short hero loop. A prompt node writes the motion brief, the image-to-video model animates the still, and a speed pass slows it. This is the step that costs real money."
+    },
+    {
+      "example": "Cut a Landscape Clip for Vertical",
+      "role": "Cut it to the frame the channel wants",
+      "handoff": "In: the 16:9 loop. Out: a 1080×1920 file. Runs through ffmpeg on your own machine — no key, no per-run charge."
+    }
+  ]
+}

--- a/packages/cli/src/harness/registry.ts
+++ b/packages/cli/src/harness/registry.ts
@@ -479,6 +479,25 @@ export const HARNESSES: HarnessEntry[] = [
     }
   },
   {
+    id: "recipes",
+    title: "Recipe chains (shipped manifests, the app listing, the site pages)",
+    // A recipe names shipped example workflows and stores no graph, so what
+    // rots is a step whose example was renamed: the app drops the recipe from
+    // its Examples listing and the site's page loses a workflow. Both readers
+    // are checked — the resolver the app calls, and the generator the site
+    // builds its pages and bundles with.
+    command: "npx tsx marketing/scripts/generate-recipes.mjs --check",
+    kind: "static",
+    capabilities: ["no-db", "gated:pr"],
+    docs: "docs/harnesses.md § Shipped recipes",
+    selfcheck: {
+      command:
+        "npm run test --workspace=packages/websocket -- example-recipes && " +
+        "npx tsx marketing/scripts/generate-recipes.mjs --check",
+      cost: "cheap"
+    }
+  },
+  {
     id: "repo-scripts",
     title: "Repo tooling scripts (test selection, validators, generators)",
     // The scripts a contributor and CI run from the repo root. Their pure
@@ -1092,6 +1111,39 @@ export const SURFACES: SurfaceEntry[] = [
     // Overlaps with the surfaces that claim individual scripts (bundle
     // staging, codegen drift, docker smoke); a diff there runs both.
     paths: ["scripts/"]
+  },
+  {
+    id: "recipes",
+    title: "Recipes (ordered chains of shipped examples)",
+    harnesses: ["recipes"],
+    // The manifests, the resolver behind the app's Examples listing, and the
+    // site pages built from the same files. Overlaps the surfaces that claim
+    // the packages and the site; a diff here runs both.
+    paths: [
+      "packages/base-nodes/nodetool/examples/recipes/",
+      "packages/protocol/src/api-schemas/recipes.ts",
+      "packages/websocket/src/lib/example-recipes.ts",
+      "web/src/components/portal/DashboardRecipes.tsx",
+      "web/src/hooks/useRecipeActions.ts",
+      "marketing/scripts/generate-recipes.mjs",
+      "marketing/scripts/recipes.mjs",
+      "marketing/src/app/recipes/",
+      "marketing/src/data/recipes.ts"
+    ]
+  },
+  {
+    id: "marketing-site",
+    title: "Marketing site (nodetool.ai)",
+    harnesses: [],
+    paths: ["marketing/"],
+    gap:
+      "A separate npm project with its own lockfile, so the root gate cannot " +
+      "install it: marketing-ci.yml runs its typecheck, lint, Next build, " +
+      "generated-data --check steps, a Playwright smoke suite and a route " +
+      "loader against its own tree. The one part the root gate does reach is " +
+      "the recipe pages, whose data comes from the shipped manifests — that " +
+      "is the `recipes` harness above. A fuller harness would drive the built " +
+      "site the way the debug harness drives the graph canvas.",
   },
   {
     id: "harness-registry",

--- a/packages/cli/tests/harness-registry.test.ts
+++ b/packages/cli/tests/harness-registry.test.ts
@@ -167,6 +167,7 @@ describe("gated capability matches a real CI trigger", () => {
     "docker-smoke": "docker-smoke.mjs http://localhost:7777",
     "provider-contract": "provider-contract-probes",
     "provider-codegen": "npm run generate:fal:check -- --strict",
+    recipes: "dev:nodetool -- harness gate",
     "node-pack-parity": "parity example-workflows"
   };
 

--- a/packages/protocol/src/api-schemas/index.ts
+++ b/packages/protocol/src/api-schemas/index.ts
@@ -30,6 +30,7 @@ export * as users from "./users.js";
 export * as sketch from "./sketch.js";
 export * as skills from "./skills.js";
 export * as storyboards from "./storyboards.js";
+export * as recipes from "./recipes.js";
 export * as applications from "./applications.js";
 export * as resources from "./resources.js";
 export * as timeline from "./timeline.js";

--- a/packages/protocol/src/api-schemas/recipes.ts
+++ b/packages/protocol/src/api-schemas/recipes.ts
@@ -1,0 +1,123 @@
+/**
+ * Recipes: a named outcome plus the ordered shipped example workflows that
+ * reach it.
+ *
+ * A recipe is a file on disk next to the example workflows it composes
+ * (`packages/base-nodes/nodetool/examples/recipes/<slug>.recipe.json`), so
+ * listing one needs no user and no database, and "installing" one is the same
+ * copy a single example takes, run once per step.
+ *
+ * Two shapes live here: {@link recipeBundle}, what a shipped file holds, and
+ * {@link exampleRecipeSummary}, what the list endpoint returns after each step
+ * has been resolved against the examples actually on disk.
+ */
+
+import { z } from "zod";
+
+/** Bumped when a field the reader depends on changes shape. */
+export const RECIPE_BUNDLE_SCHEMA_VERSION = 1;
+
+/**
+ * Another shipped example that can take a step's place and end somewhere else
+ * — the same shots delivered as an editable sequence rather than a file.
+ */
+export const recipeStepAlternative = z.object({
+  /** Example workflow name, as the shipped file records it. */
+  example: z.string().min(1),
+  /** Call to action on the step. */
+  label: z.string(),
+  /** What changes if you swap it in. */
+  why: z.string()
+});
+export type RecipeStepAlternative = z.infer<typeof recipeStepAlternative>;
+
+export const recipeBundleStep = z.object({
+  example: z.string().min(1),
+  /** What this step is for, in the recipe's terms. */
+  role: z.string(),
+  /** What goes in and what comes back out. */
+  handoff: z.string(),
+  alternative: recipeStepAlternative.nullish()
+});
+export type RecipeBundleStep = z.infer<typeof recipeBundleStep>;
+
+export const recipeBundle = z.object({
+  schemaVersion: z.number().int().positive(),
+  slug: z.string().min(1),
+  name: z.string().min(1),
+  /** One sentence: what you end up holding. */
+  outcome: z.string(),
+  audience: z.string(),
+  /** Intro paragraphs. */
+  summary: z.array(z.string()),
+  /** What the recipe does not do, stated plainly. */
+  caveats: z.array(z.string()),
+  /** Example whose thumbnail heads the recipe. */
+  hero: z.string().min(1),
+  steps: z.array(recipeBundleStep).min(1)
+});
+export type RecipeBundle = z.infer<typeof recipeBundle>;
+
+/**
+ * Parse a shipped recipe file. Returns null for anything that is not one — a
+ * malformed file is skipped rather than taking the whole listing down — and
+ * for a file written against a newer schema than this build understands.
+ */
+export function parseRecipeBundle(value: unknown): RecipeBundle | null {
+  const parsed = recipeBundle.safeParse(value);
+  if (!parsed.success) return null;
+  if (parsed.data.schemaVersion > RECIPE_BUNDLE_SCHEMA_VERSION) return null;
+  return parsed.data;
+}
+
+/** One model a step's graph calls, as the graph records it. */
+export const recipeModelRef = z.object({
+  /** Runtime provider id, e.g. "fal_ai". */
+  provider: z.string(),
+  /** Serving model id, e.g. "fal-ai/flux/schnell". */
+  model: z.string()
+});
+export type RecipeModelRef = z.infer<typeof recipeModelRef>;
+
+/** A step with its example resolved: enough to render and open it. */
+export const exampleRecipeStep = z.object({
+  /** Example workflow name — what `from_example_name` takes. */
+  example: z.string(),
+  /** The example's own id in the gallery listing (its file name). */
+  exampleId: z.string(),
+  packageName: z.string(),
+  description: z.string(),
+  role: z.string(),
+  handoff: z.string(),
+  thumbnailUrl: z.string().nullable(),
+  nodeCount: z.number(),
+  /** Empty when the step runs locally and calls no provider. */
+  models: z.array(recipeModelRef),
+  alternative: z
+    .object({
+      example: z.string(),
+      exampleId: z.string(),
+      packageName: z.string(),
+      label: z.string(),
+      why: z.string()
+    })
+    .nullable()
+});
+export type ExampleRecipeStep = z.infer<typeof exampleRecipeStep>;
+
+/** What the list endpoint returns per recipe. */
+export const exampleRecipeSummary = z.object({
+  slug: z.string(),
+  name: z.string(),
+  outcome: z.string(),
+  audience: z.string(),
+  summary: z.array(z.string()),
+  caveats: z.array(z.string()),
+  /** The hero step's thumbnail, or null when it ships without one. */
+  thumbnailUrl: z.string().nullable(),
+  /** Providers the chain calls, deduplicated across steps. */
+  providers: z.array(z.string()),
+  nodeCount: z.number(),
+  steps: z.array(exampleRecipeStep)
+});
+export type ExampleRecipeSummary = z.infer<typeof exampleRecipeSummary>;

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -171,6 +171,13 @@ export interface HttpApiOptions {
    */
   exampleStoryboardsDir?: string;
   /**
+   * Path to the directory of shipped recipe manifests (e.g.
+   * `packages/base-nodes/nodetool/examples/recipes`). Defaults to the
+   * `recipes` sibling of {@link examplesDir}, the same layout
+   * {@link exampleAppsDir} follows.
+   */
+  exampleRecipesDir?: string;
+  /**
    * Root directories that hold per-package constant assets, laid out as
    * `<root>/<package-name>/<file>`. Served (read-only, public) at
    * `/api/assets/packages/<package-name>/<file>` and referenced from workflows

--- a/packages/websocket/src/lib/example-recipes.ts
+++ b/packages/websocket/src/lib/example-recipes.ts
@@ -1,0 +1,240 @@
+/**
+ * The shipped recipes: a named outcome plus the ordered example workflows that
+ * reach it.
+ *
+ * A recipe is a file on disk next to the examples it composes
+ * (`packages/base-nodes/nodetool/examples/recipes/<slug>.recipe.json`), the
+ * same layout the example apps and storyboards use. It stores no graphs of its
+ * own — every step names a shipped example, and this module resolves those
+ * names against the examples directory the server is already serving, so a
+ * recipe cannot drift into claiming a workflow, a model, or a thumbnail the
+ * install does not have.
+ *
+ * The site's downloadable `.nodetool` bundles are packed from the same
+ * manifests (`marketing/scripts/generate-recipes.mjs`), so the chain a page
+ * describes and the chain the app offers are one list.
+ */
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import nodePath from "node:path";
+import {
+  parseRecipeBundle,
+  type ExampleRecipeStep,
+  type ExampleRecipeSummary,
+  type RecipeBundle,
+  type RecipeModelRef
+} from "@nodetool-ai/protocol/api-schemas/recipes.js";
+import { deriveExampleAssetsDir, resolveExampleJsonPath } from "../example-workflows.js";
+import { withCacheBuster } from "./example-thumbnail.js";
+import { isString } from "./wire-values.js";
+
+const BUNDLE_SUFFIX = ".recipe.json";
+
+const EXAMPLES_THUMBNAILS_PREFIX = "/api/workflows/examples/thumbnails/";
+
+export interface ExampleRecipeOptions {
+  examplesDir?: string;
+  examplesAssetsFallbackDir?: string;
+  exampleRecipesDir?: string;
+}
+
+/**
+ * Where the manifests live: an explicit override, else the `recipes` sibling of
+ * the example workflows directory — the layout the monorepo, the packaged
+ * backend, and the server image share.
+ */
+export function resolveExampleRecipesDir(
+  options: ExampleRecipeOptions
+): string | null {
+  if (options.exampleRecipesDir) {
+    return existsSync(options.exampleRecipesDir)
+      ? options.exampleRecipesDir
+      : null;
+  }
+  if (!options.examplesDir) return null;
+  const sibling = nodePath.join(
+    nodePath.dirname(options.examplesDir),
+    "recipes"
+  );
+  return existsSync(sibling) ? sibling : null;
+}
+
+function readBundle(dir: string, file: string): RecipeBundle | null {
+  // Callers only pass names that came out of readdirSync, but resolve and
+  // check containment anyway so no future caller can read outside the
+  // recipes directory by passing a path-shaped name.
+  const root = nodePath.resolve(dir);
+  const target = nodePath.resolve(root, file);
+  if (target !== root && !target.startsWith(root + nodePath.sep)) return null;
+  try {
+    return parseRecipeBundle(JSON.parse(readFileSync(target, "utf8")));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Every `{provider, model}` a graph references, in first-seen order.
+ *
+ * A model reference is any object carrying a `provider` field — that covers a
+ * top-level model property, one inside a settings object, and one nested in a
+ * list, which is why this walks rather than reads known keys.
+ */
+function modelRefs(graph: unknown): RecipeModelRef[] {
+  const seen = new Map<string, RecipeModelRef>();
+  const walk = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) walk(item);
+      return;
+    }
+    if (!value || typeof value !== "object") return;
+    const record = value as Record<string, unknown>;
+    if (isString(record.provider) && record.provider) {
+      const model = record.id ?? record.model ?? record.repo_id ?? record.name;
+      if (isString(model) && model) {
+        const key = `${record.provider} ${model}`;
+        if (!seen.has(key)) {
+          seen.set(key, { provider: record.provider, model });
+        }
+      }
+    }
+    for (const item of Object.values(record)) walk(item);
+  };
+  walk(graph);
+  return [...seen.values()];
+}
+
+/** One example workflow as a recipe step needs it: metadata, no graph. */
+interface ResolvedExample {
+  name: string;
+  id: string;
+  description: string;
+  thumbnailUrl: string | null;
+  nodeCount: number;
+  models: RecipeModelRef[];
+}
+
+function resolveExample(
+  examplesDir: string,
+  assetsDir: string,
+  exampleName: string
+): ResolvedExample | null {
+  const file = resolveExampleJsonPath(examplesDir, exampleName);
+  if (!file) return null;
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  const name = isString(parsed.name)
+    ? parsed.name
+    : nodePath.basename(file, ".json");
+  const jpgFile = `${name}.jpg`;
+  const jpgPath = nodePath.join(assetsDir, jpgFile);
+  const graph = (parsed.graph ?? {}) as Record<string, unknown>;
+  const nodes = Array.isArray(graph.nodes) ? graph.nodes : [];
+  return {
+    name,
+    id: nodePath.basename(file),
+    description: isString(parsed.description) ? parsed.description : "",
+    thumbnailUrl: existsSync(jpgPath)
+      ? withCacheBuster(
+          `${EXAMPLES_THUMBNAILS_PREFIX}${encodeURIComponent(jpgFile)}`,
+          jpgPath
+        )
+      : null,
+    nodeCount: nodes.length,
+    models: modelRefs(graph)
+  };
+}
+
+/**
+ * Resolve one manifest against the examples on disk, or null when a step names
+ * an example this install does not ship — half a chain is worse than none, and
+ * `tests/example-recipes.test.ts` fails when a shipped recipe stops resolving.
+ */
+function buildRecipe(
+  bundle: RecipeBundle,
+  examplesDir: string,
+  assetsDir: string,
+  packageName: string
+): ExampleRecipeSummary | null {
+  const steps: ExampleRecipeStep[] = [];
+  for (const step of bundle.steps) {
+    const example = resolveExample(examplesDir, assetsDir, step.example);
+    if (!example) return null;
+    let alternative: ExampleRecipeStep["alternative"] = null;
+    if (step.alternative) {
+      const alt = resolveExample(examplesDir, assetsDir, step.alternative.example);
+      if (!alt) return null;
+      alternative = {
+        example: alt.name,
+        exampleId: alt.id,
+        packageName,
+        label: step.alternative.label,
+        why: step.alternative.why
+      };
+    }
+    steps.push({
+      example: example.name,
+      exampleId: example.id,
+      packageName,
+      description: example.description,
+      role: step.role,
+      handoff: step.handoff,
+      thumbnailUrl: example.thumbnailUrl,
+      nodeCount: example.nodeCount,
+      models: example.models,
+      alternative
+    });
+  }
+  const hero = resolveExample(examplesDir, assetsDir, bundle.hero);
+  if (!hero) return null;
+  return {
+    slug: bundle.slug,
+    name: bundle.name,
+    outcome: bundle.outcome,
+    audience: bundle.audience,
+    summary: bundle.summary,
+    caveats: bundle.caveats,
+    thumbnailUrl: hero.thumbnailUrl,
+    providers: [
+      ...new Set(steps.flatMap((s) => s.models.map((m) => m.provider)))
+    ],
+    nodeCount: steps.reduce((total, step) => total + step.nodeCount, 0),
+    steps
+  };
+}
+
+/** Every shipped recipe whose steps all resolve, sorted by slug. */
+export function listExampleRecipes(
+  options: ExampleRecipeOptions
+): ExampleRecipeSummary[] {
+  const dir = resolveExampleRecipesDir(options);
+  if (!dir || !options.examplesDir || !existsSync(options.examplesDir)) {
+    return [];
+  }
+  const examplesDir = options.examplesDir;
+  const assetsDir = deriveExampleAssetsDir(
+    examplesDir,
+    options.examplesAssetsFallbackDir
+  );
+  const packageName = nodePath.basename(examplesDir);
+  let files: string[];
+  try {
+    files = readdirSync(dir)
+      .filter((file) => file.endsWith(BUNDLE_SUFFIX))
+      .sort((a, b) => a.localeCompare(b));
+  } catch {
+    return [];
+  }
+  const recipes: ExampleRecipeSummary[] = [];
+  for (const file of files) {
+    const bundle = readBundle(dir, file);
+    if (!bundle) continue;
+    const recipe = buildRecipe(bundle, examplesDir, assetsDir, packageName);
+    if (recipe) recipes.push(recipe);
+  }
+  return recipes;
+}

--- a/packages/websocket/src/trpc/routers/workflows.ts
+++ b/packages/websocket/src/trpc/routers/workflows.ts
@@ -8,6 +8,7 @@
  *   - list, get, create, update, delete
  *   - autosave
  *   - examples (list + search)
+ *   - recipes (shipped chains of examples)
  *   - public (list + get) — publicProcedure (no auth required)
  *   - versions (list, create, restore, delete)
  *
@@ -19,6 +20,7 @@
 
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import nodePath from "node:path";
+import { z } from "zod";
 import { withCacheBuster } from "../../lib/example-thumbnail.js";
 import {
   Workflow,
@@ -37,6 +39,8 @@ import {
   defaultExamplePackageName,
   deriveExampleAssetsDir
 } from "../../example-workflows.js";
+import { exampleRecipeSummary } from "@nodetool-ai/protocol/api-schemas/recipes.js";
+import { listExampleRecipes } from "../../lib/example-recipes.js";
 import { ApiErrorCode } from "../../error-codes.js";
 import { router, publicProcedure } from "../index.js";
 import { protectedProcedure } from "../middleware.js";
@@ -772,6 +776,13 @@ export const workflowsRouter = router({
         : workflows;
       return { workflows: filtered, next: null };
     }),
+
+  // ── recipes (shipped chains of example workflows) ─────────────────────────
+  // Manifest files on disk, like the examples they order: no user, no database,
+  // and each step resolved against the examples this install actually ships.
+  recipes: protectedProcedure
+    .output(z.array(exampleRecipeSummary))
+    .query(({ ctx }) => listExampleRecipes(ctx.apiOptions)),
 
   // ── public workflows ──────────────────────────────────────────────────────
   public: router({

--- a/packages/websocket/src/trpc/sandbox-coverage.ts
+++ b/packages/websocket/src/trpc/sandbox-coverage.ts
@@ -983,6 +983,13 @@ export const SANDBOX_API_COVERAGE: Readonly<
   "workflows.examples": { capability: "get_example_workflow" },
   "workflows.get": { capability: "get_workflow" },
   "workflows.list": { capability: "list_workflows" },
+  "workflows.recipes": {
+    gap:
+      "The shipped recipe chains: which example workflows to run, in what " +
+      "order, and what each hands the next. A run reaches any single step " +
+      "through get_example_workflow; the ordering and the outcome each chain " +
+      "names have no capability yet."
+  },
   "workflows.public.get": {
     elsewhere:
       "get_workflow resolves a public workflow by id."

--- a/packages/websocket/tests/example-recipes.test.ts
+++ b/packages/websocket/tests/example-recipes.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The shipped recipes, resolved against the shipped examples.
+ *
+ * These run against the real manifests in
+ * `packages/base-nodes/nodetool/examples/recipes` and the real workflows they
+ * name, so a renamed or deleted example fails here rather than dropping a
+ * recipe out of the app's Examples page with no other signal.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import nodePath from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { exampleRecipeSummary } from "@nodetool-ai/protocol/api-schemas/recipes.js";
+
+import { listExampleRecipes } from "../src/lib/example-recipes.js";
+
+const NODETOOL_DIR = nodePath.resolve(
+  nodePath.dirname(fileURLToPath(import.meta.url)),
+  "../../base-nodes/nodetool"
+);
+const EXAMPLES_DIR = nodePath.join(NODETOOL_DIR, "examples/nodetool-base");
+const RECIPES_DIR = nodePath.join(NODETOOL_DIR, "examples/recipes");
+
+const options = { examplesDir: EXAMPLES_DIR };
+
+const shippedSlugs = (): string[] =>
+  readdirSync(RECIPES_DIR)
+    .filter((file) => file.endsWith(".recipe.json"))
+    .map((file) => file.slice(0, -".recipe.json".length))
+    .sort((a, b) => a.localeCompare(b));
+
+describe("example recipes", () => {
+  it("resolves every shipped recipe against the shipped examples", () => {
+    const slugs = shippedSlugs();
+    expect(slugs.length).toBeGreaterThan(0);
+    const recipes = listExampleRecipes(options);
+    // A recipe whose step names a missing example is dropped by the listing,
+    // so comparing the slugs is what catches a renamed workflow.
+    expect(recipes.map((recipe) => recipe.slug)).toEqual(slugs);
+  });
+
+  it("matches the schema the tRPC procedure declares", () => {
+    // `workflows.recipes` parses its output through this schema, so a field
+    // the listing shapes differently would fail the call, not the build.
+    const parsed = z.array(exampleRecipeSummary).parse(listExampleRecipes(options));
+    expect(parsed.length).toBeGreaterThan(0);
+    expect(parsed.some((recipe) => recipe.thumbnailUrl !== null)).toBe(true);
+    expect(
+      parsed.some((recipe) => recipe.steps.some((step) => step.alternative))
+    ).toBe(true);
+  });
+
+  it("orders the steps the manifest names and keeps them openable", () => {
+    const recipes = listExampleRecipes(options);
+    for (const recipe of recipes) {
+      const manifest = JSON.parse(
+        readFileSync(
+          nodePath.join(RECIPES_DIR, `${recipe.slug}.recipe.json`),
+          "utf8"
+        )
+      ) as { steps: { example: string }[] };
+      expect(recipe.steps.map((step) => step.example)).toEqual(
+        manifest.steps.map((step) => step.example)
+      );
+      for (const step of recipe.steps) {
+        // exampleId is the file the copy reads; packageName is the directory
+        // it lives in. Both go straight into a create-from-example call.
+        expect(step.exampleId).toBe(`${step.example}.json`);
+        expect(step.packageName).toBe("nodetool-base");
+        expect(step.nodeCount).toBeGreaterThan(0);
+      }
+      expect(recipe.nodeCount).toBe(
+        recipe.steps.reduce((total, step) => total + step.nodeCount, 0)
+      );
+    }
+  });
+
+  it("reads each chain's models out of the graphs themselves", () => {
+    const recipes = listExampleRecipes(options);
+    for (const recipe of recipes) {
+      const fromSteps = [
+        ...new Set(
+          recipe.steps.flatMap((step) => step.models.map((m) => m.provider))
+        )
+      ];
+      expect(recipe.providers).toEqual(fromSteps);
+    }
+    // The chains ship with paid steps; a listing that found no model at all
+    // would mean the walk stopped matching the graph format.
+    expect(recipes.some((recipe) => recipe.providers.length > 0)).toBe(true);
+  });
+
+  it("returns nothing when the install ships no recipes directory", () => {
+    expect(
+      listExampleRecipes({
+        examplesDir: EXAMPLES_DIR,
+        exampleRecipesDir: nodePath.join(NODETOOL_DIR, "examples/not-here")
+      })
+    ).toEqual([]);
+  });
+});

--- a/scripts/bundle-backend.mjs
+++ b/scripts/bundle-backend.mjs
@@ -1254,6 +1254,28 @@ async function main() {
     );
   }
 
+  // The recipe manifests sit next to them too — the server resolves
+  // `exampleRecipesDir` as the `recipes` sibling of the examples dir. They hold
+  // no graphs, only the ordered example names each chain runs.
+  const exampleRecipesSrc = path.join(
+    BASE_NODES_NODETOOL_DIR,
+    "examples",
+    "recipes"
+  );
+  const exampleRecipesDest = path.join(BUNDLE_DIR, "examples", "recipes");
+  if (fs.existsSync(exampleRecipesSrc)) {
+    await fsp.mkdir(path.dirname(exampleRecipesDest), { recursive: true });
+    await copyDir(exampleRecipesSrc, exampleRecipesDest);
+    const recipeCount = (await fsp.readdir(exampleRecipesDest)).filter((f) =>
+      f.toLowerCase().endsWith(".recipe.json")
+    ).length;
+    console.log(`  Copied ${recipeCount} recipe manifest(s) to examples/recipes/`);
+  } else {
+    console.warn(
+      `  Warning: example recipes directory not found, skipping: ${exampleRecipesSrc}`
+    );
+  }
+
   // The example storyboards sit next to them, same rule: the server resolves
   // `exampleStoryboardsDir` as the `storyboards` sibling of the examples dir.
   // Their stills and clips are `package://` assets and ride along in

--- a/scripts/validate-examples.mjs
+++ b/scripts/validate-examples.mjs
@@ -34,7 +34,7 @@ import {
   writeFileSync
 } from "node:fs";
 import { availableParallelism, tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { Worker, isMainThread, parentPort } from "node:worker_threads";
 
@@ -294,6 +294,53 @@ function checkStoryboard(file) {
   return problems.length > 0 ? problems.join("\n") : null;
 }
 
+// A recipe manifest carries no graph either: it names the shipped example
+// workflows its chain runs, in order. What rots is a step whose example was
+// renamed — the app drops such a recipe from its Examples page and the site's
+// bundle generator fails, so catch it here with the rest of the examples.
+function checkRecipe(file, exampleNames) {
+  let recipe;
+  try {
+    recipe = JSON.parse(readFileSync(file, "utf8"));
+  } catch (err) {
+    return `not parsable JSON: ${err.message}`;
+  }
+  const problems = [];
+  const slug = basename(file, ".recipe.json");
+  if (recipe?.slug !== slug) {
+    problems.push(`declares slug "${recipe?.slug}" but the file is ${slug}.recipe.json`);
+  }
+  const steps = Array.isArray(recipe?.steps) ? recipe.steps : [];
+  if (steps.length === 0) {
+    return "recipe declares no steps";
+  }
+  const named = [];
+  for (const [index, step] of steps.entries()) {
+    const where = step?.example ? `step "${step.example}"` : `step ${index}`;
+    for (const [what, name] of [
+      ["example", step?.example],
+      ["alternative", step?.alternative?.example]
+    ]) {
+      if (what === "alternative" && !step?.alternative) continue;
+      if (typeof name !== "string" || !exampleNames.has(name)) {
+        problems.push(`${where} names ${what} "${name}", which no shipped example matches`);
+        continue;
+      }
+      if (what === "example") named.push(name);
+    }
+    if (typeof step?.role !== "string" || step.role.trim() === "") {
+      problems.push(`${where} has no role text`);
+    }
+    if (typeof step?.handoff !== "string" || step.handoff.trim() === "") {
+      problems.push(`${where} has no handoff text`);
+    }
+  }
+  if (!named.includes(recipe?.hero)) {
+    problems.push(`hero "${recipe?.hero}" is not one of its steps`);
+  }
+  return problems.length > 0 ? problems.join("\n") : null;
+}
+
 function statSafe(file) {
   try {
     return statSync(file);
@@ -365,11 +412,13 @@ async function main() {
   const bundles = examples.filter((f) => f.endsWith(".app.json"));
   const storyboards = examples.filter((f) => f.endsWith(".storyboard.json"));
   const compositions = examples.filter((f) => f.endsWith(".composition.json"));
+  const recipes = examples.filter((f) => f.endsWith(".recipe.json"));
   const workflowExamples = examples.filter(
     (f) =>
       !f.endsWith(".app.json") &&
       !f.endsWith(".storyboard.json") &&
-      !f.endsWith(".composition.json")
+      !f.endsWith(".composition.json") &&
+      !f.endsWith(".recipe.json")
   );
 
   if (packageExamples.length === 0) {
@@ -400,11 +449,19 @@ async function main() {
     process.exit(1);
   }
 
+  if (recipes.length === 0) {
+    console.error(
+      "No *.recipe.json manifests found under packages/**/examples/ — check the search path."
+    );
+    process.exit(1);
+  }
+
   console.log(
     `Validating ${workflowExamples.length} example workflow(s), ` +
       `${bundles.length} app bundle(s), ` +
-      `${storyboards.length} storyboard(s), and ` +
-      `${compositions.length} composition(s)...\n`
+      `${storyboards.length} storyboard(s), ` +
+      `${compositions.length} composition(s), and ` +
+      `${recipes.length} recipe(s)...\n`
   );
 
   // Each job is one graph to validate; `failure` short-circuits a job the
@@ -470,6 +527,17 @@ async function main() {
     jobs.push({
       label: file.slice(repoRoot.length + 1),
       failure: await checkComposition(file)
+    });
+  }
+  // A recipe is checked against the workflow examples this scan already found,
+  // by the name each step gives — the same name the app resolves at runtime.
+  const exampleNames = new Set(
+    workflowExamples.map((file) => basename(file, ".json"))
+  );
+  for (const file of recipes) {
+    jobs.push({
+      label: file.slice(repoRoot.length + 1),
+      failure: checkRecipe(file, exampleNames)
     });
   }
 

--- a/scripts/verify-backend-bundle.mjs
+++ b/scripts/verify-backend-bundle.mjs
@@ -235,6 +235,52 @@ export function verifyBackendBundle(bundleDir) {
     summary.push(`${exampleCompositions.length} example composition(s) staged`);
   }
 
+  // A recipe manifest holds no graphs: it names the shipped examples its chain
+  // runs, in order. Check the names against what was staged, so a recipe cannot
+  // reach the packaged app pointing at a workflow that is not in it.
+  const recipeDir = path.join(bundleDir, "examples", "recipes");
+  const recipeFiles = (listFiles(recipeDir) ?? []).filter((f) =>
+    f.toLowerCase().endsWith(".recipe.json")
+  );
+  if (recipeFiles.length === 0) {
+    errors.push(
+      "examples/recipes/ is missing or has no recipe manifests — the packaged " +
+        "app would offer no recipes on its Examples page."
+    );
+  } else {
+    const stagedExamples = new Set(
+      exampleJsons.map((file) => file.replace(/\.json$/i, ""))
+    );
+    const missingSteps = [];
+    for (const file of recipeFiles) {
+      let recipe;
+      try {
+        recipe = JSON.parse(readFileSync(path.join(recipeDir, file), "utf8"));
+      } catch (err) {
+        errors.push(`examples/recipes/${file} is not readable: ${err.message}`);
+        continue;
+      }
+      for (const step of recipe?.steps ?? []) {
+        for (const name of [step?.example, step?.alternative?.example]) {
+          if (name && !stagedExamples.has(name)) {
+            missingSteps.push(`${file}: ${name}`);
+          }
+        }
+      }
+      if (recipe?.hero && !stagedExamples.has(recipe.hero)) {
+        missingSteps.push(`${file}: ${recipe.hero} (hero)`);
+      }
+    }
+    if (missingSteps.length > 0) {
+      errors.push(
+        "recipe steps name examples that were not staged — those recipes would " +
+          `not list in the packaged app:\n  ${missingSteps.join("\n  ")}`
+      );
+    } else {
+      summary.push(`${recipeFiles.length} recipe(s) staged with their steps`);
+    }
+  }
+
   // Every shot of a shipped storyboard points at a `package://` still and
   // clip. Those live under assets/nodetool-base/storyboards/<slug>/, one
   // directory deeper than anything else staged here — so check the files the

--- a/web/src/components/portal/DashboardRecipes.tsx
+++ b/web/src/components/portal/DashboardRecipes.tsx
@@ -1,0 +1,380 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import type { Theme } from "@mui/material/styles";
+import { useTheme } from "@mui/material/styles";
+import { memo, useState } from "react";
+import type { recipes as recipeSchemas } from "@nodetool-ai/protocol/api-schemas";
+import { trpc } from "../../trpc/client";
+import { useRecipeActions } from "../../hooks/useRecipeActions";
+import { BASE_URL } from "../../stores/BASE_URL";
+import {
+  BORDER_RADIUS,
+  EmptyState,
+  LoadingSpinner,
+  MOTION,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
+import { useSectionWrap, SectionHeader } from "./dashboardChrome";
+
+type Recipe = recipeSchemas.ExampleRecipeSummary;
+type RecipeStep = recipeSchemas.ExampleRecipeStep;
+
+const thumbSrc = (url: string | null): string | null => {
+  if (!url) return null;
+  return url.startsWith("http") ? url : `${BASE_URL}${url}`;
+};
+
+const styles = (theme: Theme) =>
+  css({
+    // The page hands the rest of the viewport to the template browser below,
+    // so the recipe band keeps its own height and scrolls when a chain is
+    // expanded rather than squeezing the list under it.
+    flexShrink: 0,
+    maxHeight: "60%",
+    overflowY: "auto",
+    paddingTop: getSpacingPx(SPACING.xxl),
+    ".rcp-lede": {
+      margin: `0 0 ${getSpacingPx(SPACING.sm)}`,
+      fontSize: "var(--fontSizeSmall)",
+      color: theme.vars.palette.text.secondary
+    },
+    ".rcp-list": {
+      display: "flex",
+      flexDirection: "column",
+      gap: getSpacingPx(SPACING.sm)
+    },
+    ".rcp": {
+      border: `1px solid ${theme.vars.palette.divider}`,
+      borderRadius: BORDER_RADIUS.lg,
+      background: theme.vars.palette.c_node_bg,
+      overflow: "hidden"
+    },
+    ".rcp-head": {
+      display: "flex",
+      alignItems: "center",
+      gap: getSpacingPx(SPACING.md),
+      padding: getSpacingPx(SPACING.md)
+    },
+    ".rcp-toggle": {
+      display: "flex",
+      alignItems: "center",
+      gap: getSpacingPx(SPACING.md),
+      flex: 1,
+      minWidth: 0,
+      textAlign: "left",
+      padding: getSpacingPx(SPACING.xs),
+      margin: `-${getSpacingPx(SPACING.xs)}`,
+      background: "transparent",
+      border: "none",
+      borderRadius: BORDER_RADIUS.sm,
+      cursor: "pointer",
+      transition: `background ${MOTION.fast}`,
+      "&:hover": { background: theme.vars.palette.action.hover }
+    },
+    ".rcp-thumb": {
+      flexShrink: 0,
+      width: 96,
+      height: 54,
+      objectFit: "cover",
+      borderRadius: BORDER_RADIUS.sm,
+      background: theme.vars.palette.c_node_bg_group
+    },
+    ".rcp-text": { flex: 1, minWidth: 0 },
+    ".rcp-name": {
+      display: "block",
+      fontSize: "var(--fontSizeNormal)",
+      color: theme.vars.palette.text.primary
+    },
+    ".rcp-outcome": {
+      display: "block",
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.secondary,
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap"
+    },
+    ".rcp-meta": {
+      flexShrink: 0,
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.disabled,
+      [theme.breakpoints.down("sm")]: { display: "none" }
+    },
+    ".rcp-add": {
+      flexShrink: 0,
+      padding: `${getSpacingPx(SPACING.xs)} ${getSpacingPx(SPACING.md)}`,
+      borderRadius: BORDER_RADIUS.pill,
+      border: `1px solid rgba(${theme.vars.palette.primary.mainChannel} / 0.5)`,
+      background: `rgba(${theme.vars.palette.primary.mainChannel} / 0.12)`,
+      color: theme.vars.palette.primary.main,
+      fontSize: "var(--fontSizeSmaller)",
+      cursor: "pointer",
+      transition: `background ${MOTION.fast}`,
+      "&:hover": {
+        background: `rgba(${theme.vars.palette.primary.mainChannel} / 0.22)`
+      },
+      "&:disabled": { cursor: "wait", opacity: 0.6 }
+    },
+    ".rcp-body": {
+      borderTop: `1px solid ${theme.vars.palette.divider}`,
+      padding: getSpacingPx(SPACING.md),
+      display: "flex",
+      flexDirection: "column",
+      gap: getSpacingPx(SPACING.sm)
+    },
+    ".rcp-summary": {
+      margin: 0,
+      maxWidth: "72ch",
+      fontSize: "var(--fontSizeSmall)",
+      lineHeight: 1.6,
+      color: theme.vars.palette.text.secondary
+    },
+    ".rcp-step": {
+      display: "flex",
+      alignItems: "flex-start",
+      gap: getSpacingPx(SPACING.md),
+      width: "100%",
+      textAlign: "left",
+      padding: getSpacingPx(SPACING.sm),
+      background: "transparent",
+      border: "none",
+      borderRadius: BORDER_RADIUS.sm,
+      cursor: "pointer",
+      transition: `background ${MOTION.fast}`,
+      "&:hover": { background: theme.vars.palette.action.hover },
+      "&.loading": { cursor: "wait", pointerEvents: "none" }
+    },
+    ".rcp-index": {
+      flexShrink: 0,
+      width: 24,
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.primary.main
+    },
+    ".rcp-step-title": {
+      display: "block",
+      fontSize: "var(--fontSizeSmall)",
+      color: theme.vars.palette.text.primary
+    },
+    ".rcp-step-text": {
+      display: "block",
+      fontSize: "var(--fontSizeSmaller)",
+      lineHeight: 1.6,
+      color: theme.vars.palette.text.secondary
+    },
+    ".rcp-models": {
+      display: "flex",
+      flexWrap: "wrap",
+      gap: getSpacingPx(SPACING.xs),
+      paddingTop: getSpacingPx(SPACING.xs)
+    },
+    ".rcp-model": {
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.disabled,
+      border: `1px solid ${theme.vars.palette.divider}`,
+      borderRadius: BORDER_RADIUS.sm,
+      padding: `0 ${getSpacingPx(SPACING.xs)}`
+    },
+    ".rcp-caveat": {
+      margin: 0,
+      fontSize: "var(--fontSizeSmaller)",
+      lineHeight: 1.6,
+      color: theme.vars.palette.text.disabled
+    },
+    ".rcp-loading, .rcp-empty": {
+      display: "flex",
+      justifyContent: "center",
+      padding: `${getSpacingPx(SPACING.xxl)} 0`
+    }
+  });
+
+interface RecipeStepRowProps {
+  index: number;
+  step: RecipeStep;
+  slug: string;
+  copyingStep: string | null;
+  onOpen: (slug: string, step: RecipeStep) => void;
+}
+
+const RecipeStepRow = memo(function RecipeStepRow({
+  index,
+  step,
+  slug,
+  copyingStep,
+  onOpen
+}: RecipeStepRowProps) {
+  const loading = copyingStep === `${slug}:${step.example}`;
+  return (
+    <button
+      type="button"
+      className={loading ? "rcp-step loading" : "rcp-step"}
+      onClick={() => onOpen(slug, step)}
+      title={`Open ${step.example}`}
+    >
+      <span className="rcp-index">
+        {loading ? (
+          <LoadingSpinner size="small" />
+        ) : (
+          String(index + 1).padStart(2, "0")
+        )}
+      </span>
+      <span className="rcp-text">
+        <span className="rcp-step-title">
+          {step.role} — {step.example}
+        </span>
+        <span className="rcp-step-text">{step.handoff}</span>
+        <span className="rcp-models">
+          {step.models.length > 0 ? (
+            step.models.map((model) => (
+              <span
+                key={`${model.provider}:${model.model}`}
+                className="rcp-model"
+              >
+                {model.model}
+              </span>
+            ))
+          ) : (
+            <span className="rcp-model">Runs locally — no key needed</span>
+          )}
+        </span>
+      </span>
+    </button>
+  );
+});
+
+interface RecipeCardProps {
+  recipe: Recipe;
+  expanded: boolean;
+  onToggle: (slug: string) => void;
+}
+
+const RecipeCard = memo(function RecipeCard({
+  recipe,
+  expanded,
+  onToggle
+}: RecipeCardProps) {
+  const { copyingStep, addingSlug, openStep, addRecipe } = useRecipeActions();
+  const thumb = thumbSrc(recipe.thumbnailUrl);
+  const adding = addingSlug === recipe.slug;
+
+  return (
+    <div className="rcp">
+      <div className="rcp-head">
+        <button
+          type="button"
+          className="rcp-toggle"
+          aria-expanded={expanded}
+          onClick={() => onToggle(recipe.slug)}
+        >
+          {thumb && (
+            <img className="rcp-thumb" src={thumb} alt="" loading="lazy" />
+          )}
+          <span className="rcp-text">
+            <span className="rcp-name">{recipe.name}</span>
+            <span className="rcp-outcome">{recipe.outcome}</span>
+          </span>
+          <span className="rcp-meta">
+            {recipe.steps.length} workflows · {recipe.nodeCount} nodes
+          </span>
+        </button>
+        <button
+          type="button"
+          className="rcp-add"
+          disabled={adding}
+          onClick={() => void addRecipe(recipe)}
+        >
+          {adding ? "Adding…" : `Add all ${recipe.steps.length}`}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="rcp-body">
+          {recipe.summary.map((paragraph) => (
+            <p key={paragraph} className="rcp-summary">
+              {paragraph}
+            </p>
+          ))}
+          {recipe.steps.map((step, index) => (
+            <RecipeStepRow
+              key={step.example}
+              index={index}
+              step={step}
+              slug={recipe.slug}
+              copyingStep={copyingStep}
+              onOpen={openStep}
+            />
+          ))}
+          {recipe.caveats.map((caveat) => (
+            <p key={caveat} className="rcp-caveat">
+              {caveat}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+});
+
+/**
+ * The shipped recipes: chains of example workflows that reach one outcome,
+ * ordered. A card opens to the chain; a step opens that example as a workflow,
+ * and "Add all" copies the whole chain into the library at once.
+ */
+const DashboardRecipes: React.FC = () => {
+  const theme = useTheme();
+  const sectionWrap = useSectionWrap();
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const { data, isLoading, isError, refetch } = trpc.workflows.recipes.useQuery(
+    undefined,
+    { staleTime: 5 * 60_000 }
+  );
+
+  const recipes = data ?? [];
+  if (!isLoading && !isError && recipes.length === 0) {
+    return null;
+  }
+
+  return (
+    <section css={styles(theme)}>
+      <div css={sectionWrap}>
+        <SectionHeader title="Recipes" count={`${recipes.length}`} />
+        <p className="rcp-lede">
+          Chains of the examples below, ordered: run them top to bottom and each
+          step takes what the one before it produced.
+        </p>
+        {isLoading ? (
+          <div className="rcp-loading">
+            <LoadingSpinner size="medium" text="Loading recipes" />
+          </div>
+        ) : isError ? (
+          <div className="rcp-empty">
+            <EmptyState
+              variant="error"
+              title="Couldn't load recipes"
+              description="Try again in a moment."
+              actionText="Retry"
+              onAction={() => refetch()}
+            />
+          </div>
+        ) : (
+          <div className="rcp-list">
+            {recipes.map((recipe) => (
+              <RecipeCard
+                key={recipe.slug}
+                recipe={recipe}
+                expanded={expanded === recipe.slug}
+                onToggle={(slug) =>
+                  setExpanded((current) => (current === slug ? null : slug))
+                }
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default memo(DashboardRecipes);

--- a/web/src/components/portal/ExamplesPage.tsx
+++ b/web/src/components/portal/ExamplesPage.tsx
@@ -1,22 +1,26 @@
 import React, { memo } from "react";
 import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
 import ManagerPageLayout from "../panels/ManagerPageLayout";
+import DashboardRecipes from "./DashboardRecipes";
 import DashboardTemplates from "./DashboardTemplates";
 
 /**
- * Full-screen Examples page. Reachable from the logo menu; wraps the
- * example/template browser in the shared manager chrome (header + back
- * button) and lets it own its scroll.
+ * Full-screen Examples page. Reachable from the logo menu; wraps the recipes
+ * (ordered chains of examples) and the example/template browser in the shared
+ * manager chrome (header + back button) and lets the browser own its scroll.
  */
 const ExamplesPage: React.FC = () => (
   <ManagerPageLayout
     icon={<AutoAwesomeOutlinedIcon sx={{ fontSize: 22 }} />}
     title="Examples"
-    subtitle="Browse example workflows and start from one."
+    subtitle="Browse example workflows and recipes, and start from one."
     docsTopic="examples"
     padded={false}
   >
-    <DashboardTemplates fullPage />
+    <>
+      <DashboardRecipes />
+      <DashboardTemplates fullPage />
+    </>
   </ManagerPageLayout>
 );
 

--- a/web/src/components/portal/__tests__/DashboardRecipes.test.tsx
+++ b/web/src/components/portal/__tests__/DashboardRecipes.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import DashboardRecipes from "../DashboardRecipes";
+
+const useQuery = jest.fn();
+const openStep = jest.fn();
+const addRecipe = jest.fn();
+
+jest.mock("../../../trpc/client", () => ({
+  __esModule: true,
+  trpc: { workflows: { recipes: { useQuery: (...args: unknown[]) => useQuery(...args) } } }
+}));
+
+jest.mock("../../../hooks/useRecipeActions", () => ({
+  __esModule: true,
+  useRecipeActions: () => ({
+    copyingStep: null,
+    addingSlug: null,
+    openStep: (...args: unknown[]) => openStep(...args),
+    addRecipe: (...args: unknown[]) => addRecipe(...args)
+  })
+}));
+
+const step = (example: string, role: string, models: string[] = []) => ({
+  example,
+  exampleId: `${example}.json`,
+  packageName: "nodetool-base",
+  description: `${example} description`,
+  role,
+  handoff: `${role} handoff`,
+  thumbnailUrl: null,
+  nodeCount: 4,
+  models: models.map((model) => ({ provider: "fal_ai", model })),
+  alternative: null
+});
+
+const RECIPE = {
+  slug: "viral-video-ad-engine",
+  name: "Viral Video Ad Engine",
+  outcome: "A vertical product ad.",
+  audience: "Performance teams.",
+  summary: ["Ordered cheapest first."],
+  caveats: ["Nothing here measures performance."],
+  thumbnailUrl: "/api/thumb/hook.jpg?v=1",
+  providers: ["fal_ai"],
+  nodeCount: 8,
+  steps: [
+    step("Ad Copy in Three Registers", "Settle the register"),
+    step("Ad Loop from a Product Photo", "Put the product in motion", [
+      "fal-ai/kling"
+    ])
+  ]
+};
+
+const renderRecipes = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <DashboardRecipes />
+    </ThemeProvider>
+  );
+
+describe("DashboardRecipes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useQuery.mockReturnValue({
+      data: [RECIPE],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn()
+    });
+  });
+
+  it("lists each recipe with the size of its chain", () => {
+    renderRecipes();
+    expect(screen.getByText("Viral Video Ad Engine")).toBeInTheDocument();
+    expect(screen.getByText("A vertical product ad.")).toBeInTheDocument();
+    expect(screen.getByText("2 workflows · 8 nodes")).toBeInTheDocument();
+    // The chain stays collapsed until asked for.
+    expect(screen.queryByText(/Settle the register/)).not.toBeInTheDocument();
+  });
+
+  it("opens the chain and copies a step on click", async () => {
+    const user = userEvent.setup();
+    renderRecipes();
+
+    await user.click(
+      screen.getByRole("button", { name: /Viral Video Ad Engine/ })
+    );
+    expect(screen.getByText("Ordered cheapest first.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Nothing here measures performance.")
+    ).toBeInTheDocument();
+
+    const stepButton = screen.getByRole("button", {
+      name: /Ad Loop from a Product Photo/
+    });
+    expect(within(stepButton).getByText("fal-ai/kling")).toBeInTheDocument();
+    await user.click(stepButton);
+    expect(openStep).toHaveBeenCalledWith(
+      "viral-video-ad-engine",
+      expect.objectContaining({ example: "Ad Loop from a Product Photo" })
+    );
+  });
+
+  it("says a step needs no key when its graph names no model", async () => {
+    const user = userEvent.setup();
+    renderRecipes();
+    await user.click(
+      screen.getByRole("button", { name: /Viral Video Ad Engine/ })
+    );
+    expect(
+      screen.getByText("Runs locally — no key needed")
+    ).toBeInTheDocument();
+  });
+
+  it("adds the whole chain from the header button", async () => {
+    const user = userEvent.setup();
+    renderRecipes();
+    await user.click(screen.getByRole("button", { name: "Add all 2" }));
+    expect(addRecipe).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: "viral-video-ad-engine" })
+    );
+  });
+
+  it("renders nothing when the install ships no recipes", () => {
+    useQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn()
+    });
+    const { container } = renderRecipes();
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/web/src/hooks/__tests__/useRecipeActions.test.ts
+++ b/web/src/hooks/__tests__/useRecipeActions.test.ts
@@ -1,0 +1,97 @@
+import { renderHook, act } from "@testing-library/react";
+import * as ReactRouterDom from "react-router-dom";
+import { useRecipeActions } from "../useRecipeActions";
+
+const mockCreateWorkflow = jest.fn();
+
+jest.mock("../../contexts/WorkflowManagerContext", () => ({
+  useWorkflowManager: jest.fn(
+    (selector: (state: { create: jest.Mock }) => unknown) =>
+      selector({ create: mockCreateWorkflow })
+  )
+}));
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: jest.fn()
+}));
+
+const step = (example: string) => ({
+  example,
+  packageName: "nodetool-base",
+  description: `${example} description`
+});
+
+const recipe = {
+  slug: "viral-video-ad-engine",
+  name: "Viral Video Ad Engine",
+  outcome: "",
+  audience: "",
+  summary: [],
+  caveats: [],
+  thumbnailUrl: null,
+  providers: [],
+  nodeCount: 0,
+  steps: [
+    { ...step("Ad Copy in Three Registers"), exampleId: "a.json", role: "", handoff: "", thumbnailUrl: null, nodeCount: 2, models: [], alternative: null },
+    { ...step("Ad Loop from a Product Photo"), exampleId: "b.json", role: "", handoff: "", thumbnailUrl: null, nodeCount: 3, models: [], alternative: null }
+  ]
+};
+
+describe("useRecipeActions", () => {
+  const mockNavigate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    let created = 0;
+    mockCreateWorkflow.mockImplementation(async () => ({
+      id: `wf-${++created}`
+    }));
+    jest.mocked(ReactRouterDom.useNavigate).mockReturnValue(mockNavigate);
+  });
+
+  it("copies one step from its example and opens it", async () => {
+    const { result } = renderHook(() => useRecipeActions());
+
+    await act(() =>
+      result.current.openStep("viral-video-ad-engine", step("Transcribe a Clip"))
+    );
+
+    expect(mockCreateWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Transcribe a Clip",
+        package_name: "nodetool-base",
+        tags: ["example"]
+      }),
+      "nodetool-base",
+      "Transcribe a Clip"
+    );
+    expect(mockNavigate).toHaveBeenCalledWith("/editor/wf-1");
+    expect(result.current.copyingStep).toBeNull();
+  });
+
+  it("copies every step in order and opens the first", async () => {
+    const { result } = renderHook(() => useRecipeActions());
+
+    await act(() => result.current.addRecipe(recipe));
+
+    expect(mockCreateWorkflow.mock.calls.map((call) => call[2])).toEqual([
+      "Ad Copy in Three Registers",
+      "Ad Loop from a Product Photo"
+    ]);
+    expect(mockNavigate).toHaveBeenCalledWith("/editor/wf-1");
+    expect(result.current.addingSlug).toBeNull();
+  });
+
+  it("stops the chain and stays put when a copy fails", async () => {
+    mockCreateWorkflow.mockRejectedValueOnce(new Error("no server"));
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    const { result } = renderHook(() => useRecipeActions());
+
+    await act(() => result.current.addRecipe(recipe));
+
+    expect(mockCreateWorkflow).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(result.current.addingSlug).toBeNull();
+  });
+});

--- a/web/src/hooks/useRecipeActions.ts
+++ b/web/src/hooks/useRecipeActions.ts
@@ -1,0 +1,98 @@
+import { useCallback, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import type { recipes } from "@nodetool-ai/protocol/api-schemas";
+import { useWorkflowManager } from "../contexts/WorkflowManagerContext";
+import useOnboardingStore from "../stores/OnboardingStore";
+
+type Recipe = recipes.ExampleRecipeSummary;
+
+/** What a step needs to become a workflow in the user's library. */
+interface CopyableStep {
+  example: string;
+  packageName: string;
+  description: string;
+}
+
+interface RecipeActions {
+  /** `<slug>:<example>` while that step is being copied, else null. */
+  copyingStep: string | null;
+  /** Slug of the recipe whose whole chain is being added, else null. */
+  addingSlug: string | null;
+  /** Copy one step into the library and open it. */
+  openStep: (slug: string, step: CopyableStep) => Promise<void>;
+  /** Copy every step of a recipe, in order, then open the first. */
+  addRecipe: (recipe: Recipe) => Promise<void>;
+}
+
+const requestFor = (step: CopyableStep) => ({
+  name: step.example,
+  package_name: step.packageName,
+  description: step.description,
+  tags: ["example"],
+  access: "private",
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString()
+});
+
+/**
+ * Copying a recipe is copying the examples it names, one per step — the same
+ * path a single template takes, so a recipe needs no import format of its own.
+ */
+export const useRecipeActions = (): RecipeActions => {
+  const navigate = useNavigate();
+  const createWorkflow = useWorkflowManager((state) => state.create);
+  const [copyingStep, setCopyingStep] = useState<string | null>(null);
+  const [addingSlug, setAddingSlug] = useState<string | null>(null);
+
+  const busy = copyingStep !== null || addingSlug !== null;
+
+  const openStep = useCallback(
+    async (slug: string, step: CopyableStep) => {
+      if (busy) return;
+      useOnboardingStore.getState().markStep("open-template");
+      setCopyingStep(`${slug}:${step.example}`);
+      try {
+        const created = await createWorkflow(
+          requestFor(step),
+          step.packageName,
+          step.example
+        );
+        navigate(`/editor/${created.id}`);
+      } catch (error) {
+        console.error("Error copying recipe step:", error);
+      } finally {
+        setCopyingStep(null);
+      }
+    },
+    [busy, createWorkflow, navigate]
+  );
+
+  const addRecipe = useCallback(
+    async (recipe: Recipe) => {
+      if (busy) return;
+      useOnboardingStore.getState().markStep("open-template");
+      setAddingSlug(recipe.slug);
+      try {
+        let firstId: string | null = null;
+        for (const step of recipe.steps) {
+          const created = await createWorkflow(
+            requestFor(step),
+            step.packageName,
+            step.example
+          );
+          firstId ??= created.id;
+        }
+        if (firstId) {
+          navigate(`/editor/${firstId}`);
+        }
+      } catch (error) {
+        console.error("Error adding recipe:", error);
+      } finally {
+        setAddingSlug(null);
+      }
+    },
+    [busy, createWorkflow, navigate]
+  );
+
+  return { copyingStep, addingSlug, openStep, addRecipe };
+};


### PR DESCRIPTION
## What changed

A recipe — a named outcome plus the ordered example workflows that reach it — only existed on the marketing site, as a page plus a `.nodetool` bundle to download. Every step is a workflow the app already ships, so the app can offer the chain directly. The manifests move to `packages/base-nodes/nodetool/examples/recipes/*.recipe.json`, the layout example apps and storyboards already use, and hold no graphs: each step names a shipped example, and `listExampleRecipes` resolves those names against the examples the install has, reading node counts, thumbnails and models out of the graphs (a recipe with an unresolvable step is dropped rather than half-offered). `workflows.recipes` serves the resolved chains and the Examples page lists them above the gallery, where a step opens that example as a workflow and "Add all" copies the whole chain into the library. The site generates its `/recipes` pages and bundles from the same manifests, so the page and the product name one list of workflows, and its "Running it" walkthrough drops the download-and-import steps: install Studio, open the recipe from Examples, add keys — the bundle stays as an aside. `validate-examples` checks every step, alternative and hero resolves; `bundle-backend` stages the manifests and `verify-backend-bundle` checks the examples they name were staged with them.

A second commit fixes the harness gate the first one turned red: nothing in `packages/cli/src/harness/registry.ts` claimed `marketing/`, so its files counted as unmapped code and failed the leg (all 5 selfchecks had passed). It adds a `recipes` harness — selfcheck runs the resolver's suite plus the site generator in `--check` mode — and a `marketing-site` surface whose gap note says where the site's own checks run.

## Verification

- [x] `npm run test:affected` — the diff touches `scripts/`, so selection widens to everything. `web`: 1299 suites, 14526 tests passed. `packages/cli`: 60 suites, 782 tests passed. `npm run test:packages`: one pre-existing parallel-load flake (`blender-nodes tests/settings.test.ts` timed out at 5000ms under load; passes on its own re-run — untouched by this diff), everything else green. New suites: `packages/websocket/tests/example-recipes.test.ts` 5 passed, `DashboardRecipes` 5 passed, `useRecipeActions` 3 passed.
- [x] `npm run typecheck` — web and electron clean. The mobile leg fails on `Cannot find module 'react-native' / 'expo-*'` because `mobile/node_modules` was never installed in this container; no mobile file is touched.
- [x] `npm run lint` — exit 0.
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — exit 0, `Gate: 7/7 selfchecks passed`, no unmapped code files. **Correction to the first version of this description:** it reported this as passing on the first commit. It had not — I read the "5/5 selfchecks passed" tail through a pipe, which hid exit 1 on the unmapped marketing files. CI caught what the pipe hid; the second commit is the fix, and this run captures the exit code.
- [x] `npm run capabilities:check` — `capability table is current (268 capabilities)`.
- [x] `npm run backend:smoke` — `Copied 4 recipe manifest(s) to examples/recipes/`, `4 recipe(s) staged with their steps`, server booted and answered `/health`.
- [x] `npm run gen:recipes -- --check` (marketing) — `4 recipes up to date`; the regenerated `recipeEntries.generated.ts` is byte-identical to the one the old editorial specs produced.

## Agent capabilities

No capability added or re-declared. `npm run capabilities:check` passes.

## New checks

Both new checks were inverted by renaming one step (`"Score a Silent Clip"` → `"Score a Silent Clip X"`) in `storyboard-to-trailer.recipe.json`, and both went red:

- `npm run validate:examples`:
  ```
  FAIL  packages/base-nodes/nodetool/examples/recipes/storyboard-to-trailer.recipe.json
        step "Score a Silent ClipX" names example "Score a Silent ClipX", which no shipped example matches
  ```
- `npx vitest run tests/example-recipes.test.ts` (packages/websocket):
  ```
  AssertionError: expected [ Array(3) ] to deeply equal [ Array(4) ]
  Tests  1 failed | 3 passed (4)
  ```
- `npm run gen:recipes -- --check` (marketing):
  ```
  generate-recipes: recipe "storyboard-to-trailer" step "Score a Silent Clip X" resolves to no shipped example.
  ```
  The last two are what the new `recipes` harness selfcheck runs, so the gate carries them on any diff touching a manifest, the resolver, the Examples listing, or the recipe pages.
- [x] The examples-validator run asserts it found its targets: it exits non-zero when no `*.recipe.json` is found at all, and the vitest suite asserts the shipped slug list is non-empty and that a chain with models and an alternative is present, so neither can pass by matching nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012W8zF2qaNT3g1eVG6TxEwK