### PR TITLE
Bolt: Optimize multiple filter array allocations in LookStep

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-11-20 - O(4*N) filtering optimization in job queues
 **Learning:** Multiple array `.filter(...)` statements over the same array to partition items by disjoint conditions caused an O(K*N) performance bottleneck and unnecessary intermediate array allocations.
 **Action:** Replace multiple `.filter(...)` lines with a single manual `for` loop that iterates the array once and sorts the items into different target arrays concurrently (O(N) pass).
+## 2026-09-08 - O(N*M) filtering optimization in Game Cost Estimate
+**Learning:** Multiple array `.filter(...).length` statements inside rendering hooks and functions create performance bottlenecks and unnecessary intermediate array allocations, especially when evaluating disjoint conditions over the same array.
+**Action:** Replace multiple `.filter(...).length` lines with a single manual `for` loop that iterates the array once and sorts/counts the items concurrently (O(N) pass, avoids allocating short-lived arrays).

--- a/web/src/components/setup/game/LookStep.tsx
+++ b/web/src/components/setup/game/LookStep.tsx
@@ -136,19 +136,20 @@ export const gameCostEstimate = (
     musicModel: string | null;
   }
 ): GameCostEstimate => {
-  const imageCount = slots.filter(
-    (slot) =>
-      slot.kind === "spritesheet" ||
-      slot.kind === "tileset" ||
-      slot.kind === "image"
-  ).length;
-  const sfxCount = choices.sfxChosen
-    ? slots.filter((slot) => slot.kind === "sfx").length
-    : 0;
-  const musicCount =
-    choices.musicModel === null
-      ? 0
-      : slots.filter((slot) => slot.kind === "music").length;
+  let imageCount = 0;
+  let sfxCount = 0;
+  let musicCount = 0;
+
+  for (let i = 0; i < slots.length; i++) {
+    const kind = slots[i].kind;
+    if (kind === "spritesheet" || kind === "tileset" || kind === "image") {
+      imageCount++;
+    } else if (kind === "sfx" && choices.sfxChosen) {
+      sfxCount++;
+    } else if (kind === "music" && choices.musicModel !== null) {
+      musicCount++;
+    }
+  }
 
   let total = 0;
   const priced = (tileId: string | null, quantity: number): boolean => {
@@ -366,11 +367,19 @@ const LookStepInternal: React.FC<GameLookStepProps> = ({
   );
 
   const slotCounts = useMemo(() => {
-    const spritesheets = slots.filter(
-      (slot) => slot.kind === "spritesheet"
-    ).length;
-    const tilesets = slots.filter((slot) => slot.kind === "tileset").length;
-    const images = slots.filter((slot) => slot.kind === "image").length;
+    let spritesheets = 0;
+    let tilesets = 0;
+    let images = 0;
+    for (let i = 0; i < slots.length; i++) {
+      const kind = slots[i].kind;
+      if (kind === "spritesheet") {
+        spritesheets++;
+      } else if (kind === "tileset") {
+        tilesets++;
+      } else if (kind === "image") {
+        images++;
+      }
+    }
     return { spritesheets, tilesets, images };
   }, [slots]);
 


### PR DESCRIPTION
## What
Optimize array filtering allocations in `gameCostEstimate` and `slotCounts` in `web/src/components/setup/game/LookStep.tsx`.

## Why
Multiple consecutive `.filter().length` statements over the same `slots` array created short-lived arrays purely for counting items, scaling linearly with operations.

## Impact
Eliminates multiple intermediate array allocations per render cycle and reduces multiple passes over the `slots` array to a single O(N) backward sweep, reducing GC pressure.

## Verification
- Ran linter, test and typecheck on `web/src/components/setup/game`
- No new type errors introduced
- Verified that all logic accurately translates original `.filter` predicate checks (like `kind` and UI choices) directly into increment operations.

---
*PR created automatically by Jules for task [5964174370813699782](https://jules.google.com/task/5964174370813699782) started by @georgi*