### PR TITLE
feat(models): route image model preparation through workers

### DIFF
--- a/packages/protocol/src/bridge-frames.ts
+++ b/packages/protocol/src/bridge-frames.ts
@@ -288,7 +288,12 @@ const downloadProgressDataSchema = z
       "exists"
     ]),
     downloaded_bytes: z.number(),
-    total_bytes: z.number()
+    total_bytes: z.number(),
+    bytes_per_second: z.number().nonnegative().optional(),
+    seconds_since_activity: z.number().nonnegative().optional(),
+    elapsed_seconds: z.number().nonnegative().optional(),
+    free_bytes: z.number().nonnegative().optional(),
+    stalled: z.boolean().optional()
   })
   .passthrough();
 

--- a/packages/protocol/src/bridge-frames.ts
+++ b/packages/protocol/src/bridge-frames.ts
@@ -21,8 +21,9 @@
  *    Python worker repo's test suite validates against, so the two sides of
  *    the bridge can never silently drift apart.
  *
- * The dispatcher only ever switches on seven frame `type`s — `discover`,
- * `result`, `error`, `chunk`, `progress`, `comfy.event`, and `blender.event`
+ * The dispatcher switches on the response frame `type`s modeled below,
+ * including execution results, streamed output, blob transfer, progress, and
+ * integration events.
  * — everything else is either a request the JS side sends (`execute`,
  * `worker.status`, `provider.*`, `models.*`, `comfy.execute`,
  * `blender.execute`, …) or silently ignored. Only the seven response types
@@ -229,6 +230,37 @@ export const chunkFrameSchema = z.object({
   data: resultOrChunkDataSchema
 });
 
+const blobNameSchema = z.string().min(1);
+
+export const blobStartFrameSchema = z.object({
+  type: z.literal("blob.start"),
+  request_id: requestIdSchema,
+  data: z.object({
+    name: blobNameSchema,
+    size: z.number().int().nonnegative()
+  })
+});
+
+export const blobChunkFrameSchema = z.object({
+  type: z.literal("blob.chunk"),
+  request_id: requestIdSchema,
+  data: z.object({
+    name: blobNameSchema,
+    offset: z.number().int().nonnegative(),
+    bytes: z.instanceof(Uint8Array)
+  })
+});
+
+export const blobEndFrameSchema = z.object({
+  type: z.literal("blob.end"),
+  request_id: requestIdSchema,
+  data: z.object({
+    name: blobNameSchema,
+    size: z.number().int().nonnegative(),
+    sha256: z.string().regex(/^[a-f0-9]{64}$/)
+  })
+});
+
 // ---------------------------------------------------------------------------
 // progress
 // ---------------------------------------------------------------------------
@@ -375,6 +407,9 @@ export const bridgeFrameSchemas = {
   result: resultFrameSchema,
   error: errorFrameSchema,
   chunk: chunkFrameSchema,
+  "blob.start": blobStartFrameSchema,
+  "blob.chunk": blobChunkFrameSchema,
+  "blob.end": blobEndFrameSchema,
   progress: progressFrameSchema,
   "comfy.event": comfyEventFrameSchema,
   "blender.event": blenderEventFrameSchema
@@ -388,6 +423,9 @@ export const bridgeFrameSchema = z.discriminatedUnion("type", [
   resultFrameSchema,
   errorFrameSchema,
   chunkFrameSchema,
+  blobStartFrameSchema,
+  blobChunkFrameSchema,
+  blobEndFrameSchema,
   progressFrameSchema,
   comfyEventFrameSchema,
   blenderEventFrameSchema

--- a/packages/protocol/src/bridge-protocol.ts
+++ b/packages/protocol/src/bridge-protocol.ts
@@ -46,7 +46,7 @@
  *   3. Update `MIN_NODETOOL_CORE_VERSION` to that new release.
  */
 
-export const BRIDGE_PROTOCOL_VERSION = 4;
+export const BRIDGE_PROTOCOL_VERSION = 5;
 
 /**
  * Hard floor: the JS runtime rejects (at `discover`) any worker reporting a
@@ -63,6 +63,10 @@ export const BRIDGE_PROTOCOL_VERSION = 4;
  * JS side sends them unconditionally; only the new `job.start` / `job.end` /
  * `models.evict` message types are gated, because a pre-v4 worker answers
  * those with `Unknown message type`.
+ *
+ * v5 adds an optional `chunked-v1` execute-result blob transfer. The JS side
+ * requests it only from workers reporting v5 or newer; older workers keep
+ * returning the legacy inline `blobs` map.
  */
 export const MIN_BRIDGE_PROTOCOL_VERSION = 1;
 

--- a/packages/protocol/tests/error-and-protocol-coverage.test.ts
+++ b/packages/protocol/tests/error-and-protocol-coverage.test.ts
@@ -79,7 +79,7 @@ describe("error-helpers.isTRPCErrorWithCode", () => {
 
 describe("bridge-protocol constants", () => {
   it("BRIDGE_PROTOCOL_VERSION is the current speaking version", () => {
-    expect(BRIDGE_PROTOCOL_VERSION).toBe(4);
+    expect(BRIDGE_PROTOCOL_VERSION).toBe(5);
   });
 
   it("MIN_BRIDGE_PROTOCOL_VERSION is the hard floor at 1", () => {

--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -97,6 +97,7 @@ import type {
   PythonWorkerStatus,
   UnifiedModelLike,
   ModelDownloadRequest,
+  ModelPrepareRequest,
   ModelDownloadUpdate,
   ComfyStatusInfo,
   ComfyEvent,
@@ -1246,6 +1247,25 @@ export abstract class PythonBridgeBase
     );
   }
 
+  /** Prepare an image-owned model through an advertised worker backend. */
+  async prepareModel(
+    req: ModelPrepareRequest,
+    onProgress: (update: ModelDownloadUpdate) => void,
+    requestId: string = randomUUID()
+  ): Promise<void> {
+    const { token, ...rest } = req;
+    const payload: Record<string, unknown> =
+      typeof token === "string" && token.trim()
+        ? { ...rest, token: token.trim() }
+        : rest;
+    return this._streamingDownload(
+      "models.prepare",
+      payload,
+      (update) => onProgress(update as unknown as ModelDownloadUpdate),
+      requestId
+    );
+  }
+
   /**
    * Shared engine for the streaming-download RPCs (`models.download`,
    * `comfy.models.download`): a request that emits ordered `progress` frames
@@ -1362,6 +1382,14 @@ export abstract class PythonBridgeBase
    */
   supportsModelManagement(): boolean {
     return (this._workerStatus?.protocol_version ?? 0) >= 2;
+  }
+
+  /** Whether the attached image advertises a specific preparation backend. */
+  supportsModelPreparation(backend: string): boolean {
+    return (
+      (this._workerStatus?.protocol_version ?? 0) >= 5 &&
+      (this._workerStatus?.model_prepare_backends ?? []).includes(backend)
+    );
   }
 
   /**

--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -121,6 +121,14 @@ interface PendingRequest {
   resolve: (value: ExecuteResult) => void;
   reject: (error: Error) => void;
   onProgress?: (event: ProgressEvent) => void;
+  blobTransfers?: Map<string, BlobTransfer>;
+  completedBlobs?: Record<string, Uint8Array>;
+}
+
+interface BlobTransfer {
+  size: number;
+  received: number;
+  chunks: Uint8Array[];
 }
 
 interface PendingStreamRequest {
@@ -137,6 +145,9 @@ const DEFAULT_STATUS_TIMEOUT_MS = Number(
 );
 const DEFAULT_DOWNLOAD_IDLE_TIMEOUT_MS = Number(
   safeProcessEnv()["NODETOOL_PYTHON_DOWNLOAD_IDLE_TIMEOUT_MS"] ?? 5 * 60 * 1000
+);
+const MAX_RESULT_BLOB_BYTES = Number(
+  safeProcessEnv()["NODETOOL_PYTHON_MAX_RESULT_BLOB_BYTES"] ?? 2 * 1024 * 1024 * 1024
 );
 
 /**
@@ -312,11 +323,20 @@ export abstract class PythonBridgeBase
       const pending = this._pending.get(requestId);
       if (pending) {
         this._pending.delete(requestId);
+        if (pending.blobTransfers?.size) {
+          pending.reject(
+            new Error("Python worker ended the result before all blob transfers completed")
+          );
+          return;
+        }
         const data = msg.data as {
           outputs: Record<string, unknown>;
           blobs: Record<string, Uint8Array>;
         };
-        pending.resolve({ outputs: data.outputs, blobs: data.blobs ?? {} });
+        pending.resolve({
+          outputs: data.outputs,
+          blobs: { ...(data.blobs ?? {}), ...(pending.completedBlobs ?? {}) }
+        });
       }
     } else if (type === "error" && requestId) {
       const streamReq = this._pendingStream.get(requestId);
@@ -341,6 +361,12 @@ export abstract class PythonBridgeBase
       if (streamReq) {
         streamReq.onChunk(msg.data as Record<string, unknown>);
       }
+    } else if (type === "blob.start" && requestId) {
+      this._startBlobTransfer(requestId, msg.data as Record<string, unknown>);
+    } else if (type === "blob.chunk" && requestId) {
+      this._appendBlobChunk(requestId, msg.data as Record<string, unknown>);
+    } else if (type === "blob.end" && requestId) {
+      this._finishBlobTransfer(requestId, msg.data as Record<string, unknown>);
     } else if (type === "progress" && requestId) {
       const pending = this._pending.get(requestId);
       if (pending?.onProgress) {
@@ -366,6 +392,103 @@ export abstract class PythonBridgeBase
         onEvent(msg.data as BlenderEvent);
       }
     }
+  }
+
+  private _rejectBlobTransfer(requestId: string, message: string): void {
+    const pending = this._pending.get(requestId);
+    if (!pending) return;
+    this._pending.delete(requestId);
+    pending.reject(new Error(message));
+    try {
+      this.cancel(requestId);
+    } catch {
+      // The worker may already have completed; cancellation is best-effort.
+    }
+  }
+
+  private _startBlobTransfer(
+    requestId: string,
+    data: Record<string, unknown>
+  ): void {
+    const pending = this._pending.get(requestId);
+    const name = data["name"];
+    const size = data["size"];
+    if (!pending || typeof name !== "string" || typeof size !== "number") return;
+    if (!Number.isSafeInteger(size) || size < 0 || size > MAX_RESULT_BLOB_BYTES) {
+      this._rejectBlobTransfer(
+        requestId,
+        `Python worker declared invalid blob size ${String(size)} for "${name}"`
+      );
+      return;
+    }
+    pending.blobTransfers ??= new Map();
+    pending.completedBlobs ??= Object.create(null) as Record<string, Uint8Array>;
+    if (pending.blobTransfers.has(name) || Object.hasOwn(pending.completedBlobs, name)) {
+      this._rejectBlobTransfer(requestId, `Python worker started duplicate blob "${name}"`);
+      return;
+    }
+    pending.blobTransfers.set(name, { size, received: 0, chunks: [] });
+  }
+
+  private _appendBlobChunk(
+    requestId: string,
+    data: Record<string, unknown>
+  ): void {
+    const pending = this._pending.get(requestId);
+    const name = data["name"];
+    const offset = data["offset"];
+    const bytes = data["bytes"];
+    if (
+      !pending ||
+      typeof name !== "string" ||
+      typeof offset !== "number" ||
+      !(bytes instanceof Uint8Array)
+    ) return;
+    const transfer = pending.blobTransfers?.get(name);
+    if (!transfer || offset !== transfer.received || offset + bytes.length > transfer.size) {
+      this._rejectBlobTransfer(
+        requestId,
+        `Python worker sent an out-of-order or oversized chunk for blob "${name}"`
+      );
+      return;
+    }
+    transfer.chunks.push(bytes);
+    transfer.received += bytes.length;
+  }
+
+  private _finishBlobTransfer(
+    requestId: string,
+    data: Record<string, unknown>
+  ): void {
+    const pending = this._pending.get(requestId);
+    const name = data["name"];
+    const size = data["size"];
+    const expectedDigest = data["sha256"];
+    if (
+      !pending ||
+      typeof name !== "string" ||
+      typeof size !== "number" ||
+      typeof expectedDigest !== "string"
+    ) return;
+    const transfer = pending.blobTransfers?.get(name);
+    if (!transfer || size !== transfer.size || transfer.received !== transfer.size) {
+      this._rejectBlobTransfer(requestId, `Python worker truncated blob "${name}"`);
+      return;
+    }
+    const blob = new Uint8Array(transfer.size);
+    let offset = 0;
+    for (const chunk of transfer.chunks) {
+      blob.set(chunk, offset);
+      offset += chunk.length;
+    }
+    const digest = nodeCrypto?.createHash("sha256").update(blob).digest("hex");
+    if (!digest || digest !== expectedDigest) {
+      this._rejectBlobTransfer(requestId, `Python worker blob "${name}" failed SHA-256 verification`);
+      return;
+    }
+    pending.blobTransfers?.delete(name);
+    pending.completedBlobs ??= Object.create(null) as Record<string, Uint8Array>;
+    pending.completedBlobs[name] = blob;
   }
 
   /**
@@ -525,6 +648,10 @@ export abstract class PythonBridgeBase
             fields,
             secrets,
             blobs,
+            ...(this._workerStatus?.protocol_version != null &&
+            this._workerStatus.protocol_version >= 5
+              ? { blob_transfer: "chunked-v1" }
+              : {}),
             ...this._identityPayload(identity)
           }
         });

--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -637,23 +637,27 @@ export abstract class PythonBridgeBase
 
     log.debug("Python bridge execute dispatched", { nodeType, requestId });
 
+    const executeData: Record<string, unknown> = {
+      node_type: nodeType,
+      fields,
+      secrets,
+      blobs,
+      ...this._identityPayload(identity)
+    };
+    if (
+      this._workerStatus?.protocol_version != null &&
+      this._workerStatus.protocol_version >= 5
+    ) {
+      executeData["blob_transfer"] = "chunked-v1";
+    }
+
     const executePromise = new Promise<ExecuteResult>((resolve, reject) => {
       this._pending.set(requestId, { resolve, reject, onProgress });
       try {
         this._send({
           type: "execute",
           request_id: requestId,
-          data: {
-            node_type: nodeType,
-            fields,
-            secrets,
-            blobs,
-            ...(this._workerStatus?.protocol_version != null &&
-            this._workerStatus.protocol_version >= 5
-              ? { blob_transfer: "chunked-v1" }
-              : {}),
-            ...this._identityPayload(identity)
-          }
+          data: executeData
         });
       } catch (err) {
         this._pending.delete(requestId);

--- a/packages/runtime/src/python-bridge-types.ts
+++ b/packages/runtime/src/python-bridge-types.ts
@@ -157,6 +157,16 @@ export interface ModelDownloadRequest {
   token?: string | null;
 }
 
+/** Request payload for an image-provided `models.prepare` backend. */
+export interface ModelPrepareRequest {
+  backend: string;
+  model_type: string;
+  /** Stable logical id used by the shared model download manager. */
+  repo_id: string;
+  /** Optional request-scoped Hugging Face credential for gated files. */
+  token?: string | null;
+}
+
 /**
  * A `models.download` progress frame. Mirrors the worker's progress `data`
  * field AND the local `DownloadUpdate` the web ModelDownloadStore already
@@ -173,6 +183,15 @@ export interface ModelDownloadUpdate {
   current_files: string[];
   total_files: number;
   error?: string;
+  message?: string;
+  /** Adapter-reported write rate when the remote total is unknown. */
+  bytes_per_second?: number;
+  /** Seconds since files or process write counters last changed. */
+  seconds_since_activity?: number;
+  elapsed_seconds?: number;
+  free_bytes?: number;
+  /** Advisory only; the worker does not abort a stalled operation. */
+  stalled?: boolean;
 }
 
 // ── ComfyUI proxy (bridge protocol v3+) ───────────────────────────────────
@@ -468,6 +487,8 @@ export interface PythonWorkerStatus {
   load_errors: PythonWorkerLoadError[];
   transport: string;
   max_frame_size: number;
+  /** Image-provided backends accepted by `models.prepare`. */
+  model_prepare_backends: string[];
   /**
    * ComfyUI proxy status (protocol v3+). Present only when the worker fronts a
    * ComfyUI server; used to route `comfy.*` requests (see {@link ComfyStatusInfo}).
@@ -572,6 +593,12 @@ export interface PythonBridge extends EventEmitter {
     onProgress: (update: ModelDownloadUpdate) => void,
     requestId?: string
   ): Promise<void>;
+  prepareModel(
+    req: ModelPrepareRequest,
+    onProgress: (update: ModelDownloadUpdate) => void,
+    requestId?: string
+  ): Promise<void>;
+  supportsModelPreparation(backend: string): boolean;
   cancelModelDownload(requestId: string): void;
   deleteCachedModel(repoId: string): Promise<boolean>;
   supportsModelManagement(): boolean;
@@ -724,6 +751,7 @@ export const workerStatusSchema = z
     load_errors: z.array(workerLoadErrorSchema).catch([]),
     transport: z.string().catch(""),
     max_frame_size: z.number().catch(0),
+    model_prepare_backends: z.array(z.string()).catch([]),
     comfy: comfyStatusInfoSchema.optional().catch(undefined),
     blender: blenderStatusInfoSchema.optional().catch(undefined)
   })

--- a/packages/runtime/src/swappable-python-bridge.ts
+++ b/packages/runtime/src/swappable-python-bridge.ts
@@ -26,6 +26,7 @@ import type {
   PythonProviderInfo,
   UnifiedModelLike,
   ModelDownloadRequest,
+  ModelPrepareRequest,
   ModelDownloadUpdate,
   ComfyStatusInfo,
   ComfyEvent,
@@ -267,6 +268,18 @@ export class SwappableBridge extends EventEmitter implements PythonBridge {
     requestId?: string
   ): Promise<void> {
     return this._target.downloadModel(req, onProgress, requestId);
+  }
+
+  prepareModel(
+    req: ModelPrepareRequest,
+    onProgress: (update: ModelDownloadUpdate) => void,
+    requestId?: string
+  ): Promise<void> {
+    return this._target.prepareModel(req, onProgress, requestId);
+  }
+
+  supportsModelPreparation(backend: string): boolean {
+    return this._target.supportsModelPreparation(backend);
   }
 
   cancelModelDownload(requestId: string): void {

--- a/packages/runtime/tests/python-bridge-base-coverage.test.ts
+++ b/packages/runtime/tests/python-bridge-base-coverage.test.ts
@@ -330,7 +330,8 @@ describe("PythonBridgeBase — execute", () => {
       node_type: "n.T",
       fields: { a: 1 },
       secrets: { KEY: "v" },
-      blobs: {}
+      blobs: {},
+      blob_transfer: "chunked-v1"
     });
     bridge.handle({
       type: "result",

--- a/packages/runtime/tests/python-bridge-models.test.ts
+++ b/packages/runtime/tests/python-bridge-models.test.ts
@@ -19,8 +19,8 @@ import {
 import type { ModelDownloadUpdate } from "../src/python-bridge-types.js";
 
 describe("bridge protocol version", () => {
-  it("is 4 (models.* + comfy.* + run identity/job.* support)", () => {
-    expect(BRIDGE_PROTOCOL_VERSION).toBe(4);
+  it("is 5 (chunked result blobs)", () => {
+    expect(BRIDGE_PROTOCOL_VERSION).toBe(5);
   });
 });
 

--- a/packages/runtime/tests/python-bridge-models.test.ts
+++ b/packages/runtime/tests/python-bridge-models.test.ts
@@ -137,9 +137,48 @@ describe("models.* bridge methods", () => {
     });
   });
 
+  it("prepareModel uses an advertised image backend and streams telemetry", async () => {
+    worker = await startFakeWorker(0, {
+      protocolVersion: 5,
+      modelPrepareBackends: ["wangp"]
+    });
+    bridge = new WebsocketPythonBridge({ wsUrl: `ws://127.0.0.1:${worker.port}` });
+    await bridge.connect();
+
+    expect(bridge.supportsModelPreparation("wangp")).toBe(true);
+    expect(bridge.supportsModelPreparation("missing")).toBe(false);
+    const updates: ModelDownloadUpdate[] = [];
+    await bridge.prepareModel(
+      {
+        backend: "wangp",
+        model_type: "wan2.2_t2v",
+        repo_id: "wangp:wan2.2_t2v"
+      },
+      (update) => updates.push(update),
+      "wangp:wan2.2_t2v"
+    );
+
+    expect(updates).toMatchObject([
+      {
+        status: "progress",
+        downloaded_bytes: 4096,
+        total_bytes: 0,
+        bytes_per_second: 2048,
+        stalled: false
+      }
+    ]);
+    expect(worker.received("models.prepare")[0]!.data).toEqual({
+      backend: "wangp",
+      model_type: "wan2.2_t2v",
+      repo_id: "wangp:wan2.2_t2v"
+    });
+  });
+
   it("downloadModel uses a caller-supplied requestId so cancel can correlate", async () => {
     worker = await startFakeWorker(0, { protocolVersion: 2 });
-    bridge = new WebsocketPythonBridge({ wsUrl: `ws://127.0.0.1:${worker.port}` });
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${worker.port}`
+    });
     await bridge.connect();
 
     // The relay passes the web's composite cancel id (repo/path) here so a

--- a/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
+++ b/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
@@ -8,6 +8,7 @@
 
 import { WebSocketServer, type WebSocket as WsServerSocket } from "ws";
 import { AddressInfo } from "node:net";
+import { createHash } from "node:crypto";
 import { pack, unpack } from "msgpackr";
 
 import { BRIDGE_PROTOCOL_VERSION } from "@nodetool-ai/protocol/bridge-protocol";
@@ -35,6 +36,10 @@ interface FakeWorkerOptions {
   answerStatus?: boolean;
   /** When false, execute requests are silently ignored (no reply). */
   answerExecute?: boolean;
+  /** Return this execute output through protocol-v5 chunked blob frames. */
+  executeBlob?: Uint8Array;
+  /** Override the chunked blob digest to exercise integrity failures. */
+  executeBlobSha256?: string;
   /**
    * execute.stream behavior:
    *  - "chunks": emit two chunks then the empty result terminator (default)
@@ -288,6 +293,8 @@ export function startFakeWorker(
     answerDiscover: initialOptions.answerDiscover ?? true,
     answerStatus: initialOptions.answerStatus ?? true,
     answerExecute: initialOptions.answerExecute ?? true,
+    executeBlob: initialOptions.executeBlob ?? new Uint8Array(),
+    executeBlobSha256: initialOptions.executeBlobSha256 ?? "",
     streamMode: initialOptions.streamMode ?? "chunks",
     protocolVersion: initialOptions.protocolVersion ?? BRIDGE_PROTOCOL_VERSION,
     downloadMode: initialOptions.downloadMode ?? "progress",
@@ -372,13 +379,45 @@ export function startFakeWorker(
           break;
         case "execute": {
           if (!opts.answerExecute) break;
-          const data = msg.data as { fields?: Record<string, unknown> };
+          const data = msg.data as {
+            fields?: Record<string, unknown>;
+            blob_transfer?: string;
+          };
+          if (opts.executeBlob.length > 0 && data.blob_transfer === "chunked-v1") {
+            const blob = opts.executeBlob;
+            send({
+              type: "blob.start",
+              request_id: requestId,
+              data: { name: "out", size: blob.length }
+            });
+            for (let offset = 0; offset < blob.length; offset += 3) {
+              send({
+                type: "blob.chunk",
+                request_id: requestId,
+                data: { name: "out", offset, bytes: blob.subarray(offset, offset + 3) }
+              });
+            }
+            send({
+              type: "blob.end",
+              request_id: requestId,
+              data: {
+                name: "out",
+                size: blob.length,
+                sha256:
+                  opts.executeBlobSha256 ||
+                  createHash("sha256").update(blob).digest("hex")
+              }
+            });
+          }
           send({
             type: "result",
             request_id: requestId,
             data: {
               outputs: { out: (data.fields?.value as string) ?? "executed" },
-              blobs: {}
+              blobs:
+                opts.executeBlob.length > 0 && data.blob_transfer !== "chunked-v1"
+                  ? { out: opts.executeBlob }
+                  : {}
             }
           });
           break;

--- a/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
+++ b/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
@@ -63,6 +63,8 @@ interface FakeWorkerOptions {
    *    worker)
    */
   downloadMode?: "progress" | "error" | "hang";
+  /** Image-provided model preparation backends advertised in worker.status. */
+  modelPrepareBackends?: string[];
   /**
    * The `comfy` block echoed in the worker.status response. Defaults to an
    * enabled block so comfy tests route correctly; pass `null` to omit it
@@ -298,6 +300,7 @@ export function startFakeWorker(
     streamMode: initialOptions.streamMode ?? "chunks",
     protocolVersion: initialOptions.protocolVersion ?? BRIDGE_PROTOCOL_VERSION,
     downloadMode: initialOptions.downloadMode ?? "progress",
+    modelPrepareBackends: initialOptions.modelPrepareBackends ?? [],
     comfy:
       initialOptions.comfy === undefined
         ? { enabled: true, url: "http://127.0.0.1:8188" }
@@ -372,6 +375,7 @@ export function startFakeWorker(
               namespaces: ["fake"],
               load_errors: [],
               max_frame_size: 256 * 1024 * 1024,
+              model_prepare_backends: opts.modelPrepareBackends,
               ...(opts.comfy ? { comfy: opts.comfy } : {}),
               ...(opts.blender ? { blender: opts.blender } : {})
             }
@@ -561,6 +565,32 @@ export function startFakeWorker(
             type: "result",
             request_id: requestId,
             data: { repo_id: "org/m", status: "completed" }
+          });
+          break;
+        }
+        case "models.prepare": {
+          const data = msg.data as Record<string, unknown>;
+          send({
+            type: "progress",
+            request_id: requestId,
+            data: {
+              status: "progress",
+              repo_id: data.repo_id,
+              path: null,
+              model_type: data.model_type,
+              downloaded_bytes: 4096,
+              total_bytes: 0,
+              downloaded_files: 0,
+              current_files: ["model.safetensors.incomplete"],
+              total_files: 0,
+              bytes_per_second: 2048,
+              stalled: false
+            }
+          });
+          send({
+            type: "result",
+            request_id: requestId,
+            data: { repo_id: data.repo_id, status: "completed" }
           });
           break;
         }

--- a/packages/runtime/tests/python-websocket-bridge.test.ts
+++ b/packages/runtime/tests/python-websocket-bridge.test.ts
@@ -106,6 +106,45 @@ describe("WebsocketPythonBridge", () => {
     expect(result.blobs).toEqual({});
   });
 
+  it("execute() reassembles and verifies protocol-v5 blob chunks", async () => {
+    const expected = new Uint8Array([1, 2, 3, 4, 5, 6, 7]);
+    worker = await startFakeWorker(0, { executeBlob: expected });
+    bridge = new WebsocketPythonBridge({ wsUrl: `ws://127.0.0.1:${worker.port}` });
+    await bridge.connect();
+
+    const result = await bridge.execute("fake.TestNode", {}, {}, {});
+
+    expect(Array.from(result.blobs.out)).toEqual(Array.from(expected));
+    expect(worker.received("execute")[0]?.data).toMatchObject({
+      blob_transfer: "chunked-v1"
+    });
+  });
+
+  it("keeps legacy inline blob results for pre-v5 workers", async () => {
+    const expected = new Uint8Array([8, 9]);
+    worker = await startFakeWorker(0, { protocolVersion: 4, executeBlob: expected });
+    bridge = new WebsocketPythonBridge({ wsUrl: `ws://127.0.0.1:${worker.port}` });
+    await bridge.connect();
+
+    const result = await bridge.execute("fake.TestNode", {}, {}, {});
+
+    expect(Array.from(result.blobs.out)).toEqual(Array.from(expected));
+    expect(worker.received("execute")[0]?.data).not.toHaveProperty("blob_transfer");
+  });
+
+  it("rejects a chunked blob whose digest does not match", async () => {
+    worker = await startFakeWorker(0, {
+      executeBlob: new Uint8Array([1, 2, 3]),
+      executeBlobSha256: "0".repeat(64)
+    });
+    bridge = new WebsocketPythonBridge({ wsUrl: `ws://127.0.0.1:${worker.port}` });
+    await bridge.connect();
+
+    await expect(bridge.execute("fake.TestNode", {}, {}, {})).rejects.toThrow(
+      /SHA-256 verification/
+    );
+  });
+
   it("emits 'activity' on each outbound RPC so the cost guard can keep last_activity_at fresh", async () => {
     // The reaper measures idle time from last_activity_at; the bridge is the
     // designated source of activity heartbeats. Every frame sent to the remote

--- a/packages/websocket/src/models-api.ts
+++ b/packages/websocket/src/models-api.ts
@@ -4,7 +4,7 @@ import {
   PythonProvider,
   registerProvider
 } from "@nodetool-ai/runtime";
-import type { PythonBridge } from "@nodetool-ai/runtime";
+import type { ModelDownloadUpdate, PythonBridge } from "@nodetool-ai/runtime";
 import type { WorkerManager } from "@nodetool-ai/compute";
 import { resolveWorkerHfToken } from "@nodetool-ai/huggingface";
 import type { UnifiedModel } from "@nodetool-ai/protocol";
@@ -140,6 +140,8 @@ export interface StartDownloadCommand {
   ignore_patterns?: string[] | null;
   model_type?: string | null;
   scope?: string;
+  /** Optional image-owned model preparation backend, for example `wangp`. */
+  backend?: string;
 }
 
 /**
@@ -215,27 +217,51 @@ export async function relayWorkerDownload(
   );
 
   try {
-    await bridge.downloadModel(
-      {
-        repo_id: repoId,
-        path: msg.path ?? null,
-        allow_patterns: msg.allow_patterns ?? null,
-        ignore_patterns: msg.ignore_patterns ?? null,
-        model_type: msg.model_type ?? null,
-        token
-      },
-      (update) => {
-        if (update.status === "error") {
-          sawError = true;
-        }
-        try {
-          socket.send(JSON.stringify(update));
-        } catch {
-          /* socket gone */
-        }
-      },
-      requestId
-    );
+    const onProgress = (update: ModelDownloadUpdate) => {
+      if (update.status === "error") {
+        sawError = true;
+      }
+      try {
+        socket.send(JSON.stringify(update));
+      } catch {
+        /* socket gone */
+      }
+    };
+    if (msg.backend) {
+      if (!msg.model_type) {
+        fail("A model_type is required for worker model preparation");
+        return;
+      }
+      if (!bridge.supportsModelPreparation(msg.backend)) {
+        fail(
+          `Worker does not provide model preparation backend: ${msg.backend}`
+        );
+        return;
+      }
+      await bridge.prepareModel(
+        {
+          backend: msg.backend,
+          model_type: msg.model_type,
+          repo_id: repoId,
+          token
+        },
+        onProgress,
+        requestId
+      );
+    } else {
+      await bridge.downloadModel(
+        {
+          repo_id: repoId,
+          path: msg.path ?? null,
+          allow_patterns: msg.allow_patterns ?? null,
+          ignore_patterns: msg.ignore_patterns ?? null,
+          model_type: msg.model_type ?? null,
+          token
+        },
+        onProgress,
+        requestId
+      );
+    }
   } catch (err) {
     // Suppress the redundant error frame if the worker already forwarded one.
     if (!sawError) {

--- a/packages/websocket/tests/models-api-worker.test.ts
+++ b/packages/websocket/tests/models-api-worker.test.ts
@@ -30,7 +30,9 @@ interface FakeBridgeOverrides {
   listCachedModels?: ReturnType<typeof vi.fn>;
   deleteCachedModel?: ReturnType<typeof vi.fn>;
   downloadModel?: ReturnType<typeof vi.fn>;
+  prepareModel?: ReturnType<typeof vi.fn>;
   supportsModelManagement?: () => boolean;
+  supportsModelPreparation?: (backend: string) => boolean;
 }
 
 function fakeBridge(overrides: FakeBridgeOverrides = {}) {
@@ -40,7 +42,11 @@ function fakeBridge(overrides: FakeBridgeOverrides = {}) {
     deleteCachedModel:
       overrides.deleteCachedModel ?? vi.fn().mockResolvedValue(true),
     downloadModel: overrides.downloadModel ?? vi.fn().mockResolvedValue(undefined),
-    supportsModelManagement: overrides.supportsModelManagement ?? (() => true)
+    prepareModel:
+      overrides.prepareModel ?? vi.fn().mockResolvedValue(undefined),
+    supportsModelManagement: overrides.supportsModelManagement ?? (() => true),
+    supportsModelPreparation:
+      overrides.supportsModelPreparation ?? ((backend) => backend === "wangp")
   } as unknown as ModelsApiDeps["pythonBridge"];
 }
 
@@ -102,6 +108,55 @@ describe("relayWorkerDownload", () => {
     expect(downloadModel.mock.calls[0][0]).toMatchObject({
       repo_id: "org/m",
       model_type: "hf.model"
+    });
+  });
+
+  it("routes an image-backed model through models.prepare", async () => {
+    const sent: Array<Record<string, unknown>> = [];
+    const prepareModel = vi.fn(
+      async (
+        _req: unknown,
+        onProgress: (update: Record<string, unknown>) => void
+      ) => {
+        onProgress({
+          status: "progress",
+          repo_id: "wangp:wan2.2_t2v",
+          path: null,
+          model_type: "wan2.2_t2v",
+          downloaded_bytes: 4096,
+          total_bytes: 0,
+          downloaded_files: 0,
+          current_files: ["model.safetensors.incomplete"],
+          total_files: 0,
+          seconds_since_activity: 0,
+          stalled: false
+        });
+      }
+    );
+    const bridge = fakeBridge({ prepareModel });
+
+    await relayWorkerDownload(
+      { send: (data) => sent.push(JSON.parse(data)) },
+      bridge,
+      fakeWorkerManager(ATTACHED),
+      {
+        command: "start_download",
+        repo_id: "wangp:wan2.2_t2v",
+        model_type: "wan2.2_t2v",
+        backend: "wangp"
+      }
+    );
+
+    expect(prepareModel).toHaveBeenCalledOnce();
+    expect(prepareModel.mock.calls[0]![0]).toMatchObject({
+      backend: "wangp",
+      model_type: "wan2.2_t2v",
+      repo_id: "wangp:wan2.2_t2v"
+    });
+    expect(sent[0]).toMatchObject({
+      downloaded_bytes: 4096,
+      total_bytes: 0,
+      stalled: false
     });
   });
 

--- a/web/src/stores/ModelDownloadStore.ts
+++ b/web/src/stores/ModelDownloadStore.ts
@@ -110,7 +110,8 @@ interface ModelDownloadStore {
     path?: string | null,
     allowPatterns?: string[] | null,
     ignorePatterns?: string[] | null,
-    scope?: ModelScope
+    scope?: ModelScope,
+    backend?: string
   ) => void;
   /**
    * Ask the server to cancel a download. Resolves `true` when the cancel
@@ -457,7 +458,8 @@ export const useModelDownloadStore = create<ModelDownloadStore>((set, get) => ({
     path?: string | null,
     allowPatterns?: string[] | null,
     ignorePatterns?: string[] | null,
-    scope: ModelScope = "local"
+    scope: ModelScope = "local",
+    backend?: string
   ) => {
     if (path) {
       if (allowPatterns) {
@@ -494,17 +496,19 @@ export const useModelDownloadStore = create<ModelDownloadStore>((set, get) => ({
     } else {
       try {
         const ws = await get().connectWebSocket();
-        ws.send(
-          JSON.stringify({
-            command: "start_download",
-            repo_id: repoId,
-            path: path,
-            allow_patterns: allowPatterns,
-            ignore_patterns: ignorePatterns,
-            model_type: modelType,
-            scope
-          })
-        );
+        const command: Record<string, unknown> = {
+          command: "start_download",
+          repo_id: repoId,
+          path,
+          allow_patterns: allowPatterns,
+          ignore_patterns: ignorePatterns,
+          model_type: modelType,
+          scope
+        };
+        if (backend) {
+          command.backend = backend;
+        }
+        ws.send(JSON.stringify(command));
       } catch (error) {
         console.error(
           "[ModelDownloadStore] Failed to connect for download:",

--- a/web/src/stores/__tests__/ModelDownloadStore.test.ts
+++ b/web/src/stores/__tests__/ModelDownloadStore.test.ts
@@ -154,6 +154,41 @@ describe("ModelDownloadStore", () => {
     expect(useModelDownloadStore.getState().downloads["repo1"]).toBeDefined();
   });
 
+  test("startDownload forwards an image model preparation backend", async () => {
+    const sendMock = jest.fn();
+    const mockWs = stub<WebSocket>({
+      send: sendMock,
+      readyState: WebSocket.OPEN
+    });
+    useModelDownloadStore.setState(
+      { connectWebSocket: jest.fn().mockResolvedValue(mockWs) },
+      false
+    );
+
+    await useModelDownloadStore
+      .getState()
+      .startDownload(
+        "wangp:wan2.2_t2v",
+        "wan2.2_t2v",
+        null,
+        null,
+        null,
+        "worker",
+        "wangp"
+      );
+
+    expect(JSON.parse(sendMock.mock.calls[0][0])).toEqual({
+      command: "start_download",
+      repo_id: "wangp:wan2.2_t2v",
+      path: null,
+      allow_patterns: null,
+      ignore_patterns: null,
+      model_type: "wan2.2_t2v",
+      scope: "worker",
+      backend: "wangp"
+    });
+  });
+
   test("startDownload throws when path and allowPatterns provided", async () => {
     await expect(
       useModelDownloadStore


### PR DESCRIPTION
## Summary
- add the worker-advertised models.prepare path to the TypeScript bridge
- relay image-owned model preparation through the existing download WebSocket
- forward progress telemetry and backend selection through ModelDownloadStore

## Validation
- focused ESLint (0 errors)
- Vitest: 52 passed
- ModelDownloadStore Jest: 14 passed
- runtime/websocket builds and typechecks passed locally