### PR TITLE
feat: add opt-in MuAPI image and video nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "packages/topaz-nodes",
         "packages/reve-nodes",
         "packages/atlascloud-nodes",
+        "packages/muapi-nodes",
         "packages/together-nodes",
         "packages/sandbox-compiler",
         "packages/workflow-runner",
@@ -13103,6 +13104,10 @@
     },
     "node_modules/@nodetool-ai/models": {
       "resolved": "packages/models",
+      "link": true
+    },
+    "node_modules/@nodetool-ai/muapi-nodes": {
+      "resolved": "packages/muapi-nodes",
       "link": true
     },
     "node_modules/@nodetool-ai/node-sdk": {
@@ -52717,6 +52722,23 @@
         "node": ">=22.0.0 <23.0.0"
       }
     },
+    "packages/muapi-nodes": {
+      "name": "@nodetool-ai/muapi-nodes",
+      "version": "0.7.0-rc.40",
+      "license": "MIT",
+      "dependencies": {
+        "@nodetool-ai/node-sdk": "*",
+        "@nodetool-ai/runtime": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.2",
+        "vitest": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=22.0.0 <23.0.0"
+      }
+    },
     "packages/node-sdk": {
       "name": "@nodetool-ai/node-sdk",
       "version": "0.7.0-rc.40",
@@ -53732,6 +53754,7 @@
         "@nodetool-ai/minimax-nodes": "*",
         "@nodetool-ai/model-pricing": "*",
         "@nodetool-ai/models": "*",
+        "@nodetool-ai/muapi-nodes": "*",
         "@nodetool-ai/node-sdk": "*",
         "@nodetool-ai/protocol": "*",
         "@nodetool-ai/replicate-nodes": "*",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "packages/topaz-nodes",
     "packages/reve-nodes",
     "packages/atlascloud-nodes",
+    "packages/muapi-nodes",
     "packages/together-nodes",
     "packages/sandbox-compiler",
     "packages/workflow-runner",

--- a/packages/config/src/setting-catalog.ts
+++ b/packages/config/src/setting-catalog.ts
@@ -496,6 +496,11 @@ sec(
   "AtlasCloud",
   "AtlasCloud.ai API key for chat models (DeepSeek, Qwen, GPT, Claude, Gemini) plus hosted image (GPT Image, Nano Banana, Seedream) and video (Seedance, Veo, Kling, Wan) generation. Get yours at https://www.atlascloud.ai/"
 );
+sec(
+  "MUAPI_API_KEY",
+  "MuAPI",
+  "MuAPI API key for image and video generation. Get yours at https://muapi.ai/access-keys"
+);
 sec("MESHY_API_KEY", "Meshy", "Meshy AI API key for 3D model generation. Get yours at https://app.meshy.ai/settings/api-keys");
 sec("RODIN_API_KEY", "Rodin", "Rodin AI API key for 3D model generation. Get yours at https://hyperhuman.deemos.com/");
 sec(

--- a/packages/muapi-nodes/README.md
+++ b/packages/muapi-nodes/README.md
@@ -1,0 +1,19 @@
+# MuAPI nodes for NodeTool
+
+This package adds opt-in NodeTool nodes for MuAPI's asynchronous image and
+video generation endpoints.
+
+## Nodes
+
+- **MuAPI Text to Image** — generate an image with the FLUX 3 image routes.
+- **MuAPI Text to Video** — generate a video with the FLUX 3 text-to-video route.
+- **MuAPI Image to Video** — animate an input image with the FLUX 3 image-to-video route.
+
+The pack uses the `MUAPI_API_KEY` secret. Create a key at
+<https://muapi.ai/access-keys> and add it in NodeTool's provider settings.
+
+Requests are submitted to MuAPI, polled until completion, and downloaded with
+the runtime's retry and public-HTTPS URL checks. Generation POST requests are
+never retried, and no credential is included in a generated media URL.
+
+API reference: <https://muapi.ai/docs/api-reference>

--- a/packages/muapi-nodes/package.json
+++ b/packages/muapi-nodes/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@nodetool-ai/muapi-nodes",
+  "type": "module",
+  "engines": {
+    "node": ">=22.0.0 <23.0.0"
+  },
+  "version": "0.7.0-rc.40",
+  "description": "MuAPI image and video generation nodes for NodeTool",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "node ../../scripts/build-typescript-workspace.mjs",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@nodetool-ai/node-sdk": "*",
+    "@nodetool-ai/runtime": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.2",
+    "vitest": "^4.1.2"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nodetool-ai/nodetool.git",
+    "directory": "packages/muapi-nodes"
+  },
+  "homepage": "https://nodetool.ai",
+  "bugs": {
+    "url": "https://github.com/nodetool-ai/nodetool/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "keywords": [
+    "nodetool",
+    "ai",
+    "workflow",
+    "workflow-automation",
+    "typescript",
+    "ai-nodes",
+    "no-code",
+    "visual-programming",
+    "workflow-nodes",
+    "muapi",
+    "image-generation",
+    "video-generation"
+  ]
+}

--- a/packages/muapi-nodes/src/index.ts
+++ b/packages/muapi-nodes/src/index.ts
@@ -1,0 +1,44 @@
+import type { NodeClass } from "@nodetool-ai/node-sdk";
+
+import { MuapiImageToVideoNode } from "./nodes/image-to-video.js";
+import { MuapiTextToImageNode } from "./nodes/text-to-image.js";
+import { MuapiTextToVideoNode } from "./nodes/text-to-video.js";
+
+export { MuapiImageToVideoNode } from "./nodes/image-to-video.js";
+export { MuapiTextToImageNode } from "./nodes/text-to-image.js";
+export { MuapiTextToVideoNode } from "./nodes/text-to-video.js";
+export {
+  MUAPI_BASE_URL,
+  MUAPI_IMAGE_ASPECT_RATIOS,
+  MUAPI_IMAGE_MODELS,
+  MUAPI_IMAGE_RESOLUTIONS,
+  MUAPI_VIDEO_ASPECT_RATIOS,
+  MUAPI_VIDEO_RESOLUTIONS,
+  downloadMuapiOutput,
+  generateMuapiMedia,
+  getMuapiApiKey,
+  normalizeMuapiVideoDuration,
+  pickMuapiOutputUrl,
+  pollMuapi,
+  submitMuapi,
+  uploadMuapiImage,
+  videoRefFromBytes
+} from "./muapi-base.js";
+export type {
+  GenerateMuapiMediaOptions,
+  MuapiPollOptions
+} from "./muapi-base.js";
+
+export const MUAPI_NODES: readonly NodeClass[] = [
+  MuapiTextToImageNode,
+  MuapiTextToVideoNode,
+  MuapiImageToVideoNode
+];
+
+export function registerMuapiNodes(registry: {
+  register: (nodeClass: NodeClass) => void;
+}): void {
+  for (const nodeClass of MUAPI_NODES) {
+    registry.register(nodeClass);
+  }
+}

--- a/packages/muapi-nodes/src/muapi-base.ts
+++ b/packages/muapi-nodes/src/muapi-base.ts
@@ -1,0 +1,383 @@
+import type { ImageRef, VideoRef } from "@nodetool-ai/node-sdk";
+import {
+  assertSafePublicHttpsUrl,
+  detectImageMime,
+  loadMediaRefBytes,
+  safeFetch,
+  type ProcessingContext
+} from "@nodetool-ai/runtime";
+import {
+  fetchWithRetry,
+  imageRefFromBytes,
+  pollUntilTerminal,
+  TERMINAL_FAILURE_STATES,
+  TERMINAL_SUCCESS_STATES
+} from "@nodetool-ai/runtime/provider-transport";
+
+export const MUAPI_BASE_URL = "https://api.muapi.ai/api/v1";
+
+export const MUAPI_IMAGE_MODELS = [
+  "flux-3-text-to-image",
+  "flux-3-dev"
+] as const;
+
+export const MUAPI_IMAGE_ASPECT_RATIOS = [
+  "16:9",
+  "9:16",
+  "1:1",
+  "4:3",
+  "3:4",
+  "2:3",
+  "3:2",
+  "21:9"
+] as const;
+
+export const MUAPI_VIDEO_ASPECT_RATIOS = [
+  "16:9",
+  "9:16",
+  "1:1",
+  "4:3",
+  "3:4",
+  "21:9"
+] as const;
+
+export const MUAPI_IMAGE_RESOLUTIONS = ["1k", "2k", "4k"] as const;
+export const MUAPI_VIDEO_RESOLUTIONS = ["480p", "720p", "1080p"] as const;
+
+export function normalizeMuapiVideoDuration(value: unknown): number {
+  const duration = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(duration)) return 5;
+  return Math.min(10, Math.max(4, Math.round(duration)));
+}
+
+const MUAPI_FAILURE_STATES = new Set([
+  ...TERMINAL_FAILURE_STATES,
+  "failure"
+]);
+
+const OUTPUT_KEYS = [
+  "url",
+  "image",
+  "image_url",
+  "video",
+  "video_url",
+  "file_url",
+  "output",
+  "outputs",
+  "images",
+  "data",
+  "result",
+  "prediction",
+  "media",
+  "content",
+  "file"
+] as const;
+
+export interface MuapiPollOptions {
+  pollIntervalMs?: number;
+  maxAttempts?: number;
+  signal?: AbortSignal;
+}
+
+export interface GenerateMuapiMediaOptions {
+  apiKey: string;
+  endpoint: string;
+  payload: Record<string, unknown>;
+  kind: "image" | "video";
+  pollIntervalMs?: number;
+  maxAttempts?: number;
+  signal?: AbortSignal;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function readIdentifier(value: unknown): string | undefined {
+  const stringValue = readString(value);
+  if (stringValue) return stringValue;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return undefined;
+}
+
+async function readJsonResponse(
+  response: Response
+): Promise<{ body: unknown; text: string }> {
+  const text = await response.text();
+  if (!text.trim()) return { body: {}, text };
+  try {
+    return { body: JSON.parse(text) as unknown, text };
+  } catch {
+    return { body: null, text };
+  }
+}
+
+function apiUrl(endpoint: string): string {
+  return `${MUAPI_BASE_URL}/${endpoint.replace(/^\/+/, "")}`;
+}
+
+export function getMuapiApiKey(
+  secrets: Record<string, string> | undefined
+): string {
+  const key = secrets?.MUAPI_API_KEY || process.env.MUAPI_API_KEY || "";
+  if (!key.trim()) throw new Error("MUAPI_API_KEY is not configured");
+  return key.trim();
+}
+
+function jsonHeaders(apiKey: string): Record<string, string> {
+  return {
+    "x-api-key": apiKey,
+    "Content-Type": "application/json"
+  };
+}
+
+function authHeaders(apiKey: string): Record<string, string> {
+  return { "x-api-key": apiKey };
+}
+
+/** Submit exactly once: the provider may have created a billable job already. */
+export async function submitMuapi(
+  apiKey: string,
+  endpoint: string,
+  payload: Record<string, unknown>,
+  signal?: AbortSignal
+): Promise<string> {
+  const init: RequestInit = {
+    method: "POST",
+    headers: jsonHeaders(apiKey),
+    body: JSON.stringify(payload)
+  };
+  if (signal) init.signal = signal;
+
+  const response = await fetch(apiUrl(endpoint), init);
+  const { body, text } = await readJsonResponse(response);
+  if (!response.ok) {
+    throw new Error(
+      `MuAPI ${endpoint} submit failed: ${response.status} ${text.slice(0, 500)}`
+    );
+  }
+  if (!isRecord(body)) {
+    throw new Error(
+      `MuAPI ${endpoint} returned a non-object submission response: ${text.slice(0, 500)}`
+    );
+  }
+
+  const requestId = readIdentifier(body.request_id) ?? readIdentifier(body.id);
+  if (!requestId) {
+    throw new Error(
+      `MuAPI ${endpoint} returned no request_id: ${text.slice(0, 500)}`
+    );
+  }
+  return requestId;
+}
+
+function findOutputUrl(
+  value: unknown,
+  visited: Set<object>,
+  depth: number
+): string | undefined {
+  if (depth > 8) return undefined;
+  if (typeof value === "string") {
+    const candidate = value.trim();
+    return /^https?:\/\//i.test(candidate) ? candidate : undefined;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findOutputUrl(item, visited, depth + 1);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  if (!isRecord(value)) return undefined;
+  if (visited.has(value)) return undefined;
+  visited.add(value);
+
+  for (const key of OUTPUT_KEYS) {
+    if (key in value) {
+      const found = findOutputUrl(value[key], visited, depth + 1);
+      if (found) return found;
+    }
+  }
+  for (const item of Object.values(value)) {
+    const found = findOutputUrl(item, visited, depth + 1);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+export function pickMuapiOutputUrl(result: Record<string, unknown>): string {
+  const url = findOutputUrl(result, new Set<object>(), 0);
+  if (!url) {
+    throw new Error(
+      `MuAPI result did not contain an output URL: ${JSON.stringify(result).slice(0, 500)}`
+    );
+  }
+  return url;
+}
+
+export async function pollMuapi(
+  apiKey: string,
+  requestId: string,
+  options: MuapiPollOptions = {}
+): Promise<Record<string, unknown>> {
+  const pollUrl = apiUrl(`predictions/${encodeURIComponent(requestId)}/result`);
+  const pollIntervalMs = options.pollIntervalMs ?? 5000;
+  const maxAttempts = options.maxAttempts ?? 360;
+
+  return pollUntilTerminal<Record<string, unknown>>(
+    async () => {
+      const init: RequestInit = { headers: authHeaders(apiKey) };
+      if (options.signal) init.signal = options.signal;
+      const response = await fetchWithRetry(pollUrl, init, {
+        maxAttempts: 6
+      });
+      const { body, text } = await readJsonResponse(response);
+      if (!isRecord(body)) {
+        throw new Error(
+          `MuAPI poll returned a non-object response: ${text.slice(0, 500)}`
+        );
+      }
+
+      const status = readString(body.status)?.toLowerCase();
+      if (!response.ok && !MUAPI_FAILURE_STATES.has(status ?? "")) {
+        throw new Error(`MuAPI poll failed: ${response.status} ${text.slice(0, 500)}`);
+      }
+      return body;
+    },
+    {
+      intervalMs: pollIntervalMs,
+      maxAttempts,
+      signal: options.signal,
+      success: TERMINAL_SUCCESS_STATES,
+      failure: MUAPI_FAILURE_STATES,
+      statusOf: (body) => {
+        const status = readString(body.status)?.toLowerCase();
+        if (status) return status;
+        return findOutputUrl(body, new Set<object>(), 0)
+          ? "completed"
+          : "";
+      },
+      onFailure: (body) => {
+        const detail =
+          readString(body.error) ??
+          readString(body.message) ??
+          JSON.stringify(body).slice(0, 500);
+        return new Error(`MuAPI generation failed: ${detail}`);
+      },
+      onTimeout: () =>
+        new Error(
+          `MuAPI request ${requestId} timed out after ${maxAttempts} poll attempts`
+        )
+    }
+  );
+}
+
+/** Download an already-generated result with SSRF checks and GET retries. */
+export async function downloadMuapiOutput(
+  url: string,
+  signal?: AbortSignal
+): Promise<Uint8Array> {
+  const init: RequestInit = signal ? { signal } : {};
+  const response = await fetchWithRetry(url, init, {
+    maxAttempts: 6,
+    fetchImpl: (input, requestInit) =>
+      safeFetch(String(input), requestInit)
+  });
+  if (!response.ok) {
+    throw new Error(`MuAPI output download failed: HTTP ${response.status}`);
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.length === 0) throw new Error("MuAPI returned an empty output file");
+  return bytes;
+}
+
+export async function uploadMuapiImage(
+  apiKey: string,
+  bytes: Uint8Array,
+  signal?: AbortSignal
+): Promise<string> {
+  if (bytes.length === 0) throw new Error("Input image is empty");
+
+  const mimeType = detectImageMime(bytes);
+  const form = new FormData();
+  form.append(
+    "file",
+    new Blob([Buffer.from(bytes)], { type: mimeType }),
+    `input.${mimeType.split("/")[1] ?? "bin"}`
+  );
+  const init: RequestInit = {
+    method: "POST",
+    headers: authHeaders(apiKey),
+    body: form
+  };
+  if (signal) init.signal = signal;
+
+  const response = await fetch(apiUrl("upload_file"), init);
+  const { body, text } = await readJsonResponse(response);
+  if (!response.ok) {
+    throw new Error(`MuAPI image upload failed: ${response.status} ${text.slice(0, 500)}`);
+  }
+  if (!isRecord(body)) {
+    throw new Error(`MuAPI image upload returned an invalid response: ${text.slice(0, 500)}`);
+  }
+
+  const url = pickMuapiOutputUrl(body);
+  // The URL is sent back to MuAPI and later downloaded locally; enforce the
+  // same public HTTPS contract at the boundary instead of accepting a local URL.
+  // `safeFetch` repeats this check when the generated media is downloaded.
+  // Keeping it here also prevents sending an internal URL back to the provider.
+  assertSafePublicHttpsUrl(url);
+  return url;
+}
+
+export function videoRefFromBytes(bytes: Uint8Array): VideoRef {
+  return {
+    type: "video",
+    uri: "",
+    data: Buffer.from(bytes).toString("base64"),
+    format: "mp4"
+  };
+}
+
+export function generateMuapiMedia(
+  options: GenerateMuapiMediaOptions & { kind: "image" }
+): Promise<ImageRef>;
+export function generateMuapiMedia(
+  options: GenerateMuapiMediaOptions & { kind: "video" }
+): Promise<VideoRef>;
+export async function generateMuapiMedia(
+  options: GenerateMuapiMediaOptions
+): Promise<ImageRef | VideoRef> {
+  const requestId = await submitMuapi(
+    options.apiKey,
+    options.endpoint,
+    options.payload,
+    options.signal
+  );
+  const result = await pollMuapi(options.apiKey, requestId, {
+    pollIntervalMs: options.pollIntervalMs,
+    maxAttempts: options.maxAttempts,
+    signal: options.signal
+  });
+  const outputUrl = pickMuapiOutputUrl(result);
+  const bytes = await downloadMuapiOutput(outputUrl, options.signal);
+  if (options.kind === "image") return imageRefFromBytes(bytes);
+  return videoRefFromBytes(bytes);
+}
+
+export async function resolveInputImageBytes(
+  image: Parameters<typeof loadMediaRefBytes>[0],
+  context?: ProcessingContext
+): Promise<Uint8Array> {
+  const bytes = await loadMediaRefBytes(image, context);
+  if (!bytes || bytes.length === 0) throw new Error("An input image is required");
+  return bytes;
+}

--- a/packages/muapi-nodes/src/nodes/image-to-video.ts
+++ b/packages/muapi-nodes/src/nodes/image-to-video.ts
@@ -1,0 +1,122 @@
+import { BaseNode, prop, type ImageRef, type VideoRef } from "@nodetool-ai/node-sdk";
+import type { NodeClass } from "@nodetool-ai/node-sdk";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+
+import {
+  generateMuapiMedia,
+  getMuapiApiKey,
+  normalizeMuapiVideoDuration,
+  resolveInputImageBytes,
+  uploadMuapiImage,
+  MUAPI_VIDEO_ASPECT_RATIOS,
+  MUAPI_VIDEO_RESOLUTIONS
+} from "../muapi-base.js";
+
+const EMPTY_IMAGE: ImageRef = {
+  type: "image",
+  uri: "",
+  asset_id: null,
+  data: null
+};
+
+type MuapiImageToVideoOutputs = { output: VideoRef };
+
+export class MuapiImageToVideoNode extends BaseNode {
+  static readonly nodeType = "muapi.ImageToVideo";
+  static readonly body = "content_card";
+  static readonly title = "MuAPI Image to Video";
+  static readonly description =
+    "Animate an input image into a video using MuAPI's FLUX 3 video route.\n" +
+    "video, generation, image-to-video, i2v, muapi\n\n" +
+    "Use cases:\n" +
+    "- Bring a still image to life\n" +
+    "- Add motion to product or character art\n" +
+    "- Create animated intros from a key frame";
+  static readonly metadataOutputTypes = { output: "video" };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields = ["image", "prompt"];
+  static readonly requiredSettings = ["MUAPI_API_KEY"];
+  static readonly autoSaveAsset = true;
+
+  @prop({
+    type: "image",
+    default: EMPTY_IMAGE,
+    title: "Image",
+    description: "The image to use as the video's starting frame."
+  })
+  declare image: ImageRef;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Prompt",
+    description: "Text prompt describing the desired motion."
+  })
+  declare prompt: string;
+
+  @prop({
+    type: "enum",
+    default: "16:9",
+    title: "Aspect Ratio",
+    description: "Aspect ratio of the generated video.",
+    values: [...MUAPI_VIDEO_ASPECT_RATIOS]
+  })
+  declare aspect_ratio: string;
+
+  @prop({
+    type: "enum",
+    default: "720p",
+    title: "Resolution",
+    description: "Output video resolution.",
+    values: [...MUAPI_VIDEO_RESOLUTIONS]
+  })
+  declare resolution: string;
+
+  @prop({
+    type: "int",
+    default: 5,
+    title: "Duration",
+    description: "Video duration in seconds.",
+    min: 4,
+    max: 10
+  })
+  declare duration: number;
+
+  @prop({
+    type: "bool",
+    default: true,
+    title: "Generate Audio",
+    description: "Generate synchronized native audio when supported."
+  })
+  declare generate_audio: boolean;
+
+  async process(context?: ProcessingContext): Promise<MuapiImageToVideoOutputs> {
+    const prompt = String(this.prompt ?? "").trim();
+    if (!prompt) throw new Error("Prompt is required");
+
+    const apiKey = getMuapiApiKey(this._secrets);
+    const imageBytes = await resolveInputImageBytes(this.image, context);
+    const imageUrl = await uploadMuapiImage(apiKey, imageBytes, context?.signal);
+
+    return {
+      output: await generateMuapiMedia({
+        apiKey,
+        endpoint: "flux-3-image-to-video",
+        payload: {
+          prompt,
+          images_list: [imageUrl],
+          aspect_ratio: String(this.aspect_ratio ?? "16:9"),
+          resolution: String(this.resolution ?? "720p"),
+          duration: normalizeMuapiVideoDuration(this.duration),
+          generate_audio: Boolean(this.generate_audio ?? true)
+        },
+        kind: "video",
+        signal: context?.signal
+      })
+    };
+  }
+}
+
+export const IMAGE_TO_VIDEO_NODES: readonly NodeClass[] = [
+  MuapiImageToVideoNode
+];

--- a/packages/muapi-nodes/src/nodes/text-to-image.ts
+++ b/packages/muapi-nodes/src/nodes/text-to-image.ts
@@ -1,0 +1,89 @@
+import { BaseNode, prop, type ImageRef } from "@nodetool-ai/node-sdk";
+import type { NodeClass } from "@nodetool-ai/node-sdk";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+
+import {
+  generateMuapiMedia,
+  getMuapiApiKey,
+  MUAPI_IMAGE_ASPECT_RATIOS,
+  MUAPI_IMAGE_MODELS,
+  MUAPI_IMAGE_RESOLUTIONS
+} from "../muapi-base.js";
+
+type MuapiTextToImageOutputs = { output: ImageRef };
+
+export class MuapiTextToImageNode extends BaseNode {
+  static readonly nodeType = "muapi.TextToImage";
+  static readonly body = "content_card";
+  static readonly title = "MuAPI Text to Image";
+  static readonly description =
+    "Generate an image from a text prompt using MuAPI's FLUX 3 image routes.\n" +
+    "image, generation, text-to-image, t2i, muapi\n\n" +
+    "Use cases:\n" +
+    "- Create artwork and concept images\n" +
+    "- Produce marketing visuals\n" +
+    "- Generate images at a chosen aspect ratio";
+  static readonly metadataOutputTypes = { output: "image" };
+  static readonly inlineFields = ["prompt"];
+  static readonly inputFields = ["prompt"];
+  static readonly requiredSettings = ["MUAPI_API_KEY"];
+  static readonly autoSaveAsset = true;
+
+  @prop({
+    type: "enum",
+    default: "flux-3-text-to-image",
+    title: "Model",
+    description: "MuAPI image route to use.",
+    values: [...MUAPI_IMAGE_MODELS]
+  })
+  declare model: string;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Prompt",
+    description: "Text prompt describing the desired image."
+  })
+  declare prompt: string;
+
+  @prop({
+    type: "enum",
+    default: "1:1",
+    title: "Aspect Ratio",
+    description: "Aspect ratio of the generated image.",
+    values: [...MUAPI_IMAGE_ASPECT_RATIOS]
+  })
+  declare aspect_ratio: string;
+
+  @prop({
+    type: "enum",
+    default: "2k",
+    title: "Resolution",
+    description: "Output image resolution.",
+    values: [...MUAPI_IMAGE_RESOLUTIONS]
+  })
+  declare resolution: string;
+
+  async process(context?: ProcessingContext): Promise<MuapiTextToImageOutputs> {
+    const prompt = String(this.prompt ?? "").trim();
+    if (!prompt) throw new Error("Prompt is required");
+
+    return {
+      output: await generateMuapiMedia({
+        apiKey: getMuapiApiKey(this._secrets),
+        endpoint: String(this.model ?? MUAPI_IMAGE_MODELS[0]),
+        payload: {
+          prompt,
+          aspect_ratio: String(this.aspect_ratio ?? "1:1"),
+          resolution: String(this.resolution ?? "2k")
+        },
+        kind: "image",
+        signal: context?.signal
+      })
+    };
+  }
+}
+
+export const TEXT_TO_IMAGE_NODES: readonly NodeClass[] = [
+  MuapiTextToImageNode
+];

--- a/packages/muapi-nodes/src/nodes/text-to-video.ts
+++ b/packages/muapi-nodes/src/nodes/text-to-video.ts
@@ -1,0 +1,100 @@
+import { BaseNode, prop, type VideoRef } from "@nodetool-ai/node-sdk";
+import type { NodeClass } from "@nodetool-ai/node-sdk";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+
+import {
+  generateMuapiMedia,
+  getMuapiApiKey,
+  normalizeMuapiVideoDuration,
+  MUAPI_VIDEO_ASPECT_RATIOS,
+  MUAPI_VIDEO_RESOLUTIONS
+} from "../muapi-base.js";
+
+type MuapiTextToVideoOutputs = { output: VideoRef };
+
+export class MuapiTextToVideoNode extends BaseNode {
+  static readonly nodeType = "muapi.TextToVideo";
+  static readonly body = "content_card";
+  static readonly title = "MuAPI Text to Video";
+  static readonly description =
+    "Generate a video from a text prompt using MuAPI's FLUX 3 video route.\n" +
+    "video, generation, text-to-video, t2v, muapi\n\n" +
+    "Use cases:\n" +
+    "- Create short cinematic clips\n" +
+    "- Prototype motion concepts\n" +
+    "- Generate B-roll and social content";
+  static readonly metadataOutputTypes = { output: "video" };
+  static readonly inlineFields = ["prompt"];
+  static readonly inputFields = ["prompt"];
+  static readonly requiredSettings = ["MUAPI_API_KEY"];
+  static readonly autoSaveAsset = true;
+
+  @prop({
+    type: "str",
+    default: "",
+    title: "Prompt",
+    description: "Text prompt describing the desired video."
+  })
+  declare prompt: string;
+
+  @prop({
+    type: "enum",
+    default: "16:9",
+    title: "Aspect Ratio",
+    description: "Aspect ratio of the generated video.",
+    values: [...MUAPI_VIDEO_ASPECT_RATIOS]
+  })
+  declare aspect_ratio: string;
+
+  @prop({
+    type: "enum",
+    default: "720p",
+    title: "Resolution",
+    description: "Output video resolution.",
+    values: [...MUAPI_VIDEO_RESOLUTIONS]
+  })
+  declare resolution: string;
+
+  @prop({
+    type: "int",
+    default: 5,
+    title: "Duration",
+    description: "Video duration in seconds.",
+    min: 4,
+    max: 10
+  })
+  declare duration: number;
+
+  @prop({
+    type: "bool",
+    default: true,
+    title: "Generate Audio",
+    description: "Generate synchronized native audio when supported."
+  })
+  declare generate_audio: boolean;
+
+  async process(context?: ProcessingContext): Promise<MuapiTextToVideoOutputs> {
+    const prompt = String(this.prompt ?? "").trim();
+    if (!prompt) throw new Error("Prompt is required");
+
+    return {
+      output: await generateMuapiMedia({
+        apiKey: getMuapiApiKey(this._secrets),
+        endpoint: "flux-3-text-to-video",
+        payload: {
+          prompt,
+          aspect_ratio: String(this.aspect_ratio ?? "16:9"),
+          resolution: String(this.resolution ?? "720p"),
+          duration: normalizeMuapiVideoDuration(this.duration),
+          generate_audio: Boolean(this.generate_audio ?? true)
+        },
+        kind: "video",
+        signal: context?.signal
+      })
+    };
+  }
+}
+
+export const TEXT_TO_VIDEO_NODES: readonly NodeClass[] = [
+  MuapiTextToVideoNode
+];

--- a/packages/muapi-nodes/tests/muapi-base.test.ts
+++ b/packages/muapi-nodes/tests/muapi-base.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  downloadMuapiOutput,
+  getMuapiApiKey,
+  pickMuapiOutputUrl,
+  pollMuapi,
+  submitMuapi,
+  uploadMuapiImage,
+  videoRefFromBytes
+} from "../src/muapi-base.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.MUAPI_API_KEY;
+});
+
+describe("MuAPI configuration", () => {
+  it("prefers the injected secret and falls back to the environment", () => {
+    process.env.MUAPI_API_KEY = "env-key";
+    expect(getMuapiApiKey({ MUAPI_API_KEY: "secret-key" })).toBe("secret-key");
+    expect(getMuapiApiKey({})).toBe("env-key");
+  });
+
+  it("throws when no key is configured", () => {
+    expect(() => getMuapiApiKey({})).toThrow("MUAPI_API_KEY is not configured");
+  });
+});
+
+describe("MuAPI async transport", () => {
+  it("submits once, polls terminal output, and downloads the media", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input, init) => {
+        const url = String(input);
+        if (url.endsWith("/flux-3-text-to-image")) {
+          expect((init as RequestInit).method).toBe("POST");
+          return new Response(JSON.stringify({ request_id: "req_1" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" }
+          });
+        }
+        if (url.endsWith("/predictions/req_1/result")) {
+          return new Response(
+            JSON.stringify({ status: "completed", result: { image_url: "https://cdn.example/image.png" } }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+          );
+        }
+        if (url === "https://cdn.example/image.png") {
+          return new Response(Uint8Array.from([137, 80, 78, 71]), { status: 200 });
+        }
+        throw new Error(`unexpected URL: ${url}`);
+      }
+    );
+
+    const requestId = await submitMuapi("key", "flux-3-text-to-image", { prompt: "cat" });
+    const result = await pollMuapi("key", requestId, {
+      pollIntervalMs: 0,
+      maxAttempts: 2
+    });
+    const url = pickMuapiOutputUrl(result);
+    const bytes = await downloadMuapiOutput(url);
+
+    expect(requestId).toBe("req_1");
+    expect(url).toBe("https://cdn.example/image.png");
+    expect([...bytes]).toEqual([137, 80, 78, 71]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("recognizes failure as a terminal state", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ status: "failure", error: "bad prompt" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      })
+    );
+
+    await expect(
+      pollMuapi("key", "req_failed", { pollIntervalMs: 0, maxAttempts: 1 })
+    ).rejects.toThrow("bad prompt");
+  });
+
+  it("accepts nested upload responses and sends multipart data", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: { file: { url: "https://cdn.example/input.png" } } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      })
+    );
+
+    const url = await uploadMuapiImage("key", Uint8Array.from([137, 80, 78, 71]));
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(url).toBe("https://cdn.example/input.png");
+    expect((init.body as FormData).get("file")).toBeInstanceOf(Blob);
+    expect((init.headers as Record<string, string>)["x-api-key"]).toBe("key");
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBeUndefined();
+  });
+});
+
+describe("video refs", () => {
+  it("stores raw base64 and keeps the media type", () => {
+    expect(videoRefFromBytes(Uint8Array.from([1, 2, 3]))).toEqual({
+      type: "video",
+      uri: "",
+      data: "AQID",
+      format: "mp4"
+    });
+  });
+});

--- a/packages/muapi-nodes/tests/registration.test.ts
+++ b/packages/muapi-nodes/tests/registration.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MUAPI_NODES,
+  MuapiImageToVideoNode,
+  MuapiTextToImageNode,
+  MuapiTextToVideoNode,
+  registerMuapiNodes
+} from "../src/index.js";
+
+describe("MuAPI node pack", () => {
+  it("exports the focused generation nodes", () => {
+    expect(MUAPI_NODES).toEqual([
+      MuapiTextToImageNode,
+      MuapiTextToVideoNode,
+      MuapiImageToVideoNode
+    ]);
+  });
+
+  it("registers each node exactly once", () => {
+    const registered: unknown[] = [];
+    registerMuapiNodes({ register: (nodeClass) => registered.push(nodeClass) });
+    expect(registered).toEqual([...MUAPI_NODES]);
+  });
+});

--- a/packages/muapi-nodes/tsconfig.json
+++ b/packages/muapi-nodes/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../node-sdk"
+    }
+  ]
+}

--- a/packages/muapi-nodes/vitest.config.ts
+++ b/packages/muapi-nodes/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@nodetool-ai/runtime/provider-transport": resolve(
+        __dirname,
+        "../runtime/src/providers/provider-transport.ts"
+      )
+    }
+  },
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"]
+  }
+});

--- a/packages/protocol/src/builtin-packs.ts
+++ b/packages/protocol/src/builtin-packs.ts
@@ -120,6 +120,12 @@ export const BUILTIN_NODE_PACKS: readonly BuiltinNodePack[] = [
     namespaces: ["atlascloud"]
   },
   {
+    id: "muapi",
+    name: "MuAPI",
+    description: "Image and video generation through MuAPI.",
+    namespaces: ["muapi"]
+  },
+  {
     id: "together",
     name: "Together AI",
     description:

--- a/packages/websocket/package.json
+++ b/packages/websocket/package.json
@@ -47,6 +47,7 @@
     "@nodetool-ai/image-editor": "*",
     "@nodetool-ai/kernel": "*",
     "@nodetool-ai/kie-nodes": "*",
+    "@nodetool-ai/muapi-nodes": "*",
     "@nodetool-ai/minimax-nodes": "*",
     "@nodetool-ai/model-pricing": "*",
     "@nodetool-ai/models": "*",

--- a/packages/websocket/src/node-registry-setup.ts
+++ b/packages/websocket/src/node-registry-setup.ts
@@ -37,6 +37,7 @@ import { registerKieNodes } from "@nodetool-ai/kie-nodes";
 import { registerTopazNodes } from "@nodetool-ai/topaz-nodes";
 import { registerReveNodes } from "@nodetool-ai/reve-nodes";
 import { registerAtlasCloudNodes } from "@nodetool-ai/atlascloud-nodes";
+import { registerMuapiNodes } from "@nodetool-ai/muapi-nodes";
 import { registerTogetherNodes } from "@nodetool-ai/together-nodes";
 import { registerReplicateNodes } from "@nodetool-ai/replicate-nodes";
 import { registerHuggingFaceNodes } from "@nodetool-ai/huggingface-nodes";
@@ -103,6 +104,7 @@ const BUILTIN_PACK_REGISTRARS: Record<
   topaz: registerTopazNodes,
   reve: registerReveNodes,
   atlascloud: registerAtlasCloudNodes,
+  muapi: registerMuapiNodes,
   together: registerTogetherNodes,
   replicate: registerReplicateNodes,
   huggingface: registerHuggingFaceNodes

--- a/web/src/utils/nodeProvider.ts
+++ b/web/src/utils/nodeProvider.ts
@@ -26,6 +26,7 @@ const namespaceToSecretKey: Record<string, string> = {
   elevenlabs: "ELEVENLABS_API_KEY",
   search: "SERPAPI_API_KEY",
   atlascloud: "ATLASCLOUD_API_KEY",
+  muapi: "MUAPI_API_KEY",
   xai: "XAI_API_KEY",
   together: "TOGETHER_API_KEY",
   minimax: "MINIMAX_API_KEY"
@@ -61,6 +62,7 @@ const secretKeyToDisplayName: Record<string, string> = {
   ELEVENLABS_API_KEY: "ElevenLabs API Key",
   SERPAPI_API_KEY: "SerpAPI Key",
   ATLASCLOUD_API_KEY: "AtlasCloud API Key",
+  MUAPI_API_KEY: "MuAPI API Key",
   XAI_API_KEY: "xAI API Key",
   TOGETHER_API_KEY: "Together API Key",
   MINIMAX_API_KEY: "MiniMax API Key"


### PR DESCRIPTION
## Summary

- Add an opt-in `@nodetool-ai/muapi-nodes` pack for MuAPI image and video workflows.
- Register text-to-image, text-to-video, and image-to-video nodes with the built-in pack catalog.
- Use MuAPI's asynchronous submit/poll API with safe output downloads and secret-backed authentication.

## Verification

- Strict TypeScript source check passed.
- 8 provider-pack tests passed with mocked HTTP responses.
- `git diff --check` passed.
- No live MuAPI generation request was made.

## Links

- MuAPI API reference: https://muapi.ai/docs/api-reference
- MuAPI access keys: https://muapi.ai/access-keys
