### PR TITLE
feat(timeline): add the WT-1, BL-1 and DR-1 instruments to midi tracks

### DIFF
--- a/packages/agents/src/capabilities/timelines.specs.ts
+++ b/packages/agents/src/capabilities/timelines.specs.ts
@@ -213,10 +213,16 @@ export const EDIT_TIMELINE_SCHEMA: JsonSchema = {
         "the clip hides notes instead of deleting them. " +
         'set_track_instrument takes {"track", "instrument"}, either a named ' +
         'voice — {"preset": "bass"}, one of saw-lead, square-lead, soft-pad, ' +
-        "pluck, bass, bell — or the synth spelled out: {type: " +
+        "pluck, bass, bell, the FableSynth WT-1 wavetable patches " +
+        "wt1-prime-lead, wt1-bloom-pad, wt1-vox-morph, wt1-chime-bell, the " +
+        "BL-1 acid basslines bl1-acid, bl1-deep, bl1-rubber, and the DR-1 " +
+        "drum kit dr1-tr-void — or the synth spelled out: {type: " +
         '"subtractive", waveform, attackMs, decayMs, sustain, releaseMs, ' +
-        "cutoffHz, resonance, gainDb}. get_state reports the preset a track's " +
-        "instrument matches as presetId. " +
+        "cutoffHz, resonance, gainDb}. dr1-tr-void plays one drum per note " +
+        "from 36 (kick, kick 2, snare, clap, rim, closed hat, open hat, ride, " +
+        "three toms, crash, two percs, vox, glitch) and is silent above 51. " +
+        "get_state reports the preset a track's instrument matches as " +
+        "presetId. " +
         'set_tempo takes {"bpm", offset_ms?, beats_per_bar?, beat_unit?} and ' +
         "rescales every midi clip around offset_ms — halving the BPM doubles " +
         "each midi clip's start and length — while picture and audio stay " +

--- a/packages/agents/tests/timelines-op-input.test.ts
+++ b/packages/agents/tests/timelines-op-input.test.ts
@@ -12,7 +12,7 @@ import {
   initTestDb
 } from "@nodetool-ai/models";
 import { createCapabilityRun, UNGATED } from "../src/capabilities/invoke.js";
-import { ANIMATED_PROPERTIES } from "@nodetool-ai/timeline";
+import { ANIMATED_PROPERTIES, findInstrumentPreset } from "@nodetool-ai/timeline";
 import {
   createTimelineToolBridge,
   type TimelineAnimationBakeRequest,
@@ -1142,6 +1142,33 @@ describe("midi ops", () => {
         instrument
       })
     ).rejects.toThrow(/audio track/);
+  });
+
+  it("stores a named voice's whole patch, FableSynth kits included", async () => {
+    const { bridge, byName } = await midiBridge();
+
+    // A preset is resolved and stored, not kept as a reference: the track
+    // keeps its sound when the shipped table changes.
+    for (const id of ["wt1-bloom-pad", "bl1-acid", "dr1-tr-void"]) {
+      await byName["ui_timeline_set_track_instrument"].execute({
+        track: "Lead",
+        instrument: { preset: id }
+      });
+      expect(bridge.finalState().documentTracks[0].instrument).toEqual(
+        findInstrumentPreset(id)!.instrument
+      );
+    }
+
+    // The kit is the one voice whose notes are a drum map rather than pitches,
+    // so its pads have to survive the round trip.
+    const kit = bridge.finalState().documentTracks[0].instrument as {
+      type: string;
+      baseNote: number;
+      pads: unknown[];
+    };
+    expect(kit.type).toBe("drum");
+    expect(kit.baseNote).toBe(36);
+    expect(kit.pads).toHaveLength(16);
   });
 });
 

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -1937,7 +1937,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "edit_timeline",
     module: "timelines",
     impl: "packages/agents/src/capabilities/timelines.ts",
-    contract: "777960b73f62",
+    contract: "10f415c49c83",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-timelines.test.ts",

--- a/packages/protocol/src/api-schemas/timeline-tool-params.ts
+++ b/packages/protocol/src/api-schemas/timeline-tool-params.ts
@@ -1242,7 +1242,7 @@ export const midiInstrumentPresetRef = z.object({
   preset: z
     .string()
     .describe(
-      "A shipped voice by id: saw-lead, square-lead, soft-pad, pluck, bass, bell."
+      "A shipped voice by id: saw-lead, square-lead, soft-pad, pluck, bass, bell, wt1-prime-lead, wt1-bloom-pad, wt1-vox-morph, wt1-chime-bell, bl1-acid, bl1-deep, bl1-rubber, dr1-tr-void."
     )
 });
 export type MidiInstrumentPresetRef = z.infer<typeof midiInstrumentPresetRef>;
@@ -1253,7 +1253,7 @@ export const setTrackInstrumentParams = z.object({
   instrument: z
     .union([midiInstrument, midiInstrumentPresetRef])
     .describe(
-      "The voice this track's clips play, either way round. Named: `{\"preset\": \"soft-pad\"}` — one of saw-lead, square-lead, soft-pad, pluck, bass, bell. Spelled out: `subtractive` is one oscillator through a lowpass filter and an ADSR envelope: `waveform` saw/square/triangle/sine, `attackMs`/`decayMs`/`releaseMs` in milliseconds, `sustain` 0..1 of the peak, `cutoffHz` the filter frequency in Hz, `resonance` its Q, `gainDb` the output level in dB."
+      "The voice this track's clips play, either way round. Named: `{\"preset\": \"soft-pad\"}` — one of saw-lead, square-lead, soft-pad, pluck, bass, bell, wt1-prime-lead, wt1-bloom-pad, wt1-vox-morph, wt1-chime-bell, bl1-acid, bl1-deep, bl1-rubber, dr1-tr-void. Spelled out, there are four synths. `subtractive` is one oscillator through a lowpass filter and an ADSR envelope: `waveform` saw/square/triangle/sine, `attackMs`/`decayMs`/`releaseMs` in milliseconds, `sustain` 0..1 of the peak, `cutoffHz` the filter frequency in Hz, `resonance` its Q, `gainDb` the output level in dB. The other three are the FableSynth instruments: `wavetable` (WT-1) is two morphing wavetable oscillators plus a sub and noise through one filter swept by `modEnv`; `bass` (BL-1) is a monophonic acid line where a note at or above `accentVelocity` hits harder and a note overlapping the one before it glides over `slideMs`; `drum` (DR-1) is a kit of pads played one per note from `baseNote`, each ringing for its own decay however short the note is."
     )
 });
 export type SetTrackInstrumentParams = z.infer<typeof setTrackInstrumentParams>;

--- a/packages/protocol/src/api-schemas/timeline.ts
+++ b/packages/protocol/src/api-schemas/timeline.ts
@@ -230,9 +230,100 @@ export const midiNote = z.object({
 });
 export type MidiNote = z.infer<typeof midiNote>;
 
+/** An ADSR envelope, in milliseconds with a 0..1 sustain level. */
+export const midiEnvelope = z.object({
+  attackMs: z.number().min(0),
+  decayMs: z.number().min(0),
+  sustain: z.number().min(0).max(1),
+  releaseMs: z.number().min(0)
+});
+export type MidiEnvelope = z.infer<typeof midiEnvelope>;
+
+/** The filter shapes the FableSynth-derived voices offer. */
+export const midiFilterType = z.enum([
+  "lp12",
+  "lp24",
+  "bp12",
+  "hp12",
+  "notch"
+]);
+export type MidiFilterType = z.infer<typeof midiFilterType>;
+
+/** The tonal wavetables WT-1 and BL-1 play. */
+export const midiWavetableName = z.enum([
+  "prime",
+  "bloom",
+  "pulse",
+  "vox",
+  "chime",
+  "glitch"
+]);
+export type MidiWavetableName = z.infer<typeof midiWavetableName>;
+
+/** DR-1's percussive tables. A pad can also play any tonal table. */
+export const midiDrumTableName = z.enum(["thud", "crack", "tine", "grit"]);
+export type MidiDrumTableName = z.infer<typeof midiDrumTableName>;
+
+/** One of WT-1's two wavetable oscillators. */
+export const wavetableOscillator = z.object({
+  table: midiWavetableName,
+  /** Morph position across the table's frames, 0..1. */
+  position: z.number().min(0).max(1),
+  /** Offset from the played note, in semitones. */
+  semitones: z.number(),
+  /** Further offset in cents. */
+  fine: z.number(),
+  /** Output level, 0..1. */
+  level: z.number().min(0).max(1),
+  /** Detuned copies of the oscillator, 1..7. */
+  unison: z.number().int().min(1).max(7),
+  /** How far the copies spread, 0..1 (1 = ±50 cents). */
+  detune: z.number().min(0).max(1)
+});
+export type WavetableOscillator = z.infer<typeof wavetableOscillator>;
+
+/** One DR-1 pad: a tuned one-shot with its own envelope and filter. */
+export const drumPad = z.object({
+  name: z.string(),
+  table: z.union([midiWavetableName, midiDrumTableName]),
+  position: z.number().min(0).max(1),
+  /** Pitch offset from the pad's base note, in semitones. */
+  semitones: z.number(),
+  /** How far the pitch envelope starts above the pad's pitch, in semitones. */
+  pitchEnvAmount: z.number(),
+  pitchEnvDecayMs: z.number().min(0),
+  noiseLevel: z.number().min(0).max(1),
+  /** Noise colour, -1 (dark) to 1 (bright). */
+  noiseColor: z.number().min(-1).max(1),
+  /** Ring-modulator carrier in Hz. */
+  ringHz: z.number().positive(),
+  ringMix: z.number().min(0).max(1),
+  attackMs: z.number().min(0),
+  /** How long the envelope holds at full before decaying, in ms. */
+  holdMs: z.number().min(0),
+  decayMs: z.number().min(0),
+  /** Decay shape, 0 (a straight line) to 1 (exponential). */
+  curve: z.number().min(0).max(1),
+  /** The pad's filter, or null for no filter. */
+  filter: z
+    .object({
+      type: midiFilterType,
+      cutoffHz: z.number().positive(),
+      resonance: z.number().min(0).max(1)
+    })
+    .nullable(),
+  level: z.number().min(0).max(1),
+  /** How much velocity scales the level, 0..1. */
+  velocityToLevel: z.number().min(0).max(1)
+});
+export type DrumPad = z.infer<typeof drumPad>;
+
 /**
- * The voice a midi track plays. A discriminated union with one member today,
- * so a second synth type is added without reshaping what is already stored.
+ * The voice a midi track plays.
+ *
+ * `subtractive` is the built-in synth. The other three are ports of the
+ * FableSynth instruments (github.com/georgi/fablesynth): WT-1 the wavetable
+ * synth, BL-1 the acid bassline, DR-1 the drum machine.
  */
 export const midiInstrument = z.discriminatedUnion("type", [
   z.object({
@@ -251,6 +342,65 @@ export const midiInstrument = z.discriminatedUnion("type", [
     /** Lowpass Q. */
     resonance: z.number().positive(),
     /** Output gain in dB. */
+    gainDb: z.number()
+  }),
+  z.object({
+    type: z.literal("wavetable"),
+    oscA: wavetableOscillator,
+    oscB: wavetableOscillator,
+    /** Sine sub-oscillator level, 0..1. */
+    subLevel: z.number().min(0).max(1),
+    /** Sub octave below the note: -1 or -2. */
+    subOctave: z.number().int().min(-2).max(-1),
+    /** White noise level, 0..1. */
+    noiseLevel: z.number().min(0).max(1),
+    filterType: midiFilterType,
+    cutoffHz: z.number().positive(),
+    /** Filter resonance, 0..1. */
+    resonance: z.number().min(0).max(1),
+    /** Anti-aliased tanh drive into the filter, 0..1. */
+    drive: z.number().min(0).max(1),
+    /** How far the mod envelope sweeps the cutoff, in octaves. */
+    filterEnvAmount: z.number(),
+    /** How far the played note tracks the cutoff, 0..1. */
+    keyTrack: z.number().min(0).max(1),
+    ampEnv: midiEnvelope,
+    modEnv: midiEnvelope,
+    gainDb: z.number()
+  }),
+  z.object({
+    type: z.literal("bass"),
+    table: midiWavetableName,
+    position: z.number().min(0).max(1),
+    /** Offset from the played note, in semitones. */
+    semitones: z.number(),
+    subShape: z.enum(["sine", "square"]),
+    /** Sub octave below the note: -1 or -2. */
+    subOctave: z.number().int().min(-2).max(-1),
+    subLevel: z.number().min(0).max(1),
+    filterType: midiFilterType,
+    cutoffHz: z.number().positive(),
+    resonance: z.number().min(0).max(1),
+    drive: z.number().min(0).max(1),
+    /** How far the filter envelope sweeps the cutoff, in octaves. */
+    filterEnvAmount: z.number(),
+    keyTrack: z.number().min(0).max(1),
+    filterAttackMs: z.number().min(0),
+    filterDecayMs: z.number().min(0),
+    ampEnv: midiEnvelope,
+    /** How much an accented note adds to its level and filter sweep, 0..1. */
+    accentAmount: z.number().min(0).max(1),
+    /** The velocity at which a note counts as accented. */
+    accentVelocity: z.number().int().min(1).max(127),
+    /** How long a note overlapping the one before it glides, in ms. */
+    slideMs: z.number().min(0),
+    gainDb: z.number()
+  }),
+  z.object({
+    type: z.literal("drum"),
+    /** The MIDI note pad 0 answers to. Pads run `baseNote`..`baseNote + 15`. */
+    baseNote: z.number().int().min(0).max(127),
+    pads: z.array(drumPad),
     gainDb: z.number()
   })
 ]);

--- a/packages/timeline/AGENTS.md
+++ b/packages/timeline/AGENTS.md
@@ -102,6 +102,35 @@
   scrim came back with a hard outline the same call in the editor did not draw.
   A shape the caller filled gets no stroke it did not ask for.
 
+## Midi voices (`src/midi`, `src/midi/engines`)
+
+- **One renderer, four synths.** `renderInstrumentEvents` switches on
+  `instrument.type` and every host — the browser preview, the audition, the
+  `RenderTimeline` node — goes through it. `subtractive` is the built-in voice;
+  `wavetable`, `bass` and `drum` are ports of FableSynth's WT-1, BL-1 and DR-1
+  ([github.com/georgi/fablesynth](https://github.com/georgi/fablesynth)),
+  living in `src/midi/engines/`.
+- **What was ported is the sound-shaping, not the plugin.** The band-limited
+  wavetables and their mip ladder, the Cytomic SVF, the ADAA tanh drive, the
+  envelopes, BL-1's accent and slide, DR-1's pad voice. Not ported: stereo
+  (this renderer is mono), the LFOs and mod matrix, the FX racks, and the
+  plugins' own sequencers — a track's effects live on the track and its notes
+  live in the clip.
+- **A render is reproducible or the cache is wrong.** No `Math.random` and no
+  clock: DR-1's noise is a seeded xorshift keyed by the pad and the hit, and
+  unison start phases are a fixed spread. `midiRenderKey` hands back a previous
+  render, so a voice that drifted between two renders would play as whichever
+  one was cached first.
+- **`instrumentSignature` walks the instrument rather than listing its
+  fields.** The FableSynth voices carry nested oscillators, envelopes and
+  sixteen pads; a hand-written field list would go stale on the first one
+  added, and the cache would serve audio from before the change.
+- **A new instrument type is two edits, not one.** `types.ts` and
+  `@nodetool-ai/protocol`'s `midiInstrument` schema both describe the union, and
+  `tests/midi.protocolCompat.test.ts` parses every shipped preset through the
+  schema — so a branch added on one side fails there rather than being stripped
+  by Zod on the first autosave.
+
 ## Rendering (`src/render`, `@nodetool-ai/timeline/render`)
 
 - **One scene model, one compositor, four hosts.** The live preview, the

--- a/packages/timeline/src/midi/engines/bl1.ts
+++ b/packages/timeline/src/midi/engines/bl1.ts
@@ -39,6 +39,14 @@ interface BassNote {
  * Group the events into the order a mono voice plays them: sorted by onset,
  * and each note marked as sliding when it starts before its predecessor's
  * gate closes.
+ *
+ * "Predecessor" is the note that held the voice, not the longest note so far.
+ * The voice is monophonic, so a short note takes it over from a long one and
+ * releases on its own gate — measured against the longest gate seen, a later
+ * note would be called a slide into an envelope that had already finished, and
+ * `renderBassVoices` would render it as silence. Read this way a slide always
+ * starts while its predecessor is still gated, and a gated envelope is never
+ * released, so an inherited one is always live.
  */
 function monoOrder(events: ReadonlyArray<BassVoiceEvent>): BassNote[] {
   const sorted = [...events].sort(
@@ -55,7 +63,7 @@ function monoOrder(events: ReadonlyArray<BassVoiceEvent>): BassNote[] {
       continue;
     }
     notes.push({ event, slide: event.startFrame < previousGateOff });
-    previousGateOff = Math.max(previousGateOff, event.gateOffFrame);
+    previousGateOff = event.gateOffFrame;
   }
   return notes;
 }

--- a/packages/timeline/src/midi/engines/bl1.ts
+++ b/packages/timeline/src/midi/engines/bl1.ts
@@ -1,0 +1,172 @@
+/**
+ * BL-1 — the acid bassline voice, ported from FableSynth's
+ * `src/bass/engine/worklet-bass.js` (github.com/georgi/fablesynth).
+ *
+ * One wavetable oscillator and a sub through a resonant filter with its own
+ * decay envelope. Monophonic on purpose: that is what makes the two things a
+ * 303 line is written with work — an accented note (velocity at or above
+ * `accentVelocity`) hits harder and opens the filter further, and a note that
+ * starts before the one before it ends glides into pitch instead of
+ * retriggering.
+ *
+ * Not ported: the plugin's sequencer, its LFO and its FX rack.
+ */
+
+import type { BassMidiInstrument } from "../../types.js";
+import {
+  AdEnvelope,
+  Adsr,
+  AdaaDrive,
+  StateVariableFilter,
+  TableOscillator,
+  pitchHz
+} from "./dsp.js";
+
+export interface BassVoiceEvent {
+  pitch: number;
+  velocity: number;
+  startFrame: number;
+  gateOffFrame: number;
+}
+
+/** The state one BL-1 note leaves behind for the note that slides into it. */
+interface BassNote {
+  event: BassVoiceEvent;
+  slide: boolean;
+}
+
+/**
+ * Group the events into the order a mono voice plays them: sorted by onset,
+ * and each note marked as sliding when it starts before its predecessor's
+ * gate closes.
+ */
+function monoOrder(events: ReadonlyArray<BassVoiceEvent>): BassNote[] {
+  const sorted = [...events].sort(
+    (a, b) => a.startFrame - b.startFrame || a.pitch - b.pitch
+  );
+  const notes: BassNote[] = [];
+  let previousGateOff = -1;
+  for (const event of sorted) {
+    // A note landing on the same frame as the last one is a chord the mono
+    // voice cannot play: the later pitch wins, as it does on the hardware.
+    if (notes.length > 0 && event.startFrame === notes[notes.length - 1].event.startFrame) {
+      notes[notes.length - 1] = { event, slide: notes[notes.length - 1].slide };
+      previousGateOff = event.gateOffFrame;
+      continue;
+    }
+    notes.push({ event, slide: event.startFrame < previousGateOff });
+    previousGateOff = Math.max(previousGateOff, event.gateOffFrame);
+  }
+  return notes;
+}
+
+/**
+ * Render every note of a BL-1 part into `out`. One voice walks the whole
+ * buffer, so a slide carries the oscillator's phase and the filter's state
+ * across the note boundary rather than starting again.
+ *
+ * Returns true if the voice was still sounding at the last frame.
+ */
+export function renderBassVoices(
+  out: Float32Array,
+  events: ReadonlyArray<BassVoiceEvent>,
+  instrument: BassMidiInstrument,
+  sampleRate: number
+): boolean {
+  const notes = monoOrder(events);
+  if (notes.length === 0 || out.length === 0) return false;
+
+  const osc = new TableOscillator(instrument.table, 1, 0);
+  const filter = new StateVariableFilter();
+  const drive = new AdaaDrive();
+  const subGain = instrument.subLevel * instrument.subLevel;
+  const slideCoeff =
+    instrument.slideMs > 0
+      ? 1 - Math.exp(-1 / ((instrument.slideMs / 1000) * sampleRate))
+      : 1;
+
+  let subPhase = 0;
+  let glidePitch = notes[0].event.pitch + instrument.semitones;
+  let ampEnv = new Adsr(instrument.ampEnv, sampleRate);
+  let filterEnv = new AdEnvelope(
+    instrument.filterAttackMs,
+    instrument.filterDecayMs,
+    sampleRate
+  );
+
+  for (let i = 0; i < notes.length; i++) {
+    const { event, slide } = notes[i];
+    const startFrame = Math.max(0, event.startFrame);
+    if (startFrame >= out.length) break;
+    // The voice is mono: the next note takes it over, gate or no gate.
+    const next = notes[i + 1];
+    const endFrame = Math.min(
+      out.length,
+      next ? Math.max(startFrame, next.event.startFrame) : out.length
+    );
+
+    const accented = event.velocity >= instrument.accentVelocity;
+    const accent = accented ? instrument.accentAmount : 0;
+    // A slide is one long note whose pitch moves: the envelopes keep running,
+    // which is what makes a slid step legato instead of a new attack.
+    if (!slide) {
+      ampEnv = new Adsr(instrument.ampEnv, sampleRate);
+      filterEnv = new AdEnvelope(
+        instrument.filterAttackMs,
+        // An accent shortens the filter decay as well as deepening it, which
+        // is the snap that separates an accented step from a loud one.
+        instrument.filterDecayMs * (1 - 0.4 * accent),
+        sampleRate
+      );
+      glidePitch = event.pitch + instrument.semitones;
+      filter.reset();
+      drive.reset();
+    }
+    const targetPitch = event.pitch + instrument.semitones;
+    const velocity = event.velocity / 127;
+    const amplitude = (0.25 + 0.75 * velocity * velocity) * (1 + 0.35 * accent);
+    const keyOffset = (instrument.keyTrack * (event.pitch - 60)) / 12;
+    const envAmount = instrument.filterEnvAmount * (1 + accent);
+
+    for (let frame = startFrame; frame < endFrame; frame++) {
+      const level = ampEnv.step(frame < event.gateOffFrame);
+      if (ampEnv.stage === "done") break;
+      const fenv = filterEnv.step();
+
+      glidePitch += (targetPitch - glidePitch) * slideCoeff;
+      const hz = pitchHz(glidePitch);
+      let sample = osc.next(hz, instrument.position, sampleRate);
+      if (subGain > 0) {
+        const subPhaseInc =
+          pitchHz(glidePitch + 12 * instrument.subOctave) / sampleRate;
+        const carrier =
+          instrument.subShape === "square"
+            ? subPhase < 0.5
+              ? 1
+              : -1
+            : Math.sin(2 * Math.PI * subPhase);
+        sample += carrier * subGain;
+        subPhase += subPhaseInc;
+        if (subPhase >= 1) subPhase -= 1;
+      }
+
+      const cutoff =
+        instrument.cutoffHz * Math.pow(2, envAmount * fenv + keyOffset);
+      const driven = drive.process(sample * 0.5, instrument.drive);
+      out[frame] +=
+        filter.process(
+          driven,
+          instrument.filterType,
+          cutoff,
+          instrument.resonance,
+          sampleRate
+        ) *
+        level *
+        amplitude;
+    }
+    // Only the note that runs to the end of the buffer can leave a tail for the
+    // caller to ramp out.
+    if (endFrame >= out.length) return ampEnv.stage !== "done";
+  }
+  return false;
+}

--- a/packages/timeline/src/midi/engines/dr1.ts
+++ b/packages/timeline/src/midi/engines/dr1.ts
@@ -1,0 +1,137 @@
+/**
+ * DR-1 — the drum machine voice, ported from FableSynth's
+ * `src/drum/engine/worklet-drum.js` (github.com/georgi/fablesynth).
+ *
+ * Sixteen pads laid out from `baseNote` upward, one MIDI note each. A pad is a
+ * one-shot: a wavetable oscillator dropped by a pitch envelope, plus coloured
+ * noise and a ring modulator, through an optional filter and an attack-hold-
+ * decay envelope. The note's length does not gate it — a drum rings for as long
+ * as its decay says, which is what lets a pattern be written as sixteenth-note
+ * ticks.
+ *
+ * Not ported: the plugin's sample-player layer, its mod matrix, choke groups,
+ * output buses and per-pad FX rack.
+ */
+
+import type { DrumMidiInstrument, DrumPad } from "../../types.js";
+import {
+  AdEnvelope,
+  ColouredNoise,
+  Rng,
+  StateVariableFilter,
+  TableOscillator,
+  pitchHz
+} from "./dsp.js";
+
+export interface DrumVoiceEvent {
+  pitch: number;
+  velocity: number;
+  startFrame: number;
+}
+
+/** The pitch a pad's oscillator plays before its pitch envelope moves it. */
+const PAD_BASE_PITCH = 60;
+
+/** e^-4.5 — where the exponential decay segment lands, normalized out below. */
+const E45 = Math.exp(-4.5);
+const INV_E45 = 1 / (1 - E45);
+
+/** The pad a note plays, or null when the note is outside the kit. */
+export function padForNote(
+  instrument: DrumMidiInstrument,
+  pitch: number
+): DrumPad | null {
+  const index = pitch - instrument.baseNote;
+  if (index < 0 || index >= instrument.pads.length) return null;
+  return instrument.pads[index] ?? null;
+}
+
+/**
+ * Render one drum hit into `out`. Returns true if the pad was still sounding at
+ * the last frame of the buffer.
+ */
+export function renderDrumVoice(
+  out: Float32Array,
+  event: DrumVoiceEvent,
+  instrument: DrumMidiInstrument,
+  sampleRate: number
+): boolean {
+  const pad = padForNote(instrument, event.pitch);
+  if (!pad) return false;
+  const startFrame = Math.max(0, event.startFrame);
+  if (startFrame >= out.length) return false;
+
+  const osc = new TableOscillator(pad.table, 1, 0);
+  const pitchEnv = new AdEnvelope(0, pad.pitchEnvDecayMs, sampleRate);
+  const filter = pad.filter ? new StateVariableFilter() : null;
+  const noise =
+    pad.noiseLevel > 1e-4
+      ? new ColouredNoise(
+          // Seeded from the pad and the hit, so a rendered pattern is the same
+          // every time and two pads never share the same noise.
+          new Rng(0x1d3c5b7f ^ (event.pitch * 2654435761 + startFrame)),
+          pad.noiseColor,
+          sampleRate
+        )
+      : null;
+
+  const basePitch = PAD_BASE_PITCH + pad.semitones;
+  const noiseGain = pad.noiseLevel * pad.noiseLevel * 0.35;
+  const ringInc = Math.min(sampleRate * 0.45, Math.max(20, pad.ringHz)) / sampleRate;
+  let ringPhase = 0.25;
+
+  const velocity = event.velocity / 127;
+  const velGain = 1 - pad.velocityToLevel * (1 - velocity);
+  const levelGain = pad.level * pad.level * velGain;
+
+  const attackFrames = Math.max(1, (pad.attackMs / 1000) * sampleRate);
+  const holdFrames = (pad.holdMs / 1000) * sampleRate;
+  const decayFrames = Math.max(1, (pad.decayMs / 1000) * sampleRate);
+  const decayStart = attackFrames + holdFrames;
+  const decayEnd = decayStart + decayFrames;
+  const invDecay = 1 / decayFrames;
+
+  for (let frame = startFrame; frame < out.length; frame++) {
+    const t = frame - startFrame;
+    if (t >= decayEnd) return false;
+
+    let amp: number;
+    if (t < attackFrames) {
+      amp = t / attackFrames;
+    } else if (t < decayStart) {
+      amp = 1;
+    } else {
+      const td = t - decayStart;
+      // The exponential is normalized to reach zero rather than stepping down
+      // from its e^-4.5 tail; `curve` blends the straight line into it.
+      const exponential = (Math.exp(-4.5 * td * invDecay) - E45) * INV_E45;
+      const linear = 1 - td * invDecay;
+      amp = linear + (exponential - linear) * pad.curve;
+    }
+
+    const hz = pitchHz(basePitch + pad.pitchEnvAmount * pitchEnv.step());
+    let sample = osc.next(hz, pad.position, sampleRate);
+    if (noise) {
+      sample += noise.next() * noiseGain;
+    }
+    if (pad.ringMix > 1e-6) {
+      // A fixed-Hz carrier breaks the oscillator's harmonic series into the
+      // inharmonic sidebands struck metal and synthetic cymbals are made of.
+      const carrier = Math.sin(ringPhase * Math.PI * 2) * Math.SQRT2;
+      sample *= 1 + pad.ringMix * (carrier - 1);
+      ringPhase += ringInc;
+      if (ringPhase >= 1) ringPhase -= 1;
+    }
+    if (filter && pad.filter) {
+      sample = filter.process(
+        sample,
+        pad.filter.type,
+        pad.filter.cutoffHz,
+        pad.filter.resonance,
+        sampleRate
+      );
+    }
+    out[frame] += sample * amp * levelGain;
+  }
+  return true;
+}

--- a/packages/timeline/src/midi/engines/dsp.ts
+++ b/packages/timeline/src/midi/engines/dsp.ts
@@ -1,0 +1,433 @@
+/**
+ * The DSP pieces WT-1, BL-1 and DR-1 share, ported from FableSynth's
+ * AudioWorklets (github.com/georgi/fablesynth).
+ *
+ * Everything here is per-sample and allocation-free once constructed, and
+ * nothing reads a clock or a random source it did not seed — two renders of the
+ * same input are sample-exact equal, which the midi render cache depends on.
+ *
+ * The renderer is mono, so the worklets' stereo pan, unison spread and per-pad
+ * bus routing are not ported; the sound-shaping stages are.
+ */
+
+import { getWavetable, type TableName, type Wavetable } from "./wavetables.js";
+
+/** Concert A and its MIDI pitch. */
+const A4_HZ = 440;
+const A4_PITCH = 69;
+
+/** Frequency of a (fractional) MIDI pitch in Hz. */
+export function pitchHz(pitch: number): number {
+  return A4_HZ * Math.pow(2, (pitch - A4_PITCH) / 12);
+}
+
+// ── Wavetable oscillator ────────────────────────────────────────────────────
+
+/**
+ * 4-point cubic Hermite (Catmull-Rom) read. Indices are pre-wrapped by the
+ * caller; `off` selects the frame and mip. Linear interpolation leaves images
+ * 10-20 dB louder below C6, which is why the worklet reads this way too.
+ */
+function readHermite(
+  d: Float32Array,
+  off: number,
+  im1: number,
+  i0: number,
+  i1: number,
+  i2: number,
+  f: number
+): number {
+  const ym1 = d[off + im1];
+  const y0 = d[off + i0];
+  const y1 = d[off + i1];
+  const y2 = d[off + i2];
+  const c1 = 0.5 * (y1 - ym1);
+  const c2 = ym1 - 2.5 * y0 + 2 * y1 - 0.5 * y2;
+  const c3 = 0.5 * (y2 - ym1) + 1.5 * (y0 - y1);
+  return ((c3 * f + c2) * f + c1) * f + y0;
+}
+
+/**
+ * One wavetable oscillator: a morph position across the table's frames, up to
+ * `MAX_UNISON` detuned copies, and a mip picked from the pitch.
+ */
+export const MAX_UNISON = 7;
+
+export class TableOscillator {
+  private readonly table: Wavetable;
+  private readonly phases: Float64Array;
+  private unison = 1;
+  private detune = 0;
+
+  constructor(name: TableName, unison: number, detune: number, phase = 0) {
+    this.table = getWavetable(name);
+    this.unison = Math.max(1, Math.min(MAX_UNISON, Math.round(unison)));
+    this.detune = Math.abs(detune);
+    this.phases = new Float64Array(MAX_UNISON);
+    // A fixed spread of start phases rather than a random one: the render has
+    // to be reproducible, and identical phases would make unison a comb filter
+    // at note-on.
+    for (let u = 0; u < MAX_UNISON; u++) {
+      this.phases[u] = ((phase + u * 0.137) % 1) * this.table.size;
+    }
+  }
+
+  /**
+   * One sample at `hz` and morph `position` (0..1).
+   *
+   * The mip is chosen so the highest partial of the most-detuned copy stays
+   * under 0.475·sr, and the level below it is crossfaded in over the first 0.07
+   * octaves past a boundary — the same continuous selection the worklet uses,
+   * so a glide never steps in brightness.
+   */
+  next(hz: number, position: number, sampleRate: number): number {
+    const table = this.table;
+    const size = table.size;
+    const mask = size - 1;
+    const cps = hz / sampleRate;
+    if (!(cps > 0 && cps < 0.45)) return 0;
+
+    const posF = Math.min(1, Math.max(0, position)) * (table.frames - 1);
+    const f0 = posF | 0;
+    const f1 = Math.min(table.frames - 1, f0 + 1);
+    const ft = posF - f0;
+
+    const maxRatio = Math.pow(2, (this.detune * 50) / 1200);
+    const mipF = Math.log2((cps * maxRatio * 1024) / 0.475);
+    let mip = 0;
+    let mipBlend = 0;
+    const crossfadeOctaves = 0.07;
+    if (mipF > 0) {
+      mip = Math.min(table.mips - 1, Math.ceil(mipF));
+      const over = mipF - (mip - 1);
+      if (over < crossfadeOctaves) mipBlend = 1 - over / crossfadeOctaves;
+    }
+    const fineMip = mip > 0 ? mip - 1 : 0;
+    const off0 = (f0 * table.mips + mip) * size;
+    const off1 = (f1 * table.mips + mip) * size;
+    const off0b = (f0 * table.mips + fineMip) * size;
+    const off1b = (f1 * table.mips + fineMip) * size;
+
+    const uni = this.unison;
+    let sum = 0;
+    for (let u = 0; u < uni; u++) {
+      const spread = uni > 1 ? (u / (uni - 1)) * 2 - 1 : 0;
+      const ratio = Math.pow(2, (spread * this.detune * 50) / 1200);
+      const inc = cps * ratio * size;
+      let phase = this.phases[u];
+      const i0 = phase | 0;
+      const frac = phase - i0;
+      const im1 = (i0 - 1) & mask;
+      const i1 = (i0 + 1) & mask;
+      const i2 = (i0 + 2) & mask;
+      const a = readHermite(table.data, off0, im1, i0, i1, i2, frac);
+      const b = readHermite(table.data, off1, im1, i0, i1, i2, frac);
+      let s = a + (b - a) * ft;
+      if (mipBlend > 0) {
+        const af = readHermite(table.data, off0b, im1, i0, i1, i2, frac);
+        const bf = readHermite(table.data, off1b, im1, i0, i1, i2, frac);
+        const fine = af + (bf - af) * ft;
+        s += (fine - s) * mipBlend;
+      }
+      sum += s;
+      phase += inc;
+      if (phase >= size) phase -= size;
+      this.phases[u] = phase;
+    }
+    // Loudness is held roughly constant across unison counts.
+    return sum / Math.sqrt(uni);
+  }
+}
+
+// ── Filter ──────────────────────────────────────────────────────────────────
+
+/** The filter shapes both WT-1 and BL-1 offer. */
+export const SVF_TYPES = ["lp12", "lp24", "bp12", "hp12", "notch"] as const;
+export type SvfType = (typeof SVF_TYPES)[number];
+
+/**
+ * Cytomic (Simper) zero-delay state-variable filter, cascaded for LP24.
+ *
+ * Coefficients are recomputed per sample rather than per block: offline there
+ * is no block to amortize over, and a per-sample update is what removes the
+ * staircase the worklet spends a sub-block ramp avoiding.
+ */
+export class StateVariableFilter {
+  private ic1 = 0;
+  private ic2 = 0;
+  private ic1b = 0;
+  private ic2b = 0;
+
+  reset(): void {
+    this.ic1 = 0;
+    this.ic2 = 0;
+    this.ic1b = 0;
+    this.ic2b = 0;
+  }
+
+  process(
+    x: number,
+    type: SvfType,
+    cutoffHz: number,
+    resonance: number,
+    sampleRate: number
+  ): number {
+    const res = Math.min(0.999, Math.max(0, resonance));
+    const cut = Math.min(sampleRate * 0.45, Math.max(20, cutoffHz));
+    const twoPole = type === "lp24";
+    let k1: number;
+    let k2: number;
+    if (twoPole) {
+      // All the resonance in stage one, stage two critically damped — the
+      // 24 dB slope stays stable at high resonance this way.
+      const r2 = res * res;
+      const resT = res + 0.0035 * r2 * r2;
+      const kk = 2 - 1.93 * resT;
+      k1 = Math.max(0.02, 0.5 * kk * kk);
+      k2 = 2;
+    } else {
+      k1 = 2 - 1.93 * res;
+      k2 = k1;
+    }
+    const g = Math.tan((Math.PI * cut) / sampleRate);
+    const a1 = 1 / (1 + g * (g + k1));
+    const a2 = g * a1;
+    const a3 = g * a2;
+
+    const v3 = x - this.ic2;
+    const v1 = a1 * this.ic1 + a2 * v3;
+    const v2 = this.ic2 + a2 * this.ic1 + a3 * v3;
+    this.ic1 = 2 * v1 - this.ic1;
+    this.ic2 = 2 * v2 - this.ic2;
+
+    let y: number;
+    switch (type) {
+      case "lp12":
+      case "lp24":
+        y = v2;
+        break;
+      case "bp12":
+        y = k1 * v1;
+        break;
+      case "hp12":
+        y = x - k1 * v1 - v2;
+        break;
+      default:
+        y = x - k1 * v1;
+        break;
+    }
+    if (!twoPole) return y;
+
+    const a1b = 1 / (1 + g * (g + k2));
+    const a2b = g * a1b;
+    const a3b = g * a2b;
+    const w3 = y - this.ic2b;
+    const w1 = a1b * this.ic1b + a2b * w3;
+    const w2 = this.ic2b + a2b * this.ic1b + a3b * w3;
+    this.ic1b = 2 * w1 - this.ic1b;
+    this.ic2b = 2 * w2 - this.ic2b;
+    return w2;
+  }
+}
+
+/** Numerically stable ln(cosh(z)) — the antiderivative of tanh. */
+function lcosh(z: number): number {
+  const a = Math.abs(z);
+  return a + Math.log1p(Math.exp(-2 * a)) - Math.LN2;
+}
+
+/**
+ * Anti-aliased tanh drive (first-order antiderivative anti-aliasing).
+ *
+ * A naive per-sample saturator folds the harmonics it creates back down the
+ * spectrum; integrating between successive inputs does not. `state` carries the
+ * previous input and its antiderivative between calls.
+ */
+export class AdaaDrive {
+  private xPrev = 0;
+  private fPrev = 0;
+  private gain = -1;
+
+  reset(): void {
+    this.xPrev = 0;
+    this.fPrev = 0;
+    this.gain = -1;
+  }
+
+  process(x: number, amount: number): number {
+    if (amount <= 0.005) {
+      this.xPrev = x;
+      this.gain = -1;
+      return x;
+    }
+    const dg = 1 + amount * 7;
+    const comp = 1 / Math.pow(dg, 0.55);
+    const kF = comp / dg;
+    if (this.gain !== dg) {
+      this.gain = dg;
+      this.fPrev = kF * lcosh(dg * this.xPrev);
+    }
+    const f = kF * lcosh(dg * x);
+    const dx = x - this.xPrev;
+    // A vanishing step makes the difference quotient unstable; the midpoint
+    // tanh is the same curve there.
+    const y =
+      dx > 1e-5 || dx < -1e-5
+        ? (f - this.fPrev) / dx
+        : comp * Math.tanh(dg * 0.5 * (x + this.xPrev));
+    this.xPrev = x;
+    this.fPrev = f;
+    return y;
+  }
+}
+
+// ── Envelopes ───────────────────────────────────────────────────────────────
+
+/** How close to a target level counts as having reached it. */
+const EPSILON = 1e-9;
+
+export interface AdsrTimes {
+  attackMs: number;
+  decayMs: number;
+  sustain: number;
+  releaseMs: number;
+}
+
+/** Which segment of the ADSR a voice is in. */
+export type AdsrStage = "attack" | "decay" | "sustain" | "release" | "done";
+
+/**
+ * A linear ADSR. The same shape `voice.ts` uses for the subtractive instrument,
+ * lifted here so every engine releases from wherever it was rather than from
+ * the sustain level.
+ */
+export class Adsr {
+  stage: AdsrStage = "attack";
+  level = 0;
+  private releaseFrom = 0;
+  private readonly attackPerSample: number;
+  private readonly decayPerSample: number;
+  private readonly releasePerSample: number;
+  private readonly sustain: number;
+
+  constructor(times: AdsrTimes, sampleRate: number) {
+    const perSample = (ms: number, span: number) =>
+      ms <= 0 ? Number.POSITIVE_INFINITY : span / ((ms / 1000) * sampleRate);
+    this.attackPerSample = perSample(times.attackMs, 1);
+    this.decayPerSample = perSample(times.decayMs, 1 - times.sustain);
+    this.releasePerSample = perSample(times.releaseMs, 1);
+    this.sustain = times.sustain;
+  }
+
+  step(gateOn: boolean): number {
+    if (!gateOn && this.stage !== "release" && this.stage !== "done") {
+      this.stage = "release";
+      this.releaseFrom = this.level;
+    }
+    switch (this.stage) {
+      case "attack":
+        this.level = Math.min(1, this.level + this.attackPerSample);
+        if (this.level >= 1 - EPSILON) {
+          this.level = 1;
+          this.stage = this.sustain >= 1 ? "sustain" : "decay";
+        }
+        break;
+      case "decay":
+        this.level = Math.max(this.sustain, this.level - this.decayPerSample);
+        if (this.level - this.sustain <= EPSILON) {
+          this.level = this.sustain;
+          this.stage = "sustain";
+        }
+        break;
+      case "sustain":
+        this.level = this.sustain;
+        break;
+      case "release": {
+        const stepDown = this.releasePerSample * this.releaseFrom;
+        this.level = Number.isFinite(stepDown)
+          ? Math.max(0, this.level - stepDown)
+          : 0;
+        if (this.level <= EPSILON) {
+          this.level = 0;
+          this.stage = "done";
+        }
+        break;
+      }
+      case "done":
+        this.level = 0;
+        break;
+    }
+    return this.level;
+  }
+}
+
+/**
+ * An attack-decay envelope with no sustain — BL-1's filter envelope and DR-1's
+ * pitch envelope both use one. The decay is exponential (−4.5 nepers over the
+ * decay time), which is what gives an acid line its snap.
+ */
+export class AdEnvelope {
+  private t = 0;
+  private readonly attackFrames: number;
+  private readonly decayK: number;
+
+  constructor(attackMs: number, decayMs: number, sampleRate: number) {
+    this.attackFrames = Math.max(1, (attackMs / 1000) * sampleRate);
+    this.decayK = -4.5 / Math.max(0.002, decayMs / 1000) / sampleRate;
+  }
+
+  step(): number {
+    const t = this.t++;
+    if (t < this.attackFrames) return t / this.attackFrames;
+    return Math.exp(this.decayK * (t - this.attackFrames));
+  }
+}
+
+// ── Noise ───────────────────────────────────────────────────────────────────
+
+/**
+ * xorshift32, seeded per voice. A drum hit needs noise that is the same on
+ * every render of the same clip, so `Math.random` is not an option.
+ */
+export class Rng {
+  private s: number;
+
+  constructor(seed: number) {
+    this.s = seed >>> 0 || 0x9e3779b9;
+  }
+
+  /** Uniform in [-1, 1). */
+  uniform(): number {
+    let x = this.s;
+    x ^= x << 13;
+    x ^= x >>> 17;
+    x ^= x << 5;
+    this.s = x >>> 0;
+    return (this.s / 0x80000000) - 1;
+  }
+}
+
+/**
+ * One-pole coloured noise. `color` runs −1 (dark) to 1 (bright): the pole is
+ * mapped from the 48 kHz reference the worklet uses so the tilt is the same
+ * filter at any sample rate.
+ */
+export class ColouredNoise {
+  private y = 0;
+  private readonly a: number;
+
+  constructor(
+    private readonly rng: Rng,
+    color: number,
+    sampleRate: number
+  ) {
+    const at48k = 0.02 + (Math.min(1, Math.max(-1, color)) + 1) * 0.49;
+    this.a = 1 - Math.pow(1 - at48k, 48000 / sampleRate);
+  }
+
+  next(): number {
+    this.y += (this.rng.uniform() - this.y) * this.a;
+    return this.y;
+  }
+}
+

--- a/packages/timeline/src/midi/engines/index.ts
+++ b/packages/timeline/src/midi/engines/index.ts
@@ -1,0 +1,20 @@
+/**
+ * The FableSynth instruments (github.com/georgi/fablesynth), ported to the
+ * offline renderer: WT-1 the wavetable synth, BL-1 the acid bassline, DR-1 the
+ * drum machine.
+ *
+ * Only the names a caller outside the package needs are re-exported — the table
+ * catalogue for an instrument picker, and the shipped kit.
+ */
+
+export {
+  ALL_TABLE_NAMES,
+  DRUM_TABLE_NAMES,
+  WAVETABLE_NAMES,
+  type DrumTableName,
+  type TableName,
+  type WavetableName
+} from "./wavetables.js";
+export { SVF_TYPES, type SvfType } from "./dsp.js";
+export { TR_VOID_KIT } from "./kits.js";
+export { padForNote } from "./dr1.js";

--- a/packages/timeline/src/midi/engines/kits.ts
+++ b/packages/timeline/src/midi/engines/kits.ts
@@ -1,0 +1,130 @@
+/**
+ * The DR-1 kit that ships with the timeline, transcribed from FableSynth's
+ * TR-VOID factory kit (`src/drum/kits.ts` in github.com/georgi/fablesynth).
+ *
+ * Pads are laid out in the kit's own order — kick first, then snares, hats,
+ * toms and percussion — and answer to MIDI 36 upward, which is where a drum
+ * pattern written in any DAW puts them.
+ */
+
+import type { DrumPad } from "../../types.js";
+
+/** Everything a pad leaves unsaid, matching DR-1's per-pad defaults. */
+const PAD_DEFAULTS = {
+  position: 0,
+  semitones: 0,
+  pitchEnvAmount: 0,
+  pitchEnvDecayMs: 60,
+  noiseLevel: 0,
+  noiseColor: 0,
+  ringHz: 1200,
+  ringMix: 0,
+  attackMs: 1,
+  holdMs: 10,
+  decayMs: 240,
+  curve: 0.35,
+  filter: null,
+  level: 0.8,
+  velocityToLevel: 0.6
+} satisfies Omit<DrumPad, "name" | "table">;
+
+const pad = (
+  name: string,
+  table: DrumPad["table"],
+  over: Partial<DrumPad> = {}
+): DrumPad => ({ ...PAD_DEFAULTS, name, table, ...over });
+
+/** A high-pass on a metal pad, the way the kit thins its hats. */
+const highPass = (cutoffHz: number): DrumPad["filter"] => ({
+  type: "hp12",
+  cutoffHz,
+  resonance: 0.18
+});
+
+/** DR-1's TR-VOID kit: sixteen pads from MIDI 36. */
+export const TR_VOID_KIT: readonly DrumPad[] = [
+  pad("Kick", "thud", {
+    semitones: -26,
+    pitchEnvAmount: 22,
+    pitchEnvDecayMs: 60,
+    decayMs: 300
+  }),
+  pad("Kick 2", "thud", {
+    semitones: -19,
+    pitchEnvAmount: 16,
+    decayMs: 240
+  }),
+  pad("Snare", "crack", {
+    semitones: -12,
+    pitchEnvAmount: 5,
+    decayMs: 180,
+    noiseLevel: 0.5,
+    noiseColor: 0.3
+  }),
+  pad("Clap", "crack", {
+    semitones: 7,
+    pitchEnvAmount: 2,
+    decayMs: 140,
+    noiseLevel: 0.35
+  }),
+  pad("Rim", "tine", { semitones: 24, decayMs: 80 }),
+  pad("Closed hat", "tine", {
+    semitones: 18,
+    decayMs: 40,
+    ringHz: 6389,
+    ringMix: 0.18,
+    filter: highPass(7200)
+  }),
+  pad("Open hat", "tine", {
+    semitones: 12,
+    decayMs: 300,
+    ringHz: 5197,
+    ringMix: 0.28,
+    filter: highPass(5200)
+  }),
+  pad("Ride", "tine", {
+    semitones: 5,
+    decayMs: 1400,
+    ringHz: 1667,
+    ringMix: 0.46
+  }),
+  pad("Low tom", "thud", {
+    semitones: -19,
+    pitchEnvAmount: 12,
+    decayMs: 280
+  }),
+  pad("Mid tom", "thud", {
+    semitones: -12,
+    pitchEnvAmount: 10,
+    decayMs: 240
+  }),
+  pad("High tom", "thud", {
+    semitones: -5,
+    pitchEnvAmount: 8,
+    decayMs: 200
+  }),
+  pad("Crash", "tine", { decayMs: 1800, ringHz: 2741, ringMix: 0.62 }),
+  pad("Perc 1", "chime", {
+    semitones: -5,
+    ringHz: 731,
+    ringMix: 0.78,
+    decayMs: 160,
+    curve: 0.22
+  }),
+  pad("Perc 2", "grit", {
+    position: 0.38,
+    semitones: 17,
+    noiseLevel: 0.18,
+    noiseColor: 0.75,
+    ringHz: 3271,
+    ringMix: 0.88,
+    decayMs: 200,
+    filter: highPass(3600)
+  }),
+  pad("Vox", "vox", { semitones: -5, decayMs: 480 }),
+  pad("Glitch", "grit", {
+    semitones: -12,
+    pitchEnvAmount: 9,
+    decayMs: 220
+  })
+];

--- a/packages/timeline/src/midi/engines/wavetables.ts
+++ b/packages/timeline/src/midi/engines/wavetables.ts
@@ -1,0 +1,393 @@
+/**
+ * Band-limited wavetables, ported from FableSynth's `src/engine/wavetables.ts`
+ * (github.com/georgi/fablesynth).
+ *
+ * A table is FRAMES single cycles × MIPS brightness levels × SIZE samples. Mip
+ * `m` keeps harmonics 1..(1024 >> m), so the oscillator picks a level by pitch
+ * and no partial ever crosses Nyquist — the anti-aliasing WT-1, BL-1 and DR-1
+ * all read from.
+ *
+ * Generation is pure arithmetic and deterministic, so a table is built once per
+ * process and memoized: a render at the same sample rate hands back the same
+ * samples, which is what lets `cacheKey.ts` reuse a previous render.
+ */
+
+/** Samples per cycle. */
+export const TABLE_SIZE = 2048;
+/** Morph frames per table. */
+export const TABLE_FRAMES = 16;
+/** Mip levels per frame: max harmonic 1024, 512, … 1 (a pure sine). */
+export const TABLE_MIPS = 11;
+
+/** The tonal tables WT-1 and BL-1 play. */
+export const WAVETABLE_NAMES = [
+  "prime",
+  "bloom",
+  "pulse",
+  "vox",
+  "chime",
+  "glitch"
+] as const;
+export type WavetableName = (typeof WAVETABLE_NAMES)[number];
+
+/** DR-1's percussive tables. Every tonal table is playable by a pad too. */
+export const DRUM_TABLE_NAMES = ["thud", "crack", "tine", "grit"] as const;
+export type DrumTableName = (typeof DRUM_TABLE_NAMES)[number];
+
+/** Anything a pad or an oscillator can be pointed at. */
+export type TableName = WavetableName | DrumTableName;
+
+export interface Wavetable {
+  name: TableName;
+  frames: number;
+  mips: number;
+  size: number;
+  /** frame-major, then mip, then sample. */
+  data: Float32Array;
+}
+
+// ── FFT ─────────────────────────────────────────────────────────────────────
+
+/** Iterative radix-2 complex FFT, in place. */
+export function fft(re: Float64Array, im: Float64Array, inverse: boolean): void {
+  const n = re.length;
+  for (let i = 1, j = 0; i < n; i++) {
+    let bit = n >> 1;
+    for (; j & bit; bit >>= 1) {
+      j ^= bit;
+    }
+    j ^= bit;
+    if (i < j) {
+      const tr = re[i];
+      re[i] = re[j];
+      re[j] = tr;
+      const ti = im[i];
+      im[i] = im[j];
+      im[j] = ti;
+    }
+  }
+  for (let len = 2; len <= n; len <<= 1) {
+    const ang = ((inverse ? 2 : -2) * Math.PI) / len;
+    const wr = Math.cos(ang);
+    const wi = Math.sin(ang);
+    const half = len >> 1;
+    for (let i = 0; i < n; i += len) {
+      let cr = 1;
+      let ci = 0;
+      for (let k = 0; k < half; k++) {
+        const ur = re[i + k];
+        const ui = im[i + k];
+        const xr = re[i + k + half];
+        const xi = im[i + k + half];
+        const vr = xr * cr - xi * ci;
+        const vi = xr * ci + xi * cr;
+        re[i + k] = ur + vr;
+        im[i + k] = ui + vi;
+        re[i + k + half] = ur - vr;
+        im[i + k + half] = ui - vi;
+        const ncr = cr * wr - ci * wi;
+        ci = cr * wi + ci * wr;
+        cr = ncr;
+      }
+    }
+  }
+  if (inverse) {
+    for (let i = 0; i < n; i++) {
+      re[i] /= n;
+      im[i] /= n;
+    }
+  }
+}
+
+/** Add harmonic `k` at amplitude `a` and phase `ph` (cosine convention). */
+function setHarm(
+  re: Float64Array,
+  im: Float64Array,
+  k: number,
+  a: number,
+  ph: number
+): void {
+  re[k] += a * Math.cos(ph);
+  im[k] += a * Math.sin(ph);
+  re[TABLE_SIZE - k] += a * Math.cos(ph);
+  im[TABLE_SIZE - k] -= a * Math.sin(ph);
+}
+
+/** sin(x) === cos(x - π/2). */
+const SINE_PH = -Math.PI / 2;
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+// ── Table specs ─────────────────────────────────────────────────────────────
+
+/** PRIME: sine → triangle → saw → square. */
+function specPrime(t: number, re: Float64Array, im: Float64Array): void {
+  const seg = Math.min(2.9999, t * 3);
+  const s = seg | 0;
+  const f = seg - s;
+  for (let k = 1; k <= 1024; k++) {
+    const sine = k === 1 ? 1 : 0;
+    const tri =
+      k % 2 === 1 ? ((((k - 1) / 2) % 2 === 0 ? 1 : -1) / (k * k)) : 0;
+    const saw = 1 / k;
+    const sqr = k % 2 === 1 ? 1.27 / k : 0;
+    const shapes = [sine, tri, saw, sqr];
+    const a = lerp(shapes[s], shapes[s + 1], f);
+    if (a !== 0) setHarm(re, im, k, a, SINE_PH);
+  }
+}
+
+/** BLOOM: a fundamental opening into a bright stack. */
+function specBloom(t: number, re: Float64Array, im: Float64Array): void {
+  const n = 1 + Math.floor(t * t * 220);
+  for (let k = 1; k <= 1024; k++) {
+    const roll = Math.exp(-Math.pow(k / n, 4));
+    const a = roll / Math.pow(k, 1.25);
+    if (a < 1e-5) break;
+    setHarm(re, im, k, a, SINE_PH + Math.sin(k * 12.9898) * 0.7 * t);
+  }
+}
+
+/** PULSE: PWM, duty 50% → 6%. */
+function specPulse(t: number, re: Float64Array, im: Float64Array): void {
+  const d = 0.5 - 0.44 * t;
+  for (let k = 1; k <= 1024; k++) {
+    const a = (2 / (k * Math.PI)) * Math.sin(Math.PI * k * d);
+    setHarm(re, im, k, a, SINE_PH - Math.PI * k * d);
+  }
+}
+
+/** Formant centres for A, E, I, O, U. */
+const VOWELS = [
+  [730, 1090, 2440],
+  [530, 1840, 2480],
+  [390, 1990, 2550],
+  [570, 840, 2410],
+  [440, 1020, 2240]
+];
+const F_AMPS = [1, 0.55, 0.32];
+const F_BW = [95, 120, 160];
+
+/** VOX: a saw through a vowel filter, morphing A-E-I-O-U. */
+function specVox(t: number, re: Float64Array, im: Float64Array): void {
+  const pos = t * 4;
+  const v = Math.min(3, pos | 0);
+  const f = pos - v;
+  const formants = [0, 1, 2].map((j) =>
+    lerp(VOWELS[v][j], VOWELS[v + 1][j], f)
+  );
+  for (let k = 1; k <= 256; k++) {
+    const freq = k * 110;
+    // A broadband floor so the darkest frames are not silent.
+    let g = 0.04;
+    for (let j = 0; j < 3; j++) {
+      const d = (freq - formants[j]) / F_BW[j];
+      g += F_AMPS[j] * Math.exp(-0.5 * d * d);
+    }
+    setHarm(re, im, k, g / Math.pow(k, 0.75), SINE_PH);
+  }
+}
+
+/** CHIME: sparse inharmonic partials, hum → strike. */
+const PARTIALS = [1, 2, 3, 5, 7, 9, 13, 16, 19, 24];
+function specChime(t: number, re: Float64Array, im: Float64Array): void {
+  for (let j = 0; j < PARTIALS.length; j++) {
+    const k = PARTIALS[j];
+    const base = 1 / Math.pow(j + 1, 0.8);
+    const a = base * Math.pow(Math.max(t, 0.001), j * 0.45);
+    const ph = SINE_PH + ((j * j * 1.7) % (Math.PI * 2));
+    setHarm(re, im, k, a, ph);
+    if (j > 0 && t > 0.15) setHarm(re, im, k + 1, a * 0.28 * t, ph + 1.1);
+  }
+}
+
+/** GLITCH: a bit-crushed, sample-held sine pair. */
+function waveGlitch(t: number, out: Float64Array): void {
+  const levels = lerp(40, 2.4, t);
+  const hold = 1 + Math.round(t * 40);
+  let held = 0;
+  for (let n = 0; n < TABLE_SIZE; n++) {
+    if (n % hold === 0) {
+      const x =
+        Math.sin((2 * Math.PI * n) / TABLE_SIZE) +
+        0.45 * t * Math.sin((2 * Math.PI * 5 * n) / TABLE_SIZE + 1.3) +
+        0.2 * t * Math.sin((2 * Math.PI * 9 * n) / TABLE_SIZE + 2.6);
+      held = Math.round(x * levels) / levels;
+    }
+    out[n] = held;
+  }
+}
+
+/** THUD: a sine growing harmonics and saturation — kicks and toms. */
+function waveThud(t: number, out: Float64Array): void {
+  for (let i = 0; i < TABLE_SIZE; i++) {
+    const x = i / TABLE_SIZE;
+    let s = Math.sin(2 * Math.PI * x);
+    s += t * 0.6 * Math.sin(2 * Math.PI * 2 * x + 0.6);
+    s += t * t * 0.45 * Math.sin(2 * Math.PI * 3 * x + 1.2);
+    out[i] = Math.tanh(s * (1 + t * 1.8));
+  }
+}
+
+/** CRACK: a comb-filtered odd-harmonic burst — snares and claps. */
+function waveCrack(t: number, out: Float64Array): void {
+  for (let i = 0; i < TABLE_SIZE; i++) {
+    const x = i / TABLE_SIZE;
+    let s = 0;
+    for (let k = 1; k <= 31; k += 2) {
+      const comb = 0.5 + 0.5 * Math.cos(k * 0.9 + t * 5.2);
+      const roll = Math.exp(-Math.pow((k - 5 - t * 10) / 7, 2));
+      s += comb * roll * Math.sin(2 * Math.PI * k * x + Math.sin(k * 7.31) * 1.4);
+    }
+    out[i] = s;
+  }
+}
+
+/** TINE: struck-metal partials — hats, rides, bells. */
+const TINE_K = [1, 4, 7, 11, 16, 22];
+function waveTine(t: number, out: Float64Array): void {
+  for (let i = 0; i < TABLE_SIZE; i++) {
+    const x = i / TABLE_SIZE;
+    let s = 0;
+    for (let j = 0; j < TINE_K.length; j++) {
+      const a = Math.pow(Math.max(t, 0.001), 0.3 * j) / (j + 1);
+      s += a * Math.sin(2 * Math.PI * TINE_K[j] * x + j * j * 1.7);
+    }
+    out[i] = s;
+  }
+}
+
+/** GRIT: sample-held noise fading in over a sine — noisy percussion. */
+function waveGrit(t: number, out: Float64Array): void {
+  const hold = 2 + Math.round(30 * t);
+  let held = 0;
+  for (let i = 0; i < TABLE_SIZE; i++) {
+    if (i % hold === 0) {
+      const r = Math.sin((i + 1) * 127.1) * 43758.5453;
+      held = (r - Math.floor(r)) * 2 - 1;
+    }
+    const x = i / TABLE_SIZE;
+    out[i] = held * t + Math.sin(2 * Math.PI * x) * (1 - t);
+  }
+}
+
+interface TableSpec {
+  name: TableName;
+  spectrum?: (t: number, re: Float64Array, im: Float64Array) => void;
+  wave?: (t: number, out: Float64Array) => void;
+}
+
+const SPECS: readonly TableSpec[] = [
+  { name: "prime", spectrum: specPrime },
+  { name: "bloom", spectrum: specBloom },
+  { name: "pulse", spectrum: specPulse },
+  { name: "vox", spectrum: specVox },
+  { name: "chime", spectrum: specChime },
+  { name: "glitch", wave: waveGlitch },
+  { name: "thud", wave: waveThud },
+  { name: "crack", wave: waveCrack },
+  { name: "tine", wave: waveTine },
+  { name: "grit", wave: waveGrit }
+];
+
+// ── Band-limiting ───────────────────────────────────────────────────────────
+
+/**
+ * Turn one frame's full-band spectrum into every mip level. The mip-0 peak
+ * sets one per-frame normalization (0.92 headroom) shared by all levels, so the
+ * brightness ladder stays amplitude-matched.
+ */
+function bandlimitFrame(
+  re: Float64Array,
+  im: Float64Array,
+  data: Float32Array,
+  frame: number,
+  wre: Float64Array,
+  wim: Float64Array
+): void {
+  let scale = 1;
+  for (let m = 0; m < TABLE_MIPS; m++) {
+    const maxHarm = 1024 >> m;
+    for (let i = 0; i < TABLE_SIZE; i++) {
+      wre[i] = re[i];
+      wim[i] = im[i];
+    }
+    for (let k = maxHarm + 1; k <= TABLE_SIZE - maxHarm - 1; k++) {
+      wre[k] = 0;
+      wim[k] = 0;
+    }
+    fft(wre, wim, true);
+    if (m === 0) {
+      let peak = 1e-9;
+      for (let i = 0; i < TABLE_SIZE; i++) {
+        peak = Math.max(peak, Math.abs(wre[i]));
+      }
+      scale = 0.92 / peak;
+    }
+    const off = (frame * TABLE_MIPS + m) * TABLE_SIZE;
+    for (let i = 0; i < TABLE_SIZE; i++) {
+      data[off + i] = wre[i] * scale;
+    }
+  }
+}
+
+function generateTable(spec: TableSpec): Wavetable {
+  const re = new Float64Array(TABLE_SIZE);
+  const im = new Float64Array(TABLE_SIZE);
+  const wre = new Float64Array(TABLE_SIZE);
+  const wim = new Float64Array(TABLE_SIZE);
+  const tmp = new Float64Array(TABLE_SIZE);
+  const data = new Float32Array(TABLE_FRAMES * TABLE_MIPS * TABLE_SIZE);
+
+  for (let f = 0; f < TABLE_FRAMES; f++) {
+    const t = f / (TABLE_FRAMES - 1);
+    re.fill(0);
+    im.fill(0);
+    if (spec.spectrum) {
+      spec.spectrum(t, re, im);
+    } else {
+      spec.wave!(t, tmp);
+      for (let i = 0; i < TABLE_SIZE; i++) {
+        re[i] = tmp[i];
+        im[i] = 0;
+      }
+      fft(re, im, false);
+    }
+    // Kill DC and Nyquist before band-limiting.
+    re[0] = 0;
+    im[0] = 0;
+    re[TABLE_SIZE / 2] = 0;
+    im[TABLE_SIZE / 2] = 0;
+    bandlimitFrame(re, im, data, f, wre, wim);
+  }
+  return {
+    name: spec.name,
+    frames: TABLE_FRAMES,
+    mips: TABLE_MIPS,
+    size: TABLE_SIZE,
+    data
+  };
+}
+
+const cache = new Map<TableName, Wavetable>();
+
+/**
+ * The named table, built on first use. Each is ~1.4 MB, so only the tables a
+ * render actually touches are ever generated.
+ */
+export function getWavetable(name: TableName): Wavetable {
+  const cached = cache.get(name);
+  if (cached) return cached;
+  const spec = SPECS.find((s) => s.name === name) ?? SPECS[0];
+  const table = generateTable(spec);
+  cache.set(spec.name, table);
+  return table;
+}
+
+/** Every table name, tonal first. */
+export const ALL_TABLE_NAMES: readonly TableName[] = [
+  ...WAVETABLE_NAMES,
+  ...DRUM_TABLE_NAMES
+];

--- a/packages/timeline/src/midi/engines/wt1.ts
+++ b/packages/timeline/src/midi/engines/wt1.ts
@@ -1,0 +1,138 @@
+/**
+ * WT-1 — the wavetable voice, ported from FableSynth's `src/engine/worklet.js`
+ * (github.com/georgi/fablesynth).
+ *
+ * Two morphing wavetable oscillators plus a sub and noise, through the anti-
+ * aliased drive and the Cytomic filter, with the mod envelope sweeping the
+ * cutoff and the amp envelope shaping the note. Polyphonic: one voice per note,
+ * summed.
+ *
+ * Not ported: the plugin's stereo field (pan, unison spread), its second filter
+ * and routing modes, its LFOs and mod matrix, and the master FX rack. This
+ * renderer is mono and offline, and a track's effects live on the track.
+ */
+
+import type { WavetableMidiInstrument, WavetableOscillator } from "../../types.js";
+import {
+  Adsr,
+  AdaaDrive,
+  ColouredNoise,
+  Rng,
+  StateVariableFilter,
+  TableOscillator,
+  pitchHz
+} from "./dsp.js";
+
+/** One note being played by the voice. */
+export interface WavetableVoiceEvent {
+  pitch: number;
+  velocity: number;
+  startFrame: number;
+  gateOffFrame: number;
+}
+
+function makeOsc(
+  spec: WavetableOscillator,
+  index: number
+): TableOscillator | null {
+  if (spec.level <= 1e-4) return null;
+  // Oscillator B starts a third of a cycle in, so a two-osc patch on the same
+  // table is not one oscillator at twice the level.
+  return new TableOscillator(
+    spec.table,
+    spec.unison,
+    spec.detune,
+    index * 0.31
+  );
+}
+
+function oscPitch(spec: WavetableOscillator, pitch: number): number {
+  return pitch + spec.semitones + spec.fine / 100;
+}
+
+/**
+ * Render one WT-1 note into `out`, starting at `event.startFrame` and stopping
+ * when the amp envelope closes or the buffer ends.
+ *
+ * Returns true if the voice was still sounding at the last frame, so the caller
+ * knows the buffer needs its anti-click ramp.
+ */
+export function renderWavetableVoice(
+  out: Float32Array,
+  event: WavetableVoiceEvent,
+  instrument: WavetableMidiInstrument,
+  sampleRate: number
+): boolean {
+  const startFrame = Math.max(0, event.startFrame);
+  if (startFrame >= out.length) return false;
+
+  const oscA = makeOsc(instrument.oscA, 0);
+  const oscB = makeOsc(instrument.oscB, 1);
+  const ampEnv = new Adsr(instrument.ampEnv, sampleRate);
+  const modEnv = new Adsr(instrument.modEnv, sampleRate);
+  const filter = new StateVariableFilter();
+  const drive = new AdaaDrive();
+  // Seeded from the note, so the same clip renders the same noise every time.
+  const noise =
+    instrument.noiseLevel > 1e-4
+      ? new ColouredNoise(
+          new Rng(0x9e3779b9 ^ (event.pitch * 2654435761 + startFrame)),
+          1,
+          sampleRate
+        )
+      : null;
+
+  const hzA = pitchHz(oscPitch(instrument.oscA, event.pitch));
+  const hzB = pitchHz(oscPitch(instrument.oscB, event.pitch));
+  const subHz = pitchHz(event.pitch + 12 * instrument.subOctave);
+  const subInc = subHz / sampleRate;
+  let subPhase = 0;
+
+  // Velocity shapes the level the way the plugin does — squared, with a floor
+  // so a quiet note is quiet rather than absent.
+  const velocity = event.velocity / 127;
+  const amplitude = 0.25 + 0.75 * velocity * velocity;
+  const levelA = instrument.oscA.level * instrument.oscA.level;
+  const levelB = instrument.oscB.level * instrument.oscB.level;
+  const subGain = instrument.subLevel * instrument.subLevel;
+  const noiseGain = instrument.noiseLevel * instrument.noiseLevel * 0.35;
+  const keyOffset = (instrument.keyTrack * (event.pitch - 60)) / 12;
+
+  for (let frame = startFrame; frame < out.length; frame++) {
+    const level = ampEnv.step(frame < event.gateOffFrame);
+    if (ampEnv.stage === "done") return false;
+    const mod = modEnv.step(frame < event.gateOffFrame);
+
+    let sample = 0;
+    if (oscA) {
+      sample += oscA.next(hzA, instrument.oscA.position, sampleRate) * levelA;
+    }
+    if (oscB) {
+      sample += oscB.next(hzB, instrument.oscB.position, sampleRate) * levelB;
+    }
+    if (subGain > 0) {
+      sample += Math.sin(2 * Math.PI * subPhase) * subGain;
+      subPhase += subInc;
+      if (subPhase >= 1) subPhase -= 1;
+    }
+    if (noise) {
+      sample += noise.next() * noiseGain;
+    }
+
+    const cutoff =
+      instrument.cutoffHz *
+      Math.pow(2, instrument.filterEnvAmount * mod + keyOffset);
+    const driven = drive.process(sample * 0.5, instrument.drive);
+    out[frame] +=
+      filter.process(
+        driven,
+        instrument.filterType,
+        cutoff,
+        instrument.resonance,
+        sampleRate
+      ) *
+      level *
+      amplitude;
+  }
+  return true;
+}

--- a/packages/timeline/src/midi/index.ts
+++ b/packages/timeline/src/midi/index.ts
@@ -15,5 +15,6 @@ export * from "./presets.js";
 export * from "./grid.js";
 export * from "./instrument.js";
 export * from "./voice.js";
+export * from "./engines/index.js";
 export * from "./cacheKey.js";
 export * from "./wav.js";

--- a/packages/timeline/src/midi/instrument.ts
+++ b/packages/timeline/src/midi/instrument.ts
@@ -2,16 +2,20 @@
  * The track's voice, and a stable name for it.
  *
  * `instrumentSignature` names every field the renderer reads, so a cache key
- * built from it cannot hand back audio rendered with a different filter. A
- * field added to the instrument must be added here in the same change —
- * `tests/midi.cacheKey.test.ts` walks the object's own keys to catch that.
+ * built from it cannot hand back audio rendered with a different filter. It
+ * walks the object rather than listing fields, because the FableSynth voices
+ * (WT-1, BL-1, DR-1) carry nested oscillators, envelopes and pads — a
+ * hand-written list would go stale on the first field added to one of them.
  */
 
-import type { MidiInstrument } from "../types.js";
+import type { MidiInstrument, SubtractiveMidiInstrument } from "../types.js";
 
-/** A plain saw with a soft filter — what a midi track plays until told
- * otherwise. */
-export const DEFAULT_MIDI_INSTRUMENT: MidiInstrument = {
+/**
+ * A plain saw with a soft filter — what a midi track plays until told
+ * otherwise. Typed as the subtractive synth rather than the union, so a caller
+ * can spread it and change `waveform` without narrowing first.
+ */
+export const DEFAULT_MIDI_INSTRUMENT: SubtractiveMidiInstrument = {
   type: "subtractive",
   waveform: "saw",
   attackMs: 5,
@@ -23,17 +27,58 @@ export const DEFAULT_MIDI_INSTRUMENT: MidiInstrument = {
   gainDb: -6
 };
 
+/**
+ * A value as one string, with object keys in sorted order so two instruments
+ * that differ only in how they were built hash the same.
+ */
+function stableString(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableString).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => v !== undefined)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    return `{${entries.map(([k, v]) => `${k}:${stableString(v)}`).join(",")}}`;
+  }
+  return String(value);
+}
+
 /** Every sound-affecting field of an instrument, in one stable string. */
 export function instrumentSignature(instrument: MidiInstrument): string {
-  return [
-    instrument.type,
-    instrument.waveform,
-    instrument.attackMs,
-    instrument.decayMs,
-    instrument.sustain,
-    instrument.releaseMs,
-    instrument.cutoffHz,
-    instrument.resonance,
-    instrument.gainDb
-  ].join("|");
+  return stableString(instrument);
+}
+
+/** Middle C — the note an audition plays when the voice is a pitched one. */
+export const AUDITION_PITCH = 60;
+
+/**
+ * The note to audition a voice with. A drum kit answers only to its own pads,
+ * so middle C would preview it as silence; every other voice takes middle C.
+ */
+export function auditionPitch(instrument: MidiInstrument): number {
+  return instrument.type === "drum" ? instrument.baseNote : AUDITION_PITCH;
+}
+
+/**
+ * How long a note rings on past its gate, in ms — the release of whichever
+ * envelope ends last. An audition adds this to the note so the tail is heard
+ * rather than cut.
+ */
+export function instrumentTailMs(instrument: MidiInstrument): number {
+  switch (instrument.type) {
+    case "subtractive":
+      return instrument.releaseMs;
+    case "wavetable":
+      return Math.max(instrument.ampEnv.releaseMs, instrument.modEnv.releaseMs);
+    case "bass":
+      return instrument.ampEnv.releaseMs;
+    case "drum":
+      // A drum is a one-shot: its whole envelope plays past the gate.
+      return instrument.pads.reduce(
+        (longest, pad) =>
+          Math.max(longest, pad.attackMs + pad.holdMs + pad.decayMs),
+        0
+      );
+  }
 }

--- a/packages/timeline/src/midi/presets.ts
+++ b/packages/timeline/src/midi/presets.ts
@@ -1,12 +1,18 @@
 /**
- * Named voices a caller can pick instead of spelling out nine synth fields.
+ * Named voices a caller can pick instead of spelling out a synth's fields.
  *
  * A preset is the instrument, not a reference to one: `set_track_instrument`
  * resolves `{ preset }` to the object below and stores that on the track, so a
  * document keeps playing the same sound after this table changes.
  */
 
-import type { MidiInstrument } from "../types.js";
+import type {
+  BassMidiInstrument,
+  MidiInstrument,
+  WavetableMidiInstrument,
+  WavetableOscillator
+} from "../types.js";
+import { TR_VOID_KIT } from "./engines/kits.js";
 import { instrumentSignature } from "./instrument.js";
 
 export interface MidiInstrumentPreset {
@@ -14,6 +20,65 @@ export interface MidiInstrumentPreset {
   name: string;
   instrument: MidiInstrument;
 }
+
+/** A WT-1 oscillator with the fields a preset does not bother to state. */
+const osc = (over: Partial<WavetableOscillator>): WavetableOscillator => ({
+  table: "prime",
+  position: 0.3,
+  semitones: 0,
+  fine: 0,
+  level: 0.8,
+  unison: 1,
+  detune: 0.2,
+  ...over
+});
+
+/** A WT-1 patch, with the plugin's defaults filled in around it. */
+const wavetable = (
+  over: Partial<WavetableMidiInstrument>
+): WavetableMidiInstrument => ({
+  type: "wavetable",
+  oscA: osc({}),
+  oscB: osc({ level: 0 }),
+  subLevel: 0,
+  subOctave: -1,
+  noiseLevel: 0,
+  filterType: "lp24",
+  cutoffHz: 2200,
+  resonance: 0.35,
+  drive: 0.15,
+  filterEnvAmount: 1.5,
+  keyTrack: 0.3,
+  ampEnv: { attackMs: 5, decayMs: 200, sustain: 0.7, releaseMs: 250 },
+  modEnv: { attackMs: 2, decayMs: 320, sustain: 0, releaseMs: 200 },
+  gainDb: -8,
+  ...over
+});
+
+/** A BL-1 patch, with the plugin's defaults filled in around it. */
+const bass = (over: Partial<BassMidiInstrument>): BassMidiInstrument => ({
+  type: "bass",
+  table: "prime",
+  position: 0.3,
+  semitones: 0,
+  subShape: "square",
+  subOctave: -1,
+  subLevel: 0.55,
+  filterType: "lp24",
+  cutoffHz: 340,
+  resonance: 0.62,
+  drive: 0.45,
+  filterEnvAmount: 2.8,
+  keyTrack: 0.3,
+  filterAttackMs: 1,
+  filterDecayMs: 180,
+  ampEnv: { attackMs: 1, decayMs: 300, sustain: 0.5, releaseMs: 80 },
+  accentAmount: 0.7,
+  accentVelocity: 100,
+  slideMs: 60,
+  gainDb: -6,
+  ...over
+});
 
 /**
  * The shipped voices. `saw-lead` is spelled out rather than aliased to
@@ -110,6 +175,112 @@ export const MIDI_INSTRUMENT_PRESETS: readonly MidiInstrumentPreset[] = [
       cutoffHz: 6000,
       resonance: 0.5,
       gainDb: -7
+    }
+  },
+  {
+    id: "wt1-prime-lead",
+    name: "WT-1 Prime Lead",
+    instrument: wavetable({
+      oscA: osc({ table: "prime", position: 0.55, unison: 3, detune: 0.18 }),
+      oscB: osc({ table: "pulse", position: 0.4, semitones: -12, level: 0.5 }),
+      cutoffHz: 3200,
+      resonance: 0.4,
+      filterEnvAmount: 1.2,
+      ampEnv: { attackMs: 4, decayMs: 180, sustain: 0.75, releaseMs: 220 }
+    })
+  },
+  {
+    id: "wt1-bloom-pad",
+    name: "WT-1 Bloom Pad",
+    instrument: wavetable({
+      oscA: osc({ table: "bloom", position: 0.35, unison: 5, detune: 0.35 }),
+      oscB: osc({ table: "vox", position: 0.5, fine: 7, level: 0.55 }),
+      subLevel: 0.25,
+      cutoffHz: 1400,
+      resonance: 0.25,
+      drive: 0.08,
+      filterEnvAmount: 2,
+      ampEnv: { attackMs: 600, decayMs: 900, sustain: 0.85, releaseMs: 1400 },
+      modEnv: { attackMs: 900, decayMs: 1600, sustain: 0.4, releaseMs: 1200 },
+      gainDb: -11
+    })
+  },
+  {
+    id: "wt1-vox-morph",
+    name: "WT-1 Vox Morph",
+    instrument: wavetable({
+      oscA: osc({ table: "vox", position: 0.25, unison: 2, detune: 0.12 }),
+      oscB: osc({ table: "glitch", position: 0.6, level: 0.35 }),
+      noiseLevel: 0.12,
+      filterType: "bp12",
+      cutoffHz: 900,
+      resonance: 0.55,
+      filterEnvAmount: 2.4,
+      ampEnv: { attackMs: 40, decayMs: 400, sustain: 0.6, releaseMs: 400 }
+    })
+  },
+  {
+    id: "wt1-chime-bell",
+    name: "WT-1 Chime",
+    instrument: wavetable({
+      oscA: osc({ table: "chime", position: 0.7, detune: 0 }),
+      oscB: osc({ table: "chime", position: 0.2, semitones: 12, level: 0.4 }),
+      cutoffHz: 6000,
+      resonance: 0.2,
+      drive: 0,
+      filterEnvAmount: 0.6,
+      ampEnv: { attackMs: 2, decayMs: 1200, sustain: 0, releaseMs: 900 },
+      modEnv: { attackMs: 1, decayMs: 600, sustain: 0, releaseMs: 400 },
+      gainDb: -9
+    })
+  },
+  {
+    id: "bl1-acid",
+    name: "BL-1 Acid",
+    instrument: bass({})
+  },
+  {
+    id: "bl1-deep",
+    name: "BL-1 Deep",
+    instrument: bass({
+      table: "pulse",
+      position: 0.15,
+      subLevel: 0.75,
+      cutoffHz: 220,
+      resonance: 0.4,
+      drive: 0.25,
+      filterEnvAmount: 1.8,
+      filterDecayMs: 320,
+      ampEnv: { attackMs: 3, decayMs: 500, sustain: 0.7, releaseMs: 140 },
+      slideMs: 90
+    })
+  },
+  {
+    id: "bl1-rubber",
+    name: "BL-1 Rubber",
+    instrument: bass({
+      table: "bloom",
+      position: 0.5,
+      subShape: "sine",
+      subLevel: 0.45,
+      filterType: "lp12",
+      cutoffHz: 480,
+      resonance: 0.78,
+      drive: 0.6,
+      filterEnvAmount: 3.2,
+      filterDecayMs: 120,
+      accentAmount: 0.85,
+      slideMs: 45
+    })
+  },
+  {
+    id: "dr1-tr-void",
+    name: "DR-1 TR-Void Kit",
+    instrument: {
+      type: "drum",
+      baseNote: 36,
+      pads: [...TR_VOID_KIT],
+      gainDb: -6
     }
   }
 ];

--- a/packages/timeline/src/midi/voice.ts
+++ b/packages/timeline/src/midi/voice.ts
@@ -11,7 +11,15 @@
  * velocity 127 stay inside [-1, 1] instead of wrapping.
  */
 
-import type { MidiInstrument, TimelineClip } from "../types.js";
+import type {
+  MidiInstrument,
+  SubtractiveMidiInstrument,
+  TimelineClip
+} from "../types.js";
+import { instrumentTailMs } from "./instrument.js";
+import { renderBassVoices } from "./engines/bl1.js";
+import { renderDrumVoice } from "./engines/dr1.js";
+import { renderWavetableVoice } from "./engines/wt1.js";
 import { visibleNotes } from "./notes.js";
 import { noteWindowMs } from "./ticks.js";
 
@@ -76,7 +84,7 @@ export function sineWave(phase: number): number {
 }
 
 function oscillator(
-  waveform: MidiInstrument["waveform"],
+  waveform: SubtractiveMidiInstrument["waveform"],
   phase: number,
   dt: number
 ): number {
@@ -119,7 +127,7 @@ export interface EnvelopeState {
  * a NaN.
  */
 export function createEnvelope(
-  instrument: MidiInstrument,
+  instrument: SubtractiveMidiInstrument,
   sampleRate: number
 ): EnvelopeState {
   const perSample = (ms: number, span: number) =>
@@ -285,17 +293,50 @@ export interface VoiceEvent {
 }
 
 /**
+ * Apply the master gain, soft-limit the sum, and ramp out a tail that was still
+ * sounding at the last frame so the cut does not click.
+ *
+ * Every engine finishes this way, so a buffer's ending does not depend on which
+ * instrument filled it.
+ */
+function finishBuffer(
+  out: Float32Array,
+  gainDb: number,
+  soundingAtEnd: boolean,
+  sampleRate: number
+): Float32Array {
+  const masterGain = Math.pow(10, gainDb / 20);
+  for (let frame = 0; frame < out.length; frame++) {
+    out[frame] = softLimit(out[frame] * masterGain);
+  }
+  if (soundingAtEnd) {
+    const rampFrames = Math.min(
+      out.length,
+      Math.round((MIDI_END_RAMP_MS / 1000) * sampleRate)
+    );
+    for (let i = 0; i < rampFrames; i++) {
+      const frame = out.length - rampFrames + i;
+      out[frame] *= 1 - (i + 1) / rampFrames;
+    }
+  }
+  return out;
+}
+
+/**
  * Sum a set of voices into a buffer of exactly `totalFrames` frames.
  *
  * Everything past the buffer is discarded, release tail included: the window
  * is the contract, so a clip's audio is the same length whatever its notes do.
  * When a voice is still sounding at the last frame the tail is ramped to zero
  * over `MIDI_END_RAMP_MS` so the cut does not click.
+ *
+ * This is the built-in subtractive voice. `renderInstrumentEvents` picks it or
+ * one of the FableSynth engines from the instrument's `type`.
  */
 export function renderVoiceEvents(
   events: ReadonlyArray<VoiceEvent>,
   totalFrames: number,
-  instrument: MidiInstrument,
+  instrument: SubtractiveMidiInstrument,
   sampleRate: number
 ): Float32Array {
   const out = new Float32Array(Math.max(0, totalFrames));
@@ -306,7 +347,6 @@ export function renderVoiceEvents(
     instrument.cutoffHz,
     instrument.resonance
   );
-  const masterGain = Math.pow(10, instrument.gainDb / 20);
   let soundingAtEnd = false;
 
   for (const event of events) {
@@ -329,22 +369,50 @@ export function renderVoiceEvents(
     if (envelope.stage !== "done") soundingAtEnd = true;
   }
 
-  for (let frame = 0; frame < out.length; frame++) {
-    out[frame] = softLimit(out[frame] * masterGain);
+  return finishBuffer(out, instrument.gainDb, soundingAtEnd, sampleRate);
+}
+
+/**
+ * Render a set of note events with whichever engine the instrument names.
+ *
+ * The events are the same for every engine — pitch, velocity, and the frames
+ * the note sounds between — so a clip switched from one instrument to another
+ * plays the same phrase.
+ */
+export function renderInstrumentEvents(
+  events: ReadonlyArray<VoiceEvent>,
+  totalFrames: number,
+  instrument: MidiInstrument,
+  sampleRate: number
+): Float32Array {
+  if (instrument.type === "subtractive") {
+    return renderVoiceEvents(events, totalFrames, instrument, sampleRate);
+  }
+  const out = new Float32Array(Math.max(0, totalFrames));
+  if (out.length === 0) return out;
+  let soundingAtEnd = false;
+
+  switch (instrument.type) {
+    case "wavetable":
+      for (const event of events) {
+        if (renderWavetableVoice(out, event, instrument, sampleRate)) {
+          soundingAtEnd = true;
+        }
+      }
+      break;
+    case "bass":
+      soundingAtEnd = renderBassVoices(out, events, instrument, sampleRate);
+      break;
+    case "drum":
+      for (const event of events) {
+        if (renderDrumVoice(out, event, instrument, sampleRate)) {
+          soundingAtEnd = true;
+        }
+      }
+      break;
   }
 
-  if (soundingAtEnd) {
-    const rampFrames = Math.min(
-      out.length,
-      Math.round((MIDI_END_RAMP_MS / 1000) * sampleRate)
-    );
-    for (let i = 0; i < rampFrames; i++) {
-      const frame = out.length - rampFrames + i;
-      out[frame] *= 1 - (i + 1) / rampFrames;
-    }
-  }
-
-  return out;
+  return finishBuffer(out, instrument.gainDb, soundingAtEnd, sampleRate);
 }
 
 export interface RenderMidiClipInput {
@@ -386,7 +454,7 @@ export function renderMidiClip(input: RenderMidiClipInput): Float32Array {
     };
   });
 
-  return renderVoiceEvents(events, totalFrames, instrument, sampleRate);
+  return renderInstrumentEvents(events, totalFrames, instrument, sampleRate);
 }
 
 export interface RenderAuditionNoteInput {
@@ -407,10 +475,10 @@ export function renderAuditionNote(
 ): Float32Array {
   const { pitch, velocity, durationMs, instrument, sampleRate } = input;
   const totalFrames = Math.round(
-    ((durationMs + instrument.releaseMs) / 1000) * sampleRate
+    ((durationMs + instrumentTailMs(instrument)) / 1000) * sampleRate
   );
   const gateOffFrame = Math.round((durationMs / 1000) * sampleRate);
-  return renderVoiceEvents(
+  return renderInstrumentEvents(
     [
       {
         pitch,

--- a/packages/timeline/src/types.ts
+++ b/packages/timeline/src/types.ts
@@ -538,7 +538,18 @@ export interface MidiNote {
 
 /** The synth a midi track plays. One member today; a union so adding a second
  * synth does not reshape what is already stored. */
-export type MidiInstrument = SubtractiveMidiInstrument;
+/**
+ * The voice a midi track plays.
+ *
+ * `subtractive` is the built-in synth. The other three are ports of the
+ * FableSynth instruments (github.com/georgi/fablesynth): WT-1 the wavetable
+ * synth, BL-1 the acid bassline, DR-1 the drum machine.
+ */
+export type MidiInstrument =
+  | SubtractiveMidiInstrument
+  | WavetableMidiInstrument
+  | BassMidiInstrument
+  | DrumMidiInstrument;
 
 /** One oscillator through a lowpass filter and an ADSR envelope. */
 export interface SubtractiveMidiInstrument {
@@ -552,6 +563,176 @@ export interface SubtractiveMidiInstrument {
   cutoffHz: number;
   /** Lowpass Q. */
   resonance: number;
+  gainDb: number;
+}
+
+/** An ADSR envelope, in milliseconds with a 0..1 sustain level. */
+export interface MidiEnvelope {
+  attackMs: number;
+  decayMs: number;
+  /** Sustain level, 0..1 of the peak. */
+  sustain: number;
+  releaseMs: number;
+}
+
+/** The filter shapes the FableSynth-derived voices offer. */
+export type MidiFilterType = "lp12" | "lp24" | "bp12" | "hp12" | "notch";
+
+/** The tonal wavetables WT-1 and BL-1 play. */
+export type MidiWavetableName =
+  | "prime"
+  | "bloom"
+  | "pulse"
+  | "vox"
+  | "chime"
+  | "glitch";
+
+/** DR-1's percussive tables. A pad can also play any tonal table. */
+export type MidiDrumTableName = "thud" | "crack" | "tine" | "grit";
+
+/** One of WT-1's two wavetable oscillators. */
+export interface WavetableOscillator {
+  table: MidiWavetableName;
+  /** Morph position across the table's frames, 0..1. */
+  position: number;
+  /** Offset from the played note, in semitones. */
+  semitones: number;
+  /** Further offset in cents. */
+  fine: number;
+  /** Output level, 0..1. */
+  level: number;
+  /** Detuned copies of the oscillator, 1..7. */
+  unison: number;
+  /** How far the copies spread, 0..1 (1 = ±50 cents). */
+  detune: number;
+}
+
+/**
+ * FableSynth WT-1 — two morphing wavetable oscillators, a sub and noise, into
+ * one zero-delay filter swept by a second envelope.
+ */
+export interface WavetableMidiInstrument {
+  type: "wavetable";
+  oscA: WavetableOscillator;
+  oscB: WavetableOscillator;
+  /** Sine sub-oscillator level, 0..1. */
+  subLevel: number;
+  /** Sub octave below the note: -1 or -2. */
+  subOctave: number;
+  /** White noise level, 0..1. */
+  noiseLevel: number;
+  filterType: MidiFilterType;
+  cutoffHz: number;
+  /** Filter resonance, 0..1. */
+  resonance: number;
+  /** Anti-aliased tanh drive into the filter, 0..1. */
+  drive: number;
+  /** How far the mod envelope sweeps the cutoff, in octaves (may be negative). */
+  filterEnvAmount: number;
+  /** How far the played note tracks the cutoff, 0..1 (1 = one octave/octave). */
+  keyTrack: number;
+  ampEnv: MidiEnvelope;
+  modEnv: MidiEnvelope;
+  gainDb: number;
+}
+
+/**
+ * FableSynth BL-1 — a monophonic acid bassline: one wavetable oscillator and a
+ * square sub through a resonant filter with its own decay envelope, plus the
+ * accent and slide a 303 line is written with.
+ */
+export interface BassMidiInstrument {
+  type: "bass";
+  table: MidiWavetableName;
+  /** Morph position across the table's frames, 0..1. */
+  position: number;
+  /** Offset from the played note, in semitones. */
+  semitones: number;
+  /** Sub-oscillator shape. */
+  subShape: "sine" | "square";
+  /** Sub octave below the note: -1 or -2. */
+  subOctave: number;
+  /** Sub level, 0..1. */
+  subLevel: number;
+  filterType: MidiFilterType;
+  cutoffHz: number;
+  /** Filter resonance, 0..1. */
+  resonance: number;
+  /** Anti-aliased tanh drive into the filter, 0..1. */
+  drive: number;
+  /** How far the filter envelope sweeps the cutoff, in octaves. */
+  filterEnvAmount: number;
+  /** How far the played note tracks the cutoff, 0..1. */
+  keyTrack: number;
+  /** Filter envelope attack in ms. */
+  filterAttackMs: number;
+  /** Filter envelope decay in ms. */
+  filterDecayMs: number;
+  ampEnv: MidiEnvelope;
+  /**
+   * How much an accented note (velocity at or above `accentVelocity`) adds:
+   * 0..1 scales both its level and its filter sweep.
+   */
+  accentAmount: number;
+  /** The velocity at which a note counts as accented. */
+  accentVelocity: number;
+  /** How long a note overlapping the one before it glides, in ms. */
+  slideMs: number;
+  gainDb: number;
+}
+
+/** One DR-1 pad: a tuned one-shot with its own envelope and filter. */
+export interface DrumPad {
+  /** What the pad plays, shown in the editor. */
+  name: string;
+  table: MidiWavetableName | MidiDrumTableName;
+  /** Morph position across the table's frames, 0..1. */
+  position: number;
+  /** Pitch offset from the pad's base note, in semitones. */
+  semitones: number;
+  /** How far the pitch envelope starts above the pad's pitch, in semitones. */
+  pitchEnvAmount: number;
+  /** Pitch envelope decay in ms. */
+  pitchEnvDecayMs: number;
+  /** Noise level, 0..1. */
+  noiseLevel: number;
+  /** Noise colour, -1 (dark) to 1 (bright). */
+  noiseColor: number;
+  /** Ring-modulator carrier in Hz. */
+  ringHz: number;
+  /** How much of the ring modulator is heard, 0..1. */
+  ringMix: number;
+  /** Amp envelope attack in ms. */
+  attackMs: number;
+  /** How long the envelope holds at full before decaying, in ms. */
+  holdMs: number;
+  /** Amp envelope decay in ms. */
+  decayMs: number;
+  /** Decay shape, 0 (a straight line) to 1 (exponential). */
+  curve: number;
+  /** The pad's filter, or null for no filter. */
+  filter: {
+    type: MidiFilterType;
+    cutoffHz: number;
+    /** Filter resonance, 0..1. */
+    resonance: number;
+  } | null;
+  /** Pad level, 0..1. */
+  level: number;
+  /** How much velocity scales the level, 0..1. */
+  velocityToLevel: number;
+}
+
+/**
+ * FableSynth DR-1 — sixteen pads, played from `baseNote` upward, one per MIDI
+ * note. A note outside that range is silent rather than transposed: a pad is a
+ * drum sound, not a pitch.
+ */
+export interface DrumMidiInstrument {
+  type: "drum";
+  /** The MIDI note pad 0 answers to. Pads run `baseNote`..`baseNote + 15`. */
+  baseNote: number;
+  pads: DrumPad[];
   gainDb: number;
 }
 

--- a/packages/timeline/tests/midi.engines.test.ts
+++ b/packages/timeline/tests/midi.engines.test.ts
@@ -1,0 +1,398 @@
+/**
+ * The FableSynth instruments: WT-1, BL-1 and DR-1.
+ *
+ * The interesting claims are the ones a listener would make — a wavetable note
+ * does not alias, a bassline is monophonic and slides, a drum pad answers to
+ * one note and no other — so the assertions measure the rendered samples rather
+ * than the parameters that went in.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  fft,
+  getWavetable,
+  TABLE_FRAMES,
+  TABLE_MIPS,
+  TABLE_SIZE
+} from "../src/midi/engines/wavetables.js";
+import { renderAuditionNote, renderInstrumentEvents } from "../src/midi/voice.js";
+import { findInstrumentPreset } from "../src/midi/presets.js";
+import { instrumentSignature, instrumentTailMs } from "../src/midi/instrument.js";
+import { midiRenderKey } from "../src/midi/cacheKey.js";
+import type {
+  BassMidiInstrument,
+  DrumMidiInstrument,
+  MidiInstrument,
+  WavetableMidiInstrument
+} from "../src/types.js";
+
+const SAMPLE_RATE = 48000;
+/** Frames the spectrum tests analyze. */
+const ANALYSIS_SIZE = 8192;
+
+const preset = (id: string): MidiInstrument => {
+  const found = findInstrumentPreset(id);
+  if (!found) throw new Error(`missing preset ${id}`);
+  return found.instrument;
+};
+
+const wt1 = preset("wt1-prime-lead") as WavetableMidiInstrument;
+const bl1 = preset("bl1-acid") as BassMidiInstrument;
+const dr1 = preset("dr1-tr-void") as DrumMidiInstrument;
+
+const ms = (value: number) => Math.round((value / 1000) * SAMPLE_RATE);
+
+const note = (
+  pitch: number,
+  velocity: number,
+  startMs: number,
+  lengthMs: number
+) => ({
+  pitch,
+  velocity,
+  startFrame: ms(startMs),
+  gateOffFrame: ms(startMs + lengthMs)
+});
+
+const peak = (buffer: Float32Array, from = 0, to = buffer.length): number => {
+  let highest = 0;
+  for (let i = from; i < Math.min(to, buffer.length); i++) {
+    highest = Math.max(highest, Math.abs(buffer[i]));
+  }
+  return highest;
+};
+
+/**
+ * How bright a buffer is: the size of its sample-to-sample change against its
+ * own level. A crude derivative, but enough to say which of two renders let
+ * more high end through.
+ */
+const brightness = (buffer: Float32Array, from = 0, to = buffer.length): number => {
+  const level = rms(buffer, from, to);
+  if (level <= 0) return 0;
+  let sum = 0;
+  let count = 0;
+  for (let i = Math.max(1, from); i < Math.min(to, buffer.length); i++) {
+    const d = buffer[i] - buffer[i - 1];
+    sum += d * d;
+    count++;
+  }
+  return count > 0 ? Math.sqrt(sum / count) / level : 0;
+};
+
+const rms = (buffer: Float32Array, from = 0, to = buffer.length): number => {
+  let sum = 0;
+  let count = 0;
+  for (let i = from; i < Math.min(to, buffer.length); i++) {
+    sum += buffer[i] * buffer[i];
+    count++;
+  }
+  return count > 0 ? Math.sqrt(sum / count) : 0;
+};
+
+/**
+ * The loudest content that is not within four bins of a harmonic of
+ * `fundamental`, in dB below the loudest partial.
+ *
+ * The window is a 4-term Blackman-Harris: its sidelobes are 90 dB down, so what
+ * this reads is the signal's own foldover rather than the analysis leakage a
+ * Hann window would leave 31 dB down.
+ */
+const worstOffHarmonicDb = (
+  buffer: Float32Array,
+  fundamental: number
+): number => {
+  const size = ANALYSIS_SIZE;
+  const re = new Float64Array(size);
+  const im = new Float64Array(size);
+  for (let i = 0; i < size; i++) {
+    const x = (2 * Math.PI * i) / size;
+    const w =
+      0.35875 -
+      0.48829 * Math.cos(x) +
+      0.14128 * Math.cos(2 * x) -
+      0.01168 * Math.cos(3 * x);
+    re[i] = (buffer[i] ?? 0) * w;
+  }
+  fft(re, im, false);
+
+  const binHz = SAMPLE_RATE / size;
+  let loudest = 0;
+  let worst = 0;
+  for (let k = 1; k < size / 2; k++) {
+    const magnitude = Math.hypot(re[k], im[k]);
+    loudest = Math.max(loudest, magnitude);
+    const hz = k * binHz;
+    const harmonic = Math.round(hz / fundamental);
+    if (harmonic >= 1 && Math.abs(hz - harmonic * fundamental) <= 4 * binHz) {
+      continue;
+    }
+    worst = Math.max(worst, magnitude);
+  }
+  return loudest > 0 ? 20 * Math.log10(worst / loudest) : 0;
+};
+
+describe("wavetables", () => {
+  it("builds a table once and normalizes every mip to the same peak", () => {
+    const table = getWavetable("prime");
+    expect(getWavetable("prime")).toBe(table);
+    expect(table.data.length).toBe(TABLE_FRAMES * TABLE_MIPS * TABLE_SIZE);
+    // Frame 0 of PRIME is a sine, so its mip-0 peak is the headroom the
+    // band-limiter normalizes every frame to.
+    expect(peak(table.data, 0, TABLE_SIZE)).toBeCloseTo(0.92, 2);
+    // Coarser mips share that frame's scale rather than being renormalized —
+    // near it, and never past full scale, whatever Gibbs does to a square.
+    expect(peak(table.data)).toBeLessThan(1);
+  });
+
+  it("keeps only the harmonics a mip level is allowed", () => {
+    const table = getWavetable("prime");
+    // Frame 8 is between saw and square: full of harmonics at mip 0, and mip 5
+    // must hold nothing above harmonic 32.
+    const re = new Float64Array(TABLE_SIZE);
+    const im = new Float64Array(TABLE_SIZE);
+    const off = (8 * TABLE_MIPS + 5) * TABLE_SIZE;
+    for (let i = 0; i < TABLE_SIZE; i++) re[i] = table.data[off + i];
+    fft(re, im, false);
+    let aboveLimit = 0;
+    for (let k = 33; k < TABLE_SIZE / 2; k++) {
+      aboveLimit = Math.max(aboveLimit, Math.hypot(re[k], im[k]));
+    }
+    let fundamental = Math.hypot(re[1], im[1]);
+    expect(fundamental).toBeGreaterThan(0);
+    expect(aboveLimit / fundamental).toBeLessThan(1e-6);
+  });
+});
+
+describe("WT-1", () => {
+  it("renders the same samples every time", () => {
+    const events = [note(60, 100, 0, 400)];
+    const a = renderInstrumentEvents(events, ms(600), wt1, SAMPLE_RATE);
+    const b = renderInstrumentEvents(events, ms(600), wt1, SAMPLE_RATE);
+    expect(peak(a)).toBeGreaterThan(0.01);
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+
+  it("does not alias a high note", () => {
+    // C7 through a saw-shaped frame: every strong partial must land on a
+    // multiple of the fundamental. An aliased partial folds back to a bin that
+    // is not one, which is what `worstOffHarmonicDb` measures — and the naive
+    // saw below is the control that proves it can see one.
+    const bright: WavetableMidiInstrument = {
+      ...wt1,
+      oscA: { ...wt1.oscA, position: 0.7, unison: 1, detune: 0 },
+      oscB: { ...wt1.oscB, level: 0 },
+      cutoffHz: 20000,
+      resonance: 0,
+      drive: 0,
+      filterEnvAmount: 0,
+      keyTrack: 0,
+      ampEnv: { attackMs: 1, decayMs: 1, sustain: 1, releaseMs: 1 },
+      // Quiet enough that the master soft limiter is linear: its own harmonics
+      // would fold back and be read as the oscillator's aliasing.
+      gainDb: -40
+    };
+    const fundamental = 440 * Math.pow(2, (96 - 69) / 12);
+    const rendered = renderInstrumentEvents(
+      [note(96, 100, 0, 400)],
+      ANALYSIS_SIZE + ms(20),
+      bright,
+      SAMPLE_RATE
+    );
+    expect(
+      worstOffHarmonicDb(rendered.subarray(ms(20)), fundamental)
+    ).toBeLessThan(-60);
+
+    const naive = new Float32Array(ANALYSIS_SIZE);
+    let phase = 0;
+    for (let i = 0; i < naive.length; i++) {
+      naive[i] = 2 * phase - 1;
+      phase += fundamental / SAMPLE_RATE;
+      if (phase >= 1) phase -= 1;
+    }
+    expect(worstOffHarmonicDb(naive, fundamental)).toBeGreaterThan(-30);
+  });
+
+  it("sweeps the filter with the mod envelope", () => {
+    const swept: WavetableMidiInstrument = {
+      ...wt1,
+      cutoffHz: 300,
+      filterEnvAmount: 4,
+      modEnv: { attackMs: 1, decayMs: 400, sustain: 0, releaseMs: 50 }
+    };
+    const closed: WavetableMidiInstrument = { ...swept, filterEnvAmount: 0 };
+    const events = [note(48, 100, 0, 500)];
+    const open = renderInstrumentEvents(events, ms(600), swept, SAMPLE_RATE);
+    const dark = renderInstrumentEvents(events, ms(600), closed, SAMPLE_RATE);
+    // While the envelope is up the filter is four octaves higher, so the note
+    // is brighter; once it has decayed both are the same closed filter.
+    expect(brightness(open, 0, ms(100))).toBeGreaterThan(
+      brightness(dark, 0, ms(100)) * 1.5
+    );
+    expect(brightness(open, ms(500), ms(600))).toBeCloseTo(
+      brightness(dark, ms(500), ms(600)),
+      1
+    );
+  });
+});
+
+describe("BL-1", () => {
+  it("plays one note at a time", () => {
+    const upper = renderInstrumentEvents(
+      [note(52, 100, 0, 400)],
+      ms(500),
+      bl1,
+      SAMPLE_RATE
+    );
+    const both = renderInstrumentEvents(
+      [note(40, 100, 0, 400), note(52, 100, 0, 400)],
+      ms(500),
+      bl1,
+      SAMPLE_RATE
+    );
+    // Two notes on the same frame are not a chord: the later pitch takes the
+    // one voice, so the pair renders as that note alone.
+    expect(Array.from(both)).toEqual(Array.from(upper));
+  });
+
+  it("slides into an overlapping note instead of re-attacking", () => {
+    const slow: BassMidiInstrument = {
+      ...bl1,
+      ampEnv: { ...bl1.ampEnv, attackMs: 120, sustain: 0.9 },
+      slideMs: 40
+    };
+    const slid = renderInstrumentEvents(
+      [note(40, 100, 0, 260), note(47, 100, 200, 300)],
+      ms(600),
+      slow,
+      SAMPLE_RATE
+    );
+    const retriggered = renderInstrumentEvents(
+      [note(40, 100, 0, 150), note(47, 100, 200, 300)],
+      ms(600),
+      slow,
+      SAMPLE_RATE
+    );
+    // Right after the second onset the slid line is still at full level; the
+    // retriggered one is climbing its attack from silence.
+    const window: [number, number] = [ms(200), ms(215)];
+    expect(rms(slid, ...window)).toBeGreaterThan(rms(retriggered, ...window) * 3);
+  });
+
+  it("hits harder on an accent", () => {
+    const plain = renderInstrumentEvents(
+      [note(40, 99, 0, 300)],
+      ms(400),
+      bl1,
+      SAMPLE_RATE
+    );
+    const accented = renderInstrumentEvents(
+      [note(40, 127, 0, 300)],
+      ms(400),
+      bl1,
+      SAMPLE_RATE
+    );
+    expect(rms(accented, 0, ms(80))).toBeGreaterThan(rms(plain, 0, ms(80)));
+  });
+});
+
+describe("DR-1", () => {
+  it("answers to one note per pad and nothing outside the kit", () => {
+    const kick = renderInstrumentEvents(
+      [note(36, 100, 0, 20)],
+      ms(600),
+      dr1,
+      SAMPLE_RATE
+    );
+    const hat = renderInstrumentEvents(
+      [note(41, 100, 0, 20)],
+      ms(600),
+      dr1,
+      SAMPLE_RATE
+    );
+    const offKit = renderInstrumentEvents(
+      [note(72, 100, 0, 20)],
+      ms(600),
+      dr1,
+      SAMPLE_RATE
+    );
+    expect(peak(kick)).toBeGreaterThan(0.05);
+    expect(peak(hat)).toBeGreaterThan(0.01);
+    expect(peak(offKit)).toBe(0);
+    // The kick is the low pad and the closed hat the bright one: they are not
+    // the same sound at a different pitch.
+    expect(rms(kick, 0, ms(200))).toBeGreaterThan(rms(hat, 0, ms(200)));
+  });
+
+  it("rings for its own decay, not the note's length", () => {
+    // A one-tick note still gets the kick's full 300 ms decay.
+    const rendered = renderInstrumentEvents(
+      [note(36, 110, 0, 5)],
+      ms(600),
+      dr1,
+      SAMPLE_RATE
+    );
+    expect(peak(rendered, ms(150), ms(250))).toBeGreaterThan(0.01);
+    expect(peak(rendered, ms(400), ms(600))).toBe(0);
+  });
+
+  it("scales a hit with velocity", () => {
+    const soft = renderInstrumentEvents(
+      [note(36, 40, 0, 20)],
+      ms(400),
+      dr1,
+      SAMPLE_RATE
+    );
+    const hard = renderInstrumentEvents(
+      [note(36, 127, 0, 20)],
+      ms(400),
+      dr1,
+      SAMPLE_RATE
+    );
+    expect(peak(hard)).toBeGreaterThan(peak(soft) * 1.2);
+  });
+});
+
+describe("instrument identity", () => {
+  it("reads a nested field into the signature and the render key", () => {
+    const moved: DrumMidiInstrument = {
+      ...dr1,
+      pads: dr1.pads.map((pad, i) =>
+        i === 0 ? { ...pad, decayMs: pad.decayMs + 1 } : pad
+      )
+    };
+    expect(instrumentSignature(moved)).not.toBe(instrumentSignature(dr1));
+
+    const clip = {
+      notes: [
+        { id: "n1", pitch: 36, velocity: 100, startTick: 0, durationTick: 240 }
+      ],
+      durationMs: 1000
+    };
+    expect(midiRenderKey({ clip, bpm: 120, instrument: moved, sampleRate: 48000 })).not.toBe(
+      midiRenderKey({ clip, bpm: 120, instrument: dr1, sampleRate: 48000 })
+    );
+  });
+
+  it("is not confused by key order", () => {
+    const reordered = { gainDb: bl1.gainDb, ...bl1 };
+    expect(instrumentSignature(reordered)).toBe(instrumentSignature(bl1));
+  });
+
+  it("gives an audition room for the voice's tail", () => {
+    expect(instrumentTailMs(wt1)).toBe(
+      Math.max(wt1.ampEnv.releaseMs, wt1.modEnv.releaseMs)
+    );
+    // A drum's whole envelope plays past the gate, so its tail is the longest
+    // pad rather than a release.
+    expect(instrumentTailMs(dr1)).toBeGreaterThan(1000);
+    const audition = renderAuditionNote({
+      pitch: 47,
+      velocity: 100,
+      durationMs: 10,
+      instrument: dr1,
+      sampleRate: SAMPLE_RATE
+    });
+    expect(peak(audition)).toBeGreaterThan(0.01);
+  });
+});

--- a/packages/timeline/tests/midi.engines.test.ts
+++ b/packages/timeline/tests/midi.engines.test.ts
@@ -279,6 +279,23 @@ describe("BL-1", () => {
     expect(rms(slid, ...window)).toBeGreaterThan(rms(retriggered, ...window) * 3);
   });
 
+  it("plays a note whose predecessor already let go", () => {
+    // A short note takes the voice over from a long one and releases before
+    // the next onset. That third note does not overlap anything still
+    // sounding, so it is a fresh note — not a slide into a finished envelope.
+    const rendered = renderInstrumentEvents(
+      [
+        note(40, 100, 0, 1000),
+        note(47, 100, 200, 100),
+        note(52, 100, 500, 200)
+      ],
+      ms(900),
+      bl1,
+      SAMPLE_RATE
+    );
+    expect(peak(rendered, ms(500), ms(700))).toBeGreaterThan(0.01);
+  });
+
   it("hits harder on an accent", () => {
     const plain = renderInstrumentEvents(
       [note(40, 99, 0, 300)],

--- a/packages/timeline/tests/midi.protocolCompat.test.ts
+++ b/packages/timeline/tests/midi.protocolCompat.test.ts
@@ -20,6 +20,7 @@ import {
   type TimelineTempo as ProtocolTimelineTempo
 } from "@nodetool-ai/protocol/api-schemas/timeline.js";
 import { DEFAULT_MIDI_INSTRUMENT } from "../src/midi/instrument.js";
+import { MIDI_INSTRUMENT_PRESETS } from "../src/midi/presets.js";
 import { DEFAULT_TEMPO } from "../src/midi/tempo.js";
 import { MIDI_MAX_NOTES_PER_CLIP } from "../src/midi/notes.js";
 import { QUANTIZE_DIVISIONS } from "../src/midi/edit.js";
@@ -47,6 +48,24 @@ describe("midi types match the protocol schemas", () => {
     expect(midiNote.parse(noteBack)).toEqual(noteThere);
     expect(midiInstrument.parse(instrumentBack)).toEqual(instrumentThere);
     expect(timelineTempo.parse(tempoBack)).toEqual(tempoThere);
+  });
+
+  // The presets are the only place every branch of the instrument union is
+  // spelled out, so parsing them is what keeps the four synths in step with
+  // the schema that stores and validates them.
+  it.each(MIDI_INSTRUMENT_PRESETS.map((p) => [p.id, p] as const))(
+    "parses the %s preset through the protocol schema",
+    (_id, presetEntry) => {
+      const there: ProtocolMidiInstrument =
+        presetEntry.instrument satisfies MidiInstrument;
+      expect(midiInstrument.parse(there)).toEqual(presetEntry.instrument);
+    }
+  );
+
+  it("covers every instrument type with a preset", () => {
+    expect(
+      new Set(MIDI_INSTRUMENT_PRESETS.map((p) => p.instrument.type))
+    ).toEqual(new Set(["subtractive", "wavetable", "bass", "drum"]));
   });
 
   it("keeps the note cap the same on both sides", () => {

--- a/web/src/components/timeline/Tracks/TrackInstrumentPanel.tsx
+++ b/web/src/components/timeline/Tracks/TrackInstrumentPanel.tsx
@@ -149,6 +149,256 @@ const ParamRow: React.FC<ParamRowProps> = memo(
 );
 ParamRow.displayName = "ParamRow";
 
+interface SubtractiveEditorProps {
+  instrument: Extract<MidiInstrument, { type: "subtractive" }>;
+  onChange: (next: MidiInstrument) => void;
+}
+
+/** The built-in synth: one oscillator, one filter, one envelope. */
+const SubtractiveEditor: React.FC<SubtractiveEditorProps> = memo(
+  ({ instrument, onChange }) => {
+    const handleWaveform = useCallback(
+      (value: string) =>
+        onChange({
+          ...instrument,
+          waveform: value as typeof instrument.waveform
+        }),
+      [instrument, onChange]
+    );
+    const handleAttack = useCallback(
+      (attackMs: number) => onChange({ ...instrument, attackMs }),
+      [instrument, onChange]
+    );
+    const handleDecay = useCallback(
+      (decayMs: number) => onChange({ ...instrument, decayMs }),
+      [instrument, onChange]
+    );
+    const handleSustain = useCallback(
+      (sustain: number) => onChange({ ...instrument, sustain }),
+      [instrument, onChange]
+    );
+    const handleRelease = useCallback(
+      (releaseMs: number) => onChange({ ...instrument, releaseMs }),
+      [instrument, onChange]
+    );
+    const handleCutoff = useCallback(
+      (value: number) =>
+        onChange({ ...instrument, cutoffHz: sliderToCutoff(value) }),
+      [instrument, onChange]
+    );
+    const handleResonance = useCallback(
+      (resonance: number) => onChange({ ...instrument, resonance }),
+      [instrument, onChange]
+    );
+    const handleGain = useCallback(
+      (gainDb: number) => onChange({ ...instrument, gainDb }),
+      [instrument, onChange]
+    );
+
+    return (
+      <FlexColumn gap={SPACING.xs}>
+        <SelectField
+          label="Waveform"
+          size="small"
+          variant="outlined"
+          value={instrument.waveform}
+          options={WAVEFORM_OPTIONS}
+          onChange={handleWaveform}
+        />
+        <ParamRow
+          label="Attack"
+          value={instrument.attackMs}
+          display={`${Math.round(instrument.attackMs)} ms`}
+          min={0}
+          max={2000}
+          step={1}
+          onChange={handleAttack}
+        />
+        <ParamRow
+          label="Decay"
+          value={instrument.decayMs}
+          display={`${Math.round(instrument.decayMs)} ms`}
+          min={0}
+          max={4000}
+          step={1}
+          onChange={handleDecay}
+        />
+        <ParamRow
+          label="Sustain"
+          value={instrument.sustain}
+          display={instrument.sustain.toFixed(2)}
+          min={0}
+          max={1}
+          step={0.01}
+          onChange={handleSustain}
+        />
+        <ParamRow
+          label="Release"
+          value={instrument.releaseMs}
+          display={`${Math.round(instrument.releaseMs)} ms`}
+          min={0}
+          max={4000}
+          step={1}
+          onChange={handleRelease}
+        />
+        <ParamRow
+          label="Cutoff"
+          value={cutoffToSlider(instrument.cutoffHz)}
+          display={`${Math.round(instrument.cutoffHz)} Hz`}
+          min={0}
+          max={1}
+          step={0.001}
+          onChange={handleCutoff}
+        />
+        <ParamRow
+          label="Resonance"
+          value={instrument.resonance}
+          display={instrument.resonance.toFixed(2)}
+          min={0}
+          max={20}
+          step={0.1}
+          onChange={handleResonance}
+        />
+        <ParamRow
+          label="Gain"
+          value={instrument.gainDb}
+          display={`${instrument.gainDb.toFixed(1)} dB`}
+          min={-40}
+          max={12}
+          step={0.5}
+          onChange={handleGain}
+        />
+      </FlexColumn>
+    );
+  }
+);
+SubtractiveEditor.displayName = "SubtractiveEditor";
+
+/** What each FableSynth voice is, in one line. */
+const SYNTH_SUMMARY: Record<
+  Exclude<MidiInstrument["type"], "subtractive">,
+  string
+> = {
+  wavetable:
+    "WT-1 — two morphing wavetable oscillators through a swept filter.",
+  bass: "BL-1 — a monophonic acid line: accented notes bite, overlapping notes slide.",
+  drum: "DR-1 — one drum per note, each ringing for its own decay."
+};
+
+interface PitchedSynthEditorProps {
+  instrument: Extract<MidiInstrument, { type: "wavetable" | "bass" }>;
+  onChange: (next: MidiInstrument) => void;
+}
+
+/**
+ * WT-1 and BL-1. Their full patch is picked from the preset list on the track
+ * header; what is editable here is the handful of controls a mix asks for —
+ * how open the filter is, how hard it is driven, how loud it plays.
+ */
+const PitchedSynthEditor: React.FC<PitchedSynthEditorProps> = memo(
+  ({ instrument, onChange }) => {
+    const handleCutoff = useCallback(
+      (value: number) =>
+        onChange({ ...instrument, cutoffHz: sliderToCutoff(value) }),
+      [instrument, onChange]
+    );
+    const handleResonance = useCallback(
+      (resonance: number) => onChange({ ...instrument, resonance }),
+      [instrument, onChange]
+    );
+    const handleDrive = useCallback(
+      (drive: number) => onChange({ ...instrument, drive }),
+      [instrument, onChange]
+    );
+    const handleGain = useCallback(
+      (gainDb: number) => onChange({ ...instrument, gainDb }),
+      [instrument, onChange]
+    );
+
+    return (
+      <FlexColumn gap={SPACING.xs}>
+        <Caption color="muted">{SYNTH_SUMMARY[instrument.type]}</Caption>
+        <ParamRow
+          label="Cutoff"
+          value={cutoffToSlider(instrument.cutoffHz)}
+          display={`${Math.round(instrument.cutoffHz)} Hz`}
+          min={0}
+          max={1}
+          step={0.001}
+          onChange={handleCutoff}
+        />
+        <ParamRow
+          label="Resonance"
+          value={instrument.resonance}
+          display={instrument.resonance.toFixed(2)}
+          min={0}
+          max={1}
+          step={0.01}
+          onChange={handleResonance}
+        />
+        <ParamRow
+          label="Drive"
+          value={instrument.drive}
+          display={instrument.drive.toFixed(2)}
+          min={0}
+          max={1}
+          step={0.01}
+          onChange={handleDrive}
+        />
+        <ParamRow
+          label="Gain"
+          value={instrument.gainDb}
+          display={`${instrument.gainDb.toFixed(1)} dB`}
+          min={-40}
+          max={12}
+          step={0.5}
+          onChange={handleGain}
+        />
+      </FlexColumn>
+    );
+  }
+);
+PitchedSynthEditor.displayName = "PitchedSynthEditor";
+
+interface DrumKitEditorProps {
+  instrument: Extract<MidiInstrument, { type: "drum" }>;
+  onChange: (next: MidiInstrument) => void;
+}
+
+/**
+ * DR-1. A kit has no filter of its own — each pad carries one — so the only
+ * control here is how loud the kit plays; the pad list says what the track's
+ * notes will hit.
+ */
+const DrumKitEditor: React.FC<DrumKitEditorProps> = memo(
+  ({ instrument, onChange }) => {
+    const handleGain = useCallback(
+      (gainDb: number) => onChange({ ...instrument, gainDb }),
+      [instrument, onChange]
+    );
+
+    return (
+      <FlexColumn gap={SPACING.xs}>
+        <Caption color="muted">{SYNTH_SUMMARY.drum}</Caption>
+        <ParamRow
+          label="Gain"
+          value={instrument.gainDb}
+          display={`${instrument.gainDb.toFixed(1)} dB`}
+          min={-40}
+          max={12}
+          step={0.5}
+          onChange={handleGain}
+        />
+        <Caption color="muted">
+          {`Pads from MIDI ${instrument.baseNote}: ` +
+            instrument.pads.map((pad) => pad.name).join(", ")}
+        </Caption>
+      </FlexColumn>
+    );
+  }
+);
+DrumKitEditor.displayName = "DrumKitEditor";
+
 interface TrackInstrumentPanelProps {
   trackId: string;
 }
@@ -175,9 +425,8 @@ export const TrackInstrumentPanel: React.FC<TrackInstrumentPanelProps> = memo(
       []
     );
 
-    const apply = useCallback(
-      (patch: Partial<MidiInstrument>) => {
-        const next: MidiInstrument = { ...instrument, ...patch };
+    const commit = useCallback(
+      (next: MidiInstrument) => {
         setTrackInstrument(trackId, next);
         if (auditionTimerRef.current !== null) {
           clearTimeout(auditionTimerRef.current);
@@ -189,41 +438,7 @@ export const TrackInstrumentPanel: React.FC<TrackInstrumentPanelProps> = memo(
           });
         }, AUDITION_DEBOUNCE_MS);
       },
-      [instrument, setTrackInstrument, trackId]
-    );
-
-    const handleWaveform = useCallback(
-      (value: string) =>
-        apply({ waveform: value as MidiInstrument["waveform"] }),
-      [apply]
-    );
-    const handleAttack = useCallback(
-      (attackMs: number) => apply({ attackMs }),
-      [apply]
-    );
-    const handleDecay = useCallback(
-      (decayMs: number) => apply({ decayMs }),
-      [apply]
-    );
-    const handleSustain = useCallback(
-      (sustain: number) => apply({ sustain }),
-      [apply]
-    );
-    const handleRelease = useCallback(
-      (releaseMs: number) => apply({ releaseMs }),
-      [apply]
-    );
-    const handleCutoff = useCallback(
-      (value: number) => apply({ cutoffHz: sliderToCutoff(value) }),
-      [apply]
-    );
-    const handleResonance = useCallback(
-      (resonance: number) => apply({ resonance }),
-      [apply]
-    );
-    const handleGain = useCallback(
-      (gainDb: number) => apply({ gainDb }),
-      [apply]
+      [setTrackInstrument, trackId]
     );
 
     return (
@@ -236,83 +451,22 @@ export const TrackInstrumentPanel: React.FC<TrackInstrumentPanelProps> = memo(
             Instrument
           </Text>
           <div css={cardStyles(theme)}>
-            <FlexColumn gap={SPACING.xs}>
-              <SelectField
-                label="Waveform"
-                size="small"
-                variant="outlined"
-                value={instrument.waveform}
-                options={WAVEFORM_OPTIONS}
-                onChange={handleWaveform}
-              />
-              <ParamRow
-                label="Attack"
-                value={instrument.attackMs}
-                display={`${Math.round(instrument.attackMs)} ms`}
-                min={0}
-                max={2000}
-                step={1}
-                onChange={handleAttack}
-              />
-              <ParamRow
-                label="Decay"
-                value={instrument.decayMs}
-                display={`${Math.round(instrument.decayMs)} ms`}
-                min={0}
-                max={4000}
-                step={1}
-                onChange={handleDecay}
-              />
-              <ParamRow
-                label="Sustain"
-                value={instrument.sustain}
-                display={instrument.sustain.toFixed(2)}
-                min={0}
-                max={1}
-                step={0.01}
-                onChange={handleSustain}
-              />
-              <ParamRow
-                label="Release"
-                value={instrument.releaseMs}
-                display={`${Math.round(instrument.releaseMs)} ms`}
-                min={0}
-                max={4000}
-                step={1}
-                onChange={handleRelease}
-              />
-              <ParamRow
-                label="Cutoff"
-                value={cutoffToSlider(instrument.cutoffHz)}
-                display={`${Math.round(instrument.cutoffHz)} Hz`}
-                min={0}
-                max={1}
-                step={0.001}
-                onChange={handleCutoff}
-              />
-              <ParamRow
-                label="Resonance"
-                value={instrument.resonance}
-                display={instrument.resonance.toFixed(2)}
-                min={0}
-                max={20}
-                step={0.1}
-                onChange={handleResonance}
-              />
-              <ParamRow
-                label="Gain"
-                value={instrument.gainDb}
-                display={`${instrument.gainDb.toFixed(1)} dB`}
-                min={-40}
-                max={12}
-                step={0.5}
-                onChange={handleGain}
-              />
-            </FlexColumn>
+            {instrument.type === "subtractive" && (
+              <SubtractiveEditor instrument={instrument} onChange={commit} />
+            )}
+            {(instrument.type === "wavetable" || instrument.type === "bass") && (
+              <PitchedSynthEditor instrument={instrument} onChange={commit} />
+            )}
+            {instrument.type === "drum" && (
+              <DrumKitEditor instrument={instrument} onChange={commit} />
+            )}
           </div>
           <Caption color="muted">
-            Every clip on this track plays this voice. Changes are auditioned on
-            middle C.
+            Every clip on this track plays this voice. Changes are auditioned on{" "}
+            {instrument.type === "drum"
+              ? "the kit's first pad"
+              : "middle C"}
+            .
           </Caption>
         </FlexColumn>
       </div>

--- a/web/src/components/timeline/Tracks/__tests__/TrackHeaderInstrument.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/TrackHeaderInstrument.test.tsx
@@ -11,6 +11,7 @@ import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 
 import { findInstrumentPreset } from "@nodetool-ai/timeline";
+import type { MidiInstrument } from "@nodetool-ai/timeline";
 
 import mockTheme from "../../../../__mocks__/themeMock";
 import { TracksRegion } from "../TracksRegion";
@@ -37,6 +38,10 @@ const renderRegion = () =>
 /** The header's preset select — the toolbar has a combobox of its own. */
 const presetSelect = () =>
   screen.getByRole("combobox", { name: /instrument for bass/i });
+
+/** The waveform of a voice, when the voice is the built-in synth. */
+const waveformOf = (instrument: MidiInstrument | undefined) =>
+  instrument?.type === "subtractive" ? instrument.waveform : undefined;
 
 function seedMidiTrack(): string {
   act(() => {
@@ -95,6 +100,44 @@ describe("TrackHeader — midi instrument", () => {
     expect(presetSelect()).toHaveTextContent("Custom");
   });
 
+  it("edits a FableSynth voice with its own controls", async () => {
+    const user = userEvent.setup();
+    renderRegion();
+    const trackId = seedMidiTrack();
+
+    await user.click(presetSelect());
+    await user.click(await screen.findByRole("option", { name: "BL-1 Acid" }));
+    await user.click(screen.getByTestId(`track-instrument-${trackId}`));
+
+    // BL-1 is not the built-in synth, so the panel offers its filter and level
+    // rather than a waveform.
+    expect(
+      screen.queryByRole("combobox", { name: /waveform/i })
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("slider", { name: "Drive" })).toBeInTheDocument();
+    expect(
+      screen.getByText(/BL-1 — a monophonic acid line/)
+    ).toBeInTheDocument();
+  });
+
+  it("names the DR-1 kit's pads in the editor", async () => {
+    const user = userEvent.setup();
+    renderRegion();
+    const trackId = seedMidiTrack();
+
+    await user.click(presetSelect());
+    await user.click(
+      await screen.findByRole("option", { name: "DR-1 TR-Void Kit" })
+    );
+    await user.click(screen.getByTestId(`track-instrument-${trackId}`));
+
+    // A kit has no cutoff of its own — each pad carries its own filter.
+    expect(
+      screen.queryByRole("slider", { name: "Cutoff" })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/Pads from MIDI 36: Kick,/)).toBeInTheDocument();
+  });
+
   it("opens the instrument editor from the Edit toggle", async () => {
     const user = userEvent.setup();
     renderRegion();
@@ -123,8 +166,10 @@ describe("TrackHeader — midi instrument", () => {
     await user.click(await screen.findByRole("option", { name: "Square" }));
 
     expect(
-      useTimelineStore.getState().tracks.find((t) => t.id === trackId)
-        ?.instrument?.waveform
+      waveformOf(
+        useTimelineStore.getState().tracks.find((t) => t.id === trackId)
+          ?.instrument
+      )
     ).toBe("square");
     // Debounced: the note is scheduled, not played on the keystroke.
     await screen.findByTestId(`track-instrument-panel-${trackId}`);

--- a/web/src/components/timeline/preview/audition.ts
+++ b/web/src/components/timeline/preview/audition.ts
@@ -7,12 +7,13 @@
  * must never join the mix the export reads.
  */
 
-import { renderAuditionNote } from "@nodetool-ai/timeline";
+import { auditionPitch, renderAuditionNote } from "@nodetool-ai/timeline";
 import type { MidiInstrument } from "@nodetool-ai/timeline";
 
 /** How long the auditioned note is held before its release. */
 export const AUDITION_NOTE_MS = 600;
-/** Middle C — what an audition plays when the caller names no pitch. */
+/** Middle C — what an audition plays when the caller names no pitch and the
+ * voice is a pitched one. A drum kit is auditioned on its first pad instead. */
 export const AUDITION_DEFAULT_PITCH = 60;
 const AUDITION_DEFAULT_VELOCITY = 100;
 
@@ -25,7 +26,7 @@ const AUDITION_DEFAULT_VELOCITY = 100;
  */
 export async function playAuditionNote(
   instrument: MidiInstrument,
-  pitch: number = AUDITION_DEFAULT_PITCH,
+  pitch?: number,
   velocity: number = AUDITION_DEFAULT_VELOCITY,
   contextFactory: () => BaseAudioContext = () => new AudioContext()
 ): Promise<void> {
@@ -38,7 +39,7 @@ export async function playAuditionNote(
     await (ctx as AudioContext).resume();
   }
   const samples = renderAuditionNote({
-    pitch,
+    pitch: pitch ?? auditionPitch(instrument),
     velocity,
     durationMs: AUDITION_NOTE_MS,
     instrument,

--- a/web/src/hooks/timeline/__tests__/useTimelineAgentBridge.test.tsx
+++ b/web/src/hooks/timeline/__tests__/useTimelineAgentBridge.test.tsx
@@ -3,7 +3,7 @@
  */
 import { renderHook } from "@testing-library/react";
 import { makeClip } from "@nodetool-ai/timeline";
-import type { TimelineClip } from "@nodetool-ai/timeline";
+import type { MidiInstrument, TimelineClip } from "@nodetool-ai/timeline";
 
 import {
   createTimelineStore,
@@ -19,6 +19,10 @@ import {
 } from "../../../stores/timeline/TimelinePlaybackStore";
 import { getTimelineAgentHandler } from "../../../components/timeline/timelineAgentBridge";
 import { useTimelineAgentBridge } from "../useTimelineAgentBridge";
+
+/** The waveform of a voice, when the voice is the built-in synth. */
+const waveformOf = (instrument: MidiInstrument | undefined) =>
+  instrument?.type === "subtractive" ? instrument.waveform : undefined;
 
 let mockDoc: TimelineStoreApi;
 let mockUi: TimelineUIStoreApi;
@@ -381,10 +385,11 @@ describe("useTimelineAgentBridge midi", () => {
       resonance: 1,
       gainDb: -3
     });
-    expect(track.instrument?.waveform).toBe("square");
+    expect(waveformOf(track.instrument)).toBe("square");
     expect(
-      getTimelineAgentHandler(SEQ_ID).getSnapshot().tracks[0].instrument
-        ?.waveform
+      waveformOf(
+        getTimelineAgentHandler(SEQ_ID).getSnapshot().tracks[0].instrument
+      )
     ).toBe("square");
   });
 

--- a/web/src/stores/timeline/__tests__/TimelineStore.midi.test.ts
+++ b/web/src/stores/timeline/__tests__/TimelineStore.midi.test.ts
@@ -16,7 +16,15 @@ import {
   makeClip,
   resolveTempo
 } from "@nodetool-ai/timeline";
-import type { TimelineSequence, TimelineTempo } from "@nodetool-ai/timeline";
+import type {
+  MidiInstrument,
+  TimelineSequence,
+  TimelineTempo
+} from "@nodetool-ai/timeline";
+
+/** The waveform of a voice, when the voice is the built-in synth. */
+const waveformOf = (instrument: MidiInstrument | undefined) =>
+  instrument?.type === "subtractive" ? instrument.waveform : undefined;
 import { createTimelineStore, timelineTemporalOf } from "../TimelineStore";
 import { buildTimelineDocumentPayload } from "../../../hooks/timeline/timelineDocumentPayload";
 
@@ -192,9 +200,9 @@ describe("TimelineStore — midi tracks", () => {
         waveform: "square"
       });
 
-    expect(store.getState().tracks[0].instrument?.waveform).toBe("square");
+    expect(waveformOf(store.getState().tracks[0].instrument)).toBe("square");
     expect(store.getState().tracks[1].id).toBe(other);
-    expect(store.getState().tracks[1].instrument?.waveform).toBe("saw");
+    expect(waveformOf(store.getState().tracks[1].instrument)).toBe("saw");
   });
 
   it("round-trips tempo, instrument and notes through the save payload", () => {


### PR DESCRIPTION
## What changed

A midi track could play one voice — a saw through a lowpass. This ports the three FableSynth instruments ([github.com/georgi/fablesynth](https://github.com/georgi/fablesynth)) into the offline renderer as three more members of the `MidiInstrument` union, so a track can play any of them: `wavetable` (WT-1) is two morphing wavetable oscillators plus a sub and noise through a Cytomic filter swept by a second envelope, with the tables built from harmonic spectra and band-limited into a mip ladder so a high note does not alias; `bass` (BL-1) is a monophonic acid line where a note at or above `accentVelocity` hits harder and sweeps further and a note overlapping the one before it glides into pitch without retriggering the envelopes; `drum` (DR-1) is sixteen pads from MIDI 36, each a tuned one-shot with a pitch envelope, coloured noise and a ring modulator, ringing for its own decay rather than the note's length. Eight presets ship with them, reachable from the track header's voice picker and from `set_track_instrument` by id, and the track instrument panel gains the filter/drive/level controls for the new voices and the kit's pad list. Not ported: stereo (this renderer is mono), the LFOs and mod matrix, the FX racks, and the plugins' own sequencers — a track's effects live on the track and its notes live in the clip.

Everything funnels through `renderInstrumentEvents`, so the browser preview, the audition, the CLI render and the `RenderTimeline` node all get the new voices from one switch. `instrumentSignature` now walks the instrument instead of listing its fields, because these voices carry nested oscillators, envelopes and pads and a hand-written list would go stale on the first field added — the render cache would then serve audio from before the change.

## Verification

- [x] `npm run test:affected` — the timeline, protocol, agents and web-timeline suites pass (`packages/timeline` 960 passed, `packages/protocol` 1310 passed, `packages/agents` 4423 passed, web timeline 1278 passed). Two pre-existing environment failures are unrelated to this diff: `packages/image-nodes` vignette tests (no Vulkan driver for WebGPU in this container) and `packages/video-nodes` `timeline-time-remap-decode` (ffmpeg hook timeout).
- [x] `npm run typecheck` — web and electron clean. Mobile fails only because `mobile/node_modules` is not installed in this container (`Cannot find module 'react-native'`), which is unrelated to the diff.
- [x] `npm run lint` — exit 0.
- [x] `npm run dev:nodetool -- harness gate --base main` — 8/8 selfchecks pass, `mappingViolations: []`.

Two gate failures were fixed after the first push, both this diff's own:

1. `capabilities:check` reported `capability-table.ts is stale` — listing the new voices in the `edit_timeline` spec moved its contract fingerprint. Regenerated with `npm run capabilities:sync`. (An earlier revision of this description wrongly called that pre-existing; it was not.)
2. The gate then reported a mapping violation: `edit_timeline`'s contract moved while its coverage mapping stood still. Answered the way the rule asks — with the test, in the third commit.

New tests in `packages/timeline/tests/midi.engines.test.ts` measure the rendered samples rather than the parameters: the mip ladder holds nothing above the harmonic a level allows, a WT-1 note at C7 has no off-harmonic content within 60 dB, BL-1 renders two same-frame notes as the later one alone and keeps its envelope running through a slide, and a DR-1 pad answers to one note and is silent above the kit. `tests/midi.protocolCompat.test.ts` now parses every shipped preset through the protocol schema and asserts a preset exists for all four instrument types.

## Agent capabilities

- [x] `npm run capabilities:check` passes.
- [x] The re-declared contract names a suite that covers it: `packages/agents/tests/timelines-op-input.test.ts` now drives `ui_timeline_set_track_instrument` with `wt1-bloom-pad`, `bl1-acid` and `dr1-tr-void`, asserts the preset is resolved and stored whole rather than kept as a reference, and asserts the kit keeps its sixteen pads and its base note through the round trip.

No capability is added and no schema changes — `set_track_instrument` takes the same shape, with more voices reachable through it.

## New checks

The alias test is the one new check that could pass by measuring nothing, so it carries its own control: the same analyzer is run over a naive (deliberately aliasing) saw at the same pitch and must report the foldover above −30 dB, while the wavetable render must be below −60 dB. An earlier version of the test read the analysis window's own sidelobes as aliasing (−32.7 dB with a Hann window); the Blackman-Harris window and the control were added because of it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cAXfhNs91xuFq95uwfK1C