### PR TITLE
fix(web): anchor output-menu nodes to the handle, not the clicked row

### DIFF
--- a/web/src/components/context_menus/OutputContextMenu.tsx
+++ b/web/src/components/context_menus/OutputContextMenu.tsx
@@ -26,7 +26,7 @@ import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import useContextMenuStore from "../../stores/ContextMenuStore";
 import { useDynamicOutput } from "../../hooks/nodes/useDynamicOutput";
-import { useReactFlow } from "@xyflow/react";
+import { useReactFlow, type XYPosition } from "@xyflow/react";
 import useMetadataStore from "../../stores/MetadataStore";
 import { NodeMetadata } from "../../stores/ApiTypes";
 import { labelForType } from "../../config/data_types";
@@ -38,7 +38,8 @@ import { useRecentNodesStore } from "../../stores/RecentNodesStore";
 import NodeItem from "../node_menu/NodeItem";
 import { useAutoFocusEnabled } from "../../hooks/useAutoFocusEnabled";
 import { useCodeGenFromHandle } from "../../hooks/useCodeGenFromHandle";
-import { isNumber, isString } from "../../utils/typePredicates";
+import { useHandleNodePlacement } from "../../hooks/useHandleNodePlacement";
+import { isNumber } from "../../utils/typePredicates";
 
 const NODE_ROW_HEIGHT = 28;
 
@@ -75,6 +76,8 @@ const OutputContextMenu: React.FC = () => {
       shallow
     );
   const reactFlowInstance = useReactFlow();
+  const { handleAnchor, initialPosition, alignNodeToAnchor } =
+    useHandleNodePlacement();
   const getMetadata = useMetadataStore((state) => state.getMetadata);
   const allMetadata = useMetadataStore((state) => state.metadata);
 
@@ -154,10 +157,35 @@ const OutputContextMenu: React.FC = () => {
     []
   );
 
+  /**
+   * Where the new node belongs, in flow space.
+   *
+   * The output handle itself — not the menu row that was clicked, which sits
+   * an arbitrary distance away and flips side near a viewport edge. When the
+   * menu was opened by dropping a connection on the pane, the drop point is
+   * the anchor: the user pointed at a spot.
+   */
+  const anchorPosition = useCallback((): XYPosition | null => {
+    const dropPosition = (
+      payload as { dropPosition?: { x: number; y: number } } | null
+    )?.dropPosition;
+    if (dropPosition) {
+      return reactFlowInstance.screenToFlowPosition(dropPosition);
+    }
+    const fromHandle = nodeId
+      ? handleAnchor(nodeId, sourceHandle, "source")
+      : null;
+    if (fromHandle) {
+      return fromHandle;
+    }
+    return menuPosition
+      ? reactFlowInstance.screenToFlowPosition(menuPosition)
+      : null;
+  }, [handleAnchor, menuPosition, nodeId, payload, reactFlowInstance, sourceHandle]);
+
   const createNodeWithEdge = useCallback(
     (
       metadata: unknown,
-      anchor: { x: number; y: number },
       nodeType: string,
       targetHandle: string | null = null
     ) => {
@@ -165,30 +193,15 @@ const OutputContextMenu: React.FC = () => {
         console.info("Metadata is undefined, cannot create node.");
         return;
       }
+      const anchor = anchorPosition();
+      if (!anchor) {
+        return;
+      }
 
-      // Place the new node a short gap to the right of the output handle and
-      // vertically centered on it. Compute in flow space so the gap stays
-      // consistent regardless of zoom.
-      const extMeta = metadata as NodeMetadata & {
-        style?: { width?: number | string; height?: number | string };
-      };
-      const parseDim = (
-        value: number | string | undefined,
-        fallback: number
-      ): number => {
-        if (isNumber(value)) return value;
-        if (isString(value)) return parseInt(value, 10) || fallback;
-        return fallback;
-      };
-      const nodeHeight = parseDim(extMeta.style?.height, 200);
-      const flowAnchor = reactFlowInstance.screenToFlowPosition(anchor);
-      const GAP_X_FLOW = 40;
-      const flowPosition = {
-        x: flowAnchor.x + GAP_X_FLOW,
-        y: flowAnchor.y - nodeHeight / 2
-      };
-
-      const newNode = createNode(metadata as NodeMetadata, flowPosition);
+      const newNode = createNode(
+        metadata as NodeMetadata,
+        initialPosition(anchor)
+      );
 
       if (targetHandle) {
         newNode.data.dynamic_properties[targetHandle] = true;
@@ -228,10 +241,13 @@ const OutputContextMenu: React.FC = () => {
         type: "default",
         className: Slugify(sourceType?.type || "")
       });
+      alignNodeToAnchor(newNode.id, anchor, targetHandle);
     },
     [
+      alignNodeToAnchor,
+      anchorPosition,
       createNode,
-      reactFlowInstance,
+      initialPosition,
       addNode,
       getTargetHandle,
       addEdge,
@@ -242,123 +258,84 @@ const OutputContextMenu: React.FC = () => {
     ]
   );
 
-  const createPreviewNode = useCallback(
-    (event: React.MouseEvent) => {
-      const metadata = getMetadata(PREVIEW_NODE_TYPE);
-      if (!metadata) {
-        return;
-      }
-      createNodeWithEdge(
-        {
-          ...metadata,
-          style: {
-            width: "400px",
-            height: "300px"
-          }
-        },
-        { x: event.clientX, y: event.clientY },
-        "preview"
-      );
-    },
-    [getMetadata, createNodeWithEdge]
-  );
+  const createPreviewNode = useCallback(() => {
+    const metadata = getMetadata(PREVIEW_NODE_TYPE);
+    if (!metadata) {
+      return;
+    }
+    createNodeWithEdge(
+      { ...metadata, style: { width: "400px", height: "300px" } },
+      "preview"
+    );
+  }, [getMetadata, createNodeWithEdge]);
 
-  const createRerouteNode = useCallback(
-    (event: React.MouseEvent) => {
-      const metadata = getMetadata(REROUTE_NODE_TYPE);
-      if (!metadata) {
-        return;
-      }
-      createNodeWithEdge(
-        metadata,
-        { x: event.clientX, y: event.clientY },
-        "reroute",
-        "input_value"
-      );
-    },
-    [getMetadata, createNodeWithEdge]
-  );
+  const createRerouteNode = useCallback(() => {
+    const metadata = getMetadata(REROUTE_NODE_TYPE);
+    if (!metadata) {
+      return;
+    }
+    createNodeWithEdge(metadata, "reroute", "input_value");
+  }, [getMetadata, createNodeWithEdge]);
 
-  const createOutputNode = useCallback(
-    (event: React.MouseEvent) => {
-      if (!outputNodeMetadata) {
-        return;
-      }
-      createNodeWithEdge(
-        outputNodeMetadata,
-        { x: event.clientX, y: event.clientY },
-        "output"
-      );
-    },
-    [outputNodeMetadata, createNodeWithEdge]
-  );
+  const createOutputNode = useCallback(() => {
+    if (!outputNodeMetadata) {
+      return;
+    }
+    createNodeWithEdge(outputNodeMetadata, "output");
+  }, [outputNodeMetadata, createNodeWithEdge]);
 
-  const createSaveNode = useCallback(
-    (event: React.MouseEvent) => {
-      if (!saveNodeMetadata) {
-        return;
-      }
-      createNodeWithEdge(
-        saveNodeMetadata,
-        { x: event.clientX, y: event.clientY },
-        "save"
-      );
-    },
-    [saveNodeMetadata, createNodeWithEdge]
-  );
+  const createSaveNode = useCallback(() => {
+    if (!saveNodeMetadata) {
+      return;
+    }
+    createNodeWithEdge(saveNodeMetadata, "save");
+  }, [saveNodeMetadata, createNodeWithEdge]);
 
   const handleCreatePreviewNode = useCallback((event?: React.MouseEvent<HTMLElement>) => {
-    if (event) {
-      event.preventDefault();
-      event.stopPropagation();
-      createPreviewNode(event);
-    }
+    event?.preventDefault();
+    event?.stopPropagation();
+    createPreviewNode();
     closeContextMenu();
   }, [createPreviewNode, closeContextMenu]);
 
   const handleCreateRerouteNode = useCallback((event?: React.MouseEvent<HTMLElement>) => {
-    if (event) {
-      event.preventDefault();
-      event.stopPropagation();
-      createRerouteNode(event as React.MouseEvent);
-    }
+    event?.preventDefault();
+    event?.stopPropagation();
+    createRerouteNode();
     closeContextMenu();
   }, [createRerouteNode, closeContextMenu]);
 
   const handleCreateOutputNode = useCallback((event?: React.MouseEvent<HTMLElement>) => {
-    if (event) {
-      event.preventDefault();
-      event.stopPropagation();
-      createOutputNode(event);
-    }
+    event?.preventDefault();
+    event?.stopPropagation();
+    createOutputNode();
     closeContextMenu();
   }, [createOutputNode, closeContextMenu]);
 
   const { transformOutput } = useCodeGenFromHandle();
-  // Placement mirrors createNodeWithEdge: a fixed gap right of the handle,
-  // vertically centered on it, computed in flow space so zoom doesn't matter.
+  // Same anchor as createNodeWithEdge. transformOutput owns the node it
+  // creates and never hands back its id, so this one keeps the pre-mount
+  // estimate instead of being aligned once it renders.
   const handleTransformWithAI = useCallback(
     (event?: React.MouseEvent<HTMLElement>) => {
       event?.preventDefault();
       event?.stopPropagation();
-      if (nodeId && sourceHandle && sourceType && event) {
-        const flowAnchor = reactFlowInstance.screenToFlowPosition({
-          x: event.clientX,
-          y: event.clientY
-        });
+      const anchor = anchorPosition();
+      if (nodeId && sourceHandle && sourceType && anchor) {
         transformOutput({
           sourceNodeId: nodeId,
           sourceHandle,
           sourceType,
-          position: { x: flowAnchor.x + 40, y: flowAnchor.y - 100 }
+          position: initialPosition(anchor)
         });
       }
       closeContextMenu();
     },
     [
+      anchorPosition,
       closeContextMenu,
+      initialPosition,
       nodeId,
-      reactFlowInstance,
       sourceHandle,
       sourceType,
       transformOutput
@@ -366,11 +343,9 @@ const OutputContextMenu: React.FC = () => {
   );
 
   const handleCreateSaveNode = useCallback((event?: React.MouseEvent<HTMLElement>) => {
-    if (event) {
-      event.preventDefault();
-      event.stopPropagation();
-      createSaveNode(event);
-    }
+    event?.preventDefault();
+    event?.stopPropagation();
+    createSaveNode();
     closeContextMenu();
   }, [createSaveNode, closeContextMenu]);
 
@@ -445,26 +420,14 @@ const OutputContextMenu: React.FC = () => {
 
   const handleConnectableNodeClick = useCallback(
     (metadata: NodeMetadata) => {
-      if (!menuPosition) {
-        return;
-      }
-      const anchorPosition =
-        (payload as { dropPosition?: { x: number; y: number } } | null)
-          ?.dropPosition ?? menuPosition;
       const property = getPreferredConnectableInput(metadata);
       if (!property) {
         return;
       }
-      createNodeWithEdge(metadata, anchorPosition, "connectable", property.name);
+      createNodeWithEdge(metadata, "connectable", property.name);
       closeContextMenu();
     },
-    [
-      closeContextMenu,
-      createNodeWithEdge,
-      getPreferredConnectableInput,
-      menuPosition,
-      payload
-    ]
+    [closeContextMenu, createNodeWithEdge, getPreferredConnectableInput]
   );
 
   // Skipped on touch, where the virtual keyboard would cover the menu.

--- a/web/src/hooks/useHandleNodePlacement.ts
+++ b/web/src/hooks/useHandleNodePlacement.ts
@@ -1,0 +1,162 @@
+import { useCallback } from "react";
+import { useReactFlow, type XYPosition } from "@xyflow/react";
+
+import { useShallow } from "zustand/react/shallow";
+
+import { useNodes } from "../contexts/NodeContext";
+import {
+  ESTIMATED_INPUT_HANDLE_OFFSET_Y,
+  HANDLE_GAP_X,
+  placeAtAnchor,
+  resolveVerticalOverlap,
+  type PlacementRect
+} from "../utils/nodePlacement";
+
+/**
+ * Placement for a node created from a handle menu.
+ *
+ * The anchor is the handle itself, never the menu row the user clicked: the
+ * menu is a floating list, so its rows sit tens to hundreds of pixels away
+ * from the handle and flip side when the menu meets a viewport edge.
+ *
+ * A node's first input handle sits anywhere from ~10px to ~100px below its top
+ * edge depending on its header and body, and none of that is known until the
+ * node renders. So creation uses an estimate and `alignNodeToAnchor` corrects
+ * it on the next frames, once the real handle can be measured.
+ */
+export const useHandleNodePlacement = () => {
+  const { screenToFlowPosition } = useReactFlow();
+  const { findNode, updateNode } = useNodes(
+    useShallow((state) => ({
+      findNode: state.findNode,
+      updateNode: state.updateNode
+    }))
+  );
+
+  const flowRect = useCallback(
+    (element: Element): PlacementRect => {
+      const rect = element.getBoundingClientRect();
+      const topLeft = screenToFlowPosition({ x: rect.x, y: rect.y });
+      const bottomRight = screenToFlowPosition({
+        x: rect.right,
+        y: rect.bottom
+      });
+      return {
+        x: topLeft.x,
+        y: topLeft.y,
+        width: bottomRight.x - topLeft.x,
+        height: bottomRight.y - topLeft.y
+      };
+    },
+    [screenToFlowPosition]
+  );
+
+  /** Flow-space centre of a node's handle, or null when it is not rendered. */
+  const handleAnchor = useCallback(
+    (
+      nodeId: string,
+      handleId: string | null,
+      kind: "source" | "target"
+    ): XYPosition | null => {
+      const node = document.querySelector(
+        `.react-flow__node[data-id="${CSS.escape(nodeId)}"]`
+      );
+      if (!node) {
+        return null;
+      }
+      const handle =
+        (handleId &&
+          node.querySelector(
+            `.react-flow__handle.${kind}[data-handleid="${CSS.escape(handleId)}"]`
+          )) ||
+        node.querySelector(`.react-flow__handle.${kind}`);
+      if (!handle) {
+        return null;
+      }
+      const rect = handle.getBoundingClientRect();
+      return screenToFlowPosition({
+        x: rect.x + rect.width / 2,
+        y: rect.y + rect.height / 2
+      });
+    },
+    [screenToFlowPosition]
+  );
+
+  /** Where to create a node connected to `anchor`, before it can be measured. */
+  const initialPosition = useCallback(
+    (anchor: XYPosition): XYPosition =>
+      placeAtAnchor(anchor, ESTIMATED_INPUT_HANDLE_OFFSET_Y, HANDLE_GAP_X),
+    []
+  );
+
+  /**
+   * Once `nodeId` has rendered, move it so its input handle is level with
+   * `anchor` and it clears the nodes already on the canvas.
+   */
+  const alignNodeToAnchor = useCallback(
+    (nodeId: string, anchor: XYPosition, targetHandle: string | null) => {
+      let frames = 0;
+      const attempt = () => {
+        const element = document.querySelector(
+          `.react-flow__node[data-id="${CSS.escape(nodeId)}"]`
+        );
+        // ReactFlow mounts a node before it measures it; an unmeasured node
+        // reports height 0, which would align against nothing.
+        if (
+          (!element || element.getBoundingClientRect().height === 0) &&
+          frames++ < 5
+        ) {
+          requestAnimationFrame(attempt);
+          return;
+        }
+        if (!element) {
+          return;
+        }
+        const rect = flowRect(element);
+        const inputAnchor = handleAnchor(nodeId, targetHandle, "target");
+        const offsetY = inputAnchor
+          ? inputAnchor.y - rect.y
+          : ESTIMATED_INPUT_HANDLE_OFFSET_Y;
+
+        const obstacles = Array.from(
+          document.querySelectorAll(".react-flow__node")
+        )
+          .filter((other) => other !== element)
+          .map(flowRect)
+          // A group or comment the node sits inside is a backdrop, not an
+          // obstacle — pushing clear of it would eject the node from the
+          // group. Strict containment, so a node of the same size still
+          // counts as something to avoid.
+          .filter(
+            (other) =>
+              !(
+                other.x < rect.x &&
+                other.y < rect.y &&
+                other.x + other.width > rect.x + rect.width &&
+                other.y + other.height > rect.y + rect.height
+              )
+          );
+
+        const desired = { ...rect, y: anchor.y - offsetY };
+        const correction = resolveVerticalOverlap(desired, obstacles) - rect.y;
+        // Shift the stored position by the measured correction rather than
+        // writing the absolute one: a node inside a group stores its position
+        // relative to the group.
+        const stored = findNode(nodeId);
+        if (!stored || correction === 0) {
+          return;
+        }
+        updateNode(nodeId, {
+          position: {
+            x: stored.position.x,
+            y: stored.position.y + correction
+          }
+        });
+      };
+      requestAnimationFrame(attempt);
+    },
+    [findNode, flowRect, handleAnchor, updateNode]
+  );
+
+  return { handleAnchor, initialPosition, alignNodeToAnchor };
+};

--- a/web/src/utils/__tests__/nodePlacement.test.ts
+++ b/web/src/utils/__tests__/nodePlacement.test.ts
@@ -1,0 +1,70 @@
+import {
+  HANDLE_GAP_X,
+  OVERLAP_MARGIN,
+  placeAtAnchor,
+  resolveVerticalOverlap,
+  type PlacementRect
+} from "../nodePlacement";
+
+const rect = (
+  x: number,
+  y: number,
+  width = 200,
+  height = 100
+): PlacementRect => ({ x, y, width, height });
+
+describe("placeAtAnchor", () => {
+  it("puts the node's input handle a gap right of the anchor and level with it", () => {
+    expect(placeAtAnchor({ x: 100, y: 500 }, 24)).toEqual({
+      x: 100 + HANDLE_GAP_X,
+      y: 476
+    });
+  });
+
+  it("aligns each node type by its own input handle offset", () => {
+    // A Reroute's handle sits 10px below its top, a Preview's 27px: both end
+    // up with the handle at the anchor's y.
+    expect(placeAtAnchor({ x: 0, y: 300 }, 10).y).toBe(290);
+    expect(placeAtAnchor({ x: 0, y: 300 }, 27).y).toBe(273);
+  });
+});
+
+describe("resolveVerticalOverlap", () => {
+  it("keeps the desired position when nothing is in the way", () => {
+    expect(resolveVerticalOverlap(rect(0, 100), [rect(1000, 100)])).toBe(100);
+  });
+
+  it("moves clear of a node on the same spot", () => {
+    const other = rect(0, 100);
+    expect(resolveVerticalOverlap(rect(0, 100), [other])).toBe(
+      other.y + other.height + OVERLAP_MARGIN
+    );
+  });
+
+  it("picks the nearest free slot, above when that is closer", () => {
+    // Desired y 300. The blocker spans 260-560, so above (140) is nearer than
+    // below (580).
+    expect(resolveVerticalOverlap(rect(0, 300), [rect(0, 260, 200, 300)])).toBe(
+      140
+    );
+  });
+
+  it("prefers below when above and below are equally near", () => {
+    const blocker = rect(0, 100);
+    expect(resolveVerticalOverlap(rect(0, 100), [blocker])).toBe(220);
+  });
+
+  it("skips a candidate slot that another node already occupies", () => {
+    // Below the first blocker is taken by the second, so the free slot is
+    // above the first.
+    const y = resolveVerticalOverlap(rect(0, 100), [
+      rect(0, 100),
+      rect(0, 220)
+    ]);
+    expect(y).toBe(-20);
+  });
+
+  it("ignores nodes that do not overlap horizontally", () => {
+    expect(resolveVerticalOverlap(rect(0, 100), [rect(400, 100)])).toBe(100);
+  });
+});

--- a/web/src/utils/nodePlacement.ts
+++ b/web/src/utils/nodePlacement.ts
@@ -1,0 +1,85 @@
+import type { XYPosition } from "@xyflow/react";
+
+export type PlacementRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+/** Flow-space gap between an output handle and the left edge of the node created from it. */
+export const HANDLE_GAP_X = 60;
+
+/**
+ * Where a node's first input handle sits below its top edge, before the node
+ * has mounted and can be measured. Nodes vary from ~10px (Reroute) to ~100px
+ * (a node with a long header), so this is only the pre-mount guess —
+ * `alignNodeToAnchor` corrects it against the real handle once it renders.
+ */
+export const ESTIMATED_INPUT_HANDLE_OFFSET_Y = 24;
+
+/** Vertical clearance kept between a placed node and the nodes already there. */
+export const OVERLAP_MARGIN = 20;
+
+/**
+ * Position a node so its first input handle lands `gapX` to the right of
+ * `anchor` and level with it — the incoming edge comes out horizontal.
+ */
+export const placeAtAnchor = (
+  anchor: XYPosition,
+  inputHandleOffsetY: number,
+  gapX: number = HANDLE_GAP_X
+): XYPosition => ({
+  x: anchor.x + gapX,
+  y: anchor.y - inputHandleOffsetY
+});
+
+const intersects = (
+  a: PlacementRect,
+  b: PlacementRect,
+  margin: number
+): boolean =>
+  a.x < b.x + b.width + margin &&
+  a.x + a.width + margin > b.x &&
+  a.y < b.y + b.height + margin &&
+  a.y + a.height + margin > b.y;
+
+/**
+ * Move `rect` vertically to the nearest spot that clears every rect in
+ * `others`.
+ *
+ * Without this, two nodes created from the same handle land on exactly the
+ * same coordinates, and a node created from a handle that already has a
+ * downstream node lands on top of it. Candidates are the desired position
+ * plus the free edge below and above each obstacle; the one closest to the
+ * desired position wins, so the node stays near the handle it came from, and
+ * a tie goes downward — the direction a graph grows.
+ */
+export const resolveVerticalOverlap = (
+  rect: PlacementRect,
+  others: PlacementRect[],
+  margin: number = OVERLAP_MARGIN
+): number => {
+  const clear = (y: number): boolean =>
+    others.every((other) => !intersects({ ...rect, y }, other, margin));
+  if (clear(rect.y)) {
+    return rect.y;
+  }
+  const candidates = [
+    ...others.map((other) => other.y + other.height + margin),
+    ...others.map((other) => other.y - rect.height - margin)
+  ];
+  let best: number | null = null;
+  for (const candidate of candidates) {
+    if (!clear(candidate)) {
+      continue;
+    }
+    if (
+      best === null ||
+      Math.abs(candidate - rect.y) < Math.abs(best - rect.y)
+    ) {
+      best = candidate;
+    }
+  }
+  return best ?? rect.y;
+};

--- a/web/tests/journeys/editor.spec.ts
+++ b/web/tests/journeys/editor.spec.ts
@@ -45,6 +45,64 @@ test.describe("Editor", () => {
     await expect(editor.nodes()).toHaveCount(before + 1);
   });
 
+  /**
+   * The output menu is a floating list: its rows sit anywhere from tens to
+   * hundreds of pixels from the handle, and flip side near a viewport edge.
+   * Placing the new node against the clicked row put it wherever the menu
+   * happened to be — a Preview landed 225px right of the handle and 110px
+   * above it, a Reroute somewhere else again. The node belongs against the
+   * handle, with its input handle level with it.
+   */
+  test("places a node from the output menu level with the handle it came from", async ({
+    page
+  }) => {
+    const editor = new EditorPage(page);
+    await editor.open(FIXTURES.editorGraph);
+
+    // The fixture's Output node sits directly right of the handle; move it
+    // away so this test measures alignment, not the clearance rule below.
+    await editor.dragNode("result_output", 0, 600);
+
+    const handle = await editor.outputHandleCenter("prompt_input");
+    const created = await editor.createFromOutputHandle(
+      "prompt_input",
+      "create-preview-node"
+    );
+    const geometry = await editor.nodeGeometry(created);
+
+    expect(geometry.inputHandle).not.toBeNull();
+    // Level with the source handle: the edge between them comes out flat.
+    expect(Math.abs(geometry.inputHandle!.y - handle.y)).toBeLessThan(8);
+    // Just to the right of it, not off in the direction the menu opened.
+    expect(geometry.box.x - handle.x).toBeGreaterThan(0);
+    expect(geometry.box.x - handle.x).toBeLessThan(120);
+  });
+
+  test("keeps a second node from the same handle clear of the first", async ({
+    page
+  }) => {
+    const editor = new EditorPage(page);
+    await editor.open(FIXTURES.editorGraph);
+
+    const first = await editor.createFromOutputHandle(
+      "prompt_input",
+      "create-preview-node"
+    );
+    const second = await editor.createFromOutputHandle(
+      "prompt_input",
+      "create-preview-node"
+    );
+
+    const a = (await editor.nodeGeometry(first)).box;
+    const b = (await editor.nodeGeometry(second)).box;
+    const overlaps =
+      a.x < b.x + b.width &&
+      a.x + a.width > b.x &&
+      a.y < b.y + b.height &&
+      a.y + a.height > b.y;
+    expect(overlaps).toBe(false);
+  });
+
   test("runs the graph and shows the result on the canvas", async ({
     page
   }) => {

--- a/web/tests/journeys/pages.ts
+++ b/web/tests/journeys/pages.ts
@@ -74,6 +74,135 @@ export class EditorPage {
       .catch(() => {});
   }
 
+  /** A node's output handle — the surface the output menu opens from. */
+  outputHandle(nodeId: string): Locator {
+    return this.page
+      .locator(`[data-id="${nodeId}"] .react-flow__handle.source`)
+      .first();
+  }
+
+  /**
+   * Create a node from `nodeId`'s output handle via the row matching
+   * `rowClass` (e.g. `create-preview-node`), and return its id.
+   */
+  async createFromOutputHandle(
+    nodeId: string,
+    rowClass: string
+  ): Promise<string> {
+    const idsBefore = await this.nodeIds();
+    await this.outputHandle(nodeId).click({ button: "right" });
+    await this.page
+      .locator(".output-context-menu")
+      .waitFor({ state: "visible", timeout: 15_000 });
+    await this.page.locator(`.${rowClass}`).click();
+    await this.page.waitForFunction(
+      (count) => document.querySelectorAll(".react-flow__node").length > count,
+      idsBefore.length,
+      { timeout: 15_000 }
+    );
+    const created = (await this.nodeIds()).find(
+      (id) => !idsBefore.includes(id)
+    );
+    if (!created) {
+      throw new Error("no node was created from the output handle");
+    }
+    await this.waitForNodeSettled(created);
+    return created;
+  }
+
+  /** Drag a node by its header, the way a user moves one. */
+  async dragNode(nodeId: string, dx: number, dy: number): Promise<void> {
+    const header = this.page
+      .locator(`[data-id="${nodeId}"] .node-header`)
+      .first();
+    const box = await header.boundingBox();
+    if (!box) {
+      throw new Error(`node ${nodeId} has no header to drag`);
+    }
+    const from = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+    await this.page.mouse.move(from.x, from.y);
+    await this.page.mouse.down();
+    await this.page.mouse.move(from.x + dx, from.y + dy, { steps: 10 });
+    await this.page.mouse.up();
+    await this.waitForNodeSettled(nodeId);
+  }
+
+  /**
+   * Resolve once `nodeId` has stopped moving.
+   *
+   * A programmatic move tweens (`transform var(--motion-normal)` in
+   * `nodes.base.css`), so a rect read straight after creation is mid-slide.
+   */
+  async waitForNodeSettled(nodeId: string): Promise<void> {
+    await this.page.waitForFunction(
+      (id) => {
+        const el = document.querySelector(
+          `.react-flow__node[data-id="${id}"]`
+        ) as HTMLElement | null;
+        if (!el) {
+          return false;
+        }
+        const w = window as unknown as {
+          __settle?: { id: string; y: number; hits: number };
+        };
+        const y = el.getBoundingClientRect().y;
+        const prev = w.__settle;
+        if (!prev || prev.id !== id || Math.abs(prev.y - y) > 0.5) {
+          w.__settle = { id, y, hits: 0 };
+          return false;
+        }
+        prev.hits += 1;
+        return prev.hits >= 3;
+      },
+      nodeId,
+      { timeout: 15_000, polling: 100 }
+    );
+  }
+
+  async nodeIds(): Promise<string[]> {
+    return await this.page.evaluate(() =>
+      Array.from(document.querySelectorAll(".react-flow__node")).map(
+        (el) => el.getAttribute("data-id") ?? ""
+      )
+    );
+  }
+
+  /**
+   * Screen-space geometry of a node and of the handles the layout is judged
+   * by: its own first input handle, and its box.
+   */
+  async nodeGeometry(nodeId: string): Promise<{
+    box: { x: number; y: number; width: number; height: number };
+    inputHandle: { x: number; y: number } | null;
+  }> {
+    return await this.page.evaluate((id) => {
+      const el = document.querySelector(
+        `.react-flow__node[data-id="${id}"]`
+      ) as HTMLElement | null;
+      if (!el) {
+        throw new Error(`node ${id} is not on the canvas`);
+      }
+      const r = el.getBoundingClientRect();
+      const handle = el.querySelector(".react-flow__handle.target");
+      const hr = handle?.getBoundingClientRect() ?? null;
+      return {
+        box: { x: r.x, y: r.y, width: r.width, height: r.height },
+        inputHandle: hr
+          ? { x: hr.x + hr.width / 2, y: hr.y + hr.height / 2 }
+          : null
+      };
+    }, nodeId);
+  }
+
+  /** Screen-space centre of a node's output handle. */
+  async outputHandleCenter(nodeId: string): Promise<{ x: number; y: number }> {
+    const box = await this.outputHandle(nodeId).boundingBox();
+    if (!box) {
+      throw new Error(`node ${nodeId} has no output handle`);
+    }
+    return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+  }
+
   async run(): Promise<void> {
     await this.page.getByRole("button", { name: "Run workflow" }).click();
   }


### PR DESCRIPTION
## What changed

Nodes created from the output handle menu were positioned against the menu row the user clicked, so where a node landed depended on which row it was and where the floating menu happened to open. Measured live in the editor (Playwright against the seeded backend, zoom 1): a Preview landed 225 flow-px right of the source handle and 110px above it, an Output 44px above, a Reroute 21px, and the connectable list used a different rule again; a second node from the same handle landed exactly on top of the first. The anchor is now the output handle itself — or the drop point when the menu was opened by releasing a connection on the pane. A node's first input handle sits anywhere from 10px (Reroute) to ~100px (a node with a tall header) below its top edge, and none of that is known before it renders, so creation uses an estimate and a post-mount pass measures the real handle and shifts the node until the two are level; the same pass slides the node to the nearest free slot, so repeat creations from one handle no longer stack. The move rides the transform tween `nodes.base.css` already applies to programmatic moves, so the node glides into place. Measured after the change: every row places the node 60px right of the handle with its input handle exactly level, and clear of what is already there.

## Verification

Live measurements were taken with a throwaway Playwright probe against the journeys backend; the numbers above and below come from it. The probe was replaced by the two journey tests in `web/tests/journeys/editor.spec.ts`.

- [x] `npm run test:affected` — 4 suites, 20 tests passed
- [x] `npm run typecheck` — web and electron clean (the `mobile` leg fails on `Cannot find module 'expo'` / `react-native`: `mobile/` is not a root workspace and its dependencies are not installed in this container; unrelated to the diff)
- [x] `npm run lint` — clean
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — 1 surface (`web-editor`), 0 selfchecks to run
- [x] `npx playwright test -c playwright.journeys.config.ts tests/journeys/editor.spec.ts` — 5/5 passed

Both new journey tests were run against the pre-fix `OutputContextMenu.tsx` and failed there:

```
✘ places a node from the output menu level with the handle it came from
    Expected: < 8
    Received:   110.3125
✘ keeps a second node from the same handle clear of the first
    Expected: false
    Received: true
```

## Agent capabilities

No capability added or re-declared.

## New checks

The two journey tests are behaviour tests, not a rule or audit, and their failing output on the old code is pasted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kZZXw3qmkh87hYRwww7hX

---
_Generated by [Claude Code](https://claude.ai/code/session_017kZZXw3qmkh87hYRwww7hX)_