### PR TITLE
feat(agents): external MCP servers on the agent toolbelt

### DIFF
--- a/docs/url-egress-inventory.md
+++ b/docs/url-egress-inventory.md
@@ -104,6 +104,7 @@ Everything here fetches a URL somebody else chose, through the protected fetch.
 | Gemini node video download | `packages/llm-nodes/src/nodes/gemini.ts` | provider response |
 | provider result downloads | `packages/runtime/src/providers/{fal,replicate,kie,topaz,meshy,rodin,minimax,evolink,gemini,anthropic}-provider.ts` | provider response |
 | MCP OAuth Client ID Metadata Document fetch | `packages/websocket/src/oauth/cimd.ts` | model/client (an MCP client's self-hosted `client_id` URL) |
+| external MCP server (HTTP transport) | `packages/websocket/src/external-mcp.ts` | operator (a user's own MCP server URL; guarded under the cloud profile, loopback allowed on a local install) |
 
 The provider row is eleven files, each downloading a URL a provider's response
 named — plus one reading a URL the caller's own message named

--- a/package-lock.json
+++ b/package-lock.json
@@ -51387,6 +51387,7 @@
         "@jitl/quickjs-ng-wasmfile-release-sync": "^0.31.0",
         "@llamaindex/liteparse": "^1.5.2",
         "@mediabunny/server": "^1.54.0",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "@napi-rs/canvas": "^0.1.65",
         "@nodetool-ai/app-runtime": "*",
         "@nodetool-ai/blender-nodes": "*",
@@ -51759,6 +51760,7 @@
       },
       "devDependencies": {
         "@nodetool-ai/model3d": "*",
+        "@nodetool-ai/timeline": "*",
         "@types/node": "^22.0.0",
         "typescript": "^5.7.2",
         "vitest": "^4.1.2"
@@ -54486,6 +54488,7 @@
         "@nodetool-ai/gpu": "*",
         "@nodetool-ai/image-editor": "*",
         "@nodetool-ai/model-pricing": "*",
+        "@nodetool-ai/model3d": "*",
         "@nodetool-ai/protocol": "*",
         "@nodetool-ai/runtime": "*",
         "@nodetool-ai/timeline": "*",

--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -812,6 +812,40 @@ none — a Code node, a JS script — got a belt that could `critique_image` and
 toolbelt` after the run had paid for the prompt that produced its argument.
 Pinned by `tests/sandbox-belt-reach.test.ts`.
 
+## External MCP servers (`src/tools/external-mcp-tools.ts`)
+
+A user's own MCP servers — Blender, Hugging Face, a local script — join the
+belt as ordinary `Tool`s named `mcp_<server>_<tool>`. That one shape is why
+every loop reaches them the same way: the base provider loop and the OpenAI
+Responses loop (Codex included) dispatch through the harness `executeTool`,
+the Claude Agent SDK wraps the belt in its in-process MCP server, and a
+CodeAct guest imports them from `@nodetool-ai/sandbox-nodetool/mcp`
+(`graftedModuleFor` in `codeact/capability-modules.ts`). No provider knows
+they are remote.
+
+`McpClientPool` keeps one client per server config: `sync(configs)` opens,
+replaces or closes connections as the list changes, `discover()` caches each
+server's `listTools`, and a server that refuses is skipped for the turn and
+retried on the next sync. Stdio servers spawn with the parent's environment
+plus the config's `env`; HTTP servers try Streamable HTTP and fall back to
+SSE. `${SECRET_NAME}` in an env var or header resolves inline through the
+pool's `getSecret`; the server's persistence moves every literal value into
+an encrypted secret named `MCP_<SERVER>_<KEY as hex>` and stores the reference, and
+resolves references from the user's own secrets only, never the process
+environment. Under the cloud profile HTTP servers fetch through `safeFetch`,
+so a private or loopback URL is refused on save and on every redirect. A tool
+result's text and structured content come back as the tool's answer, and its
+image blocks ride `image_contents` like any other belt tool's pixels.
+
+The config shape (`McpServerConfig`, `@nodetool-ai/protocol`) is shared with
+the server's persistence (`packages/websocket/src/external-mcp.ts`, one
+`Setting` row per user, the `externalMcp` tRPC router) and the settings UI
+(`web/src/components/menus/ExternalMcpServersSection.tsx`). The cloud
+profile refuses stdio servers, since a command runs on the machine the server
+owns. A remote tool has no capability entry, so `gateTools` classifies it
+`external`. Tests: `tests/external-mcp-tools.test.ts` (a real MCP server over
+an in-memory transport), `packages/websocket/tests/external-mcp.test.ts`.
+
 ## Script Voicing Tools (`src/capabilities/scripts.ts`)
 
 The headless path from a written script to voiced takes and an assembled

--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -849,7 +849,12 @@ probe uses 15s) and an `AbortController` whose abort closes the transport.
 `sync` cancels the entries its list drops **before** it queues, because
 `discover()` holds the pool's queue while it waits and disabling the offending
 server is how the user recovers — a cancellation queued behind that discovery
-would be one the user has to wait out.
+would be one the user has to wait out. Every transport starts through
+`startTransport`, which refuses a start the entry has already cancelled:
+resolving secrets and importing the SDK module are awaited, so the server can
+be deleted while a connection is still being prepared, and closing an
+unstarted stdio transport does not stop a later `start()` from spawning the
+command.
 
 **Redaction is per resolved value, not per header.** `resolveSecretReferences`
 reports every value an expansion produced, at every level, so an entry blanks

--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -834,8 +834,29 @@ an encrypted secret named `MCP_<SERVER>_<KEY as hex>` and stores the reference, 
 resolves references from the user's own secrets only, never the process
 environment. Under the cloud profile HTTP servers fetch through `safeFetch`,
 so a private or loopback URL is refused on save and on every redirect. A tool
-result's text and structured content come back as the tool's answer, and its
-image blocks ride `image_contents` like any other belt tool's pixels.
+result's text and structured content come back as the tool's answer, its
+`resource_link` blocks as `resource_links` (a file the tool produced rather
+than inlined), and its image blocks ride `image_contents` like any other belt
+tool's pixels.
+
+**Opening a connection is bounded, and dropping one cancels it.**
+`Client.connect` awaits `transport.start()` before it sends the timed
+`initialize` request, so a server that accepts the socket and then says
+nothing — an HTTP server refusing the Streamable POST and opening an SSE
+stream with no `endpoint` event — leaves that first await pending forever.
+Each entry therefore carries a deadline (`connectTimeoutMs`, 30s; the settings
+probe uses 15s) and an `AbortController` whose abort closes the transport.
+`sync` cancels the entries its list drops **before** it queues, because
+`discover()` holds the pool's queue while it waits and disabling the offending
+server is how the user recovers — a cancellation queued behind that discovery
+would be one the user has to wait out.
+
+**Redaction is per resolved value, not per header.** `resolveSecretReferences`
+reports every value an expansion produced, at every level, so an entry blanks
+both `Bearer <tok>` and `<tok>` — an upstream `Invalid token <tok>` quotes the
+token, not the header it arrived in. Values under four characters are left
+alone; nothing authenticates with one, and blanking it would eat unrelated
+text.
 
 The config shape (`McpServerConfig`, `@nodetool-ai/protocol`) is shared with
 the server's persistence (`packages/websocket/src/external-mcp.ts`, one

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@jitl/quickjs-ng-wasmfile-release-sync": "^0.31.0",
     "@llamaindex/liteparse": "^1.5.2",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "@mediabunny/server": "^1.54.0",
     "@napi-rs/canvas": "^0.1.65",
     "@nodetool-ai/app-runtime": "*",

--- a/packages/agents/src/codeact/capability-modules.ts
+++ b/packages/agents/src/codeact/capability-modules.ts
@@ -18,6 +18,8 @@ import {
   generateSandboxCapabilityFacade,
   sandboxCapabilityModuleName,
   sandboxCapabilitySpecifier,
+  MCP_CAPABILITY_MODULE,
+  MCP_TOOL_PREFIX,
   SANDBOX_CAPABILITY_PACK
 } from "@nodetool-ai/protocol";
 import {
@@ -97,6 +99,17 @@ export type CapabilityModuleMount =
  * a name under it belongs to this session, not to the platform.
  */
 export const SESSION_CAPABILITY_MODULE = "session";
+
+/**
+ * The guest namespace a belt name no capability module owns is grafted onto:
+ * a client `ui_*` tool goes under `ui`, an external MCP tool under `mcp`,
+ * anything else a host added under `session`.
+ */
+export function graftedModuleFor(name: string): string {
+  if (name.startsWith("ui_")) return "ui";
+  if (name.startsWith(MCP_TOOL_PREFIX)) return MCP_CAPABILITY_MODULE;
+  return SESSION_CAPABILITY_MODULE;
+}
 
 export interface SessionCapabilityModule {
   /** The namespace to graft onto, e.g. `"ui"`. */

--- a/packages/agents/src/codeact/chat-codeact.ts
+++ b/packages/agents/src/codeact/chat-codeact.ts
@@ -34,8 +34,8 @@ import { sandboxCapabilitySpecifier } from "@nodetool-ai/protocol";
 
 import { capabilityModuleOf } from "../capabilities/registry.js";
 import {
+  graftedModuleFor,
   mountCapabilityModules,
-  SESSION_CAPABILITY_MODULE,
   type MountCapabilityModulesOptions
 } from "./capability-modules.js";
 import { stripImagePayload } from "../tools/image-injection.js";
@@ -299,7 +299,7 @@ export function createChatCodeActSession(
   for (const tool of belt) {
     const module =
       capabilityModuleOf(tool.name) ??
-      (tool.name.startsWith("ui_") ? "ui" : SESSION_CAPABILITY_MODULE);
+      graftedModuleFor(tool.name);
     graftedSpecifiers.set(tool.name, sandboxCapabilitySpecifier(module));
     graftedModules[tool.name] = module;
     const names = graftExports.get(module);
@@ -425,7 +425,7 @@ export function createChatCodeActSession(
           toolSearchHit(
             byName.get(entry.name) as ToolSignatureSource,
             capabilityModuleOf(entry.name) ??
-              (entry.name.startsWith("ui_") ? "ui" : SESSION_CAPABILITY_MODULE)
+              graftedModuleFor(entry.name)
           )
       );
       return { ok: true, result: hits };

--- a/packages/agents/src/codeact/codeact-executor.ts
+++ b/packages/agents/src/codeact/codeact-executor.ts
@@ -59,8 +59,8 @@ import { sandboxCapabilitySpecifier } from "@nodetool-ai/protocol";
 
 import { capabilityModuleOf } from "../capabilities/registry.js";
 import {
+  graftedModuleFor,
   mountCapabilityModules,
-  SESSION_CAPABILITY_MODULE,
   type MountCapabilityModulesOptions
 } from "./capability-modules.js";
 import {
@@ -671,7 +671,7 @@ export class CodeActExecutor {
     this.sessionModuleExports = new Map();
     this.graftedSpecifiers = new Map();
     for (const tool of this.tools) {
-      const module = capabilityModuleOf(tool.name) ?? SESSION_CAPABILITY_MODULE;
+      const module = capabilityModuleOf(tool.name) ?? graftedModuleFor(tool.name);
       this.graftedSpecifiers.set(tool.name, sandboxCapabilitySpecifier(module));
       const names = this.sessionModuleExports.get(module);
       if (names === undefined)
@@ -892,7 +892,7 @@ export class CodeActExecutor {
           (entry): ToolSearchHit =>
             toolSearchHit(
               byName.get(entry.name) as Tool,
-              capabilityModuleOf(entry.name) ?? SESSION_CAPABILITY_MODULE
+              capabilityModuleOf(entry.name) ?? graftedModuleFor(entry.name)
             )
         );
         return { ok: true, result: hits };

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -951,3 +951,17 @@ export type {
   RunJobOptions,
   RunJobSuiteOptions
 } from "./jtbd/index.js";
+export {
+  ExternalMcpTool,
+  McpClientPool,
+  getCachedExternalMcpTools,
+  getExternalMcpTools,
+  normalizeCallResult
+} from "./tools/external-mcp-tools.js";
+export type {
+  McpCallResult,
+  McpClientPoolOptions,
+  McpConnectError,
+  McpRemoteTool,
+  McpSecretResolver
+} from "./tools/external-mcp-tools.js";

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -963,5 +963,6 @@ export type {
   McpClientPoolOptions,
   McpConnectError,
   McpRemoteTool,
+  McpResourceLink,
   McpSecretResolver
 } from "./tools/external-mcp-tools.js";

--- a/packages/agents/src/tools/external-mcp-tools.ts
+++ b/packages/agents/src/tools/external-mcp-tools.ts
@@ -379,8 +379,7 @@ export class McpClientPool {
           .slice(0, MAX_STDERR_CHARS);
         if (text) log.debug("MCP server stderr", { server: config.id, text });
       });
-      closeOnAbort(signal, stdio);
-      await client.connect(stdio);
+      await startTransport(client, stdio, signal, config.id);
       return client;
     }
     const headers = await resolveSecretReferences(
@@ -400,18 +399,17 @@ export class McpClientPool {
         requestInit: { headers },
         ...fetchOpt
       });
-      closeOnAbort(signal, streamable);
-      await client.connect(streamable);
+      await startTransport(client, streamable, signal, config.id);
       return client;
     } catch (err) {
+      await client.close().catch(() => undefined);
+      // A cancelled entry must not fall through and open a second transport.
+      if (signal.aborted) throw cancelledError(config.id);
       log.debug("Streamable HTTP failed, trying SSE", {
         server: config.id,
         error: describeError(err, secrets)
       });
-      await client.close().catch(() => undefined);
     }
-    // A cancelled entry must not open a second transport on the way out.
-    if (signal.aborted) throw cancelledError(config.id);
     const { SSEClientTransport } = await import(
       "@modelcontextprotocol/sdk/client/sse.js"
     );
@@ -420,8 +418,7 @@ export class McpClientPool {
       requestInit: { headers },
       ...fetchOpt
     });
-    closeOnAbort(signal, sse);
-    await sseClient.connect(sse);
+    await startTransport(sseClient, sse, signal, config.id);
     return sseClient;
   }
 }
@@ -458,6 +455,29 @@ function closeOnAbort(
   const close = () => void transport.close().catch(() => undefined);
   if (signal.aborted) close();
   else signal.addEventListener("abort", close, { once: true });
+}
+
+/**
+ * Start one transport, refusing a startup its entry has already dropped.
+ *
+ * Everything before this point is awaited — resolving `${SECRET}` references,
+ * importing the SDK's transport module — so the user can disable the server,
+ * or the deadline can expire, while this connection is still being prepared.
+ * Closing an unstarted stdio transport does not mark it closed, so a
+ * `closeOnAbort` that fired during those awaits would not stop the `start()`
+ * below from spawning the command afterwards. The check and the start share
+ * one tick: `Client.connect` reaches `transport.start()` before its first
+ * await, so nothing can abort between them.
+ */
+async function startTransport(
+  client: Client,
+  transport: Parameters<Client["connect"]>[0],
+  signal: AbortSignal,
+  serverId: string
+): Promise<void> {
+  if (signal.aborted) throw cancelledError(serverId);
+  closeOnAbort(signal, transport);
+  await client.connect(transport);
 }
 
 /** Every page of `tools/list`. */

--- a/packages/agents/src/tools/external-mcp-tools.ts
+++ b/packages/agents/src/tools/external-mcp-tools.ts
@@ -1,0 +1,528 @@
+/**
+ * External MCP servers on the toolbelt.
+ *
+ * A user configures a server (Blender, Hugging Face, a local script) and its
+ * tools become ordinary {@link Tool}s named `mcp_<server>_<tool>`. Because
+ * they are plain belt tools, every loop reaches them the same way: the base
+ * provider loop and the Responses loop dispatch through the harness
+ * `executeTool`, the Claude Agent SDK wraps the belt in its in-process MCP
+ * server, and a CodeAct guest imports them from
+ * `@nodetool-ai/sandbox-nodetool/mcp`.
+ *
+ * Connections live in an {@link McpClientPool}: one client per server config,
+ * opened on first use, replaced when the config changes, and closed when the
+ * server is removed. Discovery (`listTools`) is cached per connection so a
+ * belt can be assembled synchronously from the last-known list after the
+ * first turn has awaited it.
+ */
+
+import { createLogger } from "@nodetool-ai/config";
+import type { JsonSchema, ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  mcpToolName,
+  resolveSecretReferences,
+  type McpServerConfig
+} from "@nodetool-ai/protocol";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { Tool } from "./base-tool.js";
+import { IMAGE_CONTENTS_FIELD } from "./image-injection.js";
+import { isRecord, isString } from "../utils/type-guards.js";
+
+const log = createLogger("nodetool.agents.external-mcp");
+
+/** Longest stderr line kept in a log record. */
+const MAX_STDERR_CHARS = 500;
+
+/** How a pool answers `${SECRET}` references in env vars and headers. */
+export type McpSecretResolver = (
+  name: string
+) => Promise<string | null | undefined>;
+
+/** One remote tool as the server advertised it. */
+export interface McpRemoteTool {
+  name: string;
+  description?: string;
+  inputSchema: JsonSchema;
+}
+
+interface PoolEntry {
+  config: McpServerConfig;
+  fingerprint: string;
+  client: Promise<Client>;
+  tools: McpRemoteTool[] | null;
+  /**
+   * The header/env values this connection resolved, so a log line or an
+   * error handed back about it can have them blanked out. Per entry, never
+   * shared: one user's values are no oracle for another's text.
+   */
+  secrets: Set<string>;
+}
+
+/** Replace every value in `secrets` found in `text` with a marker. */
+function redact(text: string, secrets: ReadonlySet<string>): string {
+  let out = text;
+  for (const value of secrets) {
+    out = out.split(value).join("[redacted]");
+  }
+  return out;
+}
+
+/**
+ * An error's first line, bounded and with the entry's secrets blanked, so a
+ * response body never floods a log or carries a token into one. Redaction
+ * runs before the cut, so a token straddling the cut cannot survive it.
+ */
+function describeError(err: unknown, secrets: ReadonlySet<string>): string {
+  const message = err instanceof Error ? err.message : String(err);
+  return redact(message, secrets).split("\n")[0].slice(0, 200);
+}
+
+/** The same error, with its message redacted, for a caller's callback. */
+function redactedError(err: unknown, secrets: ReadonlySet<string>): Error {
+  const message = err instanceof Error ? err.message : String(err);
+  return new Error(redact(message, secrets));
+}
+
+/** Callback the pool takes to report a server that could not be reached. */
+export type McpConnectError = (serverId: string, error: Error) => void;
+
+export interface McpClientPoolOptions {
+  getSecret?: McpSecretResolver;
+  /**
+   * The fetch HTTP transports use. A host that must not reach private
+   * networks passes its guarded fetch here; the default is the global one,
+   * for a machine that belongs to its user.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Inject the connection (tests: an in-memory transport). Values the
+   * connection resolved may be added to `secrets` for redaction.
+   */
+  connect?: (config: McpServerConfig, secrets: Set<string>) => Promise<Client>;
+}
+
+/**
+ * Keeps one live MCP client per configured server.
+ *
+ * `sync` is idempotent on the config list: unchanged servers keep their
+ * connection, changed ones reconnect, removed ones close. Nothing connects
+ * until `discover()` or a call needs it. Reconciliation is serialized so a
+ * `sync` cannot interleave with a `discover` that is dropping a dead entry.
+ */
+export class McpClientPool {
+  private readonly entries = new Map<string, PoolEntry>();
+  private readonly getSecret: McpSecretResolver;
+  private readonly fetchImpl: typeof fetch | undefined;
+  private readonly connectFn: (
+    config: McpServerConfig,
+    secrets: Set<string>
+  ) => Promise<Client>;
+  private queue: Promise<unknown> = Promise.resolve();
+
+  constructor(options: McpClientPoolOptions = {}) {
+    this.getSecret = options.getSecret ?? (async () => undefined);
+    this.fetchImpl = options.fetch;
+    this.connectFn =
+      options.connect ?? ((config, secrets) => this.connect(config, secrets));
+  }
+
+  /** Run `fn` after every queued reconciliation, and before the next. */
+  private serialized<T>(fn: () => Promise<T>): Promise<T> {
+    const next = this.queue.then(fn, fn);
+    this.queue = next.catch(() => undefined);
+    return next;
+  }
+
+  /** Reconcile the pool with the current config list. */
+  sync(configs: readonly McpServerConfig[]): Promise<void> {
+    return this.serialized(async () => {
+      const wanted = new Map(
+        configs.filter((c) => c.enabled).map((c) => [c.id, c] as const)
+      );
+      for (const [id, entry] of this.entries) {
+        const next = wanted.get(id);
+        if (next === undefined || fingerprintOf(next) !== entry.fingerprint) {
+          this.entries.delete(id);
+          await closeEntry(entry);
+        }
+      }
+      for (const [id, config] of wanted) {
+        if (!this.entries.has(id)) {
+          const secrets = new Set<string>();
+          const client = this.connectFn(config, secrets);
+          // The rejection is observed by whoever awaits the entry; without
+          // this a server that refuses between `sync` and `discover` is an
+          // unhandled rejection.
+          client.catch(() => undefined);
+          this.entries.set(id, {
+            config,
+            fingerprint: fingerprintOf(config),
+            client,
+            tools: null,
+            secrets
+          });
+        }
+      }
+    });
+  }
+
+  /** Every configured server id with a live or pending connection. */
+  serverIds(): string[] {
+    return [...this.entries.keys()];
+  }
+
+  /**
+   * Discover the tools of every server, connecting where needed. A server
+   * that fails to connect is reported through `onError`, closed, and dropped
+   * so the next `sync` retries it; it does not sink the belt.
+   */
+  discover(onError?: McpConnectError): Promise<Map<string, McpRemoteTool[]>> {
+    return this.serialized(async () => {
+      const out = new Map<string, McpRemoteTool[]>();
+      await Promise.all(
+        [...this.entries.values()].map(async (entry) => {
+          try {
+            if (entry.tools === null) {
+              const client = await entry.client;
+              entry.tools = await listAllTools(client);
+            }
+            out.set(entry.config.id, entry.tools);
+          } catch (err) {
+            log.warn("MCP server unavailable", {
+              server: entry.config.id,
+              error: describeError(err, entry.secrets)
+            });
+            await this.evict(entry);
+            onError?.(entry.config.id, redactedError(err, entry.secrets));
+          }
+        })
+      );
+      return out;
+    });
+  }
+
+  /** The last discovered tool list, without connecting. */
+  cachedTools(): Map<string, McpRemoteTool[]> {
+    const out = new Map<string, McpRemoteTool[]>();
+    for (const entry of this.entries.values()) {
+      if (entry.tools !== null) out.set(entry.config.id, entry.tools);
+    }
+    return out;
+  }
+
+  /**
+   * Invoke one remote tool. A transport failure evicts the connection so the
+   * next turn reconnects; a tool that answered `isError` is not a failure.
+   */
+  async call(
+    serverId: string,
+    remoteName: string,
+    args: Record<string, unknown>,
+    signal?: AbortSignal
+  ): Promise<McpCallResult> {
+    const entry = this.entries.get(serverId);
+    if (entry === undefined) {
+      throw new Error(`MCP server "${serverId}" is not configured or enabled`);
+    }
+    try {
+      const client = await entry.client;
+      const result = await client.callTool(
+        { name: remoteName, arguments: args },
+        undefined,
+        signal === undefined ? {} : { signal }
+      );
+      return normalizeCallResult(result);
+    } catch (err) {
+      if (signal?.aborted !== true) {
+        await this.serialized(() => this.evict(entry));
+      }
+      throw redactedError(err, entry.secrets);
+    }
+  }
+
+  /** Close every connection. */
+  close(): Promise<void> {
+    return this.serialized(async () => {
+      const entries = [...this.entries.values()];
+      this.entries.clear();
+      await Promise.all(entries.map(closeEntry));
+    });
+  }
+
+  /**
+   * Drop one entry — only if it is still the one the map holds, so a stale
+   * failure cannot remove a replacement a later `sync` installed. The close
+   * runs under the queue, so no reconnect starts before it finishes.
+   */
+  private evict(entry: PoolEntry): Promise<void> {
+    if (this.entries.get(entry.config.id) === entry) {
+      this.entries.delete(entry.config.id);
+    }
+    return closeEntry(entry);
+  }
+
+  private async connect(
+    config: McpServerConfig,
+    secrets: Set<string>
+  ): Promise<Client> {
+    const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+    const client = new Client({ name: "nodetool", version: "1.0.0" });
+    const transport = config.transport;
+    if (transport.type === "stdio") {
+      const { StdioClientTransport } = await import(
+        "@modelcontextprotocol/sdk/client/stdio.js"
+      );
+      const env = await resolveSecretReferences(transport.env, this.getSecret);
+      rememberResolved(transport.env, env, secrets);
+      const stdio = new StdioClientTransport({
+        command: transport.command,
+        args: transport.args,
+        env: { ...inheritedChildEnv(), ...env },
+        cwd: transport.cwd,
+        stderr: "pipe"
+      });
+      // Drain the child's stderr before the handshake: an undrained pipe
+      // fills and blocks a server that logs before it answers `initialize`.
+      // Only a bounded line reaches the log, never the environment.
+      stdio.stderr?.on("data", (chunk: Buffer | string) => {
+        const text = redact(chunk.toString(), secrets)
+          .trim()
+          .slice(0, MAX_STDERR_CHARS);
+        if (text) log.debug("MCP server stderr", { server: config.id, text });
+      });
+      await client.connect(stdio);
+      return client;
+    }
+    const headers = await resolveSecretReferences(
+      transport.headers,
+      this.getSecret
+    );
+    rememberResolved(transport.headers, headers, secrets);
+    const url = new URL(transport.url);
+    const fetchOpt =
+      this.fetchImpl === undefined ? {} : { fetch: this.fetchImpl };
+    const { StreamableHTTPClientTransport } = await import(
+      "@modelcontextprotocol/sdk/client/streamableHttp.js"
+    );
+    try {
+      await client.connect(
+        new StreamableHTTPClientTransport(url, {
+          requestInit: { headers },
+          ...fetchOpt
+        })
+      );
+      return client;
+    } catch (err) {
+      log.debug("Streamable HTTP failed, trying SSE", {
+        server: config.id,
+        error: describeError(err, secrets)
+      });
+      await client.close().catch(() => undefined);
+    }
+    const { SSEClientTransport } = await import(
+      "@modelcontextprotocol/sdk/client/sse.js"
+    );
+    const sseClient = new Client({ name: "nodetool", version: "1.0.0" });
+    await sseClient.connect(
+      new SSEClientTransport(url, { requestInit: { headers }, ...fetchOpt })
+    );
+    return sseClient;
+  }
+}
+
+/** Every page of `tools/list`. */
+async function listAllTools(client: Client): Promise<McpRemoteTool[]> {
+  const tools: McpRemoteTool[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await client.listTools(
+      cursor === undefined ? undefined : { cursor }
+    );
+    for (const t of page.tools) {
+      tools.push({
+        name: t.name,
+        description: t.description,
+        inputSchema: (t.inputSchema ?? {
+          type: "object",
+          properties: {}
+        }) as JsonSchema
+      });
+    }
+    cursor = page.nextCursor;
+  } while (cursor !== undefined);
+  return tools;
+}
+
+async function closeEntry(entry: PoolEntry): Promise<void> {
+  try {
+    const client = await entry.client;
+    await client.close();
+  } catch {
+    // A connection that never opened has nothing to close.
+  }
+}
+
+/**
+ * Record the values a reference produced. Only what came out of a secret
+ * counts: a literal the user typed into the config is not a secret to blank,
+ * and blanking `true` or `1` would eat unrelated text.
+ */
+function rememberResolved(
+  raw: Record<string, string>,
+  resolved: Record<string, string>,
+  secrets: Set<string>
+): void {
+  for (const [key, value] of Object.entries(resolved)) {
+    if (value && value !== raw[key]) secrets.add(value);
+  }
+}
+
+/** The parent's env: the SDK's default env is a short allowlist. */
+function inheritedChildEnv(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
+}
+
+function fingerprintOf(config: McpServerConfig): string {
+  return JSON.stringify(config);
+}
+
+/** A remote tool's answer, flattened into what a belt tool returns. */
+export interface McpCallResult {
+  text: string;
+  isError: boolean;
+  images: Array<{ data: string; mimeType: string }>;
+  /** Structured content when the server returned any. */
+  structured?: unknown;
+}
+
+export function normalizeCallResult(result: unknown): McpCallResult {
+  const out: McpCallResult = { text: "", isError: false, images: [] };
+  if (!isRecord(result)) return out;
+  out.isError = result.isError === true;
+  if (result.structuredContent !== undefined) {
+    out.structured = result.structuredContent;
+  }
+  const parts: string[] = [];
+  const content = Array.isArray(result.content) ? result.content : [];
+  for (const block of content) {
+    if (!isRecord(block)) continue;
+    if (block.type === "text" && isString(block.text)) {
+      parts.push(block.text);
+    } else if (block.type === "image" && isString(block.data)) {
+      out.images.push({
+        data: block.data,
+        mimeType: isString(block.mimeType) ? block.mimeType : "image/png"
+      });
+    } else if (block.type === "resource" && isRecord(block.resource)) {
+      const res = block.resource;
+      if (isString(res.text)) parts.push(res.text);
+      else if (isString(res.uri)) parts.push(`[resource ${res.uri}]`);
+    }
+  }
+  out.text = parts.join("\n");
+  return out;
+}
+
+/** One remote MCP tool, as a belt tool. */
+export class ExternalMcpTool extends Tool {
+  readonly name: string;
+  readonly description: string;
+  protected override readonly jsonSchema: JsonSchema;
+
+  constructor(
+    private readonly pool: McpClientPool,
+    readonly serverId: string,
+    readonly remote: McpRemoteTool,
+    name: string = mcpToolName(serverId, remote.name)
+  ) {
+    super();
+    this.name = name;
+    this.description =
+      remote.description?.trim() ||
+      `Tool "${remote.name}" from the MCP server "${serverId}".`;
+    this.jsonSchema = remote.inputSchema;
+  }
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    let result: McpCallResult;
+    try {
+      result = await this.pool.call(
+        this.serverId,
+        this.remote.name,
+        params,
+        context.signal
+      );
+    } catch (err) {
+      // `call` already redacted the message against the entry's secrets.
+      const message = err instanceof Error ? err.message : String(err);
+      return { error: "mcp_server_error", message: message.slice(0, 200) };
+    }
+    if (result.isError) {
+      return { error: "mcp_tool_error", message: result.text || "tool failed" };
+    }
+    const out: Record<string, unknown> = {};
+    if (result.structured !== undefined) out.result = result.structured;
+    if (result.text) out.text = result.text;
+    if (result.images.length > 0) {
+      out[IMAGE_CONTENTS_FIELD] = result.images.map((img) => ({
+        data: img.data,
+        mimeType: img.mimeType
+      }));
+    }
+    return out;
+  }
+}
+
+/**
+ * The belt contribution of every reachable server: one {@link ExternalMcpTool}
+ * per remote tool. Connects and discovers where needed.
+ */
+export async function getExternalMcpTools(
+  pool: McpClientPool,
+  onError?: McpConnectError
+): Promise<Tool[]> {
+  const discovered = await pool.discover(onError);
+  return toolsFrom(pool, discovered);
+}
+
+/** Same as {@link getExternalMcpTools} from the cached discovery, no I/O. */
+export function getCachedExternalMcpTools(pool: McpClientPool): Tool[] {
+  return toolsFrom(pool, pool.cachedTools());
+}
+
+/**
+ * Two remote names that normalize to one belt name (`render.scene` and
+ * `render_scene`) get numbered suffixes, so neither is silently dropped by
+ * the belt's first-wins dedup. Servers and tools are walked in sorted order,
+ * so the same name maps to the same tool on every turn, whatever order
+ * discovery answered in.
+ */
+function toolsFrom(
+  pool: McpClientPool,
+  byServer: Map<string, McpRemoteTool[]>
+): Tool[] {
+  const tools: Tool[] = [];
+  const taken = new Set<string>();
+  const servers = [...byServer.entries()].sort(([a], [b]) => a.localeCompare(b));
+  for (const [serverId, unsorted] of servers) {
+    const remotes = [...unsorted].sort((a, b) => a.name.localeCompare(b.name));
+    for (const remote of remotes) {
+      const base = mcpToolName(serverId, remote.name);
+      let name = base;
+      for (let n = 2; taken.has(name); n += 1) {
+        const suffix = `_${n}`;
+        name = `${base.slice(0, 64 - suffix.length)}${suffix}`;
+      }
+      taken.add(name);
+      tools.push(new ExternalMcpTool(pool, serverId, remote, name));
+    }
+  }
+  return tools;
+}

--- a/packages/agents/src/tools/external-mcp-tools.ts
+++ b/packages/agents/src/tools/external-mcp-tools.ts
@@ -33,6 +33,23 @@ const log = createLogger("nodetool.agents.external-mcp");
 /** Longest stderr line kept in a log record. */
 const MAX_STDERR_CHARS = 500;
 
+/**
+ * How long one server has to finish opening. `Client.connect` awaits
+ * `transport.start()` before it sends the timed `initialize` request, so a
+ * server that accepts the socket and then says nothing — an HTTP server that
+ * refuses the Streamable POST and opens an SSE stream with no `endpoint`
+ * event — leaves that first await pending forever. Discovery holds the pool's
+ * queue while it waits, and every later save or delete queues behind it.
+ */
+const DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
+
+/**
+ * Values shorter than this are not redacted. A one- or two-character secret
+ * would blank unrelated text everywhere it happened to occur, and nothing a
+ * server authenticates with is that short.
+ */
+const MIN_REDACTABLE_SECRET_CHARS = 4;
+
 /** How a pool answers `${SECRET}` references in env vars and headers. */
 export type McpSecretResolver = (
   name: string
@@ -56,6 +73,17 @@ interface PoolEntry {
    * shared: one user's values are no oracle for another's text.
    */
   secrets: Set<string>;
+  /**
+   * Cancels a connection still opening. Aborting closes the transport, which
+   * is what settles a startup nobody can finish — so dropping this server
+   * never waits on it.
+   */
+  cancel: AbortController;
+}
+
+/** Remember one value to blank out of anything this connection reports. */
+function rememberSecret(secrets: Set<string>, value: string): void {
+  if (value.length >= MIN_REDACTABLE_SECRET_CHARS) secrets.add(value);
 }
 
 /** Replace every value in `secrets` found in `text` with a marker. */
@@ -96,9 +124,16 @@ export interface McpClientPoolOptions {
   fetch?: typeof fetch;
   /**
    * Inject the connection (tests: an in-memory transport). Values the
-   * connection resolved may be added to `secrets` for redaction.
+   * connection resolved may be added to `secrets` for redaction, and
+   * `signal` aborts when the entry is dropped or its deadline expires.
    */
-  connect?: (config: McpServerConfig, secrets: Set<string>) => Promise<Client>;
+  connect?: (
+    config: McpServerConfig,
+    secrets: Set<string>,
+    signal: AbortSignal
+  ) => Promise<Client>;
+  /** How long one connection has to open. Default 30s. */
+  connectTimeoutMs?: number;
 }
 
 /**
@@ -115,15 +150,20 @@ export class McpClientPool {
   private readonly fetchImpl: typeof fetch | undefined;
   private readonly connectFn: (
     config: McpServerConfig,
-    secrets: Set<string>
+    secrets: Set<string>,
+    signal: AbortSignal
   ) => Promise<Client>;
+  private readonly connectTimeoutMs: number;
   private queue: Promise<unknown> = Promise.resolve();
 
   constructor(options: McpClientPoolOptions = {}) {
     this.getSecret = options.getSecret ?? (async () => undefined);
     this.fetchImpl = options.fetch;
     this.connectFn =
-      options.connect ?? ((config, secrets) => this.connect(config, secrets));
+      options.connect ??
+      ((config, secrets, signal) => this.connect(config, secrets, signal));
+    this.connectTimeoutMs =
+      options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
   }
 
   /** Run `fn` after every queued reconciliation, and before the next. */
@@ -135,10 +175,20 @@ export class McpClientPool {
 
   /** Reconcile the pool with the current config list. */
   sync(configs: readonly McpServerConfig[]): Promise<void> {
+    const wanted = new Map(
+      configs.filter((c) => c.enabled).map((c) => [c.id, c] as const)
+    );
+    // Cancel what this list drops *before* queueing. A discovery waiting on a
+    // server that never answers holds the queue for the whole deadline, and
+    // disabling that server is exactly how the user recovers from it — so the
+    // cancellation must not be behind the discovery it ends.
+    for (const [id, entry] of this.entries) {
+      const next = wanted.get(id);
+      if (next === undefined || fingerprintOf(next) !== entry.fingerprint) {
+        entry.cancel.abort(cancelledError(entry.config.id));
+      }
+    }
     return this.serialized(async () => {
-      const wanted = new Map(
-        configs.filter((c) => c.enabled).map((c) => [c.id, c] as const)
-      );
       for (const [id, entry] of this.entries) {
         const next = wanted.get(id);
         if (next === undefined || fingerprintOf(next) !== entry.fingerprint) {
@@ -148,22 +198,53 @@ export class McpClientPool {
       }
       for (const [id, config] of wanted) {
         if (!this.entries.has(id)) {
-          const secrets = new Set<string>();
-          const client = this.connectFn(config, secrets);
-          // The rejection is observed by whoever awaits the entry; without
-          // this a server that refuses between `sync` and `discover` is an
-          // unhandled rejection.
-          client.catch(() => undefined);
-          this.entries.set(id, {
-            config,
-            fingerprint: fingerprintOf(config),
-            client,
-            tools: null,
-            secrets
-          });
+          this.entries.set(id, this.openEntry(config));
         }
       }
     });
+  }
+
+  /**
+   * Start one connection under its deadline. The timer aborts the entry's
+   * signal, which the transport is closed by, so an expired startup rejects
+   * here instead of pending inside the SDK.
+   */
+  private openEntry(config: McpServerConfig): PoolEntry {
+    const secrets = new Set<string>();
+    const cancel = new AbortController();
+    const timer = setTimeout(() => {
+      cancel.abort(
+        new Error(
+          `MCP server "${config.id}" did not answer within ${this.connectTimeoutMs}ms`
+        )
+      );
+    }, this.connectTimeoutMs);
+    timer.unref?.();
+    const started = this.connectFn(config, secrets, cancel.signal);
+    // A connection that lands after its deadline has no owner: close it
+    // rather than leave a socket or a child process behind.
+    void started.then(
+      (client) => {
+        if (cancel.signal.aborted) void client.close().catch(() => undefined);
+      },
+      () => undefined
+    );
+    const client = Promise.race([
+      started,
+      abortRejection(cancel.signal)
+    ]).finally(() => clearTimeout(timer));
+    // The rejection is observed by whoever awaits the entry; without this a
+    // server that refuses between `sync` and `discover` is an unhandled
+    // rejection.
+    client.catch(() => undefined);
+    return {
+      config,
+      fingerprint: fingerprintOf(config),
+      client,
+      tools: null,
+      secrets,
+      cancel
+    };
   }
 
   /** Every configured server id with a live or pending connection. */
@@ -242,6 +323,9 @@ export class McpClientPool {
 
   /** Close every connection. */
   close(): Promise<void> {
+    for (const entry of this.entries.values()) {
+      entry.cancel.abort(cancelledError(entry.config.id));
+    }
     return this.serialized(async () => {
       const entries = [...this.entries.values()];
       this.entries.clear();
@@ -263,7 +347,8 @@ export class McpClientPool {
 
   private async connect(
     config: McpServerConfig,
-    secrets: Set<string>
+    secrets: Set<string>,
+    signal: AbortSignal
   ): Promise<Client> {
     const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
     const client = new Client({ name: "nodetool", version: "1.0.0" });
@@ -272,7 +357,11 @@ export class McpClientPool {
       const { StdioClientTransport } = await import(
         "@modelcontextprotocol/sdk/client/stdio.js"
       );
-      const env = await resolveSecretReferences(transport.env, this.getSecret);
+      const env = await resolveSecretReferences(
+        transport.env,
+        this.getSecret,
+        (value) => rememberSecret(secrets, value)
+      );
       rememberResolved(transport.env, env, secrets);
       const stdio = new StdioClientTransport({
         command: transport.command,
@@ -290,12 +379,14 @@ export class McpClientPool {
           .slice(0, MAX_STDERR_CHARS);
         if (text) log.debug("MCP server stderr", { server: config.id, text });
       });
+      closeOnAbort(signal, stdio);
       await client.connect(stdio);
       return client;
     }
     const headers = await resolveSecretReferences(
       transport.headers,
-      this.getSecret
+      this.getSecret,
+      (value) => rememberSecret(secrets, value)
     );
     rememberResolved(transport.headers, headers, secrets);
     const url = new URL(transport.url);
@@ -305,12 +396,12 @@ export class McpClientPool {
       "@modelcontextprotocol/sdk/client/streamableHttp.js"
     );
     try {
-      await client.connect(
-        new StreamableHTTPClientTransport(url, {
-          requestInit: { headers },
-          ...fetchOpt
-        })
-      );
+      const streamable = new StreamableHTTPClientTransport(url, {
+        requestInit: { headers },
+        ...fetchOpt
+      });
+      closeOnAbort(signal, streamable);
+      await client.connect(streamable);
       return client;
     } catch (err) {
       log.debug("Streamable HTTP failed, trying SSE", {
@@ -319,15 +410,54 @@ export class McpClientPool {
       });
       await client.close().catch(() => undefined);
     }
+    // A cancelled entry must not open a second transport on the way out.
+    if (signal.aborted) throw cancelledError(config.id);
     const { SSEClientTransport } = await import(
       "@modelcontextprotocol/sdk/client/sse.js"
     );
     const sseClient = new Client({ name: "nodetool", version: "1.0.0" });
-    await sseClient.connect(
-      new SSEClientTransport(url, { requestInit: { headers }, ...fetchOpt })
-    );
+    const sse = new SSEClientTransport(url, {
+      requestInit: { headers },
+      ...fetchOpt
+    });
+    closeOnAbort(signal, sse);
+    await sseClient.connect(sse);
     return sseClient;
   }
+}
+
+/** The error a dropped or expired entry rejects its pending connection with. */
+function cancelledError(serverId: string): Error {
+  return new Error(`MCP server "${serverId}" connection cancelled`);
+}
+
+/** A promise that rejects when `signal` aborts, and never resolves. */
+function abortRejection(signal: AbortSignal): Promise<never> {
+  return new Promise((_resolve, reject) => {
+    const fail = () => {
+      reject(
+        signal.reason instanceof Error
+          ? signal.reason
+          : new Error("MCP connection cancelled")
+      );
+    };
+    if (signal.aborted) fail();
+    else signal.addEventListener("abort", fail, { once: true });
+  });
+}
+
+/**
+ * Close a transport when its entry is cancelled. `Client.connect` awaits
+ * `transport.start()` before the timed `initialize` request, so closing the
+ * transport is the only thing that ends a startup nobody can finish.
+ */
+function closeOnAbort(
+  signal: AbortSignal,
+  transport: { close(): Promise<void> }
+): void {
+  const close = () => void transport.close().catch(() => undefined);
+  if (signal.aborted) close();
+  else signal.addEventListener("abort", close, { once: true });
 }
 
 /** Every page of `tools/list`. */
@@ -354,6 +484,9 @@ async function listAllTools(client: Client): Promise<McpRemoteTool[]> {
 }
 
 async function closeEntry(entry: PoolEntry): Promise<void> {
+  // Cancel first: a connection still opening is closed through its transport
+  // and rejects, rather than being waited on until its deadline.
+  entry.cancel.abort(cancelledError(entry.config.id));
   try {
     const client = await entry.client;
     await client.close();
@@ -363,9 +496,12 @@ async function closeEntry(entry: PoolEntry): Promise<void> {
 }
 
 /**
- * Record the values a reference produced. Only what came out of a secret
- * counts: a literal the user typed into the config is not a secret to blank,
- * and blanking `true` or `1` would eat unrelated text.
+ * Record the finished values, beside the individual secrets the resolver
+ * already reported. Both are needed: an upstream error quotes the token
+ * (`Invalid token <tok>`) as readily as the header it arrived in
+ * (`Bearer <tok>`), and neither substring covers the other. Only what came
+ * out of a secret counts — a literal the user typed into the config is not a
+ * secret to blank.
  */
 function rememberResolved(
   raw: Record<string, string>,
@@ -373,7 +509,7 @@ function rememberResolved(
   secrets: Set<string>
 ): void {
   for (const [key, value] of Object.entries(resolved)) {
-    if (value && value !== raw[key]) secrets.add(value);
+    if (value !== raw[key]) rememberSecret(secrets, value);
   }
 }
 
@@ -390,17 +526,32 @@ function fingerprintOf(config: McpServerConfig): string {
   return JSON.stringify(config);
 }
 
+/** A file a tool produced but did not inline: an MCP `resource_link` block. */
+export interface McpResourceLink {
+  uri: string;
+  name?: string;
+  mimeType?: string;
+  description?: string;
+}
+
 /** A remote tool's answer, flattened into what a belt tool returns. */
 export interface McpCallResult {
   text: string;
   isError: boolean;
   images: Array<{ data: string; mimeType: string }>;
+  /** Files the tool produced by reference. */
+  links: McpResourceLink[];
   /** Structured content when the server returned any. */
   structured?: unknown;
 }
 
 export function normalizeCallResult(result: unknown): McpCallResult {
-  const out: McpCallResult = { text: "", isError: false, images: [] };
+  const out: McpCallResult = {
+    text: "",
+    isError: false,
+    images: [],
+    links: []
+  };
   if (!isRecord(result)) return out;
   out.isError = result.isError === true;
   if (result.structuredContent !== undefined) {
@@ -421,6 +572,19 @@ export function normalizeCallResult(result: unknown): McpCallResult {
       const res = block.resource;
       if (isString(res.text)) parts.push(res.text);
       else if (isString(res.uri)) parts.push(`[resource ${res.uri}]`);
+    } else if (block.type === "resource_link" && isString(block.uri)) {
+      // A file the tool produced rather than inlined — the render it was
+      // asked for. Dropping it left a successful call with nothing to use.
+      const link: McpResourceLink = { uri: block.uri };
+      if (isString(block.name)) link.name = block.name;
+      if (isString(block.mimeType)) link.mimeType = block.mimeType;
+      if (isString(block.description)) link.description = block.description;
+      out.links.push(link);
+      parts.push(
+        link.name === undefined
+          ? `[resource ${link.uri}]`
+          : `[resource ${link.name}: ${link.uri}]`
+      );
     }
   }
   out.text = parts.join("\n");
@@ -470,6 +634,7 @@ export class ExternalMcpTool extends Tool {
     const out: Record<string, unknown> = {};
     if (result.structured !== undefined) out.result = result.structured;
     if (result.text) out.text = result.text;
+    if (result.links.length > 0) out.resource_links = result.links;
     if (result.images.length > 0) {
       out[IMAGE_CONTENTS_FIELD] = result.images.map((img) => ({
         data: img.data,

--- a/packages/agents/tests/external-mcp-tools.test.ts
+++ b/packages/agents/tests/external-mcp-tools.test.ts
@@ -21,7 +21,8 @@ import {
   McpClientPool,
   getCachedExternalMcpTools,
   getExternalMcpTools,
-  normalizeCallResult
+  normalizeCallResult,
+  type McpClientPoolOptions
 } from "../src/tools/external-mcp-tools.js";
 import { graftedModuleFor } from "../src/codeact/capability-modules.js";
 import { IMAGE_CONTENTS_FIELD } from "../src/tools/image-injection.js";
@@ -77,6 +78,38 @@ function poolOver(server: McpServer): McpClientPool {
       return client;
     }
   });
+}
+
+/**
+ * A pool whose connection never opens: the server accepted the socket and
+ * went quiet, the way an HTTP server does when it refuses the Streamable POST
+ * and then opens an SSE stream with no `endpoint` event. Only cancellation
+ * settles it — which is what a real transport's `close()` does.
+ */
+function hangingPool(overrides: Partial<McpClientPoolOptions> = {}): {
+  pool: McpClientPool;
+  cancelled: () => number;
+} {
+  let cancels = 0;
+  const pool = new McpClientPool({
+    ...overrides,
+    connect: (_config, _secrets, signal) =>
+      new Promise<Client>((_resolve, reject) => {
+        signal.addEventListener(
+          "abort",
+          () => {
+            cancels += 1;
+            reject(
+              signal.reason instanceof Error
+                ? signal.reason
+                : new Error("cancelled")
+            );
+          },
+          { once: true }
+        );
+      })
+  });
+  return { pool, cancelled: () => cancels };
 }
 
 afterEach(async () => {
@@ -143,6 +176,21 @@ describe("resolveSecretReferences", () => {
     );
     expect(out).toEqual({ Authorization: "Bearer tok" });
   });
+
+  it("reports every value an expansion produced, not just the finished one", async () => {
+    const seen: string[] = [];
+    await resolveSecretReferences(
+      { Authorization: "${MCP_HF_AUTH}" },
+      async (name) =>
+        name === "MCP_HF_AUTH"
+          ? "Bearer ${HF_TOKEN}"
+          : name === "HF_TOKEN"
+            ? "hf_secret_value"
+            : null,
+      (value) => seen.push(value)
+    );
+    expect(seen).toEqual(["hf_secret_value", "Bearer hf_secret_value"]);
+  });
 });
 
 describe("normalizeCallResult", () => {
@@ -159,6 +207,30 @@ describe("normalizeCallResult", () => {
     expect(out.images).toEqual([{ data: PNG_BYTE, mimeType: "image/jpeg" }]);
     expect(out.structured).toEqual({ n: 1 });
     expect(out.isError).toBe(false);
+    expect(out.links).toEqual([]);
+  });
+
+  it("keeps a resource_link, the only thing a file-producing tool returned", () => {
+    const out = normalizeCallResult({
+      content: [
+        {
+          type: "resource_link",
+          uri: "https://example.com/render.glb",
+          name: "render.glb",
+          mimeType: "model/gltf-binary",
+          description: "The finished render"
+        }
+      ]
+    });
+    expect(out.links).toEqual([
+      {
+        uri: "https://example.com/render.glb",
+        name: "render.glb",
+        mimeType: "model/gltf-binary",
+        description: "The finished render"
+      }
+    ]);
+    expect(out.text).toBe("[resource render.glb: https://example.com/render.glb]");
   });
 });
 
@@ -283,6 +355,62 @@ describe("McpClientPool", () => {
     await pool.sync([config]);
     expect(await getExternalMcpTools(pool)).toEqual([]);
     expect(closed).toBe(1);
+  });
+
+  it("hands back a resource link as the tool's answer", async () => {
+    const server = new McpServer({ name: "links", version: "0" });
+    server.registerTool("export", { inputSchema: {} }, async () => ({
+      content: [
+        {
+          type: "resource_link",
+          uri: "https://example.com/render.glb",
+          name: "render.glb",
+          mimeType: "model/gltf-binary"
+        }
+      ]
+    }));
+    const pool = poolOver(server);
+    await pool.sync([config]);
+    const [tool] = await getExternalMcpTools(pool);
+    const out = (await tool.process({} as ProcessingContext, {})) as Record<
+      string,
+      unknown
+    >;
+    expect(out.resource_links).toEqual([
+      {
+        uri: "https://example.com/render.glb",
+        name: "render.glb",
+        mimeType: "model/gltf-binary"
+      }
+    ]);
+    await pool.close();
+  });
+
+  it("gives up on a server that accepts the connection and never answers", async () => {
+    const { pool } = hangingPool({ connectTimeoutMs: 50 });
+    await pool.sync([config]);
+    const errors: string[] = [];
+    const tools = await getExternalMcpTools(pool, (id, err) =>
+      errors.push(`${id}:${err.message}`)
+    );
+    expect(tools).toEqual([]);
+    expect(errors[0]).toContain("did not answer within 50ms");
+    expect(pool.serverIds()).toEqual([]);
+    await pool.close();
+  });
+
+  it("lets a removal cancel a connection discovery is still waiting on", async () => {
+    const { pool, cancelled } = hangingPool({ connectTimeoutMs: 60_000 });
+    await pool.sync([config]);
+    // The turn's belt is blocked on the server that never answers.
+    const discovery = getExternalMcpTools(pool);
+    // The user disables it in Settings. Without cancellation this waits out
+    // the full deadline behind the discovery holding the pool's queue.
+    await pool.sync([{ ...config, enabled: false }]);
+    expect(pool.serverIds()).toEqual([]);
+    expect(await discovery).toEqual([]);
+    expect(cancelled()).toBe(1);
+    await pool.close();
   });
 
   it("drops disabled and removed servers, reconnects on a changed config", async () => {

--- a/packages/agents/tests/external-mcp-tools.test.ts
+++ b/packages/agents/tests/external-mcp-tools.test.ts
@@ -1,0 +1,313 @@
+/**
+ * External MCP servers on the belt: a real MCP server over an in-memory
+ * transport, discovered and called through `McpClientPool`, and the guest
+ * namespace their names graft onto.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  mcpCredentialSecretName,
+  mcpToolName,
+  resolveSecretReferences,
+  type McpServerConfig
+} from "@nodetool-ai/protocol";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  ExternalMcpTool,
+  McpClientPool,
+  getCachedExternalMcpTools,
+  getExternalMcpTools,
+  normalizeCallResult
+} from "../src/tools/external-mcp-tools.js";
+import { graftedModuleFor } from "../src/codeact/capability-modules.js";
+import { IMAGE_CONTENTS_FIELD } from "../src/tools/image-injection.js";
+
+const PNG_BYTE = "iVBORw0KGgo=";
+
+function fakeServer(): { server: McpServer; calls: unknown[] } {
+  const calls: unknown[] = [];
+  const server = new McpServer({ name: "fake", version: "0.0.1" });
+  server.registerTool(
+    "render.scene",
+    {
+      description: "Render the current scene",
+      inputSchema: { samples: z.number().int().optional() }
+    },
+    async (args) => {
+      calls.push(args);
+      return {
+        content: [
+          { type: "text", text: `rendered ${args.samples ?? 0}` },
+          { type: "image", data: PNG_BYTE, mimeType: "image/png" }
+        ]
+      };
+    }
+  );
+  server.registerTool(
+    "fail",
+    { description: "Always fails", inputSchema: {} },
+    async () => ({ isError: true, content: [{ type: "text", text: "boom" }] })
+  );
+  return { server, calls };
+}
+
+const config: McpServerConfig = {
+  id: "blender",
+  name: "Blender",
+  enabled: true,
+  transport: { type: "stdio", command: "unused", args: [], env: {} }
+};
+
+let opened: McpServer[] = [];
+
+function poolOver(server: McpServer): McpClientPool {
+  return new McpClientPool({
+    connect: async () => {
+      const [clientSide, serverSide] = InMemoryTransport.createLinkedPair();
+      const client = new Client({ name: "test", version: "0" });
+      await Promise.all([
+        client.connect(clientSide),
+        server.connect(serverSide)
+      ]);
+      opened.push(server);
+      return client;
+    }
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(opened.map((s) => s.close()));
+  opened = [];
+});
+
+describe("mcpToolName", () => {
+  it("prefixes, normalizes to an identifier, and keeps the server on truncation", () => {
+    expect(mcpToolName("blender", "render.scene")).toBe(
+      "mcp_blender_render_scene"
+    );
+    expect(mcpToolName("hf", "__weird--name__")).toBe("mcp_hf_weird_name");
+    const long = mcpToolName("hf", "a".repeat(100));
+    expect(long).toHaveLength(64);
+    expect(long.startsWith("mcp_hf_")).toBe(true);
+    expect(/^[a-z][a-z0-9_]*$/.test(long)).toBe(true);
+  });
+});
+
+describe("mcpCredentialSecretName", () => {
+  it("keeps distinct (server, key) pairs apart", () => {
+    const names = [
+      mcpCredentialSecretName("a_b", "c"),
+      mcpCredentialSecretName("a", "b_c"),
+      mcpCredentialSecretName("a", "B_C"),
+      mcpCredentialSecretName("a", "b-c")
+    ];
+    expect(new Set(names).size).toBe(names.length);
+    expect(names[2]).toBe("MCP_A_0042005F0043");
+    expect(mcpCredentialSecretName("a", "\ud800")).not.toBe(
+      mcpCredentialSecretName("a", "\ud801")
+    );
+  });
+});
+
+describe("graftedModuleFor", () => {
+  it("routes MCP names to the mcp namespace", () => {
+    expect(graftedModuleFor("mcp_blender_render_scene")).toBe("mcp");
+    expect(graftedModuleFor("ui_add_node")).toBe("ui");
+    expect(graftedModuleFor("run_node")).toBe("session");
+  });
+});
+
+describe("resolveSecretReferences", () => {
+  it("replaces ${NAME} references inline and blanks unknown ones", async () => {
+    const out = await resolveSecretReferences(
+      {
+        A: "${HF_TOKEN}",
+        B: "literal",
+        C: "${MISSING}",
+        D: "Bearer ${HF_TOKEN}"
+      },
+      async (name) => (name === "HF_TOKEN" ? "tok" : null)
+    );
+    expect(out).toEqual({ A: "tok", B: "literal", C: "", D: "Bearer tok" });
+  });
+
+  it("resolves a reference whose secret is itself a template", async () => {
+    const out = await resolveSecretReferences(
+      { Authorization: "${MCP_HF_AUTH}" },
+      async (name) =>
+        name === "MCP_HF_AUTH" ? "Bearer ${HF_TOKEN}" : name === "HF_TOKEN" ? "tok" : null
+    );
+    expect(out).toEqual({ Authorization: "Bearer tok" });
+  });
+});
+
+describe("normalizeCallResult", () => {
+  it("flattens text, images and resources", () => {
+    const out = normalizeCallResult({
+      content: [
+        { type: "text", text: "a" },
+        { type: "image", data: PNG_BYTE, mimeType: "image/jpeg" },
+        { type: "resource", resource: { uri: "file:///x", text: "b" } }
+      ],
+      structuredContent: { n: 1 }
+    });
+    expect(out.text).toBe("a\nb");
+    expect(out.images).toEqual([{ data: PNG_BYTE, mimeType: "image/jpeg" }]);
+    expect(out.structured).toEqual({ n: 1 });
+    expect(out.isError).toBe(false);
+  });
+});
+
+describe("McpClientPool", () => {
+  it("discovers tools, calls them, and reports images", async () => {
+    const { server, calls } = fakeServer();
+    const pool = poolOver(server);
+    await pool.sync([config]);
+    const tools = await getExternalMcpTools(pool);
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      "mcp_blender_fail",
+      "mcp_blender_render_scene"
+    ]);
+    const render = tools.find(
+      (t) => t.name === "mcp_blender_render_scene"
+    ) as ExternalMcpTool;
+    expect(render.inputSchema).toMatchObject({ type: "object" });
+
+    const result = (await render.process({} as ProcessingContext, {
+      samples: 4
+    })) as Record<string, unknown>;
+    expect(calls).toEqual([{ samples: 4 }]);
+    expect(result.text).toBe("rendered 4");
+    expect(result[IMAGE_CONTENTS_FIELD]).toEqual([
+      { data: PNG_BYTE, mimeType: "image/png" }
+    ]);
+
+    const failed = tools.find((t) => t.name === "mcp_blender_fail")!;
+    expect(await failed.process({} as ProcessingContext, {})).toEqual({
+      error: "mcp_tool_error",
+      message: "boom"
+    });
+
+    // The cached belt matches the discovered one without I/O.
+    expect(getCachedExternalMcpTools(pool).map((t) => t.name).sort()).toEqual(
+      tools.map((t) => t.name).sort()
+    );
+    await pool.close();
+  });
+
+  it("skips a server that refuses to connect and retries on next sync", async () => {
+    let attempts = 0;
+    const pool = new McpClientPool({
+      connect: async () => {
+        attempts += 1;
+        throw new Error("refused");
+      }
+    });
+    await pool.sync([config]);
+    const errors: string[] = [];
+    const tools = await getExternalMcpTools(pool, (id, err) =>
+      errors.push(`${id}:${err.message}`)
+    );
+    expect(tools).toEqual([]);
+    expect(errors).toEqual(["blender:refused"]);
+    expect(pool.serverIds()).toEqual([]);
+    await pool.sync([config]);
+    expect(pool.serverIds()).toEqual(["blender"]);
+    expect(attempts).toBe(2);
+    await pool.close();
+  });
+
+  it("numbers tools whose remote names normalize to one belt name", async () => {
+    const server = new McpServer({ name: "dup", version: "0" });
+    server.registerTool("render.scene", { inputSchema: {} }, async () => ({
+      content: [{ type: "text", text: "dot" }]
+    }));
+    server.registerTool("render_scene", { inputSchema: {} }, async () => ({
+      content: [{ type: "text", text: "underscore" }]
+    }));
+    const pool = poolOver(server);
+    await pool.sync([config]);
+    const tools = await getExternalMcpTools(pool);
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      "mcp_blender_render_scene",
+      "mcp_blender_render_scene_2"
+    ]);
+    // Names follow sorted remote names, so the mapping is the same every turn.
+    const byRemote = new Map(
+      tools.map((t) => [(t as ExternalMcpTool).remote.name, t.name])
+    );
+    expect(byRemote.get("render_scene")).toBe("mcp_blender_render_scene");
+    expect(byRemote.get("render.scene")).toBe("mcp_blender_render_scene_2");
+    const second = tools.find((t) => t.name.endsWith("_2"))!;
+    expect(await second.process({} as ProcessingContext, {})).toEqual({
+      text: "dot"
+    });
+    await pool.close();
+  });
+
+  it("redacts a resolved secret from the error it reports", async () => {
+    const pool = new McpClientPool({
+      connect: async (_config, secrets) => {
+        secrets.add("s3cret-token");
+        return {
+          listTools: async () => {
+            throw new Error("401 for s3cret-token from upstream");
+          },
+          close: async () => undefined
+        } as unknown as Client;
+      }
+    });
+    await pool.sync([config]);
+    const errors: string[] = [];
+    await getExternalMcpTools(pool, (_id, err) => errors.push(err.message));
+    expect(errors).toEqual(["401 for [redacted] from upstream"]);
+  });
+
+  it("closes a client whose discovery failed", async () => {
+    let closed = 0;
+    const pool = new McpClientPool({
+      connect: async () =>
+        ({
+          listTools: async () => {
+            throw new Error("list failed");
+          },
+          close: async () => {
+            closed += 1;
+          }
+        }) as unknown as Client
+    });
+    await pool.sync([config]);
+    expect(await getExternalMcpTools(pool)).toEqual([]);
+    expect(closed).toBe(1);
+  });
+
+  it("drops disabled and removed servers, reconnects on a changed config", async () => {
+    const { server } = fakeServer();
+    let connects = 0;
+    const pool = new McpClientPool({
+      connect: async () => {
+        connects += 1;
+        const [clientSide, serverSide] = InMemoryTransport.createLinkedPair();
+        const client = new Client({ name: "test", version: "0" });
+        await Promise.all([
+          client.connect(clientSide),
+          server.connect(serverSide)
+        ]);
+        opened.push(server);
+        return client;
+      }
+    });
+    await pool.sync([config]);
+    await pool.sync([config]);
+    expect(connects).toBe(1);
+    await pool.sync([{ ...config, name: "Blender 4" }]);
+    expect(connects).toBe(2);
+    await pool.sync([{ ...config, enabled: false }]);
+    expect(pool.serverIds()).toEqual([]);
+    await pool.close();
+  });
+});

--- a/packages/agents/tests/external-mcp-tools.test.ts
+++ b/packages/agents/tests/external-mcp-tools.test.ts
@@ -5,6 +5,10 @@
  */
 
 import { afterEach, describe, expect, it } from "vitest";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { z } from "zod";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -110,6 +114,31 @@ function hangingPool(overrides: Partial<McpClientPoolOptions> = {}): {
       })
   });
   return { pool, cancelled: () => cancels };
+}
+
+/** How long "the command did not run" waits before it believes itself. */
+const NO_SPAWN_WINDOW_MS = 1_500;
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/** Milliseconds until `path` appeared, or null if it never did. */
+async function waitForFile(
+  path: string,
+  timeoutMs: number
+): Promise<number | null> {
+  const started = Date.now();
+  for (;;) {
+    const elapsed = Date.now() - started;
+    if (existsSync(path)) return elapsed;
+    if (elapsed >= timeoutMs) return null;
+    await new Promise((r) => setTimeout(r, 20));
+  }
 }
 
 afterEach(async () => {
@@ -411,6 +440,52 @@ describe("McpClientPool", () => {
     expect(await discovery).toEqual([]);
     expect(cancelled()).toBe(1);
     await pool.close();
+  });
+
+  it("does not spawn a removed server's command when its secret arrives late", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "nodetool-mcp-"));
+    const marker = join(dir, "spawned");
+    // A real stdio server: the command writes a file the moment it runs, so
+    // the file is the ground truth for whether the transport started.
+    const spawning: McpServerConfig = {
+      ...config,
+      transport: {
+        type: "stdio",
+        command: process.execPath,
+        args: [
+          "-e",
+          "require('node:fs').writeFileSync(process.env.MCP_TEST_MARKER, 'x')"
+        ],
+        env: { MCP_TEST_MARKER: marker, TOKEN: "${MCP_TOKEN}" }
+      }
+    };
+
+    const held = deferred<string>();
+    const cancelled = new McpClientPool({
+      getSecret: () => held.promise,
+      connectTimeoutMs: 60_000
+    });
+    await cancelled.sync([spawning]);
+    // The user deletes the server while `connect()` is parked on the secret.
+    await cancelled.sync([]);
+    expect(cancelled.serverIds()).toEqual([]);
+    held.resolve("token-value");
+    expect(await waitForFile(marker, NO_SPAWN_WINDOW_MS)).toBeNull();
+    await cancelled.close();
+
+    // The same setup, uncancelled: the command does run, and it runs well
+    // inside the window the assertion above waited out — so that assertion
+    // cannot pass by watching a machine too slow to have spawned yet.
+    const live = new McpClientPool({
+      getSecret: async () => "token-value",
+      connectTimeoutMs: 5_000
+    });
+    await live.sync([spawning]);
+    const spawnMs = await waitForFile(marker, 10_000);
+    expect(spawnMs).not.toBeNull();
+    expect(spawnMs).toBeLessThan(NO_SPAWN_WINDOW_MS);
+    await live.close();
+    await rm(dir, { recursive: true, force: true });
   });
 
   it("drops disabled and removed servers, reconnects on a changed config", async () => {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -60,3 +60,4 @@ export {
 export * from "./nodetool-models.js";
 export * from "./predicates.js";
 export * from "./workflow-plan.js";
+export * from "./mcp-server-config.js";

--- a/packages/protocol/src/mcp-server-config.ts
+++ b/packages/protocol/src/mcp-server-config.ts
@@ -70,12 +70,26 @@ const MAX_TOOL_NAME_LENGTH = 64;
  * and the server id kept, so the name still says which server it belongs to.
  */
 export function mcpToolName(serverId: string, remoteName: string): string {
-  const remote = remoteName
-    .replace(/[^a-zA-Z0-9]+/g, "_")
-    .replace(/^_+|_+$/g, "");
   const prefix = `${MCP_TOOL_PREFIX}${serverId}_`;
   const room = Math.max(1, MAX_TOOL_NAME_LENGTH - prefix.length);
-  return `${prefix}${remote.slice(0, room)}`.replace(/_+$/, "");
+  // One linear pass: a run of non-alphanumerics becomes one `_`, never at the
+  // start; a trailing `_` is dropped. The remote name is server input, so no
+  // regex with a nested quantifier runs over it.
+  let remote = "";
+  let pendingUnderscore = false;
+  for (const ch of remoteName) {
+    if (remote.length >= room) break;
+    if (/[a-zA-Z0-9]/.test(ch)) {
+      if (pendingUnderscore && remote.length > 0 && remote.length < room - 1) {
+        remote += "_";
+      }
+      pendingUnderscore = false;
+      remote += ch;
+    } else {
+      pendingUnderscore = true;
+    }
+  }
+  return `${prefix}${remote}`;
 }
 
 const SECRET_REFERENCE = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g;

--- a/packages/protocol/src/mcp-server-config.ts
+++ b/packages/protocol/src/mcp-server-config.ts
@@ -104,14 +104,19 @@ export function secretReferencesIn(value: string): string[] {
  * `Bearer ${HF_TOKEN}` works. A reference the resolver cannot answer becomes
  * empty rather than passing through, so a placeholder never reaches a child
  * process or a wire as a literal.
+ *
+ * `onResolved` sees every value a reference produced, at every level of
+ * expansion — not just the finished string. A caller redacting `Bearer <tok>`
+ * would otherwise leave `Invalid token <tok>` from an upstream error intact.
  */
 export async function resolveSecretReferences(
   values: Record<string, string>,
-  getSecret: (name: string) => Promise<string | null | undefined>
+  getSecret: (name: string) => Promise<string | null | undefined>,
+  onResolved?: (value: string) => void
 ): Promise<Record<string, string>> {
   const out: Record<string, string> = {};
   for (const [key, raw] of Object.entries(values)) {
-    out[key] = await resolveOne(raw, getSecret, 0);
+    out[key] = await resolveOne(raw, getSecret, 0, onResolved);
   }
   return out;
 }
@@ -126,14 +131,17 @@ const MAX_REFERENCE_DEPTH = 3;
 async function resolveOne(
   raw: string,
   getSecret: (name: string) => Promise<string | null | undefined>,
-  depth: number
+  depth: number,
+  onResolved?: (value: string) => void
 ): Promise<string> {
   const names = secretReferencesIn(raw);
   if (names.length === 0 || depth >= MAX_REFERENCE_DEPTH) return raw;
   const resolved = new Map<string, string>();
   for (const name of new Set(names)) {
     const value = (await getSecret(name)) ?? "";
-    resolved.set(name, await resolveOne(value, getSecret, depth + 1));
+    const expanded = await resolveOne(value, getSecret, depth + 1, onResolved);
+    if (expanded !== "") onResolved?.(expanded);
+    resolved.set(name, expanded);
   }
   return raw.replace(SECRET_REFERENCE, (_m, name: string) =>
     resolved.get(name) ?? ""

--- a/packages/protocol/src/mcp-server-config.ts
+++ b/packages/protocol/src/mcp-server-config.ts
@@ -1,0 +1,154 @@
+/**
+ * A user-configured external MCP server — Blender, Hugging Face, a local
+ * script — whose tools join the agent's toolbelt.
+ *
+ * One shape serves every consumer: the settings store persists it, the REST
+ * route validates it, the web settings panel edits it, and the agents package
+ * connects to it. A server is reached over stdio (a child process this
+ * machine spawns) or over HTTP (Streamable HTTP, with SSE as the fallback for
+ * older servers).
+ *
+ * A header or env value is either a literal or carries `${SECRET_NAME}`
+ * references. The persistence layer moves every literal that could be a
+ * credential into an encrypted secret and stores the reference in its place,
+ * so the stored config holds no token.
+ */
+
+import { z } from "zod";
+
+/** Lowercase letters, digits and underscores: the id is part of a JS identifier. */
+export const MCP_SERVER_ID_PATTERN = /^[a-z0-9][a-z0-9_]{0,31}$/;
+
+export const McpStdioTransportSchema = z.object({
+  type: z.literal("stdio"),
+  command: z.string().min(1),
+  args: z.array(z.string()).default([]),
+  /** Extra environment for the child. Values may carry `${SECRET_NAME}` references. */
+  env: z.record(z.string(), z.string()).default({}),
+  cwd: z.string().optional()
+});
+
+export const McpHttpTransportSchema = z.object({
+  type: z.literal("http"),
+  url: z.string().url(),
+  /** Extra request headers. Values may carry `${SECRET_NAME}` references. */
+  headers: z.record(z.string(), z.string()).default({})
+});
+
+export const McpServerTransportSchema = z.discriminatedUnion("type", [
+  McpStdioTransportSchema,
+  McpHttpTransportSchema
+]);
+
+export const McpServerConfigSchema = z.object({
+  /** Stable slug; becomes the middle of every tool name (`mcp_<id>_<tool>`). */
+  id: z.string().regex(MCP_SERVER_ID_PATTERN),
+  /** Display name for the settings UI. */
+  name: z.string().min(1).max(120),
+  enabled: z.boolean().default(true),
+  transport: McpServerTransportSchema
+});
+
+export const McpServerConfigListSchema = z.array(McpServerConfigSchema);
+
+export type McpStdioTransport = z.infer<typeof McpStdioTransportSchema>;
+export type McpHttpTransport = z.infer<typeof McpHttpTransportSchema>;
+export type McpServerTransport = z.infer<typeof McpServerTransportSchema>;
+export type McpServerConfig = z.infer<typeof McpServerConfigSchema>;
+
+/** Prefix every external MCP tool name carries, and the guest namespace it imports from. */
+export const MCP_TOOL_PREFIX = "mcp_";
+export const MCP_CAPABILITY_MODULE = "mcp";
+
+/** Provider tool names are capped here, and so is the guest export. */
+const MAX_TOOL_NAME_LENGTH = 64;
+
+/**
+ * The tool name the model sees for one remote tool. It is also a guest
+ * export, so it must be a JS identifier: `[a-z0-9_]`, starting with a
+ * letter. When the whole would exceed the cap, the remote name is shortened
+ * and the server id kept, so the name still says which server it belongs to.
+ */
+export function mcpToolName(serverId: string, remoteName: string): string {
+  const remote = remoteName
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  const prefix = `${MCP_TOOL_PREFIX}${serverId}_`;
+  const room = Math.max(1, MAX_TOOL_NAME_LENGTH - prefix.length);
+  return `${prefix}${remote.slice(0, room)}`.replace(/_+$/, "");
+}
+
+const SECRET_REFERENCE = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g;
+
+/** The secret names a value refers to. */
+export function secretReferencesIn(value: string): string[] {
+  return [...value.matchAll(SECRET_REFERENCE)].map((m) => m[1]);
+}
+
+/**
+ * Substitute every `${SECRET_NAME}` in a string map, inline, so
+ * `Bearer ${HF_TOKEN}` works. A reference the resolver cannot answer becomes
+ * empty rather than passing through, so a placeholder never reaches a child
+ * process or a wire as a literal.
+ */
+export async function resolveSecretReferences(
+  values: Record<string, string>,
+  getSecret: (name: string) => Promise<string | null | undefined>
+): Promise<Record<string, string>> {
+  const out: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(values)) {
+    out[key] = await resolveOne(raw, getSecret, 0);
+  }
+  return out;
+}
+
+/**
+ * A secret's own value may be a template (`Bearer ${HF_TOKEN}`, stored whole
+ * by the persistence layer), so a reference resolves through a bounded
+ * number of levels. Past the bound, what is left is sent as it stands.
+ */
+const MAX_REFERENCE_DEPTH = 3;
+
+async function resolveOne(
+  raw: string,
+  getSecret: (name: string) => Promise<string | null | undefined>,
+  depth: number
+): Promise<string> {
+  const names = secretReferencesIn(raw);
+  if (names.length === 0 || depth >= MAX_REFERENCE_DEPTH) return raw;
+  const resolved = new Map<string, string>();
+  for (const name of new Set(names)) {
+    const value = (await getSecret(name)) ?? "";
+    resolved.set(name, await resolveOne(value, getSecret, depth + 1));
+  }
+  return raw.replace(SECRET_REFERENCE, (_m, name: string) =>
+    resolved.get(name) ?? ""
+  );
+}
+
+/**
+ * The secret name a literal header or env value is stored under when the
+ * persistence layer moves it out of the config: `MCP_<SERVER>_<KEYHEX>`.
+ * The key is hex-encoded, so the part after the last underscore is the key
+ * and everything between is the server id: no two (server, key) pairs share
+ * a name, whatever underscores or casing they carry.
+ */
+export function mcpCredentialSecretName(serverId: string, key: string): string {
+  // UTF-16 code units, four hex digits each: a lone surrogate keeps its own
+  // code, where a UTF-8 encoding would fold every one into U+FFFD.
+  let hex = "";
+  for (let i = 0; i < key.length; i += 1) {
+    hex += key.charCodeAt(i).toString(16).toUpperCase().padStart(4, "0");
+  }
+  return `MCP_${serverId.toUpperCase()}_${hex}`;
+}
+
+/** Whether a value is exactly one secret reference and nothing else. */
+export function isSecretReference(value: string): boolean {
+  return /^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/.test(value);
+}
+
+/** Whether a value is made only of references and nothing else (`${A}${B}`). */
+export function isPureSecretReferences(value: string): boolean {
+  return value !== "" && value.replace(SECRET_REFERENCE, "") === "";
+}

--- a/packages/runtime/tests/url-egress-inventory.ts
+++ b/packages/runtime/tests/url-egress-inventory.ts
@@ -266,6 +266,21 @@ export const URL_EGRESS_INVENTORY: EgressEntry[] = [
     "Reads the uri a workflow output named before storing the bytes as an asset."
   ),
 
+  {
+    file: "packages/websocket/src/external-mcp.ts",
+    owner: "external MCP server (HTTP transport)",
+    inputSource: "operator",
+    schemes: ["https"],
+    authScope:
+      "The headers the user configured for that server, resolved from their own secrets; safeFetch strips Authorization on a cross-origin hop.",
+    redirects: "checked-per-hop",
+    dnsRebinding: "deployment-egress",
+    policy: "guarded",
+    guardedBy: ["safeFetch", "assertSafePublicHttpsUrl"],
+    note:
+      "A user's own MCP server URL. Under the cloud profile the MCP transport is handed safeFetch and the URL is checked on save and probe; a local install may reach its own loopback servers and uses the global fetch."
+  },
+
   // -------------------------------------------- guarded (provider result URLs)
   guardedSafeFetch(
     "packages/kie-nodes/src/kie-base.ts",

--- a/packages/websocket/src/external-mcp.ts
+++ b/packages/websocket/src/external-mcp.ts
@@ -95,8 +95,18 @@ const guardedFetch: typeof fetch = (input, init) => {
   return safeFetch(url, init);
 };
 
-function newPool(userId: string): McpClientPool {
+/**
+ * A probe has someone watching it, so it waits less than a chat turn does for
+ * a server that accepts the socket and then says nothing.
+ */
+const PROBE_CONNECT_TIMEOUT_MS = 15_000;
+
+function newPool(
+  userId: string,
+  extra: McpClientPoolOptions = {}
+): McpClientPool {
   const options: McpClientPoolOptions = {
+    ...extra,
     getSecret: userSecretResolver(userId)
   };
   // The cloud profile fetches through the SSRF guard, which re-checks every
@@ -310,7 +320,9 @@ export async function probeExternalMcpServer(
       error: err instanceof Error ? err.message : String(err)
     };
   }
-  const pool = newPool(userId);
+  const pool = newPool(userId, {
+    connectTimeoutMs: PROBE_CONNECT_TIMEOUT_MS
+  });
   try {
     await pool.sync([{ ...config, enabled: true }]);
     let error: string | null = null;

--- a/packages/websocket/src/external-mcp.ts
+++ b/packages/websocket/src/external-mcp.ts
@@ -1,0 +1,351 @@
+/**
+ * User-configured external MCP servers: persistence and the per-user client
+ * pool that serves their tools to a chat turn.
+ *
+ * The server list is one JSON row in the plaintext `Setting` table, and it
+ * holds no credential: on save, every literal header or env value that is
+ * not already a `${SECRET_NAME}` reference is moved into an encrypted
+ * `Secret` row named `MCP_<SERVER>_<KEY>` and the reference stored in its
+ * place. References resolve at connect time from the user's own secrets and
+ * nowhere else — never from the process environment, which holds the
+ * server's infrastructure keys.
+ *
+ * Connections are process-global per user: the belt of every turn shares
+ * them, `sync` reconciles them after a save, and a server that stops
+ * answering is dropped and retried on the next turn.
+ */
+
+import { createLogger } from "@nodetool-ai/config";
+import { Secret, Setting, clearSecretCache } from "@nodetool-ai/models";
+import {
+  McpClientPool,
+  getExternalMcpTools,
+  type McpClientPoolOptions,
+  type McpRemoteTool,
+  type Tool
+} from "@nodetool-ai/agents";
+import { assertSafePublicHttpsUrl, safeFetch } from "@nodetool-ai/runtime";
+import {
+  CLOUD_PROFILE_ENV,
+  NODE_ENV_VAR,
+  McpServerConfigListSchema,
+  isCloudProfileActive,
+  isPureSecretReferences,
+  mcpCredentialSecretName,
+  secretReferencesIn,
+  type McpServerConfig
+} from "@nodetool-ai/protocol";
+
+const log = createLogger("nodetool.websocket.external-mcp");
+
+/** The `Setting` key the server list lives under. */
+export const EXTERNAL_MCP_SETTING_KEY = "EXTERNAL_MCP_SERVERS";
+
+const pools = new Map<string, McpClientPool>();
+
+/** Per-user write serialization: save and delete are read-modify-write. */
+const writeQueues = new Map<string, Promise<unknown>>();
+
+function serializedFor<T>(userId: string, fn: () => Promise<T>): Promise<T> {
+  const prior = writeQueues.get(userId) ?? Promise.resolve();
+  const next = prior.then(fn, fn);
+  writeQueues.set(
+    userId,
+    next.catch(() => undefined)
+  );
+  return next;
+}
+
+/**
+ * Whether this deployment spawns stdio servers and reaches private hosts. A
+ * stdio server is a command run on the machine the server owns, so it is
+ * offered only where that machine belongs to its user — the desktop app, a
+ * local server, a self-hosted install. The cloud profile keeps HTTP servers
+ * only, and only public https ones.
+ */
+export function isLocalMcpProfile(): boolean {
+  return !isCloudProfileActive(
+    process.env[CLOUD_PROFILE_ENV],
+    process.env[NODE_ENV_VAR]
+  );
+}
+
+export const STDIO_MCP_DISABLED_ERROR =
+  "Stdio MCP servers run a command on the server machine, so they are not " +
+  "available on this deployment. Use an HTTP server instead.";
+
+/** A resolver over the user's encrypted secrets only. */
+function userSecretResolver(userId: string) {
+  return async (name: string): Promise<string | null> => {
+    const row = await Secret.find(userId, name);
+    if (!row) return null;
+    try {
+      return await row.getDecryptedValue();
+    } catch {
+      // An undecryptable secret reads as unset; the server sees an empty
+      // header, which is what the user has to fix by re-entering it.
+      return null;
+    }
+  };
+}
+
+/** `safeFetch` in the shape the MCP transports take. */
+const guardedFetch: typeof fetch = (input, init) => {
+  const url = input instanceof Request ? input.url : String(input);
+  return safeFetch(url, init);
+};
+
+function newPool(userId: string): McpClientPool {
+  const options: McpClientPoolOptions = {
+    getSecret: userSecretResolver(userId)
+  };
+  // The cloud profile fetches through the SSRF guard, which re-checks every
+  // redirect hop. A local install may reach its own loopback servers.
+  if (!isLocalMcpProfile()) options.fetch = guardedFetch;
+  return new McpClientPool(options);
+}
+
+function poolFor(userId: string): McpClientPool {
+  let pool = pools.get(userId);
+  if (pool === undefined) {
+    pool = newPool(userId);
+    pools.set(userId, pool);
+  }
+  return pool;
+}
+
+/** Refuse what this deployment cannot connect to. */
+function assertConnectable(config: McpServerConfig): void {
+  if (isLocalMcpProfile()) return;
+  if (config.transport.type === "stdio") {
+    throw new Error(STDIO_MCP_DISABLED_ERROR);
+  }
+  assertSafePublicHttpsUrl(config.transport.url);
+}
+
+/** The servers this deployment can actually connect to. */
+function connectable(servers: McpServerConfig[]): McpServerConfig[] {
+  return servers.filter((s) => {
+    try {
+      assertConnectable(s);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+/** The user's configured servers, invalid rows dropped. */
+export async function loadExternalMcpServers(
+  userId: string
+): Promise<McpServerConfig[]> {
+  const setting = await Setting.find(userId, EXTERNAL_MCP_SETTING_KEY);
+  if (!setting) return [];
+  let raw: unknown;
+  try {
+    raw = JSON.parse(setting.getValue());
+  } catch {
+    return [];
+  }
+  const parsed = McpServerConfigListSchema.safeParse(raw);
+  if (parsed.success) return parsed.data;
+  log.warn("Ignoring malformed external MCP server list", {
+    userId,
+    issues: parsed.error.issues.length
+  });
+  return [];
+}
+
+async function writeServers(
+  userId: string,
+  servers: McpServerConfig[]
+): Promise<void> {
+  await Setting.upsert({
+    userId,
+    key: EXTERNAL_MCP_SETTING_KEY,
+    value: JSON.stringify(servers),
+    description: "External MCP servers whose tools join the agent toolbelt"
+  });
+  await poolFor(userId).sync(connectable(servers));
+}
+
+/**
+ * Move every literal header/env value into an encrypted secret and store the
+ * reference. A value already made of references is kept as written. The
+ * secrets for keys the new config no longer carries are removed.
+ */
+async function externalizeCredentials(
+  userId: string,
+  config: McpServerConfig,
+  previous: McpServerConfig | undefined
+): Promise<McpServerConfig> {
+  const t = config.transport;
+  const values = t.type === "stdio" ? t.env : t.headers;
+  const stored: Record<string, string> = {};
+  for (const [key, value] of Object.entries(values)) {
+    // Only a value made purely of references stays as written; anything
+    // carrying a literal — even beside a reference — is a credential.
+    if (value === "" || isPureSecretReferences(value)) {
+      stored[key] = value;
+      continue;
+    }
+    const name = mcpCredentialSecretName(config.id, key);
+    await Secret.upsert({
+      userId,
+      key: name,
+      value,
+      description: `${key} for the MCP server ${config.name}`
+    });
+    clearSecretCache(userId, name);
+    stored[key] = `\${${name}}`;
+  }
+  if (previous !== undefined) {
+    await removeOwnedSecrets(userId, previous, ownedReferences(config.id, stored));
+  }
+  return t.type === "stdio"
+    ? { ...config, transport: { ...t, env: stored } }
+    : { ...config, transport: { ...t, headers: stored } };
+}
+
+/** The secret names a config's values own: those it references by its own name. */
+function ownedReferences(
+  serverId: string,
+  values: Record<string, string>
+): Set<string> {
+  const owned = new Set<string>();
+  // A secret is owned by this server when any value references it, not only
+  // the value at its own key: `${MCP_HF_58}${OTHER}` still uses it.
+  const names = new Set(
+    Object.keys(values).map((key) => mcpCredentialSecretName(serverId, key))
+  );
+  for (const value of Object.values(values)) {
+    for (const ref of secretReferencesIn(value)) {
+      if (names.has(ref)) owned.add(ref);
+    }
+  }
+  return owned;
+}
+
+/** Delete the secrets a config owns, except the names in `keep`. */
+async function removeOwnedSecrets(
+  userId: string,
+  config: McpServerConfig,
+  keep: ReadonlySet<string> = new Set()
+): Promise<void> {
+  const t = config.transport;
+  const values = t.type === "stdio" ? t.env : t.headers;
+  for (const name of ownedReferences(config.id, values)) {
+    if (keep.has(name)) continue;
+    await Secret.deleteSecret(userId, name);
+    clearSecretCache(userId, name);
+  }
+}
+
+/** Create or replace one server. */
+export async function saveExternalMcpServer(
+  userId: string,
+  config: McpServerConfig
+): Promise<McpServerConfig[]> {
+  assertConnectable(config);
+  return serializedFor(userId, async () => {
+    const current = await loadExternalMcpServers(userId);
+    const previous = current.find((s) => s.id === config.id);
+    const stored = await externalizeCredentials(userId, config, previous);
+    const next = current.filter((s) => s.id !== config.id);
+    next.push(stored);
+    // A rotated literal keeps the same reference, so the fingerprint alone
+    // would keep the old connection. Drop this server first; the sync
+    // below reopens it with the values now stored.
+    await poolFor(userId).sync(
+      connectable(current.filter((s) => s.id !== config.id))
+    );
+    await writeServers(userId, next);
+    return next;
+  });
+}
+
+/** Remove one server and the secrets it owns. Returns false if absent. */
+export function deleteExternalMcpServer(
+  userId: string,
+  id: string
+): Promise<boolean> {
+  return serializedFor(userId, async () => {
+    const current = await loadExternalMcpServers(userId);
+    const target = current.find((s) => s.id === id);
+    if (target === undefined) return false;
+    await removeOwnedSecrets(userId, target);
+    await writeServers(
+      userId,
+      current.filter((s) => s.id !== id)
+    );
+    return true;
+  });
+}
+
+/** What one server answered when asked for its tools. */
+export interface ExternalMcpServerProbe {
+  id: string;
+  ok: boolean;
+  tools: McpRemoteTool[];
+  error: string | null;
+}
+
+/**
+ * Connect to one server (fresh, outside the shared pool) and list its tools.
+ * The settings UI calls this after a save so the user sees what the server
+ * offers, or why it could not be reached. A literal credential in the probe
+ * is used for the probe only; nothing is stored.
+ */
+export async function probeExternalMcpServer(
+  userId: string,
+  config: McpServerConfig
+): Promise<ExternalMcpServerProbe> {
+  try {
+    assertConnectable(config);
+  } catch (err) {
+    return {
+      id: config.id,
+      ok: false,
+      tools: [],
+      error: err instanceof Error ? err.message : String(err)
+    };
+  }
+  const pool = newPool(userId);
+  try {
+    await pool.sync([{ ...config, enabled: true }]);
+    let error: string | null = null;
+    const discovered = await pool.discover((_id, err) => {
+      error = err.message.split("\n")[0].slice(0, 300);
+    });
+    const tools = discovered.get(config.id) ?? [];
+    return { id: config.id, ok: error === null, tools, error };
+  } finally {
+    await pool.close();
+  }
+}
+
+/**
+ * The belt contribution of the user's enabled servers. Syncs the pool with
+ * the stored list first, so a server saved from the settings UI is live on
+ * the next turn without a restart.
+ */
+export async function externalMcpToolsFor(userId: string): Promise<Tool[]> {
+  const servers = await loadExternalMcpServers(userId);
+  const pool = poolFor(userId);
+  await pool.sync(connectable(servers));
+  if (pool.serverIds().length === 0) return [];
+  return getExternalMcpTools(pool, (serverId, error) => {
+    log.warn("External MCP server skipped for this turn", {
+      userId,
+      server: serverId,
+      error: error.message.split("\n")[0].slice(0, 300)
+    });
+  });
+}
+
+/** Close every user's connections (server shutdown, tests). */
+export async function closeExternalMcpPools(): Promise<void> {
+  const all = [...pools.values()];
+  pools.clear();
+  await Promise.all(all.map((p) => p.close()));
+}

--- a/packages/websocket/src/session/chat-turn.ts
+++ b/packages/websocket/src/session/chat-turn.ts
@@ -122,6 +122,7 @@ import {
   type SecretPromptStatus
 } from "@nodetool-ai/agents";
 import { mcpToolHostDeps } from "../mcp-tool-deps.js";
+import { externalMcpToolsFor } from "../external-mcp.js";
 import {
   formatSkillCatalogForPrompt,
   mergeSystemSkills,
@@ -1437,6 +1438,17 @@ export class ChatTurnHandler {
         availableSecrets: contextSecretAvailability(context),
         budget: turnBudget
       });
+    // The user's external MCP servers (Blender, Hugging Face, …). Their tools
+    // are plain belt tools named `mcp_<server>_<tool>`, so every loop reaches
+    // them the same way; a server that does not answer is skipped, not fatal.
+    let externalMcpTools: Tool[] = [];
+    try {
+      externalMcpTools = await externalMcpToolsFor(userId);
+    } catch (err) {
+      log.warn("External MCP tools unavailable for this turn", {
+        error: err instanceof Error ? err.message : String(err)
+      });
+    }
     const rawToolbelt: Tool[] = [
       ...getBuiltinTools(),
       ...(googleWorkspace ? getGoogleWorkspaceTools() : []),
@@ -1444,6 +1456,7 @@ export class ChatTurnHandler {
       // a chat discovers them (`nodetool.searchTools("apify")`) at all.
       ...getApifyTools(gatedRun),
       ...getSerpApiTools(gatedRun),
+      ...externalMcpTools,
       ...getAllMcpTools({
         registry: this.session.nodeRegistry,
         providers: chatProviders,

--- a/packages/websocket/src/trpc/router.ts
+++ b/packages/websocket/src/trpc/router.ts
@@ -6,6 +6,7 @@ import { segmentationRouter } from "./routers/segmentation.js";
 import { collectionsRouter } from "./routers/collections.js";
 import { costsRouter } from "./routers/costs.js";
 import { customProvidersRouter } from "./routers/custom-providers.js";
+import { externalMcpRouter } from "./routers/external-mcp.js";
 import { creditsRouter } from "./routers/credits.js";
 import { extensionRouter } from "./routers/extension.js";
 import { filesRouter } from "./routers/files.js";
@@ -48,6 +49,7 @@ export const appRouter = router({
   costs: costsRouter,
   credits: creditsRouter,
   customProviders: customProvidersRouter,
+  externalMcp: externalMcpRouter,
   extension: extensionRouter,
   files: filesRouter,
   fonts: fontsRouter,

--- a/packages/websocket/src/trpc/routers/external-mcp.ts
+++ b/packages/websocket/src/trpc/routers/external-mcp.ts
@@ -1,0 +1,84 @@
+/**
+ * External MCP servers — the CRUD behind Settings → MCP Servers → "External
+ * servers". A server's tools join the agent toolbelt on the next chat turn.
+ */
+
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { McpServerConfigSchema } from "@nodetool-ai/protocol";
+import { router } from "../index.js";
+import { protectedProcedure } from "../middleware.js";
+import {
+  deleteExternalMcpServer,
+  isLocalMcpProfile,
+  loadExternalMcpServers,
+  probeExternalMcpServer,
+  saveExternalMcpServer
+} from "../../external-mcp.js";
+
+const idInput = z.object({ id: z.string().min(1) });
+
+const probeOutput = z.object({
+  id: z.string(),
+  ok: z.boolean(),
+  tools: z.array(
+    z.object({
+      name: z.string(),
+      description: z.string().optional()
+    })
+  ),
+  error: z.string().nullable()
+});
+
+export const externalMcpRouter = router({
+  list: protectedProcedure
+    .output(
+      z.object({
+        servers: z.array(McpServerConfigSchema),
+        stdio_enabled: z.boolean()
+      })
+    )
+    .query(async ({ ctx }) => ({
+      servers: await loadExternalMcpServers(ctx.userId),
+      stdio_enabled: isLocalMcpProfile()
+    })),
+
+  save: protectedProcedure
+    .input(McpServerConfigSchema)
+    .output(z.array(McpServerConfigSchema))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await saveExternalMcpServer(ctx.userId, input);
+      } catch (err) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: err instanceof Error ? err.message : String(err)
+        });
+      }
+    }),
+
+  delete: protectedProcedure
+    .input(idInput)
+    .output(z.object({ deleted: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      const deleted = await deleteExternalMcpServer(ctx.userId, input.id);
+      if (!deleted) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Server not found" });
+      }
+      return { deleted };
+    }),
+
+  /** Connect once and list what the server offers. */
+  probe: protectedProcedure
+    .input(McpServerConfigSchema)
+    .output(probeOutput)
+    .mutation(async ({ ctx, input }) => {
+      const probe = await probeExternalMcpServer(ctx.userId, input);
+      const tools = probe.tools.map((t) => {
+        const tool: { name: string; description?: string } = { name: t.name };
+        if (t.description !== undefined) tool.description = t.description;
+        return tool;
+      });
+      return { ...probe, tools };
+    })
+});

--- a/packages/websocket/src/trpc/sandbox-coverage.ts
+++ b/packages/websocket/src/trpc/sandbox-coverage.ts
@@ -277,6 +277,30 @@ export const SANDBOX_API_COVERAGE: Readonly<
       "endpoints and `save`/`test` write and exercise credentials, so " +
       "the whole router is credential surface."
   },
+  "externalMcp.delete": {
+    withheld:
+      "External MCP servers carry commands, env vars and headers that may " +
+      "name secrets. `save`/`probe` spawn or connect to one, so the whole " +
+      "router is credential and host-process surface."
+  },
+  "externalMcp.list": {
+    withheld:
+      "External MCP servers carry commands, env vars and headers that may " +
+      "name secrets. `save`/`probe` spawn or connect to one, so the whole " +
+      "router is credential and host-process surface."
+  },
+  "externalMcp.probe": {
+    withheld:
+      "External MCP servers carry commands, env vars and headers that may " +
+      "name secrets. `save`/`probe` spawn or connect to one, so the whole " +
+      "router is credential and host-process surface."
+  },
+  "externalMcp.save": {
+    withheld:
+      "External MCP servers carry commands, env vars and headers that may " +
+      "name secrets. `save`/`probe` spawn or connect to one, so the whole " +
+      "router is credential and host-process surface."
+  },
   "extension.status": {
     gap:
       "Browser-extension liveness; nothing a headless run acts on."

--- a/packages/websocket/tests/external-mcp.test.ts
+++ b/packages/websocket/tests/external-mcp.test.ts
@@ -1,0 +1,190 @@
+/**
+ * External MCP server persistence: the setting row round-trips, invalid rows
+ * are dropped rather than fatal, and the cloud profile refuses stdio servers.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Secret, Setting, initTestDb } from "@nodetool-ai/models";
+import { setMasterKey } from "@nodetool-ai/security";
+import type { McpServerConfig } from "@nodetool-ai/protocol";
+import {
+  EXTERNAL_MCP_SETTING_KEY,
+  STDIO_MCP_DISABLED_ERROR,
+  closeExternalMcpPools,
+  deleteExternalMcpServer,
+  isLocalMcpProfile,
+  loadExternalMcpServers,
+  probeExternalMcpServer,
+  saveExternalMcpServer
+} from "../src/external-mcp.js";
+
+const KEYS = ["NODETOOL_NODE_PROFILE", "NODETOOL_ENV"] as const;
+const saved: Record<string, string | undefined> = {};
+
+const stdio: McpServerConfig = {
+  id: "blender",
+  name: "Blender",
+  enabled: true,
+  transport: { type: "stdio", command: "blender-mcp", args: [], env: {} }
+};
+
+const http: McpServerConfig = {
+  id: "hf",
+  name: "Hugging Face",
+  enabled: true,
+  transport: {
+    type: "http",
+    url: "https://huggingface.co/mcp",
+    headers: { Authorization: "${HF_TOKEN}" }
+  }
+};
+
+const TEST_MASTER_KEY = "dGVzdC1tYXN0ZXIta2V5LWZvci11bml0LXRlc3Rz";
+
+beforeEach(() => {
+  initTestDb();
+  setMasterKey(TEST_MASTER_KEY);
+  for (const key of KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(async () => {
+  await closeExternalMcpPools();
+  for (const key of KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+describe("external MCP persistence", () => {
+  it("saves, lists, replaces and deletes servers", async () => {
+    expect(await loadExternalMcpServers("1")).toEqual([]);
+    await saveExternalMcpServer("1", stdio);
+    await saveExternalMcpServer("1", http);
+    expect((await loadExternalMcpServers("1")).map((s) => s.id)).toEqual([
+      "blender",
+      "hf"
+    ]);
+    await saveExternalMcpServer("1", { ...stdio, name: "Blender 4" });
+    const listed = await loadExternalMcpServers("1");
+    expect(listed).toHaveLength(2);
+    expect(listed.find((s) => s.id === "blender")?.name).toBe("Blender 4");
+    // Another user sees nothing.
+    expect(await loadExternalMcpServers("2")).toEqual([]);
+    expect(await deleteExternalMcpServer("1", "blender")).toBe(true);
+    expect(await deleteExternalMcpServer("1", "blender")).toBe(false);
+    expect((await loadExternalMcpServers("1")).map((s) => s.id)).toEqual([
+      "hf"
+    ]);
+  });
+
+  it("moves a literal header into an encrypted secret and stores the reference", async () => {
+    await saveExternalMcpServer("1", {
+      ...http,
+      transport: {
+        type: "http",
+        url: http.transport.type === "http" ? http.transport.url : "",
+        headers: { Authorization: "Bearer literal-token", "X-Ref": "${HF_TOKEN}" }
+      }
+    });
+    const [stored] = await loadExternalMcpServers("1");
+    expect(stored.transport.type === "http" && stored.transport.headers).toEqual({
+      Authorization: "${MCP_HF_0041007500740068006F00720069007A006100740069006F006E}",
+      "X-Ref": "${HF_TOKEN}"
+    });
+    const row = await Secret.find("1", "MCP_HF_0041007500740068006F00720069007A006100740069006F006E");
+    expect(await row?.getDecryptedValue()).toBe("Bearer literal-token");
+    // The plaintext row never held the token.
+    const setting = await Setting.find("1", EXTERNAL_MCP_SETTING_KEY);
+    expect(setting?.getValue()).not.toContain("literal-token");
+    // Deleting the server removes the secret it owns.
+    await deleteExternalMcpServer("1", "hf");
+    expect(await Secret.find("1", "MCP_HF_0041007500740068006F00720069007A006100740069006F006E")).toBeNull();
+  });
+
+  it("encrypts a value that mixes a literal with a reference, and drops an orphaned secret", async () => {
+    const withHeaders = (headers: Record<string, string>): McpServerConfig => ({
+      ...http,
+      transport: { type: "http", url: "https://huggingface.co/mcp", headers }
+    });
+    await saveExternalMcpServer("1", withHeaders({ X: "tok-${SUFFIX}" }));
+    const [first] = await loadExternalMcpServers("1");
+    const name = "MCP_HF_0058";
+    expect(first.transport.type === "http" && first.transport.headers.X).toBe(
+      `\${${name}}`
+    );
+    expect(await (await Secret.find("1", name))?.getDecryptedValue()).toBe(
+      "tok-${SUFFIX}"
+    );
+    // A reference kept beside another still owns the secret.
+    await saveExternalMcpServer("1", withHeaders({ X: `\${${name}}\${OTHER}` }));
+    expect(await Secret.find("1", name)).not.toBeNull();
+    // Replacing the owned reference with another reference removes the secret.
+    await saveExternalMcpServer("1", withHeaders({ X: "${OTHER}" }));
+    expect(await Secret.find("1", name)).toBeNull();
+  });
+
+  it("refuses a private URL under the cloud profile", async () => {
+    process.env.NODETOOL_NODE_PROFILE = "cloud";
+    await expect(
+      saveExternalMcpServer("1", {
+        ...http,
+        transport: { type: "http", url: "http://127.0.0.1:8000/mcp", headers: {} }
+      })
+    ).rejects.toThrow(/unsafe URL/);
+  });
+
+  it("drops a malformed row instead of throwing", async () => {
+    await Setting.upsert({
+      userId: "1",
+      key: EXTERNAL_MCP_SETTING_KEY,
+      value: "not json",
+      description: ""
+    });
+    expect(await loadExternalMcpServers("1")).toEqual([]);
+    await Setting.upsert({
+      userId: "1",
+      key: EXTERNAL_MCP_SETTING_KEY,
+      value: JSON.stringify([{ id: "BAD ID" }]),
+      description: ""
+    });
+    expect(await loadExternalMcpServers("1")).toEqual([]);
+  });
+
+  it("refuses stdio servers under the cloud profile", async () => {
+    process.env.NODETOOL_NODE_PROFILE = "cloud";
+    expect(isLocalMcpProfile()).toBe(false);
+    await expect(saveExternalMcpServer("1", stdio)).rejects.toThrow(
+      STDIO_MCP_DISABLED_ERROR
+    );
+    const probe = await probeExternalMcpServer("1", stdio);
+    expect(probe).toEqual({
+      id: "blender",
+      ok: false,
+      tools: [],
+      error: STDIO_MCP_DISABLED_ERROR
+    });
+    // HTTP servers are still saved.
+    await saveExternalMcpServer("1", http);
+    expect((await loadExternalMcpServers("1")).map((s) => s.id)).toEqual([
+      "hf"
+    ]);
+  });
+
+  it("reports a server that cannot be reached", async () => {
+    const probe = await probeExternalMcpServer("1", {
+      ...stdio,
+      transport: {
+        type: "stdio",
+        command: process.execPath,
+        args: ["-e", "process.exit(3)"],
+        env: {}
+      }
+    });
+    expect(probe.ok).toBe(false);
+    expect(probe.tools).toEqual([]);
+    expect(probe.error).toBeTruthy();
+  });
+});

--- a/web/src/components/menus/ExternalMcpServersSection.tsx
+++ b/web/src/components/menus/ExternalMcpServersSection.tsx
@@ -1,0 +1,648 @@
+/** @jsxImportSource @emotion/react */
+import { memo, useCallback, useState, type ChangeEvent } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTheme } from "@mui/material/styles";
+import AddIcon from "@mui/icons-material/Add";
+import DeleteIcon from "@mui/icons-material/Delete";
+import ExtensionIcon from "@mui/icons-material/Extension";
+import {
+  MCP_SERVER_ID_PATTERN,
+  MCP_TOOL_PREFIX,
+  type McpServerConfig
+} from "@nodetool-ai/protocol";
+import {
+  BORDER_RADIUS,
+  Caption,
+  Card,
+  Checkbox,
+  Chip,
+  ConfirmDialog,
+  Dialog,
+  EditorButton,
+  EmptyState,
+  FlexColumn,
+  FlexRow,
+  MOTION,
+  SPACING,
+  SelectField,
+  Text,
+  TextInput
+} from "../ui_primitives";
+import { useNotificationStore } from "../../stores/NotificationStore";
+import { trpcClient, type RouterOutputs } from "../../trpc/client";
+
+type ProbeResult = RouterOutputs["externalMcp"]["probe"];
+
+const QUERY_KEY = ["external-mcp-servers"];
+
+interface DraftState {
+  id: string;
+  name: string;
+  enabled: boolean;
+  type: "stdio" | "http";
+  command: string;
+  args: string;
+  env: string;
+  cwd: string;
+  url: string;
+  headers: string;
+}
+
+const EMPTY_DRAFT: DraftState = {
+  id: "",
+  name: "",
+  enabled: true,
+  type: "stdio",
+  command: "",
+  args: "",
+  env: "",
+  cwd: "",
+  url: "",
+  headers: ""
+};
+
+const TRANSPORT_OPTIONS = [
+  { value: "stdio", label: "Command (stdio)" },
+  { value: "http", label: "HTTP URL" }
+] as const;
+
+/** `KEY=value` lines → record. Blank lines and lines without `=` are skipped. */
+function parseKeyValues(text: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of text.split("\n")) {
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    out[line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
+  }
+  return out;
+}
+
+function formatKeyValues(values: Record<string, string>): string {
+  return Object.entries(values)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("\n");
+}
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 32);
+}
+
+function draftFrom(server: McpServerConfig): DraftState {
+  const t = server.transport;
+  return {
+    id: server.id,
+    name: server.name,
+    enabled: server.enabled,
+    type: t.type,
+    command: t.type === "stdio" ? t.command : "",
+    args: t.type === "stdio" ? t.args.join("\n") : "",
+    env: t.type === "stdio" ? formatKeyValues(t.env) : "",
+    cwd: t.type === "stdio" ? (t.cwd ?? "") : "",
+    url: t.type === "http" ? t.url : "",
+    headers: t.type === "http" ? formatKeyValues(t.headers) : ""
+  };
+}
+
+function configFrom(draft: DraftState): McpServerConfig {
+  const base = {
+    id: draft.id,
+    name: draft.name.trim() || draft.id,
+    enabled: draft.enabled
+  };
+  if (draft.type === "http") {
+    return {
+      ...base,
+      transport: {
+        type: "http",
+        url: draft.url.trim(),
+        headers: parseKeyValues(draft.headers)
+      }
+    };
+  }
+  const transport: McpServerConfig["transport"] = {
+    type: "stdio",
+    command: draft.command.trim(),
+    args: draft.args
+      .split("\n")
+      .map((a) => a.trim())
+      .filter(Boolean),
+    env: parseKeyValues(draft.env)
+  };
+  const cwd = draft.cwd.trim();
+  if (cwd) transport.cwd = cwd;
+  return { ...base, transport };
+}
+
+function idError(id: string): string | null {
+  if (!id) return "Enter an id.";
+  if (!MCP_SERVER_ID_PATTERN.test(id)) {
+    return "Lowercase letters, digits and _ only, up to 32 characters.";
+  }
+  return null;
+}
+
+function urlError(url: string): string | null {
+  if (!url.trim()) return "Enter a URL.";
+  try {
+    const parsed = new URL(url.trim());
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return "Use an http or https URL.";
+    }
+    return null;
+  } catch {
+    return "That is not a valid URL.";
+  }
+}
+
+const ServerRow = memo(function ServerRow({
+  server,
+  onEdit,
+  onDelete,
+  onProbe,
+  onToggle,
+  probing,
+  probe
+}: {
+  server: McpServerConfig;
+  onEdit: (server: McpServerConfig) => void;
+  onDelete: (server: McpServerConfig) => void;
+  onProbe: (server: McpServerConfig) => void;
+  onToggle: (server: McpServerConfig) => void;
+  probing: boolean;
+  probe: ProbeResult | null;
+}) {
+  const theme = useTheme();
+  const handleEdit = useCallback(() => onEdit(server), [onEdit, server]);
+  const handleDelete = useCallback(() => onDelete(server), [onDelete, server]);
+  const handleProbe = useCallback(() => onProbe(server), [onProbe, server]);
+  const handleToggle = useCallback(() => onToggle(server), [onToggle, server]);
+  const t = server.transport;
+  const summary =
+    t.type === "stdio" ? [t.command, ...t.args].join(" ") : t.url;
+
+  return (
+    <Card
+      variant="outlined"
+      padding="compact"
+      sx={{
+        display: "flex",
+        flexDirection: { xs: "column", sm: "row" },
+        alignItems: { xs: "stretch", sm: "center" },
+        gap: theme.spacing(3),
+        borderRadius: BORDER_RADIUS.lg,
+        border: `1px solid ${theme.vars.palette.divider}`,
+        transition: MOTION.border,
+        opacity: server.enabled ? 1 : 0.6,
+        "&:hover": { borderColor: theme.vars.palette.grey[700] }
+      }}
+    >
+      <FlexRow align="center" gap={3} sx={{ flex: 1, minWidth: 0 }}>
+        <FlexRow
+          align="center"
+          justify="center"
+          sx={{
+            width: 48,
+            height: 48,
+            minWidth: 48,
+            borderRadius: BORDER_RADIUS.lg,
+            backgroundColor: theme.vars.palette.background.default
+          }}
+        >
+          <ExtensionIcon sx={{ fontSize: 24, opacity: 0.7 }} />
+        </FlexRow>
+        <FlexColumn sx={{ flex: 1, minWidth: 0, gap: theme.spacing(0.5) }}>
+          <FlexRow align="center" gap={0.5}>
+            <Text size="small" weight={600}>
+              {server.name}
+            </Text>
+            <Chip label={t.type} compact variant="outlined" />
+            {!server.enabled && (
+              <Chip label="Disabled" compact variant="outlined" />
+            )}
+          </FlexRow>
+          <Caption sx={{ opacity: 0.55, wordBreak: "break-all" }}>
+            {summary}
+          </Caption>
+          <Caption size="smaller" sx={{ opacity: 0.45 }}>
+            Tools appear as {`${MCP_TOOL_PREFIX}${server.id}_<tool>`}
+          </Caption>
+          {probe && (
+            <Caption
+              size="smaller"
+              color={probe.ok ? "success" : "error"}
+              sx={{ lineHeight: 1.5 }}
+            >
+              {probe.ok
+                ? probe.tools.length === 0
+                  ? "Connected. The server offers no tools."
+                  : `${probe.tools.length} tool${probe.tools.length === 1 ? "" : "s"}: ${probe.tools
+                      .map((tool) => tool.name)
+                      .join(", ")}`
+                : (probe.error ?? "Could not connect.")}
+            </Caption>
+          )}
+        </FlexColumn>
+      </FlexRow>
+
+      <FlexRow align="center" gap={0.5} sx={{ flexWrap: "wrap" }}>
+        <EditorButton
+          density="compact"
+          variant="text"
+          size="small"
+          onClick={handleProbe}
+          disabled={probing}
+        >
+          {probing ? "Connecting…" : "Test"}
+        </EditorButton>
+        <EditorButton
+          density="compact"
+          variant="text"
+          size="small"
+          onClick={handleToggle}
+        >
+          {server.enabled ? "Disable" : "Enable"}
+        </EditorButton>
+        <EditorButton
+          density="compact"
+          variant="outlined"
+          size="small"
+          onClick={handleEdit}
+        >
+          Edit
+        </EditorButton>
+        <EditorButton
+          density="compact"
+          variant="text"
+          size="small"
+          color="error"
+          startIcon={<DeleteIcon sx={{ fontSize: 14 }} />}
+          onClick={handleDelete}
+        >
+          Remove
+        </EditorButton>
+      </FlexRow>
+    </Card>
+  );
+});
+
+/**
+ * External MCP servers whose tools join the agent's toolbelt — Blender,
+ * Hugging Face, a local script. A stdio server is a command this machine
+ * runs; an HTTP server is a URL.
+ */
+export const ExternalMcpServersSection = memo(
+  function ExternalMcpServersSection() {
+    const theme = useTheme();
+    const queryClient = useQueryClient();
+    const addNotification = useNotificationStore(
+      (state) => state.addNotification
+    );
+
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [editingId, setEditingId] = useState<string | null>(null);
+    const [draft, setDraft] = useState<DraftState>(EMPTY_DRAFT);
+    const [pendingDelete, setPendingDelete] = useState<McpServerConfig | null>(
+      null
+    );
+    const [probingId, setProbingId] = useState<string | null>(null);
+    const [probes, setProbes] = useState<Record<string, ProbeResult>>({});
+
+    const { data } = useQuery({
+      queryKey: QUERY_KEY,
+      queryFn: () => trpcClient.externalMcp.list.query(),
+      refetchOnWindowFocus: false
+    });
+
+    const saveMutation = useMutation({
+      mutationFn: (config: McpServerConfig) =>
+        trpcClient.externalMcp.save.mutate(config),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+        setDialogOpen(false);
+      },
+      onError: (err) => {
+        addNotification({
+          type: "error",
+          alert: true,
+          content: `Could not save the server: ${err instanceof Error ? err.message : String(err)}`
+        });
+      }
+    });
+
+    const deleteMutation = useMutation({
+      mutationFn: (id: string) => trpcClient.externalMcp.delete.mutate({ id }),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+        setPendingDelete(null);
+      }
+    });
+
+    const handleProbe = useCallback(
+      async (server: McpServerConfig) => {
+        setProbingId(server.id);
+        try {
+          const result = await trpcClient.externalMcp.probe.mutate(server);
+          setProbes((prev) => ({ ...prev, [server.id]: result }));
+        } catch (err) {
+          setProbes((prev) => ({
+            ...prev,
+            [server.id]: {
+              id: server.id,
+              ok: false,
+              tools: [],
+              error: err instanceof Error ? err.message : String(err)
+            }
+          }));
+        } finally {
+          setProbingId(null);
+        }
+      },
+      []
+    );
+
+    const handleToggle = useCallback(
+      (server: McpServerConfig) => {
+        saveMutation.mutate({ ...server, enabled: !server.enabled });
+      },
+      [saveMutation]
+    );
+
+    const handleAdd = useCallback(() => {
+      setEditingId(null);
+      setDraft(EMPTY_DRAFT);
+      setDialogOpen(true);
+    }, []);
+
+    const handleEdit = useCallback((server: McpServerConfig) => {
+      setEditingId(server.id);
+      setDraft(draftFrom(server));
+      setDialogOpen(true);
+    }, []);
+
+    const handleClose = useCallback(() => setDialogOpen(false), []);
+
+    const field = useCallback(
+      (key: keyof DraftState) => (e: ChangeEvent<HTMLInputElement>) => {
+        const value = e.target.value;
+        setDraft((prev) => ({ ...prev, [key]: value }));
+      },
+      []
+    );
+
+    const handleNameChange = useCallback(
+      (e: ChangeEvent<HTMLInputElement>) => {
+        const name = e.target.value;
+        setDraft((prev) => ({
+          ...prev,
+          name,
+          // The id follows the name until the user types one by hand.
+          id: editingId || prev.id !== slugify(prev.name) ? prev.id : slugify(name)
+        }));
+      },
+      [editingId]
+    );
+
+    const handleTypeChange = useCallback((value: string) => {
+      setDraft((prev) => ({ ...prev, type: value === "http" ? "http" : "stdio" }));
+    }, []);
+
+    const handleEnabledChange = useCallback(
+      (e: ChangeEvent<HTMLInputElement>) => {
+        const enabled = e.target.checked;
+        setDraft((prev) => ({ ...prev, enabled }));
+      },
+      []
+    );
+
+    const servers = data?.servers ?? [];
+    const stdioEnabled = data?.stdio_enabled ?? true;
+    const draftIdError = idError(draft.id);
+    const duplicateId =
+      !editingId && servers.some((s) => s.id === draft.id);
+    const transportError =
+      draft.type === "http"
+        ? urlError(draft.url)
+        : !stdioEnabled
+          ? "Stdio servers are not available on this deployment."
+          : draft.command.trim()
+            ? null
+            : "Enter a command.";
+
+    const handleSave = useCallback(() => {
+      saveMutation.mutate(configFrom(draft));
+    }, [draft, saveMutation]);
+
+    const confirmDelete = useCallback(() => {
+      if (pendingDelete) deleteMutation.mutate(pendingDelete.id);
+    }, [deleteMutation, pendingDelete]);
+
+    const handleCancelDelete = useCallback(() => setPendingDelete(null), []);
+
+    return (
+      <div className="settings-section" style={{ marginTop: theme.spacing(SPACING.xl) }}>
+        <FlexRow
+          align="center"
+          justify="space-between"
+          sx={{ marginBottom: theme.spacing(3) }}
+        >
+          <FlexColumn gap={0.5}>
+            <Text size="big">External servers</Text>
+            <Caption sx={{ opacity: 0.55 }}>
+              Give the agent the tools of any MCP server: Blender, Hugging
+              Face, or a script of your own. Works with every model provider.
+            </Caption>
+          </FlexColumn>
+          <EditorButton
+            density="compact"
+            variant="outlined"
+            size="small"
+            startIcon={<AddIcon sx={{ fontSize: 16 }} />}
+            onClick={handleAdd}
+          >
+            Add server
+          </EditorButton>
+        </FlexRow>
+
+        {servers.length === 0 ? (
+          <EmptyState
+            variant="no-results"
+            title="No external servers"
+            description="Add a command or a URL. Its tools join the agent's toolbelt on the next message."
+          />
+        ) : (
+          <FlexColumn sx={{ gap: theme.spacing(2) }}>
+            {servers.map((server) => (
+              <ServerRow
+                key={server.id}
+                server={server}
+                onEdit={handleEdit}
+                onDelete={setPendingDelete}
+                onProbe={handleProbe}
+                onToggle={handleToggle}
+                probing={probingId === server.id}
+                probe={probes[server.id] ?? null}
+              />
+            ))}
+          </FlexColumn>
+        )}
+
+        <Dialog
+          open={dialogOpen}
+          onClose={handleClose}
+          fullWidth
+          title={
+            <Text size="big">
+              {editingId ? "Edit MCP server" : "Add MCP server"}
+            </Text>
+          }
+          onConfirm={handleSave}
+          onCancel={handleClose}
+          confirmText={editingId ? "Save" : "Add"}
+          cancelText="Cancel"
+          confirmDisabled={
+            Boolean(draftIdError) || Boolean(transportError) || duplicateId
+          }
+        >
+          <FlexColumn
+            sx={{ marginTop: theme.spacing(4), gap: theme.spacing(3) }}
+          >
+            <TextInput
+              label="Name"
+              value={draft.name}
+              onChange={handleNameChange}
+              fullWidth
+              placeholder="Blender"
+              autoFocus
+              variant="outlined"
+              size="small"
+            />
+            <TextInput
+              label="Id"
+              value={draft.id}
+              onChange={field("id")}
+              fullWidth
+              disabled={Boolean(editingId)}
+              placeholder="blender"
+              variant="outlined"
+              size="small"
+              errorMessage={
+                duplicateId
+                  ? "That id is already in use."
+                  : (draftIdError ?? undefined)
+              }
+              helperText={`Tools are named ${MCP_TOOL_PREFIX}${draft.id || "id"}_<tool>`}
+            />
+            <SelectField
+              label="Connection"
+              value={draft.type}
+              onChange={handleTypeChange}
+              options={TRANSPORT_OPTIONS}
+              size="small"
+              variant="outlined"
+              description={
+                stdioEnabled
+                  ? undefined
+                  : "This deployment cannot run commands; only HTTP servers connect."
+              }
+            />
+            {draft.type === "stdio" ? (
+              <>
+                <TextInput
+                  label="Command"
+                  value={draft.command}
+                  onChange={field("command")}
+                  fullWidth
+                  placeholder="uvx"
+                  variant="outlined"
+                  size="small"
+                  errorMessage={transportError ?? undefined}
+                />
+                <TextInput
+                  label="Arguments"
+                  value={draft.args}
+                  onChange={field("args")}
+                  fullWidth
+                  multiline
+                  rows={2}
+                  placeholder="blender-mcp"
+                  variant="outlined"
+                  size="small"
+                  helperText="One argument per line, so a path with a space stays one argument."
+                />
+                <TextInput
+                  label="Environment"
+                  value={draft.env}
+                  onChange={field("env")}
+                  fullWidth
+                  multiline
+                  rows={3}
+                  placeholder={"HF_TOKEN=${HF_TOKEN}\nDEBUG=1"}
+                  variant="outlined"
+                  size="small"
+                  helperText="One KEY=value per line. A literal value is stored encrypted; ${NAME} reads the secret NAME from your API keys."
+                />
+                <TextInput
+                  label="Working directory"
+                  value={draft.cwd}
+                  onChange={field("cwd")}
+                  fullWidth
+                  placeholder="Optional"
+                  variant="outlined"
+                  size="small"
+                />
+              </>
+            ) : (
+              <>
+                <TextInput
+                  label="URL"
+                  value={draft.url}
+                  onChange={field("url")}
+                  fullWidth
+                  placeholder="https://huggingface.co/mcp"
+                  variant="outlined"
+                  size="small"
+                  errorMessage={transportError ?? undefined}
+                  helperText="Streamable HTTP, with SSE as the fallback."
+                />
+                <TextInput
+                  label="Headers"
+                  value={draft.headers}
+                  onChange={field("headers")}
+                  fullWidth
+                  multiline
+                  rows={3}
+                  placeholder={"Authorization=Bearer ${HF_TOKEN}"}
+                  variant="outlined"
+                  size="small"
+                  helperText="One Header=value per line. A literal value is stored encrypted; ${NAME} reads the secret NAME from your API keys."
+                />
+              </>
+            )}
+            <Checkbox
+              label="Enabled"
+              checked={draft.enabled}
+              onChange={handleEnabledChange}
+              size="small"
+            />
+          </FlexColumn>
+        </Dialog>
+
+        <ConfirmDialog
+          open={Boolean(pendingDelete)}
+          title="Remove server"
+          content={`Remove ${pendingDelete?.name ?? ""}? Its tools leave the agent's toolbelt.`}
+          confirmText="Remove"
+          cancelText="Cancel"
+          onConfirm={confirmDelete}
+          onClose={handleCancelDelete}
+        />
+      </div>
+    );
+  }
+);
+
+export default ExternalMcpServersSection;

--- a/web/src/components/menus/MCPSettingsMenu.tsx
+++ b/web/src/components/menus/MCPSettingsMenu.tsx
@@ -11,6 +11,7 @@ import { Text, FlexRow, FlexColumn, NavButton } from "../ui_primitives";
 import { getSharedSettingsStyles } from "./settingsMenuStyles";
 import { useNotificationStore } from "../../stores/NotificationStore";
 import AgentAccessSection from "./AgentAccessSection";
+import ExternalMcpServersSection from "./ExternalMcpServersSection";
 import { trpcClient } from "../../trpc/client";
 
 interface TargetStatus {
@@ -299,6 +300,8 @@ const MCPSettingsMenu = () => {
             </FlexRow>
           </div>
         )}
+
+        <ExternalMcpServersSection />
 
         <AgentAccessSection />
       </div>


### PR DESCRIPTION
## Summary

Users can add external MCP servers (Blender, Hugging Face, a local script) in Settings → MCP Servers → External servers, over stdio or HTTP. Their tools join the agent toolbelt on the next chat turn.

- Each remote tool is a plain `Tool` named `mcp_<server>_<tool>`. That one shape is why it works on every provider without provider changes: the base loop and the OpenAI Responses loop (Codex included) dispatch through `executeTool`, the Claude Agent SDK wraps the belt in its in-process MCP server, and a CodeAct guest imports from `@nodetool-ai/sandbox-nodetool/mcp`.
- `McpClientPool` keeps one client per server per user: reconnects on config change, closes removed servers, caches discovery with `nextCursor` paging, evicts on failure, serializes reconciliation.
- Config shape (`McpServerConfig`) is shared through `@nodetool-ai/protocol` by the tRPC router, the persistence layer, the pool, and the settings UI.

## Security

- A literal header or env value moves into an encrypted secret named `MCP_<SERVER>_<KEY as hex>` on save; only the `${reference}` is stored. References resolve from the user's own secrets, never `process.env`.
- The cloud profile refuses stdio servers and fetches HTTP servers through `safeFetch`, which re-checks every redirect hop. Private and http URLs are refused on save and probe.
- Resolved secret values are redacted from stderr, error logs, and probe results, per connection.
- Remote tools have no capability entry, so `gateTools` classifies them `external` and the permission ladder applies.

## Verification

- `npm run lint` clean, `harness gate` 4/4, web typecheck clean (with a larger heap; the default heap runs out on this machine regardless of the change).
- New suites: `packages/agents/tests/external-mcp-tools.test.ts` (a real MCP server over an in-memory transport), `packages/websocket/tests/external-mcp.test.ts` (persistence, credential externalization, cloud gates).
- Agents, websocket, and chat-turn suites pass. Three Codex review passes; every finding closed.

## Out of scope

Agent nodes in workflows and the CLI belt do not load external servers yet; chat is the surface here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XiCF7BrK6J3ybmB2ULvFND
