### PR TITLE
docs(chrome-extension): document the chat side panel

### DIFF
--- a/docs/chrome-extension.md
+++ b/docs/chrome-extension.md
@@ -4,47 +4,29 @@ title: "Chrome Extension"
 description: "Chat with NodeTool from Chrome's side panel, and drive your real, logged-in browser from NodeTool workflows."
 ---
 
-The extension does two things. It puts the NodeTool **chat** in Chrome's side panel, so you can ask your agent something without leaving the page you're on. And it relays the Chrome DevTools Protocol between your browser and your server, so a workflow can drive the tab you're already signed in to.
+The NodeTool Chrome extension gives you two surfaces in the browser you already use.
 
-Let NodeTool workflows control your **actual Chrome browser** — the one you're already logged into — instead of a fresh, anonymous, headless one. The NodeTool Chrome Extension is a thin relay that hands the Chrome DevTools Protocol (CDP) from your browser to your NodeTool server, so a workflow node can click, type, scroll, and screenshot inside a real tab with your cookies, sessions, and 2FA already in place.
+**The chat side panel** puts NodeTool's agent beside the page you're on, so you can ask about the tab without switching windows. It reads and writes the same conversation threads as the desktop and web apps.
 
-> New here? Start with [Getting Started](getting-started.md). For headless (no-login-needed) browsing, see the regular [Browser node](developer/node-reference.md) instead — you only need the extension when a site requires your logged-in session.
+**The CDP proxy** relays the Chrome DevTools Protocol between your browser and your NodeTool server, so a workflow or an agent can click, type, scroll and screenshot inside a tab you're already signed in to — with your cookies, sessions and 2FA already in place, instead of a fresh anonymous headless browser.
+
+They work together: opening the chat panel attaches the proxy to your current tab, so the agent can act on the page you're looking at.
+
+> New here? Start with [Getting Started](getting-started.md). For headless (no-login-needed) browsing, see the regular [Browser node](developer/node-reference.md) instead — you only need the proxy when a site requires your logged-in session.
 
 ---
 
 ## Overview
 
-| Feature | Notes |
-|---------|-------|
-| **What it is** | A Manifest V3 extension with a side-panel chat UI and a CDP proxy between your server and `chrome.debugger` |
-| **What it is not** | Not an automation engine itself — it originates no commands, it only relays them |
-| **Why you'd use it** | Sites that block headless/server-launched browsers, or require your existing login (OAuth, 2FA, CAPTCHAs already solved) |
-| **Transport** | Dedicated WebSocket at `/ws/extension` on your NodeTool server, JSON frames |
-| **Scope** | One tab at a time, attached explicitly by clicking a button — never automatic |
+| | Chat side panel | CDP proxy |
+|---|---|---|
+| **What it is** | NodeTool's chat, in Chrome's side panel | A relay between your server and `chrome.debugger` |
+| **What you get** | Ask an agent about the current page; the same threads as the app | Workflows and agents drive your logged-in tab |
+| **Transport** | `/trpc` and the `/ws` chat socket, msgpack frames | `/ws/extension`, JSON frames |
+| **Scope** | One conversation at a time, any thread on the server | One tab at a time, attached explicitly — never automatic |
+| **What it is not** | Not the full app: no media generation, no workflow editor | Not an automation engine — it originates no commands, it only relays them |
 
----
-
-## Use Case
-
-Many AI product sites — Midjourney, Sora, Runway, ElevenLabs, and similar generation tools — either block headless Chrome outright or require a logged-in account with 2FA and session cookies that a fresh, server-launched browser doesn't have. Re-implementing every such site as a dedicated API integration is slow and brittle to UI changes.
-
-The Chrome Extension solves this by reusing the browser you already use every day. You attach the extension to a tab where you're already signed in, and a workflow's browser-automation node drives that tab through the same action loop (click, type, scroll, extract, screenshot) it would use against a headless browser — just over a different transport.
-
-**Typical scenario**: You're signed into Midjourney in a regular Chrome tab. You attach the extension to that tab, then run a workflow that submits a prompt, waits for the image grid to render, and downloads the results — all inside your real session, with no API key or cookie-jar wrangling.
-
----
-
-## Recipe: Generate an Image on a Logged-In Site
-
-1. **Install** the extension (see [Installing](#installing) below) and pin it to your toolbar.
-2. **Sign in** to the target site (e.g. Midjourney) in a normal Chrome tab, as you would manually.
-3. **Start your NodeTool server**: `nodetool serve --port 7777` (the extension talks to it over `ws://localhost:7777/ws/extension` by default).
-4. **Open the extension popup** on the signed-in tab and click **Attach to this tab**. Chrome shows its standard "Nodetool is debugging this browser" banner while attached.
-5. **Ask the agent**, or build a workflow. Either way the `browser_*` tools drive the attached tab — `browser_status` first to confirm the extension is attached, then `browser_restart` with `transport: "extension"` if the server is still on its headless Chrome (or set `NODETOOL_BROWSER_TRANSPORT=extension` before starting it — see [Transport Selection](#transport-selection)).
-6. **Run it**. The action loop drives your attached tab: it types the prompt, submits the form, waits for the result, and captures a screenshot or the generated asset into your library.
-7. **Detach** from the popup (or just close the tab) when you're done — an attachment lasts only for the current browser session.
-
-Because the site sees your real, logged-in browser rather than a bot-like headless process, you avoid the CAPTCHAs, bot-detection blocks, and re-authentication flows that a server-launched browser would hit.
+Both are served by a standard NodeTool server. Chrome 116 or newer is required for the side panel.
 
 ---
 
@@ -65,7 +47,7 @@ Then load it into Chrome:
 2. Enable **Developer mode** (top right).
 3. Click **Load unpacked** and select `chrome-extension/dist`.
 
-The extension icon appears in your toolbar. Click it to open the popup, which shows a connection-status dot (disconnected / connecting / connected / error), an editable server WebSocket URL, and **Attach** / **Detach** buttons.
+The extension icon appears in your toolbar. Click it to open the popup: **Open chat** opens the side panel, and below it the CDP proxy's controls — a connection-status dot (disconnected / connecting / connected / error), an editable server WebSocket URL, and **Attach** / **Detach** buttons.
 
 > **Standalone package**: `chrome-extension/` is intentionally outside the root npm workspace, Turbo pipeline, and CI — it has its own `package.json` and is built on demand. `npm run build:packages` at the repo root does **not** build it.
 
@@ -89,35 +71,90 @@ npm run dev         # vite build --watch, for iterating on the extension itself
 npm run clean       # remove dist/
 ```
 
-### Configuring the server URL
-
-By default the extension connects to `ws://localhost:7777/ws/extension` — your local NodeTool server. To point it at a different server (a remote deployment, a different port), open the popup, edit the **Server URL** field, and click **Save**. The value persists in the extension's local storage across restarts.
-
-The chat panel keeps its own server setting (an HTTP base URL, e.g. `http://localhost:7777`), edited from the gear icon inside the panel — see [Chat in the side panel](#chat-in-the-side-panel).
-
 ---
 
 ## Chat in the side panel
 
-Click the toolbar icon, then **Open chat**. Chrome's side panel opens beside the page with the NodeTool chat: pick a model from any provider your server has configured, send a message, and watch the reply stream in with the agent's tool calls listed as it works. The conversations are the same threads the desktop and web apps read and write — start something in the panel, finish it in the app.
+Click the toolbar icon, then **Open chat**. Chrome's side panel opens beside the page, and the extension attaches the CDP proxy to the current tab in the same gesture — so the agent can act on what you're looking at without a second step.
 
-The panel supports **chat only**. Image, video, audio and other media-generation modes live in the full app, as does the workflow editor.
+The empty state offers three starters that reflect what the panel is for: *Summarize this page*, *Pull the key facts out of this page into a list*, *What can I do with this page?*
 
-**Settings** (gear icon in the panel):
+### What's in the panel
+
+| Control | Behavior |
+|---|---|
+| **Model picker** | Every language model from every provider your server has configured, grouped by provider, with a search box once the list is long. Nothing is picked for you — sending stays blocked until you choose one, and the composer says why. |
+| **Permission mode** | **Ask**, **Auto** or **Plan**, persisted across sessions. See [Permission modes](#permission-modes) below. |
+| **Conversations** | The thread list, shared with the desktop and web apps. Start something in the panel and finish it in the app, or the reverse. |
+| **Transcript** | Streamed replies with the agent's tool calls listed as it works. An `execute_code` call renders its program as a titled code block rather than escaped JSON, and a call still running is marked at the tail of the turn. |
+| **Server settings** | The gear icon — see [Pointing the panel at a server](#pointing-the-panel-at-a-server). |
+
+The panel is chat only. Image, video, audio and the other media-generation modes live in the full app, as does the workflow editor.
+
+### Permission modes {#permission-modes}
+
+The picker sets how far the agent may act on its own, and the panel remembers your last choice:
+
+| Mode | Behavior |
+|---|---|
+| **Ask** | Reads run automatically; a write, execute or external call parks on an approval card. This is the default. |
+| **Auto** | Everything runs unasked. |
+| **Plan** | Read and propose only. No actions taken. |
+
+These are the same modes the full app offers, where **Ask** is labelled *Default*. [Chat & Agents](global-chat.md#agent-mode) explains what each one does to the agent loop.
+
+Auto points a running agent at whatever your server can reach, inside your signed-in browser session. Pick it only for a server you trust.
+
+### Approvals
+
+Three requests park in the transcript as cards rather than failing the turn:
+
+- **A gated tool call** asks *Run this action?*, *Make this change?* or *Allow this action?* depending on whether the call is classified `execute`, `write` or `external`. The card names the tool, expands to show the code or the arguments, and offers **Allow**, **Allow for chat** (stops the asking for the rest of the thread) or **Deny**.
+- **A proposed plan** shows its title and tasks, and takes an approval or a rejection with feedback on what should change.
+- **A missing credential** asks for the key by name. The value is saved to the server's secret store from the card; it never travels over the chat socket.
+
+### Pointing the panel at a server
+
+The gear icon holds the panel's own server setting, separate from the proxy's relay URL:
 
 | Field | Notes |
 |---|---|
 | **NodeTool server URL** | HTTP base, e.g. `http://localhost:7777`. The panel calls `/trpc` and the `/ws` chat socket on this host. |
 | **Access token** | Only for a server that enforces authentication. Leave it empty for a local server — it maps loopback requests to the local user. |
 
-Two things to know when pointing the panel at something other than a local server:
-
-- **The host has to be one Chrome lets the extension reach.** `localhost`, `127.0.0.1` and any HTTPS host are granted in the manifest. Anything else — a LAN box over plain HTTP — prompts for permission when you save it; decline, and every request to that server is blocked by CORS even though the chat socket still connects.
-- **The agent's tool calls are gated by the permission mode.** The picker in the panel offers **Plan** (no actions), **Default** (a write, execute or external call parks on an approval card) and **Auto** (everything runs unasked). It starts on Default and remembers what you last chose. Auto points a running agent at whatever the server can reach, so pick it only for a server you trust.
+**The host has to be one Chrome lets the extension reach.** `localhost`, `127.0.0.1` and any HTTPS host are granted in the manifest. Anything else — a LAN box over plain HTTP — prompts for permission when you save it; decline, and every request to that server is blocked by CORS even though the chat socket still connects. A green connection dot with failing requests is exactly this case: WebSockets are not CORS-gated, the HTTP calls are.
 
 ---
 
-## How It Works
+## Driving your logged-in browser
+
+The proxy is the half that lets a workflow or an agent act inside a tab you are signed in to.
+
+### Why you'd use it
+
+Many AI product sites — Midjourney, Sora, Runway, ElevenLabs, and similar generation tools — either block headless Chrome outright or require a logged-in account with 2FA and session cookies that a fresh, server-launched browser doesn't have. Re-implementing every such site as a dedicated API integration is slow and brittle to UI changes.
+
+The Chrome Extension solves this by reusing the browser you already use every day. You attach the extension to a tab where you're already signed in, and a workflow's browser-automation node drives that tab through the same action loop (click, type, scroll, extract, screenshot) it would use against a headless browser — just over a different transport.
+
+**Typical scenario**: You're signed into Midjourney in a regular Chrome tab. You attach the extension to that tab, then run a workflow that submits a prompt, waits for the image grid to render, and downloads the results — all inside your real session, with no API key or cookie-jar wrangling.
+
+### Recipe: generate an image on a logged-in site
+
+1. **Install** the extension (see [Installing](#installing) above) and pin it to your toolbar.
+2. **Sign in** to the target site (e.g. Midjourney) in a normal Chrome tab, as you would manually.
+3. **Start your NodeTool server**: `nodetool serve --port 7777` (the extension talks to it over `ws://localhost:7777/ws/extension` by default).
+4. **Open the extension popup** on the signed-in tab and click **Attach to this tab**. Chrome shows its standard "Nodetool is debugging this browser" banner while attached.
+5. **Ask the agent**, or build a workflow. Either way the `browser_*` tools drive the attached tab — `browser_status` first to confirm the extension is attached, then `browser_restart` with `transport: "extension"` if the server is still on its headless Chrome (or set `NODETOOL_BROWSER_TRANSPORT=extension` before starting it — see [Transport selection](#transport-selection)).
+6. **Run it**. The action loop drives your attached tab: it types the prompt, submits the form, waits for the result, and captures a screenshot or the generated asset into your library.
+7. **Detach** from the popup (or just close the tab) when you're done — an attachment lasts only for the current browser session.
+
+Because the site sees your real, logged-in browser rather than a bot-like headless process, you avoid the CAPTCHAs, bot-detection blocks, and re-authentication flows that a server-launched browser would hit.
+
+### Configuring the relay URL
+
+By default the extension connects to `ws://localhost:7777/ws/extension` — your local NodeTool server. To point it at a different server (a remote deployment, a different port), open the popup, edit the **Server URL** field, and click **Save**. The value persists in the extension's local storage across restarts.
+
+### How it works
 
 The extension is deliberately "dumb" — a pure conduit with no CDP logic of its own. All browser-automation semantics (which elements to click, how to wait for a page to settle, the action loop) live on the NodeTool server; the extension just carries the bytes.
 
@@ -139,7 +176,7 @@ Chrome Extension (service worker)
 - **Attach is a user gesture, with one exception**: `chrome.debugger.attach` is never called on page load. The popup's **Attach to this tab** button is the intended path, but a host `attach` frame on an unattached relay also attaches the *currently active* tab as a convenience (`handleAttachRequest` in `src/lib/cdp-relay.ts`). Since `/ws/extension` is unauthenticated and single-connection, any process that can reach the port can therefore start driving whatever tab is focused — which is why the bridge is off in production unless `NODETOOL_ENABLE_EXTENSION_BRIDGE=1` is set. Attaching is mutually exclusive with having Chrome DevTools open on the same tab.
 - **Wire protocol**: JSON text frames (not the MsgPack used by NodeTool's main `/ws` chat/workflow channel). Five frame kinds are live: `cdp` / `cdp_result` / `cdp_event` (command/response/event relay), `attach` / `attached` / `detach` (session lifecycle), `ping` / `pong` (heartbeat), and `error` (fatal — e.g. the user closed the tab or DevTools banner). Three more are **declared but not implemented on either side**: `asset_chunk` (server → extension, a file-upload injection) and `media_chunk` / `media_end` (extension → server, a `chrome.downloads` capture). Uploads reach a file input through an in-page `DataTransfer` injection instead, and media is captured with `Network.getResponseBody` or an in-page `fetch`; the three frames are the shape a `chrome.downloads` fallback would take if a site defeats both.
 
-### Transport Selection
+#### Transport selection
 
 One browser session exists per server process, and it is driven by either transport: a headless Chrome the server launches, or your attached tab. The same action loop, element indexing, and screenshot logic runs against both — only the CDP client differs — so nothing built for headless browsing needs different logic to use the logged-in session.
 
@@ -163,9 +200,7 @@ Restarting is the only point the transport can change, because the session is a 
 
 When the extension transport is selected but nothing is attached, the log says so — *"No browser extension is connected to `/ws/extension` — attach will time out. Install the extension and click 'Attach to this tab'."* — and the attach then spends its 30-second timeout. `browser_status` is how an agent finds this out first instead.
 
----
-
-## As an agent capability
+### As an agent capability
 
 The `browser_*` capabilities are the extension's agent-facing surface. They are registered like any other NodeTool capability, so the same fourteen names reach the chat agent, an `AgentNode` in a workflow, MCP clients, CodeAct, a Code node, and a JS script — and every one of them drives the same page.
 
@@ -210,12 +245,12 @@ The action loop itself is `@nodetool-ai/browser` (`packages/browser/`), which kn
 
 ---
 
-## Server Requirements
+## Server requirements
 
 - A running NodeTool server: `nodetool serve --port 7777` (or your deployed URL).
 - The `/ws/extension` route (CDP proxy) and the `/trpc` + `/ws` routes (chat panel) are part of the standard NodeTool WebSocket server — no extra server-side setup is required beyond running the server.
 - The extension and the server must be able to reach each other over the configured WebSocket URL (typically `localhost` for local development).
-- Chrome 116 or newer, for the side panel.
+- Chrome 116 or newer — `chrome.sidePanel` is what the chat panel opens into.
 
 ---
 
@@ -258,7 +293,7 @@ Check the server URL in the panel's settings (gear icon). If it names a host tha
 
 ---
 
-## Related Topics
+## Related topics
 
 - [Getting Started](getting-started.md) — Desktop setup and first workflow
 - [Developer: Node Reference](developer/node-reference.md) — Browser-automation node reference

--- a/docs/global-chat.md
+++ b/docs/global-chat.md
@@ -32,6 +32,7 @@ Persistent WebSocket connection — reconnects after reloads.
 
 - **From the App**: Click the **Chats** icon in the left rail, then pick a thread or start a new one
 - **Standalone Window**: Click the NodeTool system tray icon and select **Chat** for a dedicated, focused window
+- **Chrome Side Panel**: Install the [Chrome extension](chrome-extension.md#chat-in-the-side-panel) and click **Open chat** in its popup. The panel is chat only, but it reads and writes the same threads, and the agent can act on the tab you have open
 
 ### Choosing a Model
 


### PR DESCRIPTION
## What changed

`docs/chrome-extension.md` still described the extension as a CDP proxy only, so the chat side panel that shipped in #5616 had no documentation and no entry point from the chat docs. The page is now split into its two surfaces: an Overview table contrasting the panel with the proxy, then a section for each. The panel section documents the model picker, the permission modes under the labels the picker actually shows (**Ask** / **Auto** / **Plan** — the app calls Ask "Default"), the three approval card kinds and their buttons, the server setting, and the CORS rule that decides which hosts the panel can reach (a green connection dot with failing requests is a host the manifest doesn't grant — WebSockets aren't CORS-gated, the HTTP calls are). Two stale claims are corrected: the page said the panel had no approval surface and ran permissively; it has approval cards for gated tool calls, proposed plans and missing secrets, and defaults to Ask. `docs/global-chat.md` § Opening Chat now links the panel, so it is reachable from the chat docs and not only from the Apps nav.

Every behavioral claim was read out of the merged extension source rather than written from memory — `PermissionModePicker.tsx` for the mode labels, `ApprovalCards.tsx` for the card questions and buttons, `MessageList.tsx` for the starter prompts, `popup.ts` for what **Open chat** does.

## Verification

Markdown only — two files, no workspace owns them.

- [x] `npm run test:affected -- --dry-run --base origin/main` → `nothing — no workspace owns the changed files.`
- [x] `npm run dev:nodetool -- harness gate --base origin/main --dry-run` → `2 changed file(s) touch 0 surface(s)` / `0 selfcheck(s) to run`
- [ ] `npm run typecheck` — not run; no TypeScript in the diff
- [ ] `npm run lint` — not run; no linted source in the diff

Docs Lint (lychee, `--offline --include-fragments`) covers the link and anchor targets on the PR. Every anchor the two files reference resolves to a heading in the tree: `#installing`, `#downloading-a-prebuilt-copy`, `#permission-modes`, `#pointing-the-panel-at-a-server`, `#transport-selection`, `#chat-in-the-side-panel`, and `api-reference.md#downloading-the-chrome-extension`.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lt2rk1C1voKkZDzdPK7duQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lt2rk1C1voKkZDzdPK7duQ)_