### PR TITLE
Improve guided setup and storyboard entity selection

### DIFF
--- a/packages/agents/src/capabilities/storyboards.ts
+++ b/packages/agents/src/capabilities/storyboards.ts
@@ -84,6 +84,7 @@ const SETUP_STAGES: readonly StoryboardSetupStage[] = [
   "idea",
   "genre",
   "review",
+  "entities",
   "look",
   "done"
 ];

--- a/packages/agents/tests/capabilities-game-setup.test.ts
+++ b/packages/agents/tests/capabilities-game-setup.test.ts
@@ -148,7 +148,7 @@ const METADATA: Record<string, unknown> = {
     [
       ["template", "str"],
       ["name", "str"],
-      ["fills", "list[slot_fill]"],
+      ["fills", "list[union[image,audio]]"],
       ["directory", "str"],
       ["verify", "bool"]
     ],

--- a/packages/game-nodes/src/nodes/game.ts
+++ b/packages/game-nodes/src/nodes/game.ts
@@ -345,7 +345,7 @@ export class ExportGodotProjectNode extends BaseNode {
   declare name: string;
 
   @prop({
-    type: "list[slot_fill]",
+    type: "list[union[image,audio]]",
     default: [],
     title: "Fills",
     description:

--- a/packages/protocol/src/api-schemas/storyboards.ts
+++ b/packages/protocol/src/api-schemas/storyboards.ts
@@ -274,6 +274,7 @@ export const storyboardSetupStage = z.enum([
   "idea",
   "genre",
   "review",
+  "entities",
   "look",
   "done"
 ]);

--- a/packages/protocol/tests/api-schemas-storyboards.test.ts
+++ b/packages/protocol/tests/api-schemas-storyboards.test.ts
@@ -253,7 +253,14 @@ describe("setup stage and genre", () => {
   });
 
   it("round-trips every stage", () => {
-    for (const stage of ["idea", "genre", "review", "look", "done"] as const) {
+    for (const stage of [
+      "idea",
+      "genre",
+      "review",
+      "entities",
+      "look",
+      "done"
+    ] as const) {
       const doc = storyboardDocument.parse({
         ...legacyDocument,
         setupStage: stage,

--- a/packages/protocol/tests/game-graph.test.ts
+++ b/packages/protocol/tests/game-graph.test.ts
@@ -158,7 +158,7 @@ const SHAPES: Record<string, PlanNodeShape> = {
     inputs: [
       { name: "template", type: "str" },
       { name: "name", type: "str" },
-      { name: "fills", type: "list[slot_fill]" },
+      { name: "fills", type: "list[union[image,audio]]" },
       { name: "directory", type: "str" },
       { name: "verify", type: "bool" }
     ],

--- a/web/src/components/panels/FrontendToolRuntimeSync.tsx
+++ b/web/src/components/panels/FrontendToolRuntimeSync.tsx
@@ -10,8 +10,10 @@ import { getWorkflowRunnerStore } from "../../stores/WorkflowRunner";
 /**
  * Keeps the frontend tool runtime state (the context `ui_*` tools execute
  * against) in sync with the workflow manager. Mount it anywhere an agent with
- * workflow tools is active — the editor's right panel and the app builder both
- * render it so the agent can read and edit the open workflow.
+ * workflow tools is active — the workspace shell mounts it always so the
+ * guided game/workflow builds work from non-editor tabs, and the editor's
+ * right panel and the app builder both render it so the agent can read and
+ * edit the open workflow.
  */
 const FrontendToolRuntimeSync = memo(function FrontendToolRuntimeSync() {
   const navigate = useNavigate();

--- a/web/src/components/setup/AlternativesColumn.tsx
+++ b/web/src/components/setup/AlternativesColumn.tsx
@@ -58,7 +58,7 @@ const AlternativesColumnInternal: React.FC<AlternativesColumnProps> = ({
       component="ul"
       aria-label={label}
       gap={GAP.comfortable}
-      sx={{ listStyle: "none", margin: 0, padding: 0 }}
+      sx={{ listStyle: "none", margin: 0, padding: 0, "& li": { listStyle: "none" } }}
     >
       {alternatives.map((alternative) => (
         <Box component="li" key={alternative.id}>

--- a/web/src/components/setup/SetupFlow.tsx
+++ b/web/src/components/setup/SetupFlow.tsx
@@ -20,6 +20,7 @@ import React, {
 } from "react";
 
 import {
+  AlertBanner,
   Box,
   Caption,
   Dialog,
@@ -35,6 +36,7 @@ import {
   Text,
   ThinkingIndicator
 } from "../ui_primitives";
+import ReportBugButton from "../support/ReportBugButton";
 import type { SetupFlowConfig, SetupStep } from "./types";
 
 const GenerationSummary = lazy(() => import("./GenerationSummary"));
@@ -202,6 +204,31 @@ export function SetupFlow<Stage extends string>({
     }
   }, [currentIndex, isCurrent, onStageChange, step, steps]);
 
+  const handleSkip = useCallback(async () => {
+    if (!step?.onSkip) {
+      return;
+    }
+    const origin = { stage: step.stage, revision: revisionRef.current };
+    setError(null);
+    setBusy(true);
+    try {
+      await step.onSkip();
+      if (!isCurrent(origin)) {
+        return;
+      }
+      const next = steps[currentIndex + 1];
+      if (next) {
+        onStageChange(next.stage);
+      }
+    } catch (cause) {
+      if (isCurrent(origin)) {
+        setError(cause instanceof Error ? cause.message : String(cause));
+      }
+    } finally {
+      setBusy(false);
+    }
+  }, [currentIndex, isCurrent, onStageChange, step, steps]);
+
   // A stage outside the flow (a finished document) belongs to the editor, not
   // to this shell.
   if (!step) {
@@ -313,14 +340,35 @@ export function SetupFlow<Stage extends string>({
         fullHeight
         sx={{ flex: 1, minHeight: 0, paddingBottom: SPACING.xxl }}
       >
-        {step.render()}
+        {error ? (
+          <FlexColumn gap={GAP.spacious} fullWidth>
+            <Text size="big" component="h1">
+              We couldn&apos;t complete this step
+            </Text>
+            <AlertBanner severity="error" title="What failed">
+              {error}
+            </AlertBanner>
+            <Text size="normal" color="secondary">
+              Your setup is still here. Try again below, go back to change it,
+              or report the failure with its diagnostics.
+            </Text>
+            <FlexRow gap={GAP.normal} align="center" wrap>
+              <ReportBugButton
+                label="Report this failure"
+                variant="outlined"
+                size="medium"
+                context={{
+                  source: "manual",
+                  summary: `${labels.title} setup failed at ${step.label}`,
+                  errorText: error
+                }}
+              />
+            </FlexRow>
+          </FlexColumn>
+        ) : (
+          step.render()
+        )}
       </ScrollArea>
-
-      {error ? (
-        <Text size="small" color="error" role="alert">
-          {error}
-        </Text>
-      ) : null}
 
       {step.generation ? (
         <Suspense
@@ -367,6 +415,17 @@ export function SetupFlow<Stage extends string>({
               Change flow
             </EditorButton>
           ) : null}
+          {step.onSkip ? (
+            <EditorButton
+              variant="text"
+              size="large"
+              onClick={() => void handleSkip()}
+              disabled={pending}
+              sx={{ fontSize: FONT_SIZE_SANS.body }}
+            >
+              {step.skipLabel ?? "Skip"}
+            </EditorButton>
+          ) : null}
         </FlexRow>
         <FlexRow gap={GAP.normal} align="center">
           {/* Why the button is off comes first, and replaces the detail: a
@@ -392,7 +451,7 @@ export function SetupFlow<Stage extends string>({
               paddingX: SPACING.xxl
             }}
           >
-            {step.primaryLabel}
+            {error ? "Try again" : step.primaryLabel}
           </EditorButton>
         </FlexRow>
       </FlexRow>

--- a/web/src/components/setup/__tests__/SetupFlow.test.tsx
+++ b/web/src/components/setup/__tests__/SetupFlow.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 
 import mockTheme from "../../../__mocks__/themeMock";
+import { useBugReportStore } from "../../../stores/BugReportStore";
 import { SetupFlow } from "../SetupFlow";
 import type { SetupFlowConfig, SetupStep } from "../types";
 
@@ -132,13 +133,16 @@ describe("SetupFlow", () => {
     expect(onStageChange).toHaveBeenCalledWith("review");
   });
 
-  it("keeps the stage and shows the message when the step's action fails", async () => {
+  it("keeps the stage and shows a reportable failure screen when the action fails", async () => {
     const user = userEvent.setup();
+    const failingAction = jest
+      .fn()
+      .mockRejectedValue(new Error("Director unavailable"));
     const failing = steps.map((entry) =>
       entry.stage === "genre"
         ? {
             ...entry,
-            onAdvance: () => Promise.reject(new Error("Director unavailable"))
+            onAdvance: failingAction
           }
         : entry
     );
@@ -153,6 +157,22 @@ describe("SetupFlow", () => {
         "Director unavailable"
       )
     );
+    expect(
+      screen.getByRole("heading", {
+        name: "We couldn't complete this step"
+      })
+    ).toBeInTheDocument();
+    expect(screen.queryByText("genre body")).toBeNull();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeEnabled();
+
+    await user.click(
+      screen.getByRole("button", { name: "Report this failure" })
+    );
+    expect(useBugReportStore.getState().context).toMatchObject({
+      source: "manual",
+      summary: "Storyboard setup failed at Story",
+      errorText: "Director unavailable"
+    });
     expect(onStageChange).not.toHaveBeenCalled();
   });
 

--- a/web/src/components/setup/game/LookStep.tsx
+++ b/web/src/components/setup/game/LookStep.tsx
@@ -38,6 +38,9 @@ import {
 } from "../../ui_primitives";
 import { openProviderOnboarding } from "../../../stores/ProviderOnboardingStore";
 import type { OnboardingCapability } from "../../../stores/ProviderOnboardingStore";
+import ImageModelSelect from "../../properties/ImageModelSelect";
+import type { ImageModelValue } from "../../../stores/ApiTypes";
+import type { ImageModelTask } from "../../../hooks/useModelsByProvider";
 import { OptionCardGrid } from "../OptionCardGrid";
 import type { OptionCardItem } from "../OptionCardGrid";
 import { PresetTileGrid, type PresetTile } from "../PresetTileGrid";
@@ -209,6 +212,104 @@ export const gameCostLine = (estimate: GameCostEstimate): string =>
   estimate.total !== null && estimate.total > 0
     ? `About ${formatUsd(estimate.total)}`
     : "Cost unknown until the first asset returns";
+
+/** What the image picker lists: the models that draw text to image. */
+const IMAGE_MODEL_TASKS: ImageModelTask[] = ["text_to_image"];
+
+/**
+ * The image model, through the usual picker rather than tiles. Every sprite,
+ * tile and background goes through one model, and the catalog behind the
+ * picker (recents, search, Studio curation) is what a creator already knows
+ * from every other surface. The tile id on the document stays
+ * `${provider}:${id}`, so the stored answer and the build are unchanged.
+ */
+const ImageModelField: React.FC<{ row: GameModelRow }> = ({ row }) => {
+  const handleChange = useCallback(
+    (model: ImageModelValue) => row.onSelect(`${model.provider}:${model.id}`),
+    [row]
+  );
+  if (row.status === "loading") {
+    return (
+      <FlexColumn gap={GAP.normal}>
+        <Text size="normal" component="h3">
+          {row.label}
+        </Text>
+        <FlexRow gap={GAP.normal} align="center">
+          <LoadingSpinner size="small" />
+          <Caption color="secondary" component="span">
+            {`Reading what your providers offer for ${row.label.toLowerCase()}…`}
+          </Caption>
+        </FlexRow>
+      </FlexColumn>
+    );
+  }
+  if (row.status === "error") {
+    return (
+      <FlexColumn gap={GAP.normal}>
+        <Text size="normal" component="h3">
+          {row.label}
+        </Text>
+        <AlertBanner
+          severity="error"
+          action={
+            <EditorButton variant="text" onClick={row.onRetry}>
+              Try again
+            </EditorButton>
+          }
+        >
+          <Caption component="span">
+            {row.errorMessage
+              ? `${row.emptyMessage} ${row.errorMessage}`
+              : row.emptyMessage}
+          </Caption>
+        </AlertBanner>
+      </FlexColumn>
+    );
+  }
+  // The image model is required — there is no placeholder art to fall back
+  // to — so an empty catalog is a warning with the way out, not a picker
+  // with nothing in it.
+  if (row.status === "empty") {
+    return (
+      <FlexColumn gap={GAP.normal}>
+        <Text size="normal" component="h3">
+          {row.label}
+        </Text>
+        <AlertBanner
+          severity="warning"
+          action={
+            <EditorButton
+              variant="text"
+              onClick={() =>
+                openProviderOnboarding({
+                  capability: row.capability,
+                  reason: row.emptyMessage
+                })
+              }
+            >
+              Connect a provider
+            </EditorButton>
+          }
+        >
+          <Caption component="span">{row.emptyMessage}</Caption>
+        </AlertBanner>
+      </FlexColumn>
+    );
+  }
+  return (
+    <FormField
+      label="Image model"
+      helperText="Draws every sprite, tile and background. The estimate beside the button follows it."
+      sx={{ maxWidth: SETUP_FIELD_WIDTH }}
+    >
+      <ImageModelSelect
+        value={splitTileId(row.selectedId)?.id ?? ""}
+        task={IMAGE_MODEL_TASKS}
+        onChange={handleChange}
+      />
+    </FormField>
+  );
+};
 
 /** One row of tiles, with the four states its source can be in. */
 const ModelTileRow: React.FC<{ row: GameModelRow }> = ({ row }) => {
@@ -410,7 +511,7 @@ const LookStepInternal: React.FC<GameLookStepProps> = ({
         />
       </FlexColumn>
 
-      <ModelTileRow row={image} />
+      <ImageModelField row={image} />
       <ModelTileRow row={sfx} />
       <ModelTileRow row={music} />
 

--- a/web/src/components/setup/game/__tests__/steps.test.tsx
+++ b/web/src/components/setup/game/__tests__/steps.test.tsx
@@ -26,7 +26,42 @@ jest.mock("../../../model_menu/LanguageModelMenuDialog", () => ({
 }));
 jest.mock("../../../../hooks/useModelsByProvider", () => ({
   __esModule: true,
-  useLanguageModelsByProvider: () => ({ models: [], isLoading: false })
+  useLanguageModelsByProvider: () => ({ models: [], isLoading: false }),
+  useImageModelsByProvider: () => ({ models: [], isLoading: false }),
+  useMusicModelsByProvider: () => ({ models: [], isLoading: false })
+}));
+// The image row uses the usual picker; what the picker itself does is pinned
+// by its own suite. Here it only has to report a choice back.
+jest.mock("../../../properties/ImageModelSelect", () => ({
+  __esModule: true,
+  default: ({
+    value,
+    onChange
+  }: {
+    value: string;
+    onChange: (v: {
+      type: "image_model";
+      id: string;
+      provider: string;
+      name: string;
+      path: string;
+    }) => void;
+  }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onChange({
+          type: "image_model",
+          id: "picked-image",
+          provider: "fal_ai",
+          name: "Picked",
+          path: ""
+        })
+      }
+    >
+      {`image-model:${value}`}
+    </button>
+  )
 }));
 // The `Add your own style` path is the storyboard dialog plus one model call;
 // this suite only has to know the tile is offered.
@@ -343,12 +378,15 @@ describe("GameLookStep", () => {
     );
   });
 
-  it("has no placeholder tile on the image row, which is required", () => {
-    renderStep();
-    const images = screen.getByRole("radiogroup", { name: "Image model" });
+  it("uses the usual image model picker on the image row, which is required", async () => {
+    const user = userEvent.setup();
+    const onSelect = jest.fn();
+    renderStep({ image: row("Image model", { onSelect }) });
     expect(
-      within(images).queryByRole("radio", { name: /Keep the placeholder/ })
+      screen.queryByRole("radiogroup", { name: "Image model" })
     ).toBeNull();
+    await user.click(screen.getByRole("button", { name: "image-model:" }));
+    expect(onSelect).toHaveBeenCalledWith("fal_ai:picked-image");
   });
 
   it("prompts for a provider when nothing offers an image model", () => {

--- a/web/src/components/setup/game/__tests__/useGameSetupFlow.test.tsx
+++ b/web/src/components/setup/game/__tests__/useGameSetupFlow.test.tsx
@@ -24,7 +24,16 @@ jest.mock("../../../model_menu/LanguageModelMenuDialog", () => ({
 }));
 jest.mock("../../../../hooks/useModelsByProvider", () => ({
   __esModule: true,
-  useLanguageModelsByProvider: () => ({ models: [], isLoading: false })
+  useLanguageModelsByProvider: () => ({ models: [], isLoading: false }),
+  useImageModelsByProvider: () => ({ models: [], isLoading: false }),
+  useMusicModelsByProvider: () => ({ models: [], isLoading: false })
+}));
+// The image row uses the usual picker; its own suite pins what it does.
+jest.mock("../../../properties/ImageModelSelect", () => ({
+  __esModule: true,
+  default: ({ value }: { value: string }) => (
+    <button type="button">{`image-model:${value}`}</button>
+  )
 }));
 jest.mock("../useGameCustomStyle", () => ({
   __esModule: true,

--- a/web/src/components/setup/script/IdeaStep.tsx
+++ b/web/src/components/setup/script/IdeaStep.tsx
@@ -115,7 +115,11 @@ const SourcePanel: React.FC<SourcePanelProps> = ({
         {sourceSummary(source)}
       </Caption>
     </FlexColumn>
-    <FlexColumn gap={GAP.micro} component="ul" sx={{ margin: 0, paddingLeft: 0, listStyle: "none" }}>
+    <FlexColumn
+      gap={GAP.micro}
+      component="ul"
+      sx={{ margin: 0, paddingLeft: 0, listStyle: "none", "& li": { listStyle: "none" } }}
+    >
       {source.lines.slice(0, PREVIEW_LINES).map((line, index) => (
         <Caption key={`${index}-${line.text}`} component="li">
           {line.speakerName === "" ? line.text : `${line.speakerName}: ${line.text}`}
@@ -170,7 +174,7 @@ const CarriedContext: React.FC<{
       <FlexColumn
         gap={GAP.micro}
         component="ul"
-        sx={{ margin: 0, paddingLeft: 0, listStyle: "none" }}
+        sx={{ margin: 0, paddingLeft: 0, listStyle: "none", "& li": { listStyle: "none" } }}
       >
         {attachments.map((attachment) => (
           <Caption key={attachment.uri} component="li">

--- a/web/src/components/setup/storyboard/AddStyleDialog.tsx
+++ b/web/src/components/setup/storyboard/AddStyleDialog.tsx
@@ -139,7 +139,16 @@ export const AddStyleDialog: React.FC<AddStyleDialogProps> = ({
           onChange={handlePicked}
         />
         {files.length > 0 ? (
-          <FlexColumn gap={GAP.tight} component="ul">
+          <FlexColumn
+            gap={GAP.tight}
+            component="ul"
+            sx={{
+              listStyle: "none",
+              margin: 0,
+              padding: 0,
+              "& li": { listStyle: "none" }
+            }}
+          >
             {files.map((file, index) => (
               <FlexRow
                 key={`${file.name}:${index}`}

--- a/web/src/components/setup/storyboard/EntitiesStep.tsx
+++ b/web/src/components/setup/storyboard/EntitiesStep.tsx
@@ -1,0 +1,400 @@
+/**
+ * The storyboard setup's consistency step. Entities are reusable reference
+ * images plus canonical descriptions. The selection is stored on the board,
+ * while every shot gets an explicit selection the creator can refine here.
+ */
+
+import { useCallback, useState } from "react";
+import { useTheme } from "@mui/material/styles";
+import AddPhotoAlternateOutlinedIcon from "@mui/icons-material/AddPhotoAlternateOutlined";
+import type { Entity } from "@nodetool-ai/protocol";
+
+import { useEntities } from "../../../serverState/useEntities";
+import { useStoryboardStore } from "../../../stores/storyboard/StoryboardStore";
+import { entitiesForShot } from "../../../stores/storyboard/shotEntities";
+import EntityAssetPickerDialog from "../../entities/EntityAssetPickerDialog";
+import EntityEditorDialog from "../../entities/EntityEditorDialog";
+import {
+  BORDER_RADIUS,
+  Caption,
+  Checkbox,
+  EditorButton,
+  EmptyState,
+  FlexColumn,
+  FlexRow,
+  LoadingSpinner,
+  Label,
+  ResponsiveImage,
+  ScrollArea,
+  SearchInput,
+  SPACING,
+  Text
+} from "../../ui_primitives";
+
+interface EntitiesStepProps {
+  boardId: string;
+}
+
+const EMPTY_ENTITY_IDS: string[] = [];
+const ENTITY_GROUPS = [
+  { kind: "character", label: "Characters" },
+  { kind: "location", label: "Locations" },
+  { kind: "prop", label: "Props" },
+  { kind: "style", label: "Styles" }
+] as const;
+
+const setIdSelected = (
+  ids: readonly string[],
+  entityId: string,
+  selected: boolean
+): string[] =>
+  selected
+    ? ids.includes(entityId)
+      ? [...ids]
+      : [...ids, entityId]
+    : ids.filter((id) => id !== entityId);
+
+export const EntitiesStep = ({ boardId }: EntitiesStepProps) => {
+  const theme = useTheme();
+  const { data: entities, isLoading } = useEntities();
+  const board = useStoryboardStore((state) => state.boards[boardId]);
+  const setEntityIds = useStoryboardStore((state) => state.setEntityIds);
+  const updateShot = useStoryboardStore((state) => state.updateShot);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [newAssetId, setNewAssetId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [onlySelected, setOnlySelected] = useState(false);
+
+  const selectedIds = board?.entityIds ?? EMPTY_ENTITY_IDS;
+  const selectedSet = new Set(selectedIds);
+
+  const setBoardEntity = useCallback(
+    (entity: Entity, selected: boolean) => {
+      const nextBoardIds = setIdSelected(selectedIds, entity.id, selected);
+      setEntityIds(boardId, nextBoardIds);
+      for (const shot of board?.shots ?? []) {
+        const current = shot.entity_ids ?? selectedIds;
+        const belongsOnShot =
+          entitiesForShot({ ...shot, entity_ids: undefined }, [entity]).length >
+          0;
+        const next = setIdSelected(
+          current,
+          entity.id,
+          selected && belongsOnShot
+        );
+        updateShot(boardId, shot.id, { entity_ids: next });
+      }
+    },
+    [board?.shots, boardId, selectedIds, setEntityIds, updateShot]
+  );
+
+  const handleCreated = useCallback(
+    (entity: Entity | null) => {
+      if (entity) {
+        setBoardEntity(entity, true);
+      }
+    },
+    [setBoardEntity]
+  );
+
+  const toggleShot = (
+    shotId: string,
+    entityId: string,
+    checked: boolean
+  ): void => {
+    const shot = board?.shots.find((candidate) => candidate.id === shotId);
+    if (!shot) {
+      return;
+    }
+    const current = shot.entity_ids ?? selectedIds;
+    updateShot(boardId, shotId, {
+      entity_ids: setIdSelected(current, entityId, checked)
+    });
+  };
+
+  const selectedEntities = (entities ?? []).filter((entity) =>
+    selectedSet.has(entity.id)
+  );
+  const query = search.trim().toLocaleLowerCase();
+  const visibleEntities = (entities ?? []).filter(
+    (entity) =>
+      (!onlySelected || selectedSet.has(entity.id)) &&
+      `${entity.name} ${entity.kind} ${entity.descriptor}`
+        .toLocaleLowerCase()
+        .includes(query)
+  );
+
+  return (
+    <FlexColumn
+      gap={SPACING.xxl}
+      sx={{ maxWidth: 1040, width: "100%", minWidth: 0 }}
+    >
+      <FlexColumn gap={SPACING.xs}>
+        <Text size="big" component="h1">
+          Keep people and places consistent
+        </Text>
+        <Text color="secondary" sx={{ maxWidth: "65ch" }}>
+          Choose reusable references for your shots. Each entity carries an
+          image and description to keep its appearance consistent.
+        </Text>
+      </FlexColumn>
+
+      <FlexRow gap={SPACING.lg} wrap align="center" justify="space-between">
+        <FlexColumn gap={SPACING.xs}>
+          <Label component="h2">Your entity library</Label>
+          <Caption role="status">
+            {selectedEntities.length} selected for this storyboard
+          </Caption>
+        </FlexColumn>
+        <EditorButton
+          variant="outlined"
+          startIcon={<AddPhotoAlternateOutlinedIcon />}
+          onClick={() => setPickerOpen(true)}
+        >
+          Create entity from an image
+        </EditorButton>
+      </FlexRow>
+
+      {isLoading ? (
+        <LoadingSpinner text="Loading entities" />
+      ) : !entities || entities.length === 0 ? (
+        <EmptyState
+          variant="no-data"
+          title="No entities yet"
+          description="Create one from a generated or uploaded image, or skip this step."
+          size="small"
+        />
+      ) : (
+        <FlexColumn gap={SPACING.xl}>
+          <FlexRow gap={SPACING.lg} wrap align="center">
+            <FlexColumn sx={{ flex: "1 1 240px" }}>
+              <SearchInput
+                value={search}
+                onChange={setSearch}
+                placeholder="Search entities"
+                fullWidth
+              />
+            </FlexColumn>
+            <EditorButton
+              variant={onlySelected ? "outlined" : "text"}
+              aria-pressed={onlySelected}
+              onClick={() => setOnlySelected(!onlySelected)}
+            >
+              Selected ({selectedEntities.length})
+            </EditorButton>
+          </FlexRow>
+          <ScrollArea maxHeight="min(48vh, 480px)">
+            <FlexColumn gap={SPACING.xl}>
+              {visibleEntities.length === 0 ? (
+                <EmptyState
+                  variant="no-data"
+                  title={
+                    onlySelected && !query
+                      ? "No entities selected"
+                      : "No matching entities"
+                  }
+                  description={
+                    onlySelected && !query
+                      ? "Browse your library to choose references for this storyboard."
+                      : "Try another name or change the selected filter."
+                  }
+                  size="small"
+                />
+              ) : (
+                ENTITY_GROUPS.map(({ kind, label }) => {
+                  const group = visibleEntities.filter(
+                    (entity) => entity.kind === kind
+                  );
+                  if (group.length === 0) return null;
+                  return (
+                    <FlexColumn
+                      key={kind}
+                      gap={SPACING.md}
+                      component="section"
+                      aria-label={label}
+                    >
+                      <FlexRow gap={SPACING.md} align="baseline">
+                        <Label component="h3">{label}</Label>
+                        <Caption>{group.length}</Caption>
+                      </FlexRow>
+                      <FlexColumn
+                        sx={{
+                          display: "grid",
+                          gridTemplateColumns: {
+                            xs: "minmax(0, 1fr)",
+                            md: "repeat(2, minmax(0, 1fr))"
+                          },
+                          columnGap: SPACING.xl
+                        }}
+                      >
+                        {group.map((entity) => (
+                          <Checkbox
+                            key={entity.id}
+                            size="small"
+                            checked={selectedSet.has(entity.id)}
+                            onChange={(_, checked) =>
+                              setBoardEntity(entity, checked)
+                            }
+                            slotProps={{
+                              input: {
+                                "aria-label": `${entity.name} · ${entity.kind}`
+                              }
+                            }}
+                            labelProps={{
+                              sx: {
+                                m: SPACING.none,
+                                p: SPACING.md,
+                                gap: SPACING.md,
+                                minWidth: 0,
+                                borderBottom: "1px solid",
+                                borderColor: "divider",
+                                borderRadius: BORDER_RADIUS.sm,
+                                backgroundColor: selectedSet.has(entity.id)
+                                  ? theme.vars.palette.action.selected
+                                  : "transparent",
+                                "&:hover": {
+                                  backgroundColor:
+                                    theme.vars.palette.action.hover
+                                },
+                                "&:focus-within": {
+                                  outline: `2px solid ${theme.vars.palette.primary.main}`,
+                                  outlineOffset: -2
+                                },
+                                "& .MuiFormControlLabel-label": {
+                                  flex: 1,
+                                  minWidth: 0
+                                }
+                              }
+                            }}
+                            label={
+                              <FlexRow gap={SPACING.lg} align="center">
+                              {entity.reference_images?.[0] ? (
+                                  <ResponsiveImage
+                                    locator={entity.reference_images[0]}
+                                    alt=""
+                                    aspectRatio="1/1"
+                                    borderRadius={BORDER_RADIUS.sm}
+                                    sx={{
+                                      width: 56,
+                                      height: 56,
+                                      flexShrink: 0
+                                    }}
+                                  />
+                                ) : (
+                                  <FlexRow
+                                    aria-hidden
+                                    justify="center"
+                                    align="center"
+                                    sx={{
+                                      width: 56,
+                                      height: 56,
+                                      flexShrink: 0,
+                                      borderRadius: BORDER_RADIUS.sm,
+                                      bgcolor: "action.hover",
+                                      color: "text.secondary"
+                                    }}
+                                  >
+                                    <AddPhotoAlternateOutlinedIcon fontSize="small" />
+                                  </FlexRow>
+                                )}
+                                <FlexColumn
+                                  gap={SPACING.xs}
+                                  sx={{ minWidth: 0 }}
+                                >
+                                  <Label
+                                    component="span"
+                                    sx={{
+                                      m: SPACING.none,
+                                      color: "text.primary",
+                                      overflowWrap: "anywhere"
+                                    }}
+                                  >
+                                    {entity.name}
+                                  </Label>
+                                  <Caption
+                                    sx={{
+                                      display: "-webkit-box",
+                                      WebkitLineClamp: 2,
+                                      WebkitBoxOrient: "vertical",
+                                      overflow: "hidden",
+                                      overflowWrap: "anywhere"
+                                    }}
+                                  >
+                                    {entity.descriptor || "No description"}
+                                  </Caption>
+                                </FlexColumn>
+                              </FlexRow>
+                            }
+                          />
+                        ))}
+                      </FlexColumn>
+                    </FlexColumn>
+                  );
+                })
+              )}
+            </FlexColumn>
+          </ScrollArea>
+        </FlexColumn>
+      )}
+
+      {selectedEntities.length > 0 ? (
+        <FlexColumn gap={SPACING.md}>
+          <Text size="big" component="h2">
+            Assign each shot
+          </Text>
+          <Text color="secondary">
+            Remove an entity from shots where it should not appear.
+          </Text>
+          {(board?.shots ?? []).map((shot) => {
+            const shotIds = new Set(shot.entity_ids ?? selectedIds);
+            return (
+              <FlexColumn
+                key={shot.id}
+                sx={{
+                  py: SPACING.lg,
+                  borderBottom: "1px solid",
+                  borderColor: "divider"
+                }}
+              >
+                <FlexColumn gap={SPACING.sm}>
+                  <Text>{`${shot.index + 1}. ${shot.slug ?? shot.action}`}</Text>
+                  <FlexRow gap={SPACING.lg} wrap>
+                    {selectedEntities.map((entity) => (
+                      <Checkbox
+                        key={entity.id}
+                        label={entity.name}
+                        checked={shotIds.has(entity.id)}
+                        onChange={(_, checked) =>
+                          toggleShot(shot.id, entity.id, checked)
+                        }
+                      />
+                    ))}
+                  </FlexRow>
+                </FlexColumn>
+              </FlexColumn>
+            );
+          })}
+        </FlexColumn>
+      ) : null}
+
+      <EntityAssetPickerDialog
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        onPick={(assetId) => {
+          setPickerOpen(false);
+          setNewAssetId(assetId);
+        }}
+      />
+      {newAssetId ? (
+        <EntityEditorDialog
+          open
+          assetId={newAssetId}
+          onSaved={handleCreated}
+          onClose={() => setNewAssetId(null)}
+        />
+      ) : null}
+    </FlexColumn>
+  );
+};
+
+export default EntitiesStep;

--- a/web/src/components/setup/storyboard/LookStep.tsx
+++ b/web/src/components/setup/storyboard/LookStep.tsx
@@ -348,7 +348,16 @@ export const LookStep: React.FC<LookStepProps> = ({ boardId }) => {
                     shotlistImport.entries.length === 1 ? "" : "s"
                   } did not come with them`}
                 </Caption>
-                <FlexColumn gap={GAP.tight} component="ul">
+                <FlexColumn
+                  gap={GAP.tight}
+                  component="ul"
+                  sx={{
+                    listStyle: "none",
+                    margin: 0,
+                    padding: 0,
+                    "& li": { listStyle: "none" }
+                  }}
+                >
                   {shotlistImport.entries.map((entry) => (
                     <Caption
                       key={`${entry.row}:${entry.column}:${entry.value}`}

--- a/web/src/components/setup/storyboard/ShotlistReport.tsx
+++ b/web/src/components/setup/storyboard/ShotlistReport.tsx
@@ -40,7 +40,11 @@ export const ShotlistReport: React.FC<ShotlistReportProps> = ({
         {shotCount} shot{shotCount === 1 ? "" : "s"} imported. These values did
         not come with them.
       </Text>
-      <FlexColumn gap={GAP.tight} component="ul">
+      <FlexColumn
+        gap={GAP.tight}
+        component="ul"
+        sx={{ listStyle: "none", margin: 0, padding: 0, "& li": { listStyle: "none" } }}
+      >
         {entries.map((entry) => (
           <Caption
             key={`${entry.row}:${entry.column}:${entry.value}`}

--- a/web/src/components/setup/storyboard/__tests__/EntitiesStep.test.tsx
+++ b/web/src/components/setup/storyboard/__tests__/EntitiesStep.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import type { Entity } from "@nodetool-ai/protocol";
+import mockTheme from "../../../../__mocks__/themeMock";
+
+const entities: Entity[] = [
+  {
+    type: "entity",
+    id: "mara",
+    project_id: "default",
+    kind: "character",
+    name: "Mara",
+    descriptor: "Mara wears a red raincoat",
+    reference_images: [],
+    voice_id: null,
+    lora: null,
+    palette: null
+  },
+  {
+    type: "entity",
+    id: "station",
+    project_id: "default",
+    kind: "location",
+    name: "Station",
+    descriptor: "An empty concrete station",
+    reference_images: [],
+    voice_id: null,
+    lora: null,
+    palette: null
+  }
+];
+
+jest.mock("../../../../serverState/useEntities", () => ({
+  useEntities: () => ({ data: entities, isLoading: false })
+}));
+jest.mock("../../../entities/EntityAssetPickerDialog", () => () => null);
+jest.mock("../../../entities/EntityEditorDialog", () => () => null);
+
+import { useStoryboardStore } from "../../../../stores/storyboard/StoryboardStore";
+import { EntitiesStep } from "../EntitiesStep";
+
+const BOARD_ID = "board";
+
+beforeEach(() => {
+  useStoryboardStore.setState({ boards: {} });
+  useStoryboardStore.getState().ensureBoard(BOARD_ID);
+  useStoryboardStore.getState().setScreenplay(BOARD_ID, {
+    type: "screenplay",
+    id: "screenplay",
+    title: "Rain",
+    shots: [
+      {
+        type: "shot",
+        id: "shot-1",
+        index: 0,
+        action: "Mara waits",
+        status: "planned"
+      },
+      {
+        type: "shot",
+        id: "shot-2",
+        index: 1,
+        action: "The empty road",
+        status: "planned"
+      }
+    ]
+  });
+});
+
+it("assigns a selected entity to matching shots, then allows shot refinement", async () => {
+  const user = userEvent.setup();
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <EntitiesStep boardId={BOARD_ID} />
+    </ThemeProvider>
+  );
+
+  await user.click(screen.getByRole("checkbox", { name: "Mara · character" }));
+
+  let board = useStoryboardStore.getState().getBoard(BOARD_ID);
+  expect(board?.entityIds).toEqual(["mara"]);
+  expect(board?.shots.map((shot) => shot.entity_ids)).toEqual([["mara"], []]);
+
+  const shotAssignments = screen.getAllByRole("checkbox", { name: "Mara" });
+  await user.click(shotAssignments[1]);
+
+  board = useStoryboardStore.getState().getBoard(BOARD_ID);
+  expect(board?.shots.map((shot) => shot.entity_ids)).toEqual([
+    ["mara"],
+    ["mara"]
+  ]);
+
+  await user.click(
+    screen.getByRole("checkbox", { name: "Station · location" })
+  );
+  board = useStoryboardStore.getState().getBoard(BOARD_ID);
+  expect(board?.shots.map((shot) => shot.entity_ids)).toEqual([
+    ["mara", "station"],
+    ["mara", "station"]
+  ]);
+});
+
+it("filters the library without losing selections or shot assignments", async () => {
+  const user = userEvent.setup();
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <EntitiesStep boardId={BOARD_ID} />
+    </ThemeProvider>
+  );
+
+  await user.click(screen.getByRole("checkbox", { name: "Mara · character" }));
+  await user.type(
+    screen.getByRole("textbox", { name: "Search entities" }),
+    "concrete"
+  );
+  expect(
+    screen.queryByRole("checkbox", { name: "Mara · character" })
+  ).not.toBeInTheDocument();
+  expect(
+    screen.getByRole("checkbox", { name: "Station · location" })
+  ).not.toBeChecked();
+  expect(screen.getByRole("status")).toHaveTextContent(
+    "1 selected for this storyboard"
+  );
+
+  await user.click(screen.getByRole("button", { name: "Clear search" }));
+  await user.click(screen.getByRole("button", { name: "Selected (1)" }));
+  expect(
+    screen.getByRole("checkbox", { name: "Mara · character" })
+  ).toBeChecked();
+  expect(
+    screen.queryByRole("checkbox", { name: "Station · location" })
+  ).not.toBeInTheDocument();
+  expect(screen.getAllByRole("checkbox", { name: "Mara" })[0]).toBeChecked();
+});

--- a/web/src/components/setup/storyboard/__tests__/useStoryboardSetupFlow.test.tsx
+++ b/web/src/components/setup/storyboard/__tests__/useStoryboardSetupFlow.test.tsx
@@ -12,6 +12,11 @@ jest.mock("../../../../hooks/storyboard/useStoryboards", () => ({
   useExampleStoryboards: () => ({ data: [], isLoading: false })
 }));
 jest.mock("../../../../hooks/useResolvedMediaUri");
+jest.mock("../../../../serverState/useEntities", () => ({
+  useEntities: () => ({ data: [], isLoading: false })
+}));
+jest.mock("../../../entities/EntityAssetPickerDialog", () => () => null);
+jest.mock("../../../entities/EntityEditorDialog", () => () => null);
 // The Director is the one model call in this flow. Its result decides whether
 // the genre step advances, so the suite drives it directly; the hook also
 // reaches the entity library through TanStack Query, which this suite does not
@@ -267,17 +272,17 @@ describe("useStoryboardSetupFlow", () => {
     expect(direct).toHaveBeenCalledWith(BOARD_ID, 10);
   });
 
-  it("collapses genre and review into one stepper entry", () => {
+  it("shows entities as an optional step", () => {
     useStoryboardStore.getState().setSetup(BOARD_ID, { stage: "idea" });
     renderFlow();
 
     const steps = screen.getByRole("navigation", { name: "Setup steps" });
     expect(
       Array.from(steps.querySelectorAll("li")).map((item) => item.textContent)
-    ).toEqual(["1. Idea", "2. Story", "3. Look"]);
+    ).toEqual(["1. Idea", "2. Story", "3. Entities", "4. Look"]);
   });
 
-  it("walks idea to look, one stage per primary press", async () => {
+  it("walks idea through entities to look", async () => {
     const user = userEvent.setup();
     seedStepValues();
     useStoryboardStore.getState().setSetup(BOARD_ID, { stage: "idea" });
@@ -295,7 +300,24 @@ describe("useStoryboardSetupFlow", () => {
     // The mocked run writes no shots; the real one always does, and the review
     // step will not spend over an empty screenplay.
     act(() => seedScreenplay());
+    await user.click(screen.getByRole("button", { name: "Set up entities" }));
+    expect(stageOf()).toBe("entities");
+
+    act(() => useStoryboardStore.getState().setEntityIds(BOARD_ID, ["mara"]));
     await user.click(screen.getByRole("button", { name: "Choose the look" }));
+    expect(stageOf()).toBe("look");
+  });
+
+  it("lets the creator skip entities", async () => {
+    const user = userEvent.setup();
+    seedScreenplay();
+    useStoryboardStore.getState().setSetup(BOARD_ID, { stage: "entities" });
+    renderFlow();
+
+    expect(screen.getByText("Keep people and places consistent")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Choose the look" })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Skip entities" }));
+
     expect(stageOf()).toBe("look");
   });
 
@@ -314,10 +336,10 @@ describe("useStoryboardSetupFlow", () => {
     );
 
     expect(onReviewed).not.toHaveBeenCalled();
-    await user.click(screen.getByRole("button", { name: "Choose the look" }));
+    await user.click(screen.getByRole("button", { name: "Set up entities" }));
 
     await waitFor(() => expect(onReviewed).toHaveBeenCalledTimes(1));
-    expect(stageOf()).toBe("look");
+    expect(stageOf()).toBe("entities");
   });
 
   it("does not extract for a host that has no linked script", async () => {
@@ -326,8 +348,8 @@ describe("useStoryboardSetupFlow", () => {
     useStoryboardStore.getState().setSetup(BOARD_ID, { stage: "review" });
     renderFlow();
 
-    await user.click(screen.getByRole("button", { name: "Choose the look" }));
-    await waitFor(() => expect(stageOf()).toBe("look"));
+    await user.click(screen.getByRole("button", { name: "Set up entities" }));
+    await waitFor(() => expect(stageOf()).toBe("entities"));
   });
 
   it("writes done on the last step and tells the host", async () => {

--- a/web/src/components/setup/storyboard/useStoryboardSetupFlow.ts
+++ b/web/src/components/setup/storyboard/useStoryboardSetupFlow.ts
@@ -25,6 +25,7 @@ import { useImportSource } from "../../../hooks/storyboard/useImportSource";
 import { openPageTab } from "../../workspace/openPageTab";
 import type { SetupFlowConfig, SetupStep } from "../types";
 import { GenreStep } from "./GenreStep";
+import { EntitiesStep } from "./EntitiesStep";
 import { IdeaStep } from "./IdeaStep";
 import { LookStep, useLookStep } from "./LookStep";
 import { ReviewStep } from "./ReviewStep";
@@ -77,6 +78,7 @@ const FLOW_LABELS = { title: "Storyboard" } as const;
 
 /** What the Director is allowed to answer with, for the cost estimate. */
 const DIRECTOR_MAX_OUTPUT_TOKENS = 8192;
+const EMPTY_ENTITY_IDS: string[] = [];
 
 export interface StoryboardSetupFlowOptions {
   boardId: string;
@@ -112,6 +114,9 @@ export const useStoryboardSetupFlow = ({
     (state) => state.boards[boardId]?.genre ?? ""
   );
   const shots = useStoryboardStore((state) => state.boards[boardId]?.shots);
+  const entityIds = useStoryboardStore(
+    (state) => state.boards[boardId]?.entityIds ?? EMPTY_ENTITY_IDS
+  );
   const directorModel = useStoryboardStore(
     (state) => state.boards[boardId]?.directorModel ?? null
   );
@@ -276,7 +281,7 @@ export const useStoryboardSetupFlow = ({
       {
         stage: "review",
         label: "Story",
-        primaryLabel: "Choose the look",
+        primaryLabel: "Set up entities",
         canAdvance: reviewBlockedReason === undefined,
         blockedReason: reviewBlockedReason,
         // `Rewrite from brief` runs outside the shell's primary button, so the
@@ -296,6 +301,16 @@ export const useStoryboardSetupFlow = ({
             maxOutputTokens: DIRECTOR_MAX_OUTPUT_TOKENS
           }),
         onAdvance: onReviewed
+      },
+      {
+        stage: "entities",
+        label: "Entities",
+        primaryLabel: "Choose the look",
+        canAdvance: entityIds.length > 0,
+        blockedReason: "Select or create an entity, or skip this step",
+        skipLabel: "Skip entities",
+        onSkip: () => undefined,
+        render: () => createElement(EntitiesStep, { boardId })
       },
       {
         stage: "look",
@@ -324,6 +339,7 @@ export const useStoryboardSetupFlow = ({
       directErrorRef,
       directing,
       directorModel,
+      entityIds.length,
       finish,
       genre,
       hasScreenplay,

--- a/web/src/components/setup/types.ts
+++ b/web/src/components/setup/types.ts
@@ -69,6 +69,9 @@ export interface SetupStep<Stage extends string> {
    */
   primaryDetail?: ReactNode;
   generation?: GenerationSummaryProps;
+  /** Optional way to leave a non-required step without making a selection. */
+  skipLabel?: string;
+  onSkip?: () => void | Promise<void>;
 }
 
 export interface SetupFlowConfig<Stage extends string> {

--- a/web/src/components/setup/workflow/ReviewStep.tsx
+++ b/web/src/components/setup/workflow/ReviewStep.tsx
@@ -245,7 +245,7 @@ const ReviewStepInternal: React.FC<WorkflowReviewStepProps> = ({
       <FlexColumn
         gap={GAP.spacious}
         component="ol"
-        sx={{ listStyle: "none", m: 0, p: 0 }}
+        sx={{ listStyle: "none", m: 0, p: 0, "& li": { listStyle: "none" } }}
       >
         {resolved.steps.map((entry, index) => (
           <Box component="li" key={entry.step.id} sx={REVIEW_BLOCK}>

--- a/web/src/components/workspace/WorkspaceShell.tsx
+++ b/web/src/components/workspace/WorkspaceShell.tsx
@@ -19,6 +19,8 @@ import WorkspaceTabBar from "./WorkspaceTabBar";
 import TabContent from "./TabContent";
 import WorkspaceTabLayer from "./WorkspaceTabLayer";
 
+import FrontendToolRuntimeSync from "../panels/FrontendToolRuntimeSync";
+
 const NewProjectSurface = React.lazy(
   () => import("../projects/NewProjectSurface")
 );
@@ -167,6 +169,11 @@ const WorkspaceShell = () => {
 
   return (
     <div css={shellStyles} className="workspace-shell">
+      {/* The guided game/workflow flows build their graphs through the same
+          `ui_*` tools an agent drives, from tabs (e.g. New Project) where the
+          editor chrome — and its own sync — is not mounted. Without this the
+          build fails with "Frontend tool runtime state is not initialized". */}
+      <FrontendToolRuntimeSync />
       <WorkspaceTabBar />
       <div className="workspace-main">
         <Suspense fallback={null}>

--- a/web/src/components/workspace/__tests__/StoryboardSurfaceSetup.test.tsx
+++ b/web/src/components/workspace/__tests__/StoryboardSurfaceSetup.test.tsx
@@ -20,6 +20,9 @@ jest.mock("../../../components/setup/storyboard/LookStep", () => ({
     generate: jest.fn(async () => {})
   })
 }));
+jest.mock("../../../components/setup/storyboard/EntitiesStep", () => ({
+  EntitiesStep: () => null
+}));
 
 jest.mock("../../storyboard/StoryboardBoard", () => ({
   __esModule: true,
@@ -138,7 +141,8 @@ describe("StoryboardSurface setup stages", () => {
   it.each([
     ["idea", "Continue"],
     ["genre", "Generate screenplay"],
-    ["review", "Choose the look"],
+    ["review", "Set up entities"],
+    ["entities", "Choose the look"],
     ["look", "Generate your storyboard"]
   ] as const)("mounts the %s step, not the board", (stage, primary) => {
     seedBoard(stage);

--- a/web/src/components/workspace/__tests__/WorkspaceShellRuntimeSync.test.tsx
+++ b/web/src/components/workspace/__tests__/WorkspaceShellRuntimeSync.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+
+const workspaceTabsState = {
+  tabs: [],
+  activeTabId: null,
+  setTitle: jest.fn()
+};
+jest.mock("../../../stores/WorkspaceTabsStore", () => ({
+  useWorkspaceTabsStore: (
+    selector: (state: typeof workspaceTabsState) => unknown
+  ) =>
+    selector(workspaceTabsState)
+}));
+
+const workflowManagerState = {
+  setCurrentWorkflowId: jest.fn(),
+  openWorkflows: []
+};
+jest.mock("../../../contexts/WorkflowManagerContext", () => ({
+  useWorkflowManager: (
+    selector: (state: typeof workflowManagerState) => unknown
+  ) => selector(workflowManagerState)
+}));
+
+const panelState = {
+  panel: { isVisible: false, isDragging: false, panelSize: 0 }
+};
+jest.mock("../../../stores/PanelStore", () => ({
+  usePanelStore: (selector: (state: typeof panelState) => unknown) =>
+    selector(panelState)
+}));
+
+jest.mock("../../../hooks/useWorkspaceMenuShortcuts", () => ({
+  useWorkspaceMenuShortcuts: jest.fn()
+}));
+jest.mock("@mui/material", () => ({
+  ...jest.requireActual("@mui/material"),
+  useMediaQuery: () => false
+}));
+jest.mock("@mui/material/styles", () => ({
+  ...jest.requireActual("@mui/material/styles"),
+  useTheme: () => ({
+    breakpoints: { down: () => "@media(max-width: 600px)" }
+  })
+}));
+
+jest.mock("../../panels/FrontendToolRuntimeSync", () => ({
+  __esModule: true,
+  default: () => <div data-testid="frontend-tool-runtime-sync" />
+}));
+jest.mock("../WorkspaceTabBar", () => ({
+  __esModule: true,
+  default: () => null
+}));
+jest.mock("../WorkspaceTabLayer", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => children
+}));
+jest.mock("../TabContent", () => ({
+  __esModule: true,
+  default: () => null
+}));
+jest.mock("../../projects/NewProjectSurface", () => ({
+  __esModule: true,
+  default: () => <div>New project</div>
+}));
+jest.mock("../../panels/PanelLeft", () => ({
+  __esModule: true,
+  default: () => null
+}));
+jest.mock("../../panels/PanelRight", () => ({
+  __esModule: true,
+  default: () => null
+}));
+jest.mock("../../panels/PanelBottom", () => ({
+  __esModule: true,
+  default: () => null
+}));
+jest.mock("../../node_editor/Alert", () => ({
+  __esModule: true,
+  default: () => null
+}));
+
+import WorkspaceShell from "../WorkspaceShell";
+
+describe("WorkspaceShell frontend tool runtime", () => {
+  it("initializes the runtime while the New Project surface is active", async () => {
+    render(<WorkspaceShell />);
+
+    expect(await screen.findByText("New project")).toBeInTheDocument();
+    expect(screen.getByTestId("frontend-tool-runtime-sync")).toBeInTheDocument();
+  });
+});

--- a/web/src/hooks/game/__tests__/useBuildGame.test.tsx
+++ b/web/src/hooks/game/__tests__/useBuildGame.test.tsx
@@ -5,6 +5,8 @@
  * each slot's node carries its slot id and the export node its dynamic inputs,
  * the terminal stage is written as soon as the nodes are down, and the run
  * only starts on a graph that both validates and had nothing left unplaced.
+ * The build stays on the setup surface until that work completes, so a tool
+ * failure remains visible there instead of being erased by navigation.
  */
 import { act, renderHook } from "@testing-library/react";
 import type { GameAssetManifest } from "@nodetool-ai/protocol";
@@ -161,10 +163,11 @@ beforeEach(() => {
 });
 
 describe("buildGame", () => {
-  it("opens the editor, then places the nodes and the edges", async () => {
+  it("places the nodes and edges without navigating away from setup", async () => {
     await build();
-    expect(calls[0].name).toBe("ui_open_workflow");
     const names = calls.map((call) => call.name);
+    expect(names).not.toContain("ui_open_workflow");
+    expect(calls[0].name).toBe("ui_add_node");
     // Generate, resize, check and preview for the one slot, then the export
     // node and the output the project lands on.
     expect(names.filter((name) => name === "ui_add_node").length).toBe(6);

--- a/web/src/hooks/game/useBuildGame.ts
+++ b/web/src/hooks/game/useBuildGame.ts
@@ -9,9 +9,11 @@
  * function of manifest, design and choices (D26), shared with the harness, so
  * what the harness graded is what gets placed.
  *
- * The canvas opens as soon as the nodes are down, before validation and before
- * the run: a creator who is about to see an error should already be looking at
- * the graph the error is about.
+ * This hook runs from the workflow tab that owns the setup flow, so its node
+ * store is already mounted. It must not navigate through `ui_open_workflow`:
+ * that unmounts the setup shell before placement finishes and turns a rejected
+ * tool call into a disappearing error. The terminal stage swaps the same tab
+ * to the canvas after the build result has been recorded.
  *
  * `issues` is part of the result because a graph whose slots are all placed can
  * still be missing the export node, and that graph validates and writes no
@@ -91,9 +93,6 @@ export const useBuildGame = (workflowId: string): UseBuildGameResult => {
             return meta ? planNodeShape(meta) : null;
           }
         );
-
-        // The editor has to be open before a node tool can reach it.
-        await callTool("ui_open_workflow", { workflow_id: workflowId });
 
         for (const node of placement.nodes) {
           await callTool("ui_add_node", {

--- a/web/src/lib/tools/builtin/__tests__/gameSetupTools.test.ts
+++ b/web/src/lib/tools/builtin/__tests__/gameSetupTools.test.ts
@@ -40,7 +40,18 @@ const METADATA = {
     node_type: "nodetool.game.ExportGodotProject",
     properties: [
       { name: "template", type: { type: "str" } },
-      { name: "fills", type: { type: "list", type_args: [{ type: "slot_fill" }] } }
+      {
+        name: "fills",
+        type: {
+          type: "list",
+          type_args: [
+            {
+              type: "union",
+              type_args: [{ type: "image" }, { type: "audio" }]
+            }
+          ]
+        }
+      }
     ],
     outputs: [{ name: "output", type: { type: "dict" } }]
   },

--- a/web/src/lib/tools/builtin/storyboard.ts
+++ b/web/src/lib/tools/builtin/storyboard.ts
@@ -563,7 +563,7 @@ FrontendToolRegistry.register({
 FrontendToolRegistry.register({
   name: "ui_storyboard_set_setup",
   description:
-    "Write the guided-setup answers on the specified storyboard: the `brief` (what the piece is), the `genre` the Director works in, the `stage` the flow sits at, how many shots a run asks for (`shotCount`), and the file the words came from (`importSource`). Omit a field to leave it unchanged. The stages run idea → genre → review → look → done; a board that has finished setup, or was built before the flow existed, reads 'done'. Setting the stage is what moves the open flow to that step. An `importSource` with `preserveWords: true` is a contract: the Director is then asked for camera work only and may not rewrite the dialogue or the scene order.",
+    "Write the guided-setup answers on the specified storyboard: the `brief` (what the piece is), the `genre` the Director works in, the `stage` the flow sits at, how many shots a run asks for (`shotCount`), and the file the words came from (`importSource`). Omit a field to leave it unchanged. The stages run idea → genre → review → entities → look → done; a board that has finished setup, or was built before the flow existed, reads 'done'. Setting the stage is what moves the open flow to that step. An `importSource` with `preserveWords: true` is a contract: the Director is then asked for camera work only and may not rewrite the dialogue or the scene order.",
   parameters: z.object({
     storyboard_id: storyboardIdParam,
     brief: z
@@ -577,7 +577,7 @@ FrontendToolRegistry.register({
     stage: storyboards.storyboardSetupStage
       .optional()
       .describe(
-        "Where the guided flow should resume: idea, genre, review, look, or done."
+        "Where the guided flow should resume: idea, genre, review, entities, look, or done."
       ),
     shotCount: z
       .number()

--- a/web/src/studio/__tests__/StudioStoryboardSetup.test.tsx
+++ b/web/src/studio/__tests__/StudioStoryboardSetup.test.tsx
@@ -67,6 +67,9 @@ jest.mock("../../components/setup/storyboard/LookStep", () => ({
     generate: jest.fn(async () => {})
   })
 }));
+jest.mock("../../components/setup/storyboard/EntitiesStep", () => ({
+  EntitiesStep: () => null
+}));
 
 jest.mock("../../hooks/useDocumentUndoShortcuts", () => ({
   useDocumentUndoShortcuts: jest.fn()
@@ -114,7 +117,8 @@ describe("StudioStoryboardPage setup stages", () => {
   it.each([
     ["idea", "Continue"],
     ["genre", "Generate screenplay"],
-    ["review", "Choose the look"],
+    ["review", "Set up entities"],
+    ["entities", "Choose the look"],
     ["look", "Generate your storyboard"]
   ] as const)("mounts the %s step, not the board", (stage, primary) => {
     useStoryboardStore.getState().ensureBoard(BOARD_ID);


### PR DESCRIPTION
## What changed

Adds a storyboard Entities step between story review and visual styling, with selection, creation, and an explicit skip action. Guided flows support asynchronous skip actions and display recoverable errors with retry and diagnostic reporting. Game setup uses the shared image-model picker and keeps graph construction in its owning workflow tab so failures do not disappear during navigation. The workspace initializes frontend tool runtime state even when editor chrome is not mounted.

Includes the corresponding setup-stage schema, capability, runtime-sync, and test updates from the existing local commit.

## Verification

- [x] `npm run test:affected -- <changed web paths in this commit>` — 429 tests across 32 suites passed.
- [x] `npm run test --workspace=packages/protocol -- api-schemas-storyboards` — 22 tests passed.
- [x] `NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck` — passed in the development checkout.
- [x] `npm run lint` — passed in the development checkout.
- [x] `VITEST_MAX_WORKERS=2 npm run dev:nodetool -- harness gate --base origin/main` — 13/13 selfchecks passed in the development checkout.
- [ ] `npm run test --workspace=packages/agents -- capabilities-game-setup` — blocked by local disk exhaustion while Vitest wrote its module cache. 18 tests could not complete; one passed.

```text
Error: ENOSPC: no space left on device, rename '.../ssr/.tmp-...' -> '.../ssr/...'
src/capabilities/model3d.ts:21:1
```

Draft pending a successful agent-suite run. Checks used the combined development checkout. This PR preserves the existing guided-setup commit and excludes the separate timeline and seam-repair work.
