### PR TITLE
Bridge Python video providers

### DIFF
--- a/packages/runtime/src/providers/python-provider.ts
+++ b/packages/runtime/src/providers/python-provider.ts
@@ -21,7 +21,9 @@ import type {
   StreamingAudioChunk,
   TextToImageParams,
   ImageToImageParams,
-  TextToSpeechParams
+  TextToSpeechParams,
+  TextToVideoParams,
+  ImageToVideoParams
 } from "./types.js";
 import type { PythonBridgeBase } from "../python-bridge-base.js";
 import { isRecord, isString } from "@nodetool-ai/protocol";
@@ -276,6 +278,30 @@ export class PythonProvider extends BaseProvider {
       images[0] ?? new Uint8Array(),
       { ...params },
       this._secrets
+    );
+  }
+
+  async textToVideo(params: TextToVideoParams): Promise<Uint8Array> {
+    const { signal, ...wireParams } = params;
+    return this._bridge.providerTextToVideo(
+      this._pythonProviderId,
+      { ...wireParams, model: params.model.id },
+      this._secrets,
+      signal
+    );
+  }
+
+  async imageToVideo(
+    images: Uint8Array[],
+    params: ImageToVideoParams
+  ): Promise<Uint8Array> {
+    const { signal, ...wireParams } = params;
+    return this._bridge.providerImageToVideo(
+      this._pythonProviderId,
+      images[0] ?? new Uint8Array(),
+      { ...wireParams, model: params.model.id },
+      this._secrets,
+      signal
     );
   }
 

--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -17,8 +17,10 @@ import { getNodeBuiltinSync, safeProcessEnv } from "@nodetool-ai/config";
 // Lazy-load so the module *graph* loads off-Node; instantiating a concrete
 // bridge there throws at construction. Notably the base does NOT require
 // child_process — that belongs to the stdio subclass only.
-const nodeCrypto = getNodeBuiltinSync<typeof import("node:crypto")>("node:crypto");
-const nodeEvents = getNodeBuiltinSync<typeof import("node:events")>("node:events");
+const nodeCrypto =
+  getNodeBuiltinSync<typeof import("node:crypto")>("node:crypto");
+const nodeEvents =
+  getNodeBuiltinSync<typeof import("node:events")>("node:events");
 
 function notOnNode(api: string): never {
   throw new Error(`${api} requires Node — PythonBridgeBase is Node-only`);
@@ -148,7 +150,8 @@ const DEFAULT_DOWNLOAD_IDLE_TIMEOUT_MS = Number(
   safeProcessEnv()["NODETOOL_PYTHON_DOWNLOAD_IDLE_TIMEOUT_MS"] ?? 5 * 60 * 1000
 );
 const MAX_RESULT_BLOB_BYTES = Number(
-  safeProcessEnv()["NODETOOL_PYTHON_MAX_RESULT_BLOB_BYTES"] ?? 2 * 1024 * 1024 * 1024
+  safeProcessEnv()["NODETOOL_PYTHON_MAX_RESULT_BLOB_BYTES"] ??
+    2 * 1024 * 1024 * 1024
 );
 
 /**
@@ -287,8 +290,9 @@ export abstract class PythonBridgeBase
         // so an older worker keeps running everything it understands. Workers
         // that pre-date the protocol_version field are treated as version 1
         // (the initial release) — same wire format, they just don't announce.
-        const workerVersion =
-          isNumber(data.protocol_version) ? data.protocol_version : 1;
+        const workerVersion = isNumber(data.protocol_version)
+          ? data.protocol_version
+          : 1;
         if (workerVersion < MIN_BRIDGE_PROTOCOL_VERSION) {
           this._pending.delete(requestId);
           pending.reject(
@@ -326,7 +330,9 @@ export abstract class PythonBridgeBase
         this._pending.delete(requestId);
         if (pending.blobTransfers?.size) {
           pending.reject(
-            new Error("Python worker ended the result before all blob transfers completed")
+            new Error(
+              "Python worker ended the result before all blob transfers completed"
+            )
           );
           return;
         }
@@ -414,8 +420,13 @@ export abstract class PythonBridgeBase
     const pending = this._pending.get(requestId);
     const name = data["name"];
     const size = data["size"];
-    if (!pending || typeof name !== "string" || typeof size !== "number") return;
-    if (!Number.isSafeInteger(size) || size < 0 || size > MAX_RESULT_BLOB_BYTES) {
+    if (!pending || typeof name !== "string" || typeof size !== "number")
+      return;
+    if (
+      !Number.isSafeInteger(size) ||
+      size < 0 ||
+      size > MAX_RESULT_BLOB_BYTES
+    ) {
       this._rejectBlobTransfer(
         requestId,
         `Python worker declared invalid blob size ${String(size)} for "${name}"`
@@ -423,9 +434,18 @@ export abstract class PythonBridgeBase
       return;
     }
     pending.blobTransfers ??= new Map();
-    pending.completedBlobs ??= Object.create(null) as Record<string, Uint8Array>;
-    if (pending.blobTransfers.has(name) || Object.hasOwn(pending.completedBlobs, name)) {
-      this._rejectBlobTransfer(requestId, `Python worker started duplicate blob "${name}"`);
+    pending.completedBlobs ??= Object.create(null) as Record<
+      string,
+      Uint8Array
+    >;
+    if (
+      pending.blobTransfers.has(name) ||
+      Object.hasOwn(pending.completedBlobs, name)
+    ) {
+      this._rejectBlobTransfer(
+        requestId,
+        `Python worker started duplicate blob "${name}"`
+      );
       return;
     }
     pending.blobTransfers.set(name, { size, received: 0, chunks: [] });
@@ -444,9 +464,14 @@ export abstract class PythonBridgeBase
       typeof name !== "string" ||
       typeof offset !== "number" ||
       !(bytes instanceof Uint8Array)
-    ) return;
+    )
+      return;
     const transfer = pending.blobTransfers?.get(name);
-    if (!transfer || offset !== transfer.received || offset + bytes.length > transfer.size) {
+    if (
+      !transfer ||
+      offset !== transfer.received ||
+      offset + bytes.length > transfer.size
+    ) {
       this._rejectBlobTransfer(
         requestId,
         `Python worker sent an out-of-order or oversized chunk for blob "${name}"`
@@ -470,10 +495,18 @@ export abstract class PythonBridgeBase
       typeof name !== "string" ||
       typeof size !== "number" ||
       typeof expectedDigest !== "string"
-    ) return;
+    )
+      return;
     const transfer = pending.blobTransfers?.get(name);
-    if (!transfer || size !== transfer.size || transfer.received !== transfer.size) {
-      this._rejectBlobTransfer(requestId, `Python worker truncated blob "${name}"`);
+    if (
+      !transfer ||
+      size !== transfer.size ||
+      transfer.received !== transfer.size
+    ) {
+      this._rejectBlobTransfer(
+        requestId,
+        `Python worker truncated blob "${name}"`
+      );
       return;
     }
     const blob = new Uint8Array(transfer.size);
@@ -484,11 +517,17 @@ export abstract class PythonBridgeBase
     }
     const digest = nodeCrypto?.createHash("sha256").update(blob).digest("hex");
     if (!digest || digest !== expectedDigest) {
-      this._rejectBlobTransfer(requestId, `Python worker blob "${name}" failed SHA-256 verification`);
+      this._rejectBlobTransfer(
+        requestId,
+        `Python worker blob "${name}" failed SHA-256 verification`
+      );
       return;
     }
     pending.blobTransfers?.delete(name);
-    pending.completedBlobs ??= Object.create(null) as Record<string, Uint8Array>;
+    pending.completedBlobs ??= Object.create(null) as Record<
+      string,
+      Uint8Array
+    >;
     pending.completedBlobs[name] = blob;
   }
 
@@ -609,9 +648,7 @@ export abstract class PythonBridgeBase
    * them would only mean a worker that DOES understand them gets nothing
    * whenever its `worker.status` hasn't landed yet.
    */
-  protected _identityPayload(
-    identity: ExecuteIdentity | undefined
-  ) {
+  protected _identityPayload(identity: ExecuteIdentity | undefined) {
     if (!identity) return {};
     const payload: Record<string, unknown> = {};
     if (identity.nodeId) payload.node_id = identity.nodeId;
@@ -1073,6 +1110,44 @@ export abstract class PythonBridgeBase
       secrets: secrets ?? {}
     });
     return (result as { blobs: Record<string, Uint8Array> }).blobs.image;
+  }
+
+  async providerTextToVideo(
+    providerId: string,
+    params: Record<string, unknown>,
+    secrets?: Record<string, string>,
+    signal?: AbortSignal
+  ): Promise<Uint8Array> {
+    const result = await this._providerBlobCall(
+      "provider.text_to_video",
+      {
+        provider: providerId,
+        params,
+        secrets: secrets ?? {}
+      },
+      signal
+    );
+    return result.blobs.video;
+  }
+
+  async providerImageToVideo(
+    providerId: string,
+    image: Uint8Array,
+    params: Record<string, unknown>,
+    secrets?: Record<string, string>,
+    signal?: AbortSignal
+  ): Promise<Uint8Array> {
+    const result = await this._providerBlobCall(
+      "provider.image_to_video",
+      {
+        provider: providerId,
+        image,
+        params,
+        secrets: secrets ?? {}
+      },
+      signal
+    );
+    return result.blobs.video;
   }
 
   async *providerTTS(
@@ -1778,6 +1853,53 @@ export abstract class PythonBridgeBase
         this._send({ type, request_id: requestId, data });
       } catch (err) {
         this._pendingStream.delete(requestId);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+  }
+
+  /** Provider RPC variant that opts into protocol-v5 chunked result blobs. */
+  protected async _providerBlobCall(
+    type: string,
+    data: Record<string, unknown>,
+    signal?: AbortSignal
+  ): Promise<ExecuteResult> {
+    const requestId = randomUUID();
+    if (signal?.aborted) {
+      throw new Error(`Provider request "${requestId}" was cancelled.`);
+    }
+    return new Promise<ExecuteResult>((resolve, reject) => {
+      const cleanup = () => signal?.removeEventListener("abort", onAbort);
+      const onAbort = () => {
+        this._pending.delete(requestId);
+        cleanup();
+        try {
+          this.cancel(requestId);
+        } catch {
+          // Worker may already be gone; cancellation is best-effort.
+        }
+        reject(new Error(`Provider request "${requestId}" was cancelled.`));
+      };
+      this._pending.set(requestId, {
+        resolve: (value) => {
+          cleanup();
+          resolve(value);
+        },
+        reject: (error) => {
+          cleanup();
+          reject(error);
+        }
+      });
+      signal?.addEventListener("abort", onAbort, { once: true });
+      try {
+        this._send({
+          type,
+          request_id: requestId,
+          data: { ...data, blob_transfer: "chunked-v1" }
+        });
+      } catch (err) {
+        this._pending.delete(requestId);
+        cleanup();
         reject(err instanceof Error ? err : new Error(String(err)));
       }
     });

--- a/packages/runtime/src/python-bridge-types.ts
+++ b/packages/runtime/src/python-bridge-types.ts
@@ -575,6 +575,19 @@ export interface PythonBridge extends EventEmitter {
     params: Record<string, unknown>,
     secrets?: Record<string, string>
   ): Promise<Uint8Array>;
+  providerTextToVideo(
+    providerId: string,
+    params: Record<string, unknown>,
+    secrets?: Record<string, string>,
+    signal?: AbortSignal
+  ): Promise<Uint8Array>;
+  providerImageToVideo(
+    providerId: string,
+    image: Uint8Array,
+    params: Record<string, unknown>,
+    secrets?: Record<string, string>,
+    signal?: AbortSignal
+  ): Promise<Uint8Array>;
   providerASR(
     providerId: string,
     audio: Uint8Array,

--- a/packages/runtime/src/swappable-python-bridge.ts
+++ b/packages/runtime/src/swappable-python-bridge.ts
@@ -237,7 +237,42 @@ export class SwappableBridge extends EventEmitter implements PythonBridge {
     params: Record<string, unknown>,
     secrets?: Record<string, string>
   ): Promise<Uint8Array> {
-    return this._target.providerImageToImage(providerId, image, params, secrets);
+    return this._target.providerImageToImage(
+      providerId,
+      image,
+      params,
+      secrets
+    );
+  }
+
+  providerTextToVideo(
+    providerId: string,
+    params: Record<string, unknown>,
+    secrets?: Record<string, string>,
+    signal?: AbortSignal
+  ): Promise<Uint8Array> {
+    return this._target.providerTextToVideo(
+      providerId,
+      params,
+      secrets,
+      signal
+    );
+  }
+
+  providerImageToVideo(
+    providerId: string,
+    image: Uint8Array,
+    params: Record<string, unknown>,
+    secrets?: Record<string, string>,
+    signal?: AbortSignal
+  ): Promise<Uint8Array> {
+    return this._target.providerImageToVideo(
+      providerId,
+      image,
+      params,
+      secrets,
+      signal
+    );
   }
 
   providerASR(
@@ -346,7 +381,13 @@ export class SwappableBridge extends EventEmitter implements PythonBridge {
     onEvent?: (event: BlenderEvent) => void,
     requestId?: string
   ): Promise<BlenderExecuteResult> {
-    return this._target.blenderExecute(job, inputs, options, onEvent, requestId);
+    return this._target.blenderExecute(
+      job,
+      inputs,
+      options,
+      onEvent,
+      requestId
+    );
   }
 
   cancelBlenderExecute(requestId: string): void {

--- a/packages/runtime/tests/providers/provider-registry-extended.test.ts
+++ b/packages/runtime/tests/providers/provider-registry-extended.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   registerProvider,
   getProvider,
@@ -178,5 +178,38 @@ describe("provider-registry — extended coverage", () => {
       })
     ]);
     expect(calls).toEqual(["huggingface"]);
+  });
+
+  it("routes video generation through the Python bridge", async () => {
+    const textToVideo = vi.fn(async () => new Uint8Array([1]));
+    const imageToVideo = vi.fn(async () => new Uint8Array([2]));
+    const provider = new PythonProvider({
+      _id: "wangp",
+      _bridge: {
+        providerTextToVideo: textToVideo,
+        providerImageToVideo: imageToVideo
+      }
+    } as any);
+    const model = { id: "wan-model", name: "Wan", provider: "wangp" } as const;
+
+    await expect(
+      provider.textToVideo({ model, prompt: "ocean" })
+    ).resolves.toEqual(new Uint8Array([1]));
+    await expect(
+      provider.imageToVideo([new Uint8Array([9])], { model, prompt: "move" })
+    ).resolves.toEqual(new Uint8Array([2]));
+    expect(textToVideo).toHaveBeenCalledWith(
+      "wangp",
+      { model: "wan-model", prompt: "ocean" },
+      {},
+      undefined
+    );
+    expect(imageToVideo).toHaveBeenCalledWith(
+      "wangp",
+      new Uint8Array([9]),
+      { model: "wan-model", prompt: "move" },
+      {},
+      undefined
+    );
   });
 });

--- a/packages/runtime/tests/python-bridge-base-coverage.test.ts
+++ b/packages/runtime/tests/python-bridge-base-coverage.test.ts
@@ -10,14 +10,7 @@
  * bookkeeping — with zero I/O and full determinism.
  */
 
-import {
-  describe,
-  it,
-  expect,
-  beforeEach,
-  afterEach,
-  vi
-} from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 import {
   BRIDGE_PROTOCOL_VERSION,
@@ -97,9 +90,8 @@ class TestBridge extends PythonBridgeBase {
   }
 
   comfyEventsSize(): number {
-    return (
-      this as unknown as { _pendingComfyEvents: Map<string, unknown> }
-    )._pendingComfyEvents.size;
+    return (this as unknown as { _pendingComfyEvents: Map<string, unknown> })
+      ._pendingComfyEvents.size;
   }
 }
 
@@ -408,7 +400,11 @@ describe("PythonBridgeBase — execute", () => {
     await connectBridge(bridge);
     const p = bridge.execute("n.T", {}, {}, {});
     const id = bridge.reqIdOf("execute");
-    bridge.handle({ type: "result", request_id: id, data: { outputs: { ok: 1 } } });
+    bridge.handle({
+      type: "result",
+      request_id: id,
+      data: { outputs: { ok: 1 } }
+    });
     await expect(p).resolves.toEqual({ outputs: { ok: 1 }, blobs: {} });
   });
 
@@ -653,7 +649,9 @@ describe("PythonBridgeBase — provider RPCs", () => {
       model: "gpt",
       temperature: 0.5
     });
-    reply("provider.generate", { message: { role: "assistant", content: "hi" } });
+    reply("provider.generate", {
+      message: { role: "assistant", content: "hi" }
+    });
     await expect(p).resolves.toEqual({ role: "assistant", content: "hi" });
   });
 
@@ -668,10 +666,72 @@ describe("PythonBridgeBase — provider RPCs", () => {
     const input = new Uint8Array([9]);
     const output = new Uint8Array([8]);
     const p = bridge.providerImageToImage("fal", input, { strength: 0.6 });
-    const frame = bridge.sent.find((f) => f.type === "provider.image_to_image")!;
+    const frame = bridge.sent.find(
+      (f) => f.type === "provider.image_to_image"
+    )!;
     expect((frame.data as Record<string, unknown>).image).toBe(input);
     reply("provider.image_to_image", { blobs: { image: output } });
     await expect(p).resolves.toBe(output);
+  });
+
+  it("providerTextToVideo returns the video blob", async () => {
+    const output = new Uint8Array([4, 5, 6]);
+    const p = bridge.providerTextToVideo("wangp", {
+      model: "t2v_2_2",
+      prompt: "ocean"
+    });
+    const frame = bridge.sent.find((f) => f.type === "provider.text_to_video")!;
+    expect(frame.data).toEqual({
+      provider: "wangp",
+      params: { model: "t2v_2_2", prompt: "ocean" },
+      secrets: {},
+      blob_transfer: "chunked-v1"
+    });
+    reply("provider.text_to_video", { blobs: { video: output } });
+    await expect(p).resolves.toBe(output);
+  });
+
+  it("providerImageToVideo sends the image and returns the video blob", async () => {
+    const input = new Uint8Array([1, 2]);
+    const output = new Uint8Array([7, 8]);
+    const p = bridge.providerImageToVideo(
+      "wangp",
+      input,
+      { model: "i2v_2_2", prompt: "move" },
+      { TOKEN: "secret" }
+    );
+    const frame = bridge.sent.find(
+      (f) => f.type === "provider.image_to_video"
+    )!;
+    expect(frame.data).toEqual({
+      provider: "wangp",
+      image: input,
+      params: { model: "i2v_2_2", prompt: "move" },
+      secrets: { TOKEN: "secret" },
+      blob_transfer: "chunked-v1"
+    });
+    reply("provider.image_to_video", { blobs: { video: output } });
+    await expect(p).resolves.toBe(output);
+  });
+
+  it("cancels an in-flight video provider request with its abort signal", async () => {
+    const controller = new AbortController();
+    const p = bridge.providerTextToVideo(
+      "wangp",
+      { model: "t2v_2_2", prompt: "ocean" },
+      {},
+      controller.signal
+    );
+    const request = bridge.sent.find(
+      (f) => f.type === "provider.text_to_video"
+    )!;
+    controller.abort();
+    await expect(p).rejects.toThrow("was cancelled");
+    expect(bridge.sent.at(-1)).toEqual({
+      type: "cancel",
+      request_id: request.request_id,
+      data: {}
+    });
   });
 
   it("providerASR maps text and chunks", async () => {
@@ -951,7 +1011,9 @@ describe("PythonBridgeBase — models & comfy proxy RPCs", () => {
         { folder: "loras", filename: "b" }
       ]
     });
-    await expect(p).resolves.toEqual([{ folder: "checkpoints", filename: "a" }]);
+    await expect(p).resolves.toEqual([
+      { folder: "checkpoints", filename: "a" }
+    ]);
   });
 
   it("comfyModelsList returns everything when no folder is given", async () => {
@@ -1117,7 +1179,8 @@ describe("PythonBridgeBase — inbound frame validation (B3)", () => {
       });
       await expect(p).resolves.toEqual({ outputs: undefined, blobs: {} });
     } finally {
-      if (prev === undefined) delete process.env["NODETOOL_VALIDATE_BRIDGE_FRAMES"];
+      if (prev === undefined)
+        delete process.env["NODETOOL_VALIDATE_BRIDGE_FRAMES"];
       else process.env["NODETOOL_VALIDATE_BRIDGE_FRAMES"] = prev;
     }
   });

--- a/packages/runtime/tests/swappable-python-bridge.test.ts
+++ b/packages/runtime/tests/swappable-python-bridge.test.ts
@@ -87,6 +87,12 @@ class FakeBridge extends EventEmitter {
   providerImageToImage(): Promise<Uint8Array> {
     return Promise.resolve(new Uint8Array());
   }
+  providerTextToVideo(): Promise<Uint8Array> {
+    return Promise.resolve(new Uint8Array());
+  }
+  providerImageToVideo(): Promise<Uint8Array> {
+    return Promise.resolve(new Uint8Array());
+  }
   providerASR(): Promise<{ text: string }> {
     return Promise.resolve({ text: "" });
   }


### PR DESCRIPTION
## Summary
- add text-to-video and image-to-video calls to the Python bridge
- route PythonProvider video methods through the worker
- use chunked blob transfer for generated videos
- propagate AbortSignal cancellation to the worker adapter

## Validation
- runtime focused tests: 100 passed
- Prettier check clean
- TypeScript lint is blocked locally by missing newly declared OpenTelemetry packages in the shared node_modules; CI installs from lockfile