### PR TITLE
Improve timeline MIDI editing and instrument panels

### DIFF
--- a/packages/timeline/src/types.ts
+++ b/packages/timeline/src/types.ts
@@ -623,6 +623,8 @@ export interface WavetableOscillator {
  */
 export interface WavetableMidiInstrument {
   type: "wavetable";
+  /** UI parameters from the WT-1 rack that are not part of the render core. */
+  fableParams?: Record<string, number>;
   oscA: WavetableOscillator;
   oscB: WavetableOscillator;
   /** Sine sub-oscillator level, 0..1. */
@@ -653,6 +655,8 @@ export interface WavetableMidiInstrument {
  */
 export interface BassMidiInstrument {
   type: "bass";
+  /** UI parameters from the BL-1 rack that are not part of the render core. */
+  fableParams?: Record<string, number>;
   table: MidiWavetableName;
   /** Morph position across the table's frames, 0..1. */
   position: number;
@@ -740,6 +744,8 @@ export interface DrumPad {
  */
 export interface DrumMidiInstrument {
   type: "drum";
+  /** UI parameters from the DR-1 rack that are not part of the render core. */
+  fableParams?: Record<string, number>;
   /** The MIDI note pad 0 answers to. Pads run `baseNote`..`baseNote + 15`. */
   baseNote: number;
   pads: DrumPad[];

--- a/web/src/components/panels/PanelBottom.tsx
+++ b/web/src/components/panels/PanelBottom.tsx
@@ -29,6 +29,7 @@ import WorkerStatusIndicator from "../workers/WorkerStatusIndicator";
 import { VersionHistoryPanel } from "../version";
 import PanelHeadline from "../ui/PanelHeadline";
 import { useCombo } from "../../stores/KeyPressedStore";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
 import { TOOLTIP_ENTER_DELAY } from "../../config/constants";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import { ContextMenuProvider } from "../../providers/ContextMenuProvider";
@@ -469,7 +470,11 @@ const PanelBottom: React.FC = () => {
   const systemStats = useSystemStatsStore((state) => state.stats);
 
   useCombo(["Control", "Shift", "T"], () => handlePanelToggle("trace"), false);
-  useCombo(["l"], () => handlePanelToggle("logs"), false);
+  const timelineEditing = useWorkspaceTabsStore((state) => {
+    const tab = state.tabs.find((item) => item.id === state.activeTabId);
+    return tab?.type === "timeline" && tab.mode === "edit";
+  });
+  useCombo(["l"], () => handlePanelToggle("logs"), false, !timelineEditing);
 
   // Shown in the legacy editor (/editor) and the unified workspace (/workspace).
   if (!path.startsWith("/editor") && !path.startsWith("/workspace")) {

--- a/web/src/components/timeline/SourceViewerPanel.test.tsx
+++ b/web/src/components/timeline/SourceViewerPanel.test.tsx
@@ -43,7 +43,7 @@ jest.mock("../ui_primitives", () => ({
   Text: ({ children }: React.PropsWithChildren) => <span>{children}</span>,
   Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>,
   TruncatedText: ({ children }: React.PropsWithChildren) => <span>{children}</span>,
-  VideoPlayer: ({ onDurationChange }: { onDurationChange?: (duration: number) => void }) => <button aria-label="Video player" onClick={() => onDurationChange?.(5)}>Video</button>,
+  VideoPlayer: ({ onDurationChange, onTimeUpdate }: { onDurationChange?: (duration: number) => void; onTimeUpdate?: (time: number) => void }) => <button aria-label="Video player" onClick={() => { onDurationChange?.(5); onTimeUpdate?.(2); }}>Video</button>,
   SPACING: { md: 1, xs: 1, sm: 1 },
   getSpacingPx: () => "1px"
 }));
@@ -76,4 +76,26 @@ describe("SourceViewerPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Append" }));
     expect(mockPerformSourceEdit).toHaveBeenCalledWith("append", expect.objectContaining({ ui: expect.objectContaining({ sourceRange: { inMs: 1000, outMs: 2000 } }) }));
   });
+});
+
+
+it("marks the source playhead with I/O without forwarding to the timeline", () => {
+  render(<SourceViewerPanel />);
+  fireEvent.click(screen.getByRole("button", { name: "Video player" }));
+  mockSetSourceRange.mockClear();
+  const forwarded = jest.fn();
+  window.addEventListener("keydown", forwarded);
+  try {
+    fireEvent.keyDown(screen.getByTestId("source-viewer"), { key: "i" });
+    expect(mockSetSourceRange).toHaveBeenLastCalledWith({ inMs: 2000, outMs: 5000 });
+    fireEvent.keyDown(screen.getByTestId("source-viewer"), { key: "o" });
+    expect(mockSetSourceRange).toHaveBeenLastCalledWith({ inMs: 2000, outMs: 2000 });
+    expect(forwarded).not.toHaveBeenCalled();
+    mockSetSourceRange.mockClear();
+    fireEvent.keyDown(screen.getByLabelText("Source in point"), { key: "i" });
+    fireEvent.keyDown(screen.getByTestId("source-viewer"), { key: "i", ctrlKey: true });
+    expect(mockSetSourceRange).not.toHaveBeenCalled();
+  } finally {
+    window.removeEventListener("keydown", forwarded);
+  }
 });

--- a/web/src/components/timeline/SourceViewerPanel.tsx
+++ b/web/src/components/timeline/SourceViewerPanel.tsx
@@ -79,7 +79,6 @@ export const SourceViewerPanel: React.FC = memo(() => {
 
   // The player's own time, so "mark in/out here" reads where it is parked.
   const playerTimeRef = useRef(0);
-  const [playerTimeMs, setPlayerTimeMs] = useState(0);
   const [sourceDurationMs, setSourceDurationMs] = useState<number | null>(null);
   const onDurationChange = useCallback(
     (seconds: number) => {
@@ -93,7 +92,6 @@ export const SourceViewerPanel: React.FC = memo(() => {
   );
   const onTimeUpdate = useCallback((sec: number) => {
     playerTimeRef.current = Math.round(sec * 1000);
-    setPlayerTimeMs(playerTimeRef.current);
   }, []);
 
   // A new asset starts with no range.
@@ -101,7 +99,6 @@ export const SourceViewerPanel: React.FC = memo(() => {
   useEffect(() => {
     setSourceRange(null);
     setSourceDurationMs(null);
-    setPlayerTimeMs(0);
     playerTimeRef.current = 0;
   }, [assetId, setSourceRange]);
 
@@ -135,8 +132,41 @@ export const SourceViewerPanel: React.FC = memo(() => {
   const keys = (action: "sourceAppend" | "sourceInsert" | "sourceOverwrite") =>
     bindingKeys(TIMELINE_KEYMAPS[preset][action][0]);
 
+  const markSource = (edge: "in" | "out") => {
+    const currentRange = sourceRangeFor(asset, uiApi.getState().sourceRange);
+    const timeMs = Math.max(
+      0, Math.min(playerTimeRef.current, sourceDurationMs ?? Infinity)
+    );
+    setSourceRange(
+      edge === "in"
+        ? { inMs: timeMs, outMs: Math.max(timeMs, currentRange.outMs) }
+        : { inMs: Math.min(timeMs, currentRange.inMs), outMs: timeMs }
+    );
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (
+      event.ctrlKey || event.metaKey || event.altKey || event.shiftKey ||
+      event.target instanceof HTMLInputElement ||
+      event.target instanceof HTMLTextAreaElement ||
+      (event.target instanceof HTMLElement && event.target.isContentEditable)
+    ) return;
+    if (mediaType === "video" && (event.key === "i" || event.key === "o")) {
+      event.preventDefault();
+      event.stopPropagation();
+      markSource(event.key === "i" ? "in" : "out");
+    }
+  };
+
   return (
-    <div css={panelStyles(theme)} data-testid="source-viewer">
+    <div
+      css={panelStyles(theme)}
+      data-testid="source-viewer"
+      role="region"
+      aria-label="Source monitor"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+    >
       <FlexColumn gap={SPACING.md}>
         <TruncatedText variant="body2" sx={{ fontWeight: 500 }} showTooltip>
           {asset.name}
@@ -172,7 +202,7 @@ export const SourceViewerPanel: React.FC = memo(() => {
               }}
             />
             {mediaType === "video" && (
-              <Button size="small" variant="text" onClick={() => setSourceRange({ inMs: playerTimeMs, outMs: range.outMs })}>
+              <Button size="small" variant="text" onClick={() => markSource("in")} aria-label="Mark source in (I)">
                 Mark here
               </Button>
             )}
@@ -193,7 +223,7 @@ export const SourceViewerPanel: React.FC = memo(() => {
               }}
             />
             {mediaType === "video" && (
-              <Button size="small" variant="text" onClick={() => setSourceRange({ inMs: range.inMs, outMs: playerTimeMs })}>
+              <Button size="small" variant="text" onClick={() => markSource("out")} aria-label="Mark source out (O)">
                 Mark here
               </Button>
             )}

--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -76,6 +76,8 @@ import { TimelineProvider } from "../../stores/timeline/TimelineInstance";
 import { VideoLandingStrip } from "../setup/video/VideoLandingStrip";
 import { useReattachSequenceJobs } from "../../hooks/timeline/useReattachSequenceJobs";
 import { PreviewArea } from "./preview/PreviewArea";
+import { SelectFieldDensityContext } from "../ui_primitives";
+import { TimelineInstrumentsPanel } from "./TimelineInstrumentsPanel";
 import { TimelineInspector } from "./Inspector/TimelineInspector";
 import { SourceViewerPanel } from "./SourceViewerPanel";
 import MovieFilterOutlinedIcon from "@mui/icons-material/MovieFilterOutlined";
@@ -125,7 +127,13 @@ const editorStyles = (theme: Theme) =>
     width: "100%",
     height: "100%",
     overflow: "hidden",
-    backgroundColor: theme.vars.palette.background.default
+    backgroundColor: theme.vars.palette.background.default,
+    "&& .MuiOutlinedInput-root:not(.Mui-focused):not(.Mui-error)": {
+      "& .MuiOutlinedInput-notchedOutline": { borderColor: "transparent" },
+      "&:hover:not(.Mui-disabled) .MuiOutlinedInput-notchedOutline": {
+        borderColor: theme.vars.palette.divider
+      }
+    }
   });
 
 const middleAreaStyles = (theme: Theme) =>
@@ -157,7 +165,8 @@ const dragHandleStyles = (theme: Theme, tall: boolean) =>
     height: tall ? TOUCH_HANDLE_HEIGHT_PX : HANDLE_HEIGHT_PX,
     cursor: "ns-resize",
     flexShrink: 0,
-    backgroundColor: theme.vars.palette.divider,
+    backgroundColor: theme.vars.palette.background.default,
+    boxShadow: `inset 0 1px ${theme.vars.palette.divider}`,
     transition: MOTION.background,
     outline: "none",
     // The handle is a drag target, not a scroll surface: without this a touch
@@ -299,10 +308,11 @@ const PreviewRegion: React.FC<{
 });
 PreviewRegion.displayName = "PreviewRegion";
 
-type InspectorTab = "inspector" | "source" | "agent" | "history" | "script";
+type InspectorTab = "inspector" | "source" | "instrument" | "agent" | "history" | "script";
 
 const INSPECTOR_TABS = [
   { value: "inspector", label: "Inspector", icon: <TuneOutlinedIcon /> },
+  { value: "instrument", label: "Instruments", icon: <TuneOutlinedIcon /> },
   { value: "source", label: "Source", icon: <MovieFilterOutlinedIcon /> },
   { value: "agent", label: "Assistant", icon: <AutoAwesomeIcon /> },
   { value: "history", label: "History", icon: <HistoryOutlinedIcon /> }
@@ -317,7 +327,8 @@ const SCRIPT_TAB = {
 const InspectorRegion: React.FC<{ sequenceId: string | undefined }> = memo(
   ({ sequenceId }) => {
   const theme = useTheme();
-  const [tab, setTab] = useState<InspectorTab>("inspector");
+  const tab = useTimelineUIStore(s => s.panelTab);
+  const setTab = useTimelineUIStore(s => s.setPanelTab);
 
   const tabs = INSPECTOR_TABS;
 
@@ -333,7 +344,6 @@ const InspectorRegion: React.FC<{ sequenceId: string | undefined }> = memo(
           value={tab}
           onChange={(value) => setTab(value as InspectorTab)}
           size="small"
-          fullWidth
           sx={{
             flexShrink: 0,
             borderBottom: `1px solid ${theme.vars.palette.divider}`
@@ -342,6 +352,8 @@ const InspectorRegion: React.FC<{ sequenceId: string | undefined }> = memo(
         <FlexColumn fullWidth sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
           {tab === "inspector" ? (
             <TimelineInspector />
+          ) : tab === "instrument" ? (
+            <TimelineInstrumentsPanel />
           ) : tab === "source" ? (
             <SourceViewerPanel />
           ) : tab === "agent" ? (
@@ -406,7 +418,6 @@ const MobilePanelSheet: React.FC<{
       value={activeTab}
       onChange={(value) => onTabChange(value as InspectorTab)}
       size="small"
-      fullWidth
     />
   );
 
@@ -425,6 +436,10 @@ const MobilePanelSheet: React.FC<{
       <FlexColumn fullWidth sx={{ height: "52vh", minHeight: 0 }}>
         {activeTab === "inspector" ? (
           <TimelineInspector />
+        ) : activeTab === "instrument" ? (
+          <TimelineInstrumentsPanel />
+        ) : activeTab === "source" ? (
+          <SourceViewerPanel />
         ) : activeTab === "agent" ? (
           <TimelineAgentPanel />
         ) : activeTab === "script" ? (
@@ -504,7 +519,9 @@ const TimelineEditorBody: React.FC<
 
   // Phone panel sheet (Inspector / Assistant / History / Script).
   const [panelSheetOpen, setPanelSheetOpen] = useState(false);
-  const [panelTab, setPanelTab] = useState<InspectorTab>("inspector");
+  const panelTab = useTimelineUIStore(s => s.panelTab);
+  const setPanelTab = useTimelineUIStore(s => s.setPanelTab);
+  useEffect(() => { if (isMobile && panelTab === "instrument") setPanelSheetOpen(true); }, [isMobile, panelTab]);
   const openPanelSheet = useCallback(() => setPanelSheetOpen(true), []);
   const closePanelSheet = useCallback(() => setPanelSheetOpen(false), []);
   const hasSelection = useTimelineUIStore((s) => s.selectedClipIds.size > 0);
@@ -608,6 +625,13 @@ const TimelineEditorBody: React.FC<
 
   // Tracks resize ─────────────────────────────────────────────────────────
   const [tracksHeight, setTracksHeight] = useState(DEFAULT_TRACKS_HEIGHT_PX);
+  const expandedInstrumentTrackId = useTimelineUIStore((s) => s.expandedInstrumentTrackId);
+  useEffect(() => {
+    if (expandedInstrumentTrackId && !pianoRollOpen) setTracksHeight((height) => Math.max(height, 420));
+  }, [expandedInstrumentTrackId, pianoRollOpen]);
+  useEffect(() => {
+    if (pianoRollOpen) setTracksHeight((height) => Math.min(height, DEFAULT_TRACKS_HEIGHT_PX));
+  }, [pianoRollOpen]);
   const [isDragging, setIsDragging] = useState(false);
   const dragStartYRef = useRef(0);
   const dragStartHeightRef = useRef(DEFAULT_TRACKS_HEIGHT_PX);
@@ -801,6 +825,7 @@ const TimelineEditorBody: React.FC<
   );
 
   return (
+    <SelectFieldDensityContext.Provider value="compact">
     <FlexColumn fullWidth fullHeight css={editorStyles(theme)}>
       {/* ── Top bar ───────────────────────────────────────────────── */}
       <TopBar
@@ -827,7 +852,9 @@ const TimelineEditorBody: React.FC<
         onSelectFolder={(folderId) => void saveAsAsset(folderId, sequence?.name)}
       />
 
-      {/* ── Middle: assets + preview + inspector ──────────────────── */}
+      <FlexRow fullWidth sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
+      <FlexColumn sx={{ flex: 1, minWidth: 0, minHeight: 0 }}>
+      {/* ── Middle: assets + preview ──────────────────────────────── */}
       {/* Basis 0 (not `auto`): the middle row absorbs all leftover height via
        *  flex-grow, but its *content* never contributes to the column's size.
        *  With `auto`, a tall inspector (clip selected) inflated this row's
@@ -850,7 +877,6 @@ const TimelineEditorBody: React.FC<
           createSequenceErrorMessage={createErrorMessage}
           fullWidth={isMobile}
         />
-        {!isMobile && <InspectorRegion sequenceId={sequenceId} />}
       </FlexRow>
 
       {/* ── Horizontal drag handle (pointer + keyboard resizable) ─── */}
@@ -877,6 +903,9 @@ const TimelineEditorBody: React.FC<
 
       {/* ── Clip editor (piano roll) ──────────────────────────────── */}
       <PianoRollPanel fullHeight={pianoRollFullScreen} />
+      </FlexColumn>
+      {!isMobile && <InspectorRegion sequenceId={sequenceId} />}
+      </FlexRow>
 
       {/* ── Bottom status bar ─────────────────────────────────────── */}
       <TimelineStatusBar
@@ -948,6 +977,7 @@ const TimelineEditorBody: React.FC<
       </Dialog>
 
     </FlexColumn>
+    </SelectFieldDensityContext.Provider>
   );
 });
 

--- a/web/src/components/timeline/TimelineInstrumentsPanel.tsx
+++ b/web/src/components/timeline/TimelineInstrumentsPanel.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { useTimelineStore } from "../../stores/timeline/TimelineStore";
+import { useTimelineUIStore } from "../../stores/timeline/TimelineUIStore";
+import { Caption, FlexColumn, SelectField, SPACING } from "../ui_primitives";
+import { TrackInstrumentPanel } from "./Tracks/TrackInstrumentPanel";
+
+export function TimelineInstrumentsPanel() {
+  const tracks = useTimelineStore(state => state.tracks);
+  const clips = useTimelineStore(state => state.clips);
+  const selected = useTimelineUIStore(state => state.selectedClipIds);
+  const instrumentTrackId = useTimelineUIStore(state => state.expandedInstrumentTrackId);
+  const openInstrument = useTimelineUIStore(state => state.toggleExpandedInstrument);
+  const midiTracks = tracks.filter(track => track.type === "midi");
+  const selectedTrack = clips.find(clip => selected.has(clip.id))?.trackId;
+  const track = midiTracks.find(track => track.id === instrumentTrackId)
+    ?? midiTracks.find(track => track.id === selectedTrack) ?? midiTracks[0];
+  if (!track) return <Caption sx={{ p: SPACING.md }}>Add a MIDI track to choose an instrument.</Caption>;
+  return <FlexColumn fullHeight sx={{ minHeight: 0 }} data-testid="timeline-instruments-panel">
+    <FlexColumn sx={{ p: SPACING.sm }}>
+      <SelectField label="Instrument track" hideLabel size="small" value={track.id}
+        options={midiTracks.map(track => ({value: track.id, label: track.name}))} onChange={openInstrument} />
+    </FlexColumn>
+    <TrackInstrumentPanel key={track.id} trackId={track.id} />
+  </FlexColumn>;
+}

--- a/web/src/components/timeline/TimelineShortcutsDialog.tsx
+++ b/web/src/components/timeline/TimelineShortcutsDialog.tsx
@@ -102,6 +102,8 @@ const GROUPS: Group[] = [
     title: "Playback",
     rows: [
       { keys: ["Space"], label: "Play / pause" },
+      { action: "stepFrameBack", label: "Step back one frame" },
+      { action: "stepFrameForward", label: "Step forward one frame" },
       { action: "shuttleBack", label: "Shuttle backwards (again: faster)" },
       { action: "shuttleStop", label: "Stop shuttle" },
       { action: "shuttleForward", label: "Shuttle forwards (again: faster)" },

--- a/web/src/components/timeline/TopBar.tsx
+++ b/web/src/components/timeline/TopBar.tsx
@@ -234,7 +234,7 @@ export const TopBar: React.FC<TopBarProps> = memo(
 
         {onSave && (
           <EditorButton
-            variant="outlined"
+            variant="text"
             onClick={onSave}
             disabled={isSaving}
             startIcon={<SaveIcon />}
@@ -246,7 +246,7 @@ export const TopBar: React.FC<TopBarProps> = memo(
 
         {onSaveToAssets && (
           <EditorButton
-            variant="outlined"
+            variant="text"
             onClick={(e) => onSaveToAssets(e.currentTarget)}
             disabled={isExporting}
             startIcon={<VideoLibraryOutlinedIcon />}
@@ -258,7 +258,7 @@ export const TopBar: React.FC<TopBarProps> = memo(
 
         {onExportVideo && (
           <EditorButton
-            variant="outlined"
+            variant="text"
             onClick={onExportVideo}
             disabled={isExporting}
             startIcon={<FileDownloadIcon />}
@@ -270,7 +270,7 @@ export const TopBar: React.FC<TopBarProps> = memo(
 
         {onExportBundle && (
           <EditorButton
-            variant="outlined"
+            variant="text"
             onClick={onExportBundle}
             disabled={isExportingBundle}
             startIcon={<FolderZipOutlinedIcon />}

--- a/web/src/components/timeline/Tracks/FableSynthInstrumentEditors.tsx
+++ b/web/src/components/timeline/Tracks/FableSynthInstrumentEditors.tsx
@@ -1,0 +1,1002 @@
+/**
+ * FableSynth's three hardware editors, embedded in the MIDI track timeline.
+ * Sequencing belongs to the timeline. Only render-supported voice controls
+ * are shown here.
+ */
+
+import React, { useRef, useState } from "react";
+
+import type {
+  BassMidiInstrument,
+  DrumMidiInstrument,
+  DrumPad,
+  MidiEnvelope,
+  WavetableOscillator,
+  MidiFilterType,
+  MidiInstrument,
+  MidiWavetableName,
+  WavetableMidiInstrument
+} from "@nodetool-ai/timeline";
+
+import {
+  Caption,
+  EditorButton,
+  FlexRow,
+  Label,
+  SPACING
+} from "../../ui_primitives";
+
+import "./fablesynth-editor.css";
+
+type FableInstrument = Exclude<MidiInstrument, { type: "subtractive" }>;
+type KnobSize = "lg" | "md" | "sm" | "xs";
+type Accent = "a" | "b" | "f" | "n";
+
+interface ParamDef {
+  id: string;
+  label: string;
+  min: number;
+  max: number;
+  def: number;
+  curve?: "log" | "int" | "time";
+  fmt?: (value: number) => string;
+}
+
+const pct = (value: number) => `${Math.round(value * 100)}%`;
+const bi = (value: number) => `${value >= 0 ? "+" : ""}${value.toFixed(2)}`;
+const sec = (value: number) =>
+  value < 1 ? `${Math.round(value * 1000)} ms` : `${value.toFixed(2)} s`;
+const hz = (value: number) =>
+  value >= 1000
+    ? `${(value / 1000).toFixed(1)} kHz`
+    : `${Math.round(value)} Hz`;
+const st = (value: number) => `${value > 0 ? "+" : ""}${Math.round(value)} ST`;
+const ct = (value: number) => `${value > 0 ? "+" : ""}${Math.round(value)} CT`;
+
+const P = (
+  id: string,
+  label: string,
+  min: number,
+  max: number,
+  def: number,
+  fmt: ParamDef["fmt"] = pct,
+  curve?: ParamDef["curve"]
+): ParamDef => ({ id, label, min, max, def, fmt, curve });
+
+const TABLES = ["PRIME", "BLOOM", "PULSE", "VOX", "CHIME", "GLITCH"];
+const FILTERS = ["LP 12", "LP 24", "BP 12", "HP 12", "NOTCH"];
+const polar = (radius: number, degrees: number) => {
+  const angle = ((degrees - 90) * Math.PI) / 180;
+  return [40 + radius * Math.cos(angle), 40 + radius * Math.sin(angle)];
+};
+
+const arcPath = (from: number, to: number) => {
+  if (Math.abs(to - from) < 0.01) to = from + 0.01;
+  const [x0, y0] = polar(33, from);
+  const [x1, y1] = polar(33, to);
+  return `M ${x0.toFixed(2)} ${y0.toFixed(2)} A 33 33 0 ${Math.abs(to - from) > 180 ? 1 : 0} ${to > from ? 1 : 0} ${x1.toFixed(2)} ${y1.toFixed(2)}`;
+};
+
+const valueToNorm = (def: ParamDef, value: number) => {
+  if (def.curve === "time") return Math.log1p(Math.max(0, value)) / Math.log1p(def.max);
+  if (def.curve === "log") {
+    return (
+      Math.log(Math.max(def.min, value) / def.min) / Math.log(def.max / def.min)
+    );
+  }
+  return (value - def.min) / (def.max - def.min);
+};
+
+const normToValue = (def: ParamDef, norm: number) => {
+  const clamped = Math.min(1, Math.max(0, norm));
+  const raw =
+    def.curve === "time"
+      ? Math.expm1(clamped * Math.log1p(def.max))
+      : def.curve === "log"
+      ? def.min * Math.pow(def.max / def.min, clamped)
+      : def.min + (def.max - def.min) * clamped;
+  return def.curve === "int" ? Math.round(raw) : raw;
+};
+
+interface KnobProps {
+  def: ParamDef;
+  value: number;
+  onChange: (value: number) => void;
+  size?: KnobSize;
+  accent?: Accent;
+}
+
+const Knob: React.FC<KnobProps> = ({
+  def,
+  value,
+  onChange,
+  size = "md",
+  accent = "n"
+}) => {
+  const drag = useRef<{ y: number; norm: number } | null>(null);
+  const norm = Math.min(1, Math.max(0, valueToNorm(def, value)));
+  const degrees = -135 + 270 * norm;
+  const from = def.min < 0 ? -135 + 270 * valueToNorm(def, 0) : -135;
+  return (
+    <label className={`fs-knob fs-knob-${size}`} data-accent={accent}>
+      <span className="fs-knob-face">
+        <svg viewBox="0 0 80 80" aria-hidden="true">
+          <circle className="fs-k-body" cx="40" cy="40" r="26" />
+          <path className="fs-k-track" d={arcPath(-135, 135)} />
+          <path className="fs-k-arc" d={arcPath(from, degrees)} />
+          <line
+            className="fs-k-ptr"
+            x1="40"
+            y1="40"
+            x2="40"
+            y2="17"
+            transform={`rotate(${degrees} 40 40)`}
+          />
+        </svg>
+        <input
+          type="range"
+          aria-label={def.label}
+          aria-valuetext={def.fmt?.(value) ?? String(value)}
+          title="Drag up or down. Shift for fine adjustment. Double-click to reset."
+          min="0"
+          max="1"
+          step={def.curve === "int" ? 1 / (def.max - def.min) : 0.01}
+          value={norm}
+          onChange={(event) =>
+            onChange(normToValue(def, Number(event.target.value)))
+          }
+          onPointerDown={(event) => {
+            if (event.button !== 0) return;
+            event.preventDefault();
+            event.currentTarget.focus();
+            event.currentTarget.setPointerCapture(event.pointerId);
+            drag.current = { y: event.clientY, norm };
+          }}
+          onPointerMove={(event) => {
+            if (!drag.current) return;
+            const next = Math.min(
+              1,
+              Math.max(
+                0,
+                drag.current.norm +
+                  (drag.current.y - event.clientY) *
+                    (event.shiftKey ? 0.001 : 0.005)
+              )
+            );
+            drag.current = { y: event.clientY, norm: next };
+            onChange(normToValue(def, next));
+          }}
+          onPointerUp={(event) => {
+            drag.current = null;
+            if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+              event.currentTarget.releasePointerCapture(event.pointerId);
+            }
+          }}
+          onLostPointerCapture={() => {
+            drag.current = null;
+          }}
+          onPointerCancel={() => {
+            drag.current = null;
+          }}
+          onDoubleClick={() => onChange(def.def)}
+        />
+      </span>
+      <span className="fs-k-label">{def.label}</span>
+      <span className="fs-k-value">{def.fmt?.(value) ?? value.toFixed(2)}</span>
+    </label>
+  );
+};
+
+interface StepperProps {
+  label: string;
+  options: readonly string[];
+  value: number;
+  onChange: (value: number) => void;
+  accent?: Accent;
+}
+
+const Stepper: React.FC<StepperProps> = ({
+  label,
+  options,
+  value,
+  onChange,
+  accent = "n"
+}) => {
+  const index = Math.min(options.length - 1, Math.max(0, Math.round(value)));
+  const step = (amount: number) =>
+    onChange((index + amount + options.length) % options.length);
+  return (
+    <span className="fs-stepper" data-accent={accent}>
+      {label ? <span className="fs-st-label">{label}</span> : null}
+      <button
+        type="button"
+        aria-label={`previous ${label ?? "option"}`}
+        onClick={() => step(-1)}
+      >
+        ◂
+      </button>
+      <span className="fs-st-value" aria-live="polite">
+        {options[index]}
+      </span>
+      <button
+        type="button"
+        aria-label={`next ${label ?? "option"}`}
+        onClick={() => step(1)}
+      >
+        ▸
+      </button>
+    </span>
+  );
+};
+
+const Power: React.FC<{
+  on: boolean;
+  label: string;
+  onChange: () => void;
+  accent?: Accent;
+}> = ({ on, label, onChange, accent = "n" }) => (
+  <button
+    type="button"
+    className={`fs-power${on ? " on" : ""}`}
+    data-accent={accent}
+    aria-label={`${label} power`}
+    aria-pressed={on}
+    onClick={onChange}
+  />
+);
+
+const Panel: React.FC<{
+  title: string;
+  accent?: Accent;
+  className?: string;
+  head?: React.ReactNode;
+  children: React.ReactNode;
+}> = ({ title, accent, className = "", head, children }) => (
+  <section
+    className={`fs-panel ${className}`}
+    data-accent={accent}
+    aria-label={title}
+  >
+    <div className="fs-panel-head">
+      <h3>{title}</h3>
+      {head}
+    </div>
+    {children}
+  </section>
+);
+
+const NOTE_NAMES = [
+  "C",
+  "C♯",
+  "D",
+  "D♯",
+  "E",
+  "F",
+  "F♯",
+  "G",
+  "G♯",
+  "A",
+  "A♯",
+  "B"
+];
+const noteName = (pitch: number) =>
+  `${NOTE_NAMES[pitch % 12]}${Math.floor(pitch / 12) - 1}`;
+const WHITE_KEYS = [0, 2, 4, 5, 7, 9, 11, 12, 14, 16, 17, 19, 21, 23, 24];
+const BLACK_KEYS = [1, 3, 6, 8, 10, 13, 15, 18, 20, 22];
+
+export const InstrumentKeyboard = ({
+  start,
+  onPlay
+}: {
+  start: number;
+  onPlay: (pitch: number) => void;
+}) => (
+  <Panel
+    title="KEYS"
+    className="fs-keys-panel"
+    head={<Caption>Click or focus a key and press Enter</Caption>}
+  >
+    <div className="fs-keys">
+      <div className="fs-white-keys">
+        {WHITE_KEYS.map((semi) => (
+          <button
+            type="button"
+            key={semi}
+            aria-label={`Play ${noteName(start + semi)}`}
+            onClick={() => onPlay(start + semi)}
+          >
+            <span>{noteName(start + semi)}</span>
+          </button>
+        ))}
+      </div>
+      {BLACK_KEYS.map((semi) => (
+        <button
+          type="button"
+          className="fs-black-key"
+          key={semi}
+          aria-label={`Play ${noteName(start + semi)}`}
+          style={{
+            left: `calc(var(--fs-key-scale, 1) * ${(WHITE_KEYS.filter((white) => white < semi).length / 15) * 100}%)`
+          }}
+          onClick={() => onPlay(start + semi)}
+        />
+      ))}
+    </div>
+  </Panel>
+);
+
+interface EditorProps<T extends FableInstrument> {
+  instrument: T;
+  onChange: (next: T, auditionPitch?: number) => void;
+}
+
+const tableNames: readonly MidiWavetableName[] = [
+  "prime",
+  "bloom",
+  "pulse",
+  "vox",
+  "chime",
+  "glitch"
+];
+const filterTypes: readonly MidiFilterType[] = [
+  "lp12",
+  "lp24",
+  "bp12",
+  "hp12",
+  "notch"
+];
+const Filter = <T extends BassMidiInstrument | WavetableMidiInstrument>({
+  instrument,
+  onChange
+}: EditorProps<T>) => (
+  <Panel
+    title="FILTER"
+    accent="f"
+    head={
+      <Stepper
+        label="TYPE"
+        options={FILTERS}
+        value={filterTypes.indexOf(instrument.filterType)}
+        onChange={(index) =>
+          onChange({ ...instrument, filterType: filterTypes[index] })
+        }
+        accent="f"
+      />
+    }
+  >
+    <div className="fs-knob-row">
+      <Knob
+        def={P("cut", "CUT", 20, 20000, 340, hz, "log")}
+        value={instrument.cutoffHz}
+        onChange={(cutoffHz) => onChange({ ...instrument, cutoffHz })}
+        accent="f"
+      />
+      <Knob
+        def={P("res", "RES", 0, 1, 0.2)}
+        value={instrument.resonance}
+        onChange={(resonance) => onChange({ ...instrument, resonance })}
+        accent="f"
+      />
+      <Knob
+        def={P("drive", "DRIVE", 0, 1, 0)}
+        value={instrument.drive}
+        onChange={(drive) => onChange({ ...instrument, drive })}
+        accent="f"
+      />
+      <Knob
+        def={P("env", "ENV", -8, 8, 0, (value) => `${value.toFixed(1)} OCT`)}
+        value={instrument.filterEnvAmount}
+        onChange={(filterEnvAmount) =>
+          onChange({ ...instrument, filterEnvAmount })
+        }
+        accent="f"
+      />
+      <Knob
+        def={P("key", "TRACK", 0, 1, 0)}
+        value={instrument.keyTrack}
+        onChange={(keyTrack) => onChange({ ...instrument, keyTrack })}
+        accent="f"
+      />
+    </div>
+  </Panel>
+);
+
+const Envelope = ({
+  title,
+  envelope,
+  onChange
+}: {
+  title: string;
+  envelope: MidiEnvelope;
+  onChange: (value: MidiEnvelope) => void;
+}) => (
+  <Panel title={title}>
+    <div className="fs-knob-row">
+      <Knob
+        def={P("attack", "ATT", 0, 8000, 4, (v) => sec(v / 1000), "time")}
+        value={envelope.attackMs}
+        onChange={(attackMs) => onChange({ ...envelope, attackMs })}
+      />
+      <Knob
+        def={P("decay", "DEC", 0, 10000, 250, (v) => sec(v / 1000), "time")}
+        value={envelope.decayMs}
+        onChange={(decayMs) => onChange({ ...envelope, decayMs })}
+      />
+      <Knob
+        def={P("sustain", "SUS", 0, 1, 0.8)}
+        value={envelope.sustain}
+        onChange={(sustain) => onChange({ ...envelope, sustain })}
+      />
+      <Knob
+        def={P("release", "REL", 0, 12000, 300, (v) => sec(v / 1000), "time")}
+        value={envelope.releaseMs}
+        onChange={(releaseMs) => onChange({ ...envelope, releaseMs })}
+      />
+    </div>
+  </Panel>
+);
+
+const Oscillator = ({
+  title,
+  osc,
+  onChange,
+  accent
+}: {
+  title: string;
+  osc: WavetableOscillator;
+  onChange: (osc: WavetableOscillator) => void;
+  accent: Accent;
+}) => (
+  <Panel
+    title={title}
+    accent={accent}
+    head={
+      <Stepper
+        label="TABLE"
+        options={TABLES}
+        value={tableNames.indexOf(osc.table)}
+        onChange={(index) => onChange({ ...osc, table: tableNames[index] })}
+        accent={accent}
+      />
+    }
+  >
+    <div className="fs-knob-row">
+      <Knob
+        def={P("position", "POS", 0, 1, 0)}
+        value={osc.position}
+        onChange={(position) => onChange({ ...osc, position })}
+        accent={accent}
+      />
+      <Knob
+        def={P("semi", "SEMI", -48, 48, 0, st, "int")}
+        value={osc.semitones}
+        onChange={(semitones) => onChange({ ...osc, semitones })}
+        accent={accent}
+      />
+      <Knob
+        def={P("fine", "FINE", -100, 100, 0, ct, "int")}
+        value={osc.fine}
+        onChange={(fine) => onChange({ ...osc, fine })}
+        accent={accent}
+      />
+      <Knob
+        def={P("unison", "UNI", 1, 7, 1, String, "int")}
+        value={osc.unison}
+        onChange={(unison) => onChange({ ...osc, unison })}
+        accent={accent}
+      />
+      <Knob
+        def={P("detune", "DET", 0, 1, 0.2)}
+        value={osc.detune}
+        onChange={(detune) => onChange({ ...osc, detune })}
+        accent={accent}
+      />
+      <Knob
+        def={P("level", "LEVEL", 0, 1, 0.8)}
+        value={osc.level}
+        onChange={(level) => onChange({ ...osc, level })}
+        accent={accent}
+      />
+    </div>
+  </Panel>
+);
+
+const BassEditor = ({
+  instrument,
+  onChange
+}: EditorProps<BassMidiInstrument>) => (
+  <>
+    <div className="fs-voice-grid">
+      <Panel
+        title="OSC"
+        className="fs-panel-inline"
+        accent="a"
+        head={
+          <Stepper
+            label="TABLE"
+            options={TABLES}
+            value={tableNames.indexOf(instrument.table)}
+            onChange={(index) =>
+              onChange({ ...instrument, table: tableNames[index] })
+            }
+            accent="a"
+          />
+        }
+      >
+        <div className="fs-knob-row">
+          <Knob
+            def={P("pos", "POS", 0, 1, 0)}
+            value={instrument.position}
+            onChange={(position) => onChange({ ...instrument, position })}
+            accent="a"
+          />
+          <Knob
+            def={P("tune", "TUNE", -48, 48, 0, st, "int")}
+            value={instrument.semitones}
+            onChange={(semitones) => onChange({ ...instrument, semitones })}
+            accent="a"
+          />
+        </div>
+      </Panel>
+      <Panel title="SUB">
+        <FlexRow className="fs-sub-controls" gap={SPACING.md} wrap>
+          <Stepper
+            label="SHAPE"
+            options={["SINE", "SQUARE"]}
+            value={instrument.subShape === "square" ? 1 : 0}
+            onChange={(index) =>
+              onChange({ ...instrument, subShape: index ? "square" : "sine" })
+            }
+          />
+          <Stepper
+            label="OCT"
+            options={["-2", "-1"]}
+            value={instrument.subOctave === -1 ? 1 : 0}
+            onChange={(index) =>
+              onChange({ ...instrument, subOctave: index ? -1 : -2 })
+            }
+          />
+          <Knob
+            def={P("sub", "LEVEL", 0, 1, 0.5)}
+            value={instrument.subLevel}
+            onChange={(subLevel) => onChange({ ...instrument, subLevel })}
+            accent="a"
+          />
+        </FlexRow>
+      </Panel>
+      <Filter instrument={instrument} onChange={onChange} />
+      <Panel title="ENV" className="fs-panel-inline" head={<Caption>Filter envelope</Caption>}>
+        <div className="fs-knob-row">
+          <Knob
+            def={P("fattack", "F·ATT", 0, 500, 1, (v) => sec(v / 1000), "time")}
+            value={instrument.filterAttackMs}
+            onChange={(filterAttackMs) =>
+              onChange({ ...instrument, filterAttackMs })
+            }
+          />
+          <Knob
+            def={P(
+              "fdecay",
+              "F·DEC",
+              5,
+              4000,
+              180,
+              (v) => sec(v / 1000),
+              "log"
+            )}
+            value={instrument.filterDecayMs}
+            onChange={(filterDecayMs) =>
+              onChange({ ...instrument, filterDecayMs })
+            }
+          />
+        </div>
+      </Panel>
+      <Envelope
+        title="AMP ENV"
+        envelope={instrument.ampEnv}
+        onChange={(ampEnv) => onChange({ ...instrument, ampEnv })}
+      />
+      <Panel title="ACCENT · SLIDE" accent="a">
+        <div className="fs-knob-row">
+          <Knob
+            def={P("accent", "ACC AMT", 0, 1, 0.7)}
+            value={instrument.accentAmount}
+            onChange={(accentAmount) =>
+              onChange({ ...instrument, accentAmount })
+            }
+            accent="a"
+          />
+          <Knob
+            def={P("velocity", "ACC VEL", 1, 127, 100, String, "int")}
+            value={instrument.accentVelocity}
+            onChange={(accentVelocity) =>
+              onChange({ ...instrument, accentVelocity })
+            }
+            accent="a"
+          />
+          <Knob
+            def={P("slide", "SLD TIME", 0, 500, 60, (v) => sec(v / 1000), "time")}
+            value={instrument.slideMs}
+            onChange={(slideMs) => onChange({ ...instrument, slideMs })}
+            accent="a"
+          />
+        </div>
+        <Caption>
+          Accent follows note velocity. Slide joins overlapping notes.
+        </Caption>
+      </Panel>
+    </div>
+  </>
+);
+
+const WavetableEditor = ({
+  instrument,
+  onChange
+}: EditorProps<WavetableMidiInstrument>) => (
+  <>
+    <div className="fs-voice-grid">
+      <Oscillator
+        title="OSC A"
+        osc={instrument.oscA}
+        onChange={(oscA) => onChange({ ...instrument, oscA })}
+        accent="a"
+      />
+      <Oscillator
+        title="OSC B"
+        osc={instrument.oscB}
+        onChange={(oscB) => onChange({ ...instrument, oscB })}
+        accent="b"
+      />
+      <Panel title="SUB · NOISE">
+        <FlexRow gap={SPACING.md} wrap>
+          <Stepper
+            label="SUB OCT"
+            options={["-2", "-1"]}
+            value={instrument.subOctave === -1 ? 1 : 0}
+            onChange={(index) =>
+              onChange({ ...instrument, subOctave: index ? -1 : -2 })
+            }
+          />
+          <Knob
+            def={P("sub", "SUB", 0, 1, 0)}
+            value={instrument.subLevel}
+            onChange={(subLevel) => onChange({ ...instrument, subLevel })}
+            accent="a"
+          />
+          <Knob
+            def={P("noise", "NOISE", 0, 1, 0)}
+            value={instrument.noiseLevel}
+            onChange={(noiseLevel) => onChange({ ...instrument, noiseLevel })}
+            accent="b"
+          />
+        </FlexRow>
+      </Panel>
+      <Filter instrument={instrument} onChange={onChange} />
+      <Envelope
+        title="AMP ENV"
+        envelope={instrument.ampEnv}
+        onChange={(ampEnv) => onChange({ ...instrument, ampEnv })}
+      />
+      <Envelope
+        title="MOD ENV"
+        envelope={instrument.modEnv}
+        onChange={(modEnv) => onChange({ ...instrument, modEnv })}
+      />
+    </div>
+  </>
+);
+
+const DRUM_PAD_ORDER = [12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3];
+const DrumEditor = ({
+  instrument,
+  onChange
+}: EditorProps<DrumMidiInstrument>) => {
+  const [selected, setSelected] = useState(0);
+  const pad = instrument.pads[selected];
+  if (!pad) return null;
+  const filter = pad.filter;
+  const drumTables: readonly DrumPad["table"][] = [
+    ...tableNames,
+    "thud",
+    "crack",
+    "tine",
+    "grit"
+  ];
+  const commit = (next: DrumPad) =>
+    onChange(
+      {
+        ...instrument,
+        pads: instrument.pads.map((item, index) =>
+          index === selected ? next : item
+        )
+      },
+      instrument.baseNote + selected
+    );
+  return (
+    <div className="fs-dr-layout">
+      <Panel
+        title="PADS"
+        accent="b"
+        className="fs-pad-panel"
+        head={<Caption>Select to edit and audition</Caption>}
+      >
+        <div className="fs-pad-grid">
+          {DRUM_PAD_ORDER.filter((index) => index < instrument.pads.length).map(
+            (index) => (
+              <button
+                type="button"
+                key={index}
+                className={selected === index ? "selected" : ""}
+                aria-label={`Edit pad ${index + 1}: ${instrument.pads[index].name}`}
+                aria-pressed={selected === index}
+                onClick={() => {
+                  setSelected(index);
+                  onChange(instrument, instrument.baseNote + index);
+                }}
+              >
+                <b>{String(index + 1).padStart(2, "0")}</b>
+                <span>{instrument.pads[index].name}</span>
+              </button>
+            )
+          )}
+        </div>
+      </Panel>
+      <div>
+        <Label className="fs-selected-pad">
+          {String(selected + 1).padStart(2, "0")} · {pad.name.toUpperCase()}
+        </Label>
+        <div className="fs-voice-grid">
+          <Panel
+            title="OSC A"
+            accent="a"
+            head={
+              <Stepper
+                label="TABLE"
+                options={drumTables.map((table) => table.toUpperCase())}
+                value={drumTables.indexOf(pad.table)}
+                onChange={(index) =>
+                  commit({ ...pad, table: drumTables[index] })
+                }
+              />
+            }
+          >
+            <div className="fs-knob-row">
+              <Knob
+                def={P("pos", "POS", 0, 1, 0)}
+                value={pad.position}
+                onChange={(position) => commit({ ...pad, position })}
+                accent="a"
+              />
+              <Knob
+                def={P("tune", "TUNE", -48, 48, 0, st, "int")}
+                value={pad.semitones}
+                onChange={(semitones) => commit({ ...pad, semitones })}
+                accent="a"
+              />
+            </div>
+          </Panel>
+          <Panel title="NOISE + RING" accent="b">
+            <div className="fs-knob-row">
+              <Knob
+                def={P("color", "COLOR", -1, 1, 0, bi)}
+                value={pad.noiseColor}
+                onChange={(noiseColor) => commit({ ...pad, noiseColor })}
+                accent="b"
+              />
+              <Knob
+                def={P("noise", "NOISE", 0, 1, 0.2)}
+                value={pad.noiseLevel}
+                onChange={(noiseLevel) => commit({ ...pad, noiseLevel })}
+                accent="b"
+              />
+              <Knob
+                def={P("ringhz", "RING HZ", 20, 20000, 400, hz, "log")}
+                value={pad.ringHz}
+                onChange={(ringHz) => commit({ ...pad, ringHz })}
+                accent="b"
+              />
+              <Knob
+                def={P("ringmix", "RING MIX", 0, 1, 0)}
+                value={pad.ringMix}
+                onChange={(ringMix) => commit({ ...pad, ringMix })}
+                accent="b"
+              />
+            </div>
+          </Panel>
+          <Panel title="PITCH ENV" accent="b">
+            <div className="fs-knob-row">
+              <Knob
+                def={P("pitchamt", "AMT", -48, 48, 12, st, "int")}
+                value={pad.pitchEnvAmount}
+                onChange={(pitchEnvAmount) =>
+                  commit({ ...pad, pitchEnvAmount })
+                }
+                accent="b"
+              />
+              <Knob
+                def={P(
+                  "pitchdec",
+                  "DECAY",
+                  1,
+                  4000,
+                  80,
+                  (v) => sec(v / 1000),
+                  "log"
+                )}
+                value={pad.pitchEnvDecayMs}
+                onChange={(pitchEnvDecayMs) =>
+                  commit({ ...pad, pitchEnvDecayMs })
+                }
+                accent="b"
+              />
+            </div>
+          </Panel>
+          <Panel title="AMP ENV">
+            <div className="fs-knob-row">
+              <Knob
+                def={P("att", "ATT", 0, 2000, 1, (v) => sec(v / 1000), "time")}
+                value={pad.attackMs}
+                onChange={(attackMs) => commit({ ...pad, attackMs })}
+              />
+              <Knob
+                def={P("hold", "HOLD", 0, 2000, 20, (v) => sec(v / 1000), "time")}
+                value={pad.holdMs}
+                onChange={(holdMs) => commit({ ...pad, holdMs })}
+              />
+              <Knob
+                def={P("dec", "DEC", 1, 6000, 300, (v) => sec(v / 1000), "log")}
+                value={pad.decayMs}
+                onChange={(decayMs) => commit({ ...pad, decayMs })}
+              />
+              <Knob
+                def={P("curve", "CURVE", 0, 1, 0.6)}
+                value={pad.curve}
+                onChange={(curve) => commit({ ...pad, curve })}
+              />
+            </div>
+          </Panel>
+          <Panel
+            title="FILTER"
+            accent="f"
+            head={
+              <Power
+                on={Boolean(filter)}
+                label="Filter"
+                onChange={() =>
+                  commit({
+                    ...pad,
+                    filter: filter
+                      ? null
+                      : { type: "lp24", cutoffHz: 5000, resonance: 0.2 }
+                  })
+                }
+                accent="f"
+              />
+            }
+          >
+            {filter ? (
+              <>
+                <Stepper
+                  label="TYPE"
+                  options={FILTERS}
+                  value={filterTypes.indexOf(filter.type)}
+                  onChange={(index) =>
+                    commit({
+                      ...pad,
+                      filter: { ...filter, type: filterTypes[index] }
+                    })
+                  }
+                  accent="f"
+                />
+                <div className="fs-knob-row">
+                  <Knob
+                    def={P("cut", "CUT", 20, 20000, 5000, hz, "log")}
+                    value={filter.cutoffHz}
+                    onChange={(cutoffHz) =>
+                      commit({ ...pad, filter: { ...filter, cutoffHz } })
+                    }
+                    accent="f"
+                  />
+                  <Knob
+                    def={P("res", "RES", 0, 1, 0.2)}
+                    value={filter.resonance}
+                    onChange={(resonance) =>
+                      commit({ ...pad, filter: { ...filter, resonance } })
+                    }
+                    accent="f"
+                  />
+                </div>
+              </>
+            ) : (
+              <Caption>Filter bypassed. Enable to shape this pad.</Caption>
+            )}
+          </Panel>
+          <Panel title="OUTPUT" accent="b">
+            <div className="fs-knob-row">
+              <Knob
+                def={P("level", "LEVEL", 0, 1, 0.8)}
+                value={pad.level}
+                onChange={(level) => commit({ ...pad, level })}
+                accent="b"
+              />
+              <Knob
+                def={P("vel", "V→LVL", 0, 1, 1)}
+                value={pad.velocityToLevel}
+                onChange={(velocityToLevel) =>
+                  commit({ ...pad, velocityToLevel })
+                }
+                accent="b"
+              />
+            </div>
+          </Panel>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+interface FableSynthInstrumentEditorProps {
+  instrument: FableInstrument;
+  onChange: (next: MidiInstrument, auditionPitch?: number) => void;
+}
+const FableSynthInstrumentEditor = ({
+  instrument,
+  onChange
+}: FableSynthInstrumentEditorProps) => {
+  const model =
+    instrument.type === "bass"
+      ? "BL-1"
+      : instrument.type === "wavetable"
+        ? "WT-1"
+        : "DR-1";
+  return (
+    <div
+      className={`fs-editor fs-${instrument.type}`}
+      data-testid="fablesynth-editor"
+      data-device={model}
+    >
+      <FlexRow className="fs-header" gap={SPACING.lg} wrap align="center">
+        <Label>{model}</Label>
+        <Caption className="fs-description">
+          {instrument.type === "bass"
+            ? "Bass synthesizer"
+            : instrument.type === "wavetable"
+              ? "Wavetable synthesizer"
+              : "Drum synthesizer"}
+        </Caption>
+        <EditorButton
+          size="small"
+          onClick={() =>
+            onChange(
+              instrument,
+              instrument.type === "drum" ? instrument.baseNote : 60
+            )
+          }
+        >
+          Audition
+        </EditorButton>
+        <Knob
+          def={P(
+            "output",
+            "OUTPUT",
+            -40,
+            12,
+            -6,
+            (value) => `${value.toFixed(1)} dB`
+          )}
+          value={instrument.gainDb}
+          onChange={(gainDb) => onChange({ ...instrument, gainDb })}
+          size="sm"
+        />
+      </FlexRow>
+      {instrument.type === "bass" ? (
+        <BassEditor instrument={instrument} onChange={onChange} />
+      ) : instrument.type === "wavetable" ? (
+        <WavetableEditor instrument={instrument} onChange={onChange} />
+      ) : (
+        <DrumEditor instrument={instrument} onChange={onChange} />
+      )}
+    </div>
+  );
+};
+export default FableSynthInstrumentEditor;

--- a/web/src/components/timeline/Tracks/TrackHeader.tsx
+++ b/web/src/components/timeline/Tracks/TrackHeader.tsx
@@ -30,10 +30,10 @@ import VerticalAlignTopIcon from "@mui/icons-material/VerticalAlignTop";
 import VerticalAlignBottomIcon from "@mui/icons-material/VerticalAlignBottom";
 
 import {
-  MIDI_INSTRUMENT_PRESETS,
   findInstrumentPreset,
   presetIdForInstrument
 } from "@nodetool-ai/timeline";
+import { TIMELINE_INSTRUMENT_PRESETS } from "../../../stores/timeline/instrumentPresets";
 import type { TimelineTrack } from "@nodetool-ai/timeline";
 import {
   useTimelineStore,
@@ -41,6 +41,7 @@ import {
 } from "../../../stores/timeline/TimelineStore";
 import { useTimelineHistoryBatch } from "../../../stores/timeline/useTimelineHistoryBatch";
 import {
+  DEFAULT_TRACK_HEADER_WIDTH_PX,
   useTimelineUIStore,
   useTimelineUIStoreApi
 } from "../../../stores/timeline/TimelineUIStore";
@@ -67,13 +68,9 @@ import type { SelectOption } from "../../ui_primitives";
 import { useLongPress } from "../../../hooks/timeline/useLongPress";
 import type { LongPressPoint } from "../../../hooks/timeline/useLongPress";
 import { DEFAULT_TRACK_HEIGHT_PX as SHARED_DEFAULT_TRACK_HEIGHT_PX } from "./trackHeight";
-import {
-  trackTypeMeta,
-  trackTypeAccent
-} from "./trackVisuals";
+import { trackTypeMeta, trackTypeAccent } from "./trackVisuals";
 import ConfirmDialog from "../../dialogs/ConfirmDialog";
-
-export const TRACK_HEADER_WIDTH_PX = 192;
+export const TRACK_HEADER_WIDTH_PX = DEFAULT_TRACK_HEADER_WIDTH_PX;
 /**
  * Phone header width. 192px is half a 390px viewport — the lanes get less room
  * than the labels. 132px is the narrowest that still fits the full control row
@@ -102,6 +99,7 @@ const RESIZE_HANDLE_HEIGHT_PX = 6;
 const headerStyles = (theme: Theme, heightPx: number, compact: boolean) =>
   css({
     position: "relative",
+    containerType: "inline-size",
     width: trackHeaderWidthCss,
     height: heightPx,
     flexShrink: 0,
@@ -110,7 +108,7 @@ const headerStyles = (theme: Theme, heightPx: number, compact: boolean) =>
     justifyContent: "space-between",
     padding: compact
       ? `${getSpacingPx(SPACING.xs)} ${getSpacingPx(SPACING.sm)}`
-      : `${getSpacingPx(SPACING.lg)} ${getSpacingPx(SPACING.lg)} ${getSpacingPx(SPACING.lg)}`,
+      : `${getSpacingPx(SPACING.xs)} ${getSpacingPx(SPACING.md)}`,
     backgroundColor: theme.vars.palette.background.default,
     borderBottom: `1px solid ${theme.vars.palette.divider}`,
     overflow: "hidden",
@@ -171,7 +169,6 @@ const typeGlyphStyles = (theme: Theme, accent: string) =>
     alignItems: "center",
     justifyContent: "center",
     backgroundColor: theme.vars.palette.background.paper,
-    border: `1px solid ${theme.vars.palette.divider}`,
     color: accent,
     "& svg": {
       fontSize: 15
@@ -219,7 +216,6 @@ const indexChipStyles = (theme: Theme) =>
     alignItems: "center",
     justifyContent: "center",
     borderRadius: BORDER_RADIUS.sm,
-    border: `1px solid ${theme.vars.palette.divider}`,
     fontFamily:
       "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace",
     fontSize: FONT_SIZE_MONO.caption,
@@ -298,15 +294,11 @@ const resizeHandleStyles = (theme: Theme) =>
     }
   });
 
-/**
- * The preset select next to the midi controls. It is the width of two icon
- * buttons: the header is 192px (132px on a phone) and the name row above it
- * carries the track's identity, so the voice is named in as little room as a
- * name can be read in.
- */
+/** Keep the preset compact as the track header grows. */
 const presetSelectStyles = css({
-  minWidth: 96,
-  flexShrink: 0,
+  minWidth: 0,
+  flex: "0 1 160px",
+  "@container (max-width: 280px)": { display: "none" },
   "& .MuiInputBase-root": {
     height: 22
   }
@@ -316,7 +308,7 @@ const presetSelectStyles = css({
 const CUSTOM_PRESET = "custom";
 
 const PRESET_OPTIONS: readonly SelectOption[] = [
-  ...MIDI_INSTRUMENT_PRESETS.map((preset) => ({
+  ...TIMELINE_INSTRUMENT_PRESETS.map((preset) => ({
     value: preset.id,
     label: preset.name
   })),
@@ -336,589 +328,602 @@ interface TrackHeaderProps {
   compact?: boolean;
 }
 
-export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex, compact = false }) => {
-  const theme = useTheme();
+export const TrackHeader: React.FC<TrackHeaderProps> = memo(
+  ({ track, typedIndex, compact = false }) => {
+    const theme = useTheme();
 
-  const setTrackVisible = useTimelineStore((s) => s.setTrackVisible);
-  const setTrackLocked = useTimelineStore((s) => s.setTrackLocked);
-  const setTrackMuted = useTimelineStore((s) => s.setTrackMuted);
-  const setTrackSolo = useTimelineStore((s) => s.setTrackSolo);
-  const setTrackHeight = useTimelineStore((s) => s.setTrackHeight);
-  const setTrackName = useTimelineStore((s) => s.setTrackName);
-  const removeTrack = useTimelineStore((s) => s.removeTrack);
-  const reorderTracks = useTimelineStore((s) => s.reorderTracks);
-  const insertTrack = useTimelineStore((s) => s.insertTrack);
-  const duplicateTrack = useTimelineStore((s) => s.duplicateTrack);
+    const setTrackVisible = useTimelineStore((s) => s.setTrackVisible);
+    const setTrackLocked = useTimelineStore((s) => s.setTrackLocked);
+    const setTrackMuted = useTimelineStore((s) => s.setTrackMuted);
+    const setTrackSolo = useTimelineStore((s) => s.setTrackSolo);
+    const setTrackHeight = useTimelineStore((s) => s.setTrackHeight);
+    const setTrackName = useTimelineStore((s) => s.setTrackName);
+    const removeTrack = useTimelineStore((s) => s.removeTrack);
+    const reorderTracks = useTimelineStore((s) => s.reorderTracks);
+    const insertTrack = useTimelineStore((s) => s.insertTrack);
+    const duplicateTrack = useTimelineStore((s) => s.duplicateTrack);
 
-  const heightPx = track.heightPx ?? DEFAULT_TRACK_HEIGHT_PX;
-  const meta = trackTypeMeta(track.type);
-  const accent = trackTypeAccent(theme, track.type);
-  const TypeIcon = meta.Icon;
+    const heightPx = track.heightPx ?? DEFAULT_TRACK_HEIGHT_PX;
+    const meta = trackTypeMeta(track.type);
+    const accent = trackTypeAccent(theme, track.type);
+    const TypeIcon = meta.Icon;
 
-  const [editingName, setEditingName] = useState(false);
-  const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false);
-  const [contextMenuPos, setContextMenuPos] = useState<{
-    x: number;
-    y: number;
-  } | null>(null);
+    const [editingName, setEditingName] = useState(false);
+    const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false);
+    const [contextMenuPos, setContextMenuPos] = useState<{
+      x: number;
+      y: number;
+    } | null>(null);
 
-  // `InlineEditableText` owns the draft, the deferred focus (the input is
-  // read-only until the edit render lands, and the focus has to outrun the
-  // closing menu), and the guard against a stale blur committing after Escape.
-  const startRename = useCallback(() => {
-    setEditingName(true);
-  }, []);
+    // `InlineEditableText` owns the draft, the deferred focus (the input is
+    // read-only until the edit render lands, and the focus has to outrun the
+    // closing menu), and the guard against a stale blur committing after Escape.
+    const startRename = useCallback(() => {
+      setEditingName(true);
+    }, []);
 
-  const commitName = useCallback(
-    (next: string) => {
-      setTrackName(track.id, next);
-    },
-    [setTrackName, track.id]
-  );
-
-  const dragStartYRef = useRef(0);
-  const dragStartHeightRef = useRef(heightPx);
-  // Gesture-ownership flag: the move handler only runs when this handle's
-  // pointerdown started the gesture (not when another drag passes over it).
-  const isResizingRef = useRef(false);
-
-  const timelineStoreApi = useTimelineStoreApi();
-
-  // Undo batching: begin on pointerdown, mark() after each mutation (pauses
-  // history once the pre-resize state is checkpointed), end() on pointerup, so
-  // the whole resize collapses into one undo entry.
-  const history = useTimelineHistoryBatch();
-
-  const handleResizePointerDown = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      e.stopPropagation();
-      e.currentTarget.setPointerCapture(e.pointerId);
-      dragStartYRef.current = e.clientY;
-      dragStartHeightRef.current = heightPx;
-      isResizingRef.current = true;
-      history.begin();
-    },
-    [heightPx, history]
-  );
-
-  const handleResizePointerMove = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      if (!isResizingRef.current || e.buttons !== 1) {
-        return;
-      }
-      const deltaY = e.clientY - dragStartYRef.current;
-      const newHeight = Math.min(
-        MAX_TRACK_HEIGHT_PX,
-        Math.max(MIN_TRACK_HEIGHT_PX, dragStartHeightRef.current + deltaY)
-      );
-      setTrackHeight(track.id, newHeight);
-      // First effective mutation recorded the pre-resize state; batch the rest.
-      history.mark();
-    },
-    [setTrackHeight, track.id, history]
-  );
-
-  const handleResizePointerEnd = useCallback(() => {
-    isResizingRef.current = false;
-    history.end();
-  }, [history]);
-
-  // Context menu: right-click anywhere on the header, or a touch hold. The
-  // resize handle and the drag grip stop pointer/contextmenu propagation so a
-  // resize or reorder gesture never opens it.
-
-  const openHeaderMenuAt = useCallback(
-    (x: number, y: number) => {
-      if (editingName) {
-        return;
-      }
-      setContextMenuPos({ x, y });
-    },
-    [editingName]
-  );
-
-  const headerLongPress = useLongPress(
-    useCallback(
-      (point: LongPressPoint) => {
-        openHeaderMenuAt(point.clientX, point.clientY);
+    const commitName = useCallback(
+      (next: string) => {
+        setTrackName(track.id, next);
       },
-      [openHeaderMenuAt]
-    )
-  );
+      [setTrackName, track.id]
+    );
 
-  const handleHeaderContextMenu = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (editingName) {
-        return;
-      }
-      e.preventDefault();
-      openHeaderMenuAt(e.clientX, e.clientY);
-    },
-    [editingName, openHeaderMenuAt]
-  );
+    const dragStartYRef = useRef(0);
+    const dragStartHeightRef = useRef(heightPx);
+    // Gesture-ownership flag: the move handler only runs when this handle's
+    // pointerdown started the gesture (not when another drag passes over it).
+    const isResizingRef = useRef(false);
 
-  const closeContextMenu = useCallback(() => setContextMenuPos(null), []);
+    const timelineStoreApi = useTimelineStoreApi();
 
-  const stopPointerPropagation = useCallback(
-    (e: React.SyntheticEvent) => e.stopPropagation(),
-    []
-  );
+    // Undo batching: begin on pointerdown, mark() after each mutation (pauses
+    // history once the pre-resize state is checkpointed), end() on pointerup, so
+    // the whole resize collapses into one undo entry.
+    const history = useTimelineHistoryBatch();
 
-  const positionOf = useCallback(
-    () =>
-      timelineStoreApi.getState().tracks.findIndex((t) => t.id === track.id),
-    [timelineStoreApi, track.id]
-  );
+    const handleResizePointerDown = useCallback(
+      (e: React.PointerEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+        e.currentTarget.setPointerCapture(e.pointerId);
+        dragStartYRef.current = e.clientY;
+        dragStartHeightRef.current = heightPx;
+        isResizingRef.current = true;
+        history.begin();
+      },
+      [heightPx, history]
+    );
 
-  const handleMenuRename = useCallback(() => {
-    closeContextMenu();
-    startRename();
-  }, [closeContextMenu, startRename]);
-
-  const handleMenuDuplicate = useCallback(() => {
-    closeContextMenu();
-    duplicateTrack(track.id);
-  }, [closeContextMenu, duplicateTrack, track.id]);
-
-  const handleMenuInsertAbove = useCallback(() => {
-    closeContextMenu();
-    insertTrack(track.type, positionOf());
-  }, [closeContextMenu, insertTrack, positionOf, track.type]);
-
-  const handleMenuInsertBelow = useCallback(() => {
-    closeContextMenu();
-    insertTrack(track.type, positionOf() + 1);
-  }, [closeContextMenu, insertTrack, positionOf, track.type]);
-
-  const handleMenuRemove = useCallback(() => {
-    closeContextMenu();
-    setConfirmRemoveOpen(true);
-  }, [closeContextMenu]);
-
-  // A midi track is mixed like an audio one: it carries gain, mute/solo and
-  // a DSP chain, and has no picture to show or hide.
-  const isSoundTrack = track.type === "audio" || track.type === "midi";
-  const supportsEffects = isSoundTrack || track.type === "video";
-  const effectsCount = track.effects?.length ?? 0;
-  const hasActiveEffects =
-    track.effects?.some((e) => e.enabled) ?? false;
-
-  const isMidi = track.type === "midi";
-  const setTrackInstrument = useTimelineStore((s) => s.setTrackInstrument);
-  const presetId =
-    isMidi && track.instrument
-      ? (presetIdForInstrument(track.instrument) ?? CUSTOM_PRESET)
-      : CUSTOM_PRESET;
-  const handlePresetChange = useCallback(
-    (value: string) => {
-      const preset = findInstrumentPreset(value);
-      if (preset) {
-        setTrackInstrument(track.id, preset.instrument);
-      }
-    },
-    [setTrackInstrument, track.id]
-  );
-
-  const instrumentExpanded = useTimelineUIStore(
-    (s) => s.expandedInstrumentTrackId === track.id
-  );
-  const toggleExpandedInstrument = useTimelineUIStore(
-    (s) => s.toggleExpandedInstrument
-  );
-  const handleInstrumentToggle = useCallback(() => {
-    toggleExpandedInstrument(track.id);
-  }, [toggleExpandedInstrument, track.id]);
-
-  const fxExpanded = useTimelineUIStore(
-    (s) => s.expandedFxTrackId === track.id
-  );
-  const toggleExpandedFx = useTimelineUIStore((s) => s.toggleExpandedFx);
-  const handleFxToggle = useCallback(() => {
-    toggleExpandedFx(track.id);
-  }, [toggleExpandedFx, track.id]);
-
-  // Drag-reorder: the grip is the HTML5 drag source; the whole header is the drop target.
-  // Reordering is constrained to same-type tracks (see trackReorder). The drop
-  // target / indicator state lives in the UI store so sibling headers can show
-  // the insertion line; the per-header selector returns the edge only for the
-  // hovered row, so other headers don't re-render on every dragover.
-
-  const headerRef = useRef<HTMLDivElement>(null);
-  const uiStoreApi = useTimelineUIStoreApi();
-  const beginTrackDrag = useTimelineUIStore((s) => s.beginTrackDrag);
-  const setTrackDropTarget = useTimelineUIStore((s) => s.setTrackDropTarget);
-  const endTrackDrag = useTimelineUIStore((s) => s.endTrackDrag);
-  const dropEdge = useTimelineUIStore((s) =>
-    s.trackDropTarget?.trackId === track.id ? s.trackDropTarget.position : null
-  );
-
-  const handleDragStart = useCallback(
-    (e: React.DragEvent) => {
-      e.dataTransfer.effectAllowed = "move";
-      e.dataTransfer.setData(TRACK_DRAG_MIME, track.id);
-      if (headerRef.current) {
-        e.dataTransfer.setDragImage(headerRef.current, 12, 12);
-      }
-      beginTrackDrag(track.id);
-    },
-    [beginTrackDrag, track.id]
-  );
-
-  const handleDragEnd = useCallback(() => {
-    endTrackDrag();
-  }, [endTrackDrag]);
-
-  const handleDragOver = useCallback(
-    (e: React.DragEvent) => {
-      const draggingId = uiStoreApi.getState().draggingTrackId;
-      if (!draggingId || draggingId === track.id) {
-        return;
-      }
-      const dragged = timelineStoreApi
-        .getState()
-        .tracks.find((t) => t.id === draggingId);
-      // Only accept same-type drops; a cross-type hover shows no indicator.
-      if (!dragged || dragged.type !== track.type) {
-        if (uiStoreApi.getState().trackDropTarget?.trackId === track.id) {
-          setTrackDropTarget(null);
+    const handleResizePointerMove = useCallback(
+      (e: React.PointerEvent<HTMLDivElement>) => {
+        if (!isResizingRef.current || e.buttons !== 1) {
+          return;
         }
-        return;
-      }
-      e.preventDefault();
-      e.dataTransfer.dropEffect = "move";
-      const rect = e.currentTarget.getBoundingClientRect();
-      const position: TrackDropPosition =
-        e.clientY < rect.top + rect.height / 2 ? "before" : "after";
-      const current = uiStoreApi.getState().trackDropTarget;
-      if (current?.trackId !== track.id || current.position !== position) {
-        setTrackDropTarget({ trackId: track.id, position });
-      }
-    },
-    [uiStoreApi, timelineStoreApi, setTrackDropTarget, track.id, track.type]
-  );
+        const deltaY = e.clientY - dragStartYRef.current;
+        const newHeight = Math.min(
+          MAX_TRACK_HEIGHT_PX,
+          Math.max(MIN_TRACK_HEIGHT_PX, dragStartHeightRef.current + deltaY)
+        );
+        setTrackHeight(track.id, newHeight);
+        // First effective mutation recorded the pre-resize state; batch the rest.
+        history.mark();
+      },
+      [setTrackHeight, track.id, history]
+    );
 
-  const handleDrop = useCallback(
-    (e: React.DragEvent) => {
-      const draggingId = uiStoreApi.getState().draggingTrackId;
-      const position = uiStoreApi.getState().trackDropTarget?.position;
+    const handleResizePointerEnd = useCallback(() => {
+      isResizingRef.current = false;
+      history.end();
+    }, [history]);
+
+    // Context menu: right-click anywhere on the header, or a touch hold. The
+    // resize handle and the drag grip stop pointer/contextmenu propagation so a
+    // resize or reorder gesture never opens it.
+
+    const openHeaderMenuAt = useCallback(
+      (x: number, y: number) => {
+        if (editingName) {
+          return;
+        }
+        setContextMenuPos({ x, y });
+      },
+      [editingName]
+    );
+
+    const headerLongPress = useLongPress(
+      useCallback(
+        (point: LongPressPoint) => {
+          openHeaderMenuAt(point.clientX, point.clientY);
+        },
+        [openHeaderMenuAt]
+      )
+    );
+
+    const handleHeaderContextMenu = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (editingName) {
+          return;
+        }
+        e.preventDefault();
+        openHeaderMenuAt(e.clientX, e.clientY);
+      },
+      [editingName, openHeaderMenuAt]
+    );
+
+    const closeContextMenu = useCallback(() => setContextMenuPos(null), []);
+
+    const stopPointerPropagation = useCallback(
+      (e: React.SyntheticEvent) => e.stopPropagation(),
+      []
+    );
+
+    const positionOf = useCallback(
+      () =>
+        timelineStoreApi.getState().tracks.findIndex((t) => t.id === track.id),
+      [timelineStoreApi, track.id]
+    );
+
+    const handleMenuRename = useCallback(() => {
+      closeContextMenu();
+      startRename();
+    }, [closeContextMenu, startRename]);
+
+    const handleMenuDuplicate = useCallback(() => {
+      closeContextMenu();
+      duplicateTrack(track.id);
+    }, [closeContextMenu, duplicateTrack, track.id]);
+
+    const handleMenuInsertAbove = useCallback(() => {
+      closeContextMenu();
+      insertTrack(track.type, positionOf());
+    }, [closeContextMenu, insertTrack, positionOf, track.type]);
+
+    const handleMenuInsertBelow = useCallback(() => {
+      closeContextMenu();
+      insertTrack(track.type, positionOf() + 1);
+    }, [closeContextMenu, insertTrack, positionOf, track.type]);
+
+    const handleMenuRemove = useCallback(() => {
+      closeContextMenu();
+      setConfirmRemoveOpen(true);
+    }, [closeContextMenu]);
+
+    // A midi track is mixed like an audio one: it carries gain, mute/solo and
+    // a DSP chain, and has no picture to show or hide.
+    const isSoundTrack = track.type === "audio" || track.type === "midi";
+    const supportsEffects = isSoundTrack || track.type === "video";
+    const effectsCount = track.effects?.length ?? 0;
+    const hasActiveEffects = track.effects?.some((e) => e.enabled) ?? false;
+
+    const isMidi = track.type === "midi";
+    const setTrackInstrument = useTimelineStore((s) => s.setTrackInstrument);
+    const presetId =
+      isMidi && track.instrument && track.instrument.type !== "subtractive"
+        ? (presetIdForInstrument(track.instrument) ?? CUSTOM_PRESET)
+        : CUSTOM_PRESET;
+    const handlePresetChange = useCallback(
+      (value: string) => {
+        const preset = findInstrumentPreset(value);
+        if (preset) {
+          setTrackInstrument(track.id, preset.instrument);
+        }
+      },
+      [setTrackInstrument, track.id]
+    );
+
+    const instrumentExpanded = useTimelineUIStore(
+      (s) => s.panelTab === "instrument" && s.expandedInstrumentTrackId === track.id
+    );
+    const toggleExpandedInstrument = useTimelineUIStore(
+      (s) => s.toggleExpandedInstrument
+    );
+    const handleInstrumentToggle = useCallback(() => {
+      toggleExpandedInstrument(track.id);
+    }, [toggleExpandedInstrument, track.id]);
+
+    const fxExpanded = useTimelineUIStore(
+      (s) => s.expandedFxTrackId === track.id
+    );
+    const toggleExpandedFx = useTimelineUIStore((s) => s.toggleExpandedFx);
+    const handleFxToggle = useCallback(() => {
+      toggleExpandedFx(track.id);
+    }, [toggleExpandedFx, track.id]);
+
+    // Drag-reorder: the grip is the HTML5 drag source; the whole header is the drop target.
+    // Reordering is constrained to same-type tracks (see trackReorder). The drop
+    // target / indicator state lives in the UI store so sibling headers can show
+    // the insertion line; the per-header selector returns the edge only for the
+    // hovered row, so other headers don't re-render on every dragover.
+
+    const headerRef = useRef<HTMLDivElement>(null);
+    const uiStoreApi = useTimelineUIStoreApi();
+    const beginTrackDrag = useTimelineUIStore((s) => s.beginTrackDrag);
+    const setTrackDropTarget = useTimelineUIStore((s) => s.setTrackDropTarget);
+    const endTrackDrag = useTimelineUIStore((s) => s.endTrackDrag);
+    const dropEdge = useTimelineUIStore((s) =>
+      s.trackDropTarget?.trackId === track.id
+        ? s.trackDropTarget.position
+        : null
+    );
+
+    const handleDragStart = useCallback(
+      (e: React.DragEvent) => {
+        e.dataTransfer.effectAllowed = "move";
+        e.dataTransfer.setData(TRACK_DRAG_MIME, track.id);
+        if (headerRef.current) {
+          e.dataTransfer.setDragImage(headerRef.current, 12, 12);
+        }
+        beginTrackDrag(track.id);
+      },
+      [beginTrackDrag, track.id]
+    );
+
+    const handleDragEnd = useCallback(() => {
       endTrackDrag();
-      if (!draggingId || !position) {
-        return;
-      }
-      e.preventDefault();
-      e.stopPropagation();
-      const ordered = computeReorderedTrackIds(
-        timelineStoreApi.getState().tracks,
-        draggingId,
-        track.id,
-        position
-      );
-      if (ordered) {
-        reorderTracks(ordered);
-      }
-    },
-    [uiStoreApi, timelineStoreApi, endTrackDrag, reorderTracks, track.id]
-  );
+    }, [endTrackDrag]);
 
-  // A resize drag re-renders this per pointermove, one header per track. Only
-  // the root style reads heightPx; the six icon buttons share two variants.
-  const headerCss = useMemo(
-    () => headerStyles(theme, heightPx, compact),
-    [theme, heightPx, compact]
-  );
-  const dropIndicatorCss = useMemo(
-    () => (dropEdge ? dropIndicatorStyles(theme, dropEdge) : undefined),
-    [theme, dropEdge]
-  );
-  const dragHandleCss = useMemo(() => dragHandleStyles(theme), [theme]);
-  const typeGlyphCss = useMemo(
-    () => typeGlyphStyles(theme, accent),
-    [theme, accent]
-  );
-  const nameInputCss = useMemo(() => nameInputStyles(theme), [theme]);
-  const indexChipCss = useMemo(() => indexChipStyles(theme), [theme]);
-  const controlsRowCss = useMemo(
-    () => controlsRowStyles(compact, compact || isMidi),
-    [compact, isMidi]
-  );
-  const iconButtonOnCss = useMemo(() => iconButtonStyles(theme, true), [theme]);
-  const iconButtonOffCss = useMemo(
-    () => iconButtonStyles(theme, false),
-    [theme]
-  );
-  const resizeHandleCss = useMemo(() => resizeHandleStyles(theme), [theme]);
+    const handleDragOver = useCallback(
+      (e: React.DragEvent) => {
+        const draggingId = uiStoreApi.getState().draggingTrackId;
+        if (!draggingId || draggingId === track.id) {
+          return;
+        }
+        const dragged = timelineStoreApi
+          .getState()
+          .tracks.find((t) => t.id === draggingId);
+        // Only accept same-type drops; a cross-type hover shows no indicator.
+        if (!dragged || dragged.type !== track.type) {
+          if (uiStoreApi.getState().trackDropTarget?.trackId === track.id) {
+            setTrackDropTarget(null);
+          }
+          return;
+        }
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        const rect = e.currentTarget.getBoundingClientRect();
+        const position: TrackDropPosition =
+          e.clientY < rect.top + rect.height / 2 ? "before" : "after";
+        const current = uiStoreApi.getState().trackDropTarget;
+        if (current?.trackId !== track.id || current.position !== position) {
+          setTrackDropTarget({ trackId: track.id, position });
+        }
+      },
+      [uiStoreApi, timelineStoreApi, setTrackDropTarget, track.id, track.type]
+    );
 
-  return (
-    <>
-    <div
-      ref={headerRef}
-      css={headerCss}
-      data-testid={`track-header-${track.id}`}
-      onDragOver={handleDragOver}
-      onDrop={handleDrop}
-      onContextMenu={handleHeaderContextMenu}
-      onPointerDown={headerLongPress.start}
-      onPointerMove={headerLongPress.move}
-      onPointerUp={headerLongPress.cancel}
-      onPointerCancel={headerLongPress.cancel}
-    >
-      {dropEdge && (
+    const handleDrop = useCallback(
+      (e: React.DragEvent) => {
+        const draggingId = uiStoreApi.getState().draggingTrackId;
+        const position = uiStoreApi.getState().trackDropTarget?.position;
+        endTrackDrag();
+        if (!draggingId || !position) {
+          return;
+        }
+        e.preventDefault();
+        e.stopPropagation();
+        const ordered = computeReorderedTrackIds(
+          timelineStoreApi.getState().tracks,
+          draggingId,
+          track.id,
+          position
+        );
+        if (ordered) {
+          reorderTracks(ordered);
+        }
+      },
+      [uiStoreApi, timelineStoreApi, endTrackDrag, reorderTracks, track.id]
+    );
+
+    // A resize drag re-renders this per pointermove, one header per track. Only
+    // the root style reads heightPx; the six icon buttons share two variants.
+    const headerCss = useMemo(
+      () => headerStyles(theme, heightPx, compact),
+      [theme, heightPx, compact]
+    );
+    const dropIndicatorCss = useMemo(
+      () => (dropEdge ? dropIndicatorStyles(theme, dropEdge) : undefined),
+      [theme, dropEdge]
+    );
+    const dragHandleCss = useMemo(() => dragHandleStyles(theme), [theme]);
+    const typeGlyphCss = useMemo(
+      () => typeGlyphStyles(theme, accent),
+      [theme, accent]
+    );
+    const nameInputCss = useMemo(() => nameInputStyles(theme), [theme]);
+    const indexChipCss = useMemo(() => indexChipStyles(theme), [theme]);
+    const controlsRowCss = useMemo(
+      () => controlsRowStyles(compact, compact || isMidi),
+      [compact, isMidi]
+    );
+    const iconButtonOnCss = useMemo(
+      () => iconButtonStyles(theme, true),
+      [theme]
+    );
+    const iconButtonOffCss = useMemo(
+      () => iconButtonStyles(theme, false),
+      [theme]
+    );
+    const resizeHandleCss = useMemo(() => resizeHandleStyles(theme), [theme]);
+
+    return (
+      <>
         <div
-          css={dropIndicatorCss}
-          data-testid={`track-drop-indicator-${track.id}-${dropEdge}`}
-          aria-hidden
-        />
-      )}
-      {/* Top row: drag handle · type glyph · name · index chip */}
-      <div css={topRowStyles}>
-        {!compact && (
-          <>
+          ref={headerRef}
+          css={headerCss}
+          data-testid={`track-header-${track.id}`}
+          onDragOver={handleDragOver}
+          onDrop={handleDrop}
+          onContextMenu={handleHeaderContextMenu}
+          onPointerDown={headerLongPress.start}
+          onPointerMove={headerLongPress.move}
+          onPointerUp={headerLongPress.cancel}
+          onPointerCancel={headerLongPress.cancel}
+        >
+          {dropEdge && (
             <div
-              css={dragHandleCss}
-              draggable
-              onDragStart={handleDragStart}
-              onDragEnd={handleDragEnd}
-              onPointerDown={stopPointerPropagation}
-              onContextMenu={stopPointerPropagation}
-              aria-label={`Reorder ${track.name}`}
-              role="button"
-              tabIndex={-1}
-              title="Drag to reorder track"
-              data-testid={`track-drag-handle-${track.id}`}
-            >
-              <DragIndicatorIcon />
-            </div>
-            <div
-              css={typeGlyphCss}
+              css={dropIndicatorCss}
+              data-testid={`track-drop-indicator-${track.id}-${dropEdge}`}
               aria-hidden
-              title={meta.label}
-            >
-              <TypeIcon />
-            </div>
-          </>
-        )}
-        <div css={nameWrapStyles}>
-          <InlineEditableText
-            css={nameInputCss}
-            unstyled
-            displayAsInput
-            value={track.name}
-            editing={editingName}
-            onEditingChange={setEditingName}
-            onCommit={commitName}
-            ariaLabel={`Track name: ${track.name}`}
-            title="Double-click to rename"
-          />
-          <span
-            css={indexChipCss}
-            aria-label={`${meta.label} track ${typedIndex}`}
-            title={`${meta.label} ${typedIndex}`}
-          >
-            {meta.prefix}
-            {typedIndex}
-          </span>
-        </div>
-      </div>
-
-      {/* Controls row */}
-      <div
-        css={controlsRowCss}
-        className={compact ? "timeline-track-controls" : undefined}
-      >
-        {track.type !== "midi" && (
-          <Tooltip title={track.visible ? "Hide track" : "Show track"}>
-            <button
-              type="button"
-              css={track.visible ? iconButtonOnCss : iconButtonOffCss}
-              onClick={() => setTrackVisible(track.id, !track.visible)}
-              aria-label={track.visible ? "Hide track" : "Show track"}
-              aria-pressed={!track.visible}
-            >
-              {track.visible ? (
-                <VisibilityOutlinedIcon />
-              ) : (
-                <VisibilityOffOutlinedIcon />
-              )}
-            </button>
-          </Tooltip>
-        )}
-
-        <Tooltip title={track.locked ? "Unlock track" : "Lock track"}>
-          <button
-            type="button"
-            css={track.locked ? iconButtonOffCss : iconButtonOnCss}
-            onClick={() => setTrackLocked(track.id, !track.locked)}
-            aria-label={track.locked ? "Unlock track" : "Lock track"}
-            aria-pressed={track.locked}
-          >
-            {track.locked ? <LockOutlinedIcon /> : <LockOpenOutlinedIcon />}
-          </button>
-        </Tooltip>
-
-        {isSoundTrack && (
-          <>
-            <Tooltip title={track.muted ? "Unmute" : "Mute"} key="mute">
-              <button
-                type="button"
-                css={track.muted ? iconButtonOffCss : iconButtonOnCss}
-                onClick={() => setTrackMuted(track.id, !track.muted)}
-                aria-label={track.muted ? "Unmute" : "Mute"}
-                aria-pressed={!!track.muted}
-              >
-                {track.muted ? <VolumeOffOutlinedIcon /> : <VolumeUpOutlinedIcon />}
-              </button>
-            </Tooltip>
-
-            <Tooltip title={track.solo ? "Unsolo" : "Solo"}>
-              <button
-                type="button"
-                css={track.solo ? iconButtonOnCss : iconButtonOffCss}
-                onClick={() => setTrackSolo(track.id, !track.solo)}
-                aria-label={track.solo ? "Unsolo" : "Solo"}
-                aria-pressed={!!track.solo}
-              >
-                <span
-                  style={{
-                    fontSize: theme.fontSizeSmaller,
-                    fontWeight: 600,
-                    letterSpacing: "0.04em"
-                  }}
-                >
-                  S
-                </span>
-              </button>
-            </Tooltip>
-          </>
-        )}
-
-        {isMidi && (
-          <>
-            <SelectField
-              label={`Instrument for ${track.name}`}
-              hideLabel
-              size="small"
-              variant="outlined"
-              value={presetId}
-              options={PRESET_OPTIONS}
-              onChange={handlePresetChange}
-              css={presetSelectStyles}
             />
-            <Tooltip title="Edit instrument">
+          )}
+          {/* Top row: drag handle · type glyph · name · index chip */}
+          <div css={topRowStyles}>
+            {!compact && (
+              <>
+                <div
+                  css={dragHandleCss}
+                  draggable
+                  onDragStart={handleDragStart}
+                  onDragEnd={handleDragEnd}
+                  onPointerDown={stopPointerPropagation}
+                  onContextMenu={stopPointerPropagation}
+                  aria-label={`Reorder ${track.name}`}
+                  role="button"
+                  tabIndex={-1}
+                  title="Drag to reorder track"
+                  data-testid={`track-drag-handle-${track.id}`}
+                >
+                  <DragIndicatorIcon />
+                </div>
+                <div css={typeGlyphCss} aria-hidden title={meta.label}>
+                  <TypeIcon />
+                </div>
+              </>
+            )}
+            <div css={nameWrapStyles}>
+              <InlineEditableText
+                css={nameInputCss}
+                unstyled
+                displayAsInput
+                value={track.name}
+                editing={editingName}
+                onEditingChange={setEditingName}
+                onCommit={commitName}
+                ariaLabel={`Track name: ${track.name}`}
+                title="Double-click to rename"
+              />
+              <span
+                css={indexChipCss}
+                aria-label={`${meta.label} track ${typedIndex}`}
+                title={`${meta.label} ${typedIndex}`}
+              >
+                {meta.prefix}
+                {typedIndex}
+              </span>
+            </div>
+          </div>
+
+          {/* Controls row */}
+          <div
+            css={controlsRowCss}
+            className={compact ? "timeline-track-controls" : undefined}
+          >
+            {track.type !== "midi" && (
+              <Tooltip title={track.visible ? "Hide track" : "Show track"}>
+                <button
+                  type="button"
+                  css={track.visible ? iconButtonOnCss : iconButtonOffCss}
+                  onClick={() => setTrackVisible(track.id, !track.visible)}
+                  aria-label={track.visible ? "Hide track" : "Show track"}
+                  aria-pressed={!track.visible}
+                >
+                  {track.visible ? (
+                    <VisibilityOutlinedIcon />
+                  ) : (
+                    <VisibilityOffOutlinedIcon />
+                  )}
+                </button>
+              </Tooltip>
+            )}
+
+            <Tooltip title={track.locked ? "Unlock track" : "Lock track"}>
               <button
                 type="button"
-                css={instrumentExpanded ? iconButtonOnCss : iconButtonOffCss}
-                onClick={handleInstrumentToggle}
-                aria-label={
-                  instrumentExpanded ? "Hide instrument" : "Edit instrument"
-                }
-                aria-pressed={instrumentExpanded}
-                data-testid={`track-instrument-${track.id}`}
+                css={track.locked ? iconButtonOffCss : iconButtonOnCss}
+                onClick={() => setTrackLocked(track.id, !track.locked)}
+                aria-label={track.locked ? "Unlock track" : "Lock track"}
+                aria-pressed={track.locked}
               >
-                <TuneOutlinedIcon />
+                {track.locked ? <LockOutlinedIcon /> : <LockOpenOutlinedIcon />}
               </button>
             </Tooltip>
-          </>
-        )}
 
-        {supportsEffects && (
-          <Tooltip
-            title={
-              effectsCount === 0
-                ? "Effects chain (empty)"
-                : `Effects chain (${effectsCount})`
-            }
-          >
-            <button
-              type="button"
-              css={hasActiveEffects || fxExpanded ? iconButtonOnCss : iconButtonOffCss}
-              onClick={handleFxToggle}
-              aria-label={fxExpanded ? "Hide effects chain" : "Show effects chain"}
-              aria-pressed={fxExpanded}
-              data-testid={`track-fx-${track.id}`}
-            >
-              <GraphicEqOutlinedIcon />
-            </button>
-          </Tooltip>
-        )}
+            {isSoundTrack && (
+              <>
+                <Tooltip title={track.muted ? "Unmute" : "Mute"} key="mute">
+                  <button
+                    type="button"
+                    css={track.muted ? iconButtonOffCss : iconButtonOnCss}
+                    onClick={() => setTrackMuted(track.id, !track.muted)}
+                    aria-label={track.muted ? "Unmute" : "Mute"}
+                    aria-pressed={!!track.muted}
+                  >
+                    {track.muted ? (
+                      <VolumeOffOutlinedIcon />
+                    ) : (
+                      <VolumeUpOutlinedIcon />
+                    )}
+                  </button>
+                </Tooltip>
 
-        <Tooltip title="Remove track">
-          <button
-            type="button"
-            css={iconButtonOnCss}
-            onClick={() => setConfirmRemoveOpen(true)}
-            aria-label="Remove track"
-          >
-            <DeleteOutlineOutlinedIcon />
-          </button>
-        </Tooltip>
-      </div>
+                <Tooltip title={track.solo ? "Unsolo" : "Solo"}>
+                  <button
+                    type="button"
+                    css={track.solo ? iconButtonOnCss : iconButtonOffCss}
+                    onClick={() => setTrackSolo(track.id, !track.solo)}
+                    aria-label={track.solo ? "Unsolo" : "Solo"}
+                    aria-pressed={!!track.solo}
+                  >
+                    <span
+                      style={{
+                        fontSize: theme.fontSizeSmaller,
+                        fontWeight: 600,
+                        letterSpacing: "0.04em"
+                      }}
+                    >
+                      S
+                    </span>
+                  </button>
+                </Tooltip>
+              </>
+            )}
 
-      {/* Height resize handle */}
-      <div
-        css={resizeHandleCss}
-        onPointerDown={handleResizePointerDown}
-        onPointerMove={handleResizePointerMove}
-        onPointerUp={handleResizePointerEnd}
-        onPointerCancel={handleResizePointerEnd}
-        onContextMenu={stopPointerPropagation}
-        aria-label="Resize track height"
-        role="separator"
-        aria-orientation="horizontal"
-      />
-    </div>
-    <ContextMenu
-      open={contextMenuPos !== null}
-      position={contextMenuPos}
-      onClose={closeContextMenu}
-      disableRestoreFocus
-      compact
-      data-testid={`track-context-menu-${track.id}`}
-    >
-      <MenuItemPrimitive
-        label="Rename"
-        icon={<DriveFileRenameOutlineIcon fontSize="small" />}
-        onClick={handleMenuRename}
-        compact
-      />
-      <MenuItemPrimitive
-        label="Duplicate track"
-        icon={<ContentCopyIcon fontSize="small" />}
-        onClick={handleMenuDuplicate}
-        compact
-      />
-      <MenuItemPrimitive
-        label={`Insert ${meta.label} track above`}
-        icon={<VerticalAlignTopIcon fontSize="small" />}
-        onClick={handleMenuInsertAbove}
-        compact
-      />
-      <MenuItemPrimitive
-        label={`Insert ${meta.label} track below`}
-        icon={<VerticalAlignBottomIcon fontSize="small" />}
-        onClick={handleMenuInsertBelow}
-        compact
-      />
-      <MenuItemPrimitive
-        label="Remove track"
-        icon={<DeleteOutlineOutlinedIcon fontSize="small" />}
-        onClick={handleMenuRemove}
-        color="error"
-        dividerBefore
-        compact
-      />
-    </ContextMenu>
-    <ConfirmDialog
-      open={confirmRemoveOpen}
-      onClose={() => setConfirmRemoveOpen(false)}
-      onConfirm={() => removeTrack(track.id)}
-      title="Remove track"
-      content={`Remove track "${track.name}" and all its clips?`}
-      confirmText="Remove"
-      cancelText="Cancel"
-    />
-    </>
-  );
-});
+            {isMidi && (
+              <>
+                <SelectField
+                  label={`Instrument for ${track.name}`}
+                  hideLabel
+                  size="small"
+                  variant="outlined"
+                  value={presetId}
+                  options={PRESET_OPTIONS}
+                  onChange={handlePresetChange}
+                  css={presetSelectStyles}
+                />
+                <Tooltip title="Edit instrument">
+                  <button
+                    type="button"
+                    css={
+                      instrumentExpanded ? iconButtonOnCss : iconButtonOffCss
+                    }
+                    onClick={handleInstrumentToggle}
+                    aria-label="Edit instrument"
+                    aria-expanded={instrumentExpanded}
+                    aria-pressed={instrumentExpanded}
+                    data-testid={`track-instrument-${track.id}`}
+                  >
+                    <TuneOutlinedIcon />
+                  </button>
+                </Tooltip>
+              </>
+            )}
+
+            {supportsEffects && (
+              <Tooltip
+                title={
+                  effectsCount === 0
+                    ? "Effects chain (empty)"
+                    : `Effects chain (${effectsCount})`
+                }
+              >
+                <button
+                  type="button"
+                  css={
+                    hasActiveEffects || fxExpanded
+                      ? iconButtonOnCss
+                      : iconButtonOffCss
+                  }
+                  onClick={handleFxToggle}
+                  aria-label={
+                    fxExpanded ? "Hide effects chain" : "Show effects chain"
+                  }
+                  aria-pressed={fxExpanded}
+                  data-testid={`track-fx-${track.id}`}
+                >
+                  <GraphicEqOutlinedIcon />
+                </button>
+              </Tooltip>
+            )}
+
+            <Tooltip title="Remove track">
+              <button
+                type="button"
+                css={iconButtonOnCss}
+                onClick={() => setConfirmRemoveOpen(true)}
+                aria-label="Remove track"
+              >
+                <DeleteOutlineOutlinedIcon />
+              </button>
+            </Tooltip>
+          </div>
+
+          {/* Height resize handle */}
+          <div
+            css={resizeHandleCss}
+            onPointerDown={handleResizePointerDown}
+            onPointerMove={handleResizePointerMove}
+            onPointerUp={handleResizePointerEnd}
+            onPointerCancel={handleResizePointerEnd}
+            onContextMenu={stopPointerPropagation}
+            aria-label="Resize track height"
+            role="separator"
+            aria-orientation="horizontal"
+          />
+        </div>
+        <ContextMenu
+          open={contextMenuPos !== null}
+          position={contextMenuPos}
+          onClose={closeContextMenu}
+          disableRestoreFocus
+          compact
+          data-testid={`track-context-menu-${track.id}`}
+        >
+          <MenuItemPrimitive
+            label="Rename"
+            icon={<DriveFileRenameOutlineIcon fontSize="small" />}
+            onClick={handleMenuRename}
+            compact
+          />
+          <MenuItemPrimitive
+            label="Duplicate track"
+            icon={<ContentCopyIcon fontSize="small" />}
+            onClick={handleMenuDuplicate}
+            compact
+          />
+          <MenuItemPrimitive
+            label={`Insert ${meta.label} track above`}
+            icon={<VerticalAlignTopIcon fontSize="small" />}
+            onClick={handleMenuInsertAbove}
+            compact
+          />
+          <MenuItemPrimitive
+            label={`Insert ${meta.label} track below`}
+            icon={<VerticalAlignBottomIcon fontSize="small" />}
+            onClick={handleMenuInsertBelow}
+            compact
+          />
+          <MenuItemPrimitive
+            label="Remove track"
+            icon={<DeleteOutlineOutlinedIcon fontSize="small" />}
+            onClick={handleMenuRemove}
+            color="error"
+            dividerBefore
+            compact
+          />
+        </ContextMenu>
+        <ConfirmDialog
+          open={confirmRemoveOpen}
+          onClose={() => setConfirmRemoveOpen(false)}
+          onConfirm={() => removeTrack(track.id)}
+          title="Remove track"
+          content={`Remove track "${track.name}" and all its clips?`}
+          confirmText="Remove"
+          cancelText="Cancel"
+        />
+      </>
+    );
+  }
+);
 
 TrackHeader.displayName = "TrackHeader";

--- a/web/src/components/timeline/Tracks/TrackInstrumentPanel.tsx
+++ b/web/src/components/timeline/Tracks/TrackInstrumentPanel.tsx
@@ -1,403 +1,24 @@
 /** @jsxImportSource @emotion/react */
-/**
- * TrackInstrumentPanel — the voice a midi track plays.
- *
- * Expands inline under the track row, like the DSP chain editor, and edits the
- * one instrument every clip on the track is rendered with. Each change writes
- * the track and plays a middle C through the new voice, so the sound is
- * audible while the timeline is paused; the audition is debounced, since a
- * slider drag would otherwise fire one note per animation frame.
- */
-
-import React, { memo, useCallback, useEffect, useMemo, useRef } from "react";
+/** The selected MIDI track's instrument in the right-panel Instruments tab. */
+import React, { memo, useCallback, useEffect, useRef } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-
-import { DEFAULT_MIDI_INSTRUMENT } from "@nodetool-ai/timeline";
+import { findInstrumentPreset, presetIdForInstrument } from "@nodetool-ai/timeline";
 import type { MidiInstrument } from "@nodetool-ai/timeline";
-
+import { DEFAULT_TIMELINE_INSTRUMENT, TIMELINE_INSTRUMENT_PRESETS } from "../../../stores/timeline/instrumentPresets";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
-import { useBatchedGesture } from "../../../hooks/timeline/useBatchedGesture";
+import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
 import { playAuditionNote } from "../preview/audition";
-import {
-  Caption,
-  FlexColumn,
-  FlexRow,
-  NodeSlider,
-  SelectField,
-  Text,
-  BORDER_RADIUS,
-  FONT_SIZE_SANS,
-  SPACING
-} from "../../ui_primitives";
-import type { SelectOption } from "../../ui_primitives";
-import { FX_PANEL_HEIGHT_PX } from "./trackHeight";
-
-/** How long a slider must rest before the note it produced is played. */
+import FableSynthInstrumentEditor, { InstrumentKeyboard } from "./FableSynthInstrumentEditors";
+import { Button, Caption, FlexColumn, SelectField, SPACING } from "../../ui_primitives";
 export const AUDITION_DEBOUNCE_MS = 120;
-
-const WAVEFORM_OPTIONS: readonly SelectOption[] = [
-  { value: "saw", label: "Saw" },
-  { value: "square", label: "Square" },
-  { value: "triangle", label: "Triangle" },
-  { value: "sine", label: "Sine" }
-];
-
-const MIN_CUTOFF_HZ = 20;
-const MAX_CUTOFF_HZ = 20000;
-
-/** The filter sweeps by ear, not by hertz: the slider is 0..1 over log Hz. */
-const cutoffToSlider = (hz: number): number => {
-  const clamped = Math.min(MAX_CUTOFF_HZ, Math.max(MIN_CUTOFF_HZ, hz));
-  return (
-    Math.log(clamped / MIN_CUTOFF_HZ) / Math.log(MAX_CUTOFF_HZ / MIN_CUTOFF_HZ)
-  );
-};
-
-const sliderToCutoff = (value: number): number =>
-  Math.round(
-    MIN_CUTOFF_HZ * Math.pow(MAX_CUTOFF_HZ / MIN_CUTOFF_HZ, Math.min(1, Math.max(0, value)))
-  );
-
-const containerStyles = (theme: Theme) =>
-  css({
-    width: "100%",
-    height: FX_PANEL_HEIGHT_PX,
-    padding: theme.spacing(1, 1.5, 1.5),
-    backgroundColor: theme.vars.palette.background.default,
-    borderTop: `1px solid ${theme.vars.palette.divider}`,
-    borderBottom: `1px solid ${theme.vars.palette.divider}`,
-    color: theme.vars.palette.text.primary,
-    boxSizing: "border-box",
-    overflowY: "auto"
-  });
-
-const cardStyles = (theme: Theme) =>
-  css({
-    border: `1px solid ${theme.vars.palette.divider}`,
-    borderRadius: BORDER_RADIUS.sm,
-    padding: theme.spacing(1),
-    background: theme.vars.palette.background.paper
-  });
-
-const paramLabelStyles = (theme: Theme) =>
-  css({
-    width: 70,
-    flexShrink: 0,
-    fontSize: FONT_SIZE_SANS.caption,
-    color: theme.vars.palette.text.secondary
-  });
-
-const paramValueStyles = (theme: Theme) =>
-  css({
-    width: 64,
-    flexShrink: 0,
-    textAlign: "right",
-    fontVariantNumeric: "tabular-nums",
-    fontSize: FONT_SIZE_SANS.caption,
-    color: theme.vars.palette.text.primary
-  });
-
-interface ParamRowProps {
-  label: string;
-  value: number;
-  display: string;
-  min: number;
-  max: number;
-  step: number;
-  onChange: (value: number) => void;
-}
-
-const ParamRow: React.FC<ParamRowProps> = memo(
-  ({ label, value, display, min, max, step, onChange }) => {
-    const theme = useTheme();
-    const gesture = useBatchedGesture(onChange);
-    const labelCss = useMemo(() => paramLabelStyles(theme), [theme]);
-    const valueCss = useMemo(() => paramValueStyles(theme), [theme]);
-
-    const handleChange = useCallback(
-      (_e: Event, next: number | number[]) => {
-        gesture.schedule(Array.isArray(next) ? next[0] : next);
-      },
-      [gesture]
-    );
-    const handleCommitted = useCallback(
-      (_e: React.SyntheticEvent | Event, next: number | number[]) => {
-        gesture.commit(Array.isArray(next) ? next[0] : next);
-      },
-      [gesture]
-    );
-
-    return (
-      <FlexRow align="center" gap={SPACING.md}>
-        <span css={labelCss}>{label}</span>
-        <NodeSlider
-          value={value}
-          min={min}
-          max={max}
-          step={step}
-          aria-label={label}
-          onChange={handleChange}
-          onChangeCommitted={handleCommitted}
-          sx={{ flex: 1 }}
-        />
-        <span css={valueCss}>{display}</span>
-      </FlexRow>
-    );
-  }
-);
-ParamRow.displayName = "ParamRow";
-
-interface SubtractiveEditorProps {
-  instrument: Extract<MidiInstrument, { type: "subtractive" }>;
-  onChange: (next: MidiInstrument) => void;
-}
-
-/** The built-in synth: one oscillator, one filter, one envelope. */
-const SubtractiveEditor: React.FC<SubtractiveEditorProps> = memo(
-  ({ instrument, onChange }) => {
-    const handleWaveform = useCallback(
-      (value: string) =>
-        onChange({
-          ...instrument,
-          waveform: value as typeof instrument.waveform
-        }),
-      [instrument, onChange]
-    );
-    const handleAttack = useCallback(
-      (attackMs: number) => onChange({ ...instrument, attackMs }),
-      [instrument, onChange]
-    );
-    const handleDecay = useCallback(
-      (decayMs: number) => onChange({ ...instrument, decayMs }),
-      [instrument, onChange]
-    );
-    const handleSustain = useCallback(
-      (sustain: number) => onChange({ ...instrument, sustain }),
-      [instrument, onChange]
-    );
-    const handleRelease = useCallback(
-      (releaseMs: number) => onChange({ ...instrument, releaseMs }),
-      [instrument, onChange]
-    );
-    const handleCutoff = useCallback(
-      (value: number) =>
-        onChange({ ...instrument, cutoffHz: sliderToCutoff(value) }),
-      [instrument, onChange]
-    );
-    const handleResonance = useCallback(
-      (resonance: number) => onChange({ ...instrument, resonance }),
-      [instrument, onChange]
-    );
-    const handleGain = useCallback(
-      (gainDb: number) => onChange({ ...instrument, gainDb }),
-      [instrument, onChange]
-    );
-
-    return (
-      <FlexColumn gap={SPACING.xs}>
-        <SelectField
-          label="Waveform"
-          size="small"
-          variant="outlined"
-          value={instrument.waveform}
-          options={WAVEFORM_OPTIONS}
-          onChange={handleWaveform}
-        />
-        <ParamRow
-          label="Attack"
-          value={instrument.attackMs}
-          display={`${Math.round(instrument.attackMs)} ms`}
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleAttack}
-        />
-        <ParamRow
-          label="Decay"
-          value={instrument.decayMs}
-          display={`${Math.round(instrument.decayMs)} ms`}
-          min={0}
-          max={4000}
-          step={1}
-          onChange={handleDecay}
-        />
-        <ParamRow
-          label="Sustain"
-          value={instrument.sustain}
-          display={instrument.sustain.toFixed(2)}
-          min={0}
-          max={1}
-          step={0.01}
-          onChange={handleSustain}
-        />
-        <ParamRow
-          label="Release"
-          value={instrument.releaseMs}
-          display={`${Math.round(instrument.releaseMs)} ms`}
-          min={0}
-          max={4000}
-          step={1}
-          onChange={handleRelease}
-        />
-        <ParamRow
-          label="Cutoff"
-          value={cutoffToSlider(instrument.cutoffHz)}
-          display={`${Math.round(instrument.cutoffHz)} Hz`}
-          min={0}
-          max={1}
-          step={0.001}
-          onChange={handleCutoff}
-        />
-        <ParamRow
-          label="Resonance"
-          value={instrument.resonance}
-          display={instrument.resonance.toFixed(2)}
-          min={0}
-          max={20}
-          step={0.1}
-          onChange={handleResonance}
-        />
-        <ParamRow
-          label="Gain"
-          value={instrument.gainDb}
-          display={`${instrument.gainDb.toFixed(1)} dB`}
-          min={-40}
-          max={12}
-          step={0.5}
-          onChange={handleGain}
-        />
-      </FlexColumn>
-    );
-  }
-);
-SubtractiveEditor.displayName = "SubtractiveEditor";
-
-/** What each FableSynth voice is, in one line. */
-const SYNTH_SUMMARY: Record<
-  Exclude<MidiInstrument["type"], "subtractive">,
-  string
-> = {
-  wavetable:
-    "WT-1 — two morphing wavetable oscillators through a swept filter.",
-  bass: "BL-1 — a monophonic acid line: accented notes bite, overlapping notes slide.",
-  drum: "DR-1 — one drum per note, each ringing for its own decay."
-};
-
-interface PitchedSynthEditorProps {
-  instrument: Extract<MidiInstrument, { type: "wavetable" | "bass" }>;
-  onChange: (next: MidiInstrument) => void;
-}
-
-/**
- * WT-1 and BL-1. Their full patch is picked from the preset list on the track
- * header; what is editable here is the handful of controls a mix asks for —
- * how open the filter is, how hard it is driven, how loud it plays.
- */
-const PitchedSynthEditor: React.FC<PitchedSynthEditorProps> = memo(
-  ({ instrument, onChange }) => {
-    const handleCutoff = useCallback(
-      (value: number) =>
-        onChange({ ...instrument, cutoffHz: sliderToCutoff(value) }),
-      [instrument, onChange]
-    );
-    const handleResonance = useCallback(
-      (resonance: number) => onChange({ ...instrument, resonance }),
-      [instrument, onChange]
-    );
-    const handleDrive = useCallback(
-      (drive: number) => onChange({ ...instrument, drive }),
-      [instrument, onChange]
-    );
-    const handleGain = useCallback(
-      (gainDb: number) => onChange({ ...instrument, gainDb }),
-      [instrument, onChange]
-    );
-
-    return (
-      <FlexColumn gap={SPACING.xs}>
-        <Caption color="muted">{SYNTH_SUMMARY[instrument.type]}</Caption>
-        <ParamRow
-          label="Cutoff"
-          value={cutoffToSlider(instrument.cutoffHz)}
-          display={`${Math.round(instrument.cutoffHz)} Hz`}
-          min={0}
-          max={1}
-          step={0.001}
-          onChange={handleCutoff}
-        />
-        <ParamRow
-          label="Resonance"
-          value={instrument.resonance}
-          display={instrument.resonance.toFixed(2)}
-          min={0}
-          max={1}
-          step={0.01}
-          onChange={handleResonance}
-        />
-        <ParamRow
-          label="Drive"
-          value={instrument.drive}
-          display={instrument.drive.toFixed(2)}
-          min={0}
-          max={1}
-          step={0.01}
-          onChange={handleDrive}
-        />
-        <ParamRow
-          label="Gain"
-          value={instrument.gainDb}
-          display={`${instrument.gainDb.toFixed(1)} dB`}
-          min={-40}
-          max={12}
-          step={0.5}
-          onChange={handleGain}
-        />
-      </FlexColumn>
-    );
-  }
-);
-PitchedSynthEditor.displayName = "PitchedSynthEditor";
-
-interface DrumKitEditorProps {
-  instrument: Extract<MidiInstrument, { type: "drum" }>;
-  onChange: (next: MidiInstrument) => void;
-}
-
-/**
- * DR-1. A kit has no filter of its own — each pad carries one — so the only
- * control here is how loud the kit plays; the pad list says what the track's
- * notes will hit.
- */
-const DrumKitEditor: React.FC<DrumKitEditorProps> = memo(
-  ({ instrument, onChange }) => {
-    const handleGain = useCallback(
-      (gainDb: number) => onChange({ ...instrument, gainDb }),
-      [instrument, onChange]
-    );
-
-    return (
-      <FlexColumn gap={SPACING.xs}>
-        <Caption color="muted">{SYNTH_SUMMARY.drum}</Caption>
-        <ParamRow
-          label="Gain"
-          value={instrument.gainDb}
-          display={`${instrument.gainDb.toFixed(1)} dB`}
-          min={-40}
-          max={12}
-          step={0.5}
-          onChange={handleGain}
-        />
-        <Caption color="muted">
-          {`Pads from MIDI ${instrument.baseNote}: ` +
-            instrument.pads.map((pad) => pad.name).join(", ")}
-        </Caption>
-      </FlexColumn>
-    );
-  }
-);
-DrumKitEditor.displayName = "DrumKitEditor";
+const containerStyles = (theme: Theme) => css({
+  width: "100%", height: "100%", padding: theme.spacing(1),
+  backgroundColor: theme.vars.palette.background.default,
+  color: theme.vars.palette.text.primary, boxSizing: "border-box",
+  overflowY: "auto", overflowX: "hidden", overscrollBehavior: "contain"
+});
 
 interface TrackInstrumentPanelProps {
   trackId: string;
@@ -409,8 +30,11 @@ export const TrackInstrumentPanel: React.FC<TrackInstrumentPanelProps> = memo(
     const instrument = useTimelineStore(
       (s) =>
         s.tracks.find((t) => t.id === trackId)?.instrument ??
-        DEFAULT_MIDI_INSTRUMENT
+        DEFAULT_TIMELINE_INSTRUMENT
     );
+    const showKeyboard = useTimelineUIStore(s => !!s.instrumentKeyboards[trackId]);
+    const toggleKeyboard = useTimelineUIStore(s => s.toggleInstrumentKeyboard);
+    const presetId = instrument.type === "subtractive" ? "custom" : presetIdForInstrument(instrument) ?? "custom";
     const setTrackInstrument = useTimelineStore((s) => s.setTrackInstrument);
 
     // One pending audition at a time: a slider drag writes the track on every
@@ -426,19 +50,25 @@ export const TrackInstrumentPanel: React.FC<TrackInstrumentPanelProps> = memo(
     );
 
     const commit = useCallback(
-      (next: MidiInstrument) => {
-        setTrackInstrument(trackId, next);
+      (next: MidiInstrument, auditionPitch?: number) => {
+        if (next !== instrument) setTrackInstrument(trackId, next);
         if (auditionTimerRef.current !== null) {
           clearTimeout(auditionTimerRef.current);
         }
+        if (next === instrument) {
+          void playAuditionNote(next, auditionPitch).catch(() => {
+            // A host without Web Audio still supports editing.
+          });
+          return;
+        }
         auditionTimerRef.current = setTimeout(() => {
           auditionTimerRef.current = null;
-          void playAuditionNote(next).catch(() => {
+          void playAuditionNote(next, auditionPitch).catch(() => {
             // A host with no Web Audio cannot preview; the edit still stands.
           });
         }, AUDITION_DEBOUNCE_MS);
       },
-      [setTrackInstrument, trackId]
+      [setTrackInstrument, trackId, instrument]
     );
 
     return (
@@ -447,26 +77,36 @@ export const TrackInstrumentPanel: React.FC<TrackInstrumentPanelProps> = memo(
         data-testid={`track-instrument-panel-${trackId}`}
       >
         <FlexColumn gap={SPACING.md}>
-          <Text size="small" weight={500}>
-            Instrument
-          </Text>
-          <div css={cardStyles(theme)}>
-            {instrument.type === "subtractive" && (
-              <SubtractiveEditor instrument={instrument} onChange={commit} />
-            )}
-            {(instrument.type === "wavetable" || instrument.type === "bass") && (
-              <PitchedSynthEditor instrument={instrument} onChange={commit} />
-            )}
-            {instrument.type === "drum" && (
-              <DrumKitEditor instrument={instrument} onChange={commit} />
-            )}
-          </div>
+          <SelectField
+            label="Instrument preset"
+            css={css({ width: 240, maxWidth: "100%", alignSelf: "flex-start" })}
+            size="small"
+            value={presetId}
+            options={[
+              ...TIMELINE_INSTRUMENT_PRESETS.map((preset) => ({
+                value: preset.id,
+                label: preset.name
+              })),
+              { value: "custom", label: "Custom" }
+            ]}
+            onChange={(id) => {
+              const preset = findInstrumentPreset(id);
+              if (preset) commit(preset.instrument);
+            }}
+          />
+          <Button size="small" variant="text" aria-pressed={showKeyboard}
+            sx={{ alignSelf: "flex-start", color: showKeyboard ? "primary.main" : "text.secondary", backgroundColor: showKeyboard ? "action.selected" : "transparent" }}
+            onClick={() => toggleKeyboard(trackId)}>Keyboard</Button>
+          {showKeyboard && <div className={`fs-editor fs-${instrument.type}`}>
+            <InstrumentKeyboard start={instrument.type === "drum" ? instrument.baseNote : instrument.type === "bass" ? 36 : 48}
+              onPlay={pitch => commit(instrument, pitch)} />
+          </div>}
+          {instrument.type === "subtractive" ? <Caption color="muted">Choose a WT-1, BL-1, or DR-1 preset to edit this track’s instrument.</Caption> : (
+            <FableSynthInstrumentEditor key={trackId} instrument={instrument} onChange={commit} />
+          )}
           <Caption color="muted">
             Every clip on this track plays this voice. Changes are auditioned on{" "}
-            {instrument.type === "drum"
-              ? "the kit's first pad"
-              : "middle C"}
-            .
+            {instrument.type === "drum" ? "the selected pad" : "middle C"}.
           </Caption>
         </FlexColumn>
       </div>

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -44,7 +44,16 @@
  *   scrollbar stays available.
  */
 
-import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useTimelineIsActive } from "../../../stores/timeline/TimelineInstance";
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
@@ -58,7 +67,10 @@ import {
   useTimelineUIStore,
   useTimelineUIStoreApi,
   MIN_MS_PER_PX,
-  MAX_MS_PER_PX
+  MAX_MS_PER_PX,
+  MIN_TRACK_HEADER_WIDTH_PX,
+  MAX_TRACK_HEADER_WIDTH_PX,
+  maxTrackHeaderWidthForViewport
 } from "../../../stores/timeline/TimelineUIStore";
 import { useTimelinePlaybackStoreApi } from "../../../stores/timeline/TimelinePlaybackStore";
 import { useTimelineHistoryBatch } from "../../../stores/timeline/useTimelineHistoryBatch";
@@ -69,7 +81,6 @@ import {
 } from "../../../stores/timeline/clipboardOps";
 import {
   MOBILE_TRACK_HEADER_WIDTH_PX,
-  TRACK_HEADER_WIDTH_PX,
   TRACK_HEADER_WIDTH_VAR,
   trackHeaderWidthCss
 } from "./TrackHeader";
@@ -87,7 +98,6 @@ import {
   TIMELINE_SCROLLBAR_HEIGHT_PX
 } from "./TimelineScrollbar";
 import { TrackEffectsPanel } from "./TrackEffectsPanel";
-import { TrackInstrumentPanel } from "./TrackInstrumentPanel";
 import {
   ScriptLane,
   ScriptLaneHeader,
@@ -96,7 +106,17 @@ import {
 import { FX_PANEL_HEIGHT_PX } from "./trackHeight";
 import { ToolToggle } from "../ToolToggle";
 import { TimelineShortcutsDialog } from "../TimelineShortcutsDialog";
-import { FlexRow, HelpButton, FONT_SIZE_MONO, FONT_WEIGHT, BORDER_RADIUS, SPACING, getSpacingPx, Z_INDEX } from "../../ui_primitives";
+import {
+  FlexRow,
+  HelpButton,
+  ResizeHandle,
+  FONT_SIZE_MONO,
+  FONT_WEIGHT,
+  BORDER_RADIUS,
+  SPACING,
+  getSpacingPx,
+  Z_INDEX
+} from "../../ui_primitives";
 import { useHasScript } from "../../../hooks/timeline/useHasScript";
 import { useTimelineIsMobile } from "../../../hooks/timeline/useTimelineIsMobile";
 import { useVideoAudioImport } from "../../../hooks/timeline/useVideoAudioImport";
@@ -228,7 +248,7 @@ const scrollableAreaStyles = css({
 });
 
 const lanesContainerStyles = css({
-  position: "relative",
+  position: "relative"
   // Will be set dynamically via style.width
 });
 
@@ -241,6 +261,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
   ({ heightPx }) => {
     const theme = useTheme();
     const isMobile = useTimelineIsMobile();
+    const isActive = useTimelineIsActive();
     const activeExplorer = usePanelStore((s) =>
       s.panel.activeView === "library" || s.panel.activeView === "assets"
         ? s.panel.activeView
@@ -248,14 +269,23 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
     );
     const assetsAsset = useAssetsSelectedAsset();
     const libraryAsset = useLibrarySelectedAsset();
-    const activeAssetId = activeExplorer === "library"
-      ? libraryAsset?.id ?? null
-      : activeExplorer === "assets"
-        ? assetsAsset?.id ?? null
-        : null;
+    const activeAssetId =
+      activeExplorer === "library"
+        ? (libraryAsset?.id ?? null)
+        : activeExplorer === "assets"
+          ? (assetsAsset?.id ?? null)
+          : null;
+    const storedHeaderWidthPx = useTimelineUIStore((s) => s.trackHeaderWidthPx);
+    const setTrackHeaderWidthPx = useTimelineUIStore(
+      (s) => s.setTrackHeaderWidthPx
+    );
     const headerWidthPx = isMobile
       ? MOBILE_TRACK_HEADER_WIDTH_PX
-      : TRACK_HEADER_WIDTH_PX;
+      : storedHeaderWidthPx;
+    const handleHeaderResize = useCallback(
+      (delta: number) => setTrackHeaderWidthPx(headerWidthPx + delta),
+      [headerWidthPx, setTrackHeaderWidthPx]
+    );
 
     const tracks = useTimelineStore((s) => s.tracks);
     // Content extent for sizing the ruler / scroll width. The stored
@@ -392,8 +422,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         );
 
         addTrack(trackType);
-        const newTrack =
-          useTimelineStore.getState().tracks.slice(-1)[0];
+        const newTrack = useTimelineStore.getState().tracks.slice(-1)[0];
         if (!newTrack) return;
         // A video on a new video track also gets a linked audio clip
         // (extracted from the video), matching the per-lane drop path.
@@ -667,7 +696,9 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
       let startMsPerPx = 0;
       let rafId: number | null = null;
 
-      const twoPoints = (): [{ x: number; y: number }, { x: number; y: number }] | null => {
+      const twoPoints = ():
+        | [{ x: number; y: number }, { x: number; y: number }]
+        | null => {
         if (points.size !== 2) return null;
         const [a, b] = [...points.values()];
         return [a, b];
@@ -704,7 +735,10 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         if (points.size === 2) {
           const pair = twoPoints();
           if (!pair) return;
-          startDistance = Math.hypot(pair[0].x - pair[1].x, pair[0].y - pair[1].y);
+          startDistance = Math.hypot(
+            pair[0].x - pair[1].x,
+            pair[0].y - pair[1].y
+          );
           startMsPerPx = uiStoreApi.getState().msPerPx;
         }
       };
@@ -791,6 +825,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
     // regions are skipped so typing isn't hijacked.
 
     useEffect(() => {
+      if (!isActive) return;
       const isEditableTarget = (target: EventTarget | null): boolean =>
         target instanceof HTMLInputElement ||
         target instanceof HTMLTextAreaElement ||
@@ -960,6 +995,20 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
           case "trimEditRightLarge":
             if (trimEditBy(Math.round(frameMs * 10))) e.preventDefault();
             return;
+
+          case "stepFrameBack":
+          case "stepFrameForward": {
+            e.preventDefault();
+            if (playback.isPlaying) return;
+            const endMs = doc.clips.reduce(
+              (end, clip) => Math.max(end, clip.startMs + clip.durationMs),
+              0
+            );
+            const direction = action === "stepFrameBack" ? -1 : 1;
+            const nextFrame = Math.round(liveMs / frameMs) + direction;
+            playback.seek(Math.max(0, Math.min(endMs, nextFrame * frameMs)));
+            return;
+          }
 
           case "markIn":
             e.preventDefault();
@@ -1183,7 +1232,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
               ui,
               playheadMs: playback.currentTimeMs,
               asset: activeExplorer
-                ? getSelectedAssetForExplorer(activeExplorer) ?? undefined
+                ? (getSelectedAssetForExplorer(activeExplorer) ?? undefined)
                 : undefined
             });
             if (id) {
@@ -1211,6 +1260,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         endArrowNudgeBatch();
       };
     }, [
+      isActive,
       uiStoreApi,
       deleteSelected,
       duplicateSelected,
@@ -1231,13 +1281,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
       activeExplorer
     ]);
 
-    const expandedFxTrackId = useTimelineUIStore(
-      (s) => s.expandedFxTrackId
-    );
-    const expandedInstrumentTrackId = useTimelineUIStore(
-      (s) => s.expandedInstrumentTrackId
-    );
-
+    const expandedFxTrackId = useTimelineUIStore((s) => s.expandedFxTrackId);
     // Precompute per-type index map (O(n)) to avoid O(n²) per-header lookups.
     const typedIndexMap = useMemo(() => buildTypedIndexMap(tracks), [tracks]);
 
@@ -1246,8 +1290,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         (sum, t) =>
           sum +
           (t.heightPx ?? DEFAULT_TRACK_HEIGHT_PX) +
-          (t.id === expandedFxTrackId ? FX_PANEL_HEIGHT_PX : 0) +
-          (t.id === expandedInstrumentTrackId ? FX_PANEL_HEIGHT_PX : 0),
+          (t.id === expandedFxTrackId ? FX_PANEL_HEIGHT_PX : 0),
         0
       ) + (hasScript ? SCRIPT_LANE_HEIGHT_PX : 0);
 
@@ -1277,6 +1320,17 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
       ro.observe(el);
       return () => ro.disconnect();
     }, [setLanesViewportWidthPx]);
+
+    const headerResizeMaxPx =
+      fxPanelWidth === 0
+        ? MAX_TRACK_HEADER_WIDTH_PX
+        : maxTrackHeaderWidthForViewport(headerWidthPx + fxPanelWidth);
+
+    useEffect(() => {
+      if (!isMobile && headerWidthPx > headerResizeMaxPx) {
+        setTrackHeaderWidthPx(headerResizeMaxPx);
+      }
+    }, [headerResizeMaxPx, headerWidthPx, isMobile, setTrackHeaderWidthPx]);
 
     return (
       <div
@@ -1329,6 +1383,35 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
           </div>
         </FlexRow>
 
+        {!isMobile && (
+          <ResizeHandle
+            orientation="vertical"
+            value={headerWidthPx}
+            min={MIN_TRACK_HEADER_WIDTH_PX}
+            max={headerResizeMaxPx}
+            onResize={handleHeaderResize}
+            ariaLabel="Resize track headers"
+            sx={{
+              position: "absolute",
+              top: TOOLBAR_HEIGHT_PX,
+              bottom: TIMELINE_SCROLLBAR_HEIGHT_PX,
+              left: trackHeaderWidthCss,
+              width: getSpacingPx(SPACING.md),
+              transform: "translateX(-50%)",
+              zIndex: Z_INDEX.overlay,
+              "&::after": {
+                content: '""',
+                position: "absolute",
+                top: "50%",
+                left: "50%",
+                height: 32,
+                borderLeft: `2px solid ${theme.vars.palette.text.secondary}`,
+                transform: "translate(-50%, -50%)"
+              }
+            }}
+          />
+        )}
+
         {/* ── Track rows ──────────────────────────────────────────────── */}
         <FlexRow
           sx={{
@@ -1364,12 +1447,6 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
                     aria-hidden="true"
                   />
                 )}
-                {expandedInstrumentTrackId === track.id && (
-                  <div
-                    style={{ height: FX_PANEL_HEIGHT_PX }}
-                    aria-hidden="true"
-                  />
-                )}
               </React.Fragment>
             ))}
             {hasScript && scriptBeforeTrackId === null && <ScriptLaneHeader />}
@@ -1385,7 +1462,11 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
           >
             <div
               css={lanesContainerStyles}
-              style={{ minWidth: totalWidthPx, width: "100%", height: totalTracksHeight }}
+              style={{
+                minWidth: totalWidthPx,
+                width: "100%",
+                height: totalTracksHeight
+              }}
               data-timeline-lanes="true"
             >
               {/* Zero-size sticky anchor: must be the first child so its
@@ -1410,24 +1491,9 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
                       <TrackEffectsPanel trackId={track.id} />
                     </div>
                   )}
-                  {expandedInstrumentTrackId === track.id && (
-                    <div
-                      style={{
-                        position: "sticky",
-                        left: 0,
-                        width: fxPanelWidth,
-                        height: FX_PANEL_HEIGHT_PX,
-                        zIndex: Z_INDEX.base + 2
-                      }}
-                    >
-                      <TrackInstrumentPanel trackId={track.id} />
-                    </div>
-                  )}
                 </React.Fragment>
               ))}
-              {hasScript && scriptBeforeTrackId === null && (
-                <ScriptLane />
-              )}
+              {hasScript && scriptBeforeTrackId === null && <ScriptLane />}
               {/* Marquee rect — drawn here, above every lane, because a band
                   started on one lane may cover several. */}
               <RubberBandOverlay />

--- a/web/src/components/timeline/Tracks/__tests__/Clip.gestures.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/Clip.gestures.test.tsx
@@ -156,7 +156,7 @@ const dragClip = (clipId: string, fromX: number, toX: number) => {
   const el = screen.getByTestId(`clip-${clipId}`);
   fireEvent.pointerDown(el, { button: 0, buttons: 1, clientX: fromX, clientY: 20, pointerId: 1 });
   fireEvent.pointerMove(window, { buttons: 1, clientX: toX, clientY: 20, pointerId: 1 });
-  fireEvent.pointerUp(window, { pointerId: 1 });
+  fireEvent.pointerUp(window, { pointerId: 1, clientX: toX, clientY: 20 });
 };
 
 const dragHandle = (
@@ -172,6 +172,7 @@ const dragHandle = (
 };
 
 beforeEach(() => {
+  document.elementsFromPoint = () => [];
   seed();
 });
 
@@ -226,6 +227,24 @@ describe("Clip drag across tracks", () => {
     pointerOverLane("t2");
     dragClip("a1", 100, 100 + DRAG_PX);
     expect(clipState("a1")).toEqual({ trackId: "t2", startMs: 2000 + DRAG_MS, durationMs: 1000 });
+  });
+
+  it("moves vertically into another lane without changing start time", () => {
+    renderLanes();
+    pointerOverLane("t2");
+    const el = screen.getByTestId("clip-a1");
+    fireEvent.pointerDown(el, { button: 0, buttons: 1, clientX: 100, clientY: 20 });
+    fireEvent.pointerMove(window, { buttons: 1, clientX: 100, clientY: 90 });
+    fireEvent.pointerUp(window, { clientX: 100, clientY: 90 });
+    expect(clipState("a1")).toEqual({ trackId: "t2", startMs: 2000, durationMs: 1000 });
+  });
+
+  it("uses the release lane when the final hit test has not painted yet", () => {
+    rafSpy.mockImplementation(() => 1);
+    renderLanes();
+    pointerOverLane("t2");
+    dragClip("a1", 100, 130);
+    expect(clipState("a1").trackId).toBe("t2");
   });
 
   it("moves only the primary clip of a multi-selection to the new lane", () => {

--- a/web/src/components/timeline/Tracks/__tests__/Clip.snap.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/Clip.snap.test.tsx
@@ -57,6 +57,7 @@ beforeAll(installPointerEvent);
 // every whole second, so the neighbours' edges are deliberately off-grid. a4
 // starts 2 s into its source so its start edge has room to grow leftwards.
 beforeEach(() => {
+  document.elementsFromPoint = () => [];
   seedTimeline(
     [makeTrack("t1", 0), makeTrack("t2", 1)],
     [

--- a/web/src/components/timeline/Tracks/__tests__/FableSynthInstrumentEditors.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/FableSynthInstrumentEditors.test.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import { findInstrumentPreset, type MidiInstrument } from "@nodetool-ai/timeline";
+import mockTheme from "../../../../__mocks__/themeMock";
+import FableSynthInstrumentEditor, { InstrumentKeyboard } from "../FableSynthInstrumentEditors";
+
+function setup(id: string) {
+  const onChange = jest.fn();
+  const preset = findInstrumentPreset(id)!;
+  function Editor() {
+    const [instrument, setInstrument] = useState<MidiInstrument>(preset.instrument);
+    if (instrument.type === "subtractive") throw new Error("Expected a Fable instrument");
+    return <FableSynthInstrumentEditor instrument={instrument} onChange={(next, pitch) => {
+      setInstrument(next);
+      onChange(next, pitch);
+    }} />;
+  }
+  render(<ThemeProvider theme={mockTheme}><Editor /></ThemeProvider>);
+  return onChange;
+}
+
+it("auditions chromatic pitches from the labelled keyboard", async () => {
+  const user = userEvent.setup();
+  const onChange = jest.fn();
+  render(<ThemeProvider theme={mockTheme}><InstrumentKeyboard start={48} onPlay={onChange} /></ThemeProvider>);
+  for (const [key, pitch] of [["C3", 48], ["C♯3", 49], ["B3", 59], ["C5", 72]] as const) {
+    await user.click(screen.getByRole("button", {name: `Play ${key}`}));
+    expect(onChange).toHaveBeenLastCalledWith(pitch);
+  }
+});
+
+it("resets a bass knob to its actual default", () => {
+  const onChange = setup("bl1-acid");
+  const drive = screen.getByRole("slider", {name: "DRIVE"});
+  fireEvent.doubleClick(drive);
+  expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({drive: 0}), undefined);
+});
+
+it("edits only the selected drum pad and auditions its MIDI pitch", async () => {
+  const user = userEvent.setup();
+  const onChange = setup("dr1-tr-void");
+  const preset = findInstrumentPreset("dr1-tr-void")!.instrument;
+  if (preset.type !== "drum") throw new Error("Expected drum preset");
+  await user.click(screen.getByRole("button", {name: "Edit pad 3: Snare"}));
+  expect(onChange).toHaveBeenLastCalledWith(preset, preset.baseNote + 2);
+  fireEvent.change(screen.getByRole("slider", {name: "LEVEL"}), {target: {value: "0.42"}});
+  const updated = onChange.mock.lastCall![0];
+  expect(updated.pads[2].level).toBeCloseTo(0.42);
+  expect(updated.pads[0]).toEqual(preset.pads[0]);
+});

--- a/web/src/components/timeline/Tracks/__tests__/TrackHeaderInstrument.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/TrackHeaderInstrument.test.tsx
@@ -6,17 +6,19 @@
  * Edit toggle — the sound itself is `preview/audition.ts`'s own test.
  */
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 
 import { findInstrumentPreset } from "@nodetool-ai/timeline";
-import type { MidiInstrument } from "@nodetool-ai/timeline";
 
 import mockTheme from "../../../../__mocks__/themeMock";
+import { TimelineInstrumentsPanel } from "../../TimelineInstrumentsPanel";
+import { useTimelineUIStore } from "../../../../stores/timeline/TimelineUIStore";
 import { TracksRegion } from "../TracksRegion";
 import { TimelineProvider } from "../../../../stores/timeline/TimelineInstance";
 import { useTimelineStore } from "../../../../stores/timeline/TimelineStore";
+import { maxTrackHeaderWidthForViewport } from "../../../../stores/timeline/TimelineUIStore";
 
 jest.mock("../../preview/audition", () => ({
   playAuditionNote: jest.fn(async () => undefined),
@@ -26,11 +28,15 @@ jest.mock("../../preview/audition", () => ({
 
 import { playAuditionNote } from "../../preview/audition";
 
+function InstrumentDock() {
+  const tab = useTimelineUIStore(s => s.panelTab);
+  return tab === "instrument" ? <aside data-testid="instrument-dock"><TimelineInstrumentsPanel /></aside> : null;
+}
 const renderRegion = () =>
   render(
     <ThemeProvider theme={mockTheme}>
       <TimelineProvider>
-        <TracksRegion heightPx={400} />
+        <TracksRegion heightPx={400} /><InstrumentDock />
       </TimelineProvider>
     </ThemeProvider>
   );
@@ -38,10 +44,6 @@ const renderRegion = () =>
 /** The header's preset select — the toolbar has a combobox of its own. */
 const presetSelect = () =>
   screen.getByRole("combobox", { name: /instrument for bass/i });
-
-/** The waveform of a voice, when the voice is the built-in synth. */
-const waveformOf = (instrument: MidiInstrument | undefined) =>
-  instrument?.type === "subtractive" ? instrument.waveform : undefined;
 
 function seedMidiTrack(): string {
   act(() => {
@@ -54,15 +56,39 @@ function seedMidiTrack(): string {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  useTimelineUIStore.setState({panelTab: "inspector", expandedInstrumentTrackId: null, instrumentKeyboards: {}});
 });
 
 describe("TrackHeader — midi instrument", () => {
+  it("reserves lane space when calculating the maximum header width", () => {
+    expect(maxTrackHeaderWidthForViewport(600)).toBe(360);
+    expect(maxTrackHeaderWidthForViewport(1200)).toBe(480);
+    expect(maxTrackHeaderWidthForViewport(300)).toBe(160);
+  });
+
+  it("resizes the track-header column with the keyboard", async () => {
+    const user = userEvent.setup();
+    renderRegion();
+
+    const region = screen.getByTestId("tracks-region");
+    const separator = screen.getByRole("separator", {
+      name: "Resize track headers"
+    });
+    expect(separator).toHaveAttribute("aria-orientation", "vertical");
+    expect(separator).toHaveAttribute("aria-valuenow", "320");
+
+    separator.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(separator).toHaveAttribute("aria-valuenow", "336");
+    expect(region).toHaveStyle("--timeline-track-header-width: 336px");
+  });
+
   it("names the preset the track's voice matches", () => {
     renderRegion();
     seedMidiTrack();
 
-    // A new midi track gets DEFAULT_MIDI_INSTRUMENT, which is the saw lead.
-    expect(presetSelect()).toHaveTextContent("Saw Lead");
+    expect(presetSelect()).toHaveTextContent("WT-1 Prime Lead");
   });
 
   it("writes the picked preset's instrument onto the track", async () => {
@@ -71,12 +97,14 @@ describe("TrackHeader — midi instrument", () => {
     const trackId = seedMidiTrack();
 
     await user.click(presetSelect());
-    await user.click(await screen.findByRole("option", { name: "Soft Pad" }));
+    await user.click(await screen.findByRole("option", { name: "WT-1 Bloom Pad" }));
 
     const track = useTimelineStore
       .getState()
       .tracks.find((t) => t.id === trackId);
-    expect(track?.instrument).toEqual(findInstrumentPreset("soft-pad")?.instrument);
+    expect(track?.instrument).toEqual(
+      findInstrumentPreset("wt1-bloom-pad")?.instrument
+    );
   });
 
   it("reads Custom once the voice has been edited by hand", () => {
@@ -103,39 +131,74 @@ describe("TrackHeader — midi instrument", () => {
   it("edits a FableSynth voice with its own controls", async () => {
     const user = userEvent.setup();
     renderRegion();
-    const trackId = seedMidiTrack();
+    seedMidiTrack();
 
     await user.click(presetSelect());
     await user.click(await screen.findByRole("option", { name: "BL-1 Acid" }));
-    await user.click(screen.getByTestId(`track-instrument-${trackId}`));
+    await user.click(screen.getByRole("button", { name: "Edit instrument" }));
 
-    // BL-1 is not the built-in synth, so the panel offers its filter and level
-    // rather than a waveform.
+    // BL-1 exposes the device's oscillator, filter, envelope, accent and glide
+    // modules rather than the built-in synth's waveform control.
     expect(
       screen.queryByRole("combobox", { name: /waveform/i })
     ).not.toBeInTheDocument();
-    expect(screen.getByRole("slider", { name: "Drive" })).toBeInTheDocument();
+    expect(screen.getByRole("slider", { name: "DRIVE" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "OSC" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "ENV" })).toBeInTheDocument();
+    expect(screen.getByRole("slider", { name: "ACC AMT" })).toBeInTheDocument();
     expect(
-      screen.getByText(/BL-1 — a monophonic acid line/)
+      screen.getByRole("slider", { name: "SLD TIME" })
     ).toBeInTheDocument();
   });
 
-  it("names the DR-1 kit's pads in the editor", async () => {
+  it("exposes both WT-1 oscillators and envelopes", async () => {
     const user = userEvent.setup();
     renderRegion();
-    const trackId = seedMidiTrack();
+    seedMidiTrack();
+
+    await user.click(presetSelect());
+    await user.click(
+      await screen.findByRole("option", { name: "WT-1 Prime Lead" })
+    );
+    await user.click(screen.getByRole("button", { name: "Edit instrument" }));
+
+    expect(screen.getByRole("region", { name: "OSC A" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "OSC B" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "AMP ENV" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "MOD ENV" })).toBeInTheDocument();
+  });
+
+  it("selects and edits DR-1 pads", async () => {
+    const user = userEvent.setup();
+    renderRegion();
+    seedMidiTrack();
 
     await user.click(presetSelect());
     await user.click(
       await screen.findByRole("option", { name: "DR-1 TR-Void Kit" })
     );
-    await user.click(screen.getByTestId(`track-instrument-${trackId}`));
+    await user.click(screen.getByRole("button", { name: "Edit instrument" }));
 
-    // A kit has no cutoff of its own — each pad carries its own filter.
+    expect(screen.getByRole("region", { name: "PADS" })).toBeInTheDocument();
     expect(
-      screen.queryByRole("slider", { name: "Cutoff" })
-    ).not.toBeInTheDocument();
-    expect(screen.getByText(/Pads from MIDI 36: Kick,/)).toBeInTheDocument();
+      screen.getByRole("button", { name: "Edit pad 1: Kick" })
+    ).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(screen.getByRole("button", { name: "Edit pad 3: Snare" }));
+
+    expect(screen.getByText("03 · SNARE")).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("region", { name: "NOISE + RING" })).getByRole(
+        "slider",
+        { name: "NOISE" }
+      )
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("region", { name: "PITCH ENV" })).getByRole(
+        "slider",
+        { name: "AMT" }
+      )
+    ).toBeInTheDocument();
   });
 
   it("opens the instrument editor from the Edit toggle", async () => {
@@ -147,7 +210,7 @@ describe("TrackHeader — midi instrument", () => {
       screen.queryByTestId(`track-instrument-panel-${trackId}`)
     ).not.toBeInTheDocument();
 
-    await user.click(screen.getByTestId(`track-instrument-${trackId}`));
+    await user.click(screen.getByRole("button", { name: "Edit instrument" }));
 
     expect(
       screen.getByTestId(`track-instrument-panel-${trackId}`)
@@ -155,25 +218,41 @@ describe("TrackHeader — midi instrument", () => {
     expect(playAuditionNote).not.toHaveBeenCalled();
   });
 
-  it("auditions the new voice when the waveform changes", async () => {
+  it("auditions a new supported voice and keeps the panel outside track lanes", async () => {
     const user = userEvent.setup();
     renderRegion();
-    const trackId = seedMidiTrack();
-
-    await user.click(screen.getByTestId(`track-instrument-${trackId}`));
-    const waveform = screen.getByRole("combobox", { name: /waveform/i });
-    await user.click(waveform);
-    await user.click(await screen.findByRole("option", { name: "Square" }));
-
-    expect(
-      waveformOf(
-        useTimelineStore.getState().tracks.find((t) => t.id === trackId)
-          ?.instrument
-      )
-    ).toBe("square");
-    // Debounced: the note is scheduled, not played on the keystroke.
-    await screen.findByTestId(`track-instrument-panel-${trackId}`);
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    seedMidiTrack();
+    await user.click(screen.getByRole("button", {name: "Edit instrument"}));
+    expect(within(screen.getByTestId("tracks-region")).queryByTestId(/track-instrument-panel/)).not.toBeInTheDocument();
+    const picker = screen.getByRole("combobox", {name: "Instrument preset"});
+    await user.click(picker);
+    expect(screen.queryByRole("option", {name: "Saw Lead"})).not.toBeInTheDocument();
+    await user.click(screen.getByRole("option", {name: "BL-1 Acid"}));
+    expect(useTimelineStore.getState().tracks[0].instrument?.type).toBe("bass");
+    await new Promise(resolve => setTimeout(resolve, 200));
     expect(playAuditionNote).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggles a keyboard independently for each instrument track, including drums", async () => {
+    const user = userEvent.setup();
+    renderRegion();
+    const bassId = seedMidiTrack();
+    let drumId = "";
+    act(() => {
+      useTimelineStore.getState().addTrack("midi", "Drums");
+      drumId = useTimelineStore.getState().tracks[1].id;
+      useTimelineStore.getState().setTrackInstrument(drumId, findInstrumentPreset("dr1-tr-void")!.instrument);
+      useTimelineUIStore.getState().toggleExpandedInstrument(bassId);
+    });
+    expect(screen.queryByRole("region", {name: "KEYS"})).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", {name: "Keyboard"}));
+    expect(screen.getByRole("region", {name: "KEYS"})).toBeInTheDocument();
+    act(() => useTimelineUIStore.getState().toggleExpandedInstrument(drumId));
+    expect(screen.queryByRole("region", {name: "KEYS"})).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", {name: "Keyboard"}));
+    expect(screen.getByRole("region", {name: "KEYS"})).toBeInTheDocument();
+    await user.click(screen.getByRole("button", {name: "Keyboard"}));
+    act(() => useTimelineUIStore.getState().toggleExpandedInstrument(bassId));
+    expect(screen.getByRole("region", {name: "KEYS"})).toBeInTheDocument();
   });
 });

--- a/web/src/components/timeline/Tracks/__tests__/TracksRegionShortcuts.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/TracksRegionShortcuts.test.tsx
@@ -8,16 +8,23 @@
  * `window` rather than a specific element. Store state is seeded AFTER render
  * so `getState()` routes to the mounted provider's instance (not the default).
  */
-import { describe, it, expect, jest } from "@jest/globals";
+import { describe, it, expect, jest, afterEach } from "@jest/globals";
 import { act, fireEvent, render } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { makeClip } from "@nodetool-ai/timeline";
 
 import mockTheme from "../../../../__mocks__/themeMock";
 import { TracksRegion } from "../TracksRegion";
-import { TimelineProvider } from "../../../../stores/timeline/TimelineInstance";
+import { TimelineProvider, createTimelineInstance } from "../../../../stores/timeline/TimelineInstance";
 import { useTimelineStore } from "../../../../stores/timeline/TimelineStore";
 import { useTimelineUIStore } from "../../../../stores/timeline/TimelineUIStore";
+
+import { useSettingsStore } from "../../../../stores/SettingsStore";
+import { useTimelinePlaybackStore } from "../../../../stores/timeline/TimelinePlaybackStore";
+
+afterEach(() => {
+  useSettingsStore.getState().updateSettings({ timelineKeyboardPreset: "nodetool" });
+});
 
 jest.mock("../../../../lib/rest-fetch", () => ({
   restFetch: jest.fn()
@@ -143,4 +150,66 @@ describe("TracksRegion keyboard shortcuts", () => {
     });
     expect(useTimelineUIStore.getState().selectedClipIds.size).toBe(0);
   });
+});
+
+
+describe.each(["premiere", "fcp"] as const)("%s frame stepping", (preset) => {
+  it("steps the playhead without moving the selected clip", () => {
+    setup();
+    const clip = useTimelineStore.getState().clips[0];
+    act(() => {
+      useSettingsStore.getState().updateSettings({ timelineKeyboardPreset: preset });
+      useTimelineUIStore.getState().setSelection([clip.id]);
+      useTimelinePlaybackStore.getState().seek(2000);
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+    });
+    const frameMs = 1000 / useTimelineStore.getState().fps;
+    expect(useTimelinePlaybackStore.getState().currentTimeMs).toBeCloseTo(2000 + frameMs);
+    expect(useTimelineStore.getState().clips[0].startMs).toBe(0);
+    act(() => fireEvent.keyDown(window, { key: "ArrowLeft" }));
+    expect(useTimelinePlaybackStore.getState().currentTimeMs).toBeCloseTo(2000);
+  });
+
+  it("clamps frame stepping to the sequence content", () => {
+    setup();
+    act(() => {
+      useSettingsStore.getState().updateSettings({ timelineKeyboardPreset: preset });
+      useTimelinePlaybackStore.getState().seek(0);
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+    });
+    expect(useTimelinePlaybackStore.getState().currentTimeMs).toBe(0);
+    act(() => {
+      useTimelinePlaybackStore.getState().seek(6000);
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+    });
+    expect(useTimelinePlaybackStore.getState().currentTimeMs).toBe(6000);
+  });
+});
+
+
+it("routes editing shortcuts only to the active timeline", () => {
+  const hidden = createTimelineInstance();
+  const visible = createTimelineInstance();
+  for (const instance of [hidden, visible]) {
+    const clip = makeClip({ trackId: "t1", name: "clip", startMs: 0, durationMs: 1000 });
+    instance.doc.getState().addClips([clip]);
+    instance.ui.getState().setSelection([clip.id]);
+  }
+  const tree = (firstActive: boolean) => (
+    <ThemeProvider theme={mockTheme}>
+      <TimelineProvider instance={hidden} active={firstActive}>
+        <TracksRegion heightPx={400} />
+      </TimelineProvider>
+      <TimelineProvider instance={visible} active={!firstActive}>
+        <TracksRegion heightPx={400} />
+      </TimelineProvider>
+    </ThemeProvider>
+  );
+  const { rerender } = render(tree(false));
+  act(() => fireEvent.keyDown(window, { key: "Delete" }));
+  expect(hidden.doc.getState().clips).toHaveLength(1);
+  expect(visible.doc.getState().clips).toHaveLength(0);
+  rerender(tree(true));
+  act(() => fireEvent.keyDown(window, { key: "Delete" }));
+  expect(hidden.doc.getState().clips).toHaveLength(0);
 });

--- a/web/src/components/timeline/Tracks/fablesynth-editor.css
+++ b/web/src/components/timeline/Tracks/fablesynth-editor.css
@@ -1,0 +1,356 @@
+.fs-editor {
+  --fs-accent: var(--palette-info-main);
+  --fs-secondary: var(--palette-warning-main);
+  color: var(--palette-text-primary);
+  font-family: var(--fontFamily1);
+  font-size: var(--fontSizeSmaller);
+  container-type: inline-size;
+  min-width: 0;
+}
+.fs-bass {
+  --fs-accent: var(--palette-success-main);
+}
+.fs-drum {
+  --fs-accent: var(--palette-warning-main);
+}
+.fs-editor [data-accent="b"] {
+  --fs-accent: var(--fs-secondary);
+}
+.fs-editor [data-accent="f"] {
+  --fs-accent: var(--palette-secondary-main);
+}
+.fs-editor [data-accent="n"] {
+  --fs-accent: var(--palette-text-primary);
+}
+.fs-editor * {
+  box-sizing: border-box;
+}
+.fs-header {
+  padding: var(--spacing-xs) 0;
+  margin-bottom: var(--spacing-xs);
+}
+.fs-header > .fs-knob {
+  margin-left: auto;
+}
+.fs-voice-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
+  gap: var(--spacing-xs);
+}
+.fs-panel {
+  min-width: 0;
+  padding: var(--spacing-md);
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+.fs-panel-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-xs);
+}
+.fs-panel-head h3 {
+  margin: 0;
+  font-size: var(--fontSizeSmaller);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--fs-accent);
+}
+.fs-stepper {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: var(--fontSizeSmaller);
+  font-weight: 400;
+}
+.fs-st-label {
+  color: var(--palette-text-secondary);
+}
+.fs-st-value {
+  min-width: 44px;
+  text-align: center;
+  font-family: var(--fontFamily2);
+  color: var(--palette-text-primary);
+}
+.fs-stepper button {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--rounded-sm);
+  background: transparent;
+  color: var(--palette-text-primary);
+  cursor: pointer;
+}
+.fs-power {
+  width: 24px;
+  height: 24px;
+  padding: var(--spacing-xs);
+  border: 1px solid var(--palette-text-secondary);
+  border-radius: var(--rounded-circle);
+  background: var(--palette-background-default);
+  color: var(--palette-text-secondary);
+  cursor: pointer;
+}
+.fs-power::after {
+  content: "⏻";
+}
+.fs-power.on {
+  border-color: var(--fs-accent);
+  color: var(--fs-accent);
+}
+.fs-knob-row {
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  gap: var(--spacing-xs);
+}
+.fs-knob {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-micro);
+  width: 48px;
+  flex: 0 0 48px;
+  color: var(--palette-text-primary);
+  user-select: none;
+}
+.fs-knob-face {
+  display: block;
+  position: relative;
+  width: 32px;
+  height: 32px;
+}
+.fs-knob-face svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+.fs-knob input {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: ns-resize;
+  touch-action: none;
+}
+.fs-k-body {
+  fill: var(--palette-background-default);
+  stroke: var(--palette-text-secondary);
+  stroke-width: 1;
+}
+.fs-k-track,
+.fs-k-arc {
+  fill: none;
+  stroke-width: 4;
+  stroke-linecap: round;
+}
+.fs-k-track {
+  stroke: var(--palette-divider);
+}
+.fs-k-arc {
+  stroke: var(--fs-accent);
+}
+.fs-k-ptr {
+  stroke: var(--palette-text-primary);
+  stroke-width: 3;
+  stroke-linecap: round;
+}
+.fs-k-label {
+  font-size: var(--fontSizeSmaller);
+  color: var(--palette-text-secondary);
+}
+.fs-k-value {
+  font-family: var(--fontFamily2);
+  font-size: var(--fontSizeSmaller);
+  line-height: 1.4;
+  white-space: nowrap;
+}
+.fs-knob:hover .fs-k-body {
+  fill: var(--palette-action-hover);
+}
+.fs-knob:has(input:focus-visible) .fs-knob-face,
+.fs-editor button:focus-visible {
+  outline: 2px solid var(--palette-primary-main);
+  outline-offset: 2px;
+  border-radius: var(--rounded-sm);
+}
+.fs-editor button:hover {
+  background-color: var(--palette-action-hover);
+}
+.fs-keys-panel {
+  margin-top: var(--spacing-md);
+}
+.fs-keys {
+  position: relative;
+  height: 64px;
+}
+.fs-white-keys {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  gap: var(--spacing-micro);
+}
+.fs-white-keys button {
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  border: 1px solid var(--palette-text-secondary);
+  border-radius: 0 0 var(--rounded-sm) var(--rounded-sm);
+  background: var(--palette-common-white);
+  color: var(--palette-common-black);
+  cursor: pointer;
+  display: flex;
+  align-items: end;
+  justify-content: center;
+  font-size: var(--fontSizeSmaller);
+  font-family: var(--fontFamily2);
+}
+.fs-black-key {
+  position: absolute;
+  top: 0;
+  width: max(24px, 4%);
+  height: 58%;
+  padding: 0;
+  transform: translateX(-50%);
+  border: 1px solid var(--palette-text-secondary);
+  border-radius: 0 0 var(--rounded-sm) var(--rounded-sm);
+  background: var(--palette-common-black);
+  cursor: pointer;
+}
+.fs-keys button:active {
+  background: var(--fs-accent);
+}
+.fs-keys button:focus-visible {
+  outline-offset: -3px;
+}
+.fs-dr-layout {
+  display: grid;
+  grid-template-columns: minmax(240px, 0.8fr) minmax(0, 2fr);
+  gap: var(--spacing-md);
+}
+.fs-pad-panel {
+  align-self: start;
+}
+.fs-pad-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--spacing-xs);
+}
+.fs-pad-grid button {
+  min-height: 48px;
+  min-width: 0;
+  padding: var(--spacing-sm);
+  border: 1px solid transparent;
+  border-radius: var(--rounded-sm);
+  background: var(--palette-action-hover);
+  color: var(--palette-text-primary);
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+}
+.fs-pad-grid button.selected {
+  border: 1px solid var(--fs-accent);
+  background: var(--palette-action-selected);
+}
+.fs-pad-grid b {
+  display: block;
+  font-size: var(--fontSizeSmaller);
+  font-weight: 600;
+  font-family: var(--fontFamily2);
+}
+.fs-pad-grid span {
+  display: block;
+  font-size: var(--fontSizeSmaller);
+  overflow-wrap: anywhere;
+  margin-top: var(--spacing-xs);
+}
+.fs-selected-pad {
+  display: block;
+  margin-bottom: var(--spacing-md);
+}
+@container (max-width: 760px) {
+  .fs-dr-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+@container (max-width: 480px) {
+  .fs-white-keys button:nth-child(n + 9),
+  .fs-black-key:nth-of-type(n + 6) {
+    display: none;
+  }
+  .fs-keys { --fs-key-scale: 1.875; }
+  .fs-black-key { width: max(24px, 7.5%); }
+}
+.fs-header > .fs-knob {
+  flex-direction: row;
+  width: auto;
+  flex-basis: auto;
+  gap: var(--spacing-sm);
+}
+.fs-header .fs-knob-face { width: 32px; height: 32px; }
+.fs-drum .fs-knob-row {
+  gap: var(--spacing-xs);
+}
+.fs-drum .fs-knob-row .fs-knob {
+  width: 56px;
+  flex-basis: 56px;
+}
+
+/* Keep sparse voice sections horizontal in the instrument dock. */
+.fs-panel-inline {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+.fs-panel-inline .fs-panel-head {
+  align-items: flex-start;
+  flex-direction: column;
+  margin-bottom: 0;
+  gap: var(--spacing-xs);
+}
+.fs-panel-inline .fs-knob-row {
+  flex-wrap: nowrap;
+}
+.fs-k-label {
+  line-height: 1.2;
+  white-space: nowrap;
+}
+@container (max-width: 300px) {
+  .fs-panel-inline {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.fs-sub-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+  align-items: center;
+}
+.fs-sub-controls .fs-stepper {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) 24px;
+}
+.fs-sub-controls .fs-st-label {
+  grid-column: 1 / -1;
+}
+.fs-sub-controls .fs-st-value {
+  min-width: 0;
+}
+@container (max-width: 480px) {
+  .fs-description {
+    display: none;
+  }
+}
+
+.fs-voice-grid > .fs-panel + .fs-panel {
+  border-top: 1px solid var(--palette-divider);
+}

--- a/web/src/components/timeline/Tracks/useClipDrag.ts
+++ b/web/src/components/timeline/Tracks/useClipDrag.ts
@@ -148,6 +148,7 @@ export function useClipDrag({
       // element) because moveClip(id, _, toTrackId) re-parents the clip into
       // a different TrackLane mid-drag, which would unmount the captured
       // element and abort the gesture. Window listeners survive remounts.
+      const dragStartY = e.clientY;
       dragStartXRef.current = e.clientX;
       dragStartMsRef.current = clip.startMs;
       isDraggingRef.current = false;
@@ -240,7 +241,7 @@ export function useClipDrag({
 
         const scrollDeltaPx = (scrollArea?.scrollLeft ?? 0) - scrollLeftAtStart;
         const deltaPx = lastPointer.x - dragStartXRef.current + scrollDeltaPx;
-        if (!isDraggingRef.current && Math.abs(deltaPx) < DRAG_THRESHOLD_PX) {
+        if (!isDraggingRef.current && Math.hypot(deltaPx, lastPointer.y - dragStartY) < DRAG_THRESHOLD_PX) {
           return;
         }
         isDraggingRef.current = true;
@@ -361,6 +362,10 @@ export function useClipDrag({
           hitTestRafId = null;
         }
         stopAutoScroll();
+        if (isDraggingRef.current && ev?.type === "pointerup") {
+          sampleCrossTrack();
+          applyMove();
+        }
         clearGestureFeedback(useTimelineUIStore.getState());
         if (isDraggingRef.current && ev?.type === "pointerup") {
           // The drop settles inside the gesture's undo entry. Ctrl/Cmd on

--- a/web/src/components/timeline/pianoRoll/NoteSelectionInspector.tsx
+++ b/web/src/components/timeline/pianoRoll/NoteSelectionInspector.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import { moveNotes, setVelocity } from "@nodetool-ai/timeline";
+import type { MidiNote } from "@nodetool-ai/timeline";
+import { Caption, FlexRow, SPACING, TextInput } from "../../ui_primitives";
+
+interface Props {
+  notes: readonly MidiNote[];
+  selectedIds: ReadonlySet<string>;
+  beatTicks: number;
+  onChange: (notes: MidiNote[]) => void;
+}
+
+export function NoteSelectionInspector({
+  notes,
+  selectedIds,
+  beatTicks,
+  onChange
+}: Props) {
+  const selected = notes.filter((note) => selectedIds.has(note.id));
+  const first = selected[0];
+  const lowest = selected.reduce((min, note) => Math.min(min, note.pitch), 127);
+  const start = selected.reduce(
+    (min, note) => Math.min(min, note.startTick),
+    Infinity
+  );
+  const common = (key: "durationTick" | "velocity") =>
+    first && selected.every((note) => note[key] === first[key])
+      ? first[key]
+      : null;
+  const length = common("durationTick");
+  const fields = [
+    {
+      label: "Lowest pitch (MIDI)",
+      value: first ? lowest : null,
+      min: 0,
+      max: 127,
+      step: 1,
+      apply: (value: number) =>
+        moveNotes(notes, selectedIds, {
+          deltaPitch: Math.round(value) - lowest,
+          deltaTick: 0
+        })
+    },
+    {
+      label: "Start beat",
+      value: first ? 1 + start / beatTicks : null,
+      min: 1,
+      step: 1 / beatTicks,
+      apply: (value: number) =>
+        moveNotes(notes, selectedIds, {
+          deltaPitch: 0,
+          deltaTick: Math.round((value - 1) * beatTicks) - start
+        })
+    },
+    {
+      label: "Length (beats)",
+      value: length === null ? null : length / beatTicks,
+      min: 1 / beatTicks,
+      step: 1 / beatTicks,
+      apply: (value: number) =>
+        notes.map((note) =>
+          selectedIds.has(note.id)
+            ? {
+                ...note,
+                durationTick: Math.max(1, Math.round(value * beatTicks))
+              }
+            : note
+        )
+    },
+    {
+      label: "Velocity",
+      value: common("velocity"),
+      min: 1,
+      max: 127,
+      step: 1,
+      apply: (value: number) => setVelocity(notes, selectedIds, value)
+    }
+  ];
+  return (
+    <FlexRow
+      gap={SPACING.md}
+      sx={{
+        px: SPACING.sm,
+        pb: SPACING.sm,
+        flexWrap: "wrap",
+        alignItems: "end"
+      }}
+    >
+      {fields.map((field) => (
+        <TextInput
+          key={`${field.label}:${field.value}:${selected.map((note) => note.id).join(",")}`}
+          label={field.label}
+          type="number"
+          compact
+          fullWidth={false}
+          sx={{ width: 128 }}
+          disabled={!first}
+          defaultValue={field.value ?? ""}
+          placeholder={first ? "Mixed" : "—"}
+          inputProps={{ min: field.min, max: field.max, step: field.step }}
+          onBlur={(event) => {
+            const value = Math.round(Number(event.target.value) / field.step) * field.step;
+            if (
+              event.target.value.trim() &&
+              Number.isFinite(value) &&
+              value >= field.min &&
+              (field.max === undefined || value <= field.max) &&
+              value !== field.value
+            )
+              onChange(field.apply(value));
+            event.target.value = field.value === null ? "" : String(field.value);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              const input = event.target as HTMLInputElement;
+              input.value = field.value === null ? "" : String(field.value);
+              input.blur();
+            } else if (event.key === "Enter")
+              (event.target as HTMLInputElement).blur();
+          }}
+        />
+      ))}
+      <Caption color="muted">
+        Pitch/start move the group. Length/velocity set all selected notes.
+      </Caption>
+    </FlexRow>
+  );
+}

--- a/web/src/components/timeline/pianoRoll/PianoRoll.tsx
+++ b/web/src/components/timeline/pianoRoll/PianoRoll.tsx
@@ -33,6 +33,7 @@ import type { Theme } from "@mui/material/styles";
 
 import {
   addNote,
+  createTimeOrderedUuid,
   barDurationMs,
   beatDurationMs,
   divisionToTicks,
@@ -43,7 +44,6 @@ import {
   removeNotes,
   resizeNotes,
   resolveTempo,
-  setVelocity,
   snapTick,
   ticksToMs
 } from "@nodetool-ai/timeline";
@@ -54,12 +54,12 @@ import type {
   TimelineTempo
 } from "@nodetool-ai/timeline";
 
-import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+import { useTimelineStore, useTimelineStoreApi, timelineTemporalOf } from "../../../stores/timeline/TimelineStore";
 import { useTimelineUIStore } from "../../../stores/timeline/TimelineUIStore";
 import { useTimelinePlaybackStoreApi } from "../../../stores/timeline/TimelinePlaybackStore";
 import { useTimelineHistoryBatch } from "../../../stores/timeline/useTimelineHistoryBatch";
 import { findClipById } from "../../../stores/timeline/clipLookup";
-import { FlexColumn, FlexRow } from "../../ui_primitives";
+import { Button, Caption, Dialog, FlexColumn, FlexRow, Slider, SPACING } from "../../ui_primitives";
 import { playAuditionNote } from "../preview/audition";
 import { partitionTimelineWheel } from "../Tracks/timelineWheel";
 import { visibleTempoGrid } from "../Tracks/tempoGrid";
@@ -75,6 +75,7 @@ import {
 } from "./PianoRollVelocityLane";
 import {
   hitTestNote,
+  pitchName,
   initialTopPitch,
   tickToX,
   xToTick,
@@ -83,8 +84,14 @@ import {
   type PianoRollGeometry
 } from "./pianoRollGeometry";
 
+import { decodeNoteClipboard, encodeNoteClipboard, pasteNotes } from "./noteClipboard";
+import { NoteSelectionInspector } from "./NoteSelectionInspector";
+
+const isNoteControl = (target: EventTarget) => target instanceof HTMLElement &&
+  target.closest("input, select, textarea, button, [role=combobox], [role=dialog], [contenteditable=true]") !== null;
+
 /** Height of one semitone row. */
-const ROW_HEIGHT_PX = 12;
+const ROW_HEIGHT_PX = 16;
 /** Zoom bounds, in pixels per tick. */
 const MIN_PX_PER_TICK = 0.002;
 const MAX_PX_PER_TICK = 1;
@@ -149,9 +156,15 @@ type GridDrag =
       pointerStartTick: number;
       pointerStartPitch: number;
       lastPitch: number;
+      startX: number;
+      startY: number;
+      moved: boolean;
+      duplicate: boolean;
     }
   | {
       kind: "marquee";
+      additiveIds: readonly string[];
+      additive: boolean;
       startTick: number;
       startPitch: number;
       startX: number;
@@ -177,6 +190,7 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
     );
     const gridDivision = useTimelineUIStore((s) => s.gridDivision);
     const snapEnabled = useTimelineUIStore((s) => s.snapEnabled);
+    const docApi = useTimelineStoreApi();
     const playbackApi = useTimelinePlaybackStoreApi();
     const history = useTimelineHistoryBatch();
 
@@ -199,7 +213,11 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
     const gridWrapRef = useRef<HTMLDivElement | null>(null);
     const rootRef = useRef<HTMLDivElement | null>(null);
     const playheadRef = useRef<HTMLDivElement | null>(null);
+    const createdOnClickRef = useRef<{ id: string; time: number } | null>(null);
+    const [shortcutsOpen, setShortcutsOpen] = useState(false);
+    const [cursor, setCursor] = useState("crosshair");
     const dragRef = useRef<GridDrag | null>(null);
+    const velocityBaseline = useRef<readonly MidiNote[] | null>(null);
 
     const geometry: PianoRollGeometry = useMemo(
       () => ({ pxPerTick, scrollTick, rowHeightPx: ROW_HEIGHT_PX, topPitch }),
@@ -330,7 +348,7 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
     const audition = useCallback(
       (pitch: number, velocity?: number) => {
         if (!instrument) return;
-        void playAuditionNote(instrument, pitch, velocity);
+        void playAuditionNote(instrument, pitch, velocity).catch(() => undefined);
       },
       [instrument]
     );
@@ -353,6 +371,7 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
 
     const handlePointerDown = useCallback(
       (e: React.PointerEvent<HTMLDivElement>) => {
+        if (e.button !== 0) return;
         rootRef.current?.focus();
         const { x, y } = localPoint(e);
         const geo = geometryRef.current;
@@ -394,12 +413,18 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
                 : hit.note.startTick,
             pointerStartTick: pointerTick,
             pointerStartPitch: pointerPitch,
-            lastPitch: hit.note.pitch
+            lastPitch: hit.note.pitch,
+            startX: e.clientX,
+            startY: e.clientY,
+            moved: false,
+            duplicate: e.altKey && edge !== "end"
           };
           history.begin();
         } else {
           dragRef.current = {
             kind: "marquee",
+            additive: e.shiftKey,
+            additiveIds: e.shiftKey ? [...selectedIdsRef.current] : [],
             startTick: pointerTick,
             startPitch: pointerPitch,
             startX: e.clientX,
@@ -421,21 +446,20 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
     const handlePointerMove = useCallback(
       (e: React.PointerEvent<HTMLDivElement>) => {
         const drag = dragRef.current;
-        if (!drag) return;
         const { x, y } = localPoint(e);
+        if (!drag) {
+          const hit = hitTestNote(notesRef.current, x, y, geometryRef.current);
+          setCursor(hit ? hit.edge === "end" ? "ew-resize" : e.altKey ? "copy" : "grab" : "crosshair");
+          return;
+        }
+        if (!drag.moved && Math.abs(e.clientX - drag.startX) < DRAG_THRESHOLD_PX &&
+            Math.abs(e.clientY - drag.startY) < DRAG_THRESHOLD_PX) return;
         const geo = geometryRef.current;
         const pointerTick = xToTick(x, geo);
         const pointerPitch = yToPitch(y, geo);
-        const bypassSnap = e.altKey;
+        const bypassSnap = e.metaKey || e.ctrlKey;
 
         if (drag.kind === "marquee") {
-          if (
-            !drag.moved &&
-            Math.abs(e.clientX - drag.startX) < DRAG_THRESHOLD_PX &&
-            Math.abs(e.clientY - drag.startY) < DRAG_THRESHOLD_PX
-          ) {
-            return;
-          }
           drag.moved = true;
           const rect: NoteRect = {
             fromTick: drag.startTick,
@@ -446,12 +470,22 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
           setMarquee(rect);
           setSelectedIds(
             new Set(
-              notesInRectIds(notesRef.current, rect)
+              [...drag.additiveIds, ...notesInRectIds(notesRef.current, rect)]
             )
           );
           return;
         }
 
+        if (!drag.moved && drag.duplicate) {
+          const originalCount = drag.baseline.length;
+          drag.baseline = duplicateNotes(drag.baseline, drag.ids, 0);
+          drag.ids = drag.baseline.slice(originalCount).map(note => note.id);
+          const selection = new Set(drag.ids);
+          selectedIdsRef.current = selection;
+          setSelectedIds(selection);
+        }
+        drag.moved = true;
+        setCursor(drag.kind === "resize" ? "ew-resize" : drag.duplicate ? "copy" : "grabbing");
         const rawDelta = pointerTick - drag.pointerStartTick;
         const deltaTick =
           snapOrNot(drag.anchorTick + rawDelta, bypassSnap) - drag.anchorTick;
@@ -485,12 +519,14 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
 
     const handlePointerUp = useCallback(
       (e: React.PointerEvent<HTMLDivElement>) => {
+        if (dragRef.current) handlePointerMove(e);
         const drag = dragRef.current;
         dragRef.current = null;
         if (!drag) return;
         if (drag.kind === "marquee") {
           setMarquee(null);
           if (drag.moved) return;
+          if (drag.additive) return;
           // A press that never moved is a click on empty space: write a note
           // one grid unit long where it landed.
           const { x, y } = localPoint(e);
@@ -500,7 +536,10 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
             setSelectedIds(new Set());
             return;
           }
-          const startTick = snapOrNot(xToTick(x, geo), e.altKey);
+          const rawTick = xToTick(x, geo);
+          const startTick = snapEnabled && !e.metaKey && !e.ctrlKey
+            ? Math.floor(rawTick / gridStepTicks) * gridStepTicks
+            : Math.round(rawTick);
           const created = addNote(notesRef.current, {
             pitch,
             startTick,
@@ -509,21 +548,25 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
           setClipNotes(clipId, created);
           const newest = created[created.length - 1];
           if (newest) {
+            createdOnClickRef.current = { id: newest.id, time: e.timeStamp };
             setSelectedIds(new Set([newest.id]));
             audition(pitch, newest.velocity);
           }
           return;
         }
         history.end();
+        setCursor("grab");
+        if (!drag.moved && drag.kind === "move") audition(drag.lastPitch);
       },
       [
         audition,
         clipId,
         gridStepTicks,
         history,
+        handlePointerMove,
         localPoint,
         setClipNotes,
-        snapOrNot
+        snapEnabled
       ]
     );
 
@@ -539,6 +582,8 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
         const { x, y } = localPoint(e);
         const hit = hitTestNote(notesRef.current, x, y, geometryRef.current);
         if (!hit) return;
+        const created = createdOnClickRef.current;
+        if (created?.id === hit.note.id && e.timeStamp - created.time < 500) return;
         e.preventDefault();
         setClipNotes(clipId, removeNotes(notesRef.current, [hit.note.id]));
         setSelectedIds((prev) => {
@@ -552,13 +597,30 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
     );
 
     // ── Velocity lane ─────────────────────────────────────────────────────
-    const handleVelocityStart = useCallback(() => history.begin(), [history]);
+    const handleVelocityStart = useCallback(() => {
+      velocityBaseline.current = notesRef.current;
+      history.begin();
+    }, [history]);
+    const changeRelativeVelocity = useCallback((baseline: readonly MidiNote[], ids: ReadonlySet<string>, delta: number) => {
+      const selected = baseline.filter(note => ids.has(note.id));
+      const min = selected.reduce((value, note) => Math.min(value, note.velocity), 127);
+      const max = selected.reduce((value, note) => Math.max(value, note.velocity), 1);
+      const shift = Math.max(1 - min, Math.min(127 - max, Math.round(delta)));
+      commit(baseline.map(note => ids.has(note.id) ? {...note, velocity: note.velocity + shift} : note));
+    }, [commit]);
     const handleVelocityChange = useCallback(
-      (noteId: string, velocity: number) =>
-        commit(setVelocity(notesRef.current, [noteId], velocity)),
-      [commit]
+      (noteId: string, velocity: number) => {
+        const baseline = velocityBaseline.current ?? notesRef.current;
+        const anchor = baseline.find(note => note.id === noteId);
+        if (!anchor) return;
+        changeRelativeVelocity(baseline, selectedIdsRef.current.has(noteId) ? selectedIdsRef.current : new Set([noteId]), velocity - anchor.velocity);
+      },
+      [changeRelativeVelocity]
     );
-    const handleVelocityEnd = useCallback(() => history.end(), [history]);
+    const handleVelocityEnd = useCallback(() => {
+      velocityBaseline.current = null;
+      history.end();
+    }, [history]);
 
     // ── Wheel ─────────────────────────────────────────────────────────────
     // Registered by hand: React's onWheel is passive, so it cannot suppress
@@ -602,9 +664,34 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
       return () => el.removeEventListener("wheel", onWheel);
     }, [size.height]);
 
+    const copySelection = (event: React.ClipboardEvent<HTMLDivElement>, cut: boolean) => {
+      if (isNoteControl(event.target)) return;
+      const selected = notesRef.current.filter(note => selectedIdsRef.current.has(note.id));
+      if (selected.length === 0 || dragRef.current) return;
+      event.preventDefault();
+      event.stopPropagation();
+      event.clipboardData.setData("text/plain", encodeNoteClipboard(selected));
+      if (cut) {
+        setClipNotes(clipId, removeNotes(notesRef.current, selected.map(note => note.id)));
+        setSelectedIds(new Set());
+      }
+    };
+
+    const handlePaste = (event: React.ClipboardEvent<HTMLDivElement>) => {
+      if (isNoteControl(event.target) || dragRef.current) return;
+      const copied = decodeNoteClipboard(event.clipboardData.getData("text/plain"));
+      if (!copied) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const copies = pasteNotes(copied, timelineMsToTick(playbackApi.getState().getTimeMs()));
+      setClipNotes(clipId, [...notesRef.current, ...copies]);
+      setSelectedIds(new Set(copies.map(note => note.id)));
+    };
+
     // ── Keyboard ──────────────────────────────────────────────────────────
     const handleKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (isNoteControl(e.target)) return;
         const ctrl = e.ctrlKey || e.metaKey;
         const ids = [...selectedIdsRef.current];
         const current = notesRef.current;
@@ -613,6 +700,23 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
           e.stopPropagation();
         };
 
+        if (ctrl && ["c", "x", "v"].includes(e.key.toLowerCase())) {
+          e.stopPropagation();
+          return; // Let the browser dispatch its native clipboard event.
+        }
+        if (e.key === "?") {
+          handled();
+          setShortcutsOpen(true);
+          return;
+        }
+        if (ctrl && (e.key.toLowerCase() === "z" || e.key.toLowerCase() === "y")) {
+          handled();
+          if (dragRef.current) return;
+          const temporal = timelineTemporalOf(docApi);
+          if (e.shiftKey || e.key.toLowerCase() === "y") temporal.redo();
+          else temporal.undo();
+          return;
+        }
         if (e.key === "Escape") {
           handled();
           if (ids.length > 0) {
@@ -627,7 +731,33 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
           setSelectedIds(new Set(current.map((note) => note.id)));
           return;
         }
-        if (ids.length === 0) return;
+        if (ctrl && ["r", "t", "d"].includes(e.key.toLowerCase())) handled();
+        if (dragRef.current || ids.length === 0) return;
+
+        if (!ctrl && !e.altKey && e.key.toLowerCase() === "q") {
+          handled();
+          setClipNotes(clipId, current.map(note => selectedIdsRef.current.has(note.id)
+            ? { ...note, startTick: snapTick(note.startTick, gridStepTicks) }
+            : note));
+          return;
+        }
+        if (ctrl && e.key.toLowerCase() === "t") {
+          handled();
+          const tick = Math.round(timelineMsToTick(playbackApi.getState().getTimeMs()));
+          const nextIds = new Set<string>();
+          const next = current.flatMap(note => {
+            if (!selectedIdsRef.current.has(note.id)) return [note];
+            nextIds.add(note.id);
+            const end = note.startTick + note.durationTick;
+            if (tick <= note.startTick || tick >= end) return [note];
+            const right = { ...note, id: createTimeOrderedUuid(), startTick: tick, durationTick: end - tick };
+            nextIds.add(right.id);
+            return [{ ...note, durationTick: tick - note.startTick }, right];
+          });
+          setClipNotes(clipId, next);
+          setSelectedIds(nextIds);
+          return;
+        }
 
         if (e.key === "Delete" || e.key === "Backspace") {
           handled();
@@ -635,17 +765,18 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
           setSelectedIds(new Set());
           return;
         }
-        if (ctrl && e.key.toLowerCase() === "d") {
+        if (ctrl && ["d", "r"].includes(e.key.toLowerCase())) {
           handled();
           // A Set, not `ids.includes`: the selection can be the whole clip,
           // and a linear scan per note is O(n²) on a 4096-note part.
           const selectedIdSet = new Set(ids);
           const selected = current.filter((note) => selectedIdSet.has(note.id));
+          if (selected.length === 0) return;
           const minStart = Math.min(...selected.map((note) => note.startTick));
           const maxEnd = Math.max(
             ...selected.map((note) => note.startTick + note.durationTick)
           );
-          const offset = maxEnd + gridStepTicks - minStart;
+          const offset = maxEnd - minStart;
           const next = duplicateNotes(current, ids, offset);
           setClipNotes(clipId, next);
           setSelectedIds(new Set(next.slice(current.length).map((n) => n.id)));
@@ -653,7 +784,12 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
         }
         if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
           handled();
-          const step = e.key === "ArrowLeft" ? -gridStepTicks : gridStepTicks;
+          const increment = (e.altKey && !ctrl) || !snapEnabled ? 1 : gridStepTicks;
+          const step = e.key === "ArrowLeft" ? -increment : increment;
+          if (e.shiftKey) {
+            setClipNotes(clipId, resizeNotes(current, ids, Math.round(step), 1));
+            return;
+          }
           setClipNotes(
             clipId,
             moveNotes(current, ids, {
@@ -673,9 +809,13 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
           if (first) audition(first.pitch, first.velocity);
         }
       },
-      [audition, clipId, gridStepTicks, onClose, setClipNotes]
+      [audition, clipId, docApi, gridStepTicks, onClose, playbackApi, setClipNotes, snapEnabled, timelineMsToTick]
     );
 
+    const selectedNotes = notes.filter(note => selectedIds.has(note.id));
+    const selectedVelocity = selectedNotes.length
+      ? Math.round(selectedNotes.reduce((sum, note) => sum + note.velocity, 0) / selectedNotes.length)
+      : 100;
     if (!clip) return null;
 
     return (
@@ -687,10 +827,55 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
         role="application"
         aria-label={`Note editor for ${clip.name || "midi clip"}`}
         onKeyDown={handleKeyDown}
+        onCopy={event => copySelection(event, false)}
+        onCut={event => copySelection(event, true)}
+        onPaste={handlePaste}
         css={rootStyles(theme)}
         fullWidth
         sx={{ flex: 1, minHeight: 0 }}
       >
+        <FlexRow gap={SPACING.md} sx={{ px: SPACING.sm, py: SPACING.xs, flexShrink: 0, flexWrap: "wrap" }}>
+          <Caption aria-live="polite">
+            {selectedNotes.map(note => `${pitchName(note.pitch)} · velocity ${note.velocity}`).slice(0, 1).join("") || "Click to add a note"}
+            {selectedNotes.length > 1 ? ` · ${selectedNotes.length} selected` : ""}
+          </Caption>
+          <Caption color="muted">Velocity ±</Caption>
+          <Slider aria-label="Selected note velocity" min={1} max={127} step={1}
+            density="compact" sx={{ width: 96 }} disabled={selectedNotes.length === 0}
+            value={selectedVelocity} valueLabelDisplay="auto"
+            onPointerDown={handleVelocityStart}
+            onChange={(_, value) => {
+              const baseline = velocityBaseline.current ?? notesRef.current;
+              const selected = baseline.filter(note => selectedIdsRef.current.has(note.id));
+              const mean = selected.reduce((sum, note) => sum + note.velocity, 0) / selected.length;
+              changeRelativeVelocity(baseline, selectedIdsRef.current, (value as number) - Math.round(mean));
+            }}
+            onChangeCommitted={handleVelocityEnd} onPointerCancel={handleVelocityEnd} />
+          <Caption color="muted">⌘C/V copy/paste · ⌘R repeat · Q quantize</Caption>
+          <Button size="small" variant="text" onClick={() => setShortcutsOpen(true)} aria-label="Note editing shortcuts">Shortcuts</Button>
+        </FlexRow>
+        <NoteSelectionInspector notes={notes} selectedIds={selectedIds}
+          beatTicks={msToTicks(beatDurationMs(tempo), tempo.bpm)}
+          onChange={next => setClipNotes(clipId, next)} />
+        <Dialog open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} title="Note editing shortcuts">
+          <FlexColumn gap={SPACING.sm}>
+            {[
+              "⌘C / ⌘X / ⌘V — Copy / cut / paste at the playhead",
+              "⌘R — Repeat selection immediately after its end",
+              "Q — Quantize note starts to the Note grid",
+              "⌥↑ / ⌥↓ — Transpose one semitone",
+              "⇧⌥↑ / ⇧⌥↓ — Transpose one octave",
+              "⌃⌥← / ⌃⌥→ — Nudge by the Note grid",
+              "⇧← / ⇧→ — Shorten / lengthen by the Note grid",
+              "⌘T — Split selected notes at the playhead",
+              "⌘A — Select all notes · Delete — Delete selection",
+              "⌘Z / ⇧⌘Z — Undo / redo",
+              "Shift-click — Toggle selection · Drag empty space — Select notes",
+              "Option-drag — Duplicate selection · ⌘/Ctrl-drag — Bypass snapping",
+              "Ctrl substitutes for ⌘ on Windows. Existing arrow and ⌘D shortcuts also work."
+            ].map(shortcut => <Caption key={shortcut}>{shortcut}</Caption>)}
+          </FlexColumn>
+        </Dialog>
         <FlexRow fullWidth sx={{ flex: 1, minHeight: 0 }}>
           <FlexColumn sx={{ width: KEYBOARD_WIDTH_PX, flexShrink: 0 }}>
             <div style={{ height: PIANO_ROLL_RULER_HEIGHT_PX }} />
@@ -708,10 +893,12 @@ export const PianoRoll: React.FC<PianoRollProps> = memo(
               tempo={tempo}
               tickToTimelineMs={tickToTimelineMs}
               timelineMsToTick={timelineMsToTick}
+              onSeekTick={(tick) => playbackApi.getState().seek(Math.max(0, tickToTimelineMs(tick)))}
             />
             <div
               ref={gridWrapRef}
               css={gridWrapStyles}
+              style={{ cursor }}
               data-testid="piano-roll-grid"
               onPointerDown={handlePointerDown}
               onPointerMove={handlePointerMove}

--- a/web/src/components/timeline/pianoRoll/PianoRollGrid.tsx
+++ b/web/src/components/timeline/pianoRoll/PianoRollGrid.tsx
@@ -15,21 +15,25 @@ import { useColorScheme, useTheme } from "@mui/material/styles";
 
 import type { MidiNote, NoteRect } from "@nodetool-ai/timeline";
 
+import { BORDER_RADIUS, TYPOGRAPHY } from "../../ui_primitives";
 import { pickPianoRollColors } from "./pianoRollColors";
 import {
   isBlackKey,
   noteRect,
   pitchToY,
+  pitchName,
   tickToX,
   type PianoRollGeometry
 } from "./pianoRollGeometry";
 
 /** How round a note bar's corners are, in px. */
-const NOTE_CORNER_PX = 2;
+
 /** The quietest note still draws at this opacity. */
 const MIN_NOTE_ALPHA = 0.45;
 
 const canvasStyles = css({
+  ...TYPOGRAPHY.mono.caption,
+  borderRadius: BORDER_RADIUS.xs,
   position: "absolute",
   inset: 0,
   display: "block",
@@ -86,6 +90,9 @@ export const PianoRollGrid: React.FC<PianoRollGridProps> = memo(
       canvas.width = widthPx * dpr;
       canvas.height = heightPx * dpr;
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      const canvasStyle = getComputedStyle(canvas);
+      const noteRadius = parseFloat(canvasStyle.borderRadius) || 0;
+      ctx.font = `${canvasStyle.fontSize} ${canvasStyle.fontFamily}`;
 
       // Rows.
       ctx.fillStyle = colors.whiteRow;
@@ -143,10 +150,14 @@ export const PianoRollGrid: React.FC<PianoRollGridProps> = memo(
           rect.y + 1,
           Math.max(2, rect.width - 1),
           Math.max(1, rect.height - 2),
-          NOTE_CORNER_PX
+          noteRadius
         );
         ctx.fill();
         ctx.globalAlpha = 1;
+        if (rect.width > 44 && rect.height >= 16) {
+          ctx.fillStyle = colors.noteSelected;
+          ctx.fillText(pitchName(note.pitch), rect.x + 4, rect.y + rect.height - 4);
+        }
         if (selected) {
           ctx.strokeStyle = colors.noteSelected;
           ctx.stroke();

--- a/web/src/components/timeline/pianoRoll/PianoRollKeyboard.tsx
+++ b/web/src/components/timeline/pianoRoll/PianoRollKeyboard.tsx
@@ -14,6 +14,7 @@ import { useColorScheme, useTheme } from "@mui/material/styles";
 
 import type { MidiInstrument } from "@nodetool-ai/timeline";
 
+import { TYPOGRAPHY } from "../../ui_primitives";
 import { playAuditionNote } from "../preview/audition";
 import { pickPianoRollColors } from "./pianoRollColors";
 import {
@@ -32,6 +33,7 @@ const BLACK_KEY_WIDTH_RATIO = 0.62;
 const MIN_LABEL_ROW_HEIGHT_PX = 9;
 
 const canvasStyles = css({
+  ...TYPOGRAPHY.mono.caption,
   display: "block",
   width: "100%",
   cursor: "pointer",
@@ -66,18 +68,19 @@ export const PianoRollKeyboard: React.FC<PianoRollKeyboardProps> = memo(
       canvas.height = heightPx * dpr;
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 
-      ctx.fillStyle = colors.whiteRow;
+      ctx.fillStyle = theme.colorSchemes?.light?.palette.background.paper ?? colors.noteSelected;
       ctx.fillRect(0, 0, KEYBOARD_WIDTH_PX, heightPx);
 
       const rows = Math.ceil(heightPx / geometry.rowHeightPx) + 1;
       ctx.textBaseline = "middle";
-      ctx.font = "9px var(--fontFamily2), monospace";
+      const canvasStyle = getComputedStyle(canvas);
+      ctx.font = `${canvasStyle.fontSize} ${canvasStyle.fontFamily}`;
       for (let row = 0; row < rows; row++) {
         const pitch = geometry.topPitch - row;
         if (pitch < 0 || pitch > 127) continue;
         const y = pitchToY(pitch, geometry);
         if (isBlackKey(pitch)) {
-          ctx.fillStyle = colors.noteSelected;
+          ctx.fillStyle = theme.colorSchemes?.dark?.palette.background.default ?? colors.blackRow;
           ctx.fillRect(
             0,
             y,
@@ -93,7 +96,7 @@ export const PianoRollKeyboard: React.FC<PianoRollKeyboardProps> = memo(
         // Only C is labelled: every row named turns the column into a wall of
         // text, and C is what you count octaves from.
         if (pitch % 12 === 0 && geometry.rowHeightPx >= MIN_LABEL_ROW_HEIGHT_PX) {
-          ctx.fillStyle = colors.text;
+          ctx.fillStyle = theme.colorSchemes?.light?.palette.text.primary ?? colors.blackRow;
           ctx.fillText(
             pitchName(pitch),
             KEYBOARD_WIDTH_PX * BLACK_KEY_WIDTH_RATIO + 3,
@@ -105,11 +108,11 @@ export const PianoRollKeyboard: React.FC<PianoRollKeyboardProps> = memo(
 
     const handlePointerDown = useCallback(
       (e: React.PointerEvent<HTMLCanvasElement>) => {
-        if (!instrument) return;
+        if (e.button !== 0 || !instrument) return;
         const rect = e.currentTarget.getBoundingClientRect();
         const pitch = yToPitch(e.clientY - rect.top, geometry);
         if (pitch < 0 || pitch > 127) return;
-        void playAuditionNote(instrument, pitch);
+        void playAuditionNote(instrument, pitch).catch(() => undefined);
       },
       [geometry, instrument]
     );

--- a/web/src/components/timeline/pianoRoll/PianoRollPanel.tsx
+++ b/web/src/components/timeline/pianoRoll/PianoRollPanel.tsx
@@ -27,6 +27,8 @@ import {
 import { findClipById } from "../../../stores/timeline/clipLookup";
 import {
   Caption,
+  SelectField,
+  EditorButton,
   CloseButton,
   FlexColumn,
   FlexRow,
@@ -35,6 +37,7 @@ import {
   ToolbarIconButton,
   TruncatedText
 } from "../../ui_primitives";
+import type { TempoGridDivision } from "@nodetool-ai/timeline";
 import { GRID_DIVISION_OPTIONS } from "../Tracks/tempoGrid";
 import { PianoRoll } from "./PianoRoll";
 
@@ -72,7 +75,8 @@ const panelStyles = (theme: Theme) =>
 const headerStyles = (theme: Theme) =>
   css({
     flexShrink: 0,
-    height: TOUCH_HANDLE_HEIGHT_PX + HANDLE_HEIGHT_PX,
+    minHeight: 36,
+    flexWrap: "wrap",
     borderBottom: `1px solid ${theme.vars.palette.divider}`
   });
 
@@ -88,6 +92,9 @@ export const PianoRollPanel: React.FC<PianoRollPanelProps> = memo(
     const heightPx = useTimelineUIStore((s) => s.pianoRollHeightPx);
     const setHeightPx = useTimelineUIStore((s) => s.setPianoRollHeightPx);
     const closePianoRoll = useTimelineUIStore((s) => s.closePianoRoll);
+    const setGridDivision = useTimelineUIStore((s) => s.setGridDivision);
+    const snapEnabled = useTimelineUIStore((s) => s.snapEnabled);
+    const toggleSnap = useTimelineUIStore((s) => s.toggleSnap);
     const gridDivision = useTimelineUIStore((s) => s.gridDivision);
 
     // A clip the panel is open on can be deleted, or the whole document
@@ -153,10 +160,6 @@ export const PianoRollPanel: React.FC<PianoRollPanelProps> = memo(
 
     if (clipId === null || !isEditable) return null;
 
-    const gridLabel =
-      GRID_DIVISION_OPTIONS.find((option) => option.value === gridDivision)
-        ?.label ?? String(gridDivision);
-
     return (
       <>
         {!fullHeight && (
@@ -204,8 +207,12 @@ export const PianoRollPanel: React.FC<PianoRollPanelProps> = memo(
               {clip.name || "Midi clip"}
             </TruncatedText>
             <Caption color="muted">
-              {(clip.notes?.length ?? 0)} notes · grid {gridLabel}
+              {clip.notes?.length ?? 0} {(clip.notes?.length ?? 0) === 1 ? "note" : "notes"}
             </Caption>
+            <SelectField label="Note grid" hideLabel size="small" value={gridDivision}
+              options={GRID_DIVISION_OPTIONS} css={css({ width: 96 })}
+              onChange={(value) => setGridDivision(value as TempoGridDivision)} />
+            <EditorButton variant={snapEnabled ? "contained" : "text"} onClick={toggleSnap} aria-label="Snap notes" aria-pressed={snapEnabled}>Snap</EditorButton>
             <FlexRow sx={{ flex: 1 }} />
             {!fullHeight && (
               <CloseButton

--- a/web/src/components/timeline/pianoRoll/PianoRollRuler.tsx
+++ b/web/src/components/timeline/pianoRoll/PianoRollRuler.tsx
@@ -13,6 +13,7 @@ import { css } from "@emotion/react";
 import { useColorScheme, useTheme } from "@mui/material/styles";
 
 import type { TimelineTempo } from "@nodetool-ai/timeline";
+import { TYPOGRAPHY } from "../../ui_primitives";
 
 import { computeBarRulerTicks } from "../Tracks/tempoGrid";
 import { pickPianoRollColors } from "./pianoRollColors";
@@ -23,7 +24,10 @@ export const PIANO_ROLL_RULER_HEIGHT_PX = 22;
 
 const canvasStyles = css({
   display: "block",
-  width: "100%"
+  width: "100%",
+  cursor: "pointer",
+  touchAction: "none",
+  ...TYPOGRAPHY.mono.caption
 });
 
 interface PianoRollRulerProps {
@@ -34,14 +38,16 @@ interface PianoRollRulerProps {
   tickToTimelineMs: (tick: number) => number;
   /** The content tick playing at timeline ms `ms`. */
   timelineMsToTick: (ms: number) => number;
+  onSeekTick: (tick: number) => void;
 }
 
 export const PianoRollRuler: React.FC<PianoRollRulerProps> = memo(
-  ({ geometry, widthPx, tempo, tickToTimelineMs, timelineMsToTick }) => {
+  ({ geometry, widthPx, tempo, tickToTimelineMs, timelineMsToTick, onSeekTick }) => {
     const theme = useTheme();
     const { mode, systemMode } = useColorScheme();
     const activeMode = (mode === "system" ? systemMode : mode) ?? "dark";
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
+    const scrubPointer = useRef<number | null>(null);
 
     useEffect(() => {
       const canvas = canvasRef.current;
@@ -74,7 +80,8 @@ export const PianoRollRuler: React.FC<PianoRollRulerProps> = memo(
       });
 
       ctx.textBaseline = "middle";
-      ctx.font = "9px var(--fontFamily2), monospace";
+      const canvasStyle = getComputedStyle(canvas);
+      ctx.font = `${canvasStyle.fontSize} ${canvasStyle.fontFamily}`;
       for (const tick of ticks) {
         const x = Math.round(tickToX(timelineMsToTick(tick.timeMs), geometry)) + 0.5;
         ctx.strokeStyle = tick.kind === "bar" ? colors.barLine : colors.gridLine;
@@ -102,6 +109,23 @@ export const PianoRollRuler: React.FC<PianoRollRulerProps> = memo(
         ref={canvasRef}
         css={canvasStyles}
         style={{ height: PIANO_ROLL_RULER_HEIGHT_PX }}
+        data-testid="piano-roll-ruler"
+        title="Click or drag to position the playhead"
+        onPointerDown={(event) => {
+          if (event.button !== 0) return;
+          event.preventDefault();
+          event.currentTarget.closest<HTMLElement>('[data-testid="piano-roll"]')?.focus();
+          event.currentTarget.setPointerCapture(event.pointerId);
+          scrubPointer.current = event.pointerId;
+          onSeekTick(Math.round(xToTick(event.clientX - event.currentTarget.getBoundingClientRect().left, geometry)));
+        }}
+        onPointerMove={(event) => {
+          if (scrubPointer.current !== event.pointerId) return;
+          onSeekTick(Math.round(xToTick(event.clientX - event.currentTarget.getBoundingClientRect().left, geometry)));
+        }}
+        onPointerUp={() => { scrubPointer.current = null; }}
+        onPointerCancel={() => { scrubPointer.current = null; }}
+        onLostPointerCapture={() => { scrubPointer.current = null; }}
         aria-hidden
       />
     );

--- a/web/src/components/timeline/pianoRoll/PianoRollVelocityLane.tsx
+++ b/web/src/components/timeline/pianoRoll/PianoRollVelocityLane.tsx
@@ -23,7 +23,7 @@ export const VELOCITY_LANE_HEIGHT_PX = 56;
 const MAX_VELOCITY = 127;
 const MIN_VELOCITY = 1;
 /** A bar this wide is still grabbable when its note is a hairline. */
-const MIN_BAR_WIDTH_PX = 3;
+const MIN_BAR_WIDTH_PX = 8;
 
 const canvasStyles = css({
   display: "block",
@@ -96,9 +96,10 @@ export const PianoRollVelocityLane: React.FC<PianoRollVelocityLaneProps> = memo(
         ctx.fillRect(
           rect.x,
           VELOCITY_LANE_HEIGHT_PX - height,
-          Math.max(MIN_BAR_WIDTH_PX, rect.width),
+          4,
           height
         );
+        ctx.fillRect(rect.x, VELOCITY_LANE_HEIGHT_PX - height, MIN_BAR_WIDTH_PX, 4);
       }
     }, [theme, activeMode, notes, selectedIds, geometry, widthPx]);
 
@@ -108,7 +109,7 @@ export const PianoRollVelocityLane: React.FC<PianoRollVelocityLaneProps> = memo(
         for (let i = notes.length - 1; i >= 0; i--) {
           const note = notes[i]!;
           const rect = noteRect(note, geometry);
-          const width = Math.max(MIN_BAR_WIDTH_PX, rect.width);
+          const width = MIN_BAR_WIDTH_PX;
           if (x >= rect.x && x < rect.x + width) return note;
         }
         return null;
@@ -118,6 +119,7 @@ export const PianoRollVelocityLane: React.FC<PianoRollVelocityLaneProps> = memo(
 
     const handlePointerDown = useCallback(
       (e: React.PointerEvent<HTMLCanvasElement>) => {
+        if (e.button !== 0) return;
         const rect = e.currentTarget.getBoundingClientRect();
         const note = noteAtX(e.clientX - rect.left);
         if (!note) return;

--- a/web/src/components/timeline/pianoRoll/__tests__/PianoRoll.test.tsx
+++ b/web/src/components/timeline/pianoRoll/__tests__/PianoRoll.test.tsx
@@ -3,12 +3,12 @@
  *
  * The geometry is pinned by the fixture rather than assumed: the grid measures
  * 768 × 240, the clip's window is 7680 ticks, so the opening frame is exactly
- * 0.1 px per tick with C5 (72) on the top row — which is what makes "click at
+ * 0.1 px per tick with A#4 (70) on the top row — which is what makes "click at
  * x = 100" assertable as "beat two".
  */
 
 import React from "react";
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 
@@ -137,10 +137,10 @@ describe("PianoRoll", () => {
     const instance = setup();
     const grid = screen.getByTestId("piano-roll-grid");
 
-    // x = 100 → tick 1000, snapped to the beat grid at 960; y = 150 → pitch 60.
+    // x = 100 → tick 1000, snapped to the beat grid at 960; y = 166 → pitch 60.
     await user.pointer({
       target: grid,
-      coords: { clientX: 100, clientY: 150 },
+      coords: { clientX: 100, clientY: 166 },
       keys: "[MouseLeft]"
     });
 
@@ -165,10 +165,10 @@ describe("PianoRoll", () => {
     const instance = setup();
     const grid = screen.getByTestId("piano-roll-grid");
 
-    // n2 spans x 96..144 on the row for pitch 62 (y 120..132).
+    // n2 spans x 96..144 on the row for pitch 62 (y 128..144).
     await user.pointer({
       target: grid,
-      coords: { clientX: 100, clientY: 125 },
+      coords: { clientX: 100, clientY: 134 },
       keys: "[MouseLeft]"
     });
     await user.keyboard("{Delete}");
@@ -184,10 +184,10 @@ describe("PianoRoll", () => {
 
     // One beat is 960 ticks — 96 px at this zoom.
     await user.pointer([
-      { keys: "[MouseLeft>]", target: grid, coords: { clientX: 100, clientY: 125 } },
-      { target: grid, coords: { clientX: 148, clientY: 125 } },
-      { target: grid, coords: { clientX: 196, clientY: 125 } },
-      { keys: "[/MouseLeft]", target: grid, coords: { clientX: 196, clientY: 125 } }
+      { keys: "[MouseLeft>]", target: grid, coords: { clientX: 100, clientY: 134 } },
+      { target: grid, coords: { clientX: 148, clientY: 134 } },
+      { target: grid, coords: { clientX: 196, clientY: 134 } },
+      { keys: "[/MouseLeft]", target: grid, coords: { clientX: 196, clientY: 134 } }
     ]);
 
     expect(notesOf(instance).find((n) => n.id === "n2")).toMatchObject({
@@ -204,7 +204,7 @@ describe("PianoRoll", () => {
 
     await user.pointer({
       target: grid,
-      coords: { clientX: 100, clientY: 125 },
+      coords: { clientX: 100, clientY: 134 },
       keys: "[MouseLeft]"
     });
     await user.keyboard("{ArrowUp}");
@@ -218,11 +218,88 @@ describe("PianoRoll", () => {
     const grid = screen.getByTestId("piano-roll-grid");
 
     await user.pointer([
-      { keys: "[MouseLeft]", target: grid, coords: { clientX: 100, clientY: 125 } },
-      { keys: "[MouseLeft]", target: grid, coords: { clientX: 100, clientY: 125 } }
+      { keys: "[MouseLeft]", target: grid, coords: { clientX: 100, clientY: 134 } },
+      { keys: "[MouseLeft]", target: grid, coords: { clientX: 100, clientY: 134 } }
     ]);
 
     expect(notesOf(instance).map((n) => n.id)).toEqual(["n1", "n3"]);
+  });
+
+  it("undoes and redoes note edits while the piano roll has focus", async () => {
+    const user = userEvent.setup();
+    const instance = setup();
+    await user.click(screen.getByTestId("piano-roll"));
+    await user.keyboard("{Control>}a{/Control}{Delete}");
+    expect(notesOf(instance)).toHaveLength(0);
+    await user.keyboard("{Control>}z{/Control}");
+    expect(notesOf(instance)).toEqual(seedNotes());
+    await user.keyboard("{Control>}{Shift>}z{/Shift}{/Control}");
+    expect(notesOf(instance)).toHaveLength(0);
+  });
+
+  it("does not write notes with secondary buttons or Shift-click", async () => {
+    const user = userEvent.setup();
+    const instance = setup();
+    const grid = screen.getByTestId("piano-roll-grid");
+    await user.pointer({target: grid, coords: {clientX: 400, clientY: 166}, keys: "[MouseRight]"});
+    await user.keyboard("{Shift>}");
+    await user.pointer({target: grid, coords: {clientX: 400, clientY: 166}, keys: "[MouseLeft]"});
+    await user.keyboard("{/Shift}");
+    expect(notesOf(instance)).toEqual(seedNotes());
+  });
+
+  it("duplicates immediately after the selection without an extra gap", async () => {
+    const user = userEvent.setup();
+    const instance = setup();
+    await user.click(screen.getByTestId("piano-roll"));
+    await user.keyboard("{Control>}ad{/Control}");
+    expect(notesOf(instance).slice(3).map(n => n.startTick)).toEqual([2400, 3360, 4320]);
+  });
+
+  it("keeps a newly created note on a double-click in an empty cell", async () => {
+    const user = userEvent.setup();
+    const instance = setup();
+    const grid = screen.getByTestId("piano-roll-grid");
+    await user.pointer([
+      {target: grid, coords: {clientX: 440, clientY: 166}, keys: "[MouseLeft]"},
+      {target: grid, coords: {clientX: 440, clientY: 166}, keys: "[MouseLeft]"}
+    ]);
+    expect(notesOf(instance)).toHaveLength(4);
+    expect(notesOf(instance)[3].startTick).toBe(3840);
+  });
+
+  it("resizes the end without moving the note and undoes the gesture", async () => {
+    const user = userEvent.setup();
+    const instance = setup();
+    const grid = screen.getByTestId("piano-roll-grid");
+    await user.pointer([
+      {target: grid, coords: {clientX: 142, clientY: 134}, keys: "[MouseLeft>]"},
+      {target: grid, coords: {clientX: 190, clientY: 134}},
+      {target: grid, coords: {clientX: 190, clientY: 134}, keys: "[/MouseLeft]"}
+    ]);
+    expect(notesOf(instance)[1]).toMatchObject({startTick: 960, durationTick: 960});
+    await user.keyboard("{Control>}z{/Control}");
+    expect(notesOf(instance)).toEqual(seedNotes());
+  });
+
+  it("edits the selected notes' velocity without moving their pitches", async () => {
+    const user = userEvent.setup();
+    const instance = setup();
+    await user.click(screen.getByTestId("piano-roll"));
+    await user.keyboard("{Control>}a{/Control}");
+    const slider = screen.getByRole("slider", {name: "Selected note velocity"});
+    act(() => slider.focus());
+    await user.keyboard("{Home}{ArrowRight}");
+    expect(notesOf(instance).map(n => n.velocity)).toEqual([2, 2, 2]);
+    expect(notesOf(instance).map(n => n.pitch)).toEqual([60, 62, 64]);
+  });
+
+  it("does not report notes removed by undo as still selected", async () => {
+    const user = userEvent.setup();
+    setup();
+    await user.click(screen.getByTestId("piano-roll"));
+    await user.keyboard("{Control>}adz{/Control}");
+    expect(screen.getByText("Click to add a note")).toBeInTheDocument();
   });
 
   it("closes itself when the clip it edits is deleted", () => {
@@ -234,4 +311,179 @@ describe("PianoRoll", () => {
     expect(screen.queryByTestId("piano-roll")).not.toBeInTheDocument();
     expect(instance.ui.getState().pianoRollClipId).toBeNull();
   });
+});
+
+
+it("copies and pastes a phrase at the playhead with fresh ids and one undo", async () => {
+  const user = userEvent.setup();
+  const instance = setup();
+  await user.click(screen.getByTestId("piano-roll"));
+  await user.keyboard("{Meta>}a{/Meta}");
+  const data = new Map<string, string>();
+  const clipboardData = { getData: (type: string) => data.get(type) ?? "", setData: (type: string, value: string) => data.set(type, value) };
+  fireEvent.copy(screen.getByTestId("piano-roll"), { clipboardData });
+  expect(clipboardData.getData("text/plain")).toContain("nodetool-midi-notes");
+  await user.pointer({ target: screen.getByTestId("piano-roll-ruler"), keys: "[MouseLeft]", coords: { clientX: 384, clientY: 10 } });
+  expect(instance.playback.getState().getTimeMs()).toBe(2000);
+  const before = undoDepth(instance);
+  await user.paste(clipboardData.getData("text/plain"));
+  const pasted = notesOf(instance).slice(3);
+  expect(pasted.map(({ id, ...note }) => note)).toEqual(seedNotes().map(({ id, ...note }) => ({ ...note, startTick: note.startTick + 3840 })));
+  expect(new Set(notesOf(instance).map(n => n.id)).size).toBe(6);
+  expect(undoDepth(instance) - before).toBe(1);
+  await user.keyboard("{Meta>}z{/Meta}");
+  expect(notesOf(instance)).toEqual(seedNotes());
+});
+
+it("cuts notes, pastes into a different trimmed clip, and leaves source edits isolated", async () => {
+  const user = userEvent.setup();
+  const instance = setup();
+  await user.click(screen.getByTestId("piano-roll"));
+  await user.keyboard("{Control>}a{/Control}");
+  const data = new Map<string, string>();
+  const clipboardData = { getData: (type: string) => data.get(type) ?? "", setData: (type: string, value: string) => data.set(type, value) };
+  fireEvent.cut(screen.getByTestId("piano-roll"), { clipboardData });
+  expect(notesOf(instance)).toHaveLength(0);
+  act(() => {
+    const source = instance.doc.getState().clips[0];
+    instance.doc.getState().addClips([{ ...source, id: "destination", startMs: 5000, inPointMs: 500, notes: [] }]);
+    instance.ui.getState().openPianoRoll("destination");
+    instance.playback.getState().seek(6000);
+  });
+  await user.click(screen.getByTestId("piano-roll"));
+  await user.paste(clipboardData.getData("text/plain"));
+  const destination = instance.doc.getState().clips.find(c => c.id === "destination")!;
+  expect(destination.notes?.map(n => n.startTick)).toEqual([2880, 3840, 4800]);
+  expect(notesOf(instance)).toHaveLength(0);
+});
+
+it("repeats with Command-R and quantizes starts with Q without changing lengths", async () => {
+  const user = userEvent.setup();
+  const instance = setup();
+  await user.click(screen.getByTestId("piano-roll"));
+  await user.keyboard("{Meta>}ar{/Meta}");
+  expect(notesOf(instance)).toHaveLength(6);
+  await user.keyboard("{Alt>}{ArrowRight}{/Alt}q");
+  expect(notesOf(instance).slice(3).map(n => n.startTick)).toEqual([2880, 3840, 4800]);
+  expect(notesOf(instance).every(n => n.durationTick === 480)).toBe(true);
+});
+
+it("splits selected notes at the playhead with Command-T and undoes once", async () => {
+  const user = userEvent.setup();
+  const instance = setup();
+  await user.click(screen.getByTestId("piano-roll"));
+  await user.keyboard("{Meta>}a{/Meta}");
+  act(() => instance.playback.getState().seek(125));
+  await user.keyboard("{Meta>}t{/Meta}");
+  expect(notesOf(instance).filter(n => n.pitch === 60).map(n => [n.startTick, n.durationTick])).toEqual([[0, 240], [240, 240]]);
+  await user.keyboard("{Meta>}z{/Meta}");
+  expect(notesOf(instance)).toEqual(seedNotes());
+});
+
+it("supports Logic transpose and nudge modifiers without changing durations", async () => {
+  const user = userEvent.setup();
+  const instance = setup();
+  await user.click(screen.getByTestId("piano-roll"));
+  await user.keyboard("{Meta>}a{/Meta}{Alt>}{Shift>}{ArrowUp}{/Shift}{/Alt}{Control>}{Alt>}{ArrowRight}{/Alt}{/Control}");
+  expect(notesOf(instance).map(n => [n.pitch, n.startTick, n.durationTick])).toEqual([[72, 960, 480], [74, 1920, 480], [76, 2880, 480]]);
+});
+
+it("ignores unrelated clipboard text", async () => {
+  const user = userEvent.setup();
+  const instance = setup();
+  await user.click(screen.getByTestId("piano-roll"));
+  const before = notesOf(instance);
+  await user.paste("ordinary text");
+  expect(notesOf(instance)).toEqual(before);
+});
+
+it("Option-drags a selection as copies, preserves originals, and undoes once", async () => {
+  const user = userEvent.setup();
+  const instance = setup();
+  const grid = screen.getByTestId("piano-roll-grid");
+  await user.click(screen.getByTestId("piano-roll"));
+  await user.keyboard("{Meta>}a{/Meta}{Alt>}");
+  const depth = undoDepth(instance);
+  await user.pointer([
+    {target: grid, coords: {clientX: 110, clientY: 134}, keys: "[MouseLeft>]"},
+    {target: grid, coords: {clientX: 206, clientY: 118}},
+    {target: grid, coords: {clientX: 302, clientY: 118}, keys: "[/MouseLeft]"}
+  ]);
+  await user.keyboard("{/Alt}");
+  const next = notesOf(instance);
+  expect(next.filter(n => ["n1", "n2", "n3"].includes(n.id))).toEqual(seedNotes());
+  expect(next.filter(n => !["n1", "n2", "n3"].includes(n.id)).map(n => [n.pitch, n.startTick, n.durationTick])).toEqual([[61, 1920, 480], [63, 2880, 480], [65, 3840, 480]]);
+  expect(undoDepth(instance)).toBe(depth + 1);
+  await user.keyboard("{Meta>}z{/Meta}");
+  expect(notesOf(instance)).toEqual(seedNotes());
+});
+
+it("changes selected velocities relatively from the lane and restores one gesture", async () => {
+  const user = userEvent.setup();
+  const instance = setup();
+  act(() => instance.doc.getState().setClipNotes(CLIP_ID, seedNotes().map((n, i) => ({...n, velocity: [40, 70, 100][i]}))));
+  await user.click(screen.getByTestId("piano-roll"));
+  await user.keyboard("{Meta>}a{/Meta}");
+  const lane = screen.getByRole("img", {name: "Note velocities"});
+  const depth = undoDepth(instance);
+  await user.pointer([
+    {target: lane, coords: {clientX: 96, clientY: 25}, keys: "[MouseLeft>]"},
+    {target: lane, coords: {clientX: 96, clientY: 20}},
+    {target: lane, coords: {clientX: 96, clientY: 20}, keys: "[/MouseLeft]"}
+  ]);
+  expect(notesOf(instance).map(n => n.velocity)).toEqual([52, 82, 112]);
+  expect(undoDepth(instance)).toBe(depth + 1);
+  await user.keyboard("{Meta>}z{/Meta}");
+  expect(notesOf(instance).map(n => n.velocity)).toEqual([40, 70, 100]);
+  const slider = screen.getByRole("slider", {name: "Selected note velocity"});
+  act(() => slider.focus());
+  await user.keyboard("{End}");
+  expect(notesOf(instance).map(n => n.velocity)).toEqual([67, 97, 127]);
+});
+
+it("edits selection fields, preserves group spacing, and handles mixed values and cancellation", async () => {
+  const user = userEvent.setup();
+  const instance = setup();
+  act(() => instance.doc.getState().setClipNotes(CLIP_ID, seedNotes().map((n, i) => ({...n, durationTick: 480 + i * 240, velocity: 40 + i * 20}))));
+  await user.click(screen.getByTestId("piano-roll"));
+  await user.keyboard("{Meta>}a{/Meta}");
+  expect(screen.getByRole("spinbutton", {name: "Length (beats)"})).toHaveAttribute("placeholder", "Mixed");
+  expect(screen.getByRole("spinbutton", {name: "Velocity"})).toHaveValue(null);
+  const edit = async (name: string, value: string) => {
+    const field = screen.getByRole("spinbutton", {name});
+    await user.clear(field);
+    await user.type(field, value);
+    await user.keyboard("{Enter}");
+  };
+  await edit("Lowest pitch (MIDI)", "72");
+  await edit("Start beat", "3");
+  expect(notesOf(instance).map(n => [n.pitch, n.startTick])).toEqual([[72, 1920], [74, 2880], [76, 3840]]);
+  await edit("Length (beats)", "0.25");
+  await edit("Velocity", "88");
+  expect(notesOf(instance).every(n => n.durationTick === 240 && n.velocity === 88)).toBe(true);
+  const depth = undoDepth(instance);
+  await edit("Velocity", "88.4");
+  expect(screen.getByRole("spinbutton", {name: "Velocity"})).toHaveValue(88);
+  expect(undoDepth(instance)).toBe(depth);
+  const before = notesOf(instance);
+  const field = screen.getByRole("spinbutton", {name: "Velocity"});
+  await user.clear(field);
+  await user.type(field, "20");
+  await user.keyboard("{Escape}");
+  expect(notesOf(instance)).toEqual(before);
+  expect(screen.getByRole("spinbutton", {name: "Velocity"})).toHaveValue(88);
+});
+
+it("uses the time signature's beat unit in the selection inspector", async () => {
+  const user = userEvent.setup();
+  const instance = setup();
+  act(() => instance.doc.setState({tempo: {bpm: 120, offsetMs: 0, timeSignature: {beatsPerBar: 6, beatUnit: 8}}}));
+  await user.click(screen.getByTestId("piano-roll"));
+  await user.keyboard("{Meta>}a{/Meta}");
+  expect(screen.getByRole("spinbutton", {name: "Length (beats)"})).toHaveValue(1);
+  const start = screen.getByRole("spinbutton", {name: "Start beat"});
+  await user.clear(start);
+  await user.type(start, "3");
+  await user.keyboard("{Enter}");
+  expect(notesOf(instance).map(note => note.startTick)).toEqual([960, 1920, 2880]);
 });

--- a/web/src/components/timeline/pianoRoll/__tests__/noteClipboard.test.ts
+++ b/web/src/components/timeline/pianoRoll/__tests__/noteClipboard.test.ts
@@ -1,0 +1,20 @@
+import { decodeNoteClipboard, encodeNoteClipboard, pasteNotes } from "../noteClipboard";
+
+const note = { id: "original", pitch: 60, velocity: 87, startTick: 120, durationTick: 240 };
+
+it("rejects unrelated or invalid clipboard data", () => {
+  for (const text of ["hello", "null", "{}", JSON.stringify({ format: "nodetool-midi-notes", version: 1, notes: [{ ...note, pitch: 128 }] })]) {
+    expect(decodeNoteClipboard(text)).toBeNull();
+  }
+});
+
+it("pastes a large selection with fresh ids and unchanged musical spacing", () => {
+  const notes = Array.from({ length: 10000 }, (_, index) => ({ ...note, id: String(index), startTick: 120 + index * 240 }));
+  const copied = decodeNoteClipboard(encodeNoteClipboard(notes))!;
+  const pasted = pasteNotes(copied, 960);
+  expect(pasted).toHaveLength(10000);
+  expect(new Set(pasted.map(n => n.id)).size).toBe(10000);
+  expect(pasted[0]).toMatchObject({ startTick: 960, velocity: 87, durationTick: 240 });
+  expect(pasted[9999].startTick).toBe(960 + 9999 * 240);
+  expect(notes[0].startTick).toBe(120);
+});

--- a/web/src/components/timeline/pianoRoll/noteClipboard.ts
+++ b/web/src/components/timeline/pianoRoll/noteClipboard.ts
@@ -1,0 +1,43 @@
+import { createTimeOrderedUuid } from "@nodetool-ai/timeline";
+import type { MidiNote } from "@nodetool-ai/timeline";
+
+const FORMAT = "nodetool-midi-notes";
+type CopiedNote = Omit<MidiNote, "id">;
+
+export function encodeNoteClipboard(notes: readonly MidiNote[]): string {
+  return JSON.stringify({
+    format: FORMAT,
+    version: 1,
+    notes: notes.map(({ pitch, velocity, startTick, durationTick }) => ({
+      pitch, velocity, startTick, durationTick
+    }))
+  });
+}
+
+export function decodeNoteClipboard(text: string): CopiedNote[] | null {
+  try {
+    const value = JSON.parse(text);
+    if (value?.format !== FORMAT || value.version !== 1 ||
+      !Array.isArray(value.notes) || value.notes.length === 0) return null;
+    if (!value.notes.every((note: CopiedNote) => note &&
+      Number.isInteger(note.pitch) && note.pitch >= 0 && note.pitch <= 127 &&
+      Number.isInteger(note.velocity) && note.velocity >= 1 && note.velocity <= 127 &&
+      Number.isSafeInteger(note.startTick) && note.startTick >= 0 &&
+      Number.isSafeInteger(note.durationTick) && note.durationTick > 0)) return null;
+    return value.notes.map(({ pitch, velocity, startTick, durationTick }: CopiedNote) => ({
+      pitch, velocity, startTick, durationTick
+    }));
+  } catch {
+    return null;
+  }
+}
+
+export function pasteNotes(notes: readonly CopiedNote[], atTick: number): MidiNote[] {
+  const firstTick = notes.reduce((start, note) => Math.min(start, note.startTick), Infinity);
+  const offset = Math.max(0, Math.round(atTick)) - firstTick;
+  return notes.map(note => ({
+    ...note,
+    id: createTimeOrderedUuid(),
+    startTick: note.startTick + offset
+  }));
+}

--- a/web/src/components/timeline/timelineKeymap.ts
+++ b/web/src/components/timeline/timelineKeymap.ts
@@ -37,6 +37,8 @@ export type TimelineAction =
   | "copy"
   | "cut"
   | "paste"
+  | "stepFrameBack"
+  | "stepFrameForward"
   | "nudgeLeft"
   | "nudgeRight"
   | "nudgeLeftLarge"
@@ -96,6 +98,8 @@ const COMMON: Partial<Keymap> = {
   paste: [k("v", { ctrl: true })],
   markIn: [k("i")],
   markOut: [k("o")],
+  stepFrameBack: [k("ArrowLeft")],
+  stepFrameForward: [k("ArrowRight")],
   shuttleBack: [k("j")],
   shuttleStop: [k("k")],
   shuttleForward: [k("l")],
@@ -118,6 +122,8 @@ const NODETOOL: Keymap = {
   rippleDeleteSelected: [k("Delete", { shift: true }), k("Backspace", { shift: true })],
   duplicate: [k("d", { ctrl: true })],
   duplicateWithGap: [k("d", { ctrl: true, shift: true })],
+  stepFrameBack: [k("ArrowLeft", { alt: true })],
+  stepFrameForward: [k("ArrowRight", { alt: true })],
   nudgeLeft: [k("ArrowLeft")],
   nudgeRight: [k("ArrowRight")],
   nudgeLeftLarge: [k("ArrowLeft", { shift: true })],

--- a/web/src/components/ui_primitives/SelectField.tsx
+++ b/web/src/components/ui_primitives/SelectField.tsx
@@ -6,7 +6,7 @@
  * The label renders above the control via the shared Label primitive.
  */
 
-import React, { memo, useCallback, useId } from "react";
+import React, { createContext, memo, useCallback, useContext, useId } from "react";
 import {
   FormControl,
   Select,
@@ -16,8 +16,11 @@ import {
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { Label } from "./Label";
-import { CONTROL } from "./tokens";
+import { CONTROL, FONT_SIZE_SANS } from "./tokens";
 import { useFormFieldContext } from "./formFieldContext";
+
+/** Compact editor typography also reaches dropdown menus rendered in portals. */
+export const SelectFieldDensityContext = createContext<"normal" | "compact">("normal");
 
 export interface SelectOption {
   /** Option value */
@@ -130,7 +133,8 @@ const SelectFieldInternal = React.forwardRef<HTMLDivElement, SelectFieldProps>(
       [onChange]
     );
 
-    const fieldFontSize = theme.fontSizeNormal || "15px";
+    const density = useContext(SelectFieldDensityContext);
+    const fieldFontSize = density === "compact" ? FONT_SIZE_SANS.caption : FONT_SIZE_SANS.body;
     const controlHeight =
       size === "small" ? CONTROL.height.sm : CONTROL.height.lg;
 

--- a/web/src/components/ui_primitives/index.ts
+++ b/web/src/components/ui_primitives/index.ts
@@ -372,7 +372,7 @@ export type { AutocompleteProps, AutocompleteOption } from "./Autocomplete";
 export { LabeledSwitch } from "./LabeledSwitch";
 export type { LabeledSwitchProps } from "./LabeledSwitch";
 
-export { SelectField } from "./SelectField";
+export { SelectField, SelectFieldDensityContext } from "./SelectField";
 export type { SelectFieldProps, SelectOption } from "./SelectField";
 
 // Accessibility

--- a/web/src/stores/timeline/TimelineInstance.tsx
+++ b/web/src/stores/timeline/TimelineInstance.tsx
@@ -163,6 +163,10 @@ const TimelineContext: React.Context<TimelineInstance | null> = (() => {
 const useTimelineInstance = (): TimelineInstance =>
   useContext(TimelineContext) ?? getDefaultInstance();
 
+const TimelineActiveContext = createContext(true);
+
+export const useTimelineIsActive = (): boolean => useContext(TimelineActiveContext);
+
 interface TimelineProviderProps {
   /**
    * Whether this surface is the focused/visible one. While active, the
@@ -199,7 +203,9 @@ export const TimelineProvider = ({
 
   return (
     <TimelineContext.Provider value={instance}>
-      {children}
+      <TimelineActiveContext.Provider value={active}>
+        {children}
+      </TimelineActiveContext.Provider>
     </TimelineContext.Provider>
   );
 };

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_TIMELINE_INSTRUMENT } from "./instrumentPresets";
 /**
  * TimelineStore
  *
@@ -60,7 +61,6 @@ import {
   scaleVelocity,
   sortNotes,
   transposeNotes,
-  DEFAULT_MIDI_INSTRUMENT,
   clearGeneratedMatte as clearMatteOnClip,
   selectGeneratedMatteVersion as selectMatteVersionOnClip,
   findBakedAnimationIndex,
@@ -1715,7 +1715,7 @@ export const createTimelineStore = (
           // instrument-less track would render silence. `makeTrack` in
           // `@nodetool-ai/timeline` does not fill it in, so the store does.
           if (type === "midi") {
-            track.instrument = DEFAULT_MIDI_INSTRUMENT;
+            track.instrument = DEFAULT_TIMELINE_INSTRUMENT;
           }
           set((state) => {
             const next: Partial<TimelineStoreState> = {

--- a/web/src/stores/timeline/TimelineUIStore.ts
+++ b/web/src/stores/timeline/TimelineUIStore.ts
@@ -115,6 +115,8 @@ export interface TimelineUIState {
    * view can hold.
    */
   lanesViewportWidthPx: number;
+  /** Width of the desktop track-header column in pixels. */
+  trackHeaderWidthPx: number;
   /** The property Alt+K keyframes; the inspector's last-touched row. */
   keyframeProperty: KeyframeProperty;
   /** In and out on the source viewer's asset, clip-source milliseconds. */
@@ -237,6 +239,8 @@ export interface TimelineUIState {
   toggleRulerMode: () => void;
   setGridDivision: (division: TempoGridDivision) => void;
   setLanesViewportWidthPx: (px: number) => void;
+  /** Resize the desktop track-header column, clamped to its bounds. */
+  setTrackHeaderWidthPx: (px: number) => void;
   setKeyframeProperty: (property: KeyframeProperty) => void;
   setSourceRange: (range: { inMs: number; outMs: number } | null) => void;
 
@@ -271,11 +275,14 @@ export interface TimelineUIState {
   // ── Instrument panel ──────────────────────────────────────────────────────
 
   /**
-   * Id of the midi track whose instrument editor is expanded inline below its
-   * row, or null. One at a time, like the DSP chain editor.
+   * Id of the MIDI track selected in the right-panel Instruments tab.
    */
   expandedInstrumentTrackId: string | null;
-  /** Toggle the inline instrument editor for the given midi track. */
+  panelTab: "inspector" | "source" | "instrument" | "agent" | "history" | "script";
+  setPanelTab: (tab: TimelineUIState["panelTab"]) => void;
+  instrumentKeyboards: Record<string, boolean>;
+  toggleInstrumentKeyboard: (trackId: string) => void;
+  /** Open the Instruments tab for the given MIDI track. */
   toggleExpandedInstrument: (trackId: string) => void;
 
   // ── Track drag-reorder ─────────────────────────────────────────────────────
@@ -292,9 +299,24 @@ export interface TimelineUIState {
 
 export const MIN_MS_PER_PX = 0.5;
 
-export const DEFAULT_PIANO_ROLL_HEIGHT_PX = 280;
+export const DEFAULT_PIANO_ROLL_HEIGHT_PX = 360;
 export const MIN_PIANO_ROLL_HEIGHT_PX = 160;
 export const MAX_PIANO_ROLL_HEIGHT_PX = 720;
+export const DEFAULT_TRACK_HEADER_WIDTH_PX = 320;
+export const MIN_TRACK_HEADER_WIDTH_PX = 160;
+export const MAX_TRACK_HEADER_WIDTH_PX = 480;
+export const MIN_TIMELINE_LANES_WIDTH_PX = 240;
+
+export const maxTrackHeaderWidthForViewport = (
+  viewportWidthPx: number
+): number =>
+  Math.min(
+    MAX_TRACK_HEADER_WIDTH_PX,
+    Math.max(
+      MIN_TRACK_HEADER_WIDTH_PX,
+      viewportWidthPx - MIN_TIMELINE_LANES_WIDTH_PX
+    )
+  );
 
 export const MAX_MS_PER_PX = 500;
 
@@ -303,167 +325,182 @@ export type TimelineUIStoreApi = UseBoundStore<StoreApi<TimelineUIState>>;
 /** Create an isolated UI store for one timeline-editor instance. */
 export const createTimelineUIStore = (): TimelineUIStoreApi =>
   create<TimelineUIState>((set, get) => ({
-  selectedClipIds: new Set(),
-  hoveredClipId: null,
-  activeTool: "select",
-  rippleMode: false,
-  dropMode: "overwrite",
-  selectedEdit: null,
-  snapEnabled: true,
-  rulerMode: "timecode",
-  gridDivision: "beat",
-  lanesViewportWidthPx: 0,
-  keyframeProperty: "opacity",
-  sourceRange: null,
-  msPerPx: 10,
-  scrollLeftPx: 0,
-  revealRequest: null,
-  fullscreen: false,
-  matteViewEnabled: false,
-  expandedFxTrackId: null,
-  expandedInstrumentTrackId: null,
-  pianoRollClipId: null,
-  pianoRollHeightPx: DEFAULT_PIANO_ROLL_HEIGHT_PX,
-  draggingTrackId: null,
-  trackDropTarget: null,
-  selectClip: (id) =>
-    set({ selectedClipIds: new Set([id]), selectedEdit: null }),
-
-  addToSelection: (id) =>
-    set((state) => ({
-      selectedClipIds: new Set([...state.selectedClipIds, id])
+    selectedClipIds: new Set(),
+    hoveredClipId: null,
+    activeTool: "select",
+    rippleMode: false,
+    dropMode: "overwrite",
+    selectedEdit: null,
+    snapEnabled: true,
+    rulerMode: "timecode",
+    gridDivision: "beat",
+    lanesViewportWidthPx: 0,
+    trackHeaderWidthPx: DEFAULT_TRACK_HEADER_WIDTH_PX,
+    keyframeProperty: "opacity",
+    sourceRange: null,
+    msPerPx: 10,
+    scrollLeftPx: 0,
+    revealRequest: null,
+    fullscreen: false,
+    matteViewEnabled: false,
+    expandedFxTrackId: null,
+    expandedInstrumentTrackId: null,
+    panelTab: "inspector",
+    setPanelTab: (panelTab) => set({ panelTab }),
+    instrumentKeyboards: {},
+    toggleInstrumentKeyboard: (trackId) => set(state => ({
+      instrumentKeyboards: {...state.instrumentKeyboards, [trackId]: !state.instrumentKeyboards[trackId]}
     })),
+    pianoRollClipId: null,
+    pianoRollHeightPx: DEFAULT_PIANO_ROLL_HEIGHT_PX,
+    draggingTrackId: null,
+    trackDropTarget: null,
+    selectClip: (id) =>
+      set({ selectedClipIds: new Set([id]), selectedEdit: null }),
 
-  removeFromSelection: (id) =>
-    set((state) => {
-      const next = new Set(state.selectedClipIds);
-      next.delete(id);
-      return { selectedClipIds: next };
-    }),
+    addToSelection: (id) =>
+      set((state) => ({
+        selectedClipIds: new Set([...state.selectedClipIds, id])
+      })),
 
-  toggleSelection: (id) => {
-    const { selectedClipIds } = get();
-    if (selectedClipIds.has(id)) {
-      get().removeFromSelection(id);
-    } else {
-      get().addToSelection(id);
-    }
-  },
+    removeFromSelection: (id) =>
+      set((state) => {
+        const next = new Set(state.selectedClipIds);
+        next.delete(id);
+        return { selectedClipIds: next };
+      }),
 
-  clearSelection: () =>
-    set({ selectedClipIds: new Set(), selectedEdit: null }),
-
-  setSelection: (ids) =>
-    set({ selectedClipIds: new Set(ids), selectedEdit: null }),
-
-  rubberBand: null,
-
-  setRubberBand: (rect) => set({ rubberBand: rect }),
-
-  snapGuideMs: null,
-
-  setSnapGuide: (ms) => set({ snapGuideMs: ms }),
-
-  gestureReadout: null,
-
-  setGestureReadout: (readout) => set({ gestureReadout: readout }),
-
-  wordSelection: null,
-
-  beginWordSelection: (ref) => set({ wordSelection: { anchor: ref, focus: ref } }),
-
-  extendWordSelection: (ref) =>
-    set((state) => ({
-      wordSelection: {
-        anchor: state.wordSelection?.anchor ?? ref,
-        focus: ref
+    toggleSelection: (id) => {
+      const { selectedClipIds } = get();
+      if (selectedClipIds.has(id)) {
+        get().removeFromSelection(id);
+      } else {
+        get().addToSelection(id);
       }
-    })),
+    },
 
-  clearWordSelection: () => set({ wordSelection: null }),
+    clearSelection: () =>
+      set({ selectedClipIds: new Set(), selectedEdit: null }),
 
-  setHoveredClipId: (id) => set({ hoveredClipId: id }),
+    setSelection: (ids) =>
+      set({ selectedClipIds: new Set(ids), selectedEdit: null }),
 
-  setZoom: (msPerPx) =>
-    set({ msPerPx: Math.min(MAX_MS_PER_PX, Math.max(MIN_MS_PER_PX, msPerPx)) }),
+    rubberBand: null,
 
-  setScrollLeftPx: (px) => set({ scrollLeftPx: Math.max(0, px) }),
+    setRubberBand: (rect) => set({ rubberBand: rect }),
 
-  revealAt: (timeMs) => set({ revealRequest: { timeMs: Math.max(0, timeMs) } }),
+    snapGuideMs: null,
 
-  setFullscreen: (full) => set({ fullscreen: full }),
+    setSnapGuide: (ms) => set({ snapGuideMs: ms }),
 
-  toggleFullscreen: () => set((state) => ({ fullscreen: !state.fullscreen })),
+    gestureReadout: null,
 
-  setMatteViewEnabled: (on) => set({ matteViewEnabled: on }),
+    setGestureReadout: (readout) => set({ gestureReadout: readout }),
 
-  toggleMatteView: () =>
-    set((state) => ({ matteViewEnabled: !state.matteViewEnabled })),
+    wordSelection: null,
 
-  setActiveTool: (tool) => set({ activeTool: tool }),
+    beginWordSelection: (ref) =>
+      set({ wordSelection: { anchor: ref, focus: ref } }),
 
-  setRippleMode: (on) => set({ rippleMode: on }),
+    extendWordSelection: (ref) =>
+      set((state) => ({
+        wordSelection: {
+          anchor: state.wordSelection?.anchor ?? ref,
+          focus: ref
+        }
+      })),
 
-  toggleRippleMode: () => set((state) => ({ rippleMode: !state.rippleMode })),
+    clearWordSelection: () => set({ wordSelection: null }),
 
-  setDropMode: (mode) => set({ dropMode: mode }),
+    setHoveredClipId: (id) => set({ hoveredClipId: id }),
 
-  setSelectedEdit: (edit) => set({ selectedEdit: edit }),
+    setZoom: (msPerPx) =>
+      set({
+        msPerPx: Math.min(MAX_MS_PER_PX, Math.max(MIN_MS_PER_PX, msPerPx))
+      }),
 
-  toggleSnap: () => set((state) => ({ snapEnabled: !state.snapEnabled })),
+    setScrollLeftPx: (px) => set({ scrollLeftPx: Math.max(0, px) }),
 
-  setRulerMode: (mode) => set({ rulerMode: mode }),
+    revealAt: (timeMs) =>
+      set({ revealRequest: { timeMs: Math.max(0, timeMs) } }),
 
-  toggleRulerMode: () =>
-    set((state) => ({
-      rulerMode: state.rulerMode === "bars" ? "timecode" : "bars"
-    })),
+    setFullscreen: (full) => set({ fullscreen: full }),
 
-  setGridDivision: (division) => set({ gridDivision: division }),
+    toggleFullscreen: () => set((state) => ({ fullscreen: !state.fullscreen })),
 
-  setLanesViewportWidthPx: (px) =>
-    set((state) =>
-      state.lanesViewportWidthPx === px
-        ? state
-        : { lanesViewportWidthPx: Math.max(0, px) }
-    ),
+    setMatteViewEnabled: (on) => set({ matteViewEnabled: on }),
 
-  setKeyframeProperty: (property) => set({ keyframeProperty: property }),
+    toggleMatteView: () =>
+      set((state) => ({ matteViewEnabled: !state.matteViewEnabled })),
 
-  setSourceRange: (range) => set({ sourceRange: range }),
+    setActiveTool: (tool) => set({ activeTool: tool }),
 
-  setExpandedFxTrackId: (trackId) => set({ expandedFxTrackId: trackId }),
+    setRippleMode: (on) => set({ rippleMode: on }),
 
-  toggleExpandedFx: (trackId) =>
-    set((state) => ({
-      expandedFxTrackId:
-        state.expandedFxTrackId === trackId ? null : trackId
-    })),
+    toggleRippleMode: () => set((state) => ({ rippleMode: !state.rippleMode })),
 
-  openPianoRoll: (clipId) => set({ pianoRollClipId: clipId }),
+    setDropMode: (mode) => set({ dropMode: mode }),
 
-  closePianoRoll: () => set({ pianoRollClipId: null }),
+    setSelectedEdit: (edit) => set({ selectedEdit: edit }),
 
-  setPianoRollHeightPx: (px) =>
-    set({
-      pianoRollHeightPx: Math.min(
-        MAX_PIANO_ROLL_HEIGHT_PX,
-        Math.max(MIN_PIANO_ROLL_HEIGHT_PX, px)
-      )
-    }),
+    toggleSnap: () => set((state) => ({ snapEnabled: !state.snapEnabled })),
 
-  toggleExpandedInstrument: (trackId) =>
-    set((state) => ({
-      expandedInstrumentTrackId:
-        state.expandedInstrumentTrackId === trackId ? null : trackId
-    })),
+    setRulerMode: (mode) => set({ rulerMode: mode }),
 
-  beginTrackDrag: (trackId) =>
-    set({ draggingTrackId: trackId, trackDropTarget: null }),
+    toggleRulerMode: () =>
+      set((state) => ({
+        rulerMode: state.rulerMode === "bars" ? "timecode" : "bars"
+      })),
 
-  setTrackDropTarget: (target) => set({ trackDropTarget: target }),
+    setGridDivision: (division) => set({ gridDivision: division }),
 
-  endTrackDrag: () => set({ draggingTrackId: null, trackDropTarget: null })
+    setLanesViewportWidthPx: (px) =>
+      set((state) =>
+        state.lanesViewportWidthPx === px
+          ? state
+          : { lanesViewportWidthPx: Math.max(0, px) }
+      ),
+
+    setTrackHeaderWidthPx: (px) =>
+      set({
+        trackHeaderWidthPx: Math.min(
+          MAX_TRACK_HEADER_WIDTH_PX,
+          Math.max(MIN_TRACK_HEADER_WIDTH_PX, px)
+        )
+      }),
+
+    setKeyframeProperty: (property) => set({ keyframeProperty: property }),
+
+    setSourceRange: (range) => set({ sourceRange: range }),
+
+    setExpandedFxTrackId: (trackId) => set({ expandedFxTrackId: trackId }),
+
+    toggleExpandedFx: (trackId) =>
+      set((state) => ({
+        expandedFxTrackId: state.expandedFxTrackId === trackId ? null : trackId
+      })),
+
+    openPianoRoll: (clipId) => set({ pianoRollClipId: clipId }),
+
+    closePianoRoll: () => set({ pianoRollClipId: null }),
+
+    setPianoRollHeightPx: (px) =>
+      set({
+        pianoRollHeightPx: Math.min(
+          MAX_PIANO_ROLL_HEIGHT_PX,
+          Math.max(MIN_PIANO_ROLL_HEIGHT_PX, px)
+        )
+      }),
+
+    toggleExpandedInstrument: (trackId) =>
+      set({ expandedInstrumentTrackId: trackId, panelTab: "instrument" }),
+
+    beginTrackDrag: (trackId) =>
+      set({ draggingTrackId: trackId, trackDropTarget: null }),
+
+    setTrackDropTarget: (target) => set({ trackDropTarget: target }),
+
+    endTrackDrag: () => set({ draggingTrackId: null, trackDropTarget: null })
   }));
 
 // Context-bound hooks are defined against the active instance in the instance
@@ -473,4 +510,3 @@ export {
   useTimelineUIStoreApi,
   useIsClipSelected
 } from "./TimelineInstance";
-

--- a/web/src/stores/timeline/__tests__/TimelineStore.midi.test.ts
+++ b/web/src/stores/timeline/__tests__/TimelineStore.midi.test.ts
@@ -8,6 +8,7 @@
  * a silent strip only shows up as "my part came back at the wrong speed after
  * a save".
  */
+import { DEFAULT_TIMELINE_INSTRUMENT } from "../instrumentPresets";
 import { describe, it, expect } from "@jest/globals";
 import { timeline } from "@nodetool-ai/protocol/api-schemas";
 import {
@@ -56,7 +57,7 @@ describe("TimelineStore — midi tracks", () => {
   it("gives a new midi track the default instrument", () => {
     const { store } = seed();
     expect(store.getState().tracks[0].instrument).toEqual(
-      DEFAULT_MIDI_INSTRUMENT
+      DEFAULT_TIMELINE_INSTRUMENT
     );
   });
 
@@ -202,7 +203,7 @@ describe("TimelineStore — midi tracks", () => {
 
     expect(waveformOf(store.getState().tracks[0].instrument)).toBe("square");
     expect(store.getState().tracks[1].id).toBe(other);
-    expect(waveformOf(store.getState().tracks[1].instrument)).toBe("saw");
+    expect(store.getState().tracks[1].instrument).toEqual(DEFAULT_TIMELINE_INSTRUMENT);
   });
 
   it("round-trips tempo, instrument and notes through the save payload", () => {

--- a/web/src/stores/timeline/instrumentPresets.ts
+++ b/web/src/stores/timeline/instrumentPresets.ts
@@ -1,0 +1,7 @@
+import { MIDI_INSTRUMENT_PRESETS, findInstrumentPreset } from "@nodetool-ai/timeline";
+
+/** Instruments offered for new and edited tracks. Legacy voices still load. */
+export const TIMELINE_INSTRUMENT_PRESETS = MIDI_INSTRUMENT_PRESETS.filter(
+  preset => preset.instrument.type !== "subtractive"
+);
+export const DEFAULT_TIMELINE_INSTRUMENT = findInstrumentPreset("wt1-prime-lead")!.instrument;


### PR DESCRIPTION
## What changed

Makes MIDI editing and instrument control more usable in the timeline. Notes support selection-wide pitch, position, length, and velocity edits, copy/paste, duplication, quantizing, and keyboard shortcuts. Timeline and source-viewer shortcuts respect the active editor, and clip dragging handles vertical movement and final pointer updates consistently.

WT-1, BL-1, and DR-1 controls move into a full-height Instruments tab with an independent keyboard toggle per track. New MIDI tracks default to WT-1, preset menus offer the three supported devices, and older instruments retain playback compatibility. Compact module layouts, consistent dropdown typography, and fewer borders reduce visual clutter while retaining focus and selection indicators.

## Verification

- [x] `npm run test:affected -- web/src/components/timeline/TopBar.tsx web/src/components/timeline/TimelineEditor.tsx web/src/components/timeline/Tracks/TrackHeader.tsx web/src/components/timeline/Tracks/TrackInstrumentPanel.tsx` — 71 tests passed. Earlier focused piano-roll, clipboard, instrument, and store checks also passed.
- [x] `NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck` — web, Electron, and mobile passed.
- [x] `npm run lint` — passed.
- [x] `VITEST_MAX_WORKERS=2 npm run dev:nodetool -- harness gate --base origin/main` — 13/13 selfchecks passed.
- [x] Browser checks of all three instrument layouts, preset choices, independent keyboards, compact selectors, and visible input focus rings.
- [x] `git diff --check` — passed.

Checks ran in the development checkout before packaging this focused commit. The PR also includes optional numeric UI parameter metadata on the WT-1, BL-1, and DR-1 TypeScript instrument interfaces; it does not add render behavior or schema serialization for that metadata. The PR excludes unrelated game changes and a local setup commit. The selected files have no changes from that local commit, and the patch applies cleanly to origin/main.

The preset-filter regression test was temporarily inverted and observed failing because `Saw Lead` reappeared, then restored and rerun successfully.
