### PR TITLE
docs(comfyui): quickstart, setup, and recipes pages

### DIFF
--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -96,6 +96,8 @@
           <li><a href="{{ '/providers' | relative_url }}" class="sidebar-link" data-nav-path="/providers">Provider Reference</a></li>
           <li><a href="{{ '/huggingface' | relative_url }}" class="sidebar-link" data-nav-path="/huggingface">HuggingFace</a></li>
           <li><a href="{{ '/comfyui' | relative_url }}" class="sidebar-link" data-nav-path="/comfyui">ComfyUI</a></li>
+          <li><a href="{{ '/comfyui-setup' | relative_url }}" class="sidebar-link" data-nav-path="/comfyui-setup">ComfyUI Setup</a></li>
+          <li><a href="{{ '/comfyui-recipes' | relative_url }}" class="sidebar-link" data-nav-path="/comfyui-recipes">ComfyUI Recipes</a></li>
           <li><a href="{{ '/models-manager' | relative_url }}" class="sidebar-link" data-nav-path="/models-manager">Models Manager</a></li>
         </ul>
       </details>

--- a/docs/comfyui-recipes.md
+++ b/docs/comfyui-recipes.md
@@ -1,0 +1,372 @@
+---
+layout: page
+title: "ComfyUI Recipes"
+description: "What a ComfyUI workflow is good for once it is a node in a NodeTool graph: LLM-written prompts, batches, stored assets, cuts, mini apps, and running the whole thing from the CLI, the DSL, or the API."
+---
+
+A ComfyUI workflow loaded into a NodeTool node keeps doing exactly what it did
+in ComfyUI. What changes is everything on either side of it: where the prompt
+comes from, how many times it runs, where the files go, and who presses the
+button.
+
+This page is that second half. For the three nodes and their properties, see
+[ComfyUI](comfyui.md). For getting a server the node can reach, see
+[ComfyUI Setup](comfyui-setup.md).
+
+---
+
+## The shape of every recipe
+
+A loaded workflow becomes a node with typed handles. Every dynamic input is
+keyed `<comfyNodeId>:<field>` and takes the value ComfyUI would otherwise read
+from the prompt JSON. Every dynamic output is keyed `<comfyNodeId>:<kind>` and
+carries a NodeTool media ref, one per file. The ids are the keys of your
+API-format export, so a `CLIPTextEncode` saved as node `6` exposes `6:text`,
+a `LoadImage` saved as node `10` exposes `10:image`, and a `SaveImage` saved as
+node `9` emits on `9:image`. Which fields are offered, and which are never
+offered because ComfyUI wires them internally, is
+[What becomes an input or an output](comfyui.md#what-becomes-an-input-or-an-output).
+
+Two facts shape every recipe below:
+
+- **A handle only exists if you asked for it.** Media inputs and save outputs
+  are derived automatically. Seeds, steps, CFG, and prompt text are offered as
+  a checkbox list in the Load Workflow dialog. Until you tick one there is no
+  handle, and the prompt keeps its exported value. See
+  [Loading a workflow](comfyui.md#loading-a-workflow).
+- **The node runs on the server, not in your browser.** All three ComfyUI nodes
+  are server-side, so `endpoint` has to resolve from wherever the NodeTool
+  backend runs. A `127.0.0.1:8188` that works on your laptop is not the same
+  address to a cloud install.
+
+---
+
+## Recipe 1 · A model writes the prompt
+
+**What it does.** The positive prompt is generated per run instead of typed
+into the ComfyUI graph, so one saved workflow covers a brief rather than a
+sentence.
+
+**Nodes.** `nodetool.input.StringInput`, `nodetool.agents.EnhancePrompt`,
+`lib.comfy.RunWorkflow`, `nodetool.output.Output`
+
+{% mermaid %}
+graph LR
+  brief["StringInput (Brief)"]
+  enhance["EnhancePrompt (target: image)"]
+  comfy["RunWorkflow"]
+  out["Output"]
+  brief --> enhance -->|text| comfy
+  comfy -->|"9:image"| out
+{% endmermaid %}
+
+**Wiring.** `EnhancePrompt`'s `text` output goes to the comfy node's `6:text`
+handle. `nodetool.agents.Agent` works the same way when you want tools or a
+system prompt, and its `text` output is the one to wire.
+
+**Watch out.** `6:text` is not there until you tick that `CLIPTextEncode`
+field in the loader dialog. A negative prompt is a second `CLIPTextEncode` with
+its own id, so leaving it as a literal and driving only the positive one is the
+usual arrangement.
+
+---
+
+## Recipe 2 · One workflow, many runs
+
+**What it does.** The same diffusion graph runs once per item, unattended.
+
+**Nodes.** `nodetool.input.StringInput`, `nodetool.generators.ListGenerator`,
+`lib.comfy.RunWorkflow`, `nodetool.control.Collect`, `nodetool.output.Output`
+
+{% mermaid %}
+graph LR
+  brief["StringInput (Brief)"]
+  list["ListGenerator (streams item)"]
+  comfy["RunWorkflow"]
+  collect["Collect"]
+  out["Output"]
+  brief --> list -->|item| comfy
+  comfy -->|"9:image"| collect --> out
+{% endmermaid %}
+
+**Wiring.** `ListGenerator` emits `item` (a string) once per generated line, and
+each item drives one run of the comfy node. `nodetool.control.ForEach` does the
+same for a list you already have, and `nodetool.image.LoadImageAssets` does it
+for a folder of image assets, streaming `image` and `name` per file.
+`nodetool.control.Collect` gathers the results back into one list.
+
+**Watch out.** Every run gets its own `timeout`, not a shared one, so a
+fifty-item batch on a 600 second timeout can take hours before anything fails.
+On Comfy Cloud, the plan's concurrent-job limit (1, 3, or 5) is the real width
+of the fan-out: a full queue answers `429`, the SDK retries for 60 seconds, and
+then the node fails with `Comfy queue is full`.
+
+---
+
+## Recipe 3 · A stored asset in, a stored asset out
+
+**What it does.** Feeds a NodeTool image asset into a `LoadImage` node and puts
+what comes back into an asset folder.
+
+**Nodes.** `nodetool.input.ImageInput`, `lib.comfy.RunWorkflow`,
+`nodetool.image.SaveImage`
+
+{% mermaid %}
+graph LR
+  input["ImageInput"]
+  comfy["RunWorkflow"]
+  save["SaveImage (folder, name)"]
+  input -->|"10:image"| comfy
+  comfy -->|"9:image"| save
+{% endmermaid %}
+
+**Wiring.** A connected image, audio, or video ref is uploaded to the ComfyUI
+server before the prompt is submitted (`POST /upload/image`, which ComfyUI
+accepts for any input file) and the stored filename is substituted into the
+prompt. On Comfy Cloud the same ref goes through the SDK's asset API and is
+deduplicated by a blake3 hash of the bytes, so re-running with the same file
+uploads nothing the second time.
+
+**Watch out.** Outputs arrive as media refs carrying the bytes, not as saved
+assets. Nothing is written to your asset library until a node writes it, which
+is what `nodetool.image.SaveImage` is for (`nodetool.video.SaveVideo` for
+video). And a `LoadImage` field you leave as a literal filename still resolves
+against the ComfyUI server's own input directory, which is why an unwired
+workflow keeps working and a wired one replaces the file.
+
+---
+
+## Recipe 4 · Frames into a cut
+
+**What it does.** A batch of stills out of ComfyUI becomes a video without a
+second tool.
+
+**Nodes.** `lib.comfy.RunWorkflow`, `nodetool.video.FrameToVideo`,
+`nodetool.output.Output`
+
+{% mermaid %}
+graph LR
+  comfy["RunWorkflow (SaveImage batch)"]
+  frames["FrameToVideo (fps)"]
+  out["Output (Video)"]
+  comfy -->|"9:image"| frames --> out
+{% endmermaid %}
+
+**Wiring.** The comfy node emits one media ref per output file on the same
+slot, so a batch of four images is four frames rather than one list.
+`nodetool.video.FrameToVideo` takes a streamed input and collects them into a
+video at the `fps` you set. For a timeline instead of a flat encode, send the
+slot through `nodetool.control.Collect` into `nodetool.timeline.AddClips`
+(which has an `image_duration_ms` property) and render it with
+`nodetool.timeline.RenderTimeline`.
+
+**Watch out.** Nodes ComfyUI serves from its cache never emit an `executed`
+event, so their files are reconciled from `/history/<prompt_id>` after the run
+rather than streamed during it. A fully cached batch therefore arrives all at
+once at the end. Frame order follows emission order, so a graph with several
+save nodes gives you several slots to wire separately rather than one ordered
+stream.
+
+---
+
+## Recipe 5 · Behind a form, in a mini app
+
+**What it does.** Puts the workflow in front of someone who should not have to
+read a node graph, or install ComfyUI.
+
+**How.** Save the graph, open its app tab's **Design** view, add fields wired to
+the workflow's Input nodes, add a Button whose **On click** action is **Run
+workflow**, and wire an Image result widget to the Output node carrying the
+comfy slot. [App Builder](app-builder.md) covers the editor, and
+[Mini Apps](mini-apps.md) covers how one runs.
+
+**Watch out.** Widgets wire to Input and Output nodes, not to comfy handles, so
+every parameter the form should expose needs its own `nodetool.input.*` node in
+front of the handle. Publishing locks in the current state of every workflow the
+app runs, so a later edit to the graph does not reach the published app until
+you publish again.
+
+---
+
+## Recipe 6 · Ask for it in chat
+
+**What it does.** Reaches a saved ComfyUI workflow by name instead of by tab.
+
+**How.** Save the workflow in the editor, then select it in chat or ask for it
+by name. The results land in the thread. See
+[Chat & Agents](global-chat-agents.md).
+
+**Watch out.** The agent runs the graph as saved, so whatever the ComfyUI node
+holds in its `workflow` property is what runs. This is the same server-side run
+as every other path, which makes it the quickest check that `endpoint` is
+reachable from the backend rather than only from your machine.
+
+---
+
+## Running it without the editor
+
+### The CLI harnesses
+
+`validate` first, because it costs nothing:
+
+```bash
+npm run dev:nodetool -- validate <workflow_id>
+npm run dev:nodetool -- validate comfy-graph.json --json
+```
+
+It checks the **NodeTool** graph: unknown node types, missing required
+properties, dangling or mis-typed edges, and model properties naming a provider
+or a model id that does not exist (which is what catches a bad model on the
+`EnhancePrompt` node in Recipe 1). It never opens a socket to ComfyUI, so
+everything inside the `workflow` string is invisible to it. A missing
+checkpoint, an uninstalled custom node, and a `class_type` that server does not
+have all pass validation and fail at submit with `Submit failed (400)`. An empty
+`workflow` property passes too, and the node raises
+`ComfyUI workflow is required` at run time.
+
+Then `debug`, which runs the graph and keeps everything it emitted:
+
+```bash
+npm run dev:nodetool -- debug <workflow_id>
+npm run dev:nodetool -- debug comfy-graph.json --params '{"brief":"a red bicycle"}'
+npm run dev:nodetool -- debug <workflow_id> --trace
+```
+
+The bundle's `server/messages.jsonl` holds the ComfyUI lifecycle the node
+forwards into the run log: execution start, the count of reused nodes, the class
+name of each executing node, sampler progress, and the error text ComfyUI
+returned. That is the ComfyUI console without a ComfyUI browser tab.
+`--watch` re-runs a file target on every save and prints a diff of the verdict.
+
+To just run it:
+
+```bash
+npm run dev:nodetool -- workflows run <workflow_id> --params '{"brief":"a red bicycle"}'
+npm run dev:nodetool -- run comfy-graph.ts --json
+```
+
+With `--json`, an image or video payload over 64 KiB is written to
+`nodetool-output/<job_id>/payload-N.<ext>` and appears as a `{"$file": …}`
+reference instead of being inlined. Flag reference:
+[CLI › validate](cli.md#nodetool-validate-workflow_id_or_file),
+[CLI › debug](cli.md#nodetool-debug-workflow_id_or_file),
+[Harness reference](harnesses.md).
+
+### The DSL
+
+`packages/dsl/src/generated/lib.comfy.ts` exports one function per node:
+`runWorkflow`, `runWorkflowOnWorker`, and `runWorkflowOnCloud`. A file like this
+runs with `nodetool run`:
+
+```typescript
+import { libComfy, output, workflow } from "@nodetool-ai/dsl";
+
+const prompt = {
+  "3": {
+    class_type: "KSampler",
+    inputs: { seed: 42, steps: 20, cfg: 7, model: ["4", 0] }
+  }
+};
+
+const comfy = libComfy.runWorkflow({
+  endpoint: "127.0.0.1:8188",
+  workflow: JSON.stringify(prompt),
+  timeout: 600
+});
+
+export const comfyRun = workflow(
+  output.output({ name: "result", value: comfy.output() })
+);
+```
+
+**The limitation is in the generated types.** `RunWorkflowInputs` names the four
+static properties (`endpoint`, `api`, `workflow`, `timeout`) and nothing else,
+because the generator reads the node's declared props and the
+`<comfyNodeId>:<field>` handles are derived from a workflow it has never seen.
+A dynamic key in a DSL literal is a type error:
+
+```
+error TS2353: Object literal may only specify known properties,
+and '"6:text"' does not exist in type 'RunWorkflowInputs'.
+```
+
+So a DSL-authored comfy node submits its prompt with nothing injected. Two ways
+around it, in order of preference:
+
+1. **Build the values into the prompt JSON.** The node injects dynamic props
+   into `prompt[nodeId].inputs[field]` anyway, so writing them into the object
+   you stringify reaches the same place. This covers seeds, steps, CFG, and
+   prompt text, which is most of what a script varies.
+2. **Author the graph in the editor** when the workflow needs a NodeTool media
+   ref on a `Load*` handle. That upload only happens for a connected ref, so
+   there is no JSON you can write instead. Run the saved graph by id from the
+   CLI or the API.
+
+### The API
+
+A saved workflow containing a ComfyUI node runs like any other:
+
+```bash
+curl -X POST "http://localhost:7777/api/workflows/YOUR_WORKFLOW_ID/run" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -d '{"params": {"brief": "a red bicycle"}}'
+```
+
+The response is one JSON object with `job_id`, `workflow_id`, `status`,
+`outputs`, `error`, `message_count`, and `background`. `outputs` is keyed by
+output-node name, so the comfy slot reaches the caller under whatever you named
+the `nodetool.output.Output` node wired to it.
+
+`params` is keyed by **input-node name**, not by comfy handle. A workflow whose
+`6:text` is fed by a literal takes no parameter at all. Put a
+`nodetool.input.StringInput` in front of the handle and its `name` becomes the
+key. The route does not stream, so per-node progress and the ComfyUI lifecycle
+lines need the `/ws` WebSocket instead. Full shapes:
+[API Reference](api-reference.md), [WebSocket API](websocket-api.md).
+
+---
+
+## Cost, time, and failure
+
+**Cost.** No ComfyUI run writes a provider cost record, on any of the three
+nodes, so `nodetool costs` shows nothing for one. A direct or worker run is
+billed by whoever owns the GPU. A Comfy Cloud run is billed per GPU second by
+plan, and Comfy's v2 job response carries no cost field, so the node records the
+job id and no charge amount. The run log line `Comfy job <id> submitted` is the
+join key against Comfy's own billing. See
+[Known limitations](comfyui.md#known-limitations).
+
+**Time.** All three nodes default `timeout` to 600 seconds and each bounds the
+NodeTool side of the run. Raise it for video and upscale graphs. The message
+names which side gave up: `Timeout waiting for ComfyUI result` on the direct
+native path, `ComfyUI workflow did not finish within <n>s` on a v2 path, and
+`Comfy Cloud job did not finish within <n>s` on Cloud, whose own cap is 30
+minutes per job (60 on Pro) regardless of what you set here.
+
+**Cancellation** does not reach ComfyUI the same way everywhere:
+
+| Path | What a cancelled NodeTool run does |
+|---|---|
+| `RunWorkflow`, `api: native` | Posts `/interrupt` and closes the WebSocket, then fails with `ComfyUI execution was canceled` |
+| `RunWorkflow`, `api: v2` | Calls the job's cancel endpoint, so the job stops server-side |
+| `RunWorkflowOnCloud` | Calls the job's cancel endpoint, so Comfy stops billing the run |
+| `RunWorkflowOnWorker`, v2 path | Calls the job's cancel endpoint |
+| `RunWorkflowOnWorker`, bridge path | Makes no cancel call. The bridge connection closes when the call settles, and the prompt runs on inside the worker's ComfyUI |
+
+The bridge path is the one every shipped worker takes today, so treat a
+long-running worker run as uncancellable and set `timeout` accordingly. The
+error message table for everything else is
+[Troubleshooting](comfyui.md#troubleshooting).
+
+---
+
+## Related
+
+- [ComfyUI](comfyui.md): the three nodes, their properties, handles, outputs, and limitations
+- [ComfyUI Setup](comfyui-setup.md): getting a server the node can reach
+- [Creative Cookbook](cookbook.md): the same fan-out, collect, and render shapes, without ComfyUI in the middle
+- [CLI Reference](cli.md): every flag on `validate`, `debug`, `run`, and `workflows run`
+- [Harness Reference](harnesses.md): what each harness simulates and what it does not
+- [App Builder](app-builder.md): the Design view Recipe 5 uses
+- [API Reference](api-reference.md): endpoint matrix, auth, and the run payload

--- a/docs/comfyui-setup.md
+++ b/docs/comfyui-setup.md
@@ -1,0 +1,245 @@
+---
+layout: page
+title: "ComfyUI Setup"
+description: "Give NodeTool's ComfyUI nodes an endpoint: a local ComfyUI, a rented GPU, or Comfy Cloud, and the models each server has to already hold."
+---
+
+You have a ComfyUI workflow in API format and a NodeTool graph to put it in. What
+is missing is a server to run it on. This page covers getting that endpoint and
+what has to be installed on it.
+
+The nodes themselves, their properties, the workflow loader and the output slots
+are in [ComfyUI](comfyui.md).
+
+---
+
+## Choosing a path
+
+| Path | Node | Who holds the models | Cost | Reachable by |
+|---|---|---|---|---|
+| ComfyUI on your own machine | `lib.comfy.RunWorkflow` | You, on your disk | Electricity | Nothing outside your machine, when it stays on loopback |
+| ComfyUI on a rented GPU you expose | `lib.comfy.RunWorkflow` | You, on the pod's volume | Per minute while the pod is up | Anyone with the URL |
+| NodeTool ComfyUI worker on a rented GPU | `lib.comfy.RunWorkflowOnWorker` | You, on the pod's volume | Per minute while the pod is up | The bearer token holder |
+| Comfy Cloud | `lib.comfy.RunWorkflowOnCloud` | Comfy | Per job, from your Comfy account | Comfy's API key holder |
+
+Three questions usually settle it:
+
+- **Do you have a GPU that fits the workflow?** If yes, run ComfyUI locally and
+  point the direct node at it. Nothing leaves the machine and there is no start-up
+  wait.
+- **Do the weights have to stay yours?** A rented GPU keeps them on a volume you
+  control. Comfy Cloud does not: you submit a graph and Comfy supplies the models.
+- **Is the endpoint allowed to be public?** A pod's proxy URL is reachable by
+  anyone who has it, since the direct node sends no credential. The NodeTool
+  ComfyUI worker keeps ComfyUI on loopback inside the container and puts a bearer
+  token in front of it.
+
+Cold starts differ. A local ComfyUI is already warm. A rented pod pays for boot
+plus whatever model downloads its volume still needs. Comfy Cloud has no boot,
+but a full queue answers `429` and the plan's concurrent-job limit is 1, 3, or 5.
+
+---
+
+## A ComfyUI on your own machine
+
+`lib.comfy.RunWorkflow` has an `endpoint` property, defaulting to
+`127.0.0.1:8188`. A bare `host:port` gets `http://` prepended. A full `http://`
+or `https://` URL is taken as given.
+
+The process at that address has to serve ComfyUI's HTTP API and its WebSocket on
+the same port. NodeTool submits to `/prompt`, follows the run on `/ws`, downloads
+finished files from `/view`, reconciles anything it missed from
+`/history/<prompt_id>`, uploads connected media through `/upload/image`, and
+posts `/interrupt` when you cancel. A stock ComfyUI serves all of it on one
+port. See [ComfyUI's documentation](https://docs.comfy.org) for how to start it.
+
+Nothing is sent on this path except the prompt, so the endpoint has to accept an
+unauthenticated submit.
+
+### Where `127.0.0.1` is resolved from
+
+The ComfyUI nodes are server-tagged (`node`, `workers`, `edge`, never `browser`),
+so the submit is made by the NodeTool backend, not by your browser tab.
+`127.0.0.1:8188` means "port 8188 on the machine running the NodeTool server". In
+the desktop app the bundled backend runs on your machine, so a local ComfyUI is
+reachable with the default. If your NodeTool server runs somewhere else, a
+Docker container or a self-hosted box, then that host is what must reach ComfyUI,
+and loopback there is its loopback.
+
+### ComfyUI on another machine on the LAN
+
+A ComfyUI bound to loopback is unreachable from any other machine, including the
+one running NodeTool. ComfyUI's flag for binding a wider interface is `--listen`, and
+`--port` moves it off 8188. Both belong to ComfyUI, not to NodeTool: see
+[ComfyUI's documentation](https://docs.comfy.org) for the exact syntax and for
+install steps.
+
+Once it listens, set `endpoint` to that machine's `host:port`. Anyone who can
+reach the address can submit prompts to it, so keep it on a network you trust.
+
+---
+
+## A rented GPU
+
+### Expose ComfyUI yourself
+
+Run ComfyUI on a pod and reach the port from outside: a RunPod pod's HTTP proxy
+URL, a Cloudflare tunnel, an SSH tunnel. Put the resulting `https://` URL in
+`endpoint` and use the direct node. The scheme is derived from the endpoint, so a
+`https://` address upgrades the WebSocket to `wss://` on its own.
+
+This publishes ComfyUI to whoever holds the URL. There is no `Authorization`
+header on the direct node's requests, so the proxy URL is the only secret, and
+anyone with it can queue prompts, read `/history`, and download outputs. Put a
+tunnel with its own auth in front of it, or use the worker below.
+
+### The NodeTool ComfyUI worker
+
+Deploy `ghcr.io/nodetool-ai/nodetool-worker-comfy:latest`, which runs a
+co-located ComfyUI that stays loopback-only inside the container, and drive it
+with `lib.comfy.RunWorkflowOnWorker`. The node talks to the worker's bridge over
+`wss://`, authenticated with the worker's bearer token in the `worker_token`
+property. ComfyUI's own ports are never published.
+
+Provisioning, the profile and instance model, and the idle-stop and TTL guards
+that stop a forgotten pod billing are in
+[Worker Deployment](worker-deployment.md). Pick the ComfyUI image from the
+**Worker image preset** dropdown, or pass
+`--image ghcr.io/nodetool-ai/nodetool-worker-comfy:latest` on the CLI.
+
+The worker node has no workflow loader in the editor, so its `workflow` property
+and dynamic handles are filled in by hand. That and the bridge path's slot naming
+are in [Known limitations](comfyui.md#known-limitations).
+
+---
+
+## Comfy Cloud
+
+No GPU and no ComfyUI install. `lib.comfy.RunWorkflowOnCloud` submits the same
+API-format prompt to `https://cloud.comfy.org`.
+
+1. Get a key at [platform.comfy.org](https://platform.comfy.org).
+2. Store it as `COMFY_API_KEY`, either on the Comfy Cloud card in
+   **Settings → Models & Providers** or with `nodetool secrets store
+   COMFY_API_KEY`, which prompts for the value and writes it to the encrypted
+   secret store.
+
+The node declares `COMFY_API_KEY` in `requiredSettings`, so the editor badges it
+as unconfigured until the key is there, and a run without it fails with
+`COMFY_API_KEY is required to run a workflow on Comfy Cloud`.
+
+The same key is sent with the workflow as `extra_data.api_key_comfy_org`, which
+is what authenticates any partner (API) node inside the graph. One key covers
+both the job and the API nodes in it.
+
+Comfy's own limits apply to the run: 1, 3, or 5 concurrent jobs by plan, and 30
+minutes per job, 60 on Pro. Provider details are in
+[Providers › Comfy Cloud](providers.md#comfy-cloud).
+
+---
+
+## `comfy-api-proxy` for the Comfy API v2
+
+`lib.comfy.RunWorkflow`'s `api` property selects the transport. `native` is
+ComfyUI's own protocol. `v2` sends the workflow through the Comfy API v2 client
+the Cloud node uses, pointed at `endpoint`.
+
+ComfyUI core does not serve `/api/v2` yet, so a local ComfyUI needs Comfy-Org's
+own adapter in front of it. It translates v2 onto the native protocol:
+
+```bash
+pip install comfy-api-proxy
+comfy-api-proxy --comfyui http://127.0.0.1:8188 --port 8189
+```
+
+Then set `endpoint` to `127.0.0.1:8189` and `api` to `v2`. Leaving `api` on `v2`
+while `endpoint` points at a plain ComfyUI gets a `404` on `/api/v2/jobs`.
+
+No API key is sent on this path, so the proxy has to accept an unauthenticated
+submit. What changes about the run, including the different output slot naming,
+is in [Using the v2 API](comfyui.md#using-the-v2-api).
+
+---
+
+## What the server must already have
+
+A workflow in API format names its checkpoints, LoRAs, VAEs, and node classes by
+string. Those strings are resolved by the ComfyUI that runs the prompt, not by
+NodeTool. NodeTool clones the prompt, writes the connected input values into
+`prompt[nodeId].inputs[field]`, and posts it. It downloads no weights and
+installs no extensions.
+
+So the server needs, before the first run:
+
+- **Every model file the workflow names**, under the filename the prompt uses.
+  `sd_xl_base_1.0.safetensors` in the prompt is the name ComfyUI looks for in its
+  own model folders, subfolder included.
+- **Every custom node class the workflow uses.** A `class_type` that is not
+  registered on that ComfyUI is rejected at submit, exactly as it would be in
+  ComfyUI's own UI.
+
+Media inputs are the exception: a connected image, audio, or video ref is
+uploaded to the server before the prompt goes out, so input files do not have to
+pre-exist.
+
+A missing model or an unknown `class_type` fails the submit rather than the run.
+The direct node reports `Submit failed (400)` with ComfyUI's own response body
+included, which names the offending node. The full message list is in
+[Troubleshooting](comfyui.md#troubleshooting).
+
+### Checking what is there
+
+On a worker, the Python bridge exposes `comfyObjectInfo()` for the node catalog
+and `comfyModelsList(folder?)` for the model files on the volume. **No shipped
+node calls either one.** They are reachable from code against a connected bridge,
+which is what [Known limitations](comfyui.md#known-limitations) records. The
+message shapes are in [Python Bridge Protocol](python-bridge-protocol.md).
+
+For a ComfyUI you reach directly, NodeTool offers no enumeration at all. Open
+ComfyUI's own UI on that endpoint and check the loader dropdowns.
+
+For Comfy Cloud there is nothing to check from NodeTool: what is installed is
+Comfy's business, and the Comfy API enumerates no models. That is why the
+provider contributes none to the model pickers, as
+[Providers › Comfy Cloud](providers.md#comfy-cloud) notes.
+
+---
+
+## A first run to prove the wiring
+
+Use the smallest workflow you have, a text-to-image with one checkpoint and one
+`SaveImage`, before anything ambitious.
+
+1. Export it from ComfyUI with **Save (API Format)**.
+2. Add **Run ComfyUI Workflow** to a graph and load the JSON with the header
+   button. See [Loading a workflow](comfyui.md#loading-a-workflow).
+3. Set `endpoint` if it is not `127.0.0.1:8188`.
+4. Run it.
+
+A healthy run writes this sequence to the node's log:
+
+```
+Running ComfyUI workflow (7 nodes) on 127.0.0.1:8188
+Execution started
+Executing CheckpointLoaderSimple (#4)
+Executing KSampler (#3)
+Output from #9
+```
+
+A sampler progress bar appears while `KSampler` runs, and the image arrives on
+the `9:image` slot, keyed by the save node's ComfyUI id. A second run of the same
+prompt logs `Reused cache for N node(s)` instead of re-executing the unchanged
+nodes.
+
+If the log stops at `WebSocket connection failed`, the endpoint is wrong or
+ComfyUI is not listening. If it stops at `Submit failed (400)`, the server is
+reachable but missing something the workflow names.
+
+---
+
+## Related
+
+- [ComfyUI](comfyui.md) - the three nodes, their properties, the loader, and the outputs
+- [ComfyUI Recipes](comfyui-recipes.md) - worked examples of ComfyUI nodes inside NodeTool graphs
+- [Worker Deployment](worker-deployment.md) - renting a GPU and provisioning the ComfyUI worker image
+- [Providers](providers.md) - Comfy Cloud alongside every other provider, and where keys go

--- a/docs/comfyui.md
+++ b/docs/comfyui.md
@@ -418,6 +418,13 @@ the authoritative field reference is `docs/comfy-proxy.md` in `nodetool-core`.
 - **On the bridge path the worker node does not stream outputs.** It returns
   everything on completion. The v2 path yields each file as it lands, like the
   direct and Cloud nodes.
+- **Cancelling a NodeTool run does not stop a worker run on the bridge path.**
+  The direct node posts `/interrupt`, and the Cloud node and both v2 paths call
+  the job's cancel. The bridge path calls `comfy.execute` without a request id
+  and wires no abort listener, so `cancelComfyExecute` is never sent: the prompt
+  runs to completion on the worker while NodeTool stops listening. Since every
+  shipped worker image takes the bridge path, treat a worker run as
+  uncancellable and use the `timeout` property to bound it.
 - **`include_temp` is not exposed on either node.** The bridge supports it
   (`ComfyExecuteOptions.includeTemp`), so preview-node outputs can be fetched
   from code, but no node property surfaces it.

--- a/docs/comfyui.md
+++ b/docs/comfyui.md
@@ -36,6 +36,55 @@ nodes either way.
 
 ---
 
+## Quickstart
+
+From a workflow you already have to a run inside NodeTool.
+
+1. **Export in API format.** In ComfyUI use **Save (API Format)**. The regular
+   save writes the UI format, which every node here rejects with a message
+   saying exactly that.
+2. **Get an endpoint.** A ComfyUI already listening on `127.0.0.1:8188` needs
+   nothing further. With no local install and no GPU, use the Cloud node and a
+   `COMFY_API_KEY` instead. Both paths, and the rented-GPU one between them, are
+   in [ComfyUI Setup](comfyui-setup.md).
+3. **Add the node.** Search the node menu for *Run ComfyUI Workflow*. Searching
+   finds it even though `lib.comfy` is collapsed out of the browsable tree.
+4. **Load the workflow.** Use the **Load Workflow** button in the node header:
+   paste the JSON, drop the `.json`, or drop a `.png` that ComfyUI wrote. The
+   workflow's `Load*` nodes become typed input handles and its `Save*` nodes
+   become typed output handles.
+5. **Run it.** Outputs arrive one file at a time as each save node finishes.
+
+If the submit fails, the cause is usually a model or custom node the server
+doesn't have rather than anything in NodeTool. [Troubleshooting](#troubleshooting)
+lists the messages.
+
+---
+
+## When to reach for a ComfyUI node
+
+NodeTool generates images and video with its own nodes.
+`nodetool.image.TextToImage` and its siblings take a `model` property and route
+to whichever provider owns that model, so switching models is a dropdown change
+and there is no graph to maintain. That is the shorter path for most generation.
+
+A ComfyUI node earns its place when the graph itself is the point:
+
+- **The workflow already exists.** A tuned ControlNet chain, a multi-pass
+  upscale, a regional-prompting setup runs as it is, with no porting.
+- **The technique lives in custom nodes.** Anything a ComfyUI extension does
+  that no NodeTool node covers stays available, because the workflow executes on
+  ComfyUI.
+- **The weights are yours.** Checkpoints and LoRAs on your own disk never leave
+  the machine that runs them.
+
+The two compose rather than compete: a ComfyUI node is one node in a NodeTool
+graph, so an agent can write its prompt, a dataframe can drive a batch of runs,
+and its stills can feed a video assembly. Those patterns are in
+[ComfyUI Recipes](comfyui-recipes.md).
+
+---
+
 ## Run ComfyUI Workflow
 
 Point the node at a ComfyUI server you can reach. It submits the prompt over
@@ -422,6 +471,9 @@ repository (engineering specs are not part of the published site).
 
 ## Related
 
+- [ComfyUI Setup](comfyui-setup.md) — getting an endpoint these nodes can reach, and what has to be installed on it
+- [ComfyUI Recipes](comfyui-recipes.md) — composing a ComfyUI node with the rest of a graph, and running one headless
 - [Worker Deployment](worker-deployment.md) — renting a GPU and picking the ComfyUI worker image
+- [Provider Reference](providers.md) — the Comfy Cloud provider and its key
 - [Python Bridge Protocol](python-bridge-protocol.md) — the `comfy.*` message family on the wire
 - [Comparisons](comparisons.md) — how NodeTool and ComfyUI differ as tools

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -73,6 +73,10 @@ Read our full guides on how NodeTool compares to other tools:
 
 **ComfyUI** — Choose this if you are a power user who wants total, complex control over how images are generated locally.
 
+The last one is not exclusive. NodeTool runs an exported ComfyUI workflow as a
+node, so a graph you already tuned keeps working while text, audio, and video
+steps happen around it. See [ComfyUI](comfyui.md).
+
 ---
 
 ## Next steps

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -57,7 +57,9 @@ NodeTool is an open-source, local-first visual environment for building AI workf
 - [Local vs Cloud]({{ site.url }}/models): When to use which.
 - [Provider Reference]({{ site.url }}/providers): Per-provider configuration.
 - [HuggingFace]({{ site.url }}/huggingface): Models from the Hub.
-- [ComfyUI]({{ site.url }}/comfyui): Run ComfyUI workflows directly or over a GPU worker.
+- [ComfyUI]({{ site.url }}/comfyui): Run ComfyUI workflows directly, over a GPU worker, or on Comfy Cloud.
+- [ComfyUI Setup]({{ site.url }}/comfyui-setup): Getting a ComfyUI endpoint NodeTool can reach, and what must be installed on it.
+- [ComfyUI Recipes]({{ site.url }}/comfyui-recipes): Composing a ComfyUI node with the rest of a graph, and running one headless.
 - [Models Manager]({{ site.url }}/models-manager): Download and manage local models.
 
 ## Examples

--- a/docs/models-and-providers.md
+++ b/docs/models-and-providers.md
@@ -257,5 +257,6 @@ Many of these models are available through [kie.ai](https://kie.ai/), an AI prov
 - **[HuggingFace Integration](huggingface.md)** – Access 500,000+ models
 
 ### Advanced
+- **[ComfyUI](comfyui.md)** – Run an exported ComfyUI workflow as a node, locally, on a GPU worker, or on Comfy Cloud
 - **[Self-Hosted Deployment](self-hosted-deployment.md)** – Secure deployments
 - **[Deployment Guide](deployment.md)** – Cloud infrastructure

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -214,7 +214,7 @@ Nodes in the `nodetool.*` namespace take a `model` property and route to whichev
 | Node | Switches between |
 |---|---|
 | `nodetool.agents.Agent` | OpenAI, Anthropic, Gemini, xAI, DeepSeek, Ollama, any chat provider |
-| `nodetool.image.TextToImage` | FLUX.2, Nano Banana 2.0, GPT Image 2, Ideogram V3, Z-Image, HuggingFace, ComfyUI, MLX |
+| `nodetool.image.TextToImage` | FLUX.2, Nano Banana 2.0, GPT Image 2, Ideogram V3, Z-Image, HuggingFace, MLX |
 | `nodetool.image.ImageToImage` | HuggingFace, local servers, cloud services |
 | `nodetool.video.TextToVideo` | Sora 2 Pro, Veo 3.1, Seedance 2.0, Runway, Grok Imagine, Wan 2.6, Hailuo 2.3, Kling 3.0, HuggingFace |
 | `nodetool.video.ImageToVideo` | Sora 2 Pro, Veo 3.1, Seedance 2.0, Runway, Luma, Grok Imagine, Wan 2.6, Hailuo 2.3, Kling 3.0 |


### PR DESCRIPTION
## What changed

`docs/comfyui.md` was a good node reference but assumed the reader already had a server, already knew why they would use a ComfyUI node over NodeTool's own image nodes, and already knew how to compose one into a graph. This adds the missing halves as two pages and fills the gaps in the existing one.

- **`docs/comfyui.md`** gains a Quickstart (export in API format, get an endpoint, add the node, load, run) and a "When to reach for a ComfyUI node" section that sets it against `nodetool.image.TextToImage` honestly: the generic node is the shorter path for most generation, and a ComfyUI node earns its place when the graph itself is the point.
- **`docs/comfyui-setup.md`** (new) covers getting an endpoint: a local ComfyUI and where `127.0.0.1` resolves from, a rented GPU you expose versus the NodeTool ComfyUI worker, Comfy Cloud and its key, `comfy-api-proxy` for the v2 API, and what models and custom node classes the server must already hold. That last one is the most common real failure and was undocumented.
- **`docs/comfyui-recipes.md`** (new) covers composition: a model writing the prompt, one workflow over many inputs, stored assets in and out, frames into a cut, a mini app, chat, and running the whole thing from the CLI harnesses, the DSL, or the API.
- Navigation: sidebar entries, `llms.txt` entries, and cross-links from `comparisons.md`, `models-and-providers.md`, and `providers.md`.

Three corrections came out of grounding the prose in the code rather than in the existing docs:

1. **`providers.md` listed ComfyUI as a `nodetool.image.TextToImage` backend.** That contradicts footnote 5 on the same page and the code: `ComfyCloudProvider` overrides no `getAvailable*Models`, so it enumerates nothing and never appears in that picker. Removed from the list.
2. **A cancelled NodeTool run does not stop a worker run on the bridge path.** `comfyExecute` is called with no request id and no abort listener, so `cancelComfyExecute` never fires and the prompt runs on inside the worker. Every shipped worker image takes that path today. Now a documented limitation with a five-row cancellation table in the recipes page, rather than an assumption that cancel works everywhere.
3. **The DSL cannot express a ComfyUI node's dynamic handles.** The generated wrappers carry the static properties only, so a DSL-authored comfy node runs its workflow with nothing injected. The page shows the actual `tsc` error and the two workarounds.

Not included: the generated node reference under `docs/nodes/` is stale repo-wide (463 catalogued versus 515 registered, and `lib.comfy` still shows 2 nodes without the Cloud node). `npm run generate:node-docs` fixes it, but the run touches 96 files across 72 namespaces and also drops descriptions from every namespace index, which is a separate change and not one to bury here.

## Verification

Docs-only diff, 8 files.

- [x] `npm run test:affected -- --dry-run --base origin/main`: "nothing — no workspace owns the changed files"
- [x] Every relative link and `#anchor` in all three ComfyUI pages resolves against the real headings, checked with a slugifying loop over the actual target files
- [x] Forbidden-expression grep from `WRITING_STYLE.md` over all three pages: zero hits. Em-dash density within the one-per-paragraph rule
- [x] Every node type named in the recipes exists in the registry (`nodeType = "..."` grep, 10/10), and `{% mermaid %}` matches the tag documented in `THEME.md`
- [x] Claims checked against source: the executor's routes and the absence of any credential on the direct path, `COMFY_API_KEY` in `setting-catalog.ts`, `nodetool secrets store`, `nodetool costs`, `requiredSettings` on the Cloud node, and that no shipped node calls `comfyObjectInfo` or `comfyModelsList`
- [ ] `npm run typecheck` / `npm run lint` not run: no TypeScript or linted path changed
- [ ] `harness gate` not run: documentation maps to no harness entry

## Agent capabilities

Skipped, no capability added or changed.

## New checks

Skipped, no check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRYgfKMQfkTqMnu6Vm2yNA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRYgfKMQfkTqMnu6Vm2yNA)_