### PR TITLE
docs(marketing): refresh hero and README positioning copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE.txt)
 [![Powered by Atlas Cloud](https://www.atlascloud.ai/oss-program/powered-by-atlas-cloud.svg)](https://www.atlascloud.ai/?ref=PW9AD2)
 
-**Open-source Agent-First Creative Workspace**
+**Open-source creative AI workspace**
 
-Create and edit AI media in NodeTool, an open-source
-creative studio. Describe what you want and the agent builds it. What comes
-back is an editable project: open it and re-roll, re-voice or re-cut.
+Create and edit images, video, audio, and text with agents that work alongside
+you. Describe what you want, let the agent build it, then take over whenever you
+like. Refine a shot, try a different voice, or rework the cut, yourself or with
+the agent.
 
-The closed AI studios will generate your media too, priced in their credits, 
-saved in their cloud, locked away. NodeTool hands the project back, on your keys.
+You get an editable project, not just a finished file. Your workflows, assets,
+and edits stay together, so you can inspect how something was made and change
+individual parts without starting over.
 
 **[Download NodeTool Studio](https://github.com/nodetool-ai/nodetool/releases/latest)** ·
 **[Quick start](#first-run-in-studio)** ·
@@ -25,9 +27,10 @@ saved in their cloud, locked away. NodeTool hands the project back, on your keys
 
 ## Every model you need, on your own keys
 
-You connect the provider and NodeTool calls it with your key, so you pay that
-provider directly at their price. There is no NodeTool billing unit in between. 
-When a better model ships, add it the day it ships.
+Run local models or connect cloud providers with your own API keys. Choose your
+models and pay providers directly: NodeTool calls the provider with your key at
+their price, with no NodeTool billing unit in between. When a better model
+ships, add it the day it ships.
 
 [Models and Providers](docs/models-and-providers.md) lists what runs where.
 

--- a/marketing/public/index.md
+++ b/marketing/public/index.md
@@ -7,7 +7,7 @@ product: NodeTool
 ---
 # NodeTool
 
-NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Let them build and revise workflows, then inspect and edit the results yourself. Your project keeps the brief, assets, and edits together. Every editor is exposed to [agents](https://nodetool.ai/agents.md) as tools: an agent can build the workflow, run it, and repair what fails. The canvas connects image, video, audio, language, agent, and data models on a node-based graph.
+NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Describe what you want, let the agent build it, then take over whenever you like. You get an editable project, not just a finished file: your workflows, assets, and edits stay together. Every editor is exposed to [agents](https://nodetool.ai/agents.md) as tools: an agent can build the workflow, run it, and repair what fails. The canvas connects image, video, audio, language, agent, and data models on a node-based graph.
 
 ## Editions
 

--- a/marketing/public/llms.txt
+++ b/marketing/public/llms.txt
@@ -1,6 +1,6 @@
 # NodeTool
 
-> NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Let them build and revise workflows, then inspect and edit the results yourself. Your project keeps the brief, assets, and edits together. Studio is the free desktop edition; Cloud is the hosted browser edition, in alpha. Use supported local models in Studio or connect cloud providers with your own keys. Licensed AGPL-3.0.
+> NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Describe what you want, let the agent build it, then take over whenever you like. You get an editable project, not just a finished file: your workflows, assets, and edits stay together. Studio is the free desktop edition; Cloud is the hosted browser edition, in alpha. Use supported local models in Studio or connect cloud providers with your own keys. Licensed AGPL-3.0.
 
 ## What NodeTool is
 

--- a/marketing/scripts/generate-llms-txt.mjs
+++ b/marketing/scripts/generate-llms-txt.mjs
@@ -29,7 +29,7 @@ const BASE_URL = "https://nodetool.ai";
 // --- Preamble prose (hand-written; edit here) --------------------------------
 const PREAMBLE = `# NodeTool
 
-> NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Let them build and revise workflows, then inspect and edit the results yourself. Your project keeps the brief, assets, and edits together. Studio is the free desktop edition; Cloud is the hosted browser edition, in alpha. Use supported local models in Studio or connect cloud providers with your own keys. Licensed AGPL-3.0.
+> NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Describe what you want, let the agent build it, then take over whenever you like. You get an editable project, not just a finished file: your workflows, assets, and edits stay together. Studio is the free desktop edition; Cloud is the hosted browser edition, in alpha. Use supported local models in Studio or connect cloud providers with your own keys. Licensed AGPL-3.0.
 
 ## What NodeTool is
 
@@ -98,7 +98,7 @@ const MARKDOWN_PAGES = {
   "index.md": {
     title: "NodeTool",
     description: "Open-source creative AI workspace.",
-    body: `NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Let them build and revise workflows, then inspect and edit the results yourself. Your project keeps the brief, assets, and edits together. Every editor is exposed to [agents](${BASE_URL}/agents.md) as tools: an agent can build the workflow, run it, and repair what fails. The canvas connects image, video, audio, language, agent, and data models on a node-based graph.
+    body: `NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Describe what you want, let the agent build it, then take over whenever you like. You get an editable project, not just a finished file: your workflows, assets, and edits stay together. Every editor is exposed to [agents](${BASE_URL}/agents.md) as tools: an agent can build the workflow, run it, and repair what fails. The canvas connects image, video, audio, language, agent, and data models on a node-based graph.
 
 ## Editions
 

--- a/marketing/src/app/cloud/page.tsx
+++ b/marketing/src/app/cloud/page.tsx
@@ -186,9 +186,9 @@ export default function CloudPage() {
                 </h1>
                 <p className="mt-6 text-lg text-slate-300 leading-relaxed max-w-xl">
                   Create and edit images, video, audio, and text with agents that
-                  work alongside you. Let them build and revise workflows, then
-                  inspect and edit the results yourself. Your project keeps the
-                  brief, assets, and edits together. Cloud brings the workspace to
+                  work alongside you. Describe what you want, let the agent build
+                  it, then take over whenever you like. You get an editable
+                  project, not just a finished file. Cloud brings the workspace to
                   your browser with hosted storage and your own provider keys. Cloud
                   is in alpha.
                 </p>

--- a/marketing/src/app/layout.tsx
+++ b/marketing/src/app/layout.tsx
@@ -24,7 +24,7 @@ const jetBrainsMono = JetBrains_Mono({
 export const metadata: Metadata = {
   title: "NodeTool | Open-source creative AI workspace",
   description:
-    "Open-source creative AI workspace. Create images, video, audio, and text with agents, then inspect and edit their work. Keep your project context together.",
+    "Open-source creative AI workspace. Create images, video, audio, and text with agents, then take over and edit anything yourself. You get an editable project, not just a finished file.",
   metadataBase: new URL("https://nodetool.ai"),
   alternates: {
     canonical: "/",
@@ -59,7 +59,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "NodeTool | Open-source creative AI workspace",
     description:
-      "Open-source creative AI workspace. Create images, video, audio, and text with agents, then inspect and edit their work. Keep your project context together.",
+      "Open-source creative AI workspace. Create images, video, audio, and text with agents, then take over and edit anything yourself. You get an editable project, not just a finished file.",
     url: "https://nodetool.ai",
     siteName: "NodeTool",
     images: [
@@ -75,7 +75,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "NodeTool | Open-source creative AI workspace",
     description:
-      "Open-source creative AI workspace. Create images, video, audio, and text with agents, then inspect and edit their work. Keep your project context together.",
+      "Open-source creative AI workspace. Create images, video, audio, and text with agents, then take over and edit anything yourself. You get an editable project, not just a finished file.",
     images: ["/preview.png"],
   },
 };

--- a/marketing/src/app/studio/page.tsx
+++ b/marketing/src/app/studio/page.tsx
@@ -184,9 +184,9 @@ export default function StudioPage() {
                 </h1>
                 <p className="mt-6 text-lg text-slate-300 leading-relaxed max-w-xl">
                   Create and edit images, video, audio, and text with agents that
-                  work alongside you. Let them build and revise workflows, then
-                  inspect and edit the results yourself. Your project keeps the
-                  brief, assets, and edits together. Run supported local models
+                  work alongside you. Describe what you want, let the agent build
+                  it, then take over whenever you like. You get an editable
+                  project, not just a finished file. Run supported local models
                   through Ollama or MLX, or connect cloud providers with your own API
                   keys.
                 </p>

--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -42,9 +42,21 @@ export default function NodeToolHero() {
 
           <p className="mt-5 max-w-lg text-lg leading-relaxed text-slate-300">
             Create and edit images, video, audio, and text with agents that work
-            alongside you. Let them build and revise workflows, then inspect and edit
-            the results yourself. Your project keeps the brief, assets, and edits
-            together.
+            alongside you. Describe what you want, let the agent build it, then
+            take over whenever you like. Refine a shot, try a different voice, or
+            rework the cut, yourself or with the agent.
+          </p>
+
+          <p className="mt-4 max-w-lg leading-relaxed text-slate-400">
+            You get an editable project, not just a finished file. Your
+            workflows, assets, and edits stay together, so you can inspect how
+            something was made and change individual parts without starting
+            over.
+          </p>
+
+          <p className="mt-4 max-w-lg leading-relaxed text-slate-400">
+            Run local models or connect cloud providers with your own API keys.
+            Choose your models and pay providers directly.
           </p>
 
           <div className="mt-7 flex">

--- a/marketing/src/data/faqEntries.ts
+++ b/marketing/src/data/faqEntries.ts
@@ -85,7 +85,7 @@ const seeds: FaqSeed[] = [
     slug: "what-is-nodetool",
     question: "What is NodeTool?",
     answerMd:
-      "NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Let them build and revise workflows, then inspect and edit the results yourself. Your project keeps the brief, assets, and edits together. Use supported local models or connect cloud providers with your own keys.",
+      "NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Describe what you want, let the agent build it, then take over whenever you like. You get an editable project, not just a finished file: your workflows, assets, and edits stay together. Use supported local models or connect cloud providers with your own keys.",
     category: "general",
     relatedRoute: "/",
     surfaces: ["landing", "agents", "comparison"],

--- a/marketing/src/lib/siteSchema.ts
+++ b/marketing/src/lib/siteSchema.ts
@@ -14,7 +14,7 @@ export const softwareApplicationSchema: JsonLdObject = {
   "@type": "SoftwareApplication",
   name: "NodeTool",
   description:
-    "NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Let them build and revise workflows, then inspect and edit the results yourself. Your project keeps the brief, assets, and edits together. Studio runs on macOS, Windows, and Linux. Cloud is the hosted browser edition, in alpha.",
+    "NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Describe what you want, let the agent build it, then take over whenever you like. You get an editable project, not just a finished file: your workflows, assets, and edits stay together. Studio runs on macOS, Windows, and Linux. Cloud is the hosted browser edition, in alpha.",
   applicationCategory: "MultimediaApplication",
   applicationSubCategory: "Creative AI Workspace",
   operatingSystem: "macOS, Windows, Linux",
@@ -68,7 +68,7 @@ export const organizationSchema: JsonLdObject = {
     "https://discord.gg/WmQTWZRcYE",
   ],
   description:
-    "NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Let them build and revise workflows, then inspect and edit the results yourself. Your project keeps the brief, assets, and edits together. Studio runs on macOS, Windows, and Linux. Cloud is the hosted browser edition, in alpha.",
+    "NodeTool is an open-source creative AI workspace. Create and edit images, video, audio, and text with agents that work alongside you. Describe what you want, let the agent build it, then take over whenever you like. You get an editable project, not just a finished file: your workflows, assets, and edits stay together. Studio runs on macOS, Windows, and Linux. Cloud is the hosted browser edition, in alpha.",
 };
 
 /** The demo video on the home page. Emitted by the page that shows it. */


### PR DESCRIPTION
## What changed

Copy-only update to the homepage hero and the README intro. The subhead now names the handoff (describe it, let the agent build it, take over whenever you like: refine a shot, try a different voice, rework the cut) and what you get back (an editable project, not just a finished file, with workflows, assets and edits together), plus a line on running local models or connecting cloud providers with your own keys. Because that same block is mirrored across the site, the shortened form is applied in `layout.tsx` metadata (page/OG/Twitter description), `siteSchema.ts`, the "What is NodeTool" FAQ row, the llms.txt generator with its regenerated `public/llms.txt` and `public/index.md`, and the studio and cloud hero paragraphs, each keeping its edition-specific tail. In the README the two new paragraphs replace the old intro, and the BYOK sentence leads the existing "Every model you need, on your own keys" section instead of repeating it above.

## Verification

No code paths change; the diff is JSX text, string literals, and Markdown.

- `npx tsc --noEmit -p marketing/tsconfig.json` — no errors in the touched files. The only output is pre-existing missing-dependency noise (`framer-motion`, `lodash` types) from `marketing/node_modules` not being installed in this environment; it is identical before and after the change.
- `npx tsx marketing/scripts/generate-llms-txt.mjs --check` — "public agent documentation is up to date" after regenerating.
- [ ] `npm run test:affected` — not run; no workspace source changed (marketing is not a root workspace and has no suite covering hero copy).
- [ ] `npm run typecheck` / `npm run lint` — not run; they cover `packages/`, `web/`, `electron/`, `mobile/`, none of which this diff touches.
- [ ] `npm run dev:nodetool -- harness gate --base main` — not run; the diff maps to no harness entry.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193EWZySFVd9FZVHoivDm3W

---
_Generated by [Claude Code](https://claude.ai/code/session_0193EWZySFVd9FZVHoivDm3W)_