### PR TITLE
feat(web): surface the example apps on the Examples page

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -65,7 +65,7 @@ For detailed schemas, see [Chat API](chat-api.md) and [Workflow API](workflow-ap
 | Apps      | `/api/applications/{id}/export-bundle` | `GET`        | Depends on `AUTH_PROVIDER`                     | no                          | One app and the full graph of every workflow it binds, as a downloadable `ApplicationBundle` |
 | Apps      | `/api/applications/build`         | `POST`            | Depends on `AUTH_PROVIDER`                     | no                          | Build a mini app from a prompt or a pinned spec; returns the `BuildReport`. `poll: true` returns a session id instead |
 | Apps      | `/api/applications/debug`         | `POST`            | Depends on `AUTH_PROVIDER`                     | no                          | Simulate a saved app by `application_id`, or a draft posted inline as `document`; returns the compacted debug report |
-| Apps      | `/api/applications/examples`      | `GET`             | none                                           | no                          | The shipped example apps — slug, name, description, workflow names, operation count |
+| Apps      | `/api/applications/examples`      | `GET`             | none                                           | no                          | The shipped example apps — slug, name, description, workflow names, operation count, thumbnail URL |
 | Apps      | `/api/applications/examples/{slug}` | `GET`           | none                                           | no                          | One example's full `ApplicationBundle`; `404` when the slug names nothing shipped |
 | Apps      | `/api/applications/examples/{slug}/install` | `POST`  | Depends on `AUTH_PROVIDER`                     | no                          | Install an example into the caller's library, creating the workflows it binds |
 | Storyboards | `/api/storyboards/{id}/export-zip` | `GET`           | Depends on `AUTH_PROVIDER`                     | no                          | One board as a zip of Markdown plus its stills and clips; `404` when the caller does not own it |
@@ -1274,12 +1274,15 @@ curl "http://localhost:7777/api/applications/examples"
     "name": "Dataset Builder",
     "description": "The smallest app in the set, and the reference for the Table widget: a dataframe reads better as rows than as a Preview node.",
     "workflows": ["Data Generator"],
-    "operationCount": 1
+    "operationCount": 1,
+    "thumbnailUrl": "/api/workflows/examples/thumbnails/Data%20Generator.jpg?v=3f2a9c1e"
   }
 ]
 ```
 
-`workflows` names the workflows installing the app would create. To read the
+`workflows` names the workflows installing the app would create, and
+`thumbnailUrl` is the gallery art of the first of them, or `null` when it ships
+none. To read the
 whole thing first — the app document plus the full graph of every workflow it
 binds — fetch the bundle:
 

--- a/packages/protocol/src/api-schemas/applications.ts
+++ b/packages/protocol/src/api-schemas/applications.ts
@@ -131,6 +131,23 @@ export const applicationListItem = z.object({
 });
 export type ApplicationListItem = z.infer<typeof applicationListItem>;
 
+/**
+ * One shipped example app as the list endpoint describes it: no graphs, no
+ * document. `thumbnailUrl` is the gallery JPG of the first workflow the app
+ * binds, cache-busted the way example workflow thumbnails are, or null when
+ * that workflow ships no art.
+ */
+export const exampleAppSummary = z.object({
+  slug: z.string(),
+  name: z.string(),
+  description: z.string(),
+  /** Names of the workflows installing this app creates. */
+  workflows: z.array(z.string()),
+  operationCount: z.number(),
+  thumbnailUrl: z.string().nullable()
+});
+export type ExampleAppSummary = z.infer<typeof exampleAppSummary>;
+
 /** Derived at publish time from the release's bindings — never hand-written. */
 export const applicationCapabilities = z.object({
   workflows: z.array(

--- a/packages/websocket/src/lib/example-apps.ts
+++ b/packages/websocket/src/lib/example-apps.ts
@@ -17,27 +17,48 @@ import {
 } from "@nodetool-ai/app-runtime";
 import {
   importApplicationBundleInput,
-  type ApplicationResponse
+  type ApplicationResponse,
+  type ExampleAppSummary
 } from "@nodetool-ai/protocol/api-schemas/applications.js";
 import { ApiErrorCode } from "../error-codes.js";
+import { deriveExampleAssetsDir } from "../example-workflows.js";
 import { throwApiError } from "../trpc/error-formatter.js";
 import { importApplicationBundle } from "./applications-service.js";
+import { withCacheBuster } from "./example-thumbnail.js";
 
 const BUNDLE_SUFFIX = ".app.json";
+const EXAMPLES_THUMBNAILS_PREFIX = "/api/workflows/examples/thumbnails/";
 
-/** What the list endpoint returns per example — no graphs, no document. */
-export interface ExampleAppSummary {
-  slug: string;
-  name: string;
-  description: string;
-  /** Names of the workflows installing this app creates. */
-  workflows: string[];
-  operationCount: number;
-}
+export type { ExampleAppSummary };
 
 interface ExampleAppsOptions {
   examplesDir?: string;
+  examplesAssetsFallbackDir?: string;
   exampleAppsDir?: string;
+}
+
+/**
+ * The gallery art an app is shown with: the JPG of the first workflow it
+ * binds, served through the example-workflow thumbnail route. Null when the
+ * examples directory is unknown or that workflow ships no art.
+ */
+function thumbnailFor(
+  bundle: ApplicationBundle,
+  options: ExampleAppsOptions
+): string | null {
+  const first = bundle.workflows[0];
+  if (!first || !options.examplesDir) return null;
+  const assetsDir = deriveExampleAssetsDir(
+    options.examplesDir,
+    options.examplesAssetsFallbackDir
+  );
+  const jpgFile = `${first.name}.jpg`;
+  const jpgPath = nodePath.join(assetsDir, jpgFile);
+  if (!existsSync(jpgPath)) return null;
+  return withCacheBuster(
+    `${EXAMPLES_THUMBNAILS_PREFIX}${encodeURIComponent(jpgFile)}`,
+    jpgPath
+  );
 }
 
 /**
@@ -95,7 +116,8 @@ export function listExampleApps(
       name: bundle.name,
       description: bundle.description,
       workflows: bundle.workflows.map((workflow) => workflow.name),
-      operationCount: bundle.app.operations.length
+      operationCount: bundle.app.operations.length,
+      thumbnailUrl: thumbnailFor(bundle, options)
     });
   }
   return apps;

--- a/packages/websocket/tests/example-apps.test.ts
+++ b/packages/websocket/tests/example-apps.test.ts
@@ -20,9 +20,16 @@ const EXAMPLE_APPS_DIR = nodePath.resolve(
   nodePath.dirname(fileURLToPath(import.meta.url)),
   "../../base-nodes/nodetool/examples/apps"
 );
+const EXAMPLES_DIR = nodePath.resolve(
+  nodePath.dirname(fileURLToPath(import.meta.url)),
+  "../../base-nodes/nodetool/examples/nodetool-base"
+);
 
 async function buildServer(
-  apiOptions: HttpApiOptions = { exampleAppsDir: EXAMPLE_APPS_DIR }
+  apiOptions: HttpApiOptions = {
+    exampleAppsDir: EXAMPLE_APPS_DIR,
+    examplesDir: EXAMPLES_DIR
+  }
 ): Promise<FastifyInstance> {
   const app = Fastify({ logger: false });
   app.decorateRequest("userId", null);
@@ -40,6 +47,7 @@ interface ExampleSummary {
   description: string;
   workflows: string[];
   operationCount: number;
+  thumbnailUrl: string | null;
 }
 
 describe("example apps", () => {
@@ -69,6 +77,20 @@ describe("example apps", () => {
     const photo = apps.find((a) => a.slug === "photo-studio");
     expect(photo?.name).toBe("Photo Studio");
     expect(photo?.workflows).toContain("Image Enhance");
+    // The art is the first bound workflow's gallery JPG, cache-busted the way
+    // example workflow thumbnails are.
+    expect(photo?.thumbnailUrl).toMatch(
+      /^\/api\/workflows\/examples\/thumbnails\/Image%20Enhance\.jpg\?v=[0-9a-f]{8}$/
+    );
+  });
+
+  it("carries no thumbnail when the examples directory is unknown", async () => {
+    await server.close();
+    server = await buildServer({ exampleAppsDir: EXAMPLE_APPS_DIR });
+    const response = await server.inject({ url: "/api/applications/examples" });
+    const apps = response.json() as ExampleSummary[];
+    expect(apps.length).toBeGreaterThan(0);
+    expect(apps.every((app) => app.thumbnailUrl === null)).toBe(true);
   });
 
   it("serves one bundle and 404s an unknown slug", async () => {

--- a/web/src/components/portal/DashboardExampleApps.tsx
+++ b/web/src/components/portal/DashboardExampleApps.tsx
@@ -1,0 +1,283 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import type { Theme } from "@mui/material/styles";
+import { useTheme } from "@mui/material/styles";
+import { memo, useCallback, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNotificationStore } from "../../stores/NotificationStore";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import { BASE_URL } from "../../stores/BASE_URL";
+import {
+  installExampleApp,
+  listExampleApps,
+  type ExampleAppSummary
+} from "../../utils/exampleApps";
+import {
+  BORDER_RADIUS,
+  EmptyState,
+  LoadingSpinner,
+  MOTION,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
+import { useSectionWrap, SectionHeader } from "./dashboardChrome";
+
+/** Query key for the shipped example apps, shared with any invalidation. */
+export const EXAMPLE_APPS_QUERY_KEY = ["applications", "examples"] as const;
+
+const CARD_WIDTH = 220;
+
+const styles = (theme: Theme) =>
+  css({
+    // A fixed-height band between the recipes and the template browser: the
+    // cards scroll sideways so the page below keeps its viewport share.
+    flexShrink: 0,
+    paddingTop: getSpacingPx(SPACING.xxl),
+    ".apps-lede": {
+      margin: `0 0 ${getSpacingPx(SPACING.sm)}`,
+      fontSize: "var(--fontSizeSmall)",
+      color: theme.vars.palette.text.secondary
+    },
+    ".apps-strip": {
+      display: "flex",
+      gap: getSpacingPx(SPACING.md),
+      overflowX: "auto",
+      paddingBottom: getSpacingPx(SPACING.sm),
+      scrollSnapType: "x proximity"
+    },
+    ".app-card": {
+      flex: `0 0 ${CARD_WIDTH}px`,
+      display: "flex",
+      flexDirection: "column",
+      textAlign: "left",
+      padding: 0,
+      background: theme.vars.palette.c_node_bg,
+      border: `1px solid ${theme.vars.palette.divider}`,
+      borderRadius: BORDER_RADIUS.lg,
+      color: theme.vars.palette.text.primary,
+      cursor: "pointer",
+      overflow: "hidden",
+      scrollSnapAlign: "start",
+      transition: `border-color ${MOTION.fast}, background ${MOTION.fast}`,
+      "&:hover": {
+        borderColor: `rgba(${theme.vars.palette.primary.mainChannel} / 0.5)`,
+        background: theme.vars.palette.action.hover
+      },
+      "&.installing": { cursor: "wait", pointerEvents: "none" }
+    },
+    ".app-thumb": {
+      position: "relative",
+      display: "grid",
+      placeItems: "center",
+      width: "100%",
+      aspectRatio: "16 / 9",
+      background: theme.vars.palette.c_node_bg_group,
+      color: theme.vars.palette.primary.main,
+      overflow: "hidden",
+      img: {
+        width: "100%",
+        height: "100%",
+        objectFit: "cover"
+      }
+    },
+    ".app-body": {
+      display: "flex",
+      flexDirection: "column",
+      gap: getSpacingPx(SPACING.xs),
+      padding: getSpacingPx(SPACING.md)
+    },
+    ".app-name": {
+      fontSize: "var(--fontSizeNormal)",
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap"
+    },
+    ".app-desc": {
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.secondary,
+      display: "-webkit-box",
+      WebkitLineClamp: 2,
+      WebkitBoxOrient: "vertical",
+      overflow: "hidden"
+    },
+    ".app-meta": {
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.disabled
+    },
+    ".apps-loading, .apps-empty": {
+      display: "flex",
+      justifyContent: "center",
+      padding: `${getSpacingPx(SPACING.xl)} 0`,
+      color: theme.vars.palette.text.secondary,
+      fontSize: "var(--fontSizeNormal)"
+    }
+  });
+
+/** Stand-in when an app's first workflow ships no gallery art. */
+const appGlyph = (
+  <svg
+    width="28"
+    height="28"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.2"
+  >
+    <rect x="2" y="2" width="12" height="12" rx="2" />
+    <path d="M2 6h12M6 6v8" />
+  </svg>
+);
+
+const thumbSrc = (url: string | null): string | null => {
+  if (!url) return null;
+  return url.startsWith("http") ? url : `${BASE_URL}${url}`;
+};
+
+interface ExampleAppCardProps {
+  app: ExampleAppSummary;
+  installing: boolean;
+  onInstall: (app: ExampleAppSummary) => void;
+}
+
+const ExampleAppCard = memo(function ExampleAppCard({
+  app,
+  installing,
+  onInstall
+}: ExampleAppCardProps) {
+  const [thumbFailed, setThumbFailed] = useState(false);
+  const src = thumbSrc(app.thumbnailUrl);
+  const workflows = app.workflows.length;
+  return (
+    <button
+      type="button"
+      className={installing ? "app-card installing" : "app-card"}
+      title={`Add ${app.name} to your apps`}
+      aria-busy={installing}
+      onClick={() => onInstall(app)}
+    >
+      <span className="app-thumb" aria-hidden>
+        {installing ? (
+          <LoadingSpinner size="medium" />
+        ) : src && !thumbFailed ? (
+          <img
+            src={src}
+            alt=""
+            loading="lazy"
+            onError={() => setThumbFailed(true)}
+          />
+        ) : (
+          appGlyph
+        )}
+      </span>
+      <span className="app-body">
+        <span className="app-name">{app.name}</span>
+        <span className="app-desc">{app.description}</span>
+        <span className="app-meta">
+          {workflows} workflow{workflows === 1 ? "" : "s"}
+        </span>
+      </span>
+    </button>
+  );
+});
+
+/**
+ * The shipped example apps as a strip of cards on the Examples page. Clicking
+ * one installs it (the app plus the workflows it binds) and opens it.
+ */
+const DashboardExampleApps: React.FC = () => {
+  const theme = useTheme();
+  const sectionWrap = useSectionWrap();
+  const queryClient = useQueryClient();
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification
+  );
+
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: EXAMPLE_APPS_QUERY_KEY,
+    queryFn: listExampleApps,
+    staleTime: Infinity
+  });
+
+  const install = useMutation({
+    mutationFn: (app: ExampleAppSummary) => installExampleApp(app.slug),
+    onSuccess: async (created) => {
+      await queryClient.invalidateQueries({ queryKey: ["applications"] });
+      await queryClient.invalidateQueries({ queryKey: ["workflows"] });
+      openTab({ type: "application", ref: created.id, title: created.name });
+      addNotification({
+        type: "success",
+        alert: true,
+        content: `Added "${created.name}" to your apps`
+      });
+    },
+    onError: (error: unknown, app) => {
+      addNotification({
+        type: "error",
+        alert: true,
+        content: `Couldn't add ${app.name}: ${error instanceof Error ? error.message : "Unknown error"}`
+      });
+    }
+  });
+
+  const handleInstall = useCallback(
+    (app: ExampleAppSummary) => {
+      if (install.isPending) return;
+      install.mutate(app);
+    },
+    [install]
+  );
+
+  const apps = data ?? [];
+  const installingSlug = install.isPending ? install.variables?.slug : null;
+  const countLabel = `${apps.length} app${apps.length === 1 ? "" : "s"}`;
+
+  return (
+    <section css={styles(theme)} aria-labelledby="dashboard-example-apps-title">
+      <div css={sectionWrap}>
+        <SectionHeader title="Start from an app" count={countLabel} />
+        <p className="apps-lede">
+          One upload, a few choices, one result. Adding an app also adds the
+          workflows it runs, so you can open the graph behind any of them.
+        </p>
+        {isLoading ? (
+          <div className="apps-loading">
+            <LoadingSpinner size="medium" text="Loading apps" />
+          </div>
+        ) : isError ? (
+          <div className="apps-empty">
+            <EmptyState
+              variant="error"
+              title="Couldn't load apps"
+              description="Try again in a moment."
+              actionText="Retry"
+              onAction={() => refetch()}
+            />
+          </div>
+        ) : apps.length === 0 ? (
+          <div className="apps-empty">
+            <EmptyState
+              variant="no-data"
+              title="No apps available"
+              description="Example apps will appear here when the server ships them."
+            />
+          </div>
+        ) : (
+          <div className="apps-strip">
+            {apps.map((app) => (
+              <ExampleAppCard
+                key={app.slug}
+                app={app}
+                installing={installingSlug === app.slug}
+                onInstall={handleInstall}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default memo(DashboardExampleApps);

--- a/web/src/components/portal/ExamplesPage.tsx
+++ b/web/src/components/portal/ExamplesPage.tsx
@@ -1,24 +1,27 @@
 import React, { memo } from "react";
 import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
 import ManagerPageLayout from "../panels/ManagerPageLayout";
+import DashboardExampleApps from "./DashboardExampleApps";
 import DashboardRecipes from "./DashboardRecipes";
 import DashboardTemplates from "./DashboardTemplates";
 
 /**
  * Full-screen Examples page. Reachable from the logo menu; wraps the recipes
- * (ordered chains of examples) and the example/template browser in the shared
- * manager chrome (header + back button) and lets the browser own its scroll.
+ * (ordered chains of examples), the shipped example apps, and the
+ * example/template browser in the shared manager chrome (header + back
+ * button) and lets the browser own its scroll.
  */
 const ExamplesPage: React.FC = () => (
   <ManagerPageLayout
     icon={<AutoAwesomeOutlinedIcon sx={{ fontSize: 22 }} />}
     title="Examples"
-    subtitle="Browse example workflows and recipes, and start from one."
+    subtitle="Browse example apps, workflows and recipes, and start from one."
     docsTopic="examples"
     padded={false}
   >
     <>
       <DashboardRecipes />
+      <DashboardExampleApps />
       <DashboardTemplates fullPage />
     </>
   </ManagerPageLayout>

--- a/web/src/components/portal/__tests__/DashboardExampleApps.test.tsx
+++ b/web/src/components/portal/__tests__/DashboardExampleApps.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import DashboardExampleApps from "../DashboardExampleApps";
+
+const listExampleApps = jest.fn();
+const installExampleApp = jest.fn();
+const openTab = jest.fn();
+const addNotification = jest.fn();
+
+jest.mock("../../../utils/exampleApps", () => ({
+  __esModule: true,
+  listExampleApps: (...args: unknown[]) => listExampleApps(...args),
+  installExampleApp: (...args: unknown[]) => installExampleApp(...args)
+}));
+
+jest.mock("../../../stores/WorkspaceTabsStore", () => ({
+  __esModule: true,
+  useWorkspaceTabsStore: <T,>(selector: (s: { openTab: unknown }) => T) =>
+    selector({ openTab: (...args: unknown[]) => openTab(...args) })
+}));
+
+jest.mock("../../../stores/NotificationStore", () => ({
+  __esModule: true,
+  useNotificationStore: <T,>(
+    selector: (s: { addNotification: unknown }) => T
+  ) =>
+    selector({
+      addNotification: (...args: unknown[]) => addNotification(...args)
+    })
+}));
+
+const APPS = [
+  {
+    slug: "vary-image",
+    name: "Vary Image",
+    description: "Change one thing about a photo and keep the rest.",
+    workflows: ["Edit a Still with Words"],
+    operationCount: 1,
+    thumbnailUrl: "/api/workflows/examples/thumbnails/Edit.jpg?v=1"
+  },
+  {
+    slug: "product-reshoot",
+    name: "Product Reshoot",
+    description: "New setting, new light, or a clean cutout.",
+    workflows: ["Backdrop", "Relight", "Cut out"],
+    operationCount: 3,
+    thumbnailUrl: null
+  }
+];
+
+const renderApps = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={mockTheme}>
+        <DashboardExampleApps />
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+};
+
+describe("DashboardExampleApps", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    listExampleApps.mockResolvedValue(APPS);
+  });
+
+  it("lists each app as a card with its description and workflow count", async () => {
+    renderApps();
+
+    const card = await screen.findByRole("button", { name: /vary image/i });
+    expect(
+      within(card).getByText("Change one thing about a photo and keep the rest.")
+    ).toBeInTheDocument();
+    expect(within(card).getByText("1 workflow")).toBeInTheDocument();
+
+    const reshoot = screen.getByRole("button", { name: /product reshoot/i });
+    expect(within(reshoot).getByText("3 workflows")).toBeInTheDocument();
+    expect(screen.getByText("2 apps")).toBeInTheDocument();
+  });
+
+  it("installs an app on click and opens it", async () => {
+    const user = userEvent.setup();
+    installExampleApp.mockResolvedValue({ id: "app-1", name: "Vary Image" });
+    renderApps();
+
+    await user.click(await screen.findByRole("button", { name: /vary image/i }));
+
+    await waitFor(() => expect(openTab).toHaveBeenCalledTimes(1));
+    expect(installExampleApp).toHaveBeenCalledWith("vary-image");
+    expect(openTab).toHaveBeenCalledWith({
+      type: "application",
+      ref: "app-1",
+      title: "Vary Image"
+    });
+    expect(addNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "success" })
+    );
+  });
+
+  it("reports a failed install without opening anything", async () => {
+    const user = userEvent.setup();
+    installExampleApp.mockRejectedValue(new Error("No FAL key"));
+    renderApps();
+
+    await user.click(await screen.findByRole("button", { name: /vary image/i }));
+
+    await waitFor(() =>
+      expect(addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "error",
+          content: expect.stringContaining("No FAL key")
+        })
+      )
+    );
+    expect(openTab).not.toHaveBeenCalled();
+  });
+
+  it("offers a retry when the list cannot load", async () => {
+    listExampleApps.mockRejectedValueOnce(new Error("offline"));
+    const user = userEvent.setup();
+    renderApps();
+
+    await user.click(await screen.findByRole("button", { name: /retry/i }));
+
+    expect(await screen.findByRole("button", { name: /vary image/i })).toBeInTheDocument();
+  });
+});

--- a/web/src/utils/exampleApps.ts
+++ b/web/src/utils/exampleApps.ts
@@ -1,0 +1,58 @@
+/**
+ * Client helpers for the shipped example apps:
+ *   GET  /api/applications/examples                → ExampleAppSummary[]
+ *   POST /api/applications/examples/:slug/install  → the created app
+ *
+ * An example app is a curated bundle on disk; installing one creates the app
+ * and the workflows it binds in the user's library, through the same import
+ * path an uploaded bundle takes (`applicationBundle.ts`).
+ */
+import {
+  applicationResponse,
+  exampleAppSummary,
+  type ExampleAppSummary
+} from "@nodetool-ai/protocol/api-schemas/applications.js";
+import { restFetch } from "../lib/rest-fetch";
+import { isObjectLike } from "./typePredicates";
+
+export type { ExampleAppSummary };
+
+const installedApp = applicationResponse.pick({ id: true, name: true });
+export type InstalledExampleApp = ReturnType<typeof installedApp.parse>;
+
+async function failureDetail(res: Response, fallback: string): Promise<string> {
+  const data: unknown = await res.json().catch(() => null);
+  return data && isObjectLike(data) && "detail" in data
+    ? String(data.detail)
+    : fallback;
+}
+
+/** Every shipped example app, in the order the server lists them. */
+export async function listExampleApps(): Promise<ExampleAppSummary[]> {
+  const res = await restFetch("/api/applications/examples", { method: "GET" });
+  if (!res.ok) {
+    throw new Error(
+      await failureDetail(res, `Loading example apps failed (${res.status})`)
+    );
+  }
+  return exampleAppSummary.array().parse(await res.json());
+}
+
+/** Install one example: the server creates its workflows, then the app. */
+export async function installExampleApp(
+  slug: string,
+  projectId = "default"
+): Promise<InstalledExampleApp> {
+  const res = await restFetch(
+    `/api/applications/examples/${encodeURIComponent(slug)}/install`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ projectId })
+    }
+  );
+  if (!res.ok) {
+    throw new Error(await failureDetail(res, `Install failed (${res.status})`));
+  }
+  return installedApp.parse(await res.json());
+}


### PR DESCRIPTION
## What changed

The shipped example apps were reachable only through the REST endpoint and the marketing site; nothing in the product listed them. The Examples page now carries a strip of app cards between the recipes band and the template browser. Clicking a card installs the bundle (the app plus the workflows it binds, through the same import path an uploaded bundle takes) and opens it in a tab, with a notification either way. The list endpoint gains a `thumbnailUrl` per app, the gallery JPG of the first workflow it binds served through the existing example-workflow thumbnail route, so the cards show art rather than a glyph. The summary shape moves into `packages/protocol` as a Zod schema so the web parses the response at the boundary, and the API reference documents the new field.

## Verification

- [x] `npm run test --workspace=packages/websocket -- tests/example-apps.test.ts` — 9 pass, including a new assertion that Photo Studio's thumbnail resolves to the cache-busted Image Enhance JPG and a new case that it is `null` when the examples directory is unknown
- [x] `cd web && npx jest src/components/portal` — 4 suites, 18 tests pass; the new `DashboardExampleApps` suite covers listing, install-and-open, a failed install, and retry after a load error
- [x] `npm run test --workspace=packages/protocol` — 74 files, 1268 pass
- [x] `npm run typecheck:web` and `npm run lint` pass
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — 4/4 selfchecks passed
- [x] Full `packages/websocket` suite: six unrelated suites (documents route, style presets, assets, timeline) failed in this container until `npm install` and `npm run build:packages` picked up main's new `document-nodes` package and `Asset.systemEntityRefusal`; they fail identically with this diff stashed and pass after the rebuild, 104/104 across those six plus example-apps

## Agent capabilities

Skipped: no capability added or changed.

## New checks

Skipped: no check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjeordLdNTaof3WYUyTSZG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjeordLdNTaof3WYUyTSZG)_