### PR TITLE
fix(web): stop a hidden editor from swallowing Space

### DIFF
--- a/web/src/components/node_editor/NodeEditor.tsx
+++ b/web/src/components/node_editor/NodeEditor.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { memo, useMemo, useState, useRef, useEffect } from "react";
+import { memo, useCallback, useMemo, useState, useRef, useEffect } from "react";
 
 import {
   LoadingSpinner,
@@ -93,7 +93,12 @@ const NodeEditor: React.FC<NodeEditorProps> = ({ workflowId, active }) => {
   const [commandMenuOpen, setCommandMenuOpen] = useState(false);
   const [quickAddNodeOpen, setQuickAddNodeOpen] = useState(false);
   const reactFlowWrapperRef = useRef<HTMLDivElement>(null);
-  useNodeEditorShortcuts(active, () => setShowShortcuts((v) => !v));
+  const editorRoot = useCallback(() => reactFlowWrapperRef.current, []);
+  useNodeEditorShortcuts(
+    active,
+    () => setShowShortcuts((v) => !v),
+    editorRoot
+  );
 
   const { missing: missingRuntimes } = useWorkflowRuntimeCheck(workflowId);
   // Let the user dismiss the install prompt without acting on it.

--- a/web/src/components/timeline/preview/PreviewArea.tsx
+++ b/web/src/components/timeline/preview/PreviewArea.tsx
@@ -725,7 +725,12 @@ export const PreviewArea: React.FC<PreviewAreaProps> = memo(
       [seek]
     );
 
-    useCombo([" "], handlePlayPauseToggle);
+    // Targeted at the preview root: every open workspace tab stays mounted, and
+    // an inert one must not swallow Space from the visible editor.
+    const previewTarget = useCallback(() => containerRef.current, []);
+    useCombo([" "], handlePlayPauseToggle, true, true, {
+      target: previewTarget
+    });
 
     const handleKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLDivElement>) => {

--- a/web/src/components/timeline/transcript/TranscriptEditor.tsx
+++ b/web/src/components/timeline/transcript/TranscriptEditor.tsx
@@ -807,7 +807,11 @@ const EditorBody: React.FC<{
   // bows out while anything editable is focused (Write mode, inputs, the slash
   // command's own field); the Space binding additionally bows out on a focused
   // control so Space still activates buttons.
-  const scriptMode = { active: !writing } as const;
+  // Targeted at this instance's surface: an inert background workspace tab must
+  // not swallow Space (or "/" and the arrows) from the visible editor.
+  const surfaceRef = useRef<HTMLDivElement>(null);
+  const surfaceTarget = useCallback(() => surfaceRef.current, []);
+  const scriptMode = { active: !writing, target: surfaceTarget } as const;
   useGlobalCombo(
     " ",
     (event) => {
@@ -890,6 +894,7 @@ const EditorBody: React.FC<{
 
   return (
     <EditorSurface
+      ref={surfaceRef}
       className={writing ? "is-writing" : undefined}
       onKeyDown={onKeyDown}
       onClick={onClick}

--- a/web/src/hooks/useNodeEditorShortcuts.ts
+++ b/web/src/hooks/useNodeEditorShortcuts.ts
@@ -35,13 +35,18 @@ import { useSketchCanvasRefStore } from "../stores/sketch/SketchCanvasRefStore";
 /**
  * Registers the node editor's keyboard shortcuts with KeyPressedStore, using the
  * combinations defined in NODE_EDITOR_SHORTCUTS. `active` gates registration;
- * `onShowShortcuts` opens the shortcuts help dialog.
+ * `onShowShortcuts` opens the shortcuts help dialog; `getRoot` returns this
+ * editor's root element so a shortcut only fires while that editor is
+ * reachable — several editors bind the same keys (Space opens the node menu
+ * here and plays/pauses in the timeline), and every open workspace tab stays
+ * mounted with inactive ones `inert`.
  */
 const ControlOrMeta = isMac() ? "Meta" : "Control";
 
 export const useNodeEditorShortcuts = (
   active: boolean,
-  onShowShortcuts?: () => void
+  onShowShortcuts?: () => void,
+  getRoot?: () => HTMLElement | null
 ): void => {
   // Subscribe to undo/redo functions only (stable) to prevent re-renders on history changes
   const undoHistory = useTemporalNodes((state) => state.undo);
@@ -654,7 +659,8 @@ export const useNodeEditorShortcuts = (
           registerComboCallback(normalized, {
             callback: meta.callback,
             preventDefault: meta.preventDefault ?? true,
-            active: meta.active ?? true
+            active: meta.active ?? true,
+            target: getRoot
           })
         );
       });
@@ -664,6 +670,6 @@ export const useNodeEditorShortcuts = (
       disposers.forEach((dispose) => dispose());
     };
     // selectedNodeCount affects active flags for align shortcuts
-  }, [active, selectedNodeCount, electronDetails, shortcutMeta]);
+  }, [active, selectedNodeCount, electronDetails, shortcutMeta, getRoot]);
 
 };

--- a/web/src/stores/KeyPressedStore.ts
+++ b/web/src/stores/KeyPressedStore.ts
@@ -59,9 +59,10 @@ interface ComboOptions {
    */
   allowInInputs?: boolean;
   /**
-   * The element this combo acts on. When given, the combo is skipped unless
-   * `canTakeFocus(target)` holds — an instance living in an inert/hidden
-   * workspace tab never fires. Pass a getter so a ref can be read lazily.
+   * The element this combo acts on. When given, the registration is skipped
+   * unless `canTakeFocus(target)` holds — an instance living in an inert/hidden
+   * workspace tab never fires, and the next binding down the stack handles the
+   * combo instead. Pass a getter so a ref can be read lazily.
    */
   target?: () => HTMLElement | null | undefined;
 }
@@ -203,8 +204,16 @@ const unregisterComboCallback = (combo: string) => {
 };
 
 // Resolve which binding handles a combo: the topmost (most recently registered)
-// registration that is active and has a callback. Returns undefined when no
-// binding should fire, letting default browser behavior proceed.
+// registration that is active, has a callback, and whose `target` can take
+// focus. Returns undefined when no binding should fire, letting default browser
+// behavior proceed.
+//
+// The target check belongs here, not at execution time: skipping an unreachable
+// binding lets the next one down the stack win. Space is bound by the node
+// editor (open node menu) and by the timeline (play/pause), and every open
+// workspace tab stays mounted with inactive ones `inert` — swallowing the key
+// on the topmost binding instead meant a background tab ate Space for the
+// visible editor.
 const resolveComboRegistration = (
   combo: string
 ): ComboRegistration | undefined => {
@@ -214,9 +223,13 @@ const resolveComboRegistration = (
   }
   for (let i = stack.length - 1; i >= 0; i--) {
     const registration = stack[i];
-    if (registration.callback && registration.active !== false) {
-      return registration;
+    if (!registration.callback || registration.active === false) {
+      continue;
     }
+    if (registration.target && !canTakeFocus(registration.target())) {
+      continue;
+    }
+    return registration;
   }
   return undefined;
 };
@@ -287,13 +300,6 @@ const executeComboCallbacks = (
       (event?.target instanceof Element &&
         isWorkflowEditorElement(event.target)));
 
-  // --- Shared focus gate ---
-  // One predicate for every combo, so no registration has to remember it.
-  // A combo that moves or acts on a specific element only fires when that
-  // element can actually take focus (not inside an inert/hidden tab layer).
-  if (options.target && !canTakeFocus(options.target())) {
-    return;
-  }
   // Typing wins over shortcuts. `isInputFocused` is `isTextInputActive()`
   // widened to the event target, and the block below is the shared rule:
   // a registration leaves it only by opting in (`allowInInputs`/`scope:

--- a/web/src/stores/__tests__/KeyPressedStore.test.ts
+++ b/web/src/stores/__tests__/KeyPressedStore.test.ts
@@ -553,6 +553,18 @@ describe("KeyPressedStore", () => {
       });
     };
 
+    const pressSpace = () => {
+      document.body.focus();
+      const { setKeysPressed } = useKeyPressedStore.getState();
+      act(() => {
+        setKeysPressed(
+          { " ": true },
+          new KeyboardEvent("keydown", { key: " " })
+        );
+        setKeysPressed({ " ": false });
+      });
+    };
+
     it("fires the most recently registered binding for a shared combo", () => {
       const first = jest.fn();
       const second = jest.fn();
@@ -622,6 +634,56 @@ describe("KeyPressedStore", () => {
 
       disposeBg();
       disposeFg();
+    });
+
+    it("falls through when the topmost binding's target cannot take focus", () => {
+      // The regression: Space is bound by the node editor (open node menu) and
+      // by the timeline (play/pause). Every open workspace tab stays mounted
+      // and inactive ones are `inert`, so the background tab's binding sat on
+      // top of the stack and swallowed Space for the visible editor.
+      const visible = jest.fn();
+      const background = jest.fn();
+
+      const visibleEl = document.createElement("div");
+      document.body.appendChild(visibleEl);
+      const inertLayer = document.createElement("div");
+      inertLayer.setAttribute("inert", "");
+      const backgroundEl = document.createElement("div");
+      inertLayer.appendChild(backgroundEl);
+      document.body.appendChild(inertLayer);
+
+      const disposeVisible = registerComboCallback(" ", {
+        callback: visible,
+        target: () => visibleEl
+      });
+      const disposeBackground = registerComboCallback(" ", {
+        callback: background,
+        target: () => backgroundEl
+      });
+
+      pressSpace();
+
+      expect(visible).toHaveBeenCalledTimes(1);
+      expect(background).not.toHaveBeenCalled();
+
+      disposeVisible();
+      disposeBackground();
+      document.body.removeChild(visibleEl);
+      document.body.removeChild(inertLayer);
+    });
+
+    it("fires nothing when every binding's target is unreachable", () => {
+      const background = jest.fn();
+      const detached = document.createElement("div");
+      const dispose = registerComboCallback(" ", {
+        callback: background,
+        target: () => detached
+      });
+
+      pressSpace();
+
+      expect(background).not.toHaveBeenCalled();
+      dispose();
     });
   });
 


### PR DESCRIPTION
## What changed

Space is bound by the node editor (open node menu), the timeline preview (play/pause) and the transcript editor. All three land in the same combo stack in `KeyPressedStore`, keyed on `" "`, and the topmost registration won regardless of which editor was on screen — every open workspace tab stays mounted with inactive ones `inert`, so a background tab's binding ate the key for the visible editor. The `target` gate existed for exactly this case, but it was applied at execution time: an unreachable target returned early and swallowed the keystroke instead of letting the next binding down the stack handle it. This moves the check into `resolveComboRegistration` so an unreachable registration is skipped, and gives the three Space bindings a target — the node editor root (`useNodeEditorShortcuts` now takes a `getRoot`), the preview container, the transcript surface.

## Verification

Two tests added to `stores/__tests__/KeyPressedStore.test.ts`. The first was written against the unfixed dispatcher and observed failing:

```
● KeyPressedStore › stacked combo registrations (scoping) › falls through when the topmost binding's target cannot take focus
    expect(jest.fn()).toHaveBeenCalledTimes(expected)
    Expected number of calls: 1
    Received number of calls: 0
```

- [x] `npm run test:affected` — 248 suites, 2139 passed
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (only pre-existing warnings)
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — no registry entry covers the changed paths (`web/src/stores/`, `web/src/hooks/`, `web/src/components/{node_editor,timeline}/…`), so the gate maps to nothing

## Agent capabilities

No capability added or changed.

## New checks

No new check, rule, or audit — the added tests pin the dispatcher's fall-through behavior, and the first one was observed failing before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LG8RwJMXRreSKRMtoBr3st

---
_Generated by [Claude Code](https://claude.ai/code/session_01LG8RwJMXRreSKRMtoBr3st)_