### PR TITLE
docs(readme): place the node editor after the film editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,6 @@ saved in their cloud, locked away. NodeTool hands the project back, on your keys
 
 ![NodeTool: one sentence becomes a storyboard, rendered stills and clips, a cut on the timeline, and a finished film](marketing/public/hero-project-poster.webp)
 
-## The node editor
-
-![NodeTool workflow canvas](marketing/public/screen_workflow.webp)
-
-Every project is a graph you can open. Drag nodes in, connect typed ports, and
-read the live output at each step. Double-click the canvas to search and add a
-node, or drag a connection into empty space to see compatible next steps. The
-editor refuses a mismatch, so an image cannot land in a text field.
-
-The storyboard, script, timeline, sketch, and 3D editors all sit on this
-canvas, and an agent wires it through the same actions you have.
-
 ## Every model you need, on your own keys
 
 You connect the provider and NodeTool calls it with your key, so you pay that
@@ -153,6 +141,18 @@ capture a view as a depth or composition reference for an image or video model.
 The same operations run headlessly through `create_model3d`, `get_model3d`,
 `edit_model3d`, `validate_model3d`, and `render_model3d`, so a scene is
 reproducible with no editor open.
+
+## The node editor
+
+![NodeTool workflow canvas](marketing/public/screen_workflow.webp)
+
+Every project is a graph you can open. Drag nodes in, connect typed ports, and
+read the live output at each step. Double-click the canvas to search and add a
+node, or drag a connection into empty space to see compatible next steps. The
+editor refuses a mismatch, so an image cannot land in a text field.
+
+Every editor above sits on this canvas, and an agent wires it through the
+same actions you have.
 
 ## Recipes
 


### PR DESCRIPTION
## What changed

Follow-up to #5650, which put "The node editor" directly under the hero. That was too early: it cut into the pitch before the reader knows what the studio does. The section now closes the editor tour instead — storyboard, script, timeline, sketch, 3D, then the canvas they all sit on — still well ahead of the recipes, the comparison table and "What is underneath" where the screenshot used to live. Its closing line drops the editor list and points at the sections above it.

## Verification

Markdown-only diff, no code touched.

- [x] `npm run test:affected -- --dry-run` — "nothing — no workspace owns the changed files"
- [ ] `npm run typecheck` — not applicable, no TypeScript changed
- [ ] `npm run lint` — not applicable, no linted source changed
- [ ] `npm run dev:nodetool -- harness gate --base main` — no harness entry maps to README.md

## Agent capabilities

Skipped: no capability added or re-declared.

## New checks

Skipped: no check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cDyLDq7CJjw77Xk8TQC9T

---
_Generated by [Claude Code](https://claude.ai/code/session_015cDyLDq7CJjw77Xk8TQC9T)_