### PR TITLE
Bridge Python image, music, and encoded TTS providers

### DIFF
--- a/packages/cli/src/providers.ts
+++ b/packages/cli/src/providers.ts
@@ -149,7 +149,8 @@ async function ensurePythonProvidersRegistered(): Promise<void> {
         if (listRegisteredProviderIds().includes(info.id)) continue;
         registerProvider(info.id, PythonProvider as never, {
           _bridge: bridge,
-          _id: info.id
+          _id: info.id,
+          _capabilities: info.capabilities
         });
       }
     })().catch((err) => {

--- a/packages/runtime/src/providers/python-provider.ts
+++ b/packages/runtime/src/providers/python-provider.ts
@@ -15,6 +15,7 @@ import type {
   ASRModel,
   EmbeddingModel,
   VideoModel,
+  MusicModel,
   Message,
   ProviderTool,
   ProviderStreamItem,
@@ -23,10 +24,13 @@ import type {
   ImageToImageParams,
   TextToSpeechParams,
   TextToVideoParams,
-  ImageToVideoParams
+  ImageToVideoParams,
+  TextToMusicParams,
+  EncodedAudioResult
 } from "./types.js";
 import type { PythonBridgeBase } from "../python-bridge-base.js";
 import { isRecord, isString } from "@nodetool-ai/protocol";
+import { sniffAudioMime } from "./audio-mime.js";
 
 type PythonProviderOptions = Record<string, unknown> & {
   _id: string;
@@ -158,6 +162,10 @@ export class PythonProvider extends BaseProvider {
 
   async getAvailableVideoModels(): Promise<VideoModel[]> {
     return this._getModels("video") as Promise<VideoModel[]>;
+  }
+
+  async getAvailableMusicModels(): Promise<MusicModel[]> {
+    return this._getModels("music") as Promise<MusicModel[]>;
   }
 
   private async _getModels(modelType: string): Promise<unknown[]> {
@@ -331,6 +339,26 @@ export class PythonProvider extends BaseProvider {
       const copy = audioBytes.slice(0, even);
       yield { samples: new Int16Array(copy.buffer, copy.byteOffset, even / 2) };
     }
+  }
+
+  async textToSpeechEncoded(
+    args: TextToSpeechParams
+  ): Promise<EncodedAudioResult | null> {
+    const data = await this._bridge.providerTTSEncoded(
+      this._pythonProviderId,
+      { ...args },
+      this._secrets
+    );
+    return { data, mimeType: sniffAudioMime(data) };
+  }
+
+  async textToMusic(params: TextToMusicParams): Promise<EncodedAudioResult> {
+    const data = await this._bridge.providerTextToAudio(
+      this._pythonProviderId,
+      { ...params, model: params.model.id },
+      this._secrets
+    );
+    return { data, mimeType: sniffAudioMime(data) };
   }
 
   async automaticSpeechRecognition(args: {

--- a/packages/runtime/src/providers/python-provider.ts
+++ b/packages/runtime/src/providers/python-provider.ts
@@ -37,6 +37,8 @@ type PythonProviderOptions = Record<string, unknown> & {
   _bridge: PythonBridgeBase;
   /** Provider id understood by the Python worker when the public id is aliased. */
   _bridgeProviderId?: string;
+  /** Operations advertised by the Python worker for this provider. */
+  _capabilities?: string[];
 };
 
 function parseModelAdapter(value: unknown): ModelAdapterInfo | undefined {
@@ -75,6 +77,8 @@ export class PythonProvider extends BaseProvider {
   private _bridge: PythonBridgeBase;
   private _pythonProviderId: string;
   private _secrets: Record<string, string>;
+  private _supportsStreamingTTS = true;
+  private _supportsEncodedTTS = true;
 
   constructor(
     providerId: string,
@@ -98,11 +102,17 @@ export class PythonProvider extends BaseProvider {
       return;
     }
 
-    const { _id, _bridge, _bridgeProviderId, ...rawSecrets } =
+    const { _id, _bridge, _bridgeProviderId, _capabilities, ...rawSecrets } =
       providerIdOrOptions;
     super(_id);
     this._bridge = _bridge;
     this._pythonProviderId = _bridgeProviderId ?? _id;
+    if (Array.isArray(_capabilities)) {
+      this._supportsStreamingTTS = _capabilities.includes("text_to_speech");
+      this._supportsEncodedTTS = _capabilities.includes(
+        "text_to_speech_encoded"
+      );
+    }
     this._secrets = Object.fromEntries(
       Object.entries(rawSecrets).filter(
         (entry): entry is [string, string] => typeof entry[1] === "string"
@@ -345,9 +355,14 @@ export class PythonProvider extends BaseProvider {
     }
   }
 
+  override supportsStreamingTextToSpeech(): boolean {
+    return this._supportsStreamingTTS;
+  }
+
   async textToSpeechEncoded(
     args: TextToSpeechParams
   ): Promise<EncodedAudioResult | null> {
+    if (!this._supportsEncodedTTS) return null;
     const data = await this._bridge.providerTTSEncoded(
       this._pythonProviderId,
       { ...args },

--- a/packages/runtime/src/providers/python-provider.ts
+++ b/packages/runtime/src/providers/python-provider.ts
@@ -270,10 +270,12 @@ export class PythonProvider extends BaseProvider {
   // ── Media generation ──────────────────────────────────────────────
 
   async textToImage(params: TextToImageParams): Promise<Uint8Array> {
+    const { signal, ...wireParams } = params;
     return this._bridge.providerTextToImage(
       this._pythonProviderId,
-      { ...params },
-      this._secrets
+      { ...wireParams, model: params.model.id },
+      this._secrets,
+      signal
     );
   }
 
@@ -281,11 +283,13 @@ export class PythonProvider extends BaseProvider {
     images: Uint8Array[],
     params: ImageToImageParams
   ): Promise<Uint8Array> {
+    const { signal, ...wireParams } = params;
     return this._bridge.providerImageToImage(
       this._pythonProviderId,
       images[0] ?? new Uint8Array(),
-      { ...params },
-      this._secrets
+      { ...wireParams, model: params.model.id },
+      this._secrets,
+      signal
     );
   }
 

--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -1150,6 +1150,32 @@ export abstract class PythonBridgeBase
     return result.blobs.video;
   }
 
+  async providerTextToAudio(
+    providerId: string,
+    params: Record<string, unknown>,
+    secrets?: Record<string, string>
+  ): Promise<Uint8Array> {
+    const result = await this._providerBlobCall("provider.text_to_audio", {
+      provider: providerId,
+      params,
+      secrets: secrets ?? {}
+    });
+    return result.blobs.audio;
+  }
+
+  async providerTTSEncoded(
+    providerId: string,
+    params: Record<string, unknown>,
+    secrets?: Record<string, string>
+  ): Promise<Uint8Array> {
+    const result = await this._providerBlobCall("provider.tts_encoded", {
+      provider: providerId,
+      params,
+      secrets: secrets ?? {}
+    });
+    return result.blobs.audio;
+  }
+
   async *providerTTS(
     providerId: string,
     text: string,

--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -1087,29 +1087,39 @@ export abstract class PythonBridgeBase
   async providerTextToImage(
     providerId: string,
     params: Record<string, unknown>,
-    secrets?: Record<string, string>
+    secrets?: Record<string, string>,
+    signal?: AbortSignal
   ): Promise<Uint8Array> {
-    const result = await this._providerCall("provider.text_to_image", {
-      provider: providerId,
-      params,
-      secrets: secrets ?? {}
-    });
-    return (result as { blobs: Record<string, Uint8Array> }).blobs.image;
+    const result = await this._providerBlobCall(
+      "provider.text_to_image",
+      {
+        provider: providerId,
+        params,
+        secrets: secrets ?? {}
+      },
+      signal
+    );
+    return result.blobs.image;
   }
 
   async providerImageToImage(
     providerId: string,
     image: Uint8Array,
     params: Record<string, unknown>,
-    secrets?: Record<string, string>
+    secrets?: Record<string, string>,
+    signal?: AbortSignal
   ): Promise<Uint8Array> {
-    const result = await this._providerCall("provider.image_to_image", {
-      provider: providerId,
-      image,
-      params,
-      secrets: secrets ?? {}
-    });
-    return (result as { blobs: Record<string, Uint8Array> }).blobs.image;
+    const result = await this._providerBlobCall(
+      "provider.image_to_image",
+      {
+        provider: providerId,
+        image,
+        params,
+        secrets: secrets ?? {}
+      },
+      signal
+    );
+    return result.blobs.image;
   }
 
   async providerTextToVideo(

--- a/packages/runtime/src/python-bridge-types.ts
+++ b/packages/runtime/src/python-bridge-types.ts
@@ -588,6 +588,16 @@ export interface PythonBridge extends EventEmitter {
     secrets?: Record<string, string>,
     signal?: AbortSignal
   ): Promise<Uint8Array>;
+  providerTextToAudio(
+    providerId: string,
+    params: Record<string, unknown>,
+    secrets?: Record<string, string>
+  ): Promise<Uint8Array>;
+  providerTTSEncoded(
+    providerId: string,
+    params: Record<string, unknown>,
+    secrets?: Record<string, string>
+  ): Promise<Uint8Array>;
   providerASR(
     providerId: string,
     audio: Uint8Array,

--- a/packages/runtime/src/python-bridge-types.ts
+++ b/packages/runtime/src/python-bridge-types.ts
@@ -567,13 +567,15 @@ export interface PythonBridge extends EventEmitter {
   providerTextToImage(
     providerId: string,
     params: Record<string, unknown>,
-    secrets?: Record<string, string>
+    secrets?: Record<string, string>,
+    signal?: AbortSignal
   ): Promise<Uint8Array>;
   providerImageToImage(
     providerId: string,
     image: Uint8Array,
     params: Record<string, unknown>,
-    secrets?: Record<string, string>
+    secrets?: Record<string, string>,
+    signal?: AbortSignal
   ): Promise<Uint8Array>;
   providerTextToVideo(
     providerId: string,

--- a/packages/runtime/src/swappable-python-bridge.ts
+++ b/packages/runtime/src/swappable-python-bridge.ts
@@ -226,22 +226,25 @@ export class SwappableBridge extends EventEmitter implements PythonBridge {
   providerTextToImage(
     providerId: string,
     params: Record<string, unknown>,
-    secrets?: Record<string, string>
+    secrets?: Record<string, string>,
+    signal?: AbortSignal
   ): Promise<Uint8Array> {
-    return this._target.providerTextToImage(providerId, params, secrets);
+    return this._target.providerTextToImage(providerId, params, secrets, signal);
   }
 
   providerImageToImage(
     providerId: string,
     image: Uint8Array,
     params: Record<string, unknown>,
-    secrets?: Record<string, string>
+    secrets?: Record<string, string>,
+    signal?: AbortSignal
   ): Promise<Uint8Array> {
     return this._target.providerImageToImage(
       providerId,
       image,
       params,
-      secrets
+      secrets,
+      signal
     );
   }
 

--- a/packages/runtime/src/swappable-python-bridge.ts
+++ b/packages/runtime/src/swappable-python-bridge.ts
@@ -275,6 +275,22 @@ export class SwappableBridge extends EventEmitter implements PythonBridge {
     );
   }
 
+  providerTextToAudio(
+    providerId: string,
+    params: Record<string, unknown>,
+    secrets?: Record<string, string>
+  ): Promise<Uint8Array> {
+    return this._target.providerTextToAudio(providerId, params, secrets);
+  }
+
+  providerTTSEncoded(
+    providerId: string,
+    params: Record<string, unknown>,
+    secrets?: Record<string, string>
+  ): Promise<Uint8Array> {
+    return this._target.providerTTSEncoded(providerId, params, secrets);
+  }
+
   providerASR(
     providerId: string,
     audio: Uint8Array,

--- a/packages/runtime/tests/providers/provider-registry-extended.test.ts
+++ b/packages/runtime/tests/providers/provider-registry-extended.test.ts
@@ -185,6 +185,7 @@ describe("provider-registry — extended coverage", () => {
     const imageToVideo = vi.fn(async () => new Uint8Array([2]));
     const provider = new PythonProvider({
       _id: "wangp",
+      _capabilities: ["text_to_audio", "text_to_speech_encoded"],
       _bridge: {
         providerTextToVideo: textToVideo,
         providerImageToVideo: imageToVideo
@@ -257,5 +258,32 @@ describe("provider-registry — extended coverage", () => {
       { text: "hello", model: "qwen3" },
       {}
     );
+  });
+
+  it("uses declared TTS capabilities to select encoded or streaming transport", async () => {
+    const providerTTSEncoded = vi.fn(async () => new Uint8Array([1]));
+    const encoded = new PythonProvider({
+      _id: "wangp",
+      _capabilities: ["text_to_speech_encoded"],
+      _bridge: { providerTTSEncoded }
+    } as any);
+    expect(encoded.supportsStreamingTextToSpeech()).toBe(false);
+    await expect(
+      encoded.textToSpeechEncoded({ text: "hello", model: "qwen3" })
+    ).resolves.toEqual({
+      data: new Uint8Array([1]),
+      mimeType: "audio/mpeg"
+    });
+
+    const streaming = new PythonProvider({
+      _id: "huggingface",
+      _capabilities: ["text_to_speech"],
+      _bridge: { providerTTSEncoded }
+    } as any);
+    expect(streaming.supportsStreamingTextToSpeech()).toBe(true);
+    await expect(
+      streaming.textToSpeechEncoded({ text: "hello", model: "local-tts" })
+    ).resolves.toBeNull();
+    expect(providerTTSEncoded).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/runtime/tests/providers/provider-registry-extended.test.ts
+++ b/packages/runtime/tests/providers/provider-registry-extended.test.ts
@@ -212,4 +212,50 @@ describe("provider-registry — extended coverage", () => {
       undefined
     );
   });
+
+  it("discovers music and routes encoded audio through the Python bridge", async () => {
+    const wav = new Uint8Array([
+      0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x41, 0x56, 0x45
+    ]);
+    const getProviderModels = vi.fn(async () => [
+      { id: "ace", name: "ACE-Step", provider: "wangp" }
+    ]);
+    const textToAudio = vi.fn(async () => wav);
+    const ttsEncoded = vi.fn(async () => wav);
+    const provider = new PythonProvider({
+      _id: "wangp",
+      _bridge: {
+        getProviderModels,
+        providerTextToAudio: textToAudio,
+        providerTTSEncoded: ttsEncoded
+      }
+    } as any);
+
+    await expect(provider.getAvailableMusicModels()).resolves.toEqual([
+      { id: "ace", name: "ACE-Step", provider: "wangp" }
+    ]);
+    await expect(
+      provider.textToMusic({
+        model: { id: "ace", name: "ACE-Step", provider: "wangp" },
+        prompt: "ambient"
+      })
+    ).resolves.toEqual({ data: wav, mimeType: "audio/wav" });
+    await expect(
+      provider.textToSpeechEncoded({ text: "hello", model: "qwen3" })
+    ).resolves.toEqual({ data: wav, mimeType: "audio/wav" });
+    expect(getProviderModels).toHaveBeenCalledWith("wangp", "music", {});
+    expect(textToAudio).toHaveBeenCalledWith(
+      "wangp",
+      {
+        model: "ace",
+        prompt: "ambient"
+      },
+      {}
+    );
+    expect(ttsEncoded).toHaveBeenCalledWith(
+      "wangp",
+      { text: "hello", model: "qwen3" },
+      {}
+    );
+  });
 });

--- a/packages/runtime/tests/python-bridge-base-coverage.test.ts
+++ b/packages/runtime/tests/python-bridge-base-coverage.test.ts
@@ -714,6 +714,40 @@ describe("PythonBridgeBase — provider RPCs", () => {
     await expect(p).resolves.toBe(output);
   });
 
+  it("providerTextToAudio returns the encoded audio blob", async () => {
+    const output = new Uint8Array([4, 5, 6]);
+    const p = bridge.providerTextToAudio("wangp", {
+      model: "ace_step_1.5",
+      prompt: "ambient"
+    });
+    const frame = bridge.sent.find((f) => f.type === "provider.text_to_audio")!;
+    expect(frame.data).toEqual({
+      provider: "wangp",
+      params: { model: "ace_step_1.5", prompt: "ambient" },
+      secrets: {},
+      blob_transfer: "chunked-v1"
+    });
+    reply("provider.text_to_audio", { blobs: { audio: output } });
+    await expect(p).resolves.toBe(output);
+  });
+
+  it("providerTTSEncoded returns the encoded audio blob", async () => {
+    const output = new Uint8Array([7, 8, 9]);
+    const p = bridge.providerTTSEncoded("wangp", {
+      model: "qwen3_tts",
+      text: "hello"
+    });
+    const frame = bridge.sent.find((f) => f.type === "provider.tts_encoded")!;
+    expect(frame.data).toEqual({
+      provider: "wangp",
+      params: { model: "qwen3_tts", text: "hello" },
+      secrets: {},
+      blob_transfer: "chunked-v1"
+    });
+    reply("provider.tts_encoded", { blobs: { audio: output } });
+    await expect(p).resolves.toBe(output);
+  });
+
   it("cancels an in-flight video provider request with its abort signal", async () => {
     const controller = new AbortController();
     const p = bridge.providerTextToVideo(

--- a/packages/runtime/tests/python-bridge-base-coverage.test.ts
+++ b/packages/runtime/tests/python-bridge-base-coverage.test.ts
@@ -658,6 +658,10 @@ describe("PythonBridgeBase — provider RPCs", () => {
   it("providerTextToImage returns the image blob", async () => {
     const bytes = new Uint8Array([1, 2, 3]);
     const p = bridge.providerTextToImage("fal", { prompt: "x" });
+    const frame = bridge.sent.find((f) => f.type === "provider.text_to_image")!;
+    expect((frame.data as Record<string, unknown>).blob_transfer).toBe(
+      "chunked-v1"
+    );
     reply("provider.text_to_image", { blobs: { image: bytes } });
     await expect(p).resolves.toBe(bytes);
   });
@@ -670,6 +674,9 @@ describe("PythonBridgeBase — provider RPCs", () => {
       (f) => f.type === "provider.image_to_image"
     )!;
     expect((frame.data as Record<string, unknown>).image).toBe(input);
+    expect((frame.data as Record<string, unknown>).blob_transfer).toBe(
+      "chunked-v1"
+    );
     reply("provider.image_to_image", { blobs: { image: output } });
     await expect(p).resolves.toBe(output);
   });

--- a/packages/runtime/tests/swappable-python-bridge.test.ts
+++ b/packages/runtime/tests/swappable-python-bridge.test.ts
@@ -93,6 +93,12 @@ class FakeBridge extends EventEmitter {
   providerImageToVideo(): Promise<Uint8Array> {
     return Promise.resolve(new Uint8Array());
   }
+  providerTextToAudio(): Promise<Uint8Array> {
+    return Promise.resolve(new Uint8Array());
+  }
+  providerTTSEncoded(): Promise<Uint8Array> {
+    return Promise.resolve(new Uint8Array());
+  }
   providerASR(): Promise<{ text: string }> {
     return Promise.resolve({ text: "" });
   }

--- a/packages/websocket/src/models-api.ts
+++ b/packages/websocket/src/models-api.ts
@@ -44,6 +44,7 @@ export async function registerPythonProviders(
         _bridge: bridge,
         _id: publicId,
         _bridgeProviderId: info.id,
+        _capabilities: info.capabilities,
         ...secrets
       },
       {},

--- a/packages/websocket/tests/models-api-python-providers.test.ts
+++ b/packages/websocket/tests/models-api-python-providers.test.ts
@@ -30,6 +30,7 @@ describe("registerPythonProviders", () => {
     expect(getRegisteredProvider("huggingface-local")?.kwargs).toMatchObject({
       _id: "huggingface-local",
       _bridgeProviderId: "huggingface",
+      _capabilities: ["text_to_speech"],
       _bridge: bridge
     });
     expect(getRegisteredProvider("huggingface-local")?.metadata).toEqual({


### PR DESCRIPTION
## Summary
- expose music models discovered by Python workers
- add encoded music and TTS bridge calls
- use cancellable chunked transfers for Python image generation
- normalize image/video/music model ids at the provider boundary
- sniff returned audio containers for correct MIME types

## Validation
- runtime TypeScript check
- focused runtime tests (103 passed)
- oxlint on changed runtime sources