### PR TITLE
Polish Node Editor surfaces and custom node controls

### DIFF
--- a/web/src/components/Inspector.tsx
+++ b/web/src/components/Inspector.tsx
@@ -22,6 +22,8 @@ import {
   BORDER_RADIUS,
   SPACING,
   getSpacingPx,
+  TYPOGRAPHY,
+  reducedMotion,
   ScrollArea,
   Text,
   Tooltip,
@@ -58,34 +60,37 @@ const styles = (theme: Theme) =>
   css({
     "&": {
       display: "grid",
-      gridTemplateRows: "auto auto 1fr auto",
+      gridTemplateRows: "auto auto minmax(0, 1fr) auto",
       gridTemplateColumns: "100%",
       backgroundColor: theme.vars.palette.background.default,
       padding: "0",
       width: "100%",
-      maxWidth: "500px",
+      minWidth: 0,
       height: "100%",
+      containerType: "inline-size",
       overflow: "hidden"
     },
 
     /* ---------- Head: icon + title + namespace + close ---------- */
     ".inspector-head": {
       display: "grid",
-      gridTemplateColumns: "auto 1fr auto",
+      gridTemplateColumns: "auto minmax(0, 1fr) auto",
       alignItems: "center",
       gap: theme.spacing(1.5),
-      padding: `${theme.spacing(3)} ${theme.spacing(4)} ${theme.spacing(2)}`,
-      borderBottom: `1px solid ${theme.vars.palette.divider}`
+      padding: `${theme.spacing(SPACING.md)} ${theme.spacing(SPACING.lg)}`
+    },
+    ".inspector-head:not(:has(.inspector-head-icon))": {
+      gridTemplateColumns: "minmax(0, 1fr) auto"
     },
     ".inspector-head-icon": {
-      width: 32,
-      height: 32,
+      width: 24,
+      height: 24,
       borderRadius: BORDER_RADIUS.md,
       display: "grid",
       placeItems: "center",
       flexShrink: 0,
       backgroundColor:
-        "var(--inspector-icon-tint, rgba(102,144,212,0.22))",
+        theme.vars.palette.c_overlay_subtle,
       "& .icon-container": {
         width: 16,
         height: 16
@@ -103,9 +108,7 @@ const styles = (theme: Theme) =>
       gap: 0
     },
     ".inspector-title": {
-      fontFamily: theme.fontFamily1,
-      fontSize: "var(--fontSizeBig)",
-      fontWeight: 600,
+      ...TYPOGRAPHY.sans.label,
       letterSpacing: "-0.01em",
       lineHeight: 1.2,
       color: theme.vars.palette.text.primary,
@@ -133,13 +136,17 @@ const styles = (theme: Theme) =>
       font: "inherit",
       minWidth: 0,
       display: "inline-flex",
-      alignItems: "center"
+      alignItems: "center",
+      "&:focus-visible": {
+        outline: `2px solid ${theme.vars.palette.primary.main}`,
+        outlineOffset: 2
+      }
     },
     ".inspector-namespace-text": {
       whiteSpace: "nowrap",
       overflow: "hidden",
       textOverflow: "ellipsis",
-      maxWidth: "26ch"
+      maxWidth: "100%"
     },
     ".inspector-namespace .copy-button": {
       width: 16,
@@ -150,7 +157,8 @@ const styles = (theme: Theme) =>
       "& svg": { fontSize: "var(--fontSizeSmall)" }
     },
     ".inspector-head-close": {
-      paddingTop: getSpacingPx(SPACING.micro)
+      paddingTop: getSpacingPx(SPACING.micro),
+      flexShrink: 0
     },
 
     /* ---------- Tabs ---------- */
@@ -158,12 +166,13 @@ const styles = (theme: Theme) =>
       display: "flex",
       alignItems: "stretch",
       gap: 0,
-      padding: `0 ${theme.spacing(4)}`,
+      padding: `0 ${theme.spacing(SPACING.lg)}`,
       borderBottom: `1px solid ${theme.vars.palette.divider}`,
       backgroundColor: theme.vars.palette.background.default
     },
     ".inspector-tab": {
       position: "relative",
+      minHeight: 28,
       background: "transparent",
       border: "none",
       cursor: "pointer",
@@ -179,6 +188,7 @@ const styles = (theme: Theme) =>
       alignItems: "baseline",
       gap: getSpacingPx(SPACING.sm),
       transition: `color ${MOTION.fast}`,
+      ...reducedMotion({ transition: MOTION.none }),
       "&:hover": { color: theme.vars.palette.text.primary },
       "&:focus-visible": {
         outline: `2px solid ${theme.vars.palette.primary.main}`,
@@ -223,10 +233,11 @@ const styles = (theme: Theme) =>
       gap: theme.spacing(3),
       width: "100%",
       height: "100%",
-      padding: theme.spacing(4)
+      padding: theme.spacing(SPACING.lg)
     },
-    ".top-content.tab-params": {
-      paddingLeft: `calc(${theme.spacing(3)} - 2px)`
+    ".top-content.tab-params .node-property": {
+      padding: 0,
+      marginBottom: 0
     },
     ".top-content > .node-property": {
       display: "contents"
@@ -235,7 +246,8 @@ const styles = (theme: Theme) =>
     /* ---------- Property rows ---------- */
     ".property-row": {
       width: "100%",
-      minWidth: 0
+      minWidth: 0,
+      flexShrink: 0
     },
     ".property-row .node-property": {
       width: "100%",
@@ -251,7 +263,8 @@ const styles = (theme: Theme) =>
     ".property-row .inspector-header-toolbar.inspector-toolbar-hoverable .MuiIconButton-root, .property-row .inspector-header-toolbar.inspector-toolbar-hoverable .MuiButtonBase-root":
       {
         opacity: 0,
-        transition: `opacity ${MOTION.fast}`
+        transition: `opacity ${MOTION.fast}`,
+        ...reducedMotion({ transition: MOTION.none })
       },
     ".property-row:hover .inspector-header-toolbar.inspector-toolbar-hoverable .MuiIconButton-root, .property-row:hover .inspector-header-toolbar.inspector-toolbar-hoverable .MuiButtonBase-root, .property-row .inspector-header-toolbar.inspector-toolbar-hoverable:focus-within .MuiIconButton-root, .property-row .inspector-header-toolbar.inspector-toolbar-hoverable:focus-within .MuiButtonBase-root":
       {
@@ -393,9 +406,8 @@ const styles = (theme: Theme) =>
       letterSpacing: "0.02em",
       color: theme.vars.palette.text.secondary,
       padding: `${getSpacingPx(SPACING.micro)} ${getSpacingPx(SPACING.md)}`,
-      borderRadius: BORDER_RADIUS.pill,
-      backgroundColor: theme.vars.palette.action.hover,
-      border: `1px solid ${theme.vars.palette.divider}`
+      borderRadius: BORDER_RADIUS.sm,
+      backgroundColor: theme.vars.palette.action.hover
     },
     ".help-meta": {
       display: "flex",

--- a/web/src/components/costs/WorkflowCostEstimatePanel.tsx
+++ b/web/src/components/costs/WorkflowCostEstimatePanel.tsx
@@ -16,9 +16,10 @@ import { css } from "@emotion/react";
 import React, { memo } from "react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { Box } from "../ui_primitives";
+import { Box, Caption, CollapsibleSection, FlexRow, Label, SPACING } from "../ui_primitives";
 import { useWorkflowCostEstimate } from "../../hooks/useWorkflowCostEstimate";
 import { CostEstimateSummary } from "./CostEstimateSummary";
+import { useCostEstimateSummary } from "./useCostEstimateSummary";
 
 const styles = (theme: Theme) =>
   css({
@@ -48,13 +49,54 @@ const styles = (theme: Theme) =>
 
 interface WorkflowCostEstimatePanelProps {
   workflowId: string;
+  compact?: boolean;
 }
 
 const WorkflowCostEstimatePanelInternal: React.FC<
   WorkflowCostEstimatePanelProps
-> = ({ workflowId }) => {
+> = ({ workflowId, compact = false }) => {
   const theme = useTheme();
   const estimate = useWorkflowCostEstimate(workflowId);
+  const summary = useCostEstimateSummary(estimate);
+
+  if (compact) {
+    return (
+      <CollapsibleSection
+        defaultOpen={false}
+        unmountOnExit
+        onKeyDown={(event) => {
+          if (event.key === " " || event.key === "Enter") {
+            event.stopPropagation();
+          }
+        }}
+        title={
+          <FlexRow gap={SPACING.md} justify="space-between" wrap>
+            <Label>Cost estimate</Label>
+            <Caption>
+              {summary?.hasItems
+                ? `${summary.isTotalLowerBound ? "≥ " : summary.isTotalApproximate ? "~" : ""}${summary.totalLabel}${summary.unknownCount > 0 ? " · incomplete" : " / run"}`
+                : "Per run"}
+            </Caption>
+          </FlexRow>
+        }
+        sx={{
+          px: SPACING.lg,
+          py: SPACING.xs,
+          "& > [role=button]": {
+            minHeight: 28,
+            "&:focus-visible": {
+              outline: `2px solid ${theme.vars.palette.primary.main}`,
+              outlineOffset: -2
+            }
+          }
+        }}
+      >
+        <Box sx={{ py: SPACING.md }}>
+          <CostEstimateSummary estimate={estimate} />
+        </Box>
+      </CollapsibleSection>
+    );
+  }
 
   return (
     <Box css={styles(theme)} className="cost-estimate">

--- a/web/src/components/costs/__tests__/WorkflowCostEstimatePanel.test.tsx
+++ b/web/src/components/costs/__tests__/WorkflowCostEstimatePanel.test.tsx
@@ -40,6 +40,48 @@ const renderPanel = () =>
   );
 
 describe("WorkflowCostEstimatePanel", () => {
+  it("keeps a per-run estimate visible and opens details with the keyboard without canvas shortcuts", async () => {
+    mockHook.mockReturnValue(estimate as never);
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <WorkflowCostEstimatePanel workflowId="wf_1" compact />
+      </ThemeProvider>
+    );
+    const disclosure = screen.getByRole("button", { name: /Cost estimate.*\/ run/ });
+    expect(disclosure).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Text To Image")).not.toBeInTheDocument();
+    const canvasShortcut = jest.fn();
+    window.addEventListener("keydown", canvasShortcut);
+    try {
+      disclosure.focus();
+      await userEvent.keyboard(" ");
+      expect(disclosure).toHaveAttribute("aria-expanded", "true");
+      expect(await screen.findByText("Text To Image")).toBeVisible();
+      expect(canvasShortcut).not.toHaveBeenCalled();
+      await userEvent.keyboard("{Enter}");
+      expect(disclosure).toHaveAttribute("aria-expanded", "false");
+      await waitFor(() => expect(screen.queryByText("Text To Image")).not.toBeInTheDocument());
+    } finally {
+      window.removeEventListener("keydown", canvasShortcut);
+    }
+  });
+
+  it("marks an incomplete estimate before its details are opened", () => {
+    mockHook.mockReturnValue({
+      ...estimate,
+      total: 0,
+      unknown_count: 1,
+      items: [{ ...estimate.items[0], confidence: "unknown" }]
+    } as never);
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <WorkflowCostEstimatePanel workflowId="wf_1" compact />
+      </ThemeProvider>
+    );
+    expect(screen.getByRole("button", { name: "Cost estimate — · incomplete" }))
+      .toHaveAttribute("aria-expanded", "false");
+  });
+
   it("credits the price sources with the date the prices last moved", () => {
     mockHook.mockReturnValue(estimate as never);
     renderPanel();

--- a/web/src/components/inspector/RunSelectedNodesSection.tsx
+++ b/web/src/components/inspector/RunSelectedNodesSection.tsx
@@ -13,7 +13,7 @@ import {
   ShortcutHint,
   Text,
   Tooltip,
-  MOTION, BORDER_RADIUS } from "../ui_primitives";
+  MOTION, BORDER_RADIUS, SPACING, TYPOGRAPHY, reducedMotion } from "../ui_primitives";
 import { EditorButton } from "../editor_ui";
 import {
   MAX_RUNS,
@@ -27,28 +27,25 @@ const styles = (theme: Theme) =>
     "&": {
       borderTop: `1px solid ${theme.vars.palette.divider}`,
       padding: `${theme.spacing(1.5)} ${theme.spacing(3)} ${theme.spacing(2)}`,
-      display: "flex",
-      flexDirection: "column",
-      gap: theme.spacing(1),
+      display: "grid",
+      gridTemplateColumns: "auto minmax(0, 1fr)",
+      alignItems: "center",
+      gap: theme.spacing(SPACING.md),
       backgroundColor: theme.vars.palette.background.default
     },
     ".runs-row": {
-      width: "100%"
+      width: "auto",
+      gap: theme.spacing(SPACING.xs)
     },
     ".runs-label": {
-      fontFamily: theme.fontFamily1,
-      fontSize: "var(--fontSizeSmaller)",
-      fontWeight: 600,
-      letterSpacing: "0.08em",
-      textTransform: "uppercase",
+      ...TYPOGRAPHY.sans.caption,
       color: theme.vars.palette.text.secondary
     },
     ".stepper-control": {
-      border: `1px solid ${theme.vars.palette.divider}`,
       borderRadius: BORDER_RADIUS.md,
       paddingLeft: theme.spacing(0.5),
       paddingRight: theme.spacing(0.5),
-      backgroundColor: "transparent"
+      backgroundColor: theme.vars.palette.c_overlay_subtle
     },
     ".stepper-control .MuiButtonBase-root": {
       borderRadius: BORDER_RADIUS.sm,
@@ -71,10 +68,10 @@ const styles = (theme: Theme) =>
       padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`,
       backgroundColor: theme.vars.palette.primary.main,
       color: theme.vars.palette.primary.contrastText,
-      fontSize: theme.fontSizeNormal,
-      fontWeight: 500,
+      ...TYPOGRAPHY.sans.label,
       borderRadius: BORDER_RADIUS.md,
       transition: `background-color ${MOTION.fast}`,
+      ...reducedMotion({ transition: MOTION.none }),
       "&:hover": {
         backgroundColor: theme.vars.palette.primary.dark
       },
@@ -93,6 +90,11 @@ const styles = (theme: Theme) =>
       overflow: "hidden",
       textOverflow: "ellipsis",
       whiteSpace: "nowrap"
+    },
+    "@container (max-width: 240px)": {
+      "&": {
+        gridTemplateColumns: "minmax(0, 1fr)"
+      }
     }
   });
 
@@ -167,7 +169,7 @@ const RunSelectedNodesSectionInternal: React.FC = () => {
             aria-label="Run selected nodes"
           >
             <PlayArrowIcon className="play-icon" />
-            <span className="run-label">Run selected nodes</span>
+            <span className="run-label">Run selected</span>
           </EditorButton>
         </Tooltip>
         {inSequence && runProgress !== null ? (

--- a/web/src/components/node/RequiredSettingsWarning.tsx
+++ b/web/src/components/node/RequiredSettingsWarning.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from "react";
-import { Text, EditorButton } from "../ui_primitives";
+import { Text, EditorButton, FlexColumn, SPACING } from "../ui_primitives";
 import { openSettingsTab } from "../workspace/openPageTab";
 import { useRequiredSettings } from "../../hooks/useRequiredSettings";
 
@@ -27,40 +27,35 @@ const RequiredSettingsWarning: React.FC<RequiredSettingsWarningProps> = React.me
           : `Required settings ${settingsList} are not configured!`;
 
       return (
-        <>
+        <FlexColumn gap={SPACING.xs} sx={{ px: SPACING.md, py: SPACING.xs }}>
           <Text
             className="node-status required-settings-warning"
             size="smaller"
             sx={{
               width: "100%",
-              textAlign: "center",
-              textTransform: "uppercase",
-              padding: ".5em !important",
-              marginBottom: "0"
+              textAlign: "left",
+              textTransform: "none",
+              color: "warning.main",
+              overflowWrap: "anywhere",
+              marginBottom: 0
             }}
           >
             {message}
           </Text>
           <EditorButton
             className="required-settings-button"
-            variant="contained"
+            variant="text"
             color="warning"
             size="small"
             onClick={handleOpenSettings}
             sx={{
-              margin: "0 1em",
-              padding: ".2em 0 0",
-              height: "1.8em",
-              lineHeight: "1.2em",
-              color: "var(--palette-grey-1000)",
-              backgroundColor: "var(--palette-warning-main)",
-              fontSize: "var(--fontSizeSmaller)",
-              borderRadius: ".1em"
+              alignSelf: "flex-start",
+              minHeight: 24
             }}
           >
             Configure in Settings
           </EditorButton>
-        </>
+        </FlexColumn>
       );
     }, [missingSettings, handleOpenSettings]);
 

--- a/web/src/components/node/selectionStyles.ts
+++ b/web/src/components/node/selectionStyles.ts
@@ -1,7 +1,7 @@
 import type { Theme } from "@mui/material/styles";
 import type { CSSObject } from "@mui/system";
 import { NODE_COLLAPSED_BASE_NODE_SX } from "../../styles/collapsedNodeTokens";
-import { MOTION } from "../ui_primitives";
+import { MOTION, SHADOW, reducedMotion } from "../ui_primitives";
 
 type BaseNodeSelectionStyleArgs = {
   selected: boolean;
@@ -29,7 +29,7 @@ export const getPreviewNodeSelectionSx = (theme: Theme, selected: boolean) => ({
   display: "flex" as const,
   boxShadow: selected
     ? `0 0 0 2px var(--palette-grey-100)`
-    : `0 8px 20px rgb(0 0 0 / 0.16), 0 1px 0 rgb(255 255 255 / 0.03) inset`,
+    : SHADOW(theme).sm,
   backgroundColor: theme.vars.palette.c_node_bg,
   ...CRISP_NO_BLUR_STYLES
 });
@@ -40,8 +40,8 @@ export const getOutputNodeSelectionSx = (theme: Theme, selected: boolean) => ({
     ? `3px solid ${theme.vars.palette.primary.main}`
     : `1px solid ${theme.vars.palette.divider}`,
   boxShadow: selected
-    ? `0 0 0 2px rgb(${theme.vars.palette.primary.mainChannel} / 0.95), 0 0 28px rgb(${theme.vars.palette.primary.mainChannel} / 0.55), 0 8px 20px rgb(${theme.vars.palette.primary.mainChannel} / 0.25)`
-    : "0 1px 2px rgb(0 0 0 / 0.04)",
+    ? `0 0 0 1px ${theme.vars.palette.primary.main}`
+    : SHADOW(theme).sm,
   backgroundColor: theme.vars.palette.c_node_bg,
   ...CRISP_NO_BLUR_STYLES
 });
@@ -68,7 +68,7 @@ export const getBaseNodeSelectionStyles = ({
   // inset outline + depth shadow only, dropping its own crisp outer ring. The
   // outer zone is left to the run animation.
   const hasRunActivity = isLoading || hasAmbientRing;
-  const selectionDepthShadow = `0 10px 28px rgb(0 0 0 / 0.34), 0 2px 10px color-mix(in srgb, ${resolvedBaseColor} 18%, transparent)`;
+  const selectionDepthShadow = SHADOW(theme).sm;
   const selectionOuterRing = `0 0 0 1px color-mix(in srgb, ${resolvedBaseColor} 75%, white 25%)`;
   const selectionShadow = hasRunActivity
     ? selectionDepthShadow
@@ -107,8 +107,8 @@ export const getBaseNodeSelectionStyles = ({
     boxShadow: selected
       ? selectionShadow
       : isFocused
-        ? `0 0 0 2px ${theme.vars.palette.warning.main}, 0 10px 24px rgb(0 0 0 / 0.22)`
-        : `0 8px 20px rgb(0 0 0 / 0.16), 0 1px 0 rgb(255 255 255 / 0.03) inset`,
+        ? `0 0 0 2px ${theme.vars.palette.warning.main}`
+        : "none",
     outline: isFocused
       ? `2px dashed ${theme.vars.palette.warning.main}`
       : selected
@@ -117,10 +117,10 @@ export const getBaseNodeSelectionStyles = ({
     outlineOffset: "-1px",
     backgroundColor:
       hasParent && !isLoading ? parentColor : theme.vars.palette.c_node_bg,
-    backgroundImage:
-      "linear-gradient(180deg, rgb(255 255 255 / 0.025) 0%, rgb(255 255 255 / 0.008) 18%, transparent 52%)",
+    backgroundImage: "none",
     borderRadius: theme.rounded.node,
     transition: `${MOTION.shadow}, outline-color ${MOTION.normal}, ${MOTION.border}`,
+    ...reducedMotion({ transition: MOTION.none }),
     "--node-primary-color": resolvedBaseColor,
     ...resizeHandleSx,
     ...CRISP_NO_BLUR_STYLES

--- a/web/src/components/node_menu/NodeLibrary.tsx
+++ b/web/src/components/node_menu/NodeLibrary.tsx
@@ -14,7 +14,8 @@ import {
   FONT_WEIGHT,
   BORDER_RADIUS,
   SPACING,
-  getSpacingPx
+  getSpacingPx,
+  reducedMotion
 } from "../ui_primitives";
 import PanelHeadline from "../ui/PanelHeadline";
 import NodeLibraryRow from "./NodeLibraryRow";
@@ -62,7 +63,6 @@ const styles = (theme: Theme, isMobile: boolean) =>
       alignItems: "center",
       padding: `${getSpacingPx(SPACING.micro)} ${getSpacingPx(SPACING.md)}`, // was 1px 8px
       borderRadius: BORDER_RADIUS.sm,
-      backgroundColor: theme.vars.palette.action.selected,
       color: theme.vars.palette.text.secondary,
       fontSize: "var(--fontSizeSmall)",
       fontWeight: FONT_WEIGHT.medium,
@@ -81,11 +81,16 @@ const styles = (theme: Theme, isMobile: boolean) =>
       ),
       padding: theme.spacing(SPACING.xs, SPACING.xs),
       borderRadius: BORDER_RADIUS.md,
-      backgroundColor: theme.vars.palette.background.paper,
-      border: `1px solid ${theme.vars.palette.divider}`,
+      backgroundColor: theme.vars.palette.c_overlay_subtle,
+      border: "1px solid transparent",
       transition: `border-color ${MOTION.fast}`,
+      ...reducedMotion({ transition: MOTION.none }),
+      "&:hover": {
+        borderColor: theme.vars.palette.divider
+      },
       "&:focus-within": {
-        borderColor: theme.vars.palette.primary.main
+        borderColor: theme.vars.palette.primary.main,
+        outline: `1px solid ${theme.vars.palette.primary.main}`
       },
       "& .nl-search-icon": {
         fontSize: 17,
@@ -100,19 +105,25 @@ const styles = (theme: Theme, isMobile: boolean) =>
         outline: "none",
         color: theme.vars.palette.text.primary,
         fontFamily: theme.fontFamily1,
-        fontSize: theme.fontSizeNormal
+        fontSize: theme.fontSizeSmall
       },
       "& .nl-search-clear": {
         display: "inline-flex",
         alignItems: "center",
         justifyContent: "center",
         padding: getSpacingPx(SPACING.micro),
+        minWidth: 24,
+        minHeight: 24,
         border: "none",
         background: "transparent",
         borderRadius: BORDER_RADIUS.sm,
         color: theme.vars.palette.text.secondary,
         cursor: "pointer",
         "&:hover": { color: theme.vars.palette.text.primary },
+        "&:focus-visible": {
+          outline: `2px solid ${theme.vars.palette.primary.main}`,
+          outlineOffset: -2
+        },
         "& svg": { fontSize: 15 }
       }
     },
@@ -146,19 +157,18 @@ const styles = (theme: Theme, isMobile: boolean) =>
       minHeight: 0
     },
     ".nl-info": {
-      flex: "0 0 200px",
+      flex: "0 0 128px",
       display: "flex",
-      height: 200,
+      height: 128,
       overflow: "hidden",
       borderTop: `1px solid ${theme.vars.palette.divider}`,
-      backgroundColor: theme.vars.palette.background.paper,
       // NodeInfo pins its own width/maxHeight for the floating menu; here it
       // fills the width and scrolls within this fixed-height bottom strip, so
       // the node list above keeps the rest of the height.
       "& > div": {
         width: "100% !important",
-        height: "200px !important",
-        maxHeight: "200px !important",
+        height: "128px",
+        maxHeight: "128px",
         flex: 1,
         minHeight: 0
       }
@@ -168,14 +178,15 @@ const styles = (theme: Theme, isMobile: boolean) =>
       alignItems: "center",
       justifyContent: "center",
       textAlign: "center",
-      padding: theme.spacing(3),
+      padding: theme.spacing(SPACING.lg),
       color: theme.vars.palette.text.secondary,
       fontSize: "var(--fontSizeSmall)",
       lineHeight: 1.5
     },
 
     ".nl-rail": {
-      width: isMobile ? "106px" : "120px",
+      width: isMobile ? "124px" : "156px",
+      maxWidth: "42%",
       flexShrink: 0,
       display: "flex",
       flexDirection: "column",
@@ -187,7 +198,6 @@ const styles = (theme: Theme, isMobile: boolean) =>
         isMobile ? SPACING.xs : SPACING.lg
       ),
       overflowY: "auto",
-      borderRight: `1px solid ${theme.vars.palette.divider}`,
       ...thinScrollbarStyles(theme)
     },
     ".nl-cat": {
@@ -206,6 +216,7 @@ const styles = (theme: Theme, isMobile: boolean) =>
       textAlign: "left",
       cursor: "pointer",
       transition: `${MOTION.background}, color ${MOTION.fast}`,
+      ...reducedMotion({ transition: MOTION.none }),
       "& .nl-cat-icon": {
         display: "inline-flex",
         flexShrink: 0,
@@ -514,8 +525,8 @@ const NodeLibrary = memo<NodeLibraryProps>(
               <NodeInfo nodeMetadata={infoNode} showConnections={false} />
             ) : (
               <div className="nl-info-empty">
-                <Text component="span">
-                  Drag a node to place it on the workspace. Hover for details
+                <Text component="span" size="small" color="secondary">
+                  Drag a node onto the canvas. Hover for details.
                 </Text>
               </div>
             )}

--- a/web/src/components/node_types/CodeBody.tsx
+++ b/web/src/components/node_types/CodeBody.tsx
@@ -108,8 +108,8 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     ".code-toolbar": {
@@ -117,8 +117,8 @@ const styles = (theme: Theme) =>
       display: "flex",
       alignItems: "center",
       justifyContent: "space-between",
-      gap: theme.spacing(0.5),
-      padding: `0 ${theme.spacing(0.5)}`
+      gap: theme.spacing(SPACING.micro),
+      padding: `0 ${theme.spacing(SPACING.micro)}`
     },
     ".code-language": {
       fontFamily: theme.fontFamily2,
@@ -131,19 +131,19 @@ const styles = (theme: Theme) =>
     ".code-actions": {
       display: "flex",
       alignItems: "center",
-      gap: theme.spacing(0.5)
+      gap: theme.spacing(SPACING.micro)
     },
     ".editor-area": {
       flex: "1 1 auto",
       minHeight: 180,
       position: "relative",
       overflow: "hidden",
-      backgroundColor: "var(--palette-grey-600)",
-      border: "1px solid var(--palette-grey-500)",
+      backgroundColor: theme.vars.palette.action.hover,
+      border: "1px solid transparent",
       borderRadius: BORDER_RADIUS.sm
     },
     ".editor-area:focus-within": {
-      borderColor: "var(--palette-grey-400)"
+      borderColor: theme.vars.palette.primary.main
     },
     ".editor-loading, .editor-error, .editor-placeholder": {
       width: "100%",

--- a/web/src/components/node_types/editing/AdjustmentBody.tsx
+++ b/web/src/components/node_types/editing/AdjustmentBody.tsx
@@ -22,7 +22,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 
-import { CheckerDropzone, BORDER_RADIUS } from "../../ui_primitives";
+import { SPACING, CheckerDropzone, BORDER_RADIUS } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import ImageRefPreview from "../../node/ImageRefPreview";
 import { NodeOutputs } from "../../node/NodeOutputs";
@@ -47,22 +47,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 140,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -76,11 +76,11 @@ const styles = (theme: Theme) =>
     ".controls": {
       flex: "0 0 auto",
       display: "grid",
-      gridTemplateColumns: "minmax(52px, auto) 1fr auto",
+      gridTemplateColumns: "minmax(0, 1fr) minmax(48px, 1.4fr) auto",
       alignItems: "center",
-      columnGap: theme.spacing(1.5),
-      rowGap: theme.spacing(1),
-      padding: `${theme.spacing(1)} ${theme.spacing(1)} ${theme.spacing(1)}`
+      columnGap: theme.spacing(SPACING.sm),
+      rowGap: theme.spacing(SPACING.xs),
+      padding: `${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.xs)}`
     },
     ".outputs-row": {
       flex: "0 0 auto"

--- a/web/src/components/node_types/editing/AdjustmentSlider.tsx
+++ b/web/src/components/node_types/editing/AdjustmentSlider.tsx
@@ -18,7 +18,7 @@ import React, { memo, useCallback } from "react";
 import { css } from "@emotion/react";
 import type { Theme } from "@mui/material/styles";
 
-import { NodeSlider, BORDER_RADIUS, FONT_WEIGHT, Z_INDEX } from "../../ui_primitives";
+import { NodeSlider, BORDER_RADIUS, FONT_WEIGHT, SPACING, Z_INDEX } from "../../ui_primitives";
 
 const TRACK_HEIGHT = 4;
 const THUMB_SIZE = 12;
@@ -55,12 +55,10 @@ export const adjustmentSliderStyles = (theme: Theme) =>
       fontSize: theme.fontSizeSmaller,
       fontWeight: FONT_WEIGHT.medium,
       color: theme.vars.palette.text.secondary,
-      textTransform: "uppercase",
-      letterSpacing: "0.045em",
-      lineHeight: 1,
-      whiteSpace: "nowrap",
-      overflow: "hidden",
-      textOverflow: "ellipsis"
+      letterSpacing: "normal",
+      lineHeight: 1.3,
+      minWidth: 0,
+      overflowWrap: "anywhere"
     },
     // Wraps the slider so the centre tick + bipolar fill can be positioned
     // over the rail. Zero vertical jitter: the slider's rail sits at 50%.
@@ -69,7 +67,7 @@ export const adjustmentSliderStyles = (theme: Theme) =>
       display: "flex",
       alignItems: "center",
       width: "100%",
-      height: 16
+      height: 24
     },
     ".slider-wrap .center-tick": {
       position: "absolute",
@@ -78,7 +76,7 @@ export const adjustmentSliderStyles = (theme: Theme) =>
       width: 2,
       height: 9,
       borderRadius: BORDER_RADIUS.xs,
-      backgroundColor: theme.vars.palette.grey[600],
+      backgroundColor: theme.vars.palette.text.disabled,
       pointerEvents: "none",
       zIndex: 0
     },
@@ -87,7 +85,7 @@ export const adjustmentSliderStyles = (theme: Theme) =>
       top: "50%",
       transform: "translateY(-50%)",
       height: TRACK_HEIGHT,
-      borderRadius: TRACK_HEIGHT / 2,
+      borderRadius: BORDER_RADIUS.pill,
       backgroundColor: theme.vars.palette.primary.main,
       pointerEvents: "none",
       zIndex: Z_INDEX.raised
@@ -97,12 +95,10 @@ export const adjustmentSliderStyles = (theme: Theme) =>
       fontSize: theme.fontSizeSmaller,
       fontVariantNumeric: "tabular-nums",
       color: theme.vars.palette.text.primary,
-      minWidth: 46,
+      minWidth: 40,
       textAlign: "right",
       lineHeight: 1,
-      padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`,
-      borderRadius: BORDER_RADIUS.sm,
-      backgroundColor: theme.vars.palette.grey[800]
+      padding: `0 ${theme.spacing(SPACING.xs)}`
     },
     // Slider polish — rounded rail/track, ring-style thumb. Scoped here so the
     // app's square editor sliders elsewhere are untouched.
@@ -112,13 +108,13 @@ export const adjustmentSliderStyles = (theme: Theme) =>
     },
     ".controls .MuiSlider-rail": {
       height: TRACK_HEIGHT,
-      borderRadius: TRACK_HEIGHT / 2,
+      borderRadius: BORDER_RADIUS.pill,
       opacity: 1,
-      backgroundColor: theme.vars.palette.grey[700]
+      backgroundColor: theme.vars.palette.action.selected
     },
     ".controls .MuiSlider-track": {
       height: TRACK_HEIGHT,
-      borderRadius: TRACK_HEIGHT / 2,
+      borderRadius: BORDER_RADIUS.pill,
       border: "none",
       backgroundColor: theme.vars.palette.primary.main
     },
@@ -128,8 +124,8 @@ export const adjustmentSliderStyles = (theme: Theme) =>
       width: THUMB_SIZE,
       height: THUMB_SIZE,
       borderRadius: BORDER_RADIUS.circle,
-      border: `2px solid ${theme.vars.palette.primary.main}`,
-      boxShadow: "0 1px 3px rgba(0, 0, 0, 0.45)",
+      border: `2px solid ${theme.vars.palette.background.paper}`,
+      boxShadow: "none",
       "&:hover, &.Mui-focusVisible, &.Mui-active": {
         boxShadow: `0 0 0 6px color-mix(in srgb, ${theme.vars.palette.primary.main} 20%, transparent)`
       }

--- a/web/src/components/node_types/editing/BlurBody.tsx
+++ b/web/src/components/node_types/editing/BlurBody.tsx
@@ -13,7 +13,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 
-import {
+import { SPACING,
   CheckerDropzone,
   NodeSlider,
   BORDER_RADIUS,
@@ -48,22 +48,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 160,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -77,17 +77,16 @@ const styles = (theme: Theme) =>
     ".controls": {
       flex: "0 0 auto",
       display: "grid",
-      gridTemplateColumns: "auto 1fr auto",
-      columnGap: theme.spacing(1),
-      rowGap: theme.spacing(1),
+      gridTemplateColumns: "minmax(0, auto) minmax(40px, 1fr) auto",
+      columnGap: theme.spacing(SPACING.xs),
+      rowGap: theme.spacing(SPACING.xs),
       alignItems: "center",
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.micro)}`
     },
     ".ctrl-label": {
       fontSize: theme.fontSizeSmaller,
       color: theme.vars.palette.text.secondary,
-      textTransform: "uppercase",
-      letterSpacing: "0.04em",
+      letterSpacing: "normal",
       lineHeight: 1
     },
     ".ctrl-value": {
@@ -103,7 +102,7 @@ const styles = (theme: Theme) =>
       width: "100%",
       fontSize: theme.fontSizeSmaller,
       ".MuiSelect-select": {
-        padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)} 0`
+        padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.micro)} 0`
       }
     },
     ".outputs-row": {

--- a/web/src/components/node_types/editing/CanvasResizeBody.tsx
+++ b/web/src/components/node_types/editing/CanvasResizeBody.tsx
@@ -12,7 +12,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 
-import {
+import { SPACING,
   CheckerDropzone,
   FlexColumn,
   FlexRow,
@@ -43,17 +43,17 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 160,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -77,9 +77,9 @@ const styles = (theme: Theme) =>
       },
       ".dimensions-badge": {
         position: "absolute",
-        bottom: theme.spacing(0.5),
-        right: theme.spacing(0.5),
-        padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+        bottom: theme.spacing(SPACING.micro),
+        right: theme.spacing(SPACING.micro),
+        padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)}`,
         background: theme.vars.palette.c_scrim,
         color: theme.vars.palette.common.white,
         fontFamily: theme.fontFamily2,
@@ -96,7 +96,7 @@ const styles = (theme: Theme) =>
       display: "flex",
       flexWrap: "wrap",
       alignItems: "flex-end",
-      gap: theme.spacing(0.5)
+      gap: theme.spacing(SPACING.micro)
     },
     ".field": {
       flex: "1 1 45%",
@@ -279,6 +279,7 @@ const CanvasResizeBodyInner: React.FC<CanvasResizeBodyProps> = ({
 
       <FlexColumn className="mode-row" gap={0.5}>
         <ToggleGroup
+          quiet
           value={mode}
           exclusive
           onChange={handleModeChange}
@@ -346,6 +347,7 @@ const CanvasResizeBodyInner: React.FC<CanvasResizeBodyProps> = ({
         {mode === "padding" && (
           <FlexColumn gap={0.5}>
             <ToggleGroup
+          quiet
               value={paddingUnit}
               exclusive
               onChange={handlePaddingUnitChange}

--- a/web/src/components/node_types/editing/ChannelsBody.tsx
+++ b/web/src/components/node_types/editing/ChannelsBody.tsx
@@ -13,7 +13,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 
-import {
+import { SPACING,
   CheckerDropzone,
   FlexColumn,
   FlexRow,
@@ -50,22 +50,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 160,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -78,7 +78,7 @@ const styles = (theme: Theme) =>
     },
     ".controls": {
       flex: "0 0 auto",
-      paddingTop: theme.spacing(0.5)
+      paddingTop: theme.spacing(SPACING.micro)
     },
     ".channel-toggle": {
       width: "100%"
@@ -162,6 +162,7 @@ const ChannelsBodyInner: React.FC<ChannelsBodyProps> = ({
       <FlexColumn className="controls" gap={0.5}>
         <FlexRow align="center" gap={0.5}>
           <ToggleGroup
+          quiet
             className="channel-toggle"
             size="small"
             value={channel}

--- a/web/src/components/node_types/editing/ChromaKeyBody.tsx
+++ b/web/src/components/node_types/editing/ChromaKeyBody.tsx
@@ -12,7 +12,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 
-import { CheckerDropzone, BORDER_RADIUS } from "../../ui_primitives";
+import { SPACING, CheckerDropzone, BORDER_RADIUS } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import ImageRefPreview from "../../node/ImageRefPreview";
 import { NodeOutputs } from "../../node/NodeOutputs";
@@ -46,22 +46,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 140,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -74,11 +74,11 @@ const styles = (theme: Theme) =>
     },
     ".controls": {
       display: "grid",
-      gridTemplateColumns: "auto 1fr auto",
-      columnGap: theme.spacing(1),
-      rowGap: theme.spacing(0.5),
+      gridTemplateColumns: "minmax(0, auto) minmax(40px, 1fr) auto",
+      columnGap: theme.spacing(SPACING.xs),
+      rowGap: theme.spacing(SPACING.micro),
       alignItems: "center",
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.micro)}`
     },
     ".color-row": {
       display: "contents"

--- a/web/src/components/node_types/editing/CollectionBody.tsx
+++ b/web/src/components/node_types/editing/CollectionBody.tsx
@@ -73,8 +73,7 @@ const styles = (theme: Theme) =>
     },
     ".col-header .spacer": { flex: 1 },
     ".col-type": {
-      textTransform: "uppercase",
-      letterSpacing: "0.04em",
+      letterSpacing: "normal",
       color: theme.vars.palette.primary.main
     },
     ".col-grid": {

--- a/web/src/components/node_types/editing/ColorOverlayBody.tsx
+++ b/web/src/components/node_types/editing/ColorOverlayBody.tsx
@@ -12,7 +12,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 
-import { CheckerDropzone, BORDER_RADIUS } from "../../ui_primitives";
+import { SPACING, CheckerDropzone, BORDER_RADIUS } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import ImageRefPreview from "../../node/ImageRefPreview";
 import { NodeOutputs } from "../../node/NodeOutputs";
@@ -44,22 +44,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 140,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -74,24 +74,23 @@ const styles = (theme: Theme) =>
       display: "flex",
       alignItems: "center",
       justifyContent: "space-between",
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)}`
     },
     ".color-row-label": {
       fontSize: theme.fontSizeSmaller,
       fontWeight: 500,
       color: theme.vars.palette.text.secondary,
-      textTransform: "uppercase",
       letterSpacing: "0.045em",
       lineHeight: 1,
       whiteSpace: "nowrap"
     },
     ".controls": {
       display: "grid",
-      gridTemplateColumns: "auto 1fr auto",
-      columnGap: theme.spacing(1),
-      rowGap: theme.spacing(0.5),
+      gridTemplateColumns: "minmax(0, auto) minmax(40px, 1fr) auto",
+      columnGap: theme.spacing(SPACING.xs),
+      rowGap: theme.spacing(SPACING.micro),
       alignItems: "center",
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.micro)}`
     },
     ".outputs-row": {
       flex: "0 0 auto"

--- a/web/src/components/node_types/editing/CompositorBody.tsx
+++ b/web/src/components/node_types/editing/CompositorBody.tsx
@@ -30,7 +30,7 @@ import {
 } from "@nodetool-ai/gpu";
 import type { LayerTransform2D } from "@nodetool-ai/gpu/webgpu";
 
-import {
+import { SPACING,
   CheckerDropzone,
   DynamicInputButton,
   EditButton,
@@ -104,18 +104,18 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     ".preview-area": {
       position: "relative",
       flex: "0 0 auto",
-      minHeight: 160,
+      minHeight: 96,
       maxHeight: 280,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -132,20 +132,20 @@ const styles = (theme: Theme) =>
       overflowY: "auto",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      paddingRight: theme.spacing(0.5)
+      gap: theme.spacing(SPACING.micro),
+      paddingRight: theme.spacing(SPACING.micro)
     },
     ".add-row": {
       flex: "0 0 auto",
       display: "flex",
       justifyContent: "flex-start",
-      paddingTop: theme.spacing(0.5)
+      paddingTop: theme.spacing(SPACING.micro)
     },
     ".outputs-row": {
       flex: "0 0 auto"
     },
     ".empty-state": {
-      padding: theme.spacing(1),
+      padding: theme.spacing(SPACING.xs),
       color: theme.vars.palette.text.secondary,
       fontFamily: theme.fontFamily2,
       fontSize: theme.fontSizeSmaller,

--- a/web/src/components/node_types/editing/CropBody.tsx
+++ b/web/src/components/node_types/editing/CropBody.tsx
@@ -30,7 +30,7 @@ import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 
-import {
+import { SPACING,
   CheckerDropzone,
   BORDER_RADIUS,
   MenuItem,
@@ -81,22 +81,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 160,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center"
@@ -144,9 +144,9 @@ const styles = (theme: Theme) =>
     },
     ".dim-badge": {
       position: "absolute",
-      top: theme.spacing(0.5),
-      left: theme.spacing(0.5),
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+      top: theme.spacing(SPACING.micro),
+      left: theme.spacing(SPACING.micro),
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)}`,
       background: theme.vars.palette.c_scrim,
       color: theme.vars.palette.common.white,
       fontFamily: theme.fontFamily2,
@@ -157,17 +157,16 @@ const styles = (theme: Theme) =>
     ".controls": {
       flex: "0 0 auto",
       display: "grid",
-      gridTemplateColumns: "auto 1fr auto",
-      columnGap: theme.spacing(1),
-      rowGap: theme.spacing(1),
+      gridTemplateColumns: "minmax(0, auto) minmax(40px, 1fr) auto",
+      columnGap: theme.spacing(SPACING.xs),
+      rowGap: theme.spacing(SPACING.xs),
       alignItems: "center",
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.micro)}`
     },
     ".ctrl-label": {
       fontSize: theme.fontSizeSmaller,
       color: theme.vars.palette.text.secondary,
-      textTransform: "uppercase",
-      letterSpacing: "0.04em",
+      letterSpacing: "normal",
       lineHeight: 1
     },
     ".aspect-select": {
@@ -175,13 +174,13 @@ const styles = (theme: Theme) =>
       width: "100%",
       fontSize: theme.fontSizeSmaller,
       ".MuiSelect-select": {
-        padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)} 0`
+        padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.micro)} 0`
       }
     },
     ".dims-cluster": {
       display: "flex",
       alignItems: "center",
-      gap: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
       minWidth: 0,
       "& .dim-field": {
         flex: "1 1 0",

--- a/web/src/components/node_types/editing/CurvesBody.tsx
+++ b/web/src/components/node_types/editing/CurvesBody.tsx
@@ -15,7 +15,7 @@ import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 
-import {
+import { SPACING,
   CheckerDropzone,
   FlexRow,
   StateIconButton, BORDER_RADIUS } from "../../ui_primitives";
@@ -60,22 +60,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 140,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -90,13 +90,13 @@ const styles = (theme: Theme) =>
       flex: "0 0 auto",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5)
+      gap: theme.spacing(SPACING.micro)
     },
     ".section-header": {
       display: "flex",
       alignItems: "center",
       justifyContent: "space-between",
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)}`
     },
     ".section-title": {
       fontSize: theme.fontSizeSmaller,
@@ -107,11 +107,11 @@ const styles = (theme: Theme) =>
     },
     ".controls": {
       display: "grid",
-      gridTemplateColumns: "auto 1fr auto",
-      columnGap: theme.spacing(1),
-      rowGap: theme.spacing(0.5),
+      gridTemplateColumns: "minmax(0, auto) minmax(40px, 1fr) auto",
+      columnGap: theme.spacing(SPACING.xs),
+      rowGap: theme.spacing(SPACING.micro),
       alignItems: "center",
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.micro)}`
     },
     // Channel tints layered over the shared `.ctrl-label` styles.
     ".ctrl-label.red": { color: theme.vars.palette.error.main },

--- a/web/src/components/node_types/editing/DropShadowBody.tsx
+++ b/web/src/components/node_types/editing/DropShadowBody.tsx
@@ -14,7 +14,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 
-import { CheckerDropzone, FlexRow, BORDER_RADIUS } from "../../ui_primitives";
+import { SPACING, CheckerDropzone, FlexRow, BORDER_RADIUS } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import ImageRefPreview from "../../node/ImageRefPreview";
 import { NodeOutputs } from "../../node/NodeOutputs";
@@ -49,22 +49,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 140,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -77,14 +77,14 @@ const styles = (theme: Theme) =>
     },
     ".controls": {
       display: "grid",
-      gridTemplateColumns: "auto 1fr auto",
-      columnGap: theme.spacing(1),
-      rowGap: theme.spacing(0.5),
+      gridTemplateColumns: "minmax(0, auto) minmax(40px, 1fr) auto",
+      columnGap: theme.spacing(SPACING.xs),
+      rowGap: theme.spacing(SPACING.micro),
       alignItems: "center",
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.micro)}`
     },
     ".color-row": {
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)}`,
       display: "flex",
       alignItems: "center",
       justifyContent: "space-between"
@@ -93,7 +93,6 @@ const styles = (theme: Theme) =>
       fontSize: theme.fontSizeSmaller,
       fontWeight: 500,
       color: theme.vars.palette.text.secondary,
-      textTransform: "uppercase",
       letterSpacing: "0.045em",
       lineHeight: 1,
       whiteSpace: "nowrap"

--- a/web/src/components/node_types/editing/ExtractVideoFrameBody.tsx
+++ b/web/src/components/node_types/editing/ExtractVideoFrameBody.tsx
@@ -98,19 +98,19 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: theme.spacing(0)
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 140,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
       backgroundColor: theme.vars.palette.common.black,
@@ -157,7 +157,7 @@ const styles = (theme: Theme) =>
       flexWrap: "wrap",
       alignItems: "center",
       justifyContent: "center",
-      gap: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
       minWidth: 0
     },
     ".time-display": {
@@ -188,13 +188,13 @@ const styles = (theme: Theme) =>
       flex: "0 0 auto",
       display: "flex",
       alignItems: "center",
-      gap: theme.spacing(1),
+      gap: theme.spacing(SPACING.xs),
       paddingTop: theme.spacing(SPACING.micro)
     },
     ".field": {
       display: "flex",
       alignItems: "center",
-      gap: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
       minWidth: 0
     },
     ".field-label": {

--- a/web/src/components/node_types/editing/FitBody.tsx
+++ b/web/src/components/node_types/editing/FitBody.tsx
@@ -15,7 +15,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 
-import { CheckerDropzone, FlexRow, BORDER_RADIUS } from "../../ui_primitives";
+import { SPACING, CheckerDropzone, FlexRow, BORDER_RADIUS } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import ImageRefPreview from "../../node/ImageRefPreview";
 import { NodeOutputs } from "../../node/NodeOutputs";
@@ -39,17 +39,17 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 160,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "visible",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -66,9 +66,9 @@ const styles = (theme: Theme) =>
       },
       ".dimensions-badge": {
         position: "absolute",
-        bottom: theme.spacing(0.5),
-        right: theme.spacing(0.5),
-        padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+        bottom: theme.spacing(SPACING.micro),
+        right: theme.spacing(SPACING.micro),
+        padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)}`,
         background: theme.vars.palette.c_scrim,
         color: theme.vars.palette.common.white,
         fontFamily: theme.fontFamily2,
@@ -81,7 +81,7 @@ const styles = (theme: Theme) =>
       flex: "0 0 auto",
       display: "flex",
       alignItems: "flex-end",
-      gap: theme.spacing(0.5)
+      gap: theme.spacing(SPACING.micro)
     },
     ".dim-field": {
       flex: "1 1 50%",
@@ -91,21 +91,20 @@ const styles = (theme: Theme) =>
       flex: "0 0 auto",
       display: "flex",
       alignItems: "center",
-      gap: theme.spacing(0.5),
-      paddingTop: theme.spacing(0.5),
-      paddingLeft: theme.spacing(0.5),
-      paddingRight: theme.spacing(0.5)
+      gap: theme.spacing(SPACING.micro),
+      paddingTop: theme.spacing(SPACING.micro),
+      paddingLeft: theme.spacing(SPACING.micro),
+      paddingRight: theme.spacing(SPACING.micro)
     },
     ".presets-label": {
       fontSize: theme.fontSizeSmaller,
       color: theme.vars.palette.text.secondary,
-      textTransform: "uppercase",
-      letterSpacing: "0.04em",
+      letterSpacing: "normal",
       lineHeight: 1
     },
     ".preset-chip": {
       cursor: "pointer",
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)}`,
       borderRadius: BORDER_RADIUS.sm,
       border: `1px solid ${theme.vars.palette.divider}`,
       background: "transparent",

--- a/web/src/components/node_types/editing/GeneratorBody.tsx
+++ b/web/src/components/node_types/editing/GeneratorBody.tsx
@@ -19,7 +19,7 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
-import { CheckerDropzone, FlexRow, BORDER_RADIUS } from "../../ui_primitives";
+import { SPACING, CheckerDropzone, FlexRow, BORDER_RADIUS } from "../../ui_primitives";
 import ImageRefPreview from "../../node/ImageRefPreview";
 import { NodeOutputs } from "../../node/NodeOutputs";
 import NodeProgress from "../../node/NodeProgress";
@@ -75,17 +75,17 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 160,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -97,7 +97,7 @@ const styles = (theme: Theme) =>
       }
     },
     ".color-row": {
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)}`,
       flex: "0 0 auto"
     },
     // `.controls` (not a custom name) so the shared adjustmentSliderStyles'
@@ -105,11 +105,11 @@ const styles = (theme: Theme) =>
     ".controls": {
       flex: "0 0 auto",
       display: "grid",
-      gridTemplateColumns: "minmax(52px, auto) 1fr auto",
+      gridTemplateColumns: "minmax(0, 1fr) minmax(48px, 1.4fr) auto",
       alignItems: "center",
-      columnGap: theme.spacing(1.5),
-      rowGap: theme.spacing(1),
-      padding: `${theme.spacing(1)} ${theme.spacing(1)} ${theme.spacing(1)}`
+      columnGap: theme.spacing(SPACING.sm),
+      rowGap: theme.spacing(SPACING.xs),
+      padding: `${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.xs)}`
     },
     ".outputs-row": {
       flex: "0 0 auto"

--- a/web/src/components/node_types/editing/GetVariableBody.tsx
+++ b/web/src/components/node_types/editing/GetVariableBody.tsx
@@ -13,7 +13,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { shallow } from "zustand/shallow";
 
-import { SelectField, BORDER_RADIUS } from "../../ui_primitives";
+import { SPACING, SelectField, BORDER_RADIUS } from "../../ui_primitives";
 import type { SelectOption } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import { NodeOutputs } from "../../node/NodeOutputs";
@@ -39,13 +39,13 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(1),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.xs),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: theme.spacing(0)
     },
     ".explanation": {
@@ -53,17 +53,16 @@ const styles = (theme: Theme) =>
       fontSize: theme.fontSizeSmaller,
       lineHeight: 1.4,
       color: theme.vars.palette.text.secondary,
-      padding: `${theme.spacing(0.5)} ${theme.spacing(0.5)}`,
-      borderRadius: BORDER_RADIUS.sm,
-      background: theme.vars.palette.background.default
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.micro)}`,
+      borderRadius: BORDER_RADIUS.sm
     },
     ".picker": { flex: "0 0 auto" },
     ".empty-hint": {
       flex: "0 0 auto",
       fontSize: theme.fontSizeSmaller,
       lineHeight: 1.4,
-      color: theme.vars.palette.warning.main,
-      padding: theme.spacing(0.5)
+      color: theme.vars.palette.text.secondary,
+      padding: theme.spacing(SPACING.micro)
     },
     ".outputs-row": { flex: "0 0 auto" }
   });

--- a/web/src/components/node_types/editing/HSLAdjustBody.tsx
+++ b/web/src/components/node_types/editing/HSLAdjustBody.tsx
@@ -13,7 +13,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 
-import {
+import { SPACING,
   CheckerDropzone,
   NodeSlider,
   BORDER_RADIUS,
@@ -64,22 +64,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 160,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -93,17 +93,16 @@ const styles = (theme: Theme) =>
     ".controls": {
       flex: "0 0 auto",
       display: "grid",
-      gridTemplateColumns: "auto 1fr auto",
-      columnGap: theme.spacing(1),
-      rowGap: theme.spacing(0.5),
+      gridTemplateColumns: "minmax(0, auto) minmax(40px, 1fr) auto",
+      columnGap: theme.spacing(SPACING.xs),
+      rowGap: theme.spacing(SPACING.micro),
       alignItems: "center",
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.micro)}`
     },
     ".ctrl-label": {
       fontSize: theme.fontSizeSmaller,
       color: theme.vars.palette.text.secondary,
-      textTransform: "uppercase",
-      letterSpacing: "0.04em",
+      letterSpacing: "normal",
       lineHeight: 1
     },
     ".ctrl-value": {
@@ -120,7 +119,7 @@ const styles = (theme: Theme) =>
       fontSize: theme.fontSizeSmaller,
       textTransform: "capitalize",
       ".MuiSelect-select": {
-        padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)} 0`
+        padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.micro)} 0`
       }
     },
     ".outputs-row": {

--- a/web/src/components/node_types/editing/LevelsBody.tsx
+++ b/web/src/components/node_types/editing/LevelsBody.tsx
@@ -24,7 +24,7 @@ import React, {
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { ToggleGroup, ToggleOption, BORDER_RADIUS } from "../../ui_primitives";
+import { SPACING, ToggleGroup, ToggleOption, BORDER_RADIUS } from "../../ui_primitives";
 import ImageIcon from "@mui/icons-material/Image";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 
@@ -80,22 +80,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 160,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -109,12 +109,12 @@ const styles = (theme: Theme) =>
     ".histogram-area": {
       flex: "0 0 auto",
       position: "relative",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       borderRadius: BORDER_RADIUS.sm,
-      padding: theme.spacing(0.5),
+      padding: theme.spacing(SPACING.micro),
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5)
+      gap: theme.spacing(SPACING.micro)
     },
     ".histogram-canvas": {
       width: "100%",
@@ -128,7 +128,7 @@ const styles = (theme: Theme) =>
       width: "100%",
       ".MuiToggleButton-root": {
         flex: "1 1 auto",
-        padding: `${theme.spacing(0.5)} ${theme.spacing(0.5)}`,
+        padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.micro)}`,
         fontSize: theme.fontSizeSmaller,
         fontFamily: theme.fontFamily2,
         textTransform: "none",
@@ -136,8 +136,8 @@ const styles = (theme: Theme) =>
       }
     },
     ".slider-row": {
-      paddingLeft: theme.spacing(0.5),
-      paddingRight: theme.spacing(0.5)
+      paddingLeft: theme.spacing(SPACING.micro),
+      paddingRight: theme.spacing(SPACING.micro)
     },
     ".slider-label": {
       flex: "0 0 auto",
@@ -155,7 +155,7 @@ const styles = (theme: Theme) =>
       textAlign: "right"
     },
     ".action-row": {
-      paddingTop: theme.spacing(0.5),
+      paddingTop: theme.spacing(SPACING.micro),
       display: "flex",
       justifyContent: "flex-end"
     },
@@ -482,6 +482,7 @@ const LevelsBodyInner: React.FC<LevelsBodyProps> = ({
       <div className="histogram-area">
         <canvas ref={canvasRef} className="histogram-canvas" />
         <ToggleGroup
+          quiet
           className="hist-toggle"
           size="small"
           value={histView}
@@ -500,6 +501,7 @@ const LevelsBodyInner: React.FC<LevelsBodyProps> = ({
       <FlexColumn className="controls" gap={0.5}>
         <FlexRow align="center" gap={0.5}>
           <ToggleGroup
+          quiet
             className="channel-toggle"
             size="small"
             value={channel}

--- a/web/src/components/node_types/editing/MaskBody.tsx
+++ b/web/src/components/node_types/editing/MaskBody.tsx
@@ -13,7 +13,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 
-import {
+import { SPACING,
   CheckerDropzone,
   FlexColumn,
   FlexRow,
@@ -49,22 +49,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 160,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -79,7 +79,7 @@ const styles = (theme: Theme) =>
       width: "100%",
       ".MuiToggleButton-root": {
         flex: "1 1 auto",
-        padding: `${theme.spacing(0.5)} ${theme.spacing(0.5)}`,
+        padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.micro)}`,
         fontSize: theme.fontSizeSmaller,
         fontFamily: theme.fontFamily2,
         textTransform: "none",
@@ -180,6 +180,7 @@ const MaskBodyInner: React.FC<MaskBodyProps> = ({
       <FlexColumn className="controls" gap={0.5}>
         <FlexRow align="center" gap={0.5}>
           <ToggleGroup
+          quiet
             className="tab-toggle"
             size="small"
             value={tab}

--- a/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
@@ -49,6 +49,7 @@ jest.mock("../../node/NodeProgress", () => ({
 }));
 
 jest.mock("../../ui_primitives", () => ({
+  ...jest.requireActual("../../ui_primitives/spacing"),
   BORDER_RADIUS: jest.requireActual("../../ui_primitives/tokens").BORDER_RADIUS,
   CheckerDropzone: ({ message }: { message: string }) => (
     <div data-testid="checker-dropzone">{message}</div>
@@ -115,7 +116,7 @@ jest.mock("../../ui_primitives", () => ({
 jest.mock("@mui/material/styles", () => ({
   useTheme: () => ({
     spacing: (n: number) => `${n * 8}px`,
-    vars: { palette: { grey: { 900: "#000" }, divider: "#ccc", common: { white: "#fff" }, text: { secondary: "#999", primary: "#fff" }, action: { hover: "#333" } } },
+    vars: { palette: { background: { default: "#18191d" }, grey: { 900: "#000" }, divider: "#ccc", common: { white: "#fff" }, text: { secondary: "#999", primary: "#fff" }, action: { hover: "#333" } } },
     fontSizeSmaller: "0.75rem",
     fontFamily2: "sans-serif"
   })

--- a/web/src/components/node_types/editing/MasksExtractorBody.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.tsx
@@ -19,7 +19,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 
-import {
+import { SPACING,
   CheckerDropzone,
   FlexColumn,
   FlexRow,
@@ -60,22 +60,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 160,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -88,13 +88,13 @@ const styles = (theme: Theme) =>
     },
     ".controls": {
       flex: "0 0 auto",
-      paddingTop: theme.spacing(0.5)
+      paddingTop: theme.spacing(SPACING.micro)
     },
     ".tab-toggle": {
       width: "100%",
       ".MuiToggleButton-root": {
         flex: "1 1 auto",
-        padding: `${theme.spacing(0.5)} ${theme.spacing(0.5)}`,
+        padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.micro)}`,
         fontSize: theme.fontSizeSmaller,
         fontFamily: theme.fontFamily2,
         textTransform: "none",
@@ -102,7 +102,7 @@ const styles = (theme: Theme) =>
       }
     },
     ".action-row": {
-      paddingTop: theme.spacing(0.5),
+      paddingTop: theme.spacing(SPACING.micro),
       display: "flex",
       justifyContent: "flex-end"
     },
@@ -201,6 +201,7 @@ const MasksExtractorBodyInner: React.FC<MasksExtractorBodyProps> = ({
       <FlexColumn className="controls" gap={0.5}>
         <FlexRow align="center" gap={0.5}>
           <ToggleGroup
+          quiet
             className="tab-toggle"
             size="small"
             value={tab}

--- a/web/src/components/node_types/editing/OffsetBody.tsx
+++ b/web/src/components/node_types/editing/OffsetBody.tsx
@@ -17,8 +17,8 @@ import {
   BORDER_RADIUS,
   SPACING,
   getSpacingPx,
-  ToggleButton,
-  ToggleButtonGroup
+  ToggleOption,
+  ToggleGroup
 } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import ImageRefPreview from "../../node/ImageRefPreview";
@@ -53,22 +53,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 140,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -82,18 +82,18 @@ const styles = (theme: Theme) =>
     ".controls": {
       flex: "0 0 auto",
       display: "grid",
-      gridTemplateColumns: "minmax(52px, auto) 1fr auto",
-      columnGap: theme.spacing(1),
-      rowGap: theme.spacing(0.5),
+      gridTemplateColumns: "minmax(0, 1fr) minmax(48px, 1.4fr) auto",
+      columnGap: theme.spacing(SPACING.xs),
+      rowGap: theme.spacing(SPACING.micro),
       alignItems: "center",
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.micro)}`
     },
     ".wrap-row": {
       gridColumn: "1 / -1",
       display: "flex",
       alignItems: "center",
-      gap: theme.spacing(1),
-      paddingTop: theme.spacing(0.5)
+      gap: theme.spacing(SPACING.xs),
+      paddingTop: theme.spacing(SPACING.micro)
     },
     ".wrap-label": {
       fontSize: theme.fontSizeSmaller,
@@ -208,7 +208,8 @@ const OffsetBodyInner: React.FC<OffsetBodyProps> = ({
 
         <div className="wrap-row">
           <span className="wrap-label">Wrap</span>
-          <ToggleButtonGroup
+          <ToggleGroup
+            quiet
             value={String(Math.round(wrapValue))}
             exclusive
             onChange={handleWrapChange}
@@ -216,11 +217,11 @@ const OffsetBodyInner: React.FC<OffsetBodyProps> = ({
             aria-label="Wrap mode"
           >
             {WRAP_LABELS.map((label, i) => (
-              <ToggleButton key={i} value={String(i)} aria-label={label}>
+              <ToggleOption key={i} value={String(i)} aria-label={label}>
                 {label}
-              </ToggleButton>
+              </ToggleOption>
             ))}
-          </ToggleButtonGroup>
+          </ToggleGroup>
         </div>
       </div>
 

--- a/web/src/components/node_types/editing/OutlineBody.tsx
+++ b/web/src/components/node_types/editing/OutlineBody.tsx
@@ -13,7 +13,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 
-import { CheckerDropzone, BORDER_RADIUS } from "../../ui_primitives";
+import { SPACING, CheckerDropzone, BORDER_RADIUS } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import ImageRefPreview from "../../node/ImageRefPreview";
 import { NodeOutputs } from "../../node/NodeOutputs";
@@ -46,22 +46,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 140,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -76,24 +76,23 @@ const styles = (theme: Theme) =>
       display: "flex",
       alignItems: "center",
       justifyContent: "space-between",
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)}`
     },
     ".color-row-label": {
       fontSize: theme.fontSizeSmaller,
       fontWeight: 500,
       color: theme.vars.palette.text.secondary,
-      textTransform: "uppercase",
       letterSpacing: "0.045em",
       lineHeight: 1,
       whiteSpace: "nowrap"
     },
     ".controls": {
       display: "grid",
-      gridTemplateColumns: "auto 1fr auto",
-      columnGap: theme.spacing(1),
-      rowGap: theme.spacing(0.5),
+      gridTemplateColumns: "minmax(0, auto) minmax(40px, 1fr) auto",
+      columnGap: theme.spacing(SPACING.xs),
+      rowGap: theme.spacing(SPACING.micro),
       alignItems: "center",
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.micro)}`
     },
     ".outputs-row": {
       flex: "0 0 auto"

--- a/web/src/components/node_types/editing/PadBody.tsx
+++ b/web/src/components/node_types/editing/PadBody.tsx
@@ -12,7 +12,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 
-import { CheckerDropzone, BORDER_RADIUS } from "../../ui_primitives";
+import { SPACING, CheckerDropzone, BORDER_RADIUS } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import ImageRefPreview from "../../node/ImageRefPreview";
 import { NodeOutputs } from "../../node/NodeOutputs";
@@ -47,22 +47,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 140,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -75,17 +75,16 @@ const styles = (theme: Theme) =>
     },
     ".controls": {
       display: "grid",
-      gridTemplateColumns: "auto 1fr auto",
-      columnGap: theme.spacing(1),
-      rowGap: theme.spacing(0.5),
+      gridTemplateColumns: "minmax(0, auto) minmax(40px, 1fr) auto",
+      columnGap: theme.spacing(SPACING.xs),
+      rowGap: theme.spacing(SPACING.micro),
       alignItems: "center",
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.micro)}`
     },
     ".ctrl-label": {
       fontSize: theme.fontSizeSmaller,
       fontWeight: 500,
       color: theme.vars.palette.text.secondary,
-      textTransform: "uppercase",
       letterSpacing: "0.045em",
       lineHeight: 1,
       whiteSpace: "nowrap"

--- a/web/src/components/node_types/editing/PainterBody.tsx
+++ b/web/src/components/node_types/editing/PainterBody.tsx
@@ -36,7 +36,7 @@ import UndoIcon from "@mui/icons-material/Undo";
 import RedoIcon from "@mui/icons-material/Redo";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 
-import {
+import { SPACING,
   FlexColumn,
   FlexRow,
   SvgIcon,
@@ -103,15 +103,15 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     ".paint-row": {
       flex: "1 1 auto",
-      minHeight: 200,
+      minHeight: 96,
       display: "flex",
-      gap: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
       // Canvas is now full-bleed — no side toolbar column.
       width: "100%",
       // HandleColumn lives here (sibling of `.paint-area`, not inside it) so
@@ -154,7 +154,7 @@ const styles = (theme: Theme) =>
       minHeight: 0,
       // Checker pattern only on the canvas footprint, so transparent
       // regions of the paint canvas read as "unpainted".
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       backgroundImage: `linear-gradient(45deg, ${theme.vars.palette.grey[800]} 25%, transparent 25%),
         linear-gradient(-45deg, ${theme.vars.palette.grey[800]} 25%, transparent 25%),
         linear-gradient(45deg, transparent 75%, ${theme.vars.palette.grey[800]} 75%),
@@ -233,19 +233,18 @@ const styles = (theme: Theme) =>
       flex: "0 0 auto",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(1),
-      padding: theme.spacing(1),
+      gap: theme.spacing(SPACING.xs),
+      padding: theme.spacing(SPACING.xs),
       margin: theme.spacing(0.5, 0),
       borderRadius: BORDER_RADIUS.sm,
-      background: theme.vars.palette.action.hover,
-      border: `1px solid ${theme.vars.palette.divider}`,
+      borderTop: `1px solid ${theme.vars.palette.divider}`,
       fontFamily: theme.fontFamily2,
       fontSize: theme.fontSizeSmaller
     },
     ".bottom-row": {
       display: "flex",
       alignItems: "center",
-      gap: theme.spacing(0.5)
+      gap: theme.spacing(SPACING.micro)
     },
     /* Row 2 sliders: equal-width tracks so the three numeric fields align. */
     ".sliders-row .slider-field": {
@@ -278,12 +277,9 @@ const styles = (theme: Theme) =>
       padding: theme.spacing(0.5, 1),
       "& svg": { fontSize: 22 }
     },
-    /* History cluster (undo/redo/clear) styled as proper buttons: the
-       background separates them from the surrounding toolbar tint so they
-       read as actionable rather than just hoverable. */
+    /* History actions share the toolbar surface until hovered or focused. */
     ".tools-row .toolbar-icon-button": {
-      backgroundColor: theme.vars.palette.action.selected,
-      border: `1px solid ${theme.vars.palette.divider}`,
+      backgroundColor: "transparent",
       borderRadius: BORDER_RADIUS.sm,
       "&:hover": {
         backgroundColor: theme.vars.palette.action.focus
@@ -1045,6 +1041,7 @@ const PainterBodyInner: React.FC<PainterBodyProps> = ({
             icon strip; no sliders here so the row stays tight. */}
         <FlexRow className="bottom-row tools-row" align="center" gap={0.5}>
           <ToggleGroup
+          quiet
             className="tool-toggle"
             value={tool}
             exclusive

--- a/web/src/components/node_types/editing/PasteBody.tsx
+++ b/web/src/components/node_types/editing/PasteBody.tsx
@@ -14,7 +14,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 
-import { CheckerDropzone, FlexRow, BORDER_RADIUS } from "../../ui_primitives";
+import { SPACING, CheckerDropzone, FlexRow, BORDER_RADIUS } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import ImageRefPreview from "../../node/ImageRefPreview";
 import { NodeOutputs } from "../../node/NodeOutputs";
@@ -39,22 +39,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 160,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -73,9 +73,9 @@ const styles = (theme: Theme) =>
       },
       ".dimensions-badge": {
         position: "absolute",
-        bottom: theme.spacing(0.5),
-        right: theme.spacing(0.5),
-        padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+        bottom: theme.spacing(SPACING.micro),
+        right: theme.spacing(SPACING.micro),
+        padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)}`,
         background: theme.vars.palette.c_scrim,
         color: theme.vars.palette.common.white,
         fontFamily: theme.fontFamily2,
@@ -88,7 +88,7 @@ const styles = (theme: Theme) =>
       flex: "0 0 auto",
       display: "flex",
       alignItems: "flex-end",
-      gap: theme.spacing(0.5)
+      gap: theme.spacing(SPACING.micro)
     },
     ".coord-field": {
       flex: "1 1 50%",

--- a/web/src/components/node_types/editing/PromptComposerBody.tsx
+++ b/web/src/components/node_types/editing/PromptComposerBody.tsx
@@ -33,7 +33,7 @@ import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 
-import {
+import { SPACING,
   DynamicInputButton,
   BORDER_RADIUS,
   MOTION,
@@ -75,8 +75,8 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     ".composer-area": {
@@ -84,20 +84,20 @@ const styles = (theme: Theme) =>
       flex: "1 1 auto",
       minHeight: 90,
       borderRadius: BORDER_RADIUS.sm,
-      border: `1px solid ${theme.vars.palette.divider}`,
-      // Blend into the node body by default; only recess into a higher-contrast
-      // well (and accent the border) once the field is focused for editing.
-      background: "transparent",
-      padding: theme.spacing(1),
+      border: "1px solid transparent",
+      background: theme.vars.palette.action.hover,
+      padding: theme.spacing(SPACING.xs),
       overflow: "auto",
       // The node body carries `.node-drag-handle` (cursor: grabbing !important);
       // the composer is a text field, so override it back to a text caret.
       cursor: "text !important",
       transition: `${MOTION.background}, ${MOTION.border}`,
       ...reducedMotion({ transition: MOTION.none }),
+      "&:hover": { borderColor: theme.vars.palette.divider },
       "&:focus-within": {
         background: theme.vars.palette.background.default,
-        borderColor: theme.vars.palette.primary.main
+        borderColor: theme.vars.palette.primary.main,
+        outline: `1px solid ${theme.vars.palette.primary.main}`
       }
     },
     ".composer-input": {
@@ -115,8 +115,8 @@ const styles = (theme: Theme) =>
     },
     ".composer-placeholder": {
       position: "absolute",
-      top: theme.spacing(1),
-      left: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      left: theme.spacing(SPACING.xs),
       color: theme.vars.palette.text.disabled,
       fontFamily: theme.fontFamily1,
       fontSize: theme.fontSizeSmall,
@@ -127,17 +127,16 @@ const styles = (theme: Theme) =>
       display: "flex",
       flexWrap: "wrap",
       alignItems: "center",
-      gap: theme.spacing(0.5)
+      gap: theme.spacing(SPACING.micro)
     },
     ".variable-bar-label": {
       fontSize: theme.fontSizeSmaller,
       color: theme.vars.palette.text.secondary,
-      textTransform: "uppercase",
-      letterSpacing: "0.04em"
+      letterSpacing: "normal"
     },
     ".variable-insert-chip": {
       cursor: "pointer",
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)}`,
       borderRadius: BORDER_RADIUS.sm,
       border: `1px solid ${theme.vars.palette.divider}`,
       background: "transparent",

--- a/web/src/components/node_types/editing/ResizeBody.tsx
+++ b/web/src/components/node_types/editing/ResizeBody.tsx
@@ -15,7 +15,7 @@ import LinkIcon from "@mui/icons-material/Link";
 import LinkOffIcon from "@mui/icons-material/LinkOff";
 import ImageIcon from "@mui/icons-material/Image";
 
-import { CheckerDropzone, FlexRow, StateIconButton, BORDER_RADIUS } from "../../ui_primitives";
+import { SPACING, CheckerDropzone, FlexRow, StateIconButton, BORDER_RADIUS } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import ImageRefPreview from "../../node/ImageRefPreview";
 import { NodeOutputs } from "../../node/NodeOutputs";
@@ -41,17 +41,17 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 160,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "visible",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -68,9 +68,9 @@ const styles = (theme: Theme) =>
       },
       ".dimensions-badge": {
         position: "absolute",
-        bottom: theme.spacing(0.5),
-        right: theme.spacing(0.5),
-        padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+        bottom: theme.spacing(SPACING.micro),
+        right: theme.spacing(SPACING.micro),
+        padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)}`,
         background: theme.vars.palette.c_scrim,
         color: theme.vars.palette.common.white,
         fontFamily: theme.fontFamily2,
@@ -83,7 +83,7 @@ const styles = (theme: Theme) =>
       flex: "0 0 auto",
       display: "flex",
       alignItems: "flex-end",
-      gap: theme.spacing(0.5)
+      gap: theme.spacing(SPACING.micro)
     },
     ".dim-field": {
       flex: "1 1 50%",

--- a/web/src/components/node_types/editing/ResizeImageBody.tsx
+++ b/web/src/components/node_types/editing/ResizeImageBody.tsx
@@ -13,7 +13,7 @@ import LinkIcon from "@mui/icons-material/Link";
 import LinkOffIcon from "@mui/icons-material/LinkOff";
 import ImageIcon from "@mui/icons-material/Image";
 
-import {
+import { SPACING,
   CheckerDropzone,
   FlexRow,
   NodeSlider,
@@ -47,17 +47,17 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 160,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "visible",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -74,9 +74,9 @@ const styles = (theme: Theme) =>
       },
       ".dimensions-badge": {
         position: "absolute",
-        bottom: theme.spacing(0.5),
-        right: theme.spacing(0.5),
-        padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+        bottom: theme.spacing(SPACING.micro),
+        right: theme.spacing(SPACING.micro),
+        padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)}`,
         background: theme.vars.palette.c_scrim,
         color: theme.vars.palette.common.white,
         fontFamily: theme.fontFamily2,
@@ -87,27 +87,26 @@ const styles = (theme: Theme) =>
     },
     ".mode-row": {
       flex: "0 0 auto",
-      padding: `0 ${theme.spacing(0.5)}`
+      padding: `0 ${theme.spacing(SPACING.micro)}`
     },
     ".controls-row": {
       flex: "0 0 auto",
       display: "flex",
       alignItems: "flex-end",
-      gap: theme.spacing(0.5)
+      gap: theme.spacing(SPACING.micro)
     },
     ".scale-controls": {
       flex: "0 0 auto",
       display: "grid",
-      gridTemplateColumns: "auto 1fr auto",
-      columnGap: theme.spacing(1),
+      gridTemplateColumns: "minmax(0, auto) minmax(40px, 1fr) auto",
+      columnGap: theme.spacing(SPACING.xs),
       alignItems: "center",
-      padding: `0 ${theme.spacing(1)} ${theme.spacing(0.5)}`
+      padding: `0 ${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.micro)}`
     },
     ".ctrl-label": {
       fontSize: theme.fontSizeSmaller,
       color: theme.vars.palette.text.secondary,
-      textTransform: "uppercase",
-      letterSpacing: "0.04em"
+      letterSpacing: "normal"
     },
     ".ctrl-value": {
       fontFamily: theme.fontFamily2,
@@ -124,18 +123,17 @@ const styles = (theme: Theme) =>
       flex: "0 0 auto",
       display: "flex",
       alignItems: "center",
-      gap: theme.spacing(0.5),
-      padding: `${theme.spacing(0.5)} ${theme.spacing(0.5)} 0`
+      gap: theme.spacing(SPACING.micro),
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.micro)} 0`
     },
     ".presets-label": {
       fontSize: theme.fontSizeSmaller,
       color: theme.vars.palette.text.secondary,
-      textTransform: "uppercase",
-      letterSpacing: "0.04em"
+      letterSpacing: "normal"
     },
     ".preset-chip": {
       cursor: "pointer",
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)}`,
       borderRadius: BORDER_RADIUS.sm,
       border: `1px solid ${theme.vars.palette.divider}`,
       background: "transparent",
@@ -303,6 +301,7 @@ const ResizeImageBodyInner: React.FC<ResizeImageBodyProps> = ({
 
       <div className="mode-row">
         <ToggleGroup
+          quiet
           value={mode}
           exclusive
           onChange={handleModeChange}

--- a/web/src/components/node_types/editing/RotateAndFlipBody.tsx
+++ b/web/src/components/node_types/editing/RotateAndFlipBody.tsx
@@ -14,7 +14,7 @@ import ImageIcon from "@mui/icons-material/Image";
 import FlipIcon from "@mui/icons-material/Flip";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 
-import {
+import { SPACING,
   CheckerDropzone,
   FlexColumn,
   FlexRow,
@@ -34,15 +34,15 @@ import { ROTATE_AND_FLIP_NODE_TYPE } from "../../../constants/nodeTypes";
 // 90° snap marks across the slider's full -360..360 range. Material UI's
 // `Slider` shows ticks for `marks`; the user can still drag freely between.
 const ANGLE_MARKS = [
-  { value: -360, label: "-360" },
+  { value: -360 },
   { value: -270 },
   { value: -180 },
   { value: -90 },
-  { value: 0, label: "0" },
+  { value: 0 },
   { value: 90 },
   { value: 180 },
   { value: 270 },
-  { value: 360, label: "360" }
+  { value: 360 }
 ];
 
 const styles = (theme: Theme) =>
@@ -53,22 +53,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 160,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -81,11 +81,11 @@ const styles = (theme: Theme) =>
     },
     ".controls": {
       flex: "0 0 auto",
-      paddingTop: theme.spacing(0.5)
+      paddingTop: theme.spacing(SPACING.micro)
     },
     ".angle-row": {
-      paddingLeft: theme.spacing(0.5),
-      paddingRight: theme.spacing(0.5)
+      paddingLeft: theme.spacing(SPACING.micro),
+      paddingRight: theme.spacing(SPACING.micro)
     },
     ".angle-readout": {
       flex: "0 0 auto",
@@ -96,7 +96,7 @@ const styles = (theme: Theme) =>
       textAlign: "right"
     },
     ".action-row": {
-      paddingTop: theme.spacing(0.5)
+      paddingTop: theme.spacing(SPACING.micro)
     },
     ".outputs-row": {
       flex: "0 0 auto"

--- a/web/src/components/node_types/editing/ScaleBody.tsx
+++ b/web/src/components/node_types/editing/ScaleBody.tsx
@@ -13,7 +13,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 
-import { CheckerDropzone, NodeSlider, BORDER_RADIUS } from "../../ui_primitives";
+import { SPACING, CheckerDropzone, NodeSlider, BORDER_RADIUS } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import ImageRefPreview from "../../node/ImageRefPreview";
 import { NodeOutputs } from "../../node/NodeOutputs";
@@ -38,22 +38,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 160,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -65,9 +65,9 @@ const styles = (theme: Theme) =>
       },
       ".dimensions-badge": {
         position: "absolute",
-        bottom: theme.spacing(0.5),
-        right: theme.spacing(0.5),
-        padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+        bottom: theme.spacing(SPACING.micro),
+        right: theme.spacing(SPACING.micro),
+        padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)}`,
         background: theme.vars.palette.c_scrim,
         color: theme.vars.palette.common.white,
         fontFamily: theme.fontFamily2,
@@ -79,17 +79,16 @@ const styles = (theme: Theme) =>
     ".controls": {
       flex: "0 0 auto",
       display: "grid",
-      gridTemplateColumns: "auto 1fr auto",
-      columnGap: theme.spacing(1),
-      rowGap: theme.spacing(1),
+      gridTemplateColumns: "minmax(0, auto) minmax(40px, 1fr) auto",
+      columnGap: theme.spacing(SPACING.xs),
+      rowGap: theme.spacing(SPACING.xs),
       alignItems: "center",
-      padding: `${theme.spacing(0.5)} ${theme.spacing(1)} ${theme.spacing(0.5)}`
+      padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.micro)}`
     },
     ".ctrl-label": {
       fontSize: theme.fontSizeSmaller,
       color: theme.vars.palette.text.secondary,
-      textTransform: "uppercase",
-      letterSpacing: "0.04em",
+      letterSpacing: "normal",
       lineHeight: 1
     },
     ".ctrl-value": {

--- a/web/src/components/node_types/editing/SimpleFilterBody.tsx
+++ b/web/src/components/node_types/editing/SimpleFilterBody.tsx
@@ -16,7 +16,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import ImageIcon from "@mui/icons-material/Image";
 
-import {
+import { SPACING,
   CheckerDropzone,
   FlexColumn,
   FlexRow,
@@ -44,22 +44,22 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(0.5),
-      padding: theme.spacing(0.5),
+      gap: theme.spacing(SPACING.micro),
+      padding: theme.spacing(SPACING.micro),
       minHeight: 0
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: `calc(${theme.spacing(0)})`
     },
     ".preview-area": {
       position: "relative",
       flex: "1 1 auto",
-      minHeight: 160,
+      minHeight: 96,
       borderRadius: BORDER_RADIUS.sm,
       overflow: "hidden",
-      backgroundColor: theme.vars.palette.grey[900],
+      backgroundColor: theme.vars.palette.background.default,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -80,7 +80,7 @@ const styles = (theme: Theme) =>
       width: "100%",
       ".MuiToggleButton-root": {
         flex: "1 1 auto",
-        padding: `${theme.spacing(0.5)} ${theme.spacing(0.5)}`,
+        padding: `${theme.spacing(SPACING.micro)} ${theme.spacing(SPACING.micro)}`,
         fontSize: theme.fontSizeSmaller,
         fontFamily: theme.fontFamily2,
         textTransform: "none",
@@ -213,6 +213,7 @@ const SimpleFilterBodyInner: React.FC<SimpleFilterBodyProps> = ({
       <FlexColumn className="preview-tab-bar" gap={0.5}>
         <FlexRow className="tab-toggle-row" align="center" gap={0.5}>
           <ToggleGroup
+          quiet
             className="tab-toggle"
             size="small"
             value={tab}

--- a/web/src/components/node_types/editing/__tests__/AdjustmentBody.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/AdjustmentBody.test.tsx
@@ -72,6 +72,8 @@ jest.mock("@mui/material/styles", () => ({
     spacing: (n: number) => `${n * 8}px`,
     vars: {
       palette: {
+        background: { default: "#18191d", paper: "#24262b" },
+        action: { selected: "#34373e" },
         primary: { main: "#6a8dff" },
         grey: { 900: "#111", 800: "#222", 700: "#333", 600: "#555", 500: "#888" },
         text: { secondary: "#999", primary: "#fff" }

--- a/web/src/components/node_types/synth/AudioOutBody.tsx
+++ b/web/src/components/node_types/synth/AudioOutBody.tsx
@@ -12,7 +12,7 @@ import React, { memo, useCallback, useMemo, useRef } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { BORDER_RADIUS, FONT_WEIGHT } from "../../ui_primitives";
+import { SPACING, BORDER_RADIUS, FONT_WEIGHT } from "../../ui_primitives";
 
 import HandleColumn from "../../node/HandleColumn";
 import { NodeOutputs } from "../../node/NodeOutputs";
@@ -31,15 +31,14 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(1),
-      padding: theme.spacing(1),
+      gap: theme.spacing(SPACING.xs),
+      padding: theme.spacing(SPACING.xs),
       minHeight: 0,
-      borderRadius: BORDER_RADIUS.sm,
-      backgroundColor: theme.vars.palette.grey[900]
+      borderRadius: BORDER_RADIUS.sm
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: 0
     },
     ".module-label": {
@@ -47,18 +46,17 @@ const styles = (theme: Theme) =>
       fontFamily: theme.fontFamily2,
       fontSize: theme.fontSizeSmaller,
       fontWeight: FONT_WEIGHT.semibold,
-      letterSpacing: "0.18em",
+      letterSpacing: "0.04em",
       textTransform: "uppercase",
       lineHeight: 1,
       color: theme.vars.palette.text.secondary,
-      padding: `2px ${theme.spacing(1)}`,
-      borderRadius: BORDER_RADIUS.sm,
-      border: `1px solid ${theme.vars.palette.grey[800]}`
+      padding: `2px ${theme.spacing(SPACING.xs)}`,
+      borderRadius: BORDER_RADIUS.sm
     },
     ".player": {
       flex: "1 1 auto",
       minHeight: 0,
-      padding: `0 ${theme.spacing(0.5)}`
+      padding: `0 ${theme.spacing(SPACING.micro)}`
     },
     ".idle-hint": {
       flex: "1 1 auto",

--- a/web/src/components/node_types/synth/SynthKnob.tsx
+++ b/web/src/components/node_types/synth/SynthKnob.tsx
@@ -55,7 +55,8 @@ export const synthKnobStyles = (theme: Theme) =>
       width: KNOB_SIZE + 12,
       outline: "none",
       "&:focus-visible .knob-face": {
-        boxShadow: `0 0 0 2px color-mix(in srgb, ${theme.vars.palette.primary.main} 60%, transparent)`
+        outline: `2px solid ${theme.vars.palette.primary.main}`,
+        outlineOffset: 3
       }
     },
     ".knob-face": {
@@ -64,15 +65,13 @@ export const synthKnobStyles = (theme: Theme) =>
       borderRadius: BORDER_RADIUS.circle,
       cursor: "ns-resize",
       touchAction: "none",
-      backgroundColor: theme.vars.palette.grey[800],
-      boxShadow: "inset 0 1px 2px rgba(0,0,0,0.5), 0 1px 1px rgba(0,0,0,0.3)"
+      backgroundColor: theme.vars.palette.action.hover
     },
     ".knob-label": {
       fontSize: theme.fontSizeSmaller,
       fontWeight: FONT_WEIGHT.medium,
       color: theme.vars.palette.text.secondary,
-      textTransform: "uppercase",
-      letterSpacing: "0.05em",
+      letterSpacing: "normal",
       lineHeight: 1,
       whiteSpace: "nowrap"
     },

--- a/web/src/components/node_types/synth/SynthModuleBody.tsx
+++ b/web/src/components/node_types/synth/SynthModuleBody.tsx
@@ -12,7 +12,7 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
-import { ToggleGroup, ToggleOption, BORDER_RADIUS, FONT_WEIGHT } from "../../ui_primitives";
+import { SPACING, ToggleGroup, ToggleOption, BORDER_RADIUS, FONT_WEIGHT } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
 import { NodeOutputs } from "../../node/NodeOutputs";
 import NodeProgress from "../../node/NodeProgress";
@@ -40,15 +40,14 @@ const styles = (theme: Theme) =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      gap: theme.spacing(1),
-      padding: theme.spacing(1),
+      gap: theme.spacing(SPACING.xs),
+      padding: theme.spacing(SPACING.xs),
       minHeight: 0,
-      borderRadius: BORDER_RADIUS.sm,
-      backgroundColor: theme.vars.palette.grey[900]
+      borderRadius: BORDER_RADIUS.sm
     },
     "& > .handle-column": {
-      top: theme.spacing(1),
-      bottom: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
+      bottom: theme.spacing(SPACING.xs),
       left: 0
     },
     ".module-label": {
@@ -56,21 +55,20 @@ const styles = (theme: Theme) =>
       fontFamily: theme.fontFamily2,
       fontSize: theme.fontSizeSmaller,
       fontWeight: FONT_WEIGHT.semibold,
-      letterSpacing: "0.18em",
+      letterSpacing: "0.04em",
       textTransform: "uppercase",
       lineHeight: 1,
       color: theme.vars.palette.text.secondary,
-      padding: `2px ${theme.spacing(1)}`,
-      borderRadius: BORDER_RADIUS.sm,
-      border: `1px solid ${theme.vars.palette.grey[800]}`
+      padding: `2px ${theme.spacing(SPACING.xs)}`,
+      borderRadius: BORDER_RADIUS.sm
     },
     ".adsr-preview": {
-      padding: `0 ${theme.spacing(0.5)}`
+      padding: `0 ${theme.spacing(SPACING.micro)}`
     },
     ".mode-toggle": {
       alignSelf: "center",
       ".MuiToggleButton-root": {
-        padding: `2px ${theme.spacing(1.5)}`,
+        padding: `2px ${theme.spacing(SPACING.sm)}`,
         fontSize: theme.fontSizeSmaller,
         fontFamily: theme.fontFamily2,
         lineHeight: 1.4,
@@ -84,8 +82,8 @@ const styles = (theme: Theme) =>
       justifyContent: "center",
       alignItems: "flex-start",
       alignContent: "center",
-      columnGap: theme.spacing(0.5),
-      rowGap: theme.spacing(1),
+      columnGap: theme.spacing(SPACING.micro),
+      rowGap: theme.spacing(SPACING.xs),
       minHeight: 0
     },
     ".jack-labels": {
@@ -94,7 +92,7 @@ const styles = (theme: Theme) =>
       gap: 2,
       position: "absolute",
       left: theme.spacing(1.25),
-      top: theme.spacing(1),
+      top: theme.spacing(SPACING.xs),
       pointerEvents: "none"
     },
     ".jack-label": {
@@ -104,7 +102,7 @@ const styles = (theme: Theme) =>
       letterSpacing: "0.05em",
       lineHeight: "18px",
       height: 18,
-      marginBottom: theme.spacing(2),
+      marginBottom: theme.spacing(SPACING.md),
       "&:last-child": { marginBottom: 0 }
     },
     ".outputs-row": {
@@ -283,6 +281,7 @@ const SynthModuleBodyInner: React.FC<SynthModuleBodyProps> = ({
 
       {config.modeToggle && (
         <ToggleGroup
+          quiet
           className="mode-toggle nodrag"
           size="small"
           exclusive
@@ -305,6 +304,7 @@ const SynthModuleBodyInner: React.FC<SynthModuleBodyProps> = ({
           props[t.name] === undefined ? t.default : Boolean(props[t.name]);
         return (
           <ToggleGroup
+          quiet
             key={t.name}
             className="mode-toggle nodrag"
             size="small"

--- a/web/src/components/node_types/synth/WaveformSelector.tsx
+++ b/web/src/components/node_types/synth/WaveformSelector.tsx
@@ -34,7 +34,7 @@ export const waveformSelectorStyles = (theme: Theme) =>
       alignItems: "center",
       justifyContent: "center",
       width: 26,
-      height: 20,
+      height: 24,
       padding: 0,
       border: "none",
       borderRadius: BORDER_RADIUS.sm,
@@ -42,10 +42,14 @@ export const waveformSelectorStyles = (theme: Theme) =>
       color: theme.vars.palette.text.secondary,
       cursor: "pointer",
       "&:hover": {
-        backgroundColor: theme.vars.palette.grey[800]
+        backgroundColor: theme.vars.palette.action.hover
       },
       "&.active": {
-        backgroundColor: theme.vars.palette.grey[800]
+        backgroundColor: theme.vars.palette.action.selected
+      },
+      "&:focus-visible": {
+        outline: `2px solid ${theme.vars.palette.primary.main}`,
+        outlineOffset: 2
       }
     }
   });

--- a/web/src/components/panels/FloatingToolBar.tsx
+++ b/web/src/components/panels/FloatingToolBar.tsx
@@ -5,7 +5,7 @@ import type { Theme } from "@mui/material/styles";
 import React, { memo, useCallback, useEffect } from "react";
 import { useMediaQuery } from "@mui/material";
 import { EditorMenu } from "../ui_primitives";
-import { Tooltip, AlertBanner, FlexRow, MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
+import { Tooltip, AlertBanner, FlexRow, MOTION, BORDER_RADIUS, SPACING, getSpacingPx, SHADOW, reducedMotion } from "../ui_primitives";
 import AddCircleIcon from "@mui/icons-material/AddCircle";
 import PlayArrow from "@mui/icons-material/PlayArrow";
 import StopIcon from "@mui/icons-material/Stop";
@@ -27,9 +27,11 @@ import { useNodes } from "../../contexts/NodeContext";
 import { useSettingsStore } from "../../stores/SettingsStore";
 import { useMiniMapStore } from "../../stores/MiniMapStore";
 import { useBottomPanelStore } from "../../stores/BottomPanelStore";
+import { useRightPanelStore } from "../../stores/RightPanelStore";
+import { usePanelStore } from "../../stores/PanelStore";
 import { useCombo } from "../../stores/KeyPressedStore";
 import MobilePaneMenu from "../menus/MobilePaneMenu";
-import { TOOLTIP_ENTER_DELAY } from "../../config/constants";
+import { TOOLTIP_ENTER_DELAY, TOOLBAR_WIDTH, LEFT_PANEL_MIN_DRAWER_WIDTH } from "../../config/constants";
 import { getShortcutTooltip } from "../../config/shortcuts";
 import { cn } from "../editor_ui/editorUtils";
 import { MenuItemPrimitive } from "../ui_primitives";
@@ -105,6 +107,44 @@ const dockStyles = (theme: Theme) =>
     alignItems: "stretch",
     gap: `${theme.spacing(1)}`,
     pointerEvents: "auto",
+    minWidth: 0,
+    maxWidth: `calc(100% - ${getSpacingPx(SPACING.xl)})`,
+    containerType: "inline-size",
+    containerName: "canvas-dock",
+
+    ".media-compose-card": {
+      borderRadius: BORDER_RADIUS.lg,
+      background: theme.vars.palette.background.paper,
+      backdropFilter: "none",
+      boxShadow: SHADOW(theme).sm,
+      gap: theme.spacing(SPACING.xs),
+      "&:focus-within": {
+        boxShadow: `0 0 0 1px ${theme.vars.palette.primary.main}`
+      }
+    },
+    ".media-compose-card textarea.media-compose-input": {
+      padding: `${theme.spacing(SPACING.xs)} ${theme.spacing(SPACING.md)}`
+    },
+    "@container canvas-dock (max-width: 640px)": {
+      ".media-chip-row.has-trailing": {
+        flexWrap: "wrap",
+        rowGap: theme.spacing(SPACING.xs)
+      },
+      ".media-chip-row.has-trailing .media-chip-main": {
+        flexBasis: "100%",
+        overflowX: "auto"
+      },
+      ".composer-drag-handle, .media-primary-action": {
+        order: 1
+      },
+      ".composer-workflow-actions": {
+        order: 1,
+        marginLeft: "auto",
+        paddingLeft: 0,
+        borderLeft: "none",
+        flexWrap: "wrap"
+      }
+    },
 
     // Grab affordance the user drags to move the whole dock. Rendered as a
     // span (not a button) so the drag hook's `cancel="button"` doesn't exclude
@@ -157,7 +197,12 @@ const actionStyles = (theme: Theme) =>
       border: "none",
       cursor: "pointer",
       borderRadius: BORDER_RADIUS.pill,
-      transition: `${MOTION.background}, color ${MOTION.fast}`
+      transition: `${MOTION.background}, color ${MOTION.fast}`,
+      ...reducedMotion({ transition: MOTION.none }),
+      "&:focus-visible": {
+        outline: `2px solid ${theme.vars.palette.primary.main}`,
+        outlineOffset: 2
+      }
     },
 
     ".composer-run": {
@@ -298,6 +343,13 @@ const FloatingToolBar: React.FC = memo(function FloatingToolBar() {
   const toolbarPosition = useFloatingToolbarPosition(
     bottomPanelVisible,
     bottomPanelSize
+  );
+  const inspectorWidth = useRightPanelStore((state) =>
+    state.panel.isVisible ? state.panel.panelSize : 0
+  );
+  const leftPanelWidth = usePanelStore((state) => state.panel.isVisible
+    ? Math.max(state.panel.panelSize, TOOLBAR_WIDTH + LEFT_PANEL_MIN_DRAWER_WIDTH)
+    : TOOLBAR_WIDTH
   );
 
   const { instantUpdate, setInstantUpdate, editorViewMode, setEditorViewMode } =
@@ -652,7 +704,11 @@ const FloatingToolBar: React.FC = memo(function FloatingToolBar() {
     <>
       <div
         css={dockLayerStyles(theme)}
-        style={isMobile ? MOBILE_DOCK_LAYER_STYLE : toolbarPosition}
+        style={isMobile ? MOBILE_DOCK_LAYER_STYLE : {
+          ...toolbarPosition,
+          right: inspectorWidth,
+          left: leftPanelWidth
+        }}
       >
         <div
           ref={dockRef}

--- a/web/src/components/panels/PanelRight.tsx
+++ b/web/src/components/panels/PanelRight.tsx
@@ -28,7 +28,6 @@ import {
   FlexColumn,
   MOTION,
   reducedMotion,
-  SHADOW,
   Z_INDEX
 } from "../ui_primitives";
 
@@ -56,7 +55,6 @@ const styles = (theme: Theme, bottomOffset: number, isVisible: boolean) =>
       height: "100%",
       backgroundColor: theme.vars.palette.background.default,
       borderLeft: `1px solid ${theme.vars.palette.divider}`,
-      boxShadow: SHADOW(theme).panelRight,
       overflow: "hidden",
       display: "flex",
       flexDirection: "column"
@@ -255,7 +253,7 @@ const PanelRight: React.FC = () => {
             <div className="inspector-region">{inspectorBody}</div>
             {currentWorkflowId && (
               <div className="cost-region">
-                <WorkflowCostEstimatePanel workflowId={currentWorkflowId} />
+                <WorkflowCostEstimatePanel workflowId={currentWorkflowId} compact />
               </div>
             )}
           </div>

--- a/web/src/components/themes/components/editorControls.ts
+++ b/web/src/components/themes/components/editorControls.ts
@@ -20,7 +20,7 @@ export const editorControlsComponents: Components<Theme> = {
             minHeight: "unset",
             padding: 0,
             color: theme.vars.palette.text.primary,
-            backgroundColor: theme.vars.palette.Paper.overlay,
+            backgroundColor: theme.vars.palette.c_overlay_subtle,
             borderRadius: editor.controlRadius,
             transition: theme.transitions.create(
               ["border-color", "background-color"],
@@ -30,7 +30,7 @@ export const editorControlsComponents: Components<Theme> = {
             ),
 
             "& .MuiOutlinedInput-notchedOutline": {
-              borderColor: theme.vars.palette.divider,
+              borderColor: "transparent",
               borderWidth: "1px",
               transition: theme.transitions.create(["border-color"], {
                 duration: theme.transitions.duration.shortest
@@ -49,8 +49,15 @@ export const editorControlsComponents: Components<Theme> = {
             "&.Mui-focused": {
               backgroundColor: theme.vars.palette.action.selected,
               "& .MuiOutlinedInput-notchedOutline": {
-                borderColor: theme.vars.palette.primary.main
+                borderColor: theme.vars.palette.primary.main,
+                borderWidth: "2px"
               }
+            },
+            "&.Mui-error .MuiOutlinedInput-notchedOutline": {
+              borderColor: theme.vars.palette.error.main
+            },
+            "&.Mui-disabled": {
+              backgroundColor: theme.vars.palette.action.disabledBackground
             },
 
             // Notched outline legend (hide it) — avoids weird notch sizing on dense controls
@@ -63,7 +70,7 @@ export const editorControlsComponents: Components<Theme> = {
               padding: `${editor.padYInspector} ${editor.padXInspector}`,
               minHeight: "1.7em",
               lineHeight: "1.5em",
-              fontSize: theme.fontSizeSmaller
+              fontSize: theme.fontSizeSmall
             },
             [`&.${editorUiClasses.scopeNode} .MuiOutlinedInput-input`]: {
               padding: 0,
@@ -101,9 +108,9 @@ export const editorControlsComponents: Components<Theme> = {
             padding: `${editor.padYNode} ${editor.padXNode}`,
             paddingRight: getSpacingPx(SPACING.xxl),
             fontSize: theme.fontSizeSmaller,
-            backgroundColor: theme.vars.palette.Paper.overlay,
+            backgroundColor: "transparent",
             borderRadius: editor.controlRadius,
-            border: `1px solid ${theme.vars.palette.divider}`,
+            border: "none",
             margin: 0,
             minHeight: editor.heightNode,
             display: "flex",
@@ -115,12 +122,10 @@ export const editorControlsComponents: Components<Theme> = {
               }
             ),
             "&:hover": {
-              backgroundColor: theme.vars.palette.action.selected,
-              borderColor: theme.vars.palette.text.secondary
+              backgroundColor: "transparent"
             },
             "&:focus": {
-              backgroundColor: theme.vars.palette.action.selected,
-              borderColor: theme.vars.palette.primary.main
+              backgroundColor: "transparent"
             }
           },
           [`.${editorUiClasses.control}.${editorUiClasses.scopeInspector} &`]: {

--- a/web/src/components/ui_primitives/CheckerDropzone.tsx
+++ b/web/src/components/ui_primitives/CheckerDropzone.tsx
@@ -14,7 +14,7 @@ import React, { memo, useCallback, useState } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
-import { MOTION } from "./tokens";
+import { MOTION, BORDER_RADIUS, reducedMotion } from "./tokens";
 
 const DEFAULT_CHECKER_SIZE = 12;
 
@@ -29,19 +29,19 @@ const styles = (theme: Theme, checkerSize: number, isOver: boolean) =>
     alignItems: "center",
     justifyContent: "center",
     gap: theme.spacing(0.5),
-    borderRadius: "var(--rounded-sm)",
-    color: theme.vars.palette.grey[400],
+    borderRadius: BORDER_RADIUS.sm,
+    color: theme.vars.palette.text.secondary,
     fontFamily: theme.fontFamily1,
     fontSize: theme.fontSizeSmall,
     textAlign: "center",
     overflow: "hidden",
     // CSS-only checker pattern using two layered gradients
-    backgroundColor: theme.vars.palette.grey[900],
+    backgroundColor: theme.vars.palette.c_overlay_subtle,
     backgroundImage: `
-      linear-gradient(45deg, ${theme.vars.palette.grey[800]} 25%, transparent 25%),
-      linear-gradient(-45deg, ${theme.vars.palette.grey[800]} 25%, transparent 25%),
-      linear-gradient(45deg, transparent 75%, ${theme.vars.palette.grey[800]} 75%),
-      linear-gradient(-45deg, transparent 75%, ${theme.vars.palette.grey[800]} 75%)
+      linear-gradient(45deg, color-mix(in srgb, ${theme.vars.palette.c_overlay_subtle} 35%, transparent) 25%, transparent 25%),
+      linear-gradient(-45deg, color-mix(in srgb, ${theme.vars.palette.c_overlay_subtle} 35%, transparent) 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, color-mix(in srgb, ${theme.vars.palette.c_overlay_subtle} 35%, transparent) 75%),
+      linear-gradient(-45deg, transparent 75%, color-mix(in srgb, ${theme.vars.palette.c_overlay_subtle} 35%, transparent) 75%)
     `,
     backgroundSize: `${checkerSize * 2}px ${checkerSize * 2}px`,
     backgroundPosition: [
@@ -50,7 +50,8 @@ const styles = (theme: Theme, checkerSize: number, isOver: boolean) =>
       `${checkerSize}px -${checkerSize}px`,
       `-${checkerSize}px 0px`
     ].join(", "),
-    transition: `${MOTION.shadow}, border-color 150ms ease`,
+    transition: `${MOTION.shadow}, ${MOTION.border}`,
+    ...reducedMotion({ transition: MOTION.none }),
     outline: isOver
       ? `2px dashed ${theme.vars.palette.primary.main}`
       : "1px solid transparent",
@@ -58,7 +59,7 @@ const styles = (theme: Theme, checkerSize: number, isOver: boolean) =>
     ".checker-icon": {
       opacity: 0.55,
       "& svg": {
-        fontSize: 36,
+        fontSize: "1.5em",
         display: "block"
       }
     },

--- a/web/src/components/ui_primitives/NodeSlider.tsx
+++ b/web/src/components/ui_primitives/NodeSlider.tsx
@@ -15,7 +15,8 @@ import { Slider, SliderProps } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { useEditorScope } from "../editor_ui";
 import { editorClassNames, cn } from "../editor_ui/editorUtils";
-import { MOTION } from "./tokens";
+import { BORDER_RADIUS, MOTION, reducedMotion } from "./tokens";
+import { SPACING } from "./spacing";
 
 export interface NodeSliderProps extends Omit<SliderProps, "size"> {
   /**
@@ -53,42 +54,47 @@ export const NodeSlider = forwardRef<HTMLSpanElement, NodeSliderProps>(
     useEditorScope();
 
     const sliderSx = useMemo(() => ({
-      marginTop: density === "compact" ? "4px" : "6px",
-      padding: 0,
+      marginTop: 0,
+      minWidth: 0,
+      padding: `${theme.spacing(SPACING.md)} 0`,
       "& .MuiSlider-rail": {
-        backgroundColor: theme.vars.palette.grey[500],
-        borderRadius: 0,
-        height: density === "compact" ? 5 : 6
+        backgroundColor: theme.vars.palette.action.selected,
+        opacity: 1,
+        borderRadius: BORDER_RADIUS.pill,
+        height: density === "compact" ? 4 : 6
       },
       "& .MuiSlider-track": {
-        height: density === "compact" ? 5 : 6,
+        height: density === "compact" ? 4 : 6,
         opacity: 1,
         left: 0,
-        borderRadius: 0,
+        borderRadius: BORDER_RADIUS.pill,
+        border: "none",
         backgroundColor: theme.vars.palette.primary.main
       },
       "& .MuiSlider-thumb": {
         backgroundColor: changed
           ? theme.vars.palette.primary.main
-          : theme.vars.palette.grey[200],
-        boxShadow: `0px 0px 5px 1px rgba(${theme.vars.palette.common.blackChannel ?? '0 0 0'} / 0.25)`,
-        borderRadius: 0,
-        width: density === "compact" ? 8 : 10,
-        height: density === "compact" ? 8 : 10,
+          : theme.vars.palette.text.secondary,
+        boxShadow: "none",
+        borderRadius: BORDER_RADIUS.circle,
+        width: density === "compact" ? 10 : 12,
+        height: density === "compact" ? 10 : 12,
         transition: MOTION.background,
+        ...reducedMotion({ transition: MOTION.none }),
         "&:hover, &:focus, &:active": {
-          boxShadow: `0px 0px 5px 1px rgba(${theme.vars.palette.common.blackChannel ?? '0 0 0'} / 0.25)`,
+          boxShadow: `0 0 0 4px ${theme.vars.palette.action.selected}`,
           backgroundColor: theme.vars.palette.primary.main
         },
         "&.Mui-focusVisible": {
-          boxShadow: `0px 0px 5px 1px rgba(${theme.vars.palette.common.blackChannel ?? '0 0 0'} / 0.25)`
+          outline: `2px solid ${theme.vars.palette.primary.main}`,
+          outlineOffset: 3
         },
         "&.Mui-active": {
-          boxShadow: `0px 0px 5px 1px rgba(${theme.vars.palette.common.blackChannel ?? '0 0 0'} / 0.25)`
+          boxShadow: `0 0 0 4px ${theme.vars.palette.action.selected}`
         },
         "&::before, &::after": {
-          width: density === "compact" ? 12 : 14,
-          height: density === "compact" ? 12 : 14
+          width: 24,
+          height: 24
         }
       },
       ...sx

--- a/web/src/components/ui_primitives/ToggleGroup.tsx
+++ b/web/src/components/ui_primitives/ToggleGroup.tsx
@@ -13,7 +13,8 @@ import {
   ToggleButtonProps,
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
-import { MOTION } from "./tokens";
+import { BORDER_RADIUS, MOTION, reducedMotion } from "./tokens";
+import { SPACING } from "./spacing";
 
 // --- ToggleGroup ---
 
@@ -23,6 +24,8 @@ export interface ToggleGroupProps
   size?: "small" | "medium" | "large";
   /** Compact mode with reduced padding */
   compact?: boolean;
+  /** Quiet node controls: no enclosing border, with a filled selected option. */
+  quiet?: boolean;
   /**
    * Segmented toolbar variant: a single bordered pill with a fixed 32px
    * height, sentence-case small text, and standardized selected/hover colors.
@@ -58,6 +61,7 @@ const SEGMENTED_HEIGHT = 32;
 const ToggleGroupInternal: React.FC<ToggleGroupProps> = ({
   size = "medium",
   compact = false,
+  quiet = false,
   segmented = false,
   fullWidth = false,
   sx,
@@ -121,6 +125,29 @@ const ToggleGroupInternal: React.FC<ToggleGroupProps> = ({
             },
           }),
         ...segmentedSx,
+        ...(quiet && {
+          gap: SPACING.micro,
+          "& .MuiToggleButtonGroup-grouped": {
+            minHeight: 24,
+            margin: 0,
+            border: "none",
+            borderRadius: BORDER_RADIUS.sm,
+            color: palette.text.secondary,
+            transition: MOTION.background,
+            ...reducedMotion({ transition: MOTION.none }),
+            "&:hover": { backgroundColor: palette.action.hover },
+            "&.Mui-selected": {
+              backgroundColor: palette.action.selected,
+              color: palette.text.primary,
+              "&:hover": { backgroundColor: palette.action.selected }
+            },
+            "&.Mui-focusVisible": {
+              outline: `2px solid ${palette.primary.main}`,
+              outlineOffset: -2
+            },
+            "&.Mui-disabled": { color: palette.action.disabled }
+          }
+        }),
         ...sx,
       }}
       {...props}

--- a/web/src/hooks/useFloatingToolbarPosition.ts
+++ b/web/src/hooks/useFloatingToolbarPosition.ts
@@ -1,10 +1,8 @@
 import { useMemo } from "react";
 
 /**
- * Position styles for the floating toolbar. Reacts only to the bottom panel
- * (which is user-driven). The right panel auto-opens on node selection, so
- * shifting the toolbar with it would make it jump on every click — instead
- * the toolbar stays centered and the inspector overlays it when needed.
+ * Vertical position for the floating toolbar above the bottom panel.
+ * FloatingToolBar sets horizontal bounds from the visible side panels.
  */
 export const useFloatingToolbarPosition = (
   bottomPanelVisible: boolean,

--- a/web/src/styles/nodes.base.css
+++ b/web/src/styles/nodes.base.css
@@ -90,21 +90,6 @@
   }
 }
 
-.react-flow__node .node-body::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  pointer-events: none;
-  background: linear-gradient(
-    180deg,
-    rgb(255 255 255 / 0.04) 0%,
-    rgb(255 255 255 / 0.015) 16%,
-    transparent 42%
-  );
-  opacity: 0.8;
-}
-
 .react-flow .has-result {
   border-bottom: 3px solid var(--palette-primary-main);
 }

--- a/web/src/styles/nodes.states.css
+++ b/web/src/styles/nodes.states.css
@@ -8,18 +8,7 @@
     --node-primary-color,
     var(--palette-text-primary)
   ) !important;
-  /* box-shadow instead of filter: drop-shadow(...) — filter forces the node's
-     paint through the filter pipeline and re-rasterizes the blur region on
-     every repaint (every drag frame while selected). box-shadow is composited
-     without re-rasterizing the node content. */
-  box-shadow:
-    0 0 10px
-      color-mix(
-        in srgb,
-        var(--node-primary-color, var(--palette-primary-main)) 22%,
-        transparent
-      ),
-    0 14px 24px rgb(0 0 0 / 0.18);
+  box-shadow: none;
 }
 
 .react-flow__node:not(.selected) {


### PR DESCRIPTION
## What changed

The Node Editor used nested borders, strong background fills, and oversized spacing that competed with workflow content. This change simplifies node surfaces, makes custom-node controls quieter, and compacts the inspector, node library, cost disclosure, and canvas composer. Editable fields retain hover and focus emphasis, selected toggles retain a visible fill, and node selection, execution, and error states remain distinct. The composer now accounts for open side panels and wraps within its available width.

## Verification

- [ ] `npm run test:affected`: 522 suites passed, 1 failed. The existing `useTimelineAgentBridge.test.tsx:400` failure expects `saw-lead` and receives `wt1-prime-lead`. This failure was also reproduced against the unchanged baseline during validation.
- [x] `NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck`: passed for web, Electron, and mobile. The first run exhausted Node’s default heap.
- [x] `npm run lint`
- [x] `npm run dev:nodetool -- harness gate --base origin/main`: passed, no applicable automatic selfchecks. The gate listed the optional expensive and manual harnesses without running them.

Rendered the editor at 1024, 1280, and 1600px widths, plus narrow inspector and node layouts. Checked keyboard slider adjustment and focus, toggle selection, blur mode changes, synth waveform selection, and the code editor. Added coverage for keyboard activation of the compact cost disclosure, preventing canvas shortcuts, and identifying incomplete estimates.

Rendered 101 custom node variants and four reference nodes in before/after sheets, then created all 105 on a single saved canvas using actual palette-drop events and default dimensions. No workflow was executed.

## Remaining dimension issues

Draft pending the default-size follow-up: the single-canvas check confirmed lower controls are clipped at 280 × 280 in Levels (`nodetool.image.Levels`), Color Grade (`lib.image.color.Grade`), CDL (`lib.image.color_grading.CDL`), and Exposure (`lib.image.color_grading.Exposure`). No control clipping was detected in the default state of the other 101 nodes. This is not exhaustive coverage of conditional controls or populated media states. Automatic content-driven node sizing is not implemented in this PR.
