### PR TITLE
feat(entities): swap an entity's picture without moving its id

### DIFF
--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -988,9 +988,12 @@ reads one in full, and **`apply_entities`** pastes their descriptors into a
 prompt and returns the reference-image asset ids to pass to an image model.
 **`create_entity`** tags one of the caller's image assets as an entity (the
 same marker write the browser's Save Entity does; generate or save the image
-first), **`update_entity`** changes an existing entity's fields or moves it to
-a new photo via `asset_id`, and **`delete_entity`** untags one (marker cleared,
-asset kept).
+first), **`update_entity`** changes an existing entity's fields — or the
+picture it shows, via `asset_id` — and **`delete_entity`** untags one (marker
+cleared, asset kept). Swapping the picture writes `reference_asset_id` onto the
+marker instead of moving the marker to the other asset, so the entity keeps the
+id boards and scripts cast it by; `asset_id: null` puts it back on its own
+bytes. The browser's entity editor writes the same field.
 
 The injection rule is `injectEntities` in `@nodetool-ai/protocol`, shared with
 the browser's `ui_entity_apply` and the Director node: with explicit

--- a/packages/agents/src/capabilities/entities.specs.ts
+++ b/packages/agents/src/capabilities/entities.specs.ts
@@ -163,7 +163,7 @@ export const createEntitySpec: CapabilitySpec = {
     "location, style, or prop). The asset keeps its bytes; this writes the " +
     "entity marker onto it, exactly what the browser's Save Entity does. The " +
     "asset must be yours and must be an image, and must not already be an " +
-    "entity — update_entity retags one.",
+    "entity — update_entity edits the one that is already there.",
   inputSchema: CREATE_ENTITY_SCHEMA,
   category: "write",
   userMessage: (params) =>
@@ -178,10 +178,13 @@ export const UPDATE_ENTITY_SCHEMA: JsonSchema = {
       description: "The entity's id (its asset id), from list_entities."
     },
     asset_id: {
-      type: "string",
+      type: ["string", "null"],
       description:
-        "Move the entity to a different image asset (retarget in one call). " +
-        "The new asset must be yours and must be an image. Omit to keep the current photo."
+        "Swap the entity's picture for a different image asset. The new asset " +
+        "must be yours and must be an image; the entity keeps its id, so every " +
+        "board and script that cast it still resolves. Pass null (or the " +
+        "entity's own id) to go back to its original image. Omit to leave the " +
+        "picture alone."
     },
     kind: {
       ...KIND_PROPERTY,
@@ -217,9 +220,9 @@ export const updateEntitySpec: CapabilitySpec = {
   name: "update_entity",
   description:
     "Change an existing entity's fields — kind, name, descriptor, notes, " +
-    "voice, tags, LoRA, palette, or its reference photo via asset_id. Only the " +
-    "fields you pass change; pass asset_id to retarget the entity to a " +
-    "different image asset in one call (otherwise use delete_entity + create_entity).",
+    "voice, tags, LoRA, palette, or the picture it shows via asset_id. Only " +
+    "the fields you pass change. Swapping the picture keeps the entity's id, " +
+    "so nothing that already cast it has to be re-pointed.",
   inputSchema: UPDATE_ENTITY_SCHEMA,
   category: "write",
   userMessage: (params) => `Updating entity ${String(params["entity_id"])}`

--- a/packages/agents/src/capabilities/entities.ts
+++ b/packages/agents/src/capabilities/entities.ts
@@ -9,7 +9,7 @@
  * The browser reads the library through `ui_entity_list` / `ui_entity_apply`,
  * which need an open app. These six answer the same questions with no
  * browser: list, read one, season a prompt, tag an asset as an entity,
- * retag one, and untag one. The injection rule itself is `injectEntities` in
+ * edit one (its fields, or the picture it shows), and untag one. The injection rule itself is `injectEntities` in
  * `@nodetool-ai/protocol`, shared with the browser tool and the Director node,
  * so a prompt seasoned here and one seasoned in the editor come out the same.
  */
@@ -39,6 +39,13 @@ import { isRecord, isString } from "../utils/type-guards.js";
 
 /** The metadata key an entity's marker lives under, set by the library UI. */
 export const ENTITY_METADATA_KEY = "nodetool_entity";
+
+/**
+ * The marker field naming the image an entity shows, when it is not the marker
+ * asset's own bytes. Swapping the picture writes this rather than moving the
+ * marker, so the entity id — which storyboards and scripts store — never moves.
+ */
+export const REFERENCE_ASSET_KEY = "reference_asset_id";
 
 export const ENTITY_KINDS: ReadonlySet<string> = new Set([
   "character",
@@ -71,6 +78,20 @@ export function entityFromAsset(
   if (!ENTITY_KINDS.has(kind)) return null;
 
   const ext = MIME_TO_EXT[asset.content_type] ?? "png";
+  // A swapped reference image points at another asset, whose content type is
+  // not in hand here — `asset://<id>` with no extension is what the web library
+  // writes too, and resolves through the extension-tolerant asset lookup.
+  const swapped = isString(raw[REFERENCE_ASSET_KEY])
+    ? raw[REFERENCE_ASSET_KEY].trim()
+    : "";
+  const referenceImage =
+    swapped && swapped !== asset.id
+      ? { type: "image" as const, asset_id: swapped, uri: `asset://${swapped}` }
+      : {
+          type: "image" as const,
+          asset_id: asset.id,
+          uri: `asset://${asset.id}.${ext}`
+        };
   const entity: Entity = {
     type: "entity",
     id: asset.id,
@@ -80,9 +101,7 @@ export function entityFromAsset(
     voice_id: isString(raw["voice_id"]) ? raw["voice_id"] : null,
     lora: (raw["lora"] as Entity["lora"]) ?? null,
     palette: (raw["palette"] as Entity["palette"]) ?? null,
-    reference_images: [
-      { type: "image", asset_id: asset.id, uri: `asset://${asset.id}.${ext}` }
-    ]
+    reference_images: [referenceImage]
   };
   if (isString(raw["description"])) {
     entity.description = raw["description"];
@@ -372,6 +391,27 @@ const createEntity: CapabilityExport = {
   }
 };
 
+/**
+ * The asset a swap points the entity's picture at: it must be the caller's and
+ * must be an image. Returns the error to hand back, or null when it is usable.
+ */
+const referenceAssetProblem = async (
+  run: CapabilityRun,
+  assetId: string
+): Promise<string | null> => {
+  const userId = userIdOf(run.context);
+  if (!userId) return "No user is bound to this session.";
+  const { Asset } = await import("@nodetool-ai/models");
+  const asset = await Asset.find(userId, assetId);
+  if (!asset) {
+    return `Asset ${assetId} was not found.`;
+  }
+  if (!asset.content_type.startsWith("image/")) {
+    return `${asset.name || asset.id} is a ${asset.content_type} asset; entities are image assets. Generate or upload an image first.`;
+  }
+  return null;
+};
+
 const updateEntity: CapabilityExport = {
   spec: updateEntitySpec,
   impl: async (run, params) => {
@@ -380,103 +420,23 @@ const updateEntity: CapabilityExport = {
       return { error: "entity_id is required (use list_entities to find one)." };
     }
 
+    // A swap changes which picture the entity shows, never which asset carries
+    // the marker: boards and scripts store the entity id, and moving it would
+    // leave every one of those references pointing at nothing.
     const rawAssetId = params["asset_id"];
-    const wantsRetarget =
-      rawAssetId !== undefined &&
-      isString(rawAssetId) &&
-      rawAssetId.trim() !== "" &&
-      rawAssetId.trim() !== entityId.trim();
-    if (rawAssetId !== undefined && !wantsRetarget) {
-      if (!isString(rawAssetId)) {
-        return { error: "asset_id must be a string." };
-      }
-      const trimmed = rawAssetId.trim();
-      if (trimmed !== "" && trimmed === entityId.trim()) {
-        // Same-asset — treat as no move; fall through to normal field update.
-      } else if (trimmed === "") {
-        return { error: "asset_id must be a non-empty string." };
+    let swapTo: string | null | undefined;
+    if (rawAssetId !== undefined) {
+      if (rawAssetId === null) {
+        swapTo = null;
+      } else if (!isString(rawAssetId) || rawAssetId.trim() === "") {
+        return { error: "asset_id must be a non-empty string, or null to go back to the entity's own image." };
       } else {
-        return { error: "asset_id must be a string." };
-      }
-    }
-
-    if (wantsRetarget) {
-      const targetId = (rawAssetId as string).trim();
-      const userId = userIdOf(run.context);
-      if (!userId) return { error: "No user is bound to this session." };
-      const { Asset } = await import("@nodetool-ai/models");
-      const sourceAsset = await Asset.find(userId, entityId.trim());
-      const sourceEntity = sourceAsset ? entityFromAsset(sourceAsset) : null;
-      if (!sourceEntity || !sourceAsset) {
-        return { error: `Asset ${entityId} is not an entity — use create_entity to tag it.` };
-      }
-      const readOnly = Asset.systemEntityRefusal(sourceAsset);
-      if (readOnly) {
-        return { error: readOnly };
-      }
-      const targetAsset = await Asset.find(userId, targetId);
-      if (!targetAsset) {
-        return { error: `Asset ${targetId} was not found.` };
-      }
-      if (!targetAsset.content_type.startsWith("image/")) {
-        return {
-          error: `${targetAsset.name || targetAsset.id} is a ${targetAsset.content_type} asset; entities are image assets. Generate or upload an image first.`
-        };
-      }
-      const targetExisting = entityFromAsset(targetAsset);
-      if (targetExisting) {
-        return {
-          error: "That asset is already an entity — pick another photo or update that entity instead."
-        };
-      }
-      const rawMarker = sourceAsset.metadata?.[ENTITY_METADATA_KEY];
-      const marker: Record<string, unknown> = isRecord(rawMarker)
-        ? { ...rawMarker }
-        : {};
-      const touched = { value: 1 }; // the move itself counts
-      let problem: string | null = null;
-
-      const kind = params["kind"];
-      if (kind !== undefined) {
-        if (!isString(kind) || !ENTITY_KINDS.has(kind)) {
-          problem = `kind must be one of: ${[...ENTITY_KINDS].join(", ")}.`;
-        } else {
-          marker["kind"] = kind;
-          touched.value += 1;
+        swapTo = rawAssetId.trim();
+        if (swapTo !== entityId.trim()) {
+          const problem = await referenceAssetProblem(run, swapTo);
+          if (problem) return { error: problem };
         }
       }
-      for (const field of ["name", "descriptor", "description"] as const) {
-        const value = params[field];
-        if (value === undefined) continue;
-        if (
-          !isString(value) ||
-          (field !== "description" && value.trim() === "")
-        ) {
-          problem =
-            problem ??
-            `${field} must be${field === "description" ? " a string" : " a non-empty string"}.`;
-          break;
-        }
-        marker[field] = value;
-        touched.value += 1;
-      }
-      if (problem) return { error: problem };
-      problem = applyOptionalMarkerFields(marker, params, touched);
-      if (problem) return { error: problem };
-
-      targetAsset.metadata = {
-        ...(targetAsset.metadata ?? {}),
-        [ENTITY_METADATA_KEY]: marker
-      };
-      await targetAsset.save();
-      const nextSourceMeta = { ...(sourceAsset.metadata ?? {}) } as Record<string, unknown>;
-      delete nextSourceMeta[ENTITY_METADATA_KEY];
-      sourceAsset.metadata = nextSourceMeta;
-      await sourceAsset.save();
-      const entity = entityFromAsset(targetAsset);
-      return entity
-        ? { entity, moved_from: entityId.trim(), moved_to: targetId }
-        : { error: "The entity marker was not readable after saving." };
     }
 
     return saveEntityAsset(run, entityId, (marker, existing) => {
@@ -487,6 +447,16 @@ const updateEntity: CapabilityExport = {
       }
       const touched = { value: 0 };
       let problem: string | null = null;
+
+      if (swapTo !== undefined) {
+        // Null, or the entity's own asset, means "show your own bytes again".
+        if (swapTo === null || swapTo === entityId.trim()) {
+          delete marker[REFERENCE_ASSET_KEY];
+        } else {
+          marker[REFERENCE_ASSET_KEY] = swapTo;
+        }
+        touched.value += 1;
+      }
 
       const kind = params["kind"];
       if (kind !== undefined) {

--- a/packages/agents/tests/capabilities-entities.test.ts
+++ b/packages/agents/tests/capabilities-entities.test.ts
@@ -109,6 +109,21 @@ describe("the marker convention", () => {
       ]
     });
 
+    expect(
+      entityFromAsset({
+        ...tagged,
+        metadata: {
+          nodetool_entity: {
+            ...tagged.metadata.nodetool_entity,
+            reference_asset_id: "a9"
+          }
+        }
+      })
+    ).toMatchObject({
+      id: "a1",
+      reference_images: [{ type: "image", asset_id: "a9", uri: "asset://a9" }]
+    });
+
     const base = { id: "a2", content_type: "image/png", created_at: "" };
     expect(entityFromAsset({ ...base, metadata: null })).toBeNull();
     expect(
@@ -365,7 +380,7 @@ describe("create_entity and update_entity", () => {
     ).toMatchObject({ error: expect.stringMatching(/was not found/) });
   });
 
-  it("moves an entity to a new image asset when asset_id is passed", async () => {
+  it("swaps an entity's picture without moving its id", async () => {
     const mara = await makeEntity("Mara", "character", "red hair", {
       voice_id: "v1"
     });
@@ -375,48 +390,84 @@ describe("create_entity and update_entity", () => {
       content_type: "image/png"
     })) as Asset;
 
-    const moved = (await run().invoke("update_entity", {
+    const swapped = (await run().invoke("update_entity", {
       entity_id: mara.id,
       asset_id: target.id,
       descriptor: "a tall woman with cropped red hair"
     })) as {
-      entity: { id: string; descriptor: string; voice_id: string | null };
-      moved_from: string;
-      moved_to: string;
+      entity: {
+        id: string;
+        descriptor: string;
+        voice_id: string | null;
+        reference_images: Array<{ asset_id: string; uri: string }>;
+      };
     };
-    expect(moved.entity.id).toBe(target.id);
-    expect(moved.entity.descriptor).toBe("a tall woman with cropped red hair");
-    expect(moved.moved_from).toBe(mara.id);
-    expect(moved.moved_to).toBe(target.id);
+    // The id every board and script cast is the marker asset's, and it stays.
+    expect(swapped.entity.id).toBe(mara.id);
+    expect(swapped.entity.voice_id).toBe("v1");
+    expect(swapped.entity.descriptor).toBe("a tall woman with cropped red hair");
+    expect(swapped.entity.reference_images[0]).toEqual({
+      type: "image",
+      asset_id: target.id,
+      uri: `asset://${target.id}`
+    });
 
-    // Source no longer lists, target does; source asset keeps bytes.
+    // The library still lists it once, under the id it always had, and the
+    // target asset did not become an entity of its own.
     const listed = (await run().invoke("list_entities", {})) as {
       entities: Array<{ id: string }>;
     };
-    expect(listed.entities.map((e) => e.id)).not.toContain(mara.id);
-    expect(listed.entities.map((e) => e.id)).toContain(target.id);
-    const sourceStill = await Asset.find(USER, mara.id);
-    expect(sourceStill?.metadata?.["nodetool_entity"]).toBeUndefined();
-
-    // Refuses a target that is already an entity or not an image.
-    const other = await makeEntity("Rex", "character", "a dog");
+    expect(listed.entities.map((e) => e.id)).toContain(mara.id);
+    expect(listed.entities.map((e) => e.id)).not.toContain(target.id);
     expect(
-      await run().invoke("update_entity", {
-        entity_id: target.id,
-        asset_id: other.id
-      })
-    ).toMatchObject({ error: expect.stringMatching(/already an entity/) });
+      (await Asset.find(USER, target.id))?.metadata?.["nodetool_entity"]
+    ).toBeUndefined();
+
+    // apply_entities hands the model the swapped picture, not the old one.
+    const applied = (await run().invoke("apply_entities", {
+      text: "",
+      entity_ids: [mara.id]
+    })) as { referenceAssetIds: string[] };
+    expect(applied.referenceAssetIds).toEqual([target.id]);
+
+    // null puts the entity back on its own bytes.
+    const reset = (await run().invoke("update_entity", {
+      entity_id: mara.id,
+      asset_id: null
+    })) as { entity: { reference_images: Array<{ asset_id: string }> } };
+    expect(reset.entity.reference_images[0]?.asset_id).toBe(mara.id);
+  });
+
+  it("refuses a picture that is missing, not an image, or not yours", async () => {
+    const mara = await makeEntity("Mara", "character", "red hair");
     const doc = (await Asset.create({
       user_id: USER,
       name: "notes.pdf",
       content_type: "application/pdf"
     })) as Asset;
-    expect(
-      await run().invoke("update_entity", {
-        entity_id: target.id,
-        asset_id: doc.id
-      })
-    ).toMatchObject({ error: expect.stringMatching(/entities are image assets/) });
+    const theirs = (await Asset.create({
+      user_id: "someone-else",
+      name: "theirs.png",
+      content_type: "image/png"
+    })) as Asset;
+
+    for (const [assetId, pattern] of [
+      [doc.id, /entities are image assets/],
+      [theirs.id, /was not found/],
+      ["gone", /was not found/]
+    ] as const) {
+      expect(
+        await run().invoke("update_entity", {
+          entity_id: mara.id,
+          asset_id: assetId
+        })
+      ).toMatchObject({ error: expect.stringMatching(pattern) });
+    }
+    // A refused swap leaves the entity showing what it showed before.
+    const after = (await run().invoke("get_entity", {
+      entity_id: mara.id
+    })) as { entity: { reference_images: Array<{ asset_id: string }> } };
+    expect(after.entity.reference_images[0]?.asset_id).toBe(mara.id);
   });
 
   it("removes the marker but keeps the asset, and reports missing ids", async () => {

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -2532,7 +2532,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "create_entity",
     module: "entities",
     impl: "packages/agents/src/capabilities/entities.ts",
-    contract: "c566aa83ff94",
+    contract: "8ac31a88d9ee",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-entities.test.ts",
@@ -2542,7 +2542,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "update_entity",
     module: "entities",
     impl: "packages/agents/src/capabilities/entities.ts",
-    contract: "0364dc0ba668",
+    contract: "f157df08f573",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-entities.test.ts",

--- a/web/src/components/entities/EntityEditorDialog.tsx
+++ b/web/src/components/entities/EntityEditorDialog.tsx
@@ -1,14 +1,18 @@
 /**
  * EntityEditorDialog — tag an existing image asset as a reusable entity, or edit
- * an existing entity's fields. The reference image is chosen upstream (the
- * library picks the asset first); this dialog only writes the marker fields via
- * {@link useSaveEntity}.
+ * an existing entity's fields, including the picture it shows. Swapping the
+ * picture points the marker at another image asset; the entity keeps the id
+ * boards and scripts cast it by.
  */
 
 import React, { memo, useCallback, useEffect, useState } from "react";
+import { useTheme } from "@mui/material/styles";
 import type { Entity, EntityKind } from "@nodetool-ai/protocol";
 import {
+  BORDER_RADIUS,
   Dialog,
+  EditorButton,
+  FlexRow,
   Label,
   TextInput,
   ToggleGroup,
@@ -17,16 +21,21 @@ import {
   SPACING
 } from "../ui_primitives";
 import { useSaveEntity } from "../../serverState/useEntities";
+import { mediaRefFromAsset } from "../../utils/mediaRef";
+import ImageRefPreview from "../node/ImageRefPreview";
+import EntityAssetPickerDialog from "./EntityAssetPickerDialog";
 
 interface EntityEditorDialogProps {
   open: boolean;
   onClose: () => void;
-  /** The image asset to tag as this entity's reference. */
+  /** The asset carrying the entity marker — the entity's id once saved. */
   assetId: string;
   /** When editing, prefill from this entity. */
   entity?: Entity;
   onSaved?: (entity: Entity | null) => void;
 }
+
+const PREVIEW_SIZE = 96;
 
 const KINDS: EntityKind[] = ["character", "location", "style", "prop"];
 
@@ -37,7 +46,10 @@ const EntityEditorDialogInternal: React.FC<EntityEditorDialogProps> = ({
   entity,
   onSaved
 }) => {
+  const theme = useTheme();
   const saveEntity = useSaveEntity();
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [referenceAssetId, setReferenceAssetId] = useState(assetId);
   const [kind, setKind] = useState<EntityKind>("character");
   const [name, setName] = useState("");
   const [descriptor, setDescriptor] = useState("");
@@ -48,12 +60,18 @@ const EntityEditorDialogInternal: React.FC<EntityEditorDialogProps> = ({
     if (!open) {
       return;
     }
+    setReferenceAssetId(entity?.reference_images?.[0]?.asset_id ?? assetId);
     setKind(entity?.kind ?? "character");
     setName(entity?.name ?? "");
     setDescriptor(entity?.descriptor ?? "");
     setVoiceId(entity?.voice_id ?? "");
     setTags(entity?.tags?.join(", ") ?? "");
-  }, [open, entity]);
+  }, [open, entity, assetId]);
+
+  const handlePickImage = useCallback((picked: string) => {
+    setReferenceAssetId(picked);
+    setPickerOpen(false);
+  }, []);
 
   const handleKindChange = useCallback(
     (_e: React.MouseEvent<HTMLElement>, value: EntityKind | null) => {
@@ -65,8 +83,11 @@ const EntityEditorDialogInternal: React.FC<EntityEditorDialogProps> = ({
   );
 
   const handleConfirm = useCallback(async () => {
+    // A new entity simply IS the picked image, so changing it there changes
+    // which asset gets the marker. An existing one keeps its id and points at
+    // the new picture instead.
     const saved = await saveEntity.mutateAsync({
-      assetId,
+      assetId: entity ? assetId : referenceAssetId,
       kind,
       name: name.trim(),
       descriptor: descriptor.trim(),
@@ -74,18 +95,21 @@ const EntityEditorDialogInternal: React.FC<EntityEditorDialogProps> = ({
       tags: tags
         .split(",")
         .map((t) => t.trim())
-        .filter(Boolean)
+        .filter(Boolean),
+      reference_asset_id: referenceAssetId
     });
     onSaved?.(saved);
     onClose();
   }, [
     saveEntity,
+    entity,
     assetId,
     kind,
     name,
     descriptor,
     voiceId,
     tags,
+    referenceAssetId,
     onSaved,
     onClose
   ]);
@@ -104,6 +128,29 @@ const EntityEditorDialogInternal: React.FC<EntityEditorDialogProps> = ({
       isLoading={saveEntity.isPending}
     >
       <FlexColumn gap={SPACING.md} sx={{ pt: 1, minWidth: 360 }}>
+        <FlexColumn gap={SPACING.xs}>
+          <Label>Image</Label>
+          <FlexRow gap={SPACING.md} align="center">
+            <div
+              style={{
+                width: PREVIEW_SIZE,
+                height: PREVIEW_SIZE,
+                flexShrink: 0,
+                overflow: "hidden",
+                borderRadius: BORDER_RADIUS.sm,
+                background: theme.vars.palette.background.default
+              }}
+            >
+              <ImageRefPreview
+                value={mediaRefFromAsset({ id: referenceAssetId }, "image")}
+              />
+            </div>
+            <EditorButton variant="outlined" onClick={() => setPickerOpen(true)}>
+              Change image
+            </EditorButton>
+          </FlexRow>
+        </FlexColumn>
+
         <FlexColumn gap={SPACING.xs}>
           <Label>Kind</Label>
           <ToggleGroup
@@ -158,6 +205,12 @@ const EntityEditorDialogInternal: React.FC<EntityEditorDialogProps> = ({
           compact
         />
       </FlexColumn>
+
+      <EntityAssetPickerDialog
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        onPick={handlePickImage}
+      />
     </Dialog>
   );
 };

--- a/web/src/components/entities/__tests__/EntityEditorDialog.test.tsx
+++ b/web/src/components/entities/__tests__/EntityEditorDialog.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import type { Entity } from "@nodetool-ai/protocol";
+import mockTheme from "../../../__mocks__/themeMock";
+
+jest.mock("../../node/ImageRefPreview", () => ({
+  __esModule: true,
+  default: ({ value }: { value?: { asset_id?: string } }) => (
+    <div data-testid="preview">{value?.asset_id}</div>
+  )
+}));
+
+jest.mock("../EntityAssetPickerDialog", () => ({
+  __esModule: true,
+  default: ({
+    open,
+    onPick
+  }: {
+    open: boolean;
+    onPick: (assetId: string) => void;
+  }) =>
+    open ? (
+      <button type="button" onClick={() => onPick("asset-2")}>
+        pick asset-2
+      </button>
+    ) : null
+}));
+
+const mockSave = jest.fn();
+jest.mock("../../../serverState/useEntities", () => ({
+  useSaveEntity: () => ({ mutateAsync: mockSave, isPending: false })
+}));
+
+import EntityEditorDialog from "../EntityEditorDialog";
+
+const entity: Entity = {
+  type: "entity",
+  id: "asset-1",
+  kind: "character",
+  name: "Mara",
+  descriptor: "a tall woman with red hair",
+  reference_images: [
+    { type: "image", asset_id: "asset-1", uri: "asset://asset-1" }
+  ]
+};
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>);
+
+describe("EntityEditorDialog", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSave.mockResolvedValue(entity);
+  });
+
+  it("swaps an existing entity's picture and keeps its id", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(
+      <EntityEditorDialog
+        open
+        onClose={jest.fn()}
+        assetId="asset-1"
+        entity={entity}
+      />
+    );
+    expect(screen.getByTestId("preview")).toHaveTextContent("asset-1");
+
+    await user.click(screen.getByRole("button", { name: "Change image" }));
+    await user.click(screen.getByRole("button", { name: "pick asset-2" }));
+    expect(screen.getByTestId("preview")).toHaveTextContent("asset-2");
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(mockSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assetId: "asset-1",
+        reference_asset_id: "asset-2"
+      })
+    );
+  });
+
+  it("tags the picked asset itself when creating a new entity", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(
+      <EntityEditorDialog open onClose={jest.fn()} assetId="asset-1" />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Change image" }));
+    await user.click(screen.getByRole("button", { name: "pick asset-2" }));
+
+    await user.type(screen.getByLabelText(/Name/), "Rex");
+    await user.type(screen.getByLabelText(/Descriptor/), "a scruffy terrier");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(mockSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assetId: "asset-2",
+        reference_asset_id: "asset-2"
+      })
+    );
+  });
+});

--- a/web/src/serverState/useEntities.ts
+++ b/web/src/serverState/useEntities.ts
@@ -7,6 +7,10 @@
  * are the entity's primary reference image (`asset://<id>`); the marker holds the
  * kind/name/descriptor and other prompt-injection fields. Tagging and untagging
  * never create or delete the underlying asset — they only write the marker.
+ *
+ * Swapping an entity's picture writes `reference_asset_id` onto that marker
+ * rather than moving it to the other asset: boards and scripts store the entity
+ * id, so an entity that changed asset would leave every one of them dangling.
  */
 
 import {
@@ -32,6 +36,8 @@ interface EntityMarker {
   tags?: string[];
   lora?: Entity["lora"];
   palette?: Entity["palette"];
+  /** The image the entity shows, when it is not the marker asset's own bytes. */
+  reference_asset_id?: string;
 }
 
 const ENTITY_METADATA_KEY = "nodetool_entity";
@@ -67,11 +73,18 @@ export function readEntityMarker(
       ? obj.tags.filter((t): t is string => typeof t === "string")
       : undefined,
     lora: (obj.lora as EntityMarker["lora"]) ?? undefined,
-    palette: (obj.palette as EntityMarker["palette"]) ?? undefined
+    palette: (obj.palette as EntityMarker["palette"]) ?? undefined,
+    reference_asset_id:
+      isString(obj.reference_asset_id) && obj.reference_asset_id.trim() !== ""
+        ? obj.reference_asset_id.trim()
+        : undefined
   };
 }
 
-/** Map a marked asset to an {@link Entity}, using the asset itself as the ref image. */
+/**
+ * Map a marked asset to an {@link Entity}, using the marker's swapped reference
+ * image when it names one and the asset's own bytes otherwise.
+ */
 export function assetToEntity(asset: Asset): Entity | null {
   const marker = readEntityMarker(asset.metadata);
   if (!marker) {
@@ -88,7 +101,9 @@ export function assetToEntity(asset: Asset): Entity | null {
     tags: marker.tags,
     lora: marker.lora ?? null,
     palette: marker.palette ?? null,
-    reference_images: [mediaRefFromAsset(asset, "image")],
+    reference_images: [
+      mediaRefFromAsset({ id: marker.reference_asset_id ?? asset.id }, "image")
+    ],
     created_at: asset.created_at
   };
 }
@@ -126,6 +141,11 @@ interface SaveEntityInput {
   tags?: string[];
   lora?: Entity["lora"];
   palette?: Entity["palette"];
+  /**
+   * The image asset the entity should show. Null, undefined, or `assetId`
+   * itself means the entity's own bytes.
+   */
+  reference_asset_id?: string | null;
 }
 
 /** Tag (or re-tag) an existing image asset as an entity. */
@@ -146,7 +166,11 @@ export function useSaveEntity(): UseMutationResult<
         voice_id: input.voice_id,
         tags: input.tags,
         lora: input.lora,
-        palette: input.palette
+        palette: input.palette,
+        reference_asset_id:
+          input.reference_asset_id && input.reference_asset_id !== input.assetId
+            ? input.reference_asset_id
+            : undefined
       };
       const updated = await trpcClient.assets.update.mutate({
         id: input.assetId,


### PR DESCRIPTION
## What changed

The entity library had no way to change an entity's reference image — the picture was fixed at tag time — and the one mechanism that came close, `update_entity`'s `asset_id`, moved the marker to the other asset. An entity IS its asset, so that move changed the entity's id, and boards (`entityIds`, a shot's `entity_ids`) and script speakers (`entityId`) store that id, so every one of those references silently dangled. A swap now writes `reference_asset_id` onto the marker instead: the marker asset never moves, and `asset_id: null` puts the entity back on its own bytes. The field joins the shared `EntityMarker` and its Zod schema in `@nodetool-ai/protocol`, so the agent capability and the browser library read it through one parser; in `update_entity` it is one more marker field written through `saveEntityAsset` beside `project_id`, and the retarget branch is gone. `EntityEditorDialog` gains the picture and a **Change image** button over the existing asset picker; tagging a brand new entity still tags the picked asset itself, since there the picture is the entity.

Merged `origin/main` (#5636, entity project membership) and re-applied the swap on top of it — that PR is where `readEntityMarker` moved into `protocol`, which is why the swap is parsed once rather than twice.

## Verification

Run on the merge head (`2ab0623`):

- [x] `npm run test:affected` — one failure, unrelated to this diff and identical before the merge: `packages/image-nodes` shader tests abort in Dawn/Vulkan (`CheckVkSuccessImpl … VulkanError.cpp:106`), the missing-ICD case AGENTS.md documents. 86/98 tasks succeeded, the rest cached.
- [x] `npm run typecheck:web` and `npm run typecheck:electron` — both clean. `typecheck:mobile` is not runnable here: `mobile/node_modules` is not installed (mobile is deliberately not a root workspace) and no mobile file is touched.
- [x] `npm run lint` — zero errors; only pre-existing `no-unused-vars` warnings in files this diff does not touch.
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — `Gate: 7/7 selfchecks passed`.
- [x] `npx vitest run tests/capabilities-entities.test.ts --root packages/agents` — 21 passed (the swap cases plus #5636's project cases).
- [x] `npx vitest run --root packages/protocol` — 74 files, 1268 tests passed.
- [x] `npx jest src/components/entities src/components/projects src/serverState` (in `web/`) — 29 suites, 255 tests passed.

## Agent capabilities

- [x] `npm run capabilities:check` passes (`capabilities:sync` refreshed the `create_entity` / `update_entity` contract fingerprints, which moved with their schemas and descriptions).
- [x] Both re-declared capabilities already name `packages/agents/tests/capabilities-entities.test.ts` in `capability-table.ts`, and that suite is where the two new cases landed.

## New checks

The two new capability cases were inverted once — `entityFromAsset` forced to ignore `reference_asset_id` — and both failed as intended before the change was restored:

```
Tests  2 failed | 14 passed (16)
 FAIL  tests/capabilities-entities.test.ts > create_entity and update_entity > swaps an entity's picture without moving its id
 FAIL  tests/capabilities-entities.test.ts > create_entity and update_entity > refuses a picture that is missing, not an image, or not yours
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpTaG6utkBqVjVBUSNuERV

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpTaG6utkBqVjVBUSNuERV)_
