### PR TITLE
feat(workspace): show the tab title tooltip fast on hover

### DIFF
--- a/web/src/components/workspace/WorkspaceTabItem.tsx
+++ b/web/src/components/workspace/WorkspaceTabItem.tsx
@@ -16,8 +16,15 @@ import {
   CloseButton,
   ContextMenu,
   LoadingSpinner,
-  MenuItemPrimitive
+  MenuItemPrimitive,
+  Tooltip
 } from "../ui_primitives";
+
+// Tabs are scanned, not studied — the title has to land while the pointer is
+// still moving. Well under the 700ms chrome default, and the native `title`
+// attribute this replaced was slower still (~1s, browser-controlled).
+const TAB_TITLE_TOOLTIP_DELAY = 150;
+const TAB_TITLE_TOOLTIP_NEXT_DELAY = 0;
 
 interface WorkspaceTabItemProps {
   tab: WorkspaceTab;
@@ -200,12 +207,14 @@ const WorkspaceTabItem = ({
                 color="primary"
               />
             )}
-            <span
-              className="tab-name"
+            <Tooltip
               title={tab.title}
+              placement="bottom"
+              delay={TAB_TITLE_TOOLTIP_DELAY}
+              nextDelay={TAB_TITLE_TOOLTIP_NEXT_DELAY}
             >
-              {tab.title}
-            </span>
+              <span className="tab-name">{tab.title}</span>
+            </Tooltip>
             {isWorkflowDirty && (
               <span
                 className="dirty-dot"

--- a/web/src/components/workspace/__tests__/WorkspaceTabItem.test.tsx
+++ b/web/src/components/workspace/__tests__/WorkspaceTabItem.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";
@@ -62,10 +62,23 @@ const renderTab = (overrides: Partial<React.ComponentProps<typeof WorkspaceTabIt
 };
 
 describe("WorkspaceTabItem rename input", () => {
-  it("shows the full tab name on hover", () => {
-    renderTab();
+  it("shows the full tab name on hover well before the chrome delay", async () => {
+    jest.useFakeTimers();
+    try {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      renderTab();
 
-    expect(screen.getByText(tab.title)).toHaveAttribute("title", tab.title);
+      await user.hover(screen.getByText(tab.title));
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(tab.title);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it("lets the user type spaces into the rename input", async () => {


### PR DESCRIPTION
## What changed

The workspace tab name carried its full title in the native `title` attribute, so the browser decided when the popup appeared — roughly a second, with no way to tune it and no theming. Tabs get scanned rather than studied, so the title needs to land while the pointer is still moving. It now renders through the `Tooltip` primitive at a 150ms enter delay, with no delay when a neighbouring tab's tooltip was just open, so sweeping across the tab strip reads continuously.

## Verification

- [x] `npm run test:affected` — the web suite passes, including the rewritten `WorkspaceTabItem` hover test.
- [x] `npm run typecheck` — passes in CI on this head (`Quality Gate / typecheck`).
- [x] `npm run lint` — clean, warnings only, none in the changed files.
- [x] `npm run dev:nodetool -- harness gate --base main` — passes in CI on this head (`Quality Gate / harness-gate`).

All 22 checks are green on `ee8ca0b`.

A correction to an earlier version of this description: locally, `typecheck`, `build:packages` and `harness gate` failed on implicit-`any` errors in `packages/agents/src/capabilities/godot.ts` and a missing `@nodetool-ai/base-nodes/dist`. I described those as pre-existing repo breakage. CI runs both green on this exact commit, so they were an artifact of my sandbox's dependency state, not the repo's.

The existing test asserted the native `title` attribute, so it was rewritten to hover the tab under fake timers and assert the tooltip appears after 200ms — well inside the 700ms chrome default. Inverting the component back to the native `title` makes it fail:

```
Unable to find an accessible element with the role "tooltip"
  at Object.<anonymous> (src/components/workspace/__tests__/WorkspaceTabItem.test.tsx:78:21)
Tests: 1 failed, 7 skipped, 8 total
```

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added — the one test changed is a behaviour test, and its failing output is above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U73oELonF5b85hybWTCN5j