### PR TITLE
feat(chat): keep the model per conversation, not per app

### DIFF
--- a/web/src/components/appbuilder/AppBuilderAgentPanel.tsx
+++ b/web/src/components/appbuilder/AppBuilderAgentPanel.tsx
@@ -8,6 +8,7 @@ import ChatView from "../chat/containers/ChatView";
 import ChatPanelHeader from "../chat/containers/ChatPanelHeader";
 import useGlobalChatStore from "../../stores/GlobalChatStore";
 import { useChatViewThread } from "../../hooks/chat/useChatViewThread";
+import useThreadModel from "../../hooks/chat/useThreadModel";
 import { Box, Caption, FlexColumn, Text } from "../ui_primitives";
 
 type ChatViewStatus = React.ComponentProps<typeof ChatView>["status"];
@@ -87,21 +88,17 @@ const AppBuilderAgentPanel: React.FC<AppBuilderAgentPanelProps> = ({
   applicationId,
   workflowId
 }) => {
-  const selectedModel = useGlobalChatStore((state) => state.selectedModel);
-
   const {
     connect,
     openWorkflowThread,
     newWorkflowThread,
-    createNewThread,
-    setSelectedModel
+    createNewThread
   } = useGlobalChatStore(
     useShallow((state) => ({
       connect: state.connect,
       openWorkflowThread: state.openWorkflowThread,
       newWorkflowThread: state.newWorkflowThread,
-      createNewThread: state.createNewThread,
-      setSelectedModel: state.setSelectedModel
+      createNewThread: state.createNewThread
     }))
   );
   const {
@@ -112,6 +109,9 @@ const AppBuilderAgentPanel: React.FC<AppBuilderAgentPanelProps> = ({
     sendMessage,
     stopGeneration
   } = useChatViewThread();
+
+  // The builder's conversation keeps its own model.
+  const { model, setModel } = useThreadModel(threadId);
 
   // Connect and bind a thread to this workflow so the agent's runs and graph
   // edits target it. Without a workflow the panel opens one plain thread —
@@ -210,8 +210,8 @@ const AppBuilderAgentPanel: React.FC<AppBuilderAgentPanelProps> = ({
           total={runtime.progress.total}
           progressMessage={runtime.statusMessage}
           runningToolCallId={runtime.runningToolCallId}
-          model={selectedModel}
-          onModelChange={setSelectedModel}
+          model={model}
+          onModelChange={setModel}
           onStop={stopGeneration}
           onNewChat={handleNewChat}
           currentPlanningUpdate={runtime.planningUpdate}

--- a/web/src/components/chat/assistant/AssistantChatPanel.tsx
+++ b/web/src/components/chat/assistant/AssistantChatPanel.tsx
@@ -3,7 +3,6 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { memo, useCallback, useEffect, useMemo } from "react";
-import { useShallow } from "zustand/react/shallow";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import type { ChatSource, UiContext, UiDocumentRef } from "@nodetool-ai/protocol";
 
@@ -12,6 +11,7 @@ import ChatView from "../containers/ChatView";
 import ChatPanelHeader from "../containers/ChatPanelHeader";
 import useGlobalChatStore from "../../../stores/GlobalChatStore";
 import { useChatViewThread } from "../../../hooks/chat/useChatViewThread";
+import useThreadModel from "../../../hooks/chat/useThreadModel";
 import { useInStudio } from "../../../studio/StudioContext";
 import type { DocsTopic } from "../../../config/docsLinks";
 import type { BuildUiContextOptions } from "../../../lib/chat/uiContext";
@@ -76,12 +76,6 @@ const AssistantChatPanel = ({
   const cssStyles = useMemo(() => styles(theme), [theme]);
   const hideModelPicker = useInStudio();
 
-  const { selectedModel, setSelectedModel } = useGlobalChatStore(
-    useShallow((state) => ({
-      selectedModel: state.selectedModel,
-      setSelectedModel: state.setSelectedModel
-    }))
-  );
   const connect = useGlobalChatStore((state) => state.connect);
   const {
     threadId,
@@ -92,6 +86,10 @@ const AssistantChatPanel = ({
     sendMessage,
     stopGeneration
   } = useChatViewThread({ isolated: true });
+
+  // This panel's conversation keeps its own model, independent of the chat
+  // tabs and the other assistant panels.
+  const { model, setModel } = useThreadModel(threadId);
 
   useEffect(() => {
     connect().catch((err) => {
@@ -158,8 +156,8 @@ const AssistantChatPanel = ({
           progress={runtime.progress.current}
           total={runtime.progress.total}
           progressMessage={runtime.statusMessage}
-          model={selectedModel}
-          onModelChange={setSelectedModel}
+          model={model}
+          onModelChange={setModel}
           hideModelPicker={hideModelPicker}
           onStop={stopGeneration}
           onNewChat={handleNewChat}

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -177,7 +177,9 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
 
   // Language-model selection from chat store (used in chat mode & forwarded
   // as provider/model for media calls when a media model is not picked).
-  const languageModel = useGlobalChatStore((s) => s.selectedModel);
+  const languageModel = useGlobalChatStore((s) =>
+    s.getSelectedModel(threadId ?? s.currentThreadId)
+  );
   // A new account has an unsendable placeholder here. Fill it once from the
   // recommended models rather than let the menu's first row decide.
   useFirstRunLanguageModel();

--- a/web/src/components/projects/ProjectAgentPanel.tsx
+++ b/web/src/components/projects/ProjectAgentPanel.tsx
@@ -27,6 +27,7 @@ import ChatView from "../chat/containers/ChatView";
 import useGlobalChatStore, {
   useThreadRuntime
 } from "../../stores/GlobalChatStore";
+import useThreadModel from "../../hooks/chat/useThreadModel";
 import type { Message, MessageContent } from "../../stores/ApiTypes";
 import { trpc } from "../../trpc/client";
 import {
@@ -103,10 +104,10 @@ const ProjectAgentPanel = ({
   // Subscribed narrowly so a reconnect re-runs the first-turn effect below: a
   // turn refused with `not_connected` stays staged and has no other trigger.
   const connectionStatus = useGlobalChatStore((state) => state.status);
-  const selectedModel = useGlobalChatStore((state) => state.selectedModel);
-  const setSelectedModel = useGlobalChatStore(
-    (state) => state.setSelectedModel
-  );
+  // The project's conversation keeps its own model, independent of the chat
+  // tabs and the other assistant panels.
+  const { model: selectedModel, setModel: setSelectedModel } =
+    useThreadModel(threadId);
 
   // The shared chat socket is a singleton; other mounted surfaces depend on
   // it, so this never disconnects on unmount.

--- a/web/src/components/projects/__tests__/ProjectAgentPanel.test.tsx
+++ b/web/src/components/projects/__tests__/ProjectAgentPanel.test.tsx
@@ -42,7 +42,13 @@ const chatState = {
   messageCache: {} as Record<string, unknown[]>,
   status: "connected",
   selectedModel: { provider: "anthropic", id: "claude-sonnet-5" },
-  setSelectedModel: jest.fn()
+  setSelectedModel: jest.fn(),
+  threadModel: {} as Record<string, unknown>,
+  forcedModel: null,
+  pinThreadModel: jest.fn(),
+  getSelectedModel: (threadId: string | null) =>
+    (threadId ? chatState.threadModel[threadId] : undefined) ??
+    chatState.selectedModel
 };
 jest.mock("../../../stores/GlobalChatStore", () => ({
   __esModule: true,

--- a/web/src/components/workspace/ChatSurface.tsx
+++ b/web/src/components/workspace/ChatSurface.tsx
@@ -8,7 +8,8 @@ import useGlobalChatStore, {
   useThreadRuntime
 } from "../../stores/GlobalChatStore";
 import useChatDraftStore from "../../stores/ChatDraftStore";
-import type { Message, LanguageModel } from "../../stores/ApiTypes";
+import useThreadModel from "../../hooks/chat/useThreadModel";
+import type { Message } from "../../stores/ApiTypes";
 import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
 import DocumentLoadStatus from "./DocumentLoadStatus";
 
@@ -63,9 +64,7 @@ const ChatSurface = ({ refId, active }: ChatSurfaceProps) => {
     loadMessages,
     createNewThread,
     sendMessage,
-    stopGeneration,
-    selectedModel,
-    setSelectedModel
+    stopGeneration
   } = useGlobalChatStore(
     useShallow((state) => ({
       connect: state.connect,
@@ -75,11 +74,12 @@ const ChatSurface = ({ refId, active }: ChatSurfaceProps) => {
       loadMessages: state.loadMessages,
       createNewThread: state.createNewThread,
       sendMessage: state.sendMessage,
-      stopGeneration: state.stopGeneration,
-      selectedModel: state.selectedModel,
-      setSelectedModel: state.setSelectedModel
+      stopGeneration: state.stopGeneration
     }))
   );
+
+  // Each tab keeps its own model: a pick here never moves another tab's.
+  const { model, setModel } = useThreadModel(refId);
 
   const workflowId = useGlobalChatStore(
     (state) =>
@@ -164,11 +164,6 @@ const ChatSurface = ({ refId, active }: ChatSurfaceProps) => {
     stopGeneration(refId);
   }, [stopGeneration, refId]);
 
-  const handleModelChange = useCallback(
-    (model: LanguageModel) => setSelectedModel(model),
-    [setSelectedModel]
-  );
-
   // A suggestion is a starting point, not a finished turn: "Analyze an image"
   // used to go out with no image attached. Seed the composer and let the user
   // add what it needs.
@@ -214,8 +209,8 @@ const ChatSurface = ({ refId, active }: ChatSurfaceProps) => {
         total={runtime.progress.total}
         progressMessage={runtime.statusMessage}
         runningToolCallId={runtime.runningToolCallId}
-        model={selectedModel}
-        onModelChange={handleModelChange}
+        model={model}
+        onModelChange={setModel}
         onStop={handleStop}
         onNewChat={() => void handleNewChat()}
         currentPlanningUpdate={runtime.planningUpdate}

--- a/web/src/components/workspace/__tests__/ChatSurface.test.tsx
+++ b/web/src/components/workspace/__tests__/ChatSurface.test.tsx
@@ -24,11 +24,17 @@ const chatState = {
   threads: {} as Record<string, { id: string; title: string }>,
   messageCache: {} as Record<string, unknown[]>,
   threadWorkflowId: {} as Record<string, string | null>,
+  threadModel: {} as Record<string, unknown>,
+  forcedModel: null,
+  pinThreadModel: jest.fn(),
   selectedModel: {
     type: "language_model",
     provider: "openai",
     id: "gpt-5"
   },
+  getSelectedModel: (threadId: string | null) =>
+    (threadId ? chatState.threadModel[threadId] : undefined) ??
+    chatState.selectedModel,
   connect,
   fetchThread,
   ensureLocalThread,

--- a/web/src/hooks/chat/__tests__/useThreadModel.test.ts
+++ b/web/src/hooks/chat/__tests__/useThreadModel.test.ts
@@ -1,0 +1,54 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { useThreadModel } from "../useThreadModel";
+import useGlobalChatStore from "../../../stores/GlobalChatStore";
+import type { LanguageModel } from "../../../stores/ApiTypes";
+
+const gpt: LanguageModel = {
+  type: "language_model",
+  provider: "openai",
+  id: "gpt-5.4-mini",
+  name: "gpt-5.4-mini"
+};
+const claude: LanguageModel = {
+  type: "language_model",
+  provider: "anthropic",
+  id: "claude-opus-5",
+  name: "claude-opus-5"
+};
+
+describe("useThreadModel", () => {
+  beforeEach(() => {
+    useGlobalChatStore.setState({
+      selectedModel: gpt,
+      threadModel: {},
+      forcedModel: null
+    });
+  });
+
+  it("leaves the other conversation alone when one picks a model", () => {
+    const a = renderHook(() => useThreadModel("thread-a"));
+    const b = renderHook(() => useThreadModel("thread-b"));
+
+    act(() => a.result.current.setModel(claude));
+
+    expect(a.result.current.model).toEqual(claude);
+    expect(b.result.current.model).toEqual(gpt);
+  });
+
+  it("makes the pick the default for a conversation that has none", () => {
+    const a = renderHook(() => useThreadModel("thread-a"));
+    act(() => a.result.current.setModel(claude));
+
+    const fresh = renderHook(() => useThreadModel("thread-new"));
+    expect(fresh.result.current.model).toEqual(claude);
+  });
+
+  it("reports a forced model over the conversation's own pick", () => {
+    const a = renderHook(() => useThreadModel("thread-a"));
+    act(() => a.result.current.setModel(gpt));
+    act(() => useGlobalChatStore.getState().setForcedModel(claude));
+
+    expect(a.result.current.model).toEqual(claude);
+  });
+});

--- a/web/src/hooks/chat/useThreadModel.ts
+++ b/web/src/hooks/chat/useThreadModel.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect } from "react";
+
+import useGlobalChatStore from "../../stores/GlobalChatStore";
+import type { LanguageModel } from "../../stores/ApiTypes";
+
+interface UseThreadModelResult {
+  /** The conversation's own model, falling back to the last global pick. */
+  model: LanguageModel;
+  /** Pick a model for this conversation (and make it the default for new ones). */
+  setModel: (model: LanguageModel) => void;
+}
+
+/**
+ * Bind a chat surface's model picker to one conversation.
+ *
+ * Several chat tabs and assistant panels are open at once and all read the
+ * same store, so a pick used to move every one of them. The selection is
+ * per-thread instead: opening a surface pins its conversation to the model it
+ * starts on, and a pick here writes only that pin (plus the global default a
+ * conversation with no pin of its own starts from).
+ */
+export const useThreadModel = (
+  threadId: string | null
+): UseThreadModelResult => {
+  const model = useGlobalChatStore((state) =>
+    state.getSelectedModel(threadId)
+  );
+  const setSelectedModel = useGlobalChatStore(
+    (state) => state.setSelectedModel
+  );
+  const pinThreadModel = useGlobalChatStore((state) => state.pinThreadModel);
+
+  // `model` is a dependency so a conversation opened before anything was
+  // picked (the first-run placeholder) pins as soon as a real model lands.
+  useEffect(() => {
+    if (threadId) {
+      pinThreadModel(threadId);
+    }
+  }, [threadId, model, pinThreadModel]);
+
+  const setModel = useCallback(
+    (next: LanguageModel) => setSelectedModel(next, threadId),
+    [setSelectedModel, threadId]
+  );
+
+  return { model, setModel };
+};
+
+export default useThreadModel;

--- a/web/src/hooks/editor/useChatIntegration.ts
+++ b/web/src/hooks/editor/useChatIntegration.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef } from "react";
 import type * as monaco from "monaco-editor";
-import { useShallow } from "zustand/react/shallow";
 import useGlobalChatStore from "../../stores/GlobalChatStore";
 import { useChatViewThread } from "../chat/useChatViewThread";
+import useThreadModel from "../chat/useThreadModel";
 import type {
   MessageContent,
   Message
@@ -37,13 +37,7 @@ export function useChatIntegration(params: {
     currentText
   } = params;
 
-  const { selectedModel, setSelectedModel, createThread } = useGlobalChatStore(
-    useShallow((state) => ({
-      selectedModel: state.selectedModel,
-      setSelectedModel: state.setSelectedModel,
-      createThread: state.createNewThread
-    }))
-  );
+  const createThread = useGlobalChatStore((state) => state.createNewThread);
   const {
     threadId,
     messages,
@@ -52,6 +46,10 @@ export function useChatIntegration(params: {
     sendMessage: sendThreadMessage,
     stopGeneration
   } = useChatViewThread();
+
+  // The editor's conversation keeps its own model.
+  const { model: selectedModel, setModel: setSelectedModel } =
+    useThreadModel(threadId);
 
   // Register editor adapter so frontend tools can read/edit the document
   useEffect(() => {

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -267,9 +267,27 @@ export interface GlobalChatState {
    */
   subAgentMessages: SubAgentMessages;
 
-  // Selections
+  // Selections. `selectedModel` is the last model the user picked and the
+  // default for a conversation that has none of its own. `threadModel` pins a
+  // conversation to its model, so a pick in another chat tab or assistant
+  // panel does not move it.
   selectedModel: LanguageModel;
-  setSelectedModel: (model: LanguageModel) => void;
+  threadModel: Record<string, LanguageModel>;
+  /**
+   * A model a shell pins on every conversation while it is mounted (the
+   * Studio shell). Overrides both the per-thread pin and the global default,
+   * and is never persisted — the user's own selections stay untouched.
+   */
+  forcedModel: LanguageModel | null;
+  setForcedModel: (model: LanguageModel | null) => void;
+  getSelectedModel: (threadId: string | null) => LanguageModel;
+  setSelectedModel: (model: LanguageModel, threadId?: string | null) => void;
+  /**
+   * Pin `threadId` to the model it resolves to right now, so a pick in another
+   * chat tab stops moving it. No-op when the thread is already pinned, when a
+   * shell forces a model, or when nothing real is picked yet.
+   */
+  pinThreadModel: (threadId: string) => void;
 
   // Per-thread permission mode (governs how gated tool calls are handled).
   // A thread with no entry uses lastPermissionMode, then Default.
@@ -440,6 +458,7 @@ interface PersistedChatState {
   threads: Record<string, Thread>;
   lastUsedThreadId: string | null;
   selectedModel: LanguageModel | null;
+  threadModel?: Record<string, LanguageModel>;
   permissionMode: Record<string, PermissionMode>;
   lastPermissionMode?: PermissionMode;
   workflowThreadId?: Record<string, string>;
@@ -554,8 +573,36 @@ const useGlobalChatStore = create<GlobalChatState>()(
 
       // Selections
       selectedModel: buildDefaultLanguageModel(),
-      setSelectedModel: (model: LanguageModel) => {
-        set({ selectedModel: model });
+      threadModel: {},
+      forcedModel: null,
+      setForcedModel: (model: LanguageModel | null) => {
+        set({ forcedModel: model });
+      },
+      getSelectedModel: (threadId: string | null) =>
+        get().forcedModel ??
+        (threadId ? get().threadModel[threadId] : undefined) ??
+        get().selectedModel,
+      setSelectedModel: (model: LanguageModel, threadId?: string | null) => {
+        set((state) => ({
+          selectedModel: model,
+          threadModel: threadId
+            ? { ...state.threadModel, [threadId]: model }
+            : state.threadModel
+        }));
+      },
+      pinThreadModel: (threadId: string) => {
+        const { forcedModel, threadModel, selectedModel } = get();
+        if (forcedModel || threadModel[threadId]) {
+          return;
+        }
+        // The shipped default is an unsendable placeholder; pinning it would
+        // strand the conversation on it after the first real pick lands.
+        if (!isModelSelected(selectedModel)) {
+          return;
+        }
+        set({
+          threadModel: { ...threadModel, [threadId]: selectedModel }
+        });
       },
 
       // Per-thread permission mode. lastPermissionMode is what the user last
@@ -939,7 +986,12 @@ const useGlobalChatStore = create<GlobalChatState>()(
         message: Message | ChatOutgoingMessage,
         targetThreadId?: string
       ): Promise<ChatSendOutcome> => {
-        const { currentThreadId, workflowId, selectedModel } = get();
+        const { currentThreadId, workflowId } = get();
+        // The turn runs on the target conversation's own model, not on
+        // whatever another tab last picked.
+        const selectedModel = get().getSelectedModel(
+          targetThreadId ?? currentThreadId
+        );
 
         // Agent mode is no longer a UI toggle — every chat session runs the
         // unified LLM-with-tools loop, and the agent decides for itself
@@ -1012,6 +1064,13 @@ const useGlobalChatStore = create<GlobalChatState>()(
           threadId = await get().createNewThread();
         }
         const tid = threadId;
+
+        // Pin the conversation to the model this turn runs on. Without this a
+        // thread the user never explicitly picked for would follow the global
+        // default when another tab changes it.
+        if (!isMediaGeneration) {
+          get().pinThreadModel(tid);
+        }
 
         // Clear the target thread's existing safety timeout
         const existingTimeoutId = getThreadRuntime(
@@ -1358,6 +1417,8 @@ const useGlobalChatStore = create<GlobalChatState>()(
             } = state.chatReplayCursors;
             const { [threadId]: deletedRuntime, ...remainingRuntime } =
               state.threadRuntime;
+            const { [threadId]: _deletedModel, ...remainingThreadModel } =
+              state.threadModel;
             if (deletedRuntime?.sendMessageTimeoutId != null) {
               clearTimeout(deletedRuntime.sendMessageTimeoutId);
             }
@@ -1370,7 +1431,8 @@ const useGlobalChatStore = create<GlobalChatState>()(
               todosByThread: remainingTodos,
               subAgentMessages: remainingSubAgents,
               threadRuntime: remainingRuntime,
-              chatReplayCursors: remainingReplayCursors
+              chatReplayCursors: remainingReplayCursors,
+              threadModel: remainingThreadModel
             };
 
             // If deleting current thread, switch to another or create new
@@ -1754,6 +1816,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
           threads: state.threads || {},
           lastUsedThreadId: state.lastUsedThreadId,
           selectedModel: state.selectedModel,
+          threadModel: state.threadModel,
           permissionMode: state.permissionMode,
           lastPermissionMode: state.lastPermissionMode,
           // Per-workflow thread binding so the editor side panel restores the
@@ -1781,6 +1844,10 @@ const useGlobalChatStore = create<GlobalChatState>()(
             ...(persisted.permissionMode ?? {}),
             ...currentState.permissionMode
           },
+          threadModel: {
+            ...(persisted.threadModel ?? {}),
+            ...currentState.threadModel
+          },
           workflowThreadId: {
             ...(persisted.workflowThreadId ?? {}),
             ...currentState.workflowThreadId
@@ -1800,6 +1867,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
           threads: {},
           lastUsedThreadId: null as string | null,
           selectedModel: null as LanguageModel | null,
+          threadModel: {} as Record<string, LanguageModel>,
           permissionMode: {},
           lastPermissionMode: DEFAULT_PERMISSION_MODE as PermissionMode
         };
@@ -1822,6 +1890,12 @@ const useGlobalChatStore = create<GlobalChatState>()(
             state.selectedModel && typeof state.selectedModel === "object"
               ? (state.selectedModel as LanguageModel)
               : fallback.selectedModel,
+          threadModel:
+            state.threadModel &&
+            isObjectLike(state.threadModel) &&
+            !Array.isArray(state.threadModel)
+              ? (state.threadModel as Record<string, LanguageModel>)
+              : fallback.threadModel,
           permissionMode:
             state.permissionMode &&
             isObjectLike(state.permissionMode) &&

--- a/web/src/stores/__tests__/GlobalChatStore.test.ts
+++ b/web/src/stores/__tests__/GlobalChatStore.test.ts
@@ -388,6 +388,129 @@ describe("GlobalChatStore", () => {
     expect(store.getState().messageCache[threadId] ?? []).toEqual([]);
   });
 
+  describe("per-conversation model", () => {
+    const gpt = {
+      type: "language_model" as const,
+      provider: "openai" as const,
+      id: "gpt-5.4-mini",
+      name: "gpt-5.4-mini"
+    };
+    const claude = {
+      type: "language_model" as const,
+      provider: "anthropic" as const,
+      id: "claude-opus-5",
+      name: "claude-opus-5"
+    };
+
+    it("keeps each thread on its own model when another tab picks a different one", () => {
+      store.getState().setSelectedModel(claude, "thread-a");
+      store.getState().setSelectedModel(gpt, "thread-b");
+
+      expect(store.getState().getSelectedModel("thread-a")).toEqual(claude);
+      expect(store.getState().getSelectedModel("thread-b")).toEqual(gpt);
+    });
+
+    it("falls back to the last pick for a thread that has none of its own", () => {
+      store.getState().setSelectedModel(claude, "thread-a");
+
+      expect(store.getState().getSelectedModel("thread-unpicked")).toEqual(
+        claude
+      );
+      expect(store.getState().getSelectedModel(null)).toEqual(claude);
+    });
+
+    it("sends a thread's own model and does not follow a later pick elsewhere", async () => {
+      mockGlobalWebSocketManager.isConnectionOpen.mockReturnValue(true);
+      mockGlobalWebSocketManager.isConnected = true;
+      const sent: unknown[] = [];
+      mockGlobalWebSocketManager.send.mockImplementation(
+        async (data: unknown) => {
+          sent.push(data);
+        }
+      );
+
+      const threadId = await store.getState().createNewThread();
+      store.getState().setSelectedModel(claude, threadId);
+      // Another tab picks a different model afterwards.
+      store.getState().setSelectedModel(gpt, "other-thread");
+
+      await store
+        .getState()
+        .sendMessage(
+          { role: "user", type: "message", content: "hi" } as Message,
+          threadId
+        );
+
+      const last = sent[sent.length - 1] as { data: Record<string, unknown> };
+      expect(last.data).toMatchObject({
+        thread_id: threadId,
+        model: claude.id,
+        provider: claude.provider
+      });
+    });
+
+    it("pins a thread to the model its first turn ran on", async () => {
+      mockGlobalWebSocketManager.isConnectionOpen.mockReturnValue(true);
+      mockGlobalWebSocketManager.isConnected = true;
+      mockGlobalWebSocketManager.send.mockResolvedValue(undefined);
+      store.setState({ selectedModel: claude } as any);
+
+      const threadId = await store.getState().createNewThread();
+      await store
+        .getState()
+        .sendMessage(
+          { role: "user", type: "message", content: "hi" } as Message,
+          threadId
+        );
+
+      store.getState().setSelectedModel(gpt);
+      expect(store.getState().getSelectedModel(threadId)).toEqual(claude);
+    });
+
+    it("forcedModel overrides both the thread pin and the last pick", () => {
+      store.getState().setSelectedModel(gpt, "thread-a");
+      store.getState().setSelectedModel(claude);
+      store.getState().setForcedModel(claude);
+
+      expect(store.getState().getSelectedModel("thread-a")).toEqual(claude);
+      expect(store.getState().getSelectedModel(null)).toEqual(claude);
+
+      // Clearing the force gives the conversation its own pick back rather
+      // than leaving it on what the shell imposed.
+      store.getState().setForcedModel(null);
+      expect(store.getState().getSelectedModel("thread-a")).toEqual(gpt);
+    });
+
+    it("does not pin while a shell forces a model", () => {
+      store.getState().setForcedModel(claude);
+      store.getState().pinThreadModel("thread-a");
+
+      expect(store.getState().threadModel["thread-a"]).toBeUndefined();
+    });
+
+    it("does not pin the unsendable first-run placeholder", () => {
+      store.setState({
+        selectedModel: {
+          type: "language_model",
+          provider: "empty",
+          id: "",
+          name: ""
+        }
+      } as any);
+      store.getState().pinThreadModel("thread-a");
+
+      expect(store.getState().threadModel["thread-a"]).toBeUndefined();
+    });
+
+    it("drops a deleted thread's model pin", async () => {
+      const first = await store.getState().createNewThread();
+      store.getState().setSelectedModel(claude, first);
+      await store.getState().deleteThread(first);
+
+      expect(store.getState().threadModel[first]).toBeUndefined();
+    });
+  });
+
   it("switchThread does nothing for invalid id", () => {
     store.getState().createNewThread();
     store.getState().switchThread("nonexistent");

--- a/web/src/studio/useStudioAssistantModel.ts
+++ b/web/src/studio/useStudioAssistantModel.ts
@@ -1,11 +1,10 @@
 /**
- * Pin the Studio assistants to the curated director model. Every editor's
- * agent panel reads `GlobalChatStore.selectedModel`, so inside the Studio
- * shell that selection is forced to the curated model and the panels hide
- * their model chip — picking the brain behind the assistants is not a
- * beginner's decision. Turns run on it, metered like all `nodetool`-provider
- * calls. The user's own selection is restored when the shell unmounts, so
- * workspace chat is untouched.
+ * Pin the Studio assistants to the curated director model. Inside the Studio
+ * shell every agent panel runs on that model and hides its model chip —
+ * picking the brain behind the assistants is not a beginner's decision. Turns
+ * run on it, metered like all `nodetool`-provider calls. The force is store
+ * state, not a write to the user's selection, so workspace chat and the
+ * per-conversation model pins are untouched.
  */
 
 import { useEffect } from "react";
@@ -14,15 +13,11 @@ import { STUDIO_DIRECTOR_MODEL } from "./curatedModels";
 
 export function useStudioAssistantModel(): void {
   useEffect(() => {
-    const store = useGlobalChatStore.getState();
-    const previous = store.selectedModel;
-    if (previous.id !== STUDIO_DIRECTOR_MODEL.id) {
-      store.setSelectedModel({ ...STUDIO_DIRECTOR_MODEL });
-    }
+    useGlobalChatStore.getState().setForcedModel({ ...STUDIO_DIRECTOR_MODEL });
     return () => {
       // Route swaps unmount the old shell before the next one mounts, so a
-      // studio-to-studio navigation restores here and re-pins immediately.
-      useGlobalChatStore.getState().setSelectedModel(previous);
+      // studio-to-studio navigation clears here and re-forces immediately.
+      useGlobalChatStore.getState().setForcedModel(null);
     };
   }, []);
 }


### PR DESCRIPTION
## What changed

Every chat tab and assistant panel read one `selectedModel` off `GlobalChatStore`, so picking a model in one moved all of them — and `trySendMessage` resolved that same global value, so an open tab's next turn ran on whatever another tab had picked last. The selection is per-thread now: `threadModel` pins a conversation to its model and `getSelectedModel(threadId)` falls back to `selectedModel`, which stays as the last pick a conversation with no pin of its own starts from. A surface pins its thread when it opens (`pinThreadModel`, via the new `useThreadModel` hook) and the send path pins the model a turn actually ran on, so a thread stops following the global default once it exists. Pins persist next to `permissionMode` and are dropped with the thread. The Studio shell used to force its curated model by overwriting `selectedModel` and restoring it on unmount; that goes through a new in-memory `forcedModel` which outranks both the pin and the default, so the shell no longer writes to the user's own selection.

Wired through `ChatSurface` (workspace chat tabs), `AssistantChatPanel`, `AppBuilderAgentPanel`, `ProjectAgentPanel`, `useChatIntegration` and `MediaChatComposer`'s model fallback.

## Verification

- [x] `npm run test:affected` — 235/236 suites pass. The one failure, `TimelineInspector.motionControls` (4 tests), is pre-existing: it fails identically on a stashed working tree.
- [x] `npm run typecheck` — 11 errors, all pre-existing and identical before/after the change (`@nodetool-ai/base-nodes`, `@nodetool-ai/godot`, `@nodetool-ai/godot-templates` have no build in this checkout, which also blocks `packages/agents` from building).
- [x] `npm run lint` — 0 errors.
- [ ] `npm run dev:nodetool -- harness gate --base main` — cannot run here: the CLI fails to import `@nodetool-ai/base-nodes/dist/index.js` for the same unbuilt-package reason above, unrelated to this diff (which touches only `web/src`).

Inverting the new behaviour (`getSelectedModel` ignoring `threadModel`) fails three of the new store tests:

```
✕ keeps each thread on its own model when another tab picks a different one
✕ sends a thread's own model and does not follow a later pick elsewhere
✕ pins a thread to the model its first turn ran on
```

`useThreadModel`'s "leaves the other conversation alone when one picks a model" likewise failed before the open-time pin was added.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added — the new tests cover behaviour, and each was observed failing against the old resolution (output above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9ypB1vWNhhvifZ1L3qf5S

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9ypB1vWNhhvifZ1L3qf5S)_