### PR TITLE
fix(marketing): stop the surface loops degrading to a black frame

### DIFF
--- a/marketing/src/components/SurfaceShowcase.tsx
+++ b/marketing/src/components/SurfaceShowcase.tsx
@@ -5,6 +5,17 @@
  * (demo/src/hero/SurfaceLoop.tsx), so what a tab shows is what the app does.
  *
  * Each tab is deep-linkable as `#surface-<id>`.
+ *
+ * Every loop opens on an empty editor and fills up over its six seconds, so
+ * frame 0 is all but black. That rules out `<video poster>`, which a browser
+ * only shows until playback first starts: once `currentTime` has moved, a
+ * video that then stops paints its own frame instead. Leaving a tab rewinds it
+ * to 0, so on any browser that refuses to restart the loop (Dia, Low Power
+ * Mode, power saving, a backgrounded tab) coming back to that tab left a black
+ * rectangle. The poster is a plain `<img>` underneath instead, and the video
+ * is revealed only while it is actually painting frames. Playback starts when
+ * the section reaches the viewport, not at mount, and a control appears
+ * whenever the loop is not running.
  */
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
@@ -12,6 +23,7 @@ import {
   FileText,
   Film,
   Brush,
+  Play,
   Box as BoxIcon,
   type LucideIcon,
 } from "lucide-react";
@@ -71,6 +83,12 @@ const SURFACES: Surface[] = [
 
 export default function SurfaceShowcase() {
   const [active, setActive] = useState(0);
+  const [inView, setInView] = useState(false);
+  // Which video is painting frames, if any. A single flag keyed off `active`
+  // misses the pause of the tab being left, so returning to it revealed a
+  // stopped video on its black first frame.
+  const [playingIndex, setPlayingIndex] = useState<number | null>(null);
+  const sectionRef = useRef<HTMLElement>(null);
   const videoRefs = useRef<(HTMLVideoElement | null)[]>([]);
 
   // Deep link: `#surface-timeline` opens that tab.
@@ -85,21 +103,44 @@ export default function SurfaceShowcase() {
     return () => window.removeEventListener("hashchange", fromHash);
   }, []);
 
+  // A loop that starts while the section is still far below the fold has
+  // finished before anyone sees it, and browsers that throttle offscreen media
+  // refuse the play() outright. Wait for the section.
+  useEffect(() => {
+    const section = sectionRef.current;
+    if (!section || typeof IntersectionObserver === "undefined") {
+      setInView(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          setInView(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "200px" }
+    );
+    observer.observe(section);
+    return () => observer.disconnect();
+  }, []);
+
   // Only the visible loop decodes; the rest stay paused and rewound.
   useEffect(() => {
     videoRefs.current.forEach((video, i) => {
       if (!video) return;
       if (i === active) {
+        if (!inView) return;
         void video.play().catch(() => {
-          // Autoplay can be refused (reduced motion, power saving). The
-          // poster stays, which is the right fallback.
+          // Refused (Dia, Low Power Mode, power saving, a background tab).
+          // The poster holds and the button offers the loop by hand.
         });
       } else {
         video.pause();
         video.currentTime = 0;
       }
     });
-  }, [active]);
+  }, [active, inView]);
 
   const select = useCallback((index: number) => {
     setActive(index);
@@ -119,8 +160,14 @@ export default function SurfaceShowcase() {
     [active, select]
   );
 
+  // The click is the user gesture the refusing browser was holding out for.
+  const startByHand = useCallback(() => {
+    void videoRefs.current[active]?.play().catch(() => {});
+  }, [active]);
+
   return (
     <section
+      ref={sectionRef}
       id="surfaces"
       aria-labelledby="surfaces-title"
       className="relative py-24 overflow-clip-safe"
@@ -183,21 +230,55 @@ export default function SurfaceShowcase() {
             hidden={i !== active}
           >
             <div className="card relative overflow-hidden rounded-2xl bg-slate-900/60 border border-slate-800/60 ring-1 ring-white/5 backdrop-blur-md">
-              <video
-                ref={(el) => {
-                  videoRefs.current[i] = el;
-                }}
-                poster={`/${surface.asset}-poster.webp`}
-                muted
-                loop
-                playsInline
-                preload={i === active ? "metadata" : "none"}
-                aria-label={`${surface.label} editor, six second loop`}
-                className="w-full h-auto block"
-              >
-                <source src={`/${surface.asset}.webm`} type="video/webm" />
-                <source src={`/${surface.asset}.mp4`} type="video/mp4" />
-              </video>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={`/${surface.asset}-poster.webp`}
+                alt={`${surface.label} editor`}
+                width={1920}
+                height={1080}
+                decoding="async"
+                loading={i === 0 ? "eager" : "lazy"}
+                className="block h-auto w-full"
+              />
+              {inView && (
+                <video
+                  ref={(el) => {
+                    videoRefs.current[i] = el;
+                  }}
+                  muted
+                  loop
+                  playsInline
+                  preload={i === active ? "metadata" : "none"}
+                  onPlaying={() => setPlayingIndex(i)}
+                  onPause={() =>
+                    setPlayingIndex((at) => (at === i ? null : at))
+                  }
+                  aria-label={`${surface.label} editor, six second loop`}
+                  className={`absolute inset-0 block h-full w-full object-cover motion-safe:transition-opacity motion-safe:duration-500 ${
+                    playingIndex === i ? "opacity-100" : "opacity-0"
+                  }`}
+                >
+                  {/* The codecs are spelled out so a browser that cannot decode
+                      VP9 rejects this source outright instead of selecting it
+                      on a bare type and stalling. */}
+                  <source
+                    src={`/${surface.asset}.webm`}
+                    type='video/webm; codecs="vp9"'
+                  />
+                  <source src={`/${surface.asset}.mp4`} type="video/mp4" />
+                </video>
+              )}
+
+              {i === active && inView && playingIndex !== i && (
+                <button
+                  type="button"
+                  onClick={startByHand}
+                  aria-label={`Play the ${surface.label} loop`}
+                  className="absolute bottom-3 right-3 inline-flex h-10 w-10 items-center justify-center rounded-full border border-slate-600 bg-slate-900/80 text-slate-200 backdrop-blur focus-ring hover:border-slate-400 hover:text-white"
+                >
+                  <Play className="h-4 w-4" aria-hidden />
+                </button>
+              )}
             </div>
 
             <div className="mt-6 max-w-3xl">

--- a/marketing/tests/e2e/surface-loops.spec.ts
+++ b/marketing/tests/e2e/surface-loops.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * The five editing-surface loops never degrade to a black rectangle.
+ *
+ * Each loop opens on an empty editor and fills over its six seconds, so its
+ * first frame is all but black (measured mean luminance 0.3/255 for the
+ * storyboard loop). `<video poster>` does not cover that: a browser shows the
+ * poster only until playback first starts, and the tab strip rewinds a loop it
+ * leaves back to 0. On any browser that then refuses to restart it — Dia, iOS
+ * Low Power Mode, power saving, a backgrounded tab — the panel painted the
+ * video's own black first frame instead of the poster.
+ *
+ * The assertion is the mechanism rather than a screenshot: with playback
+ * refused, whatever the panel is showing must not be black, and the reader must
+ * be offered a way to start the loop by hand. Refusal is simulated by rejecting
+ * play(), which is what an autoplay-blocking browser does, so this holds in a
+ * Chromium runner.
+ */
+
+const PANEL = "#surface-panel-storyboard";
+
+/** Mean luminance, 0-255, of whichever layer the panel is actually showing. */
+async function shownLuminance(page: import("@playwright/test").Page) {
+  return page.evaluate((panelSel) => {
+    const panel = document.querySelector(panelSel);
+    if (!panel) throw new Error("no storyboard panel");
+    const video = panel.querySelector("video");
+    const poster = panel.querySelector("img");
+    const shown =
+      video && getComputedStyle(video).opacity === "1" ? video : poster;
+    if (!shown) throw new Error("panel shows neither video nor poster");
+    const canvas = document.createElement("canvas");
+    canvas.width = 320;
+    canvas.height = 180;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("no 2d context");
+    ctx.drawImage(shown as CanvasImageSource, 0, 0, 320, 180);
+    const { data } = ctx.getImageData(0, 0, 320, 180);
+    let sum = 0;
+    for (let i = 0; i < data.length; i += 4) {
+      sum += (data[i] + data[i + 1] + data[i + 2]) / 3;
+    }
+    return sum / (data.length / 4);
+  }, PANEL);
+}
+
+test("a surface loop that will not play shows its poster, not a black frame", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    const real = HTMLMediaElement.prototype.play;
+    (window as unknown as { __allowPlay: boolean }).__allowPlay = true;
+    HTMLMediaElement.prototype.play = function play(this: HTMLMediaElement) {
+      if ((window as unknown as { __allowPlay: boolean }).__allowPlay) {
+        return real.call(this);
+      }
+      return Promise.reject(new DOMException("blocked", "NotAllowedError"));
+    };
+  });
+
+  await page.goto("/", { waitUntil: "load" });
+  await page.locator("#surfaces").scrollIntoViewIfNeeded();
+
+  // Let the storyboard loop run, so its currentTime leaves 0 and the poster
+  // attribute would no longer cover the element.
+  await expect
+    .poll(async () => shownLuminance(page), { timeout: 15_000 })
+    .toBeGreaterThan(5);
+
+  // Leave the tab (which rewinds the loop), then come back with playback
+  // refused — the case that used to paint black.
+  await page.locator("#surface-tab-timeline").click();
+  await page.evaluate(() => {
+    (window as unknown as { __allowPlay: boolean }).__allowPlay = false;
+  });
+  await page.locator("#surface-tab-storyboard").click();
+
+  // The symptom: the panel used to paint the loop's black first frame here.
+  expect(await shownLuminance(page)).toBeGreaterThan(5);
+  await expect(
+    page.locator(`${PANEL} button[aria-label="Play the Storyboard loop"]`)
+  ).toBeVisible();
+
+  // The click is the gesture a refusing browser was holding out for.
+  await page.evaluate(() => {
+    (window as unknown as { __allowPlay: boolean }).__allowPlay = true;
+  });
+  await page
+    .locator(`${PANEL} button[aria-label="Play the Storyboard loop"]`)
+    .click();
+  await expect(page.locator(`${PANEL} video`)).toHaveCSS("opacity", "1");
+});
+
+test("every surface tab reaches a playing loop", async ({ page }) => {
+  await page.goto("/", { waitUntil: "load" });
+  await page.locator("#surfaces").scrollIntoViewIfNeeded();
+
+  for (const id of ["storyboard", "script", "timeline", "sketch", "3d"]) {
+    await page.locator(`#surface-tab-${id}`).click();
+    const video = page.locator(`#surface-panel-${id} video`);
+    await expect(video).toHaveCSS("opacity", "1");
+    expect(
+      await video.evaluate((el: HTMLVideoElement) => el.paused)
+    ).toBe(false);
+  }
+});


### PR DESCRIPTION
## What changed

The five editing-surface loops on the homepage each open on an empty editor and fill over six seconds, so their first frame is all but black — measured mean luminance 0.3/255 for the storyboard loop against 24.8 for its poster. `<video poster>` does not cover that: a browser shows the poster only until playback first starts, and once `currentTime` has moved a video that then stops paints its own frame instead. Selecting another tab ran `pause(); currentTime = 0`, so on any browser that refuses to restart the loop — Dia, iOS Low Power Mode, power saving, a backgrounded tab — returning to that tab left a black rectangle where the editor should be. The storyboard tab is the one served selected, which is why it is the one readers hit. The poster becomes a plain `<img>` underneath, the video is layered over it and revealed only while it is painting frames, playback starts when the section reaches the viewport rather than at mount, and a play control appears whenever the loop is not running — the pattern `HeroDemoPlayer` already uses for the same reason. Two smaller fixes ride along: which video is playing is tracked per element, because a single flag keyed off the active tab missed the pause of the tab being left; and the sources spell out their codecs so a browser that cannot decode VP9 rejects that source outright instead of selecting it and stalling.

## Verification

`marketing/` is a separate npm project and the harness registry declares it has no root harnesses (`marketing-site`, `packages/cli/src/harness/registry.ts`) — `marketing-ci.yml` runs its own typecheck, lint, Next build and Playwright suite, so those are what I ran. The root `test:affected` plan for this diff is "changed files outside every workspace — run everything", which CI does on the PR.

- `npx tsc --noEmit -p tsconfig.json` (marketing) — passes
- `npx next lint --dir src/components --dir tests` — no findings in the changed files
- `npx next build` — passes, 611 pages prerendered
- `npx playwright test surface-loops cls idle-animation` against `next start` on that build — 8 passed; homepage CLS 0.0002 against a 0.1 budget
- Root `npm run test:affected -- --dry-run --base origin/main` — plans the full pass because `marketing/` is not a workspace; not run locally
- Root `npm run dev:nodetool -- harness gate` — needs `build:packages` first, and the registry maps `marketing/` to no harnesses, so it has nothing to run for this diff

## New checks

`marketing/tests/e2e/surface-loops.spec.ts` asserts the mechanism rather than a screenshot: with `play()` rejected, whatever the panel is showing must not be black and the reader must be offered a control to start the loop.

- [x] The check was inverted once and observed failing. Against the previous component on the same page:

```
  ✘  tests/e2e/surface-loops.spec.ts:48:5 › a surface loop that will not play shows its poster, not a black frame
    Expected: > 5
    Received:   0
  1 failed
  1 passed
```

  `Received: 0` is the black panel itself — mean luminance of the layer the panel was actually showing. With the fix the same spec passes.
- [x] The luminance is sampled from whichever layer is visible (`opacity === "1"`), so the assertion cannot pass by measuring a hidden element.

## Not fixed here, worth a separate look

Production serves every video with HTTP 200 and no `Accept-Ranges`/`206`, site-wide (`curl -H "Range: bytes=0-100" https://nodetool.ai/surface-storyboard.webm`). The proxy I tested through does pass `Range` — a control request to another host returns `206` — so this is nodetool.ai's own behaviour, presumably Cloudflare Workers Assets. It does not block Chromium, but it prevents seeking and is a known way to make WebKit refuse a `<video>` outright. Out of scope for this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YD99yPvfPG4aSZ3kxQmtnu

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD99yPvfPG4aSZ3kxQmtnu)_