### PR TITLE
docs(timeline): design and task plan for 3D clips on the timeline

### DIFF
--- a/docs/plans/3d-timeline-clips-tasks.md
+++ b/docs/plans/3d-timeline-clips-tasks.md
@@ -27,7 +27,7 @@ M1: T1 (schema) ──► T2 (scene model + channels)   T3 (render session) is i
     T2 + T3 ──► T5 (agent frames on the server)
     T1 + T2 ──► T6 (ops, tools, capabilities)
 M2: T4 ──► T7 (add clip, drag-and-drop)   T4 + T6 ──► T8 (inspector)   T4 ──► T9 (lane thumbnails, clip frames)   T8 ──► T10 (preview orbit)
-M3: T6 + T8 ──► T11 (bake)   every task ──► T12 (docs, harness registry)
+M3: T6 + T8 ──► T11 (opaque bake)   T11 ──► T13 (alpha bake)   every task ──► T12 (docs, harness registry)
 ```
 
 ---
@@ -92,7 +92,8 @@ camera channels, and offers an `orbit` preset.
    `sourceTimeSec` (from `clipSourceTimeSec` times `animation.speed`).
 2. In `computeActiveLayersWithHorizon`, a `model3d` clip with a fresh bake
    (hash matches, T1's function) emits a `video` layer with
-   `assetId = bake.assetId`; otherwise a `model3d` layer with
+   `assetId = bake.assetId` and `bakeSourceTimeSec = (timeMs - clip.startMs) / 1000`
+   (design §D6, time origin); otherwise a `model3d` layer with
    `assetId = effectiveAssetId(clip)`. Count live `model3d` layers against
    `MAX_MODEL3D_LAYERS = 2`; over it, push a dropped layer with the new
    reason `model3d_layer_cap`.
@@ -110,8 +111,10 @@ camera channels, and offers an `orbit` preset.
 
 - `packages/timeline/tests/sceneModel*.test.ts`: a `model3d` clip yields a
   `model3d` layer with the right `sourceTimeSec` after a trim and a 2x speed;
-  a fresh bake yields a `video` layer; a stale bake yields `model3d`; a third
-  active 3D clip is dropped with `model3d_layer_cap`.
+  a fresh bake yields a `video` layer whose `bakeSourceTimeSec` is 0 at the
+  clip's first frame for a clip with a 5 s in point and a 2x speed; a stale
+  bake yields `model3d`; a third active 3D clip is dropped with
+  `model3d_layer_cap`.
 - Animation tests: `orbit` over a 4 s clip samples `cameraAzimuth` 180 at 2 s;
   a keyframed `cameraZoom` folds multiplicatively with the style's zoom in
   `resolveModel3DCamera`.
@@ -131,11 +134,14 @@ and `orbitOffset`).
 **Steps:**
 
 1. Split `renderGlbToPng` into `createModel3DRenderSession(glb, options)`
-   (load, meshopt, bounding sphere, lights, background, renderer, mixer) and
-   `session.render(frame)` (camera from `ClipModel3DCamera` through the
+   (load, meshopt, bounding sphere, lights, background, renderer, mixer with
+   the actions `options.animation` selects: the named clip, or every clip)
+   and `session.render(frame)` (camera from `ClipModel3DCamera` through the
    existing `computeFraming` and `orbitOffset`, `scene` mode picks the named
-   glTF camera, `mixer.setTime(frame.timeSec)`, render, return the canvas).
-   `session.animations` and `session.cameras` list the glTF's names.
+   glTF camera, `mixer.setTime(t)` with `t` wrapped at the selected actions'
+   longest duration when `loop` is on and clamped to it when off, render,
+   return the canvas). `session.animations` and `session.cameras` list the
+   glTF's names; an unknown `clipName` throws naming the available ones.
    `renderGlbToPng` becomes create, render once, `convertToBlob`, dispose.
 2. `render3d-page.ts`: `__nodetoolRenderGlbFrames(glbBase64, options, frames[])`
    returns one PNG per frame from one session.
@@ -148,9 +154,14 @@ and `orbitOffset`).
 
 - Existing `RenderToImage` tests pass unchanged.
 - New unit test on the pure part: `scene` mode with an unknown camera name
-  throws a message naming the available cameras; `frames` with two times on
-  an animated fixture yield two different PNGs (the existing headless test
-  harness, skipped without Chrome the way the current one is).
+  throws a message naming the available cameras; the loop and clamp time
+  mapping is a pure function (`mixerTimeFor(t, duration, loop)`) tested at
+  `t` past the end for both modes.
+- Headless tests on a fixture with two named animations (the existing
+  harness, skipped without Chrome the way the current one is): selecting
+  each name yields a different PNG at the same time; loop off at 1.5x the
+  duration equals the last frame; rendering `t = 0.2` after `t = 5` equals
+  rendering `t = 0.2` first.
 
 ### T4 — Browser layer source, preview, export
 
@@ -169,10 +180,12 @@ resolver it builds, `OffscreenVideoPool` usage), `render/TimelineRenderer.ts`
    (`copyExternalImageToTexture` and `drawImage` both take one). Add the
    test in `preview/gpu/__tests__/` that a canvas source composites.
 2. `preview/Model3DLayerSource.ts`: a pool keyed by clip id, cap 2, of
-   `{ session, assetId }`. `acquire(layer)` fetches the GLB by asset URL,
-   caches parsed bytes per asset id (least recently used, small cap), creates
-   the session with the style's lighting and background, and returns null
-   while loading. `frame(layer, anim)` calls `resolveModel3DCamera` and
+   `{ session, assetId, options: Model3DSessionOptions }`. `acquire(layer)`
+   fetches the GLB by asset URL, caches parsed bytes per asset id (least
+   recently used, small cap), creates the session from the style's lighting,
+   intensity, background and animation, and returns null while loading. A
+   layer whose asset id or session options differ from the pooled entry's
+   disposes it and creates a new one. `frame(layer, anim)` calls `resolveModel3DCamera` and
    `session.render` and returns the canvas. `release(clipId)` disposes.
    No WebGL is a `Model3DUnavailable` state the preview draws as an
    outlined placeholder with the clip name.
@@ -185,7 +198,8 @@ resolver it builds, `OffscreenVideoPool` usage), `render/TimelineRenderer.ts`
 
 - A Jest test for `Model3DLayerSource` with a mocked session: the pool
   evicts at cap, returns null while loading, reuses a session across frames,
-  and reports unavailable without WebGL.
+  re-creates the session when the clip's background or lighting changes and
+  not when only the camera changes, and reports unavailable without WebGL.
 - Manual: drop a GLB on an overlay track over a video clip, scrub, play,
   export, and the exported MP4 shows the model at the same pose as the
   preview at 1 s and 3 s (compare with `compare_timeline_frames` against
@@ -205,10 +219,10 @@ Chromium and reports them.
 **Steps:**
 
 1. Before compositing, walk the requested timecodes, collect every
-   `model3d` layer, group by asset id, and call `renderGlbFramesHeadless`
-   once per asset with the folded camera and `sourceTimeSec` per frame. Cache
-   the decoded images by `(assetId, style hash, camera, timeSec)` for the
-   call.
+   `model3d` layer, group by asset id plus `Model3DSessionOptions` (lighting,
+   intensity, background, animation), and call `renderGlbFramesHeadless` once
+   per group with the folded camera and `sourceTimeSec` per frame. Cache the
+   decoded images by `(group key, camera, timeSec)` for the call.
 2. The resolver's `model3d` branch returns the decoded image; `layerText`
    style reporting gains `camera` and `animation_time_sec` on the layer
    report.
@@ -219,8 +233,9 @@ Chromium and reports them.
 
 - `packages/agents/tests/timeline-model3d-frames.test.ts` with the headless
   call mocked: two timecodes and one asset make one call with two frames;
-  the report lists the layer with its camera; a rejected launch yields the
-  degradation and a frame without the layer.
+  two clips on the same asset with different backgrounds make two calls with
+  their own options; the report lists the layer with its camera; a rejected
+  launch yields the degradation and a frame without the layer.
 - The real headless path runs under the same Chrome-gated skip as the
   `RenderToImage` test.
 
@@ -319,27 +334,79 @@ documented degrees-per-pixel and produces one store patch.
 
 ## Milestone 3 — Bake and documentation
 
-### T11 — Bake with Blender
+### T11 — Opaque bake with Blender
 
-**Read first:** design §D6. `packages/blender-nodes/src/nodes/render-animation.ts`,
-`job.ts` (camera vocabulary, `orbit_degrees`), `packages/timeline/src/dependencyHash.ts`,
+**Read first:** design §D6 in full. `packages/blender-nodes/src/nodes/render-animation.ts`,
+`job.ts` (`RenderAnimationParams`, `orbit_degrees`),
+`packages/blender-nodes/blender_ops/ops/render_animation.py` (`run`, the
+`not animated and mode == "orbit"` branch), `packages/timeline/src/dependencyHash.ts`,
+`web/src/components/timeline/render/TimelineRenderer.ts` and
+`preview/PreviewCompositor.tsx` (the video seek),
 `web/src/stores/timeline/TimelineGenerationStore.ts` (how a generated clip
 registers a job and stores a version).
 
 **Steps:**
 
-1. `computeModel3DBakeHash(clip)` in `packages/timeline`: style, asset id,
-   and the camera curves.
-2. `bake_model3d_clip` op: refuses with a message when the clip has custom
-   camera keyframes; otherwise builds the `RenderAnimation` params (orbit
-   terms, `orbit_degrees` from the `orbit` preset or 0, fps, frame range,
-   transparent) and runs it as a generation job; on completion stores
-   `model3dStyle.bake` and a clip version.
-3. Inspector Bake row: run, progress, stale badge from `bake_stale`.
+1. Blender prerequisite: `render_animation.py` keyframes the orbit camera
+   whenever `camera_mode == "orbit"`, animated model or not, and the model's
+   animation plays underneath; `orbit_degrees: 0` is a held orbit camera.
+   Update the op's docstring and `job.ts` comment, which say the sweep runs
+   only without glTF animation.
+2. `computeModel3DBakeHash(clip, sequence)` in `packages/timeline`, covering
+   exactly the inputs design §D6 lists and nothing from `bake` itself.
+   Replace T1's placeholder.
+3. Both video resolvers seek by `layer.bakeSourceTimeSec` when present, and
+   by `clipSourceTimeSec` otherwise.
+4. `bake_model3d_clip` op: refuses a transparent style (until T13) and a
+   clip with custom camera keyframes, each with a message naming the reason;
+   otherwise builds the `RenderAnimation` params (camera mode and orbit terms
+   from the style, `orbit_degrees` from the `orbit` preset or 0, fps, width
+   and height from the sequence, frame range from the clip's evaluated
+   duration) and runs it as a generation job; on completion stores
+   `model3dStyle.bake` with the hash and a clip version.
+5. Inspector Bake row: run, progress, stale badge from `bake_stale`.
 
-**Acceptance:** a test that a style edit after a bake makes the scene model
-emit the live layer again; a test that the op refuses keyframed cameras with
-the reason; the capability suite bakes a fixture with the runner mocked.
+**Acceptance:**
+
+- Scene model: after a bake, changing the in point, the speed, the time
+  remap, the duration or the sequence fps makes the layer live again;
+  changing the clip's start or opacity does not.
+- Resolver test (mocked video pool): a baked clip with a 5 s in point seeks
+  the bake to 0 at the clip's first frame and to 1 s one second later.
+- The op refuses a transparent style and a keyframed camera, each with the
+  reason.
+- Blender op test (skipped without `BLENDER_BIN`, the way the existing ones
+  are): an animated fixture with `orbit_degrees: 180` renders frames whose
+  camera location differs between the first, middle and last frame, and the
+  stats name the orbit camera.
+- The capability suite bakes an opaque fixture with the runner mocked.
+
+### T13 — Transparent bake
+
+**Read first:** design §D6 output format. `render_animation.py`,
+`packages/video-nodes/src/nodes/timeline/outputFormats.ts` (the `webm`
+VP9 `yuva420p` entry), `packages/video-nodes/src/nodes/ffmpeg-helpers.ts`,
+`packages/blender-nodes/blender_ops/ops/render_passes.py` (RGBA PNG output).
+
+**Steps:**
+
+1. `render_animation` gains an `output: "mp4" | "png_sequence"` param; the
+   sequence path writes RGBA PNGs with `film_transparent` into the job's
+   output directory.
+2. The bake op, for a transparent style, runs the sequence render and then
+   ffmpeg to WebM VP9 `yuva420p` through the existing helper, and stores that
+   asset.
+3. The browser video resolvers treat a decode error or a bake whose first
+   frame reports no alpha as `bake_undecodable`: the live layer draws and the
+   degradation is reported.
+
+**Acceptance:**
+
+- A test that composites a baked transparent fixture over a solid color
+  through the export path and asserts the background color is visible in a
+  pixel the model does not cover.
+- The op no longer refuses a transparent style.
+- A mocked decode failure yields `bake_undecodable` and the live layer.
 
 ### T12 — Documentation and harness registry
 

--- a/docs/plans/3d-timeline-clips-tasks.md
+++ b/docs/plans/3d-timeline-clips-tasks.md
@@ -1,0 +1,355 @@
+# 3D Clips on the Timeline — Implementation Plan
+
+Companion to [3d-timeline-clips.md](3d-timeline-clips.md) (the technical
+design). Every task below is written to be executed by an agent with no prior
+conversation context. Each task's first step is: read
+`docs/plans/3d-timeline-clips.md` in full. It is the contract; this file adds
+sequencing, file-level pointers and acceptance criteria.
+
+Ground rules for every task:
+
+- After changes run the four checks in `AGENTS.md` § Mandatory Post-Change
+  Verification: `npm run test:affected`, `npm run typecheck`, `npm run lint`,
+  `npm run dev:nodetool -- harness gate --base origin/main`.
+- `packages/timeline` is pure TypeScript: no DOM, no GPU, no three.js, no
+  store imports. The render session lives in `packages/video-nodes`.
+- Web UI: primitives from `web/src/components/ui_primitives/` only, tokens per
+  `docs/DESIGN.md`. Never import raw MUI.
+- A new check must be shown failing once (`AGENTS.md` § Claims, Checks, and
+  Measurements). Every task names the test that proves it.
+- Commit per task with a conventional message. Do not reformat unrelated code.
+
+Dependency graph:
+
+```
+M1: T1 (schema) ──► T2 (scene model + channels)   T3 (render session) is independent
+    T2 + T3 ──► T4 (browser source, preview, export)
+    T2 + T3 ──► T5 (agent frames on the server)
+    T1 + T2 ──► T6 (ops, tools, capabilities)
+M2: T4 ──► T7 (add clip, drag-and-drop)   T4 + T6 ──► T8 (inspector)   T4 ──► T9 (lane thumbnails, clip frames)   T8 ──► T10 (preview orbit)
+M3: T6 + T8 ──► T11 (bake)   every task ──► T12 (docs, harness registry)
+```
+
+---
+
+## Milestone 1 — A dropped GLB previews and exports
+
+### T1 — Schema, types, defaults, validation
+
+**Goal:** a `model3d` clip round-trips through the wire schema and the
+document types, with defaults and validator codes.
+
+**Read first:** design §D1, §D2. `packages/protocol/src/api-schemas/timeline.ts`
+(`timelineClip`, `clipShapeStyle` as the pattern), `packages/timeline/src/types.ts`
+(`ClipShapeStyle`, `TimelineClip`), `packages/timeline/src/defaults.ts`,
+`packages/execution/src/timeline-debug/validate.ts`.
+
+**Steps:**
+
+1. Add `"model3d"` to `mediaType` in the Zod schema and the type. Add
+   `clipModel3DStyle` (camera, animation, lighting, lightIntensity,
+   background, bake) and `model3dStyle: clipModel3DStyle.optional()` on
+   `timelineClip`, with the doc comment that explains why an unlisted field
+   is stripped on PATCH.
+2. Mirror the types in `packages/timeline/src/types.ts` as
+   `ClipModel3DCamera`, `ClipModel3DAnimation`, `ClipModel3DStyle`, and
+   `model3dStyle?` on `TimelineClip`.
+3. `defaults.ts`: `DEFAULT_MODEL3D_STYLE` (orbit, azimuth 45, elevation 25,
+   fov 35, zoom 1, all animations, loop on, speed 1, studio lighting,
+   intensity 1, transparent). Match the `RenderToImage` prop defaults.
+4. `validate.ts`: `model3d_style_missing` (error) for a `model3d` clip with
+   no `model3dStyle` or no asset; `bake_stale` (warning) when
+   `model3dStyle.bake.dependencyHash` differs from
+   `computeModel3DBakeHash(clip)` (T11 owns the real hash; land the function
+   here as the style hash plus `currentAssetId`).
+5. `field_stripped` already detects fields the schema drops; add a case that
+   proves a `model3dStyle` survives `timelineClip.parse`.
+
+**Acceptance:**
+
+- `packages/execution/tests/timeline-debug.test.ts` (the validator suite): a
+  `model3d` clip without a style yields
+  `model3d_style_missing`; with a stale bake yields `bake_stale`; a valid
+  clip yields nothing new.
+- `packages/protocol` test: parsing a clip with `model3dStyle` keeps every
+  field.
+
+### T2 — Scene model kind, camera channels, orbit preset
+
+**Goal:** the pure scene model emits `kind: "model3d"` layers, samples four
+camera channels, and offers an `orbit` preset.
+
+**Read first:** design §D3, §D4. `packages/timeline/src/render/sceneModel.ts`
+(`ActiveLayer`, the `shape` branch of `computeActiveLayersWithHorizon`,
+`MAX_VIDEO_LAYERS`, `DroppedLayerReason`, `clipSourceTimeSec`,
+`resolveAnimatedLayerProps`), `packages/timeline/src/animation/types.ts`
+(`ANIMATED_PROPERTIES`, `ANIMATED_PROPERTY_FOLD`), `animation/presets.ts`
+(`spin` as the pattern), `keyframes.ts` (`KEYFRAME_PROPERTIES`).
+
+**Steps:**
+
+1. `ActiveLayer.kind` gains `"model3d"`; the layer carries `model3dStyle` and
+   `sourceTimeSec` (from `clipSourceTimeSec` times `animation.speed`).
+2. In `computeActiveLayersWithHorizon`, a `model3d` clip with a fresh bake
+   (hash matches, T1's function) emits a `video` layer with
+   `assetId = bake.assetId`; otherwise a `model3d` layer with
+   `assetId = effectiveAssetId(clip)`. Count live `model3d` layers against
+   `MAX_MODEL3D_LAYERS = 2`; over it, push a dropped layer with the new
+   reason `model3d_layer_cap`.
+3. Channels `cameraAzimuth` (add, 0), `cameraElevation` (add, 0),
+   `cameraZoom` (multiply, 1), `cameraFov` (add, 0) in `ANIMATED_PROPERTIES`,
+   the fold table and `KEYFRAME_PROPERTIES`. `resolveAnimatedLayerProps`
+   returns them in `anim`.
+4. Export `resolveModel3DCamera(style, anim): ClipModel3DCamera` that folds
+   the sampled channels into the style's camera. Both hosts call it so the
+   fold lives once.
+5. Preset `orbit`: role `loop`, params `degrees` (default 360) and
+   `direction`, compiles to a linear `cameraAzimuth` curve over the clip.
+
+**Acceptance:**
+
+- `packages/timeline/tests/sceneModel*.test.ts`: a `model3d` clip yields a
+  `model3d` layer with the right `sourceTimeSec` after a trim and a 2x speed;
+  a fresh bake yields a `video` layer; a stale bake yields `model3d`; a third
+  active 3D clip is dropped with `model3d_layer_cap`.
+- Animation tests: `orbit` over a 4 s clip samples `cameraAzimuth` 180 at 2 s;
+  a keyframed `cameraZoom` folds multiplicatively with the style's zoom in
+  `resolveModel3DCamera`.
+- The horizon (`nextChangeMs`) is unchanged by 3D layers.
+
+### T3 — Render session in video-nodes, multi-frame headless entry
+
+**Goal:** `createModel3DRenderSession` in the browser core, a multi-frame CDP
+entry in the page bundle, and `renderGlbFramesHeadless` on Node.
+`RenderToImage` keeps its behavior.
+
+**Read first:** design §D5. `packages/video-nodes/src/nodes/model3d/render3d-core.ts`,
+`render3d-page.ts`, `render3d-headless.ts`, `render.ts`,
+`scripts/bundle-render3d-page.mjs`, `packages/video-nodes/tests/model3d-render.test.ts` (covers `computeFraming`
+and `orbitOffset`).
+
+**Steps:**
+
+1. Split `renderGlbToPng` into `createModel3DRenderSession(glb, options)`
+   (load, meshopt, bounding sphere, lights, background, renderer, mixer) and
+   `session.render(frame)` (camera from `ClipModel3DCamera` through the
+   existing `computeFraming` and `orbitOffset`, `scene` mode picks the named
+   glTF camera, `mixer.setTime(frame.timeSec)`, render, return the canvas).
+   `session.animations` and `session.cameras` list the glTF's names.
+   `renderGlbToPng` becomes create, render once, `convertToBlob`, dispose.
+2. `render3d-page.ts`: `__nodetoolRenderGlbFrames(glbBase64, options, frames[])`
+   returns one PNG per frame from one session.
+3. `render3d-headless.ts`: `renderGlbFramesHeadless(glb, options, frames)`,
+   one Chrome launch, calls the new entry, returns `Uint8Array[]`.
+   `renderGlbHeadless` stays and delegates for one frame.
+4. Rebuild the page bundle; `PACKAGE_RUNTIME_ASSETS` already registers it.
+
+**Acceptance:**
+
+- Existing `RenderToImage` tests pass unchanged.
+- New unit test on the pure part: `scene` mode with an unknown camera name
+  throws a message naming the available cameras; `frames` with two times on
+  an animated fixture yield two different PNGs (the existing headless test
+  harness, skipped without Chrome the way the current one is).
+
+### T4 — Browser layer source, preview, export
+
+**Goal:** the live preview and the browser export draw `model3d` layers.
+
+**Read first:** design §D5 host 1. `web/src/components/timeline/preview/compositeLayers.ts`
+(`CompositeSourceResolver`), `preview/gpu/types.ts` (`CompositeSource`),
+`preview/gpu/compositor.ts` and `canvas2dCompositor.ts` (where a source
+becomes a texture or a `drawImage`), `preview/PreviewCompositor.tsx` (the
+resolver it builds, `OffscreenVideoPool` usage), `render/TimelineRenderer.ts`
+(the export resolver), `Tracks/useAssetUrl.ts`, `utils/assetHelpers.ts`.
+
+**Steps:**
+
+1. `CompositeSource` gains `OffscreenCanvas`. Both compositors accept it
+   (`copyExternalImageToTexture` and `drawImage` both take one). Add the
+   test in `preview/gpu/__tests__/` that a canvas source composites.
+2. `preview/Model3DLayerSource.ts`: a pool keyed by clip id, cap 2, of
+   `{ session, assetId }`. `acquire(layer)` fetches the GLB by asset URL,
+   caches parsed bytes per asset id (least recently used, small cap), creates
+   the session with the style's lighting and background, and returns null
+   while loading. `frame(layer, anim)` calls `resolveModel3DCamera` and
+   `session.render` and returns the canvas. `release(clipId)` disposes.
+   No WebGL is a `Model3DUnavailable` state the preview draws as an
+   outlined placeholder with the clip name.
+3. `PreviewCompositor.tsx` and `TimelineRenderer.ts`: the resolver's
+   `model3d` branch calls the source. The export creates its own pool and
+   disposes it when done.
+4. `rasterClipFrames.ts` keeps throwing for `model3d`; T9 handles it.
+
+**Acceptance:**
+
+- A Jest test for `Model3DLayerSource` with a mocked session: the pool
+  evicts at cap, returns null while loading, reuses a session across frames,
+  and reports unavailable without WebGL.
+- Manual: drop a GLB on an overlay track over a video clip, scrub, play,
+  export, and the exported MP4 shows the model at the same pose as the
+  preview at 1 s and 3 s (compare with `compare_timeline_frames` against
+  T5's frames once it lands).
+
+### T5 — Agent frames on the server
+
+**Goal:** `preview_timeline_frame` renders `model3d` layers through headless
+Chromium and reports them.
+
+**Read first:** design §D5 host 2. `packages/agents/src/timeline-preview/frames.ts`
+(the `shape` resolver branch, `PreviewLayerReport`, `PreviewDegradation`,
+`Canvas2DDegradationReason`), `rasterize.ts` (`PreviewRasterizer` cache),
+`packages/video-nodes/src/nodes/model3d/render3d-headless.ts` (T3's
+`renderGlbFramesHeadless`).
+
+**Steps:**
+
+1. Before compositing, walk the requested timecodes, collect every
+   `model3d` layer, group by asset id, and call `renderGlbFramesHeadless`
+   once per asset with the folded camera and `sourceTimeSec` per frame. Cache
+   the decoded images by `(assetId, style hash, camera, timeSec)` for the
+   call.
+2. The resolver's `model3d` branch returns the decoded image; `layerText`
+   style reporting gains `camera` and `animation_time_sec` on the layer
+   report.
+3. Chrome missing or the launch failing is a `PreviewDegradation` with reason
+   `model3d_unavailable`, not a thrown error; the layer is skipped.
+
+**Acceptance:**
+
+- `packages/agents/tests/timeline-model3d-frames.test.ts` with the headless
+  call mocked: two timecodes and one asset make one call with two frames;
+  the report lists the layer with its camera; a rejected launch yields the
+  degradation and a frame without the layer.
+- The real headless path runs under the same Chrome-gated skip as the
+  `RenderToImage` test.
+
+### T6 — Ops, tools, capabilities
+
+**Goal:** an agent can add a 3D clip, set its style, and animate its camera
+from `ui_timeline_edit` and `edit_timeline`.
+
+**Read first:** design §D8. `packages/timeline/src/ops/op.ts`,
+`ops/apply.ts` (`add_shape_clip`, `set_clip_params`),
+`packages/protocol/src/api-schemas/timeline-tool-params.ts`
+(`shapeStyleParams`, `withFieldNotes`), `web/src/lib/tools/builtin/timeline.ts`
+(`ui_timeline_edit`), `packages/agents/src/capabilities/timelines.ts` and
+`timelines.specs.ts`, `packages/agents/tests/timeline-op-parity.test.ts`.
+
+**Steps:**
+
+1. Ops `add_model3d_clip`, `set_model3d_style` in `op.ts` and `apply.ts`.
+   `add_model3d_clip` needs an asset id, lands on the named track or the
+   first `overlay` track (creating one when none), default duration 4 s,
+   default style. `set_model3d_style` is a deep partial patch.
+2. `model3dStyleParams` with field notes in `timeline-tool-params.ts`; the
+   `animate_clip` preset list picks up `orbit` from the catalog.
+3. Wire both ops through `ui_timeline_edit` and the `edit_timeline`
+   capability; the parity test enforces that both hosts expose the same op
+   set, so it fails until both do.
+4. A `timelines.specs.ts` case: add a 3D clip, set orbit, preview a frame,
+   expect a `model3d` layer in the report.
+
+**Acceptance:**
+
+- `timeline-op-parity` passes with the two new ops.
+- `capabilities-timelines` covers add, patch and the validator error for a
+  missing asset.
+
+---
+
+## Milestone 2 — Editing surface
+
+### T7 — Add clip menu and drag-and-drop
+
+**Read first:** design §D7. `web/src/components/timeline/AddClipMenu.tsx`,
+`dnd/assetToClipAdapter.ts` and its tests, `web/src/utils/nodeGenerations.ts`
+(how a model asset is recognized), `README.md` drop table.
+
+**Steps:** "3D model" entry opening the asset picker filtered to models;
+`assetToClipAdapter` accepts `model/*` or a `.glb` / `.gltf` name on `video`
+and `overlay` lanes and builds a `model3d` clip with the default style; the
+warning banner for other lanes stays.
+
+**Acceptance:** adapter tests for accept on video, accept on overlay, reject
+on audio; a `model3d` clip from the menu has the default style.
+
+### T8 — Inspector section and keyframes
+
+**Read first:** `Inspector/ClipShapeSection.tsx` (pattern),
+`Inspector/TimelineInspector.tsx`, `Inspector/ClipKeyframes.tsx`,
+`Inspector/InspectorPrimitives.tsx`, `usePersistedFold.ts`.
+
+**Steps:** `ClipModel3DSection` with camera mode, the four orbit fields,
+scene-camera and animation pickers fed by the layer source's session (a
+loading state until it resolves), loop, speed, lighting, intensity,
+background, and a Bake row (disabled with the reason until T11). Keyframes
+section lists the camera channels for a `model3d` clip.
+
+**Acceptance:** RTL tests: the section renders for a `model3d` clip only,
+patches `model3dStyle.camera.azimuthDeg` through `patchClip`, and the
+animation picker shows the names the session reports.
+
+### T9 — Lane thumbnails and clip frames
+
+**Read first:** `Tracks/clipThumbnails.ts`, `Tracks/useClipThumbnails.ts`,
+`Tracks/filmstripCells.ts`, `preview/rasterClipFrames.ts`.
+
+**Steps:** a `model3d` clip requests cells from the layer source at the cell
+source times; `renderRasterClipFrames` handles `model3d` through the same
+source so `ui_timeline_get_clip_frames` returns real frames.
+
+**Acceptance:** thumbnails test with a mocked source; `rasterClipFrames`
+test that a `model3d` clip returns one data URL per requested time.
+
+### T10 — Orbit gesture in the preview
+
+**Read first:** `preview/TransformGizmoOverlay.tsx`,
+`preview/ClipTransformContextMenu.tsx`, `Model3DEditor.tsx` orbit math.
+
+**Steps:** with a `model3d` clip selected, Alt-drag maps pointer delta to
+azimuth and elevation, Alt-wheel to zoom, written through `patchClip` on
+pointer up (one undo step per gesture). A readout shows the pose while
+dragging.
+
+**Acceptance:** RTL test that a drag of 100 px changes azimuth by the
+documented degrees-per-pixel and produces one store patch.
+
+---
+
+## Milestone 3 — Bake and documentation
+
+### T11 — Bake with Blender
+
+**Read first:** design §D6. `packages/blender-nodes/src/nodes/render-animation.ts`,
+`job.ts` (camera vocabulary, `orbit_degrees`), `packages/timeline/src/dependencyHash.ts`,
+`web/src/stores/timeline/TimelineGenerationStore.ts` (how a generated clip
+registers a job and stores a version).
+
+**Steps:**
+
+1. `computeModel3DBakeHash(clip)` in `packages/timeline`: style, asset id,
+   and the camera curves.
+2. `bake_model3d_clip` op: refuses with a message when the clip has custom
+   camera keyframes; otherwise builds the `RenderAnimation` params (orbit
+   terms, `orbit_degrees` from the `orbit` preset or 0, fps, frame range,
+   transparent) and runs it as a generation job; on completion stores
+   `model3dStyle.bake` and a clip version.
+3. Inspector Bake row: run, progress, stale badge from `bake_stale`.
+
+**Acceptance:** a test that a style edit after a bake makes the scene model
+emit the live layer again; a test that the op refuses keyframed cameras with
+the reason; the capability suite bakes a fixture with the runner mocked.
+
+### T12 — Documentation and harness registry
+
+**Steps:** `web/src/components/timeline/README.md` drop table and a "3D
+clips" section; `docs/harnesses.md` entry for the 3D layer in
+`preview_timeline_frame`; `packages/cli/src/harness/registry.ts` maps a diff
+under `packages/video-nodes/src/nodes/model3d/` to the T3 and T5 suites;
+`AGENTS.md` harness table row if a new command appears. Set this design's
+status to implemented.
+
+**Acceptance:** `npm run check:agents-docs` and `npm run capabilities:check`
+pass; `harness gate --dry-run` on a diff touching `render3d-core.ts` lists
+the T3 suite.

--- a/docs/plans/3d-timeline-clips-tasks.md
+++ b/docs/plans/3d-timeline-clips-tasks.md
@@ -351,9 +351,15 @@ generated clip registers a job and stores a version).
 
 1. Blender prerequisite, the sampled producer: `RenderAnimationParams` gains
    `frame_times?: number[]` (model time in seconds per output frame),
-   `animation_name?: string`, and `cameras?: CameraParams[]` (one per
-   frame). With `frame_times` set, `render_animation.py` selects the named
-   action (mutes every other NLA track), and for each entry calls
+   `animation_name?: string`, and `cameras?: BakeCameraParams[]` (one per
+   frame). `BakeCameraParams` extends `CameraParams` with
+   `scene_camera_name?` and `target_offset?`, the two fields
+   `ClipModel3DCamera` carries that the existing DTO does not; the mapping
+   from `ClipModel3DCamera` is one function in `packages/timeline`, tested
+   both ways. With `frame_times` set, `render_animation.py` selects the named
+   action (mutes every other NLA track) or, with `animation_name` absent,
+   leaves every action playing, the D2 default; a model with no animations
+   renders its rest pose at every entry. For each entry it calls
    `scene.frame_set(frame, subframe)` from the model time and the scene fps,
    places the orbit camera from that entry (`scene` mode keeps the glTF
    camera), and renders one still to `frame_%06d.png`; the op returns the
@@ -396,7 +402,11 @@ generated clip registers a job and stores a version).
   second frame equal to `render_image` at model time 1.0 and a third equal to
   0.5, within the existing image-compare tolerance; the same fixture with a
   180° camera sweep has different camera locations in its stats for the
-  first, middle and last frame.
+  first, middle and last frame; a two-animation fixture with no
+  `animation_name` differs from the same fixture with either name selected;
+  a fixture with no animations renders identical frames at every entry; a
+  fixture with a named glTF camera baked in `scene` mode reports that camera
+  in its stats.
 - The capability suite bakes an opaque fixture with the runner mocked.
 
 ### T13 — Transparent bake

--- a/docs/plans/3d-timeline-clips-tasks.md
+++ b/docs/plans/3d-timeline-clips-tasks.md
@@ -337,48 +337,66 @@ documented degrees-per-pixel and produces one store patch.
 ### T11 — Opaque bake with Blender
 
 **Read first:** design §D6 in full. `packages/blender-nodes/src/nodes/render-animation.ts`,
-`job.ts` (`RenderAnimationParams`, `orbit_degrees`),
-`packages/blender-nodes/blender_ops/ops/render_animation.py` (`run`, the
-`not animated and mode == "orbit"` branch), `packages/timeline/src/dependencyHash.ts`,
+`job.ts` (`RenderAnimationParams`), `packages/blender-nodes/blender_ops/ops/render_animation.py`
+(`run`, `_animate_orbit`, the `not animated and mode == "orbit"` branch),
+`render_image.py` (`write_still`), `packages/model3d/src/gltf.ts`
+(`GltfAnimation`, accessor reads), `packages/timeline/src/dependencyHash.ts`,
 `web/src/components/timeline/render/TimelineRenderer.ts` and
 `preview/PreviewCompositor.tsx` (the video seek),
-`web/src/stores/timeline/TimelineGenerationStore.ts` (how a generated clip
-registers a job and stores a version).
+`packages/agents/src/timeline-preview/frames.ts` (`decodeVideoFrameAt` and its
+`video` branch), `web/src/stores/timeline/TimelineGenerationStore.ts` (how a
+generated clip registers a job and stores a version).
 
 **Steps:**
 
-1. Blender prerequisite: `render_animation.py` keyframes the orbit camera
-   whenever `camera_mode == "orbit"`, animated model or not, and the model's
-   animation plays underneath; `orbit_degrees: 0` is a held orbit camera.
-   Update the op's docstring and `job.ts` comment, which say the sweep runs
-   only without glTF animation.
-2. `computeModel3DBakeHash(clip, sequence)` in `packages/timeline`, covering
+1. Blender prerequisite, the sampled producer: `RenderAnimationParams` gains
+   `frame_times?: number[]` (model time in seconds per output frame),
+   `animation_name?: string`, and `cameras?: CameraParams[]` (one per
+   frame). With `frame_times` set, `render_animation.py` selects the named
+   action (mutes every other NLA track), and for each entry calls
+   `scene.frame_set(frame, subframe)` from the model time and the scene fps,
+   places the orbit camera from that entry (`scene` mode keeps the glTF
+   camera), and renders one still to `frame_%06d.png`; the op returns the
+   sequence and the TS side muxes it with the ffmpeg helper. Without
+   `frame_times` the op behaves as today, so the node is unchanged.
+2. `packages/model3d`: `animationDurations(gltf)` from each animation's
+   sampler input accessor max. `packages/timeline`:
+   `computeModel3DBakeSamples(clip, sequence, durations)` returning
+   `{ frameTimes, cameras }` from `clipSourceTimeSec` at each output frame,
+   `animation.speed`, `loop` wrap or clamp, and `resolveModel3DCamera` at
+   each frame.
+3. `computeModel3DBakeHash(clip, sequence)` in `packages/timeline`, covering
    exactly the inputs design §D6 lists and nothing from `bake` itself.
    Replace T1's placeholder.
-3. Both video resolvers seek by `layer.bakeSourceTimeSec` when present, and
-   by `clipSourceTimeSec` otherwise.
-4. `bake_model3d_clip` op: refuses a transparent style (until T13) and a
-   clip with custom camera keyframes, each with a message naming the reason;
-   otherwise builds the `RenderAnimation` params (camera mode and orbit terms
-   from the style, `orbit_degrees` from the `orbit` preset or 0, fps, width
-   and height from the sequence, frame range from the clip's evaluated
-   duration) and runs it as a generation job; on completion stores
-   `model3dStyle.bake` with the hash and a clip version.
-5. Inspector Bake row: run, progress, stale badge from `bake_stale`.
+4. Every video decoder seeks by `layer.bakeSourceTimeSec` when present and
+   `clipSourceTimeSec` otherwise: the preview resolver, the export resolver,
+   and `decodeVideoFrameAt` in `frames.ts`, which takes the resolved seek
+   time as an argument instead of recomputing it from the clip.
+5. `bake_model3d_clip` op: refuses a transparent style (until T13) with a
+   message naming the reason; otherwise builds the sampled request from step
+   2 and the style, runs it as a generation job, muxes to MP4, and on
+   completion stores `model3dStyle.bake` with the hash and a clip version.
+6. Inspector Bake row: run, progress, stale badge from `bake_stale`.
 
 **Acceptance:**
 
+- Samples test: a clip with a 5 s in point and 2x speed yields
+  `frameTimes[i] = 5 + 2 * i / fps`; a reversed remap yields a decreasing
+  list; loop on past the animation's end wraps, loop off clamps; the camera
+  list under the `orbit` preset sweeps the degrees across the clip.
 - Scene model: after a bake, changing the in point, the speed, the time
   remap, the duration or the sequence fps makes the layer live again;
   changing the clip's start or opacity does not.
-- Resolver test (mocked video pool): a baked clip with a 5 s in point seeks
-  the bake to 0 at the clip's first frame and to 1 s one second later.
-- The op refuses a transparent style and a keyframed camera, each with the
-  reason.
+- Decoder tests: the browser resolvers (mocked video pool) and
+  `decodeVideoFrameAt` (mocked `forEachVideoFrame`) each seek a fresh
+  trimmed bake to 0 at the clip's first frame and to 1 s one second later;
+  the agent test asserts the first requested source timestamp is zero.
 - Blender op test (skipped without `BLENDER_BIN`, the way the existing ones
-  are): an animated fixture with `orbit_degrees: 180` renders frames whose
-  camera location differs between the first, middle and last frame, and the
-  stats name the orbit camera.
+  are): an animated fixture baked with `frame_times: [0, 1.0, 0.5]` renders a
+  second frame equal to `render_image` at model time 1.0 and a third equal to
+  0.5, within the existing image-compare tolerance; the same fixture with a
+  180° camera sweep has different camera locations in its stats for the
+  first, middle and last frame.
 - The capability suite bakes an opaque fixture with the runner mocked.
 
 ### T13 — Transparent bake
@@ -390,11 +408,10 @@ VP9 `yuva420p` entry), `packages/video-nodes/src/nodes/ffmpeg-helpers.ts`,
 
 **Steps:**
 
-1. `render_animation` gains an `output: "mp4" | "png_sequence"` param; the
-   sequence path writes RGBA PNGs with `film_transparent` into the job's
-   output directory.
-2. The bake op, for a transparent style, runs the sequence render and then
-   ffmpeg to WebM VP9 `yuva420p` through the existing helper, and stores that
+1. The sampled producer from T11 already writes PNGs; under a transparent
+   style they carry alpha through `film_transparent` and `color_mode RGBA`.
+2. The bake op, for a transparent style, muxes the sequence to WebM VP9
+   `yuva420p` through the existing helper instead of MP4, and stores that
    asset.
 3. The browser video resolvers treat a decode error or a bake whose first
    frame reports no alpha as `bake_undecodable`: the live layer draws and the

--- a/docs/plans/3d-timeline-clips.md
+++ b/docs/plans/3d-timeline-clips.md
@@ -154,17 +154,36 @@ export interface Model3DRenderSession {
   dispose(): void;
 }
 
+/** Everything a session fixes at creation. Two layers share a session only
+ * when these are equal, so the key of every pool and every headless group is
+ * `assetId` plus this object, never `assetId` alone. */
+export interface Model3DSessionOptions {
+  lighting: ClipModel3DStyle["lighting"];
+  lightIntensity: number;
+  background: ClipModel3DStyle["background"];
+  animation: ClipModel3DAnimation;
+}
+
 export function createModel3DRenderSession(
   glb: Uint8Array,
-  options: { lighting; lightIntensity; background }
+  options: Model3DSessionOptions
 ): Promise<Model3DRenderSession>;
 ```
+
+`animation` selects the mixer's actions: `clipName` plays that one glTF
+animation, absent plays all of them. `render` sets absolute time, so a scrub
+backwards after the end is a plain `setTime`. With `loop` on, the time wraps at
+the longest selected animation's duration; off, it clamps to the last frame.
+A style edit to any session option disposes the session and creates a new
+one, in the browser pool and in the headless group alike, because a mixer
+whose actions were rebuilt mid-session is the same picture as a fresh one and
+harder to prove.
 
 `renderGlbToPng` becomes a one-frame call on a session, so `RenderToImage`
 keeps its behavior and its tests. The hosts:
 
-1. **Live preview and browser export.** `web/src/components/timeline/preview/Model3DLayerSource.ts` holds a session per active `model3d` layer, keyed by clip id, in a pool capped like the video pool (a WebGL context per session, browsers allow about sixteen). It loads the GLB through the asset URL, caches parsed scenes per asset id, and its resolver returns the session's canvas as the layer's `CompositeSource`. `CompositeSource` grows an `OffscreenCanvas` member; the WebGPU compositor's `copyExternalImageToTexture` and the Canvas2D fallback both take one directly, so there is no per-frame bitmap transfer. Export steps the same resolver at exact frame times, so it is deterministic.
-2. **Agent frames.** `frames.ts` gathers the `model3d` layers across every requested timecode, groups them by asset, and renders each group in one headless Chromium page through a new `renderGlbFramesHeadless` (one launch, N frames, PNG each). The PNGs decode with `@napi-rs/canvas` `loadImage` and join the layer list like a rasterized shape. No Chrome on the host is a `PreviewDegradation` with reason `model3d_unavailable`; the layer is left out and the report says so, so an agent never mistakes a missing renderer for an empty clip.
+1. **Live preview and browser export.** `web/src/components/timeline/preview/Model3DLayerSource.ts` holds a session per active `model3d` layer, keyed by clip id and re-created when the clip's asset or session options change, in a pool capped like the video pool (a WebGL context per session, browsers allow about sixteen). It loads the GLB through the asset URL, caches parsed scenes per asset id, and its resolver returns the session's canvas as the layer's `CompositeSource`. `CompositeSource` grows an `OffscreenCanvas` member; the WebGPU compositor's `copyExternalImageToTexture` and the Canvas2D fallback both take one directly, so there is no per-frame bitmap transfer. Export steps the same resolver at exact frame times, so it is deterministic.
+2. **Agent frames.** `frames.ts` gathers the `model3d` layers across every requested timecode, groups them by asset id plus `Model3DSessionOptions`, and renders each group in one headless Chromium page through a new `renderGlbFramesHeadless` (one launch, N frames, PNG each). The PNGs decode with `@napi-rs/canvas` `loadImage` and join the layer list like a rasterized shape. No Chrome on the host is a `PreviewDegradation` with reason `model3d_unavailable`; the layer is left out and the report says so, so an agent never mistakes a missing renderer for an empty clip.
 3. **Clip frames for the agent in the browser** (`ui_timeline_get_clip_frames`, `rasterClipFrames.ts`) and **lane thumbnails** use host 1's source.
 4. **Bake** (D6) is Blender, not the session, and is the only host that draws with a different renderer.
 
@@ -174,19 +193,51 @@ lighting match to the pixel, the way text does today.
 ### D6. Bake with Blender for final quality
 
 A "Bake" action in the inspector and a `bake_model3d_clip` op run
-`nodetool.blender.RenderAnimation` with `camera_mode` and the orbit terms
-derived from `model3dStyle`, `fps` and frame range from the sequence and the
-clip, and `transparent` from the style. The result is stored in
-`model3dStyle.bake` with the `dependencyHash` of the style, the asset and the
-camera curves. The scene model emits a `video` layer from `bake.assetId` while
-the hash matches and the live `model3d` layer otherwise, so a stale bake is
-never played silently. The clip's existing version history holds the bakes.
+`nodetool.blender.RenderAnimation` and store the result in
+`model3dStyle.bake`. The scene model emits a `video` layer from `bake.assetId`
+while `bake.dependencyHash` matches the live document and the live `model3d`
+layer otherwise, so a stale bake is never played silently. The clip's existing
+version history holds the bakes.
 
-Blender's orbit sweep is constant speed, so a bake reproduces the `orbit`
-preset and a static camera exactly and approximates arbitrary camera keyframes
-by sampling them into a camera path. That sampling is a second Blender job
-option and its own task; until it ships, the bake action refuses a clip with
-custom camera keyframes and says why.
+**Time origin.** A bake is the clip's evaluated picture, clip-local: frame `i`
+of the video is what the live layer draws at timeline time
+`clip.startMs + i / fps`, with in point, speed, time remap, `animation.speed`
+and the camera curves already applied. The scene model therefore emits the
+baked `video` layer with `bakeSourceTimeSec = (timeMs - clip.startMs) / 1000`
+and both video resolvers seek by that field when it is present instead of
+`clipSourceTimeSec(clip, timeMs)`. A trimmed clip whose source starts at 5 s
+bakes into a video that starts at 0 s and plays from 0 s.
+
+**Dependency hash.** `computeModel3DBakeHash(clip, sequence)` covers every
+input the picture depends on: `model3dStyle` without `bake`, the asset id, the
+clip's animations (the camera curves and the `orbit` preset among them),
+`inPointMs`, `outPointMs`, `durationMs`, `speed`, the time remap, and the
+sequence's fps, width and height. A change to any of them makes the bake
+stale; a change to the clip's start, track, transform, opacity, effects, mask
+or matte does not, because those apply to the baked layer the way they apply
+to any video.
+
+**Output format.** The Blender op writes MP4/H.264 in `yuv420p`, which has no
+alpha. An opaque bake (`background.transparent === false`) uses it unchanged.
+A transparent bake needs a second path: Blender renders an RGBA PNG sequence
+with `film_transparent`, and ffmpeg (the bounded runner the timeline node
+already uses) encodes it to WebM VP9 `yuva420p`, the same alpha format
+`packages/video-nodes/src/nodes/timeline/outputFormats.ts` already declares.
+Until that path ships, `bake_model3d_clip` refuses a transparent style and
+says so. A browser that cannot decode the alpha bake (the video element errors
+or reports no alpha) falls back to the live layer with a
+`bake_undecodable` degradation rather than drawing an opaque box over footage.
+
+**Camera.** Blender's orbit is keyframed only when the model has no animation
+of its own (`render_animation.py`, the `not animated and mode == "orbit"`
+branch), so an animated model with the `orbit` preset would bake without its
+camera move. The bake task adds a Blender-side prerequisite: `orbit_degrees`
+drives the orbit camera whether or not the model is animated, with the model's
+animation playing underneath. A static camera bakes through `camera_mode:
+orbit` with `orbit_degrees: 0`, the `orbit` preset through its degrees, and a
+`scene` camera through `camera_mode: scene`. Custom camera keyframes need a
+sampled camera path the job does not accept yet; the op refuses them and
+names the reason.
 
 ### D7. Editing surface
 
@@ -209,6 +260,7 @@ custom camera keyframes and says why.
 - **R3. Server preview latency.** One Chromium launch per `preview_timeline_frame` call with 3D layers, about a second, then per-frame render under SwiftShader. Acceptable for a tool that returns a handful of frames; the report carries the render time.
 - **R4. Large models.** A GLB is fetched and parsed once per asset per session pool and evicted least recently used. The inspector shows a loading state until the session resolves.
 - **R5. Bake fidelity.** Blender's lighting presets and three's are not the same picture. The bake is the intended look, the live layer is the proxy, and the inspector says so.
+- **R6. Alpha bakes in the browser.** VP9 with alpha decodes in Chromium and Firefox and not in Safari. The `bake_undecodable` fallback keeps the live layer on screen there, and the export still runs in Chromium.
 
 ## Rollout
 
@@ -216,7 +268,8 @@ custom camera keyframes and says why.
 2. Scene model kind, camera channels, orbit preset, browser layer source: a dropped GLB previews and exports.
 3. Agent frames on the server, ops and tools, capability suites.
 4. Inspector, add menu, drag-and-drop, lane thumbnails, preview orbit gesture.
-5. Bake with Blender.
+5. Opaque bakes with Blender, with the orbit-on-animated-model prerequisite.
+6. Transparent bakes through the PNG sequence and ffmpeg.
 
 Steps 1 and 2 are a shippable slice: a glTF asset on an overlay track,
 rendered over footage with a transparent background, its animation scrubbed

--- a/docs/plans/3d-timeline-clips.md
+++ b/docs/plans/3d-timeline-clips.md
@@ -201,12 +201,31 @@ version history holds the bakes.
 
 **Time origin.** A bake is the clip's evaluated picture, clip-local: frame `i`
 of the video is what the live layer draws at timeline time
-`clip.startMs + i / fps`, with in point, speed, time remap, `animation.speed`
-and the camera curves already applied. The scene model therefore emits the
-baked `video` layer with `bakeSourceTimeSec = (timeMs - clip.startMs) / 1000`
-and both video resolvers seek by that field when it is present instead of
-`clipSourceTimeSec(clip, timeMs)`. A trimmed clip whose source starts at 5 s
-bakes into a video that starts at 0 s and plays from 0 s.
+`clip.startMs + 1000 * i / fps`, with in point, speed, time remap,
+`animation.speed` and the camera curves already applied. The scene model
+therefore emits the baked `video` layer with
+`bakeSourceTimeSec = (timeMs - clip.startMs) / 1000`, and every video decoder
+seeks by that field when it is present instead of `clipSourceTimeSec(clip,
+timeMs)`: the live preview, the browser export, and the agent frame path's
+`decodeVideoFrameAt`. A trimmed clip whose source starts at 5 s bakes into a
+video that starts at 0 s and plays from 0 s in all three.
+
+**Producer.** The existing job renders consecutive scene frames at the output
+fps, which cannot express a trimmed, sped-up, reversed or looped clip. The
+bake sends Blender the evaluated sample list instead: `render_animation`
+gains `frame_times: number[]`, one model time in seconds per output frame,
+plus `animation_name` and the camera per frame. The timeline side computes
+the list with the same functions the live layer uses: `clipSourceTimeSec` at
+each output frame, times `animation.speed`, wrapped or clamped by
+`animation.loop` against the selected animation's duration, which
+`packages/model3d` reads from the glTF's sampler input accessors. Blender
+then renders one still per entry, setting the scene frame from the model time
+(`frame_set` with the subframe), the orbit camera from that entry's camera,
+and the selected action as the only one playing, and the frames are muxed
+with ffmpeg. This is the same still-per-frame loop the transparent bake needs,
+so both bake formats share one op path and the H.264 branch becomes the mux
+of an opaque sequence. A reversed remap is a decreasing list; a loop past the
+end wraps in the list; neither needs anything from Blender beyond `frame_set`.
 
 **Dependency hash.** `computeModel3DBakeHash(clip, sequence)` covers every
 input the picture depends on: `model3dStyle` without `bake`, the asset id, the
@@ -217,27 +236,26 @@ stale; a change to the clip's start, track, transform, opacity, effects, mask
 or matte does not, because those apply to the baked layer the way they apply
 to any video.
 
-**Output format.** The Blender op writes MP4/H.264 in `yuv420p`, which has no
-alpha. An opaque bake (`background.transparent === false`) uses it unchanged.
-A transparent bake needs a second path: Blender renders an RGBA PNG sequence
-with `film_transparent`, and ffmpeg (the bounded runner the timeline node
-already uses) encodes it to WebM VP9 `yuva420p`, the same alpha format
-`packages/video-nodes/src/nodes/timeline/outputFormats.ts` already declares.
-Until that path ships, `bake_model3d_clip` refuses a transparent style and
-says so. A browser that cannot decode the alpha bake (the video element errors
+**Output format.** The sampled producer writes a PNG sequence, RGBA under
+`film_transparent`. An opaque bake muxes it to MP4/H.264 `yuv420p`; a
+transparent bake encodes it to WebM VP9 `yuva420p`, the alpha format
+`packages/video-nodes/src/nodes/timeline/outputFormats.ts` already declares,
+both through the bounded ffmpeg runner the timeline node uses. Until the
+transparent encode ships (T13), `bake_model3d_clip` refuses a transparent
+style and says so. A browser that cannot decode the alpha bake (the video element errors
 or reports no alpha) falls back to the live layer with a
 `bake_undecodable` degradation rather than drawing an opaque box over footage.
 
 **Camera.** Blender's orbit is keyframed only when the model has no animation
 of its own (`render_animation.py`, the `not animated and mode == "orbit"`
 branch), so an animated model with the `orbit` preset would bake without its
-camera move. The bake task adds a Blender-side prerequisite: `orbit_degrees`
-drives the orbit camera whether or not the model is animated, with the model's
-animation playing underneath. A static camera bakes through `camera_mode:
-orbit` with `orbit_degrees: 0`, the `orbit` preset through its degrees, and a
-`scene` camera through `camera_mode: scene`. Custom camera keyframes need a
-sampled camera path the job does not accept yet; the op refuses them and
-names the reason.
+camera move. The sampled producer above removes that branch: each
+`frame_times` entry carries its own resolved `ClipModel3DCamera` (the style
+folded with the sampled channels, the same `resolveModel3DCamera` the live
+layer calls), and the op places the orbit camera per still. A static camera,
+the `orbit` preset and custom camera keyframes are all just different lists;
+`scene` mode uses the glTF camera and ignores the orbit terms. Nothing is
+refused for its camera.
 
 ### D7. Editing surface
 

--- a/docs/plans/3d-timeline-clips.md
+++ b/docs/plans/3d-timeline-clips.md
@@ -1,0 +1,223 @@
+# 3D Clips on the Timeline — Technical Design
+
+Status: proposed.
+Companion doc: [3d-timeline-clips-tasks.md](3d-timeline-clips-tasks.md) (implementation plan, agent-consumable tasks).
+
+## Goal
+
+Put a glTF scene on the timeline the way an image or a title goes on it: drop a
+model on a video or overlay track, scrub it, orbit the camera, key the camera,
+let its glTF animation play against the playhead, composite it over footage
+with the effects, masks, mattes and transitions every other clip has, and see
+the same picture in the live preview, the browser export, and the agent's
+`preview_timeline_frame`. Final quality comes from a bake through Blender into
+an ordinary video asset the clip then plays.
+
+## Non-goals
+
+- A new track type. 3D is picture, so it lives on `video` and `overlay` tracks.
+- Editing geometry, materials or lights from the timeline. That is the model
+  editor and `edit_model3d`, on the asset.
+- Per-clip overrides of individual scene nodes. A variant is a second asset.
+- More than one model per clip. Two models are two clips, composed with a
+  group.
+- Rendering 3D in the server ffmpeg rough cut. It stays a rough cut, and a
+  baked clip is a video clip it already handles.
+
+## What exists
+
+| Concern | Where it lives |
+| --- | --- |
+| Clip kinds | `mediaType` in `packages/protocol/src/api-schemas/timeline.ts` and `packages/timeline/src/types.ts`; `text` and `shape` clips carry `textStyle` / `shapeStyle` and no asset. |
+| Scene resolution | `packages/timeline/src/render/sceneModel.ts`: `computeActiveLayersWithHorizon` emits `ActiveLayer { kind: "video" \| "image" \| "text" \| "shape" \| "caption" }`, resolves groups, mattes, masks, transitions, and drops layers over `MAX_VIDEO_LAYERS` with a `DroppedLayerReason`. |
+| Animation | `packages/timeline/src/animation/`: `ANIMATED_PROPERTIES` with a fold per channel, presets, and `resolveAnimatedLayerProps` sampling every channel for a layer at a time. Keyframes are curves on the `custom` preset (`keyframes.ts`). |
+| Browser compositing | `web/src/components/timeline/preview/compositeLayers.ts` maps `ActiveLayer` to `CompositeLayer` for both the live `PreviewCompositor` and the `TimelineRenderer` export. A host supplies pixels through `CompositeSourceResolver`; `CompositeSource` is a video element, an image element or an `ImageBitmap`. |
+| Agent frames | `packages/agents/src/timeline-preview/frames.ts` composites the same layers on `@napi-rs/canvas`; `PreviewRasterizer` draws text, shape and caption layers; the report lists degradations and dropped layers. |
+| 3D rendering, browser | `packages/video-nodes/src/nodes/model3d/render3d-core.ts`: three.js `renderGlbToPng` on an `OffscreenCanvas`, orbit camera in `azimuthDeg` / `elevationDeg` / `fovDeg` / `zoom`, lighting presets, transparent background. |
+| 3D rendering, server | `render3d-headless.ts` launches headless Chromium with SwiftShader and calls the bundled `render3d-page.js` over CDP. `@nodetool-ai/agents` already depends on `@nodetool-ai/video-nodes`. |
+| 3D rendering, final | `packages/blender-nodes`: `nodetool.blender.RenderAnimation` renders a glTF's animation or an orbit sweep to H.264 with the same camera vocabulary. |
+| 3D editor | `web/src/components/model_editor/Model3DEditor.tsx` on react-three-fiber; `Model3DCameraPose` is orbit terms around a target. |
+| Generated clips | `bindingKind`, `paramOverrides`, `currentAssetId`, versions, `dependencyHash.ts` and `staleSet.ts` decide when a generated clip is stale. |
+
+## Decisions
+
+### D1. A `model3d` clip, not a 3D track
+
+`mediaType: "model3d"` joins `image`, `video`, `text`, `shape`. Tracks keep
+their five types. A track type changes what the mixer, ripple, drop rules and
+header controls do, and none of that differs for a 3D picture. Drop rules
+extend the existing table: a `model/*` or `.glb` asset lands on `video` and
+`overlay` lanes.
+
+### D2. The model is the clip's asset, the look is `model3dStyle`
+
+The glTF lives in `currentAssetId`, exactly where an image clip keeps its
+image. Replace, drag-and-drop, `effectiveAssetId`, thumbnails, versions and
+`inputAssetHashes` in the dependency hash all work unchanged. Everything the
+timeline adds on top is one optional block, persisted in the Zod schema (a
+field absent from the schema is stripped on PATCH):
+
+```ts
+// packages/timeline/src/types.ts
+
+export type Model3DCameraMode = "orbit" | "scene";
+
+export interface ClipModel3DCamera {
+  /** `orbit` frames the model's bounding sphere; `scene` uses a glTF camera. */
+  mode: Model3DCameraMode;
+  /** Orbit terms, the vocabulary of RenderToImage, the Blender job and the editor pose. */
+  azimuthDeg: number;
+  elevationDeg: number;
+  fovDeg: number;
+  /** Distance multiplier on the auto-framed fit: >1 closer. */
+  zoom: number;
+  /** Look-at offset from the bounding-sphere center, world units. */
+  targetOffset?: [number, number, number];
+  /** `scene` mode: the glTF camera's name; the first camera when absent. */
+  sceneCameraName?: string;
+}
+
+export interface ClipModel3DAnimation {
+  /** glTF animation name; every animation plays when absent. */
+  clipName?: string;
+  loop: boolean;
+  /** Playback multiplier on top of the clip's own speed / time remap. */
+  speed: number;
+}
+
+export interface ClipModel3DStyle {
+  camera: ClipModel3DCamera;
+  animation: ClipModel3DAnimation;
+  lighting: "studio" | "soft" | "flat";
+  lightIntensity: number;
+  background: { transparent: true } | { transparent: false; color: string };
+  /**
+   * A Blender render of this clip at a given style. The scene model plays it
+   * as video while `dependencyHash` matches the live style; a style edit
+   * makes it stale and the live layer draws again.
+   */
+  bake?: { assetId: string; dependencyHash: string };
+}
+```
+
+`TimelineClip.model3dStyle?: ClipModel3DStyle`. Defaults live in
+`packages/timeline/src/defaults.ts` next to the text and shape defaults.
+
+### D3. Time: the glTF animation follows the clip's source time
+
+`clipSourceTimeSec(clip, timeMs)` already resolves in point, speed and time
+remap for video. A 3D layer uses the same number, times `animation.speed`, as
+the `AnimationMixer` time. Trimming hides animation instead of deleting it,
+a split copies the style and moves `inPointMs`, and a reversed remap plays the
+animation backwards, the same as video. With `loop` on, the mixer wraps at the
+animation's duration; off, it holds the last frame.
+
+### D4. Camera moves are animation channels
+
+Four channels join `ANIMATED_PROPERTIES`, each additive on top of
+`model3dStyle.camera`:
+
+| Channel | Fold | Identity |
+| --- | --- | --- |
+| `cameraAzimuth` | add | 0 |
+| `cameraElevation` | add | 0 |
+| `cameraZoom` | multiply | 1 |
+| `cameraFov` | add | 0 |
+
+Keyframes come free: `KEYFRAME_PROPERTIES` gains the four, the inspector's
+Keyframes section keys them at the playhead, and `keyframeValueAt` samples
+them. One preset joins the catalog: `orbit` (role `loop`, `degrees` 360,
+`direction`) drives `cameraAzimuth`, so "make it a turntable" is one
+`animate_clip` call. The channels are ignored on any layer that is not
+`model3d`, the way `wipeProgress` is ignored without a wipe.
+
+### D5. One render session, four hosts
+
+`render3d-core.ts` becomes a session: load once, render many.
+
+```ts
+// packages/video-nodes/src/nodes/model3d/render3d-core.ts
+
+export interface Model3DRenderFrame {
+  timeSec: number;
+  camera: ClipModel3DCamera;   // already folded with the sampled channels
+  width: number;
+  height: number;
+}
+
+export interface Model3DRenderSession {
+  /** Names of the glTF's animations and cameras, for the inspector and the validator. */
+  readonly animations: readonly string[];
+  readonly cameras: readonly string[];
+  /** Draws one frame into the session's canvas and returns it. */
+  render(frame: Model3DRenderFrame): OffscreenCanvas;
+  dispose(): void;
+}
+
+export function createModel3DRenderSession(
+  glb: Uint8Array,
+  options: { lighting; lightIntensity; background }
+): Promise<Model3DRenderSession>;
+```
+
+`renderGlbToPng` becomes a one-frame call on a session, so `RenderToImage`
+keeps its behavior and its tests. The hosts:
+
+1. **Live preview and browser export.** `web/src/components/timeline/preview/Model3DLayerSource.ts` holds a session per active `model3d` layer, keyed by clip id, in a pool capped like the video pool (a WebGL context per session, browsers allow about sixteen). It loads the GLB through the asset URL, caches parsed scenes per asset id, and its resolver returns the session's canvas as the layer's `CompositeSource`. `CompositeSource` grows an `OffscreenCanvas` member; the WebGPU compositor's `copyExternalImageToTexture` and the Canvas2D fallback both take one directly, so there is no per-frame bitmap transfer. Export steps the same resolver at exact frame times, so it is deterministic.
+2. **Agent frames.** `frames.ts` gathers the `model3d` layers across every requested timecode, groups them by asset, and renders each group in one headless Chromium page through a new `renderGlbFramesHeadless` (one launch, N frames, PNG each). The PNGs decode with `@napi-rs/canvas` `loadImage` and join the layer list like a rasterized shape. No Chrome on the host is a `PreviewDegradation` with reason `model3d_unavailable`; the layer is left out and the report says so, so an agent never mistakes a missing renderer for an empty clip.
+3. **Clip frames for the agent in the browser** (`ui_timeline_get_clip_frames`, `rasterClipFrames.ts`) and **lane thumbnails** use host 1's source.
+4. **Bake** (D6) is Blender, not the session, and is the only host that draws with a different renderer.
+
+Browser and server share the core, so the tone mapping, color space and
+lighting match to the pixel, the way text does today.
+
+### D6. Bake with Blender for final quality
+
+A "Bake" action in the inspector and a `bake_model3d_clip` op run
+`nodetool.blender.RenderAnimation` with `camera_mode` and the orbit terms
+derived from `model3dStyle`, `fps` and frame range from the sequence and the
+clip, and `transparent` from the style. The result is stored in
+`model3dStyle.bake` with the `dependencyHash` of the style, the asset and the
+camera curves. The scene model emits a `video` layer from `bake.assetId` while
+the hash matches and the live `model3d` layer otherwise, so a stale bake is
+never played silently. The clip's existing version history holds the bakes.
+
+Blender's orbit sweep is constant speed, so a bake reproduces the `orbit`
+preset and a static camera exactly and approximates arbitrary camera keyframes
+by sampling them into a camera path. That sampling is a second Blender job
+option and its own task; until it ships, the bake action refuses a clip with
+custom camera keyframes and says why.
+
+### D7. Editing surface
+
+- **Add.** `AddClipMenu` gets "3D model" (pick a glTF asset). `assetToClipAdapter` accepts `model/*` content types and `.glb` names for `video` and `overlay` lanes.
+- **Inspector.** `ClipModel3DSection`: camera mode, the four orbit fields, a scene-camera picker and an animation picker filled from the session's `cameras` and `animations`, loop and speed, lighting and intensity, background, and Bake with its stale state. The Keyframes section offers the camera channels.
+- **Preview.** With a `model3d` clip selected, Alt-drag on the preview orbits (`azimuthDeg`, `elevationDeg`), Alt-wheel changes `zoom`, and either writes `model3dStyle.camera` through `patchClip` like the 2D transform gizmo writes `transform`.
+- **Lane.** A filmstrip like video, cells from the layer source at a few source times.
+
+### D8. Agent surface
+
+- Ops in `packages/timeline/src/ops/op.ts`, applied in `apply.ts`, parsed by `timeline-tool-params.ts`: `add_model3d_clip { assetId, trackId?, startMs?, durationMs?, style? }`, `set_model3d_style { target, patch }`, `bake_model3d_clip { target }`. Both `ui_timeline_edit` and the `edit_timeline` capability reach them through the shared op union.
+- `preview_timeline_frame` reports a `model3d` layer with the camera it drew and the animation time, next to the text a text layer reports.
+- `validate_timeline` adds `model3d_style_missing` (a `model3d` clip without a style or asset) and `bake_stale` (a bake whose hash no longer matches, as a warning).
+- The model3d capability suite and the timeline capability suite each gain a case; `harness gate` runs them on a diff under either package.
+
+## Risks
+
+- **R1. GPU-less browsers.** The session runs on WebGL; a machine without it gets the same `model3d_unavailable` degradation the server reports, drawn as an outlined placeholder in the preview. Nothing else in the timeline breaks.
+- **R2. Context limits.** One WebGL context per active 3D layer, capped at two, over the existing video cap. A third active 3D clip is reported as a dropped layer with reason `model3d_layer_cap`.
+- **R3. Server preview latency.** One Chromium launch per `preview_timeline_frame` call with 3D layers, about a second, then per-frame render under SwiftShader. Acceptable for a tool that returns a handful of frames; the report carries the render time.
+- **R4. Large models.** A GLB is fetched and parsed once per asset per session pool and evicted least recently used. The inspector shows a loading state until the session resolves.
+- **R5. Bake fidelity.** Blender's lighting presets and three's are not the same picture. The bake is the intended look, the live layer is the proxy, and the inspector says so.
+
+## Rollout
+
+1. Schema, defaults, validation, and the render session with tests.
+2. Scene model kind, camera channels, orbit preset, browser layer source: a dropped GLB previews and exports.
+3. Agent frames on the server, ops and tools, capability suites.
+4. Inspector, add menu, drag-and-drop, lane thumbnails, preview orbit gesture.
+5. Bake with Blender.
+
+Steps 1 and 2 are a shippable slice: a glTF asset on an overlay track,
+rendered over footage with a transparent background, its animation scrubbed
+with the playhead, exported.


### PR DESCRIPTION
## What changed

Two documents under `docs/plans/`, no code. `3d-timeline-clips.md` is the technical design for putting a glTF scene on the timeline: a `model3d` clip on video and overlay tracks rather than a new track type, the model as the clip's asset with a `model3dStyle` block for camera, animation, lighting and background, the glTF animation following the clip's source time, four additive camera channels plus an `orbit` preset in the existing animation system, one three.js render session in `packages/video-nodes` shared by the browser preview, the browser export and the headless agent preview, and a Blender bake stored on the clip for final quality. `3d-timeline-clips-tasks.md` cuts it into twelve agent-executable tasks across three milestones with file pointers, dependency graph and acceptance tests, following the format of `motion-design-tasks.md`.

## Verification

- [x] `npm run test:affected -- --dry-run` reports `nothing — no workspace owns the changed files` (docs only)
- [ ] `npm run typecheck` (no code changed)
- [ ] `npm run lint` (no code changed)
- [ ] `npm run dev:nodetool -- harness gate --base main` (docs-only diff maps to no harness)

## Agent capabilities

Skipped: no capability is added or changed by this diff. The design names the capabilities a later task adds.

## New checks

Skipped: no check, rule or audit is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016T3mw6LABZatUNrN6E4Wxi

---
_Generated by [Claude Code](https://claude.ai/code/session_016T3mw6LABZatUNrN6E4Wxi)_