### PR TITLE
fix: workspace symlink containment and self-sufficient package test builds

### DIFF
--- a/packages/runtime/src/storage-workspace.ts
+++ b/packages/runtime/src/storage-workspace.ts
@@ -326,6 +326,12 @@ export class StorageWorkspace implements Workspace {
 
   async deleteAll(path: string): Promise<number> {
     const key = normalize(path);
+    // Same containment rule as every other mutating operation: without it a
+    // symlinked directory inside the workspace (`out -> ~/Documents`) makes
+    // this delete the link's target. `list` reads through the symlink and
+    // hands back keys that are lexically inside the root, so the adapter's own
+    // lexical check passes and `unlink` follows the link out.
+    if (key) await this.assertContained(key);
     const listing = await this.storage.list(key ? `${key}/` : "");
     let deleted = 0;
     for (const entry of listing.entries) {
@@ -350,7 +356,9 @@ export class StorageWorkspace implements Workspace {
     // into it.
     if (this.localDir) {
       const key = normalize(path);
-      if (key) await requireNode().fs.mkdir(resolvePath(this.localDir, key), {
+      if (!key) return;
+      await this.assertContained(key);
+      await requireNode().fs.mkdir(resolvePath(this.localDir, key), {
         recursive: true
       });
     }

--- a/packages/runtime/tests/run-budget.test.ts
+++ b/packages/runtime/tests/run-budget.test.ts
@@ -7,7 +7,7 @@
  * indistinguishable from a free one (assumption A-5, invariant I-4). Both are
  * pinned here.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   CompositeTurnBudget,
   createCounter,
@@ -313,17 +313,28 @@ describe("RunBudget", () => {
     expect(budget.turnCount.current).toBe(0);
   });
 
-  it("keeps the first reason when a second ceiling is hit later", async () => {
+  it("keeps the first reason when a second ceiling is hit later", () => {
     // Reporting the deadline for a run that had already run out of money would
     // point whoever reads it at the wrong limit.
-    const budget = createRunBudget({ ...options, capUsd: 0, deadlineMs: 10 });
-    expect(budget.turns.reserve(pricedTurn())).toBeNull();
-    expect(budget.exhausted?.kind).toBe("cost");
+    //
+    // On a fake clock, because `reserve` checks the deadline before the cost:
+    // against the wall clock, any pause between construction and the first
+    // reserve longer than the deadline (a loaded CI runner, a GC pause) marks
+    // the run exhausted on "deadline" and the first assertion fails. Time here
+    // moves only when the test moves it.
+    vi.useFakeTimers();
+    try {
+      const budget = createRunBudget({ ...options, capUsd: 0, deadlineMs: 10 });
+      expect(budget.turns.reserve(pricedTurn())).toBeNull();
+      expect(budget.exhausted?.kind).toBe("cost");
 
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(budget.deadline.expired()).toBe(true);
-    expect(budget.turns.reserve(pricedTurn())).toBeNull();
-    expect(budget.exhausted?.kind).toBe("cost");
+      vi.advanceTimersByTime(20);
+      expect(budget.deadline.expired()).toBe(true);
+      expect(budget.turns.reserve(pricedTurn())).toBeNull();
+      expect(budget.exhausted?.kind).toBe("cost");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/runtime/tests/storage-workspace.test.ts
+++ b/packages/runtime/tests/storage-workspace.test.ts
@@ -272,6 +272,40 @@ describe("Workspace over a local directory", () => {
     expect(await readFile(resolve(dir, "notes.md"), "utf8")).toBe("on disk");
   });
 
+  it("refuses to deleteAll through a symlinked-out directory", async () => {
+    // `list` reads through the symlink and returns keys that look lexically
+    // inside the root, so the adapter's own check passes and `unlink` follows
+    // the link out — deleting the user's real files.
+    const outside = await mkdtemp(join(tmpdir(), "ws-outside-"));
+    try {
+      await writeFile(join(outside, "important.txt"), "KEEP");
+      await symlink(outside, join(dir, "escape"));
+      const workspace = new StorageWorkspace(new FileStorageAdapter(dir));
+
+      await expect(workspace.deleteAll("escape")).rejects.toThrow(
+        WorkspacePathError
+      );
+      expect(existsSync(join(outside, "important.txt"))).toBe(true);
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to mkdir under a symlinked-out directory", async () => {
+    const outside = await mkdtemp(join(tmpdir(), "ws-outside-"));
+    try {
+      await symlink(outside, join(dir, "escape"));
+      const workspace = new StorageWorkspace(new FileStorageAdapter(dir));
+
+      await expect(workspace.mkdir("escape/planted")).rejects.toThrow(
+        WorkspacePathError
+      );
+      expect(existsSync(join(outside, "planted"))).toBe(false);
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
   it("accepts a workspace root reached through a symlink alias", async () => {
     const actual = join(dir, "actual");
     const alias = join(dir, "alias");

--- a/packages/websocket/tests/build-typescript-workspace.test.ts
+++ b/packages/websocket/tests/build-typescript-workspace.test.ts
@@ -56,6 +56,26 @@ describe("prepareTypeScriptWorkspaceBuild", () => {
     expect(existsSync(join(workspaceDir, "dist", "index.js"))).toBe(true);
   });
 
+  it("drops a tsbuildinfo whose dist was removed, so tsc re-emits", async () => {
+    // `rm -rf dist` without the build info leaves tsc believing every output
+    // is current: the build reports success, emits nothing, and the package
+    // fails to resolve at import.
+    const workspaceDir = await mkdtemp(join(tmpdir(), "nodetool-build-helper-"));
+    tempDirs.push(workspaceDir);
+
+    await mkdir(join(workspaceDir, "src"), { recursive: true });
+    await writeFile(join(workspaceDir, "src", "index.ts"), "export const a = 1;");
+    await writeFile(join(workspaceDir, "tsconfig.tsbuildinfo"), "stale build state");
+
+    const runCommand = vi.fn(async () => {
+      expect(existsSync(join(workspaceDir, "tsconfig.tsbuildinfo"))).toBe(false);
+    });
+
+    await prepareTypeScriptWorkspaceBuild(workspaceDir, runCommand);
+
+    expect(runCommand).toHaveBeenCalled();
+  });
+
   it("advances the build stamp even when tsc re-emits nothing", async () => {
     // `tsc --build` decides by content, so a source whose mtime moved without
     // its bytes changing keeps its older output. Callers must compare against

--- a/scripts/build-typescript-workspace.mjs
+++ b/scripts/build-typescript-workspace.mjs
@@ -80,6 +80,23 @@ export async function pruneOrphanedDistOutputs(workspaceDir) {
   }
 }
 
+/**
+ * Drop a `tsconfig.tsbuildinfo` left behind by a removed `dist/`.
+ *
+ * `tsc --build` trusts that state: with the build info still claiming every
+ * output is current, a package whose `dist/` was deleted (a hand-rolled clean,
+ * a partial checkout) builds green and emits nothing, and the next import of
+ * it fails with "Failed to resolve entry for package". Reproduced against
+ * @nodetool-ai/document-nodes. Only the build info is removed — `dist/` is
+ * never wiped here, so the parallel-task race described below stays closed.
+ */
+export async function dropOrphanedBuildInfo(workspaceDir) {
+  if (await pathExists(resolve(workspaceDir, "dist"))) {
+    return;
+  }
+  await rm(resolve(workspaceDir, "tsconfig.tsbuildinfo"), { force: true });
+}
+
 export async function runCommand(command, args, options = {}) {
   await new Promise((resolveRun, rejectRun) => {
     const child = spawn(command, args, {
@@ -115,6 +132,8 @@ export async function prepareTypeScriptWorkspaceBuild(workspaceDir, execute = ru
   // prune those after the build instead of wiping dist/ up front, so already
   // up-to-date outputs stay available throughout and only genuinely orphaned
   // files disappear.
+  await dropOrphanedBuildInfo(workspaceDir);
+
   const { command, args } = getTypeScriptBuildCommand(repoRoot, {
     force: process.env.NODETOOL_FORCE_TSC_BUILD === "1",
   });

--- a/turbo.json
+++ b/turbo.json
@@ -41,7 +41,15 @@
       "outputs": ["dist/**", "tsconfig.tsbuildinfo"]
     },
     "test": {
-      "dependsOn": ["^build"],
+      // Also the package's OWN build: 84 test files across 13 node packages
+      // import their package by name (`@nodetool-ai/document-nodes`), which
+      // resolves through `exports` to `dist/`. With only `^build`, a package
+      // that nothing in the selected set depends on is tested without ever
+      // being built, and vitest fails at import with "Failed to resolve entry
+      // for package" — `npm run test:affected` on a clean checkout hit exactly
+      // that for document-nodes. Builds are cached, so this costs one cache
+      // hit per package after the first run.
+      "dependsOn": ["^build", "build"],
       "inputs": [
         "src/**",
         "__tests__/**",


### PR DESCRIPTION
## What changed

Three defects found while auditing the repo, each with a reproduction that fails
against the previous code. `StorageWorkspace.deleteAll` and `.mkdir` skipped the
`assertContained` check every other mutating operation runs, so a symlinked
directory inside a local workspace (`escape -> /outside`) let `deleteAll("escape")`
delete the link's target and `mkdir("escape/x")` create directories outside the
root — the exact escape the class's symlink handling exists to prevent. Separately,
turbo's `test` task depended only on `^build`, so a package nothing in the selected
set depends on was tested without ever being built; 84 test files across 13 node
packages import their own package by name, which resolves through `exports` to
`dist/`, and `npm run test:affected` on a clean checkout failed for document-nodes
with "Failed to resolve entry for package". The related silent failure — `tsc --build`
trusting a `tsconfig.tsbuildinfo` whose `dist/` was deleted by hand, reporting
success and emitting nothing — is fixed in the build helper, which drops an orphaned
build info without ever wiping `dist/`.

The turbo change invalidates every cached test task, which made `runtime`'s suite
actually execute rather than replay a cache hit, and that surfaced a latent flake:
`run-budget.test.ts` builds a budget with `deadlineMs: 10` and expects the first
`reserve` to refuse on cost, but `reserve` checks the deadline first, so any pause
over 10ms before that call reports `deadline`. The test now runs on a fake clock
that moves only when it moves it.

Audit findings not fixed here, with no code change proposed: `npm audit` reports 2
critical and 17 high advisories against a rule that says high/critical block merge
(`concurrently`/`shell-quote` have fixes; `expr-eval`'s prototype pollution is
reachable only inside the QuickJS sandbox pack); `packages/core-nodes` tests import
`@nodetool-ai/base-nodes`, which depends back on core-nodes, so the dependency
cannot be declared and nothing in the task graph guarantees base-nodes is built
before those tests run; GAP-CORR-1 and GAP-CORR-2 in `docs/correlation-design.md`
remain open with their `it.skip` regressions in place; `npm run lint` reports 202
warnings, 98 of them `react-hooks/exhaustive-deps` concentrated in the sketch and
node-editing components.

## Verification

- [x] `npm run test:affected` — the only failure is `@nodetool-ai/image-nodes#test`,
      which needs a Vulkan ICD this container has no driver for
      ("Failed to create instance … VulkanError"); documented in AGENTS.md as a
      missing driver, not a test failure. document-nodes and core-nodes, which
      failed before these commits, now pass. `packages/runtime` passes in full
      (178 files, 3381 tests) with ffmpeg installed.
- [x] `npm run typecheck` — packages are covered by `npm run build:packages` (exit 0,
      which is `tsc --build` over every package). The root `tsc --noEmit` cannot run
      here: `mobile/` is not a root workspace and its dependency tree is not
      installed in this container, so it reports `Cannot find module 'react-native'`
      and friends. No file in this diff is reachable from mobile. CI's `typecheck`
      leg is green on the head commit.
- [x] `npm run lint` — exit 0.
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — Gate: 5/5 selfchecks passed.
- [x] All 23 CI checks green on `01289a1f`.

Each fix was inverted and observed failing:

```
$ git stash push packages/runtime/src/storage-workspace.ts && npm run test --workspace=packages/runtime -- storage-workspace
 × refuses to deleteAll through a symlinked-out directory
 × refuses to mkdir under a symlinked-out directory
 Tests  2 failed | 51 passed (53)

$ git stash push scripts/build-typescript-workspace.mjs && npm run test --workspace=packages/websocket -- build-typescript-workspace
 × drops a tsbuildinfo whose dist was removed, so tsc re-emits
 Tests  1 failed | 5 passed (6)
```

The budget flake was reproduced by sleeping 15ms between constructing the budget
and the first reserve against the real clock: `exhausted.kind` comes back
`deadline`, the same assertion CI failed on.

## Agent capabilities

No capability added or re-declared.

## New checks

No new check, rule, or audit — the added tests pin behavior that already had a
contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaYw2F7FYDzvytMbk7YuwL