### PR TITLE
docs(readme): move the node editor up front

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ saved in their cloud, locked away. NodeTool hands the project back, on your keys
 
 ![NodeTool: one sentence becomes a storyboard, rendered stills and clips, a cut on the timeline, and a finished film](marketing/public/hero-project-poster.webp)
 
+## The node editor
+
+![NodeTool workflow canvas](marketing/public/screen_workflow.webp)
+
+Every project is a graph you can open. Drag nodes in, connect typed ports, and
+read the live output at each step. Double-click the canvas to search and add a
+node, or drag a connection into empty space to see compatible next steps. The
+editor refuses a mismatch, so an image cannot land in a text field.
+
+The storyboard, script, timeline, sketch, and 3D editors all sit on this
+canvas, and an agent wires it through the same actions you have.
+
 ## Every model you need, on your own keys
 
 You connect the provider and NodeTool calls it with your key, so you pay that
@@ -202,12 +214,10 @@ cost. See the [agent guide](https://docs.nodetool.ai/agents/) and
 
 ## What is underneath
 
-The film surfaces sit on a node canvas, and everything on it is reachable
-without the film.
+Everything the film surfaces do is reachable on the canvas without the film.
 
 | | |
 | :--- | :--- |
-| **Node canvas** | Drag-and-drop nodes with type-safe connections. Live output at every step. |
 | **Mini apps** | Give a workflow a screen: inputs, a Run button, a place for the result. Hand it to a teammate who never sees the canvas. |
 | **Editing tools as nodes** | Mask, inpaint, outpaint, relight, upscale, layer, and composite. |
 | **Every modality** | Image, video, audio, and text in one workflow. |
@@ -218,12 +228,6 @@ without the film.
 | **MCP server** | Point Claude Desktop, Claude Code, Codex, or any MCP agent at the toolbelt. |
 | **Custom nodes** | Extend in TypeScript or Python. |
 | **Deploy and scale** | Self-host with Docker. Rent GPU workers on RunPod or Vast. |
-
-![NodeTool workflow canvas](marketing/public/screen_workflow.webp)
-
-Double-click the canvas to search and add a node, or drag a connection into
-empty space to see compatible next steps. The editor refuses a mismatch, so an
-image cannot land in a text field.
 
 ## Documentation
 


### PR DESCRIPTION
## What changed

The workflow canvas screenshot sat at line 222 of the README, under "What is underneath", below the film surfaces, the recipes and the comparison table. NodeTool is a node editor first, so the canvas screenshot now appears directly under the hero as its own "The node editor" section, carrying the add-node and type-check behavior that was previously stranded next to it. The old spot loses the image and the duplicated paragraph, and its "Node canvas" table row, now covered by the new section.

## Verification

Markdown-only diff, no code touched.

- [x] `npm run test:affected` — dry run selects nothing (documentation-only change)
- [ ] `npm run typecheck` — not applicable, no TypeScript changed
- [ ] `npm run lint` — not applicable, no linted source changed
- [ ] `npm run dev:nodetool -- harness gate --base main` — no harness entry maps to README.md

Image path `marketing/public/screen_workflow.webp` verified present; no in-repo link targets the removed heading text.

## Agent capabilities

Skipped: no capability added or re-declared.

## New checks

Skipped: no check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cDyLDq7CJjw77Xk8TQC9T

---
_Generated by [Claude Code](https://claude.ai/code/session_015cDyLDq7CJjw77Xk8TQC9T)_