### PR TITLE
fix(timeline): retry failed or stalled video seeks during export

### DIFF
--- a/web/src/components/timeline/render/OffscreenVideoPool.ts
+++ b/web/src/components/timeline/render/OffscreenVideoPool.ts
@@ -7,17 +7,75 @@
  * to an exact source time and waits for the `seeked` event before handing the
  * element to the compositor. That makes every exported frame reproducible and
  * tearing-free, however slow the underlying decode is.
+ *
+ * A `<video>` element that fires `error` is dead: the browser tears down its
+ * decoder and every later seek errors too. Range requests against the asset
+ * server do fail mid-export (a dropped connection, a decoder reset after
+ * hundreds of seeks), so a failed or stalled seek is retried on a fresh
+ * element before the export is failed.
  */
 
 const SEEK_EPSILON_SEC = 1 / 1000;
+
+/** Fresh elements tried for one seek before it is reported as a failure. */
+export const SEEK_ATTEMPTS = 3;
+/** Pause before a retry, so a server that just dropped the connection has a
+ *  moment to accept a new one. Grows linearly per attempt. */
+const RETRY_DELAY_MS = 250;
+/** A seek that has not fired `seeked` by then is treated as stalled: the
+ *  element is replaced and the seek retried. The decode of one frame never
+ *  takes this long; a hung range request does. */
+export const SEEK_TIMEOUT_MS = 15_000;
 
 interface PoolEntry {
   el: HTMLVideoElement;
   url: string;
 }
 
+interface PoolOptions {
+  seekTimeoutMs?: number;
+  retryDelayMs?: number;
+  attempts?: number;
+}
+
 function abortError(): DOMException {
   return new DOMException("Video seek aborted", "AbortError");
+}
+
+function isAbort(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}
+
+const MEDIA_ERROR_NAMES: Record<number, string> = {
+  1: "MEDIA_ERR_ABORTED",
+  2: "MEDIA_ERR_NETWORK",
+  3: "MEDIA_ERR_DECODE",
+  4: "MEDIA_ERR_SRC_NOT_SUPPORTED"
+};
+
+/** "MEDIA_ERR_NETWORK (2): <browser message>" — the part of a media failure
+ *  the user can act on, instead of only the URL. */
+export function describeMediaError(el: HTMLVideoElement): string {
+  const err = el.error;
+  if (!err) return "no media error reported";
+  const name = MEDIA_ERROR_NAMES[err.code] ?? "MEDIA_ERR_UNKNOWN";
+  const message = err.message?.trim();
+  return message ? `${name} (${err.code}): ${message}` : `${name} (${err.code})`;
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(abortError());
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 export class OffscreenVideoPool {
@@ -27,8 +85,14 @@ export class OffscreenVideoPool {
    *  upload happens (a shared element would show the last-seeked time on all
    *  layers). Elements are still reused across frames for the same clip. */
   private readonly entries = new Map<string, PoolEntry>();
+  private readonly seekTimeoutMs: number;
+  private readonly retryDelayMs: number;
+  private readonly attempts: number;
 
-  constructor() {
+  constructor(options: PoolOptions = {}) {
+    this.seekTimeoutMs = options.seekTimeoutMs ?? SEEK_TIMEOUT_MS;
+    this.retryDelayMs = options.retryDelayMs ?? RETRY_DELAY_MS;
+    this.attempts = Math.max(1, options.attempts ?? SEEK_ATTEMPTS);
     this.container = document.createElement("div");
     this.container.style.cssText =
       "position:fixed;width:0;height:0;overflow:hidden;pointer-events:none;opacity:0;left:-9999px;top:-9999px;";
@@ -37,10 +101,10 @@ export class OffscreenVideoPool {
 
   /**
    * Return a video element for `clipId` decoded to `timeSec` of `url`.
-   * Resolves once the exact frame is available; rejects on media error or
-   * when `signal` aborts. Subsequent calls for the same clip reuse the
-   * element. The returned element must be uploaded synchronously by the
-   * caller before the next `seek` for the same clip.
+   * Resolves once the exact frame is available; rejects when `signal` aborts
+   * or when every attempt hit a media error or stalled. Subsequent calls for
+   * the same clip reuse the element. The returned element must be uploaded
+   * synchronously by the caller before the next `seek` for the same clip.
    */
   async seek(
     clipId: string,
@@ -48,8 +112,42 @@ export class OffscreenVideoPool {
     timeSec: number,
     signal?: AbortSignal
   ): Promise<HTMLVideoElement> {
-    if (signal?.aborted) throw abortError();
+    let lastError: unknown;
+    for (let attempt = 0; attempt < this.attempts; attempt++) {
+      if (signal?.aborted) throw abortError();
+      if (attempt > 0) {
+        // The previous element is in an error state (or hung); a fresh one
+        // reopens the connection and the decoder from scratch.
+        this.release(clipId);
+        await delay(this.retryDelayMs * attempt, signal);
+      }
+      try {
+        return await this.seekOnce(clipId, url, timeSec, signal);
+      } catch (err) {
+        if (isAbort(err)) throw err;
+        lastError = err;
+      }
+    }
+    const reason = lastError instanceof Error ? lastError.message : String(lastError);
+    throw new Error(
+      `Video seek failed after ${this.attempts} attempts: ${reason}`
+    );
+  }
+
+  private async seekOnce(
+    clipId: string,
+    url: string,
+    timeSec: number,
+    signal?: AbortSignal
+  ): Promise<HTMLVideoElement> {
     const el = this.ensureElement(clipId, url);
+    if (el.error) {
+      // An element that already failed never recovers; replacing it here
+      // makes the retry loop's fresh element the one that gets seeked.
+      throw new Error(
+        `Video failed to load: ${describeMediaError(el)}: ${el.src}`
+      );
+    }
     await this.whenMetadata(el, signal);
 
     const duration = Number.isFinite(el.duration) ? el.duration : Infinity;
@@ -59,12 +157,24 @@ export class OffscreenVideoPool {
     );
 
     // Already on the target frame — nothing to wait for.
-    if (Math.abs(el.currentTime - target) < SEEK_EPSILON_SEC) {
+    if (Math.abs(el.currentTime - target) < SEEK_EPSILON_SEC && !el.seeking) {
       return el;
     }
 
     await new Promise<void>((resolve, reject) => {
+      const timer =
+        this.seekTimeoutMs > 0
+          ? setTimeout(() => {
+              cleanup();
+              reject(
+                new Error(
+                  `Video seek to ${target.toFixed(3)}s stalled for ${this.seekTimeoutMs}ms: ${el.src}`
+                )
+              );
+            }, this.seekTimeoutMs)
+          : null;
       const cleanup = () => {
+        if (timer) clearTimeout(timer);
         el.removeEventListener("seeked", onSeeked);
         el.removeEventListener("error", onError);
         signal?.removeEventListener("abort", onAbort);
@@ -75,7 +185,11 @@ export class OffscreenVideoPool {
       };
       const onError = () => {
         cleanup();
-        reject(new Error(`Video error while seeking: ${el.src}`));
+        reject(
+          new Error(
+            `Video error while seeking to ${target.toFixed(3)}s: ${describeMediaError(el)}: ${el.src}`
+          )
+        );
       };
       const onAbort = () => {
         cleanup();
@@ -119,19 +233,35 @@ export class OffscreenVideoPool {
     // readyState >= HAVE_METADATA means duration + dimensions are known.
     if (el.readyState >= 1 && el.videoWidth > 0) return Promise.resolve();
     return new Promise<void>((resolve, reject) => {
+      const timer =
+        this.seekTimeoutMs > 0
+          ? setTimeout(() => {
+              cleanup();
+              reject(
+                new Error(
+                  `Video metadata not loaded after ${this.seekTimeoutMs}ms: ${el.src}`
+                )
+              );
+            }, this.seekTimeoutMs)
+          : null;
       const onLoaded = () => {
         cleanup();
         resolve();
       };
       const onError = () => {
         cleanup();
-        reject(new Error(`Failed to load video: ${el.src}`));
+        reject(
+          new Error(
+            `Failed to load video: ${describeMediaError(el)}: ${el.src}`
+          )
+        );
       };
       const onAbort = () => {
         cleanup();
         reject(abortError());
       };
       const cleanup = () => {
+        if (timer) clearTimeout(timer);
         el.removeEventListener("loadedmetadata", onLoaded);
         el.removeEventListener("error", onError);
         signal?.removeEventListener("abort", onAbort);
@@ -148,7 +278,8 @@ export class OffscreenVideoPool {
    * passed — each clip occupies a single contiguous span, so a released clip
    * can never be seeked again. Without this, a many-clip export pins one live
    * `<video>` element (and hardware decoder) per clip for the whole render,
-   * well past what browsers/decoders allow concurrently.
+   * well past what browsers/decoders allow concurrently. A failed seek also
+   * releases its element so the retry starts from a fresh one.
    */
   release(clipId: string): void {
     const entry = this.entries.get(clipId);
@@ -156,6 +287,7 @@ export class OffscreenVideoPool {
     entry.el.pause();
     entry.el.removeAttribute("src");
     entry.el.load();
+    entry.el.remove();
     this.entries.delete(clipId);
   }
 

--- a/web/src/components/timeline/render/__tests__/OffscreenVideoPool.test.ts
+++ b/web/src/components/timeline/render/__tests__/OffscreenVideoPool.test.ts
@@ -1,0 +1,153 @@
+import { OffscreenVideoPool, describeMediaError } from "../OffscreenVideoPool";
+
+/**
+ * jsdom implements no media pipeline: `load()` is a stub and `currentTime`
+ * assignments fire nothing. Each test scripts the element by hand — set
+ * readyState/videoWidth, then dispatch `loadedmetadata`, `seeked` or `error`.
+ */
+function ready(el: HTMLVideoElement, duration = 10): void {
+  Object.defineProperty(el, "readyState", { value: 1, configurable: true });
+  Object.defineProperty(el, "videoWidth", { value: 640, configurable: true });
+  Object.defineProperty(el, "duration", { value: duration, configurable: true });
+}
+
+function fail(el: HTMLVideoElement, code = 2, message = "range request"): void {
+  Object.defineProperty(el, "error", {
+    value: { code, message },
+    configurable: true
+  });
+  el.dispatchEvent(new Event("error"));
+}
+
+function videos(): HTMLVideoElement[] {
+  return Array.from(document.querySelectorAll("video"));
+}
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("OffscreenVideoPool", () => {
+  let loadSpy: jest.SpyInstance;
+  let pauseSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    loadSpy = jest
+      .spyOn(HTMLMediaElement.prototype, "load")
+      .mockImplementation(() => undefined);
+    pauseSpy = jest
+      .spyOn(HTMLMediaElement.prototype, "pause")
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    loadSpy.mockRestore();
+    pauseSpy.mockRestore();
+    document.body.innerHTML = "";
+  });
+
+  it("resolves with the element once the seek lands", async () => {
+    const pool = new OffscreenVideoPool({ retryDelayMs: 0 });
+    const p = pool.seek("clip", "http://x/a.mp4", 2);
+    const [el] = videos();
+    ready(el);
+    el.dispatchEvent(new Event("loadedmetadata"));
+    await flush();
+    el.dispatchEvent(new Event("seeked"));
+    await expect(p).resolves.toBe(el);
+    pool.dispose();
+  });
+
+  it("retries a seek that errors on a fresh element", async () => {
+    const pool = new OffscreenVideoPool({ retryDelayMs: 0 });
+    const p = pool.seek("clip", "http://x/a.mp4", 2);
+    const [first] = videos();
+    ready(first);
+    first.dispatchEvent(new Event("loadedmetadata"));
+    await flush();
+    fail(first);
+    await flush();
+    await flush();
+
+    const current = videos();
+    expect(current).toHaveLength(1);
+    const second = current[0];
+    expect(second).not.toBe(first);
+    expect(first.isConnected).toBe(false);
+
+    ready(second);
+    second.dispatchEvent(new Event("loadedmetadata"));
+    await flush();
+    second.dispatchEvent(new Event("seeked"));
+    await expect(p).resolves.toBe(second);
+    pool.dispose();
+  });
+
+  it("reports the media error code once every attempt fails", async () => {
+    const pool = new OffscreenVideoPool({ retryDelayMs: 0, attempts: 2 });
+    const p = pool.seek("clip", "http://x/a.mp4", 2);
+    const rejection = expect(p).rejects.toThrow(
+      /after 2 attempts.*MEDIA_ERR_DECODE \(3\): bad frame/
+    );
+    for (let i = 0; i < 2; i++) {
+      const [el] = videos();
+      ready(el);
+      el.dispatchEvent(new Event("loadedmetadata"));
+      await flush();
+      fail(el, 3, "bad frame");
+      await flush();
+      await flush();
+    }
+    await rejection;
+    pool.dispose();
+  });
+
+  it("treats a seek that never fires seeked as stalled and retries", async () => {
+    jest.useFakeTimers();
+    try {
+      const pool = new OffscreenVideoPool({
+        retryDelayMs: 0,
+        seekTimeoutMs: 100,
+        attempts: 2
+      });
+      const p = pool.seek("clip", "http://x/a.mp4", 2);
+      const [first] = videos();
+      ready(first);
+      first.dispatchEvent(new Event("loadedmetadata"));
+      await Promise.resolve();
+      await Promise.resolve();
+      jest.advanceTimersByTime(101);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const [second] = videos();
+      expect(second).not.toBe(first);
+      ready(second);
+      second.dispatchEvent(new Event("loadedmetadata"));
+      await Promise.resolve();
+      await Promise.resolve();
+      second.dispatchEvent(new Event("seeked"));
+      await expect(p).resolves.toBe(second);
+      pool.dispose();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("does not retry after an abort", async () => {
+    const pool = new OffscreenVideoPool({ retryDelayMs: 0 });
+    const ctrl = new AbortController();
+    const p = pool.seek("clip", "http://x/a.mp4", 2, ctrl.signal);
+    await flush();
+    ctrl.abort();
+    await expect(p).rejects.toMatchObject({ name: "AbortError" });
+    expect(videos()).toHaveLength(1);
+    pool.dispose();
+  });
+
+  it("describes a media error by name and code", () => {
+    const el = document.createElement("video");
+    expect(describeMediaError(el)).toBe("no media error reported");
+    Object.defineProperty(el, "error", { value: { code: 2, message: "" } });
+    expect(describeMediaError(el)).toBe("MEDIA_ERR_NETWORK (2)");
+  });
+});


### PR DESCRIPTION
## What changed

Timeline export failed with `Video error while seeking: http://127.0.0.1:7777/api/storage/…mp4` whenever one range request against the asset server dropped mid-render. A `<video>` element that fires `error` never recovers (the browser tears down its decoder), so a single transient failure ended the export. `OffscreenVideoPool.seek` now retries on a fresh element (three attempts with a short growing pause), treats a seek that never fires `seeked` within 15 s as stalled and retries it the same way, and reports the `MediaError` name and code (`MEDIA_ERR_NETWORK (2): …`) so the failure message says what went wrong rather than only which file. Aborts are never retried. A new Jest suite scripts the media events by hand and covers the success, retry, exhausted-retries, stall and abort paths.

## Verification

- [x] `npx jest src/components/timeline/render` in `web/`: 3 suites, 16 tests pass (`test:affected` selects the same suites for this diff)
- [x] `npm run typecheck`: no errors in the touched files. The container reports pre-existing `Cannot find module '@nodetool-ai/godot'` and unbuilt-package errors unrelated to this diff.
- [x] `npm run lint` (web): no errors, only pre-existing warnings in other files
- [ ] `npm run dev:nodetool -- harness gate --base main`: could not run here, `build:packages` fails on the unlinked `@nodetool-ai/godot` workspace in this container. The diff touches only `web/src/components/timeline/render`.

## Agent capabilities

Not applicable, no capability changed.

## New checks

Not applicable, no check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YJPeG6XEdgKnTx9sQAuNx

---
_Generated by [Claude Code](https://claude.ai/code/session_017YJPeG6XEdgKnTx9sQAuNx)_