### PR TITLE
Add reference-to-video support to providers and storyboards

### DIFF
--- a/packages/agents/scripts/dump-creative-run.ts
+++ b/packages/agents/scripts/dump-creative-run.ts
@@ -79,7 +79,7 @@ function createFalMediaBackend(fal: {
       return save(label, "png", bytes);
     },
     async video(from, prompt, label, durationSeconds) {
-      const bytes = await fal.imageToVideo([from], {
+      const bytes = await fal.imageToVideo(from, {
         model: videoModel,
         prompt,
         durationSeconds,

--- a/packages/agents/src/capabilities/models.specs.ts
+++ b/packages/agents/src/capabilities/models.specs.ts
@@ -17,6 +17,7 @@ export const SUPPORTED_CAPABILITIES = [
   "segment_image",
   "text_to_video",
   "image_to_video",
+  "reference_to_video",
   "text_to_speech",
   "text_to_music",
   "automatic_speech_recognition",

--- a/packages/agents/src/capabilities/models.ts
+++ b/packages/agents/src/capabilities/models.ts
@@ -153,6 +153,7 @@ const CAPABILITY_REF_TYPE = {
   segment_image: "image_model",
   text_to_video: "video_model",
   image_to_video: "video_model",
+  reference_to_video: "video_model",
   text_to_speech: "tts_model",
   // A music-typed node property takes a `music_model`, never a `tts_model`.
   // Handing back the wrong tag made every music ref unassignable: the property
@@ -201,6 +202,8 @@ function capabilityToRecommendedTasks(
       return new Set(["text_to_video"]);
     case "image_to_video":
       return new Set(["image_to_video"]);
+    case "reference_to_video":
+      return new Set(["reference_to_video"]);
     case "generate_embedding":
       return new Set(["embedding"]);
     case "generate_message":
@@ -222,6 +225,7 @@ function capabilityToRecommendedModalities(
       return new Set(["image"]);
     case "text_to_video":
     case "image_to_video":
+    case "reference_to_video":
       return new Set(["video"]);
     case "text_to_speech":
       return new Set(["tts"]);
@@ -246,6 +250,7 @@ async function fetchModelsForCapability(
       return await provider.getAvailableImageModels();
     case "text_to_video":
     case "image_to_video":
+    case "reference_to_video":
       return await provider.getAvailableVideoModels();
     case "text_to_speech":
       return await provider.getAvailableTTSModels();
@@ -287,6 +292,7 @@ function capabilityTask(capability: SupportedCapability): string | null {
     case "image_to_image":
     case "text_to_video":
     case "image_to_video":
+    case "reference_to_video":
     case "text_to_speech":
     case "text_to_music":
       return capability;

--- a/packages/agents/src/capabilities/storyboards.specs.ts
+++ b/packages/agents/src/capabilities/storyboards.specs.ts
@@ -124,11 +124,12 @@ export const RENDER_CLIPS_SCHEMA: JsonSchema = {
     },
     mode: {
       type: "string",
-      enum: ["keyframe", "direct"],
+      enum: ["keyframe", "direct", "reference"],
       description:
         "Override how the selected shots render, for this call only. " +
         "'keyframe' animates each shot's still (image_to_video); 'direct' " +
-        "generates from the prompt with no still (text_to_video). Defaults " +
+        "generates from the prompt with no still (text_to_video); 'reference' " +
+        "uses entity reference images (reference_to_video). Defaults " +
         "to each shot's own render_mode, which defaults to 'keyframe'. Set " +
         "the shot's render_mode with edit_storyboard to make it stick."
     },
@@ -338,7 +339,8 @@ export const renderStoryboardClipsSpec: CapabilitySpec = {
     "directly — no workflow is created or run. A shot renders the way its " +
     "render_mode says: 'keyframe' (the default) animates its selected still " +
     "with image_to_video, 'direct' generates from the prompt with " +
-    "text_to_video and needs no still. Pass `mode` to override both for this " +
+    "text_to_video and needs no still; 'reference' uses entity reference images " +
+    "with reference_to_video. Pass `mode` to override for this " +
     "call. Each clip is saved as an asset and attached to its shot (previous " +
     "takes are kept as versions), leaving the shot 'rendered' and ready for " +
     "assemble_storyboard_timeline. Omit `targets` to render every shot that " +
@@ -346,7 +348,7 @@ export const renderStoryboardClipsSpec: CapabilitySpec = {
     "shot's generation already has its picture and is skipped. " +
     "A keyframe-mode shot with no " +
     "still is reported, not rendered — run render_storyboard_stills first, or " +
-    "set its render_mode to 'direct'. This is the expensive step.",
+    "set its render_mode to 'direct' or 'reference'. This is the expensive step.",
   inputSchema: RENDER_CLIPS_SCHEMA,
   category: "write",
   userMessage: (params) => {

--- a/packages/agents/src/capabilities/storyboards.ts
+++ b/packages/agents/src/capabilities/storyboards.ts
@@ -438,7 +438,7 @@ interface ShotOutcome {
   index: number;
   slug?: string;
   /** How the clip was rendered. Absent on a stills outcome. */
-  render_mode?: "keyframe" | "direct";
+  render_mode?: "keyframe" | "direct" | "reference";
   ok: boolean;
   asset_id?: string;
   asset_uri?: string;
@@ -790,36 +790,54 @@ const renderStoryboardClips: CapabilityExport = {
     const { row, doc } = board;
 
     const override = params["mode"];
-    if (override !== undefined && override !== "keyframe" && override !== "direct") {
-      return { error: 'mode must be "keyframe" or "direct".' };
+    if (override !== undefined && override !== "keyframe" && override !== "direct" && override !== "reference") {
+      return { error: 'mode must be "keyframe", "direct", or "reference".' };
     }
     // The call's override wins over the shot's own setting, for this call only.
     const { shotRenderMode } = await import("@nodetool-ai/protocol");
-    const modeOf = (shot: Shot): "keyframe" | "direct" =>
-      override === "keyframe" || override === "direct"
+    const modeOf = (shot: Shot): "keyframe" | "direct" | "reference" =>
+      override === "keyframe" || override === "direct" || override === "reference"
         ? override
         : shotRenderMode(shot);
-
-    const model = resolveModel(
-      params,
-      doc.videoModel,
-      "clip",
-      // A board renders one way or the other far more often than both, so name
-      // the capability the selection actually needs.
-      doc.shots.every((s) => modeOf(s) === "direct")
-        ? "text_to_video"
-        : "image_to_video"
-    );
-    if (isError(model)) return model;
 
     const selected = selectShots(
       doc.shots,
       params["targets"],
       (s) =>
         !shotHasPicture(s, doc.shots) &&
-        (modeOf(s) === "direct" || !!s.keyframe)
+        (modeOf(s) === "direct" || modeOf(s) === "reference" || !!s.keyframe)
     );
     if (isError(selected)) return selected;
+    const requiredCapabilities = new Set(
+      selected.map((shot) =>
+        modeOf(shot) === "direct"
+          ? "text_to_video"
+          : modeOf(shot) === "reference"
+            ? "reference_to_video"
+            : "image_to_video"
+      )
+    );
+    const capability = requiredCapabilities.has("reference_to_video")
+      ? "reference_to_video"
+      : requiredCapabilities.has("image_to_video")
+        ? "image_to_video"
+        : "text_to_video";
+    const model = resolveModel(params, doc.videoModel, "clip", capability);
+    if (isError(model)) return model;
+    const declaredTasks = doc.videoModel?.supported_tasks;
+    if (
+      Array.isArray(declaredTasks) && declaredTasks.length > 0 &&
+      model.model === doc.videoModel?.id && model.provider === doc.videoModel?.provider
+    ) {
+      const unsupported = [...requiredCapabilities].find(
+        (task) => !declaredTasks.includes(task)
+      );
+      if (unsupported) {
+        return {
+          error: `The selected clip model does not support ${unsupported}; choose a model that supports every selected shot mode.`
+        };
+      }
+    }
     const entities = await loadBoardEntities(context, doc);
     const fresh = await filterStale(selected, params, doc, entities, "clip");
     const skipped = fresh.skipped;
@@ -1684,8 +1702,8 @@ function applyShotFields(
   }
   if (args["render_mode"] !== undefined) {
     const mode = String(args["render_mode"]);
-    if (mode !== "keyframe" && mode !== "direct") {
-      throw new Error('render_mode must be "keyframe" or "direct".');
+    if (mode !== "keyframe" && mode !== "direct" && mode !== "reference") {
+      throw new Error('render_mode must be "keyframe", "direct", or "reference".');
     }
     next.render_mode = mode;
   }

--- a/packages/agents/src/prompts/workflow-authoring-knowledge.ts
+++ b/packages/agents/src/prompts/workflow-authoring-knowledge.ts
@@ -23,6 +23,7 @@ export type GenericNodeCapability =
   | "image_to_image"
   | "text_to_video"
   | "image_to_video"
+  | "reference_to_video"
   | "text_to_speech"
   | "automatic_speech_recognition"
   | "generate_embedding"
@@ -77,6 +78,14 @@ export const GENERIC_AI_NODES: readonly GenericAINode[] = [
     task: "Image → Video",
     summary:
       "Animate a source image into a video. Required: image, prompt, model.",
+    acceptsModel: true
+  },
+  {
+    type: "nodetool.video.ReferenceToVideo",
+    capability: "reference_to_video",
+    task: "Reference → Video",
+    summary:
+      "Generate a video guided by ordered reference images and videos. Required: at least one reference image or video, prompt, model.",
     acceptsModel: true
   },
   {

--- a/packages/agents/tests/capabilities-models-and-storyboards-reference-video.test.ts
+++ b/packages/agents/tests/capabilities-models-and-storyboards-reference-video.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { BaseProvider } from "@nodetool-ai/runtime";
+import type { ProcessingContext, ProviderId, VideoModel } from "@nodetool-ai/runtime";
+import { Asset, ModelObserver, Storyboard, initTestDb } from "@nodetool-ai/models";
+import type { Shot } from "@nodetool-ai/protocol";
+import { toolForCapabilityName } from "../src/capabilities/lazy-tool.js";
+import { createCapabilityRun, UNGATED } from "../src/capabilities/invoke.js";
+import { withGenerationSeam } from "./_helpers/generation-seam.js";
+
+class ReferenceVideoProvider extends BaseProvider {
+  constructor(private readonly models: VideoModel[]) {
+    super("fal_ai" as ProviderId);
+  }
+  override async referenceToVideo(): Promise<Uint8Array> { return new Uint8Array(); }
+  override async getAvailableVideoModels(): Promise<VideoModel[]> {
+    return this.models;
+  }
+}
+
+const ctx = { userId: "u1" } as ProcessingContext;
+const shot = (overrides: Partial<Shot> & { id: string; index: number }): Shot => ({
+  type: "shot",
+  action: `action ${overrides.index}`,
+  status: "planned",
+  ...overrides
+});
+
+function renderContext(referenceIds: [string, string]) {
+  return withGenerationSeam({
+    userId: "u1",
+    runProviderPrediction: vi.fn(async () => new Uint8Array([0, 0, 0, 24, 102, 116, 121, 112])),
+    hasModelInterface: () => true,
+    createAsset: vi.fn(async (args: { name: string; contentType: string; content: Uint8Array }) => {
+      return Asset.create<Asset>({ user_id: "u1", name: args.name, content_type: args.contentType });
+    }),
+    resolveAssetBytes: vi.fn(async (uri: string) => ({
+      bytes: uri.includes(referenceIds[0]) ? new Uint8Array([1, 2]) : new Uint8Array([3, 4])
+    }))
+  }) as ProcessingContext & { runProviderPrediction: ReturnType<typeof vi.fn> };
+}
+
+describe("reference_to_video capability contracts", () => {
+  beforeEach(() => initTestDb());
+  afterEach(() => ModelObserver.clear());
+
+  it("find_model filters video models by reference_to_video", async () => {
+    const provider = new ReferenceVideoProvider([
+      { id: "image-model", name: "Image model", provider: "fal_ai", supportedTasks: ["image_to_video"] },
+      { id: "reference-model", name: "Reference model", provider: "fal_ai", supportedTasks: ["reference_to_video"] }
+    ]);
+    const tool = toolForCapabilityName("find_model", (context) =>
+      createCapabilityRun({ context, gate: UNGATED, providers: { fal_ai: provider } })
+    );
+    const result = (await tool.process(ctx, { capability: "reference_to_video" })) as {
+      results: Array<{ model_id: string }>;
+    };
+    expect(result.results.map((model) => model.model_id)).toEqual(["reference-model"]);
+  });
+
+  it("render_storyboard_clips dispatches a reference shot through reference_to_video", async () => {
+    const first = await Asset.create<Asset>({
+      user_id: "u1", name: "ref-a.png", content_type: "image/png",
+      metadata: { nodetool_entity: { kind: "character", name: "A", descriptor: "first" } }
+    });
+    const second = await Asset.create<Asset>({
+      user_id: "u1", name: "ref-b.png", content_type: "image/png",
+      metadata: { nodetool_entity: { kind: "character", name: "B", descriptor: "second" } }
+    });
+    const board = await Storyboard.create<Storyboard>({
+      user_id: "u1", project_id: "default", name: "Reference board",
+      document: JSON.stringify({
+        screenplay: null,
+        shots: [shot({ id: "s1", index: 0, render_mode: "reference", entity_ids: [first.id, second.id] })],
+        brief: "", style: "", entityIds: [first.id, second.id], aspectRatio: "16:9",
+        directorModel: null, imageModel: null,
+        videoModel: { type: "video_model", id: "reference-model", provider: "fal_ai" }
+      })
+    });
+    const context = renderContext([first.id, second.id]);
+    const result = (await toolForCapabilityName("render_storyboard_clips").process(context, {
+      storyboard_id: board.id
+    })) as { rendered: number };
+    expect(result.rendered).toBe(1);
+    expect(context.runProviderPrediction.mock.calls[0][0]).toMatchObject({
+      capability: "reference_to_video",
+      model: "reference-model",
+      params: { reference_images: [new Uint8Array([1, 2]), new Uint8Array([3, 4])] }
+    });
+  });
+});

--- a/packages/agents/tests/generic-ai-nodes.test.ts
+++ b/packages/agents/tests/generic-ai-nodes.test.ts
@@ -11,6 +11,7 @@ const VALID_CAPABILITIES: GenericNodeCapability[] = [
   "image_to_image",
   "text_to_video",
   "image_to_video",
+  "reference_to_video",
   "text_to_speech",
   "automatic_speech_recognition",
   "generate_embedding",

--- a/packages/agents/tests/storyboard-render-tools.test.ts
+++ b/packages/agents/tests/storyboard-render-tools.test.ts
@@ -327,7 +327,7 @@ describe("storyboard render tools", () => {
       ops: [{ op: "update_shot", target: "s1", render_mode: "sideways" }]
     })) as { failed: number; ops: Array<{ error?: string }> };
     expect(rejected.failed).toBe(1);
-    expect(rejected.ops[0].error).toContain('"keyframe" or "direct"');
+    expect(rejected.ops[0].error).toContain('"keyframe", "direct", or "reference"');
   });
 
   it("revises a clip in place, keeping the previous take as a version", async () => {

--- a/packages/base-nodes/src/index.ts
+++ b/packages/base-nodes/src/index.ts
@@ -226,6 +226,7 @@ export {
 export {
   TextToVideoNode,
   ImageToVideoNode,
+  ReferenceToVideoNode,
   LoadVideoFileNode,
   SaveVideoFileVideoNode,
   LoadVideoAssetsNode,

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -315,11 +315,11 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "find_model",
     module: "models",
     impl: "packages/agents/src/capabilities/models.ts",
-    contract: "fdb5f2e60161",
+    contract: "cc6866ced0fd",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-models.test.ts",
-      "packages/agents/tests/capabilities-models-rankings.test.ts",
+      "packages/agents/tests/capabilities-models-and-storyboards-reference-video.test.ts",
     ],
     evals: [
       {
@@ -2473,11 +2473,11 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "render_storyboard_clips",
     module: "storyboards",
     impl: "packages/agents/src/capabilities/storyboards.ts",
-    contract: "99052baaa53f",
+    contract: "568457bf299c",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-storyboards.test.ts",
-      "packages/agents/tests/capabilities-storyboard-board-ops.test.ts",
+      "packages/agents/tests/capabilities-models-and-storyboards-reference-video.test.ts",
     ],
     evals: [
       {

--- a/packages/dsl/src/flow/generated/nodetool.video.ts
+++ b/packages/dsl/src/flow/generated/nodetool.video.ts
@@ -46,6 +46,29 @@ export function imageToVideo(inputs: ImageToVideoInputs): Promise<ImageToVideoOu
   return callNode<ImageToVideoOutputs>("nodetool.video.ImageToVideo", inputs);
 }
 
+// Reference To Video — nodetool.video.ReferenceToVideo
+export type ReferenceToVideoInputs = {
+  reference_images?: ImageRef[];
+  reference_videos?: VideoRef[];
+  model?: unknown;
+  prompt?: string;
+  use_reference_video_audio?: boolean;
+  negative_prompt?: string;
+  entities?: Entity[];
+  aspect_ratio?: string;
+  resolution?: string;
+  duration?: number;
+  timeout_seconds?: number;
+};
+
+export interface ReferenceToVideoOutputs {
+  output: VideoRef;
+}
+
+export function referenceToVideo(inputs: ReferenceToVideoInputs): Promise<ReferenceToVideoOutputs> {
+  return callNode<ReferenceToVideoOutputs>("nodetool.video.ReferenceToVideo", inputs);
+}
+
 // Load Video File — nodetool.video.LoadVideoFile
 export type LoadVideoFileInputs = {
   path?: string;

--- a/packages/dsl/src/generated/nodetool.video.ts
+++ b/packages/dsl/src/generated/nodetool.video.ts
@@ -44,6 +44,29 @@ export function imageToVideo(inputs: ImageToVideoInputs): DslNode<ImageToVideoOu
   return createNode("nodetool.video.ImageToVideo", inputs, { outputNames: ["output"], defaultOutput: "output" });
 }
 
+// Reference To Video — nodetool.video.ReferenceToVideo
+export type ReferenceToVideoInputs = {
+  reference_images?: Connectable<ImageRef[]>;
+  reference_videos?: Connectable<VideoRef[]>;
+  model?: Connectable<unknown>;
+  prompt?: Connectable<string>;
+  use_reference_video_audio?: Connectable<boolean>;
+  negative_prompt?: Connectable<string>;
+  entities?: Connectable<Entity[]>;
+  aspect_ratio?: Connectable<string>;
+  resolution?: Connectable<string>;
+  duration?: Connectable<number>;
+  timeout_seconds?: Connectable<number>;
+};
+
+export interface ReferenceToVideoOutputs {
+  output: VideoRef;
+}
+
+export function referenceToVideo(inputs: ReferenceToVideoInputs): DslNode<ReferenceToVideoOutputs, "output"> {
+  return createNode("nodetool.video.ReferenceToVideo", inputs, { outputNames: ["output"], defaultOutput: "output" });
+}
+
 // Load Video File — nodetool.video.LoadVideoFile
 export type LoadVideoFileInputs = {
   path?: Connectable<string>;

--- a/packages/execution/src/cost-ledger.ts
+++ b/packages/execution/src/cost-ledger.ts
@@ -55,6 +55,7 @@ const UNIT_BILLED_CAPABILITIES = new Set([
   "inpainting",
   "text_to_video",
   "image_to_video",
+  "reference_to_video",
   "video_to_video",
   "upscale_image",
   "remove_background",

--- a/packages/execution/tests/cost-ledger.test.ts
+++ b/packages/execution/tests/cost-ledger.test.ts
@@ -87,6 +87,7 @@ describe("isUnitBilledCapability", () => {
   it("covers generation and excludes the token-billed capabilities", () => {
     expect(isUnitBilledCapability("text_to_image")).toBe(true);
     expect(isUnitBilledCapability("image_to_video")).toBe(true);
+    expect(isUnitBilledCapability("reference_to_video")).toBe(true);
     expect(isUnitBilledCapability("text_to_speech")).toBe(true);
     // Chat and embeddings are accounted for in tokens by BaseProvider.
     expect(isUnitBilledCapability("generate_message")).toBe(false);

--- a/packages/execution/tests/generation-seam-audit.test.ts
+++ b/packages/execution/tests/generation-seam-audit.test.ts
@@ -40,6 +40,7 @@ const MEDIA_METHODS = [
   "textToMusic",
   "textToVideo",
   "imageToVideo",
+  "referenceToVideo",
   "videoToVideo",
   "lipSync",
   "textTo3D",

--- a/packages/game-nodes/tests/game-nodes.test.ts
+++ b/packages/game-nodes/tests/game-nodes.test.ts
@@ -435,7 +435,7 @@ describe("ExportGodotProject", () => {
     expect(await workspace.readText("game/scripts/player.gd")).toContain(
       "# hand edited"
     );
-  });
+  }, 15_000);
 
   it("exports the template's own art when nothing was filled", async () => {
     // The blank-template path (game-prd § 4.1): a project that runs in Godot

--- a/packages/models/src/project-summary.ts
+++ b/packages/models/src/project-summary.ts
@@ -327,6 +327,7 @@ const CAPABILITY_CATEGORY: Record<string, SpendCategory> = {
   vectorize_image: "stills",
   text_to_video: "clips",
   image_to_video: "clips",
+  reference_to_video: "clips",
   video_to_video: "clips",
   lip_sync: "clips",
   text_to_speech: "voice",

--- a/packages/models/tests/project.test.ts
+++ b/packages/models/tests/project.test.ts
@@ -339,6 +339,7 @@ describe("spend rollup", () => {
   it("routes a row by capability, then by node type, then to pipeline", () => {
     expect(spendCategory(row({ metadata: { capability: "text_to_image" } }))).toBe("stills");
     expect(spendCategory(row({ metadata: { capability: "image_to_video" } }))).toBe("clips");
+    expect(spendCategory(row({ metadata: { capability: "reference_to_video" } }))).toBe("clips");
     expect(spendCategory(row({ metadata: { capability: "text_to_speech" } }))).toBe("voice");
     // An unpriced generation records its capability as the billing unit.
     expect(spendCategory(row({ billing_unit: "lip_sync" }))).toBe("clips");

--- a/packages/protocol/src/api-schemas/storyboards.ts
+++ b/packages/protocol/src/api-schemas/storyboards.ts
@@ -37,8 +37,8 @@ export const storyboardShot = z
     /** Linked line texts as last projected, joined "\n" — drift only. */
     script_text_snapshot: z.string().optional(),
     duration_source: z.enum(["audio", "manual"]).optional(),
-    /** Animate the shot's still, or generate the clip straight from text. */
-    render_mode: z.enum(["keyframe", "direct"]).optional(),
+    /** Animate a still, generate from text, or use entity reference images. */
+    render_mode: z.enum(["keyframe", "direct", "reference"]).optional(),
     /** The scene this shot belongs to. Absent on legacy, unscened shots. */
     scene_id: z.string().optional()
   })

--- a/packages/protocol/src/creative.ts
+++ b/packages/protocol/src/creative.ts
@@ -349,6 +349,8 @@ export interface RenderInputs {
   style_entity_id: string | null;
   /** The still a keyframe-mode clip animated. */
   source_version_id?: string;
+  reference_asset_ids?: string[];
+  render_mode?: ShotRenderMode;
   recorded_at: string;
 }
 
@@ -374,6 +376,9 @@ export function renderInputsMatch(a: RenderInputs, b: RenderInputs): boolean {
     a.model === b.model &&
     a.aspect_ratio === b.aspect_ratio &&
     a.style_entity_id === b.style_entity_id &&
+    JSON.stringify(a.reference_asset_ids ?? []) ===
+      JSON.stringify(b.reference_asset_ids ?? []) &&
+    a.render_mode === b.render_mode &&
     a.source_version_id === b.source_version_id
   );
 }
@@ -499,12 +504,15 @@ export type ShotDurationSource = "audio" | "manual";
  * the native-audio models (dialogue, synced sound) are weakest on their
  * image path.
  */
-export type ShotRenderMode = "keyframe" | "direct";
+export type ShotRenderMode = "keyframe" | "direct" | "reference";
 
 /** A shot's render mode, with the default applied. */
 export const shotRenderMode = (
   shot: Pick<Shot, "render_mode">
-): ShotRenderMode => (shot.render_mode === "direct" ? "direct" : "keyframe");
+): ShotRenderMode =>
+  shot.render_mode === "direct" || shot.render_mode === "reference"
+    ? shot.render_mode
+    : "keyframe";
 
 /**
  * A scene: the set of shots sharing its id. Those shots are contiguous in

--- a/packages/protocol/src/render-record.ts
+++ b/packages/protocol/src/render-record.ts
@@ -53,6 +53,8 @@ export interface BoardRenderContext {
   style: string;
   /** The screenplay's scenes, so a shot's lighting can be found. */
   scenes?: readonly Scene[] | null;
+  /** Ordered entity reference image asset ids for reference-mode clips. */
+  reference_asset_ids?: readonly string[];
 }
 
 /** A {@link RenderInputs} before it is stamped — what the comparison reads. */
@@ -113,11 +115,15 @@ export function currentRenderInputs(
     aspect_ratio: board.aspect_ratio,
     style_entity_id: board.style_entity_id
   };
+  if (kind === "clip") draft.render_mode = shotRenderMode(shot);
   // A keyframe-mode clip animates the selected still, so which still that was
   // is one of its inputs: re-picking a take makes the clip stale. A direct clip
   // has no source.
   if (kind === "clip" && shotRenderMode(shot) === "keyframe") {
     draft.source_version_id = versionId(shot.keyframe);
+  }
+  if (kind === "clip" && shotRenderMode(shot) === "reference") {
+    draft.reference_asset_ids = [...(board.reference_asset_ids ?? [])];
   }
   return draft;
 }
@@ -163,6 +169,9 @@ function renderInputsMatchDraft(
     recorded.model === current.model &&
     recorded.aspect_ratio === current.aspect_ratio &&
     recorded.style_entity_id === current.style_entity_id &&
+    recorded.render_mode === current.render_mode &&
+    JSON.stringify(recorded.reference_asset_ids ?? []) ===
+      JSON.stringify(current.reference_asset_ids ?? []) &&
     recorded.source_version_id === current.source_version_id
   );
 }

--- a/packages/protocol/src/toolSchemas.ts
+++ b/packages/protocol/src/toolSchemas.ts
@@ -140,6 +140,7 @@ export const MODEL_SEARCH_KINDS = [
   "image_to_image",
   "text_to_video",
   "image_to_video",
+  "reference_to_video",
   "text_to_speech",
   "text_to_music",
   "speech_to_text",
@@ -153,7 +154,7 @@ export const uiSearchModelsParams = {
     .describe(
       "Model task category. Match to the AI node you're configuring: " +
         "`text_to_image` for nodetool.image.TextToImage, `image_to_image` for nodetool.image.ImageToImage, " +
-        "`text_to_video` for nodetool.video.TextToVideo, `image_to_video` for nodetool.video.ImageToVideo, " +
+        "`text_to_video` for nodetool.video.TextToVideo, `image_to_video` for nodetool.video.ImageToVideo, `reference_to_video` for nodetool.video.ReferenceToVideo, " +
         "`text_to_speech` for nodetool.audio.TextToSpeech, `text_to_music` for nodetool.audio.TextToMusic, " +
         "`speech_to_text` for nodetool.text.AutomaticSpeechRecognition, " +
         "`text_generation` for nodetool.agents.* and nodetool.generators.*, `embedding` for nodetool.text.Embedding."
@@ -188,7 +189,7 @@ export const uiToolSchemas: Record<string, UiToolSchema> = {
   },
   ui_search_models: {
     description:
-      "List recommended/available AI models for a given task. Required: `kind` (one of: text_to_image, image_to_image, text_to_video, image_to_video, text_to_speech, speech_to_text, text_generation, embedding). Returns model ids you can write to a generic AI node's `model` property via ui_update_node_data.",
+      "List recommended/available AI models for a given task. Required: `kind` (one of: text_to_image, image_to_image, text_to_video, image_to_video, reference_to_video, text_to_speech, speech_to_text, text_generation, embedding). Returns model ids you can write to a generic AI node's `model` property via ui_update_node_data.",
     parameters: uiSearchModelsParams
   },
   ui_add_node: {

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -44,8 +44,10 @@ import { generationRegistry } from "./generation-registry.js";
 import { redactGenerationParams } from "./redact-params.js";
 import {
   isCallable,
+  isBoolean,
   isNonEmptyString,
   isObjectLike,
+  isNumber,
   isRecord,
   isString
 } from "@nodetool-ai/protocol";
@@ -300,6 +302,7 @@ export type ProviderCapability =
   | "vectorize_image"
   | "text_to_video"
   | "image_to_video"
+  | "reference_to_video"
   | "video_to_video"
   | "lip_sync"
   | "text_to_speech"
@@ -385,6 +388,7 @@ export type ProviderPredictionResult = Awaited<
       | "inpaint"
       | "textToVideo"
       | "imageToVideo"
+      | "referenceToVideo"
       | "upscaleImage"
       | "removeBackground"
       | "relightImage"
@@ -780,6 +784,21 @@ function coerceImageList(params: Record<string, unknown>): Uint8Array[] {
   }
   const single = params.image;
   return single instanceof Uint8Array ? [single] : [];
+}
+
+function coerceByteList(value: unknown): Uint8Array[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (item): item is Uint8Array => item instanceof Uint8Array && item.byteLength > 0
+  );
+}
+
+function firstNonEmptyByteList(value: Uint8Array[]): Uint8Array {
+  return value.find((bytes) => bytes.byteLength > 0) ?? new Uint8Array();
+}
+
+function isAbortSignal(value: unknown): value is AbortSignal {
+  return isObjectLike(value) && isBoolean(value.aborted) && isCallable(value.addEventListener);
 }
 
 /**
@@ -2978,7 +2997,7 @@ export class ProcessingContext {
           timeoutSeconds: params.timeout_seconds as number | undefined
         });
       case "image_to_video":
-        return provider.imageToVideo(coerceImageList(params), {
+        return provider.imageToVideo(firstNonEmptyByteList(coerceImageList(params)), {
           signal: params.signal as AbortSignal | undefined,
           prompt: params.prompt as string | undefined,
           entities: await coerceEntityList(params, this),
@@ -2990,6 +3009,37 @@ export class ProcessingContext {
           resolution: params.resolution as string | undefined,
           timeoutSeconds: params.timeout_seconds as number | undefined
         });
+      case "reference_to_video": {
+        const images = coerceByteList(params.reference_images);
+        const videos = coerceByteList(params.reference_videos);
+        if (images.length === 0 && videos.length === 0) {
+          throw new Error("reference_to_video requires at least one reference image or video");
+        }
+        return provider.referenceToVideo(
+          { images, videos },
+          {
+            model: { id: req.model, name: req.model, provider: req.provider },
+            prompt: isString(params.prompt) ? params.prompt : "",
+            entities: await coerceEntityList(params, this),
+            useReferenceVideoAudio: isBoolean(params.use_reference_video_audio)
+              ? params.use_reference_video_audio
+              : undefined,
+            negativePrompt: isString(params.negative_prompt)
+              ? params.negative_prompt
+              : undefined,
+            numFrames: isNumber(params.num_frames) ? params.num_frames : undefined,
+            durationSeconds: isNumber(params.duration_seconds)
+              ? params.duration_seconds
+              : undefined,
+            aspectRatio: isString(params.aspect_ratio) ? params.aspect_ratio : undefined,
+            resolution: isString(params.resolution) ? params.resolution : undefined,
+            timeoutSeconds: isNumber(params.timeout_seconds)
+              ? params.timeout_seconds
+              : undefined,
+            signal: isAbortSignal(params.signal) ? params.signal : undefined
+          }
+        );
+      }
       case "upscale_image":
         return provider.upscaleImage(params.image as Uint8Array, {
           model: { id: req.model, name: req.model, provider: req.provider },
@@ -3960,6 +4010,7 @@ function generationResultData(
 const VIDEO_CAPABILITIES: ReadonlySet<ProviderCapability> = new Set([
   "text_to_video",
   "image_to_video",
+  "reference_to_video",
   "video_to_video",
   "lip_sync"
 ]);

--- a/packages/runtime/src/providers/atlascloud-provider.ts
+++ b/packages/runtime/src/providers/atlascloud-provider.ts
@@ -28,6 +28,7 @@
 
 import { OpenAICompatProvider } from "./openai-compat-provider.js";
 import { bytesToImageDataUri } from "./image-mime.js";
+import { sniffMediaMime } from "./media-mime.js";
 import type { OpenAICompatProviderOptions } from "./openai-compat-provider.js";
 import { createLogger } from "@nodetool-ai/config";
 import { isBoolean, isNumber } from "@nodetool-ai/protocol";
@@ -41,6 +42,8 @@ import {
 import {
   getManifestNodeMeta,
   getModelInputFields,
+  getModelReferenceInputs,
+  validateReferenceInputs,
   loadImageModels,
   loadManifest,
   loadVideoModels
@@ -54,6 +57,7 @@ import type {
   TextToVideoParams,
   VideoModel
 } from "./types.js";
+import type { ReferenceToVideoInputs, ReferenceToVideoParams } from "./types.js";
 
 const log = createLogger("nodetool.runtime.providers.atlascloud");
 
@@ -604,38 +608,28 @@ export class AtlasCloudProvider extends OpenAICompatProvider {
   }
 
   override async imageToVideo(
-    images: Uint8Array[],
+    image: Uint8Array,
     params: ImageToVideoParams
   ): Promise<Uint8Array> {
-    const image = images[0];
     if (!image || image.length === 0) {
       throw new Error("image must not be empty");
     }
+    const model = (await this.getAvailableVideoModels()).find((item) => item.id === params.model.id);
+    if (!model?.supportedTasks?.includes("image_to_video")) {
+      throw new Error(`AtlasCloud model ${params.model.id} does not support image_to_video`);
+    }
     const info = this.resolveModel(params.model.id, "video");
     const input = mapVideoParams(info, params);
-    // Each endpoint family names its input image differently: Seedance uses
-    // `image` (singular), Grok Imagine Video `image_url`, the edit endpoints
-    // `images`, and reference-to-video `reference_images`. First match wins.
     const dataUri = bytesToImageDataUri(image);
-    const imageField = ["image", "image_url", "images", "reference_images"].find(
+    const imageField = ["first_frame_image", "start_image", "image", "image_url", "images", "image_urls"].find(
       (name) => info.fields.has(name)
     );
-    if (imageField) {
-      // Wan 3.0 / MiniMax H3 take one mixed `refers` array of `{url, type}`
-      // objects; the manifest splits it into typed inputs that name it.
-      const wrapInto = info.fields.get(imageField)?.wrapInto;
-      if (wrapInto) {
-        input[wrapInto] = [{ url: dataUri, type: "image" }];
-      } else if (imageField === "images" || imageField === "reference_images") {
-        input[imageField] = [dataUri];
-      } else {
-        input[imageField] = dataUri;
-      }
-    } else {
-      throw new Error(
-        `AtlasCloud model ${params.model.id} does not accept an input image (try the Seedance image-to-video variant)`
-      );
+    if (!imageField) {
+      throw new Error(`AtlasCloud model ${params.model.id} does not declare a start image field`);
     }
+    input[imageField] = info.fields.get(imageField)?.type.startsWith("list[")
+      ? [dataUri]
+      : dataUri;
     return this.runJob(
       "video",
       params.model.id,
@@ -643,5 +637,48 @@ export class AtlasCloudProvider extends OpenAICompatProvider {
       input,
       runJobOptions(params)
     );
+  }
+
+  override async referenceToVideo(
+    inputs: ReferenceToVideoInputs,
+    params: ReferenceToVideoParams
+  ): Promise<Uint8Array> {
+    const modelId = params.model.id;
+    const model = (await this.getAvailableVideoModels()).find((item) => item.id === modelId);
+    if (!model?.supportedTasks?.includes("reference_to_video")) {
+      throw new Error(`AtlasCloud model ${modelId} does not support reference_to_video`);
+    }
+    const fields = getModelReferenceInputs(ATLASCLOUD_MANIFEST_PKG, ATLASCLOUD_MANIFEST_PATH, modelId);
+    const references = {
+      images: inputs.images.filter((bytes) => bytes.length > 0),
+      videos: inputs.videos.filter((bytes) => bytes.length > 0)
+    };
+    validateReferenceInputs("AtlasCloud", modelId, references, fields);
+    const info = this.resolveModel(modelId, "video");
+    const audioField = info.fields.get("use_reference_video_audio");
+    if (params.useReferenceVideoAudio === true && (!audioField || references.videos.length === 0)) {
+      throw new Error(`AtlasCloud model ${modelId} does not support reference video audio for these inputs`);
+    }
+    const input = mapVideoParams(info, params);
+    const groups = new Map<string, Array<{ url: string; type: "image" | "video" }>>();
+    for (const field of fields) {
+      const buffers = field.kind === "image" ? references.images : references.videos;
+      if (buffers.length === 0) continue;
+      const urls = buffers.map((bytes) => field.kind === "image"
+        ? bytesToImageDataUri(bytes)
+        : `data:${sniffMediaMime(bytes, "video/mp4")};base64,${Buffer.from(bytes).toString("base64")}`);
+      if (field.wrapInto) {
+        const group = groups.get(field.wrapInto) ?? [];
+        group.push(...urls.map((url) => ({ url, type: field.kind })));
+        groups.set(field.wrapInto, group);
+      } else {
+        input[field.apiName] = field.isList ? urls : urls[0];
+      }
+    }
+    for (const [name, values] of groups) input[name] = values;
+    if (audioField && params.useReferenceVideoAudio != null) {
+      input.use_reference_video_audio = params.useReferenceVideoAudio;
+    }
+    return this.runJob("video", modelId, info, input, runJobOptions(params));
   }
 }

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -6,6 +6,8 @@ import type {
   ImageToImageParams,
   InpaintingParams,
   ImageToVideoParams,
+  ReferenceToVideoInputs,
+  ReferenceToVideoParams,
   LanguageModel,
   LipSyncParams,
   Message,
@@ -199,6 +201,7 @@ export type ProviderCapability =
   | "vectorize_image"
   | "text_to_video"
   | "image_to_video"
+  | "reference_to_video"
   | "video_to_video"
   | "lip_sync"
   | "text_to_speech"
@@ -236,6 +239,11 @@ export function providerCapabilities(
     BaseProvider.prototype.getAvailableVideoModels
   ) {
     capabilities.push("text_to_video", "image_to_video");
+  }
+  if (
+    instance.referenceToVideo !== BaseProvider.prototype.referenceToVideo
+  ) {
+    capabilities.push("reference_to_video");
   }
   // The remaining task types don't have their own model-discovery method —
   // they reuse Image/VideoModel (advertised via each model's `supportedTasks`).
@@ -524,11 +532,15 @@ export abstract class BaseProvider {
               model: extractModelId(args)
             });
             if (!alreadyActive) {
+              const failureArgs =
+                name === "referenceToVideo"
+                  ? [referenceVideoDiagnostics(args)]
+                  : args;
               this.recordCallFailure({
                 model: extractModelId(args),
                 operation: name,
-                request: peekLastRequest(),
-                nodetoolArgs: args,
+                request: name === "referenceToVideo" ? undefined : peekLastRequest(),
+                nodetoolArgs: failureArgs,
                 error: err,
                 startedAt
               });
@@ -1787,14 +1799,21 @@ export abstract class BaseProvider {
   }
 
   /**
-   * Animate one or more source images into a video. Single-frame providers
-   * use `images[0]`; providers with multi-reference support may use more.
+   * Animate a single source image into a video. Reference media uses
+   * {@link referenceToVideo} so the input role remains explicit.
    */
   async imageToVideo(
-    _images: Uint8Array[],
+    _image: Uint8Array,
     _params: ImageToVideoParams
   ): Promise<Uint8Array> {
     throw new Error(`${this.provider} does not support imageToVideo`);
+  }
+
+  async referenceToVideo(
+    _inputs: ReferenceToVideoInputs,
+    _params: ReferenceToVideoParams
+  ): Promise<Uint8Array> {
+    throw new Error(`${this.provider} does not support referenceToVideo`);
   }
 
   /** Restyle / edit an existing video, guided by a prompt. */
@@ -2015,6 +2034,27 @@ type ModalityResult = Awaited<
   ReturnType<BaseProvider[(typeof MODALITY_PROMISE_METHODS)[number]]>
 >;
 
+function referenceVideoDiagnostics(args: unknown[]): Record<string, unknown> {
+  const inputs = args[0];
+  const params = args[1];
+  const media = isRecord(inputs) ? inputs : {};
+  const listBytes = (value: unknown): number =>
+    Array.isArray(value)
+      ? value.reduce(
+          (total, item) =>
+            total + (item instanceof Uint8Array ? item.byteLength : 0),
+          0
+        )
+      : 0;
+  return {
+    image_count: Array.isArray(media.images) ? media.images.length : 0,
+    video_count: Array.isArray(media.videos) ? media.videos.length : 0,
+    image_bytes: listBytes(media.images),
+    video_bytes: listBytes(media.videos),
+    model: extractModelId([params])
+  };
+}
+
 const MODALITY_PROMISE_METHODS = [
   "textToImage",
   "textToImages",
@@ -2032,6 +2072,7 @@ const MODALITY_PROMISE_METHODS = [
   "automaticSpeechRecognition",
   "textToVideo",
   "imageToVideo",
+  "referenceToVideo",
   "videoToVideo",
   "lipSync",
   "textTo3D",

--- a/packages/runtime/src/providers/entity-references.ts
+++ b/packages/runtime/src/providers/entity-references.ts
@@ -42,6 +42,7 @@ const PARAMS_INDEX: Record<string, number> = {
   inpaintImages: 1,
   textToVideo: 0,
   imageToVideo: 1,
+  referenceToVideo: 1,
   videoToVideo: 1
 };
 

--- a/packages/runtime/src/providers/evolink-provider.ts
+++ b/packages/runtime/src/providers/evolink-provider.ts
@@ -226,10 +226,9 @@ export class EvolinkProvider extends OpenAICompatProvider {
   }
 
   override async imageToVideo(
-    images: Uint8Array[],
+    image: Uint8Array,
     params: ImageToVideoParams
   ): Promise<Uint8Array> {
-    const image = images[0];
     if (!image || image.length === 0) {
       throw new Error("The input image cannot be empty.");
     }

--- a/packages/runtime/src/providers/fake-provider.ts
+++ b/packages/runtime/src/providers/fake-provider.ts
@@ -380,7 +380,7 @@ export class FakeProvider extends BaseProvider {
   }
 
   override async imageToVideo(
-    _images: Uint8Array[],
+    _image: Uint8Array,
     _params: ImageToVideoParams
   ): Promise<Uint8Array> {
     this.callCount++;

--- a/packages/runtime/src/providers/fal-provider.ts
+++ b/packages/runtime/src/providers/fal-provider.ts
@@ -35,6 +35,7 @@ import type {
   VideoToVideoParams,
   LipSyncParams
 } from "./types.js";
+import type { ReferenceToVideoInputs, ReferenceToVideoParams } from "./types.js";
 import {
   loadImageModels,
   loadManifest,
@@ -45,9 +46,11 @@ import {
   sizeEnumToAspect,
   type ModelImageInput
 } from "./manifest-models.js";
+import { validateReferenceInputs, getModelReferenceInputs } from "./manifest-models.js";
 import { sniffAudioMime } from "./audio-mime.js";
 import { snapToGptImage2Size } from "./gpt-image-size.js";
 import { detectImageMime } from "./image-mime.js";
+import { sniffMediaMime } from "./media-mime.js";
 import { safeFetch } from "./safe-url.js";
 import {
   isNonEmptyString,
@@ -57,6 +60,13 @@ import {
 } from "@nodetool-ai/protocol";
 
 const log = createLogger("nodetool.runtime.providers.fal");
+
+function combineSignals(signal: AbortSignal | undefined, timeoutSeconds?: number | null): AbortSignal | undefined {
+  const timeout = timeoutSeconds && timeoutSeconds > 0 ? AbortSignal.timeout(timeoutSeconds * 1000) : undefined;
+  if (!signal) return timeout;
+  if (!timeout) return signal;
+  return AbortSignal.any([signal, timeout]);
+}
 
 const FAL_MANIFEST_PKG = "@nodetool-ai/fal-nodes";
 const FAL_MANIFEST_PATH = "fal-manifest.json";
@@ -431,6 +441,21 @@ class FalArgsBuilder {
     } else {
       this.args[fallbackApiName ?? `${kind}_url`] = urls[0];
     }
+    return this;
+  }
+
+  referenceAssetInputs(kind: "image" | "video"): ModelImageInput[] {
+    return getModelReferenceInputs(FAL_MANIFEST_PKG, FAL_MANIFEST_PATH, this.modelId)
+      .filter((field) => field.kind === kind)
+      .map(({ kind: _kind, ...field }) => field);
+  }
+
+  attachReferenceAssets(kind: "image" | "video", urls: string[]): this {
+    if (urls.length === 0) return this;
+    const fields = this.referenceAssetInputs(kind);
+    const field = fields[0];
+    if (!field) return this;
+    this.args[field.apiName] = field.isList ? urls : urls[0];
     return this;
   }
 
@@ -1064,7 +1089,7 @@ export class FalProvider extends BaseProvider {
     });
     const data = (result.data ?? result) as Record<string, unknown>;
     const urls = extractImageUrls(data);
-    return Promise.all(urls.map(downloadBytes));
+    return Promise.all(urls.map((url) => downloadBytes(url)));
   }
 
   override async textToVideo(params: TextToVideoParams): Promise<Uint8Array> {
@@ -1107,7 +1132,7 @@ export class FalProvider extends BaseProvider {
     });
     const data = (result.data ?? result) as Record<string, unknown>;
     const urls = extractImageUrls(data);
-    return Promise.all(urls.map(downloadBytes));
+    return Promise.all(urls.map((url) => downloadBytes(url)));
   }
 
   override async textToImages(
@@ -1133,16 +1158,17 @@ export class FalProvider extends BaseProvider {
     });
     const data = (result.data ?? result) as Record<string, unknown>;
     const urls = extractImageUrls(data);
-    return Promise.all(urls.map(downloadBytes));
+    return Promise.all(urls.map((url) => downloadBytes(url)));
   }
 
   override async imageToVideo(
-    images: Uint8Array[],
+    image: Uint8Array,
     params: ImageToVideoParams
   ): Promise<Uint8Array> {
+    if (!(loadVideoModels(FAL_MANIFEST_PKG, FAL_MANIFEST_PATH, "fal_ai").find((m) => m.id === params.model.id)?.supportedTasks?.includes("image_to_video") ?? false)) throw new Error(`FAL model ${params.model.id} does not support image_to_video`);
     const client = await this.getClient();
     const modelId = params.model.id;
-    const args = await this.buildImageToVideoArgs(modelId, images, params);
+    const args = await this.buildImageToVideoArgs(modelId, [image], params);
     this.recordRequestPayload(args);
     log.debug("FAL imageToVideo", { model: modelId });
     const result = await client.subscribe(modelId, {
@@ -1153,6 +1179,40 @@ export class FalProvider extends BaseProvider {
     });
     const data = (result.data ?? result) as Record<string, unknown>;
     return downloadBytes(extractVideoUrl(data));
+  }
+
+  override async referenceToVideo(
+    inputs: ReferenceToVideoInputs,
+    params: ReferenceToVideoParams
+  ): Promise<Uint8Array> {
+    const images = inputs.images.filter((b) => b.length > 0);
+    const videos = inputs.videos.filter((b) => b.length > 0);
+    if (images.length === 0 && videos.length === 0) {
+      throw new Error("reference_to_video requires at least one reference image or video");
+    }
+    const modelId = params.model.id;
+    const builder = new FalArgsBuilder(modelId);
+    if (!(loadVideoModels(FAL_MANIFEST_PKG, FAL_MANIFEST_PATH, "fal_ai").find((m) => m.id === modelId)?.supportedTasks?.includes("reference_to_video") ?? false)) throw new Error(`FAL model ${modelId} does not support reference_to_video`);
+    validateReferenceInputs("FAL", modelId, inputs, getModelReferenceInputs(FAL_MANIFEST_PKG, FAL_MANIFEST_PATH, modelId));
+    const imageFields = builder.referenceAssetInputs("image");
+    const videoFields = builder.referenceAssetInputs("video");
+    if (images.length > 0 && imageFields.length === 0) throw new Error(`FAL model ${modelId} does not support reference images`);
+    if (videos.length > 0 && videoFields.length === 0) throw new Error(`FAL model ${modelId} does not support reference videos`);
+    if (params.useReferenceVideoAudio === true && videos.length === 0) throw new Error(`FAL model ${modelId} requires a reference video when audio is enabled`);
+    if (params.useReferenceVideoAudio === true && !builder.has("use_reference_video_audio")) throw new Error(`FAL model ${modelId} does not support reference video audio`);
+    const signal = combineSignals(params.signal, params.timeoutSeconds);
+    signal?.throwIfAborted();
+    const imageUrls = await Promise.all(images.map((b) => this.upload(b, detectImageMime(b))));
+    const videoUrls = await Promise.all(videos.map((b) => this.upload(b, sniffMediaMime(b, "video/mp4"))));
+    signal?.throwIfAborted();
+    builder.attachReferenceAssets("image", imageUrls).attachReferenceAssets("video", videoUrls)
+      .set("prompt", params.prompt).set("negative_prompt", params.negativePrompt)
+      .set("duration", params.durationSeconds).setSize(params.aspectRatio, params.resolution)
+      .set("use_reference_video_audio", params.useReferenceVideoAudio);
+    this.recordRequestPayload(builder.args);
+    const client = await this.getClient();
+    const result = await client.subscribe(modelId, { input: builder.args, logs: true, onQueueUpdate: this.makeQueueUpdateHandler(), abortSignal: signal });
+    return downloadBytes(extractVideoUrl((result.data ?? result) as Record<string, unknown>), signal);
   }
 
   /** Upload raw bytes to FAL storage and return the hosted URL. */
@@ -1704,8 +1764,8 @@ export function extractAudioUrl(result: Record<string, unknown>): string {
   throw new Error(`Unexpected FAL audio response: ${JSON.stringify(result)}`);
 }
 
-async function downloadBytes(url: string): Promise<Uint8Array> {
-  const res = await safeFetch(url);
+async function downloadBytes(url: string, signal?: AbortSignal): Promise<Uint8Array> {
+  const res = await safeFetch(url, signal ? { signal } : undefined);
   if (!res.ok) throw new Error(`Failed to download FAL result: ${res.status}`);
   const buf = await res.arrayBuffer();
   return new Uint8Array(buf);

--- a/packages/runtime/src/providers/gemini-provider.ts
+++ b/packages/runtime/src/providers/gemini-provider.ts
@@ -2302,10 +2302,9 @@ export class GeminiProvider extends BaseProvider {
   // ---------------------------------------------------------------------------
 
   override async imageToVideo(
-    images: Uint8Array[],
+    image: Uint8Array,
     params: ImageToVideoParams
   ): Promise<Uint8Array> {
-    const image = images[0];
     if (!image || image.length === 0) {
       throw new Error("Input image cannot be empty.");
     }

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -357,6 +357,8 @@ export type {
   ImageBox,
   TextToVideoParams,
   ImageToVideoParams,
+  ReferenceToVideoInputs,
+  ReferenceToVideoParams,
   EntityReference,
   ProviderStreamItem,
   ProviderSession,

--- a/packages/runtime/src/providers/kie-provider.ts
+++ b/packages/runtime/src/providers/kie-provider.ts
@@ -31,21 +31,25 @@ import type {
   TTSModel,
   VideoModel
 } from "./types.js";
+import type { ReferenceToVideoInputs, ReferenceToVideoParams } from "./types.js";
 import {
   loadVideoModels,
   loadImageModels,
   loadMusicModels,
   loadTTSModels,
   getModelImageInputs,
+  getModelReferenceInputs,
   getModelInputFields,
   getManifestNodeMeta,
   selectPrimaryImageInput,
   selectMaskImageInput,
   type ModelInputField
 } from "./manifest-models.js";
+import { validateReferenceInputs } from "./manifest-models.js";
 import { registerWebhookWait } from "./kie-webhook-registry.js";
 import { sniffAudioMime } from "./audio-mime.js";
 import { detectImageMime, extForImageMime } from "./image-mime.js";
+import { sniffMediaMime } from "./media-mime.js";
 import { OpenAIProvider } from "./openai-provider.js";
 import { AnthropicProvider } from "./anthropic-provider.js";
 import {
@@ -59,6 +63,12 @@ import {
 } from "./responses-api.js";
 
 const log = createLogger("nodetool.runtime.providers.kie");
+
+function combineSignals(signal: AbortSignal | undefined, timeout: AbortSignal | undefined): AbortSignal | undefined {
+  if (!signal) return timeout;
+  if (!timeout) return signal;
+  return AbortSignal.any([signal, timeout]);
+}
 
 const KIE_API_BASE = "https://api.kie.ai";
 const KIE_UPLOAD_URL =
@@ -496,6 +506,27 @@ async function uploadImageBytes(
   if (!downloadUrl) {
     throw new Error(`No downloadUrl in Kie upload response`);
   }
+  return downloadUrl;
+}
+
+async function uploadMediaBytes(
+  apiKey: string,
+  bytes: Uint8Array,
+  signal: AbortSignal | undefined,
+  kind: "image" | "video"
+): Promise<string> {
+  const mime = sniffMediaMime(bytes, kind === "image" ? "image/png" : "video/mp4");
+  const ext = kind === "image" ? (extForImageMime(mime) ?? "png") : "mp4";
+  const fileName = `upload-${Date.now()}.${ext}`;
+  const form = new FormData();
+  form.append("file", new Blob([new Uint8Array(bytes)], { type: mime }), fileName);
+  form.append("uploadPath", kind === "image" ? "images/user-uploads" : "videos/user-uploads");
+  form.append("fileName", fileName);
+  const res = await fetch(KIE_UPLOAD_URL, { method: "POST", headers: { Authorization: `Bearer ${apiKey}` }, body: form, signal });
+  const data = await parseKieJson(res, "upload");
+  if (!res.ok || !data.success) throw new Error(`Kie upload failed: ${res.status} ${JSON.stringify(data)}`);
+  const downloadUrl = (data.data as Record<string, unknown>)?.downloadUrl;
+  if (typeof downloadUrl !== "string" || !downloadUrl) throw new Error("No downloadUrl in Kie upload response");
   return downloadUrl;
 }
 
@@ -1410,12 +1441,17 @@ export class KieProvider extends BaseProvider {
    * whether the frame goes to a single field (`image_url`) or a list.
    */
   override async imageToVideo(
-    images: Uint8Array[],
+    image: Uint8Array,
     params: ImageToVideoParams
   ): Promise<Uint8Array> {
+    const selected = loadVideoModels(KIE_MANIFEST_PKG, KIE_MANIFEST_PATH, "kie")
+      .find((model) => model.id === params.model.id);
+    if (selected && !selected.supportedTasks?.includes("image_to_video")) {
+      throw new Error(`Kie model ${params.model.id} does not support image_to_video`);
+    }
     const apiKey = this.requireApiKey();
     const signal = this.timeoutSignal(params.timeoutSeconds);
-    const imageUrls = await this.uploadImages(apiKey, images, signal);
+    const imageUrls = await this.uploadImages(apiKey, [image], signal);
     if (imageUrls.length === 0) {
       throw new Error("The input image is empty.");
     }
@@ -1438,6 +1474,51 @@ export class KieProvider extends BaseProvider {
     );
     const taskId = await submitTaskWithWebhook(apiKey, modelId, input, signal);
     await waitForCompletion(apiKey, taskId, pollInterval, maxAttempts, signal);
+    return downloadResultBytes(apiKey, taskId, signal);
+  }
+
+  override async referenceToVideo(inputs: ReferenceToVideoInputs, params: ReferenceToVideoParams): Promise<Uint8Array> {
+    const images = inputs.images.filter((b) => b.length > 0);
+    const videos = inputs.videos.filter((b) => b.length > 0);
+    if (images.length === 0 && videos.length === 0) throw new Error("reference_to_video requires at least one reference image or video");
+    const apiKey = this.requireApiKey();
+    const signal = combineSignals(params.signal, this.timeoutSignal(params.timeoutSeconds));
+    if (params.useReferenceVideoAudio === true && videos.length === 0) throw new Error(`Kie model ${params.model.id} requires a reference video when audio is enabled`);
+    if (!(loadVideoModels(KIE_MANIFEST_PKG, KIE_MANIFEST_PATH, "kie").find((m) => m.id === params.model.id)?.supportedTasks?.includes("reference_to_video") ?? false)) throw new Error(`Kie model ${params.model.id} does not support reference_to_video`);
+    const referenceFields = getModelReferenceInputs(KIE_MANIFEST_PKG, KIE_MANIFEST_PATH, params.model.id);
+    // H3's generated minimum describes clip duration (2 seconds), not video count.
+    if (params.model.id === "minimax-h3/reference-to-video") {
+      for (const field of referenceFields) {
+        if (field.kind === "video") delete field.min;
+      }
+    }
+    validateReferenceInputs("Kie", params.model.id, inputs, referenceFields);
+    const imageField = referenceFields.find((f) => f.kind === "image");
+    const videoField = referenceFields.find((f) => f.kind === "video");
+    const fieldsForModel = getModelInputFields(KIE_MANIFEST_PKG, KIE_MANIFEST_PATH, params.model.id);
+    if (params.useReferenceVideoAudio === true && !fieldsForModel.some((field) => field.name === "use_reference_video_audio")) {
+      throw new Error(`Kie model ${params.model.id} does not support reference video audio`);
+    }
+    signal?.throwIfAborted();
+    const [imageUrls, videoUrls] = await Promise.all([
+      Promise.all(images.map((b) => uploadMediaBytes(apiKey, b, signal, "image"))),
+      Promise.all(videos.map((b) => uploadMediaBytes(apiKey, b, signal, "video")))
+    ]);
+    const input: Record<string, unknown> = {};
+    if (imageField && imageUrls.length > 0) input[imageField.apiName] = imageField.isList ? imageUrls : imageUrls[0];
+    if (videoField && videoUrls.length > 0) input[videoField.apiName] = videoField.isList ? videoUrls : videoUrls[0];
+    if (params.prompt) input.prompt = params.prompt;
+    if (params.negativePrompt && fieldsForModel.some((f) => f.name === "negative_prompt")) input.negative_prompt = params.negativePrompt;
+    this.applyEditOptions(input, fieldsForModel, params);
+    if (params.useReferenceVideoAudio === true) {
+      input.use_reference_video_audio = true;
+    }
+    this.applyVideoDuration(input, fieldsForModel, params);
+    this.applyRequiredDefaults(input, fieldsForModel);
+    this.assertRequiredTextFields(input, fieldsForModel, params.model.id);
+    const taskId = await submitTaskWithWebhook(apiKey, params.model.id, input, signal);
+    const polling = this.pollConfig(params.model.id, params.timeoutSeconds);
+    await waitForCompletion(apiKey, taskId, polling.pollInterval, polling.maxAttempts, signal);
     return downloadResultBytes(apiKey, taskId, signal);
   }
 

--- a/packages/runtime/src/providers/manifest-models.ts
+++ b/packages/runtime/src/providers/manifest-models.ts
@@ -25,6 +25,8 @@ interface ManifestInputField {
   enumValues?: string[];
   /** Whether the endpoint refuses the call without this field. */
   required?: boolean;
+  min?: number;
+  max?: number;
 }
 
 /**
@@ -271,7 +273,14 @@ const IMAGE_CONDITIONED_KEYWORDS = [
   "start-end-to-video",
   "keyframes-to-video",
   "frames-to-video",
-  "reference-to-video"
+];
+
+const REFERENCE_VIDEO_KEYWORDS = [
+  "reference-to-video",
+  "reference to video",
+  "referencetovideo",
+  "ref-to-video",
+  "r2v"
 ];
 
 export function inferVideoTasks(name: string, id: string): string[] {
@@ -316,6 +325,9 @@ export function inferVideoTasks(name: string, id: string): string[] {
     EXTEND_SEGMENT.test(id.toLowerCase())
   ) {
     return ["video_to_video"];
+  }
+  if (matchesAny(hay, ...REFERENCE_VIDEO_KEYWORDS)) {
+    return ["reference_to_video"];
   }
   if (matchesAny(hay, ...IMAGE_CONDITIONED_KEYWORDS)) {
     return ["image_to_video"];
@@ -511,6 +523,20 @@ export function narrowTasksByRequiredInputs(
   const generationTask = kind === "image" ? "text_to_image" : "text_to_video";
   const transformTask = kind === "image" ? "image_to_image" : "video_to_video";
   const drop = new Set<string>();
+  const hasRequiredReference = (entry: ManifestNode): boolean =>
+    manifestEntryMediaInputs(entry).some(
+      (field) => /reference|refers|subject/i.test(`${field.name} ${field.apiName}`) &&
+        ((entry.inputFields ?? []).some((f) => (f.apiParamName ?? f.name) === field.apiName && f.required === true) ||
+          (entry.fields ?? []).some((f) => f.name === field.apiName && f.required === true))
+    );
+  if (kind === "video" && !tasks.includes("video_to_video") &&
+      !hasRequiredSourceMedia(n) && hasRequiredReference(n)) {
+    drop.add("text_to_video");
+    drop.add("image_to_video");
+    const referenceTasks = tasks.filter((task) => task === "reference_to_video");
+    if (referenceTasks.length > 0) return referenceTasks;
+    return ["reference_to_video"];
+  }
   if (requiresMediaInput(n, "image")) drop.add(generationTask);
   if (kind === "video" && requiresMediaInput(n, "video")) {
     drop.add("text_to_video");
@@ -533,9 +559,16 @@ export function buildVideoModels(
     const id = nodeId(n);
     if (!id) continue;
     const name = nodeName(n);
-    const tasks =
-      explicitTasks(n) ??
-      narrowTasksByRequiredInputs(inferVideoTasks(name, id), n, "video");
+    const declared = explicitTasks(n);
+    const inferred = inferVideoTasks(name, id);
+    const referenceInputs = manifestEntryReferenceInputs(n);
+    if (!declared && referenceInputs.length > 0 &&
+        !hasRequiredSourceMedia(n) && !inferred.includes("video_to_video")) {
+      inferred.splice(0, inferred.length, "reference_to_video");
+    }
+    const tasks = (declared ?? narrowTasksByRequiredInputs(inferred, n, "video"))
+      .filter((task) => task !== "reference_to_video" || referenceInputs.length > 0);
+    if (tasks.length === 0) continue;
 
     const existing = seen.get(id);
     if (existing) {
@@ -570,6 +603,126 @@ export interface ModelImageInput {
   isList: boolean;
   /** Declared field/input name, used for primary-vs-auxiliary heuristics. */
   name: string;
+  required?: boolean;
+  min?: number;
+  max?: number;
+  wrapInto?: string;
+}
+
+/** A typed media input declared by a manifest. */
+export interface ModelMediaInput extends ModelImageInput {
+  kind: "image" | "video";
+}
+
+export function manifestEntryMediaInputs(entry: ManifestNode): ModelMediaInput[] {
+  const fromUploads = (entry.uploads ?? [])
+    .filter((u) => u.kind === "image" || u.kind === "video")
+    .map((u) => {
+      const field = (entry.fields ?? []).find((f) => f.name === u.field);
+      const input = (entry.inputFields ?? []).find((f) => f.name === u.field || (f.apiParamName ?? f.name) === (u.paramName ?? u.field));
+      return {
+      apiName: u.paramName ?? `${u.field}_url${u.isList ? "s" : ""}`,
+      isList: Boolean(u.isList),
+      name: u.field,
+      kind: u.kind as "image" | "video",
+      required: field?.required ?? input?.required,
+      min: field?.min ?? input?.min,
+      max: field?.max ?? input?.max,
+      wrapInto: field?.wrapInto
+      };
+    });
+  if (fromUploads.length > 0) return fromUploads;
+  const fromInput = (entry.inputFields ?? [])
+    .filter((f) => {
+      const type = f.propType.toLowerCase();
+      return type === "image" || type === "list[image]" || type === "video" || type === "list[video]";
+    })
+    .map((f) => {
+      const type = f.propType.toLowerCase();
+      return {
+        apiName: f.apiParamName ?? f.name,
+        isList: type.startsWith("list["),
+        name: f.name,
+        kind: (type.includes("video") ? "video" : "image") as "image" | "video",
+        required: f.required,
+        min: f.min,
+        max: f.max
+      };
+    });
+  if (fromInput.length > 0) return fromInput;
+  return (entry.fields ?? [])
+    .filter((f) => /^(image|video|list\[(image|video)\])$/i.test(f.type))
+    .map((f) => ({
+      apiName: f.name,
+      isList: f.type.toLowerCase().startsWith("list["),
+      name: f.name,
+      kind: f.type.toLowerCase().includes("video") ? "video" : "image",
+      required: f.required,
+      min: f.min,
+      max: f.max,
+      wrapInto: f.wrapInto
+    }));
+}
+
+export function getModelReferenceInputs(
+  packageName: string,
+  exportPath: string,
+  modelId: string
+): ModelMediaInput[] {
+  const entry = loadManifest(packageName, exportPath).find((n) => nodeId(n) === modelId);
+  if (!entry) return [];
+  return manifestEntryReferenceInputs(entry);
+}
+
+function hasRequiredSourceMedia(entry: ManifestNode): boolean {
+  const references = manifestEntryReferenceInputs(entry);
+  return manifestEntryMediaInputs(entry).some((field) => field.required &&
+    !references.some((reference) => reference.apiName === field.apiName));
+}
+
+function manifestEntryReferenceInputs(entry: ManifestNode): ModelMediaInput[] {
+  const explicitReference = entry.supportedTasks?.includes("reference_to_video") === true ||
+    inferVideoTasks(nodeName(entry), nodeId(entry)).includes("reference_to_video");
+  return manifestEntryMediaInputs(entry).filter((field) => {
+    const names = [field.name, field.apiName];
+    if (field.kind === "image" && /video/i.test(field.apiName)) return false;
+    if (field.kind === "video" && /image/i.test(field.apiName)) return false;
+    if (names.some((name) => /reference|refers|subject/i.test(name))) return true;
+    return explicitReference && names.some((name) => /^(?:input_)?(?:images?|videos?)(?:_urls?)?$/i.test(name));
+  });
+}
+
+export function validateReferenceInputs(
+  provider: string,
+  modelId: string,
+  inputs: { images: readonly Uint8Array[]; videos: readonly Uint8Array[] },
+  fields: readonly ModelMediaInput[]
+): void {
+  const images = inputs.images.filter((b) => b.length > 0);
+  const videos = inputs.videos.filter((b) => b.length > 0);
+  if (images.length === 0 && videos.length === 0) {
+    throw new Error("reference_to_video requires at least one reference image or video");
+  }
+  for (const [kind, count] of [["image", images.length], ["video", videos.length]] as const) {
+    if (count === 0) continue;
+    const matching = fields.filter((field) => field.kind === kind);
+    if (matching.length > 1) throw new Error(`${provider} model ${modelId} has ambiguous reference ${kind} inputs`);
+    const field = matching[0];
+    if (!field) throw new Error(`${provider} model ${modelId} does not support reference ${kind}s`);
+    if (!field.isList && count > 1) throw new Error(`${provider} model ${modelId} accepts only one reference ${kind}`);
+    if (!field.wrapInto && field.min !== undefined && count < field.min) throw new Error(`${provider} model ${modelId} requires at least ${field.min} reference ${kind}(s)`);
+    if (!field.wrapInto && field.max !== undefined && count > field.max) throw new Error(`${provider} model ${modelId} accepts at most ${field.max} reference ${kind}(s)`);
+  }
+  const requiredGroups = new Set<string>();
+  for (const field of fields) {
+    if (!field.required) continue;
+    requiredGroups.add(field.wrapInto ?? `${field.kind}:${field.apiName}`);
+  }
+  for (const group of requiredGroups) {
+    const groupFields = fields.filter((field) => (field.wrapInto ?? `${field.kind}:${field.apiName}`) === group);
+    const count = groupFields.reduce((total, field) => total + (field.kind === "image" ? images.length : videos.length), 0);
+    if (count === 0) throw new Error(`${provider} model ${modelId} requires at least one reference image or video`);
+  }
 }
 
 /**

--- a/packages/runtime/src/providers/minimax-provider.ts
+++ b/packages/runtime/src/providers/minimax-provider.ts
@@ -17,6 +17,7 @@ import type { OpenAIProvider } from "./openai-provider.js";
 import { createLogger } from "@nodetool-ai/config";
 import { safeFetch } from "./safe-url.js";
 import { fetchWithRetry, pollUntilTerminal } from "./http-transport.js";
+import { sniffImageMime } from "./image-mime.js";
 import type {
   EncodedAudioResult,
   ImageModel,
@@ -29,13 +30,23 @@ import type {
   TextToMusicParams,
   TextToVideoParams,
   TTSModel,
-  VideoModel
+  VideoModel,
+  ReferenceToVideoInputs,
+  ReferenceToVideoParams
 } from "./types.js";
 
 const log = createLogger("nodetool.runtime.providers.minimax");
 
 const MINIMAX_BASE_URL = "https://api.minimax.io";
 const MINIMAX_OPENAI_BASE_URL = `${MINIMAX_BASE_URL}/v1`;
+
+function combineSignals(
+  request: AbortSignal | undefined,
+  timeout: AbortSignal | undefined
+): AbortSignal | undefined {
+  if (request && timeout) return AbortSignal.any([request, timeout]);
+  return request ?? timeout;
+}
 
 /**
  * Known voice IDs shipped with MiniMax speech models. This is a curated subset
@@ -278,7 +289,7 @@ export class MinimaxProvider extends OpenAICompatProvider {
         id: "S2V-01",
         name: "MiniMax Video-01 Subject",
         provider: "minimax",
-        supportedTasks: ["image_to_video"]
+        supportedTasks: ["reference_to_video"]
       }
     ];
   }
@@ -557,20 +568,39 @@ export class MinimaxProvider extends OpenAICompatProvider {
       prompt: params.prompt,
       durationSeconds: params.durationSeconds,
       resolution: params.resolution,
-      signal: this._timeoutSignal(params.timeoutSeconds)
+      signal: combineSignals(params.signal, this._timeoutSignal(params.timeoutSeconds))
     });
   }
 
   override async imageToVideo(
-    images: Uint8Array[],
+    image: Uint8Array,
     params: ImageToVideoParams
   ): Promise<Uint8Array> {
+    const model = (await this.getAvailableVideoModels()).find((m) => m.id === params.model.id);
+    if (!model?.supportedTasks?.includes("image_to_video")) throw new Error(`MiniMax model ${params.model.id} does not support image_to_video`);
     return this._generateVideo(params.model.id, {
       prompt: params.prompt ?? undefined,
       durationSeconds: params.durationSeconds,
       resolution: params.resolution,
-      firstFrame: images[0],
-      signal: this._timeoutSignal(params.timeoutSeconds)
+      firstFrame: image,
+      signal: combineSignals(params.signal, this._timeoutSignal(params.timeoutSeconds))
+    });
+  }
+
+  override async referenceToVideo(inputs: ReferenceToVideoInputs, params: ReferenceToVideoParams): Promise<Uint8Array> {
+    const images = inputs.images.filter((b) => b.length > 0);
+    const videos = inputs.videos.filter((b) => b.length > 0);
+    if (images.length === 0 && videos.length === 0) throw new Error("reference_to_video requires at least one reference image or video");
+    if (params.model.id !== "S2V-01") throw new Error(`MiniMax model ${params.model.id} does not support reference_to_video`);
+    if (videos.length > 0) throw new Error(`MiniMax model ${params.model.id} does not support reference videos`);
+    if (params.useReferenceVideoAudio === true) throw new Error(`MiniMax model ${params.model.id} does not support reference video audio`);
+    if (images.length !== 1) throw new Error(`MiniMax model ${params.model.id} accepts exactly one reference image`);
+    return this._generateVideo(params.model.id, {
+      prompt: params.prompt ?? undefined,
+      durationSeconds: params.durationSeconds,
+      resolution: params.resolution,
+      subjectReference: images[0],
+      signal: combineSignals(params.signal, this._timeoutSignal(params.timeoutSeconds))
     });
   }
 
@@ -594,6 +624,7 @@ export class MinimaxProvider extends OpenAICompatProvider {
       durationSeconds?: number | null;
       resolution?: string | null;
       firstFrame?: Uint8Array;
+      subjectReference?: Uint8Array;
       signal?: AbortSignal;
     }
   ): Promise<Uint8Array> {
@@ -633,15 +664,13 @@ export class MinimaxProvider extends OpenAICompatProvider {
       }
     }
 
-    if (opts.firstFrame) {
+    if (opts.subjectReference) {
+      const mime = sniffImageMime(opts.subjectReference) ?? "image/png";
+      const dataUrl = `data:${mime};base64,${b64(opts.subjectReference)}`;
+      body.subject_reference = [{ type: "character", image: [dataUrl] }];
+    } else if (opts.firstFrame) {
       const dataUrl = `data:image/png;base64,${b64(opts.firstFrame)}`;
-      if (modelId === "S2V-01") {
-        // S2V-01 animates a character reference, not a first frame, and
-        // rejects first_frame_image.
-        body.subject_reference = [{ type: "character", image: [dataUrl] }];
-      } else {
-        body.first_frame_image = dataUrl;
-      }
+      body.first_frame_image = dataUrl;
     }
 
     log.debug("MiniMax textToVideo submit", { model: modelId });

--- a/packages/runtime/src/providers/nodetool-provider.ts
+++ b/packages/runtime/src/providers/nodetool-provider.ts
@@ -44,6 +44,7 @@ import type {
   TTSModel,
   VideoModel
 } from "./types.js";
+import type { ReferenceToVideoInputs, ReferenceToVideoParams } from "./types.js";
 import { FalProvider } from "./fal-provider.js";
 import { AnthropicProvider } from "./anthropic-provider.js";
 
@@ -101,6 +102,9 @@ export class NodetoolProvider extends BaseProvider {
         `NodeTool model "${modelId}" is not available on this server.`
       );
     }
+    if (task && Array.isArray(def.tasks) && !def.tasks.includes(task)) {
+      throw new Error(`NodeTool model "${modelId}" does not support ${task}.`);
+    }
     const delegate =
       (task === "image_to_image" ? def.editDelegate : undefined) ??
       (task === "text_to_video" ? def.textDelegate : undefined) ??
@@ -154,7 +158,8 @@ export class NodetoolProvider extends BaseProvider {
         if (def.editDelegate) capabilities.push("image_to_image");
       }
       if (def.kind === "video") {
-        capabilities.push("image_to_video");
+        if (def.tasks?.includes("image_to_video")) capabilities.push("image_to_video");
+        if (def.tasks?.includes("reference_to_video")) capabilities.push("reference_to_video");
         if (def.textDelegate) capabilities.push("text_to_video");
       }
       if (def.kind === "tts") capabilities.push("text_to_speech");
@@ -246,16 +251,24 @@ export class NodetoolProvider extends BaseProvider {
   }
 
   override async imageToVideo(
-    images: Uint8Array[],
+    image: Uint8Array,
     params: ImageToVideoParams
   ): Promise<Uint8Array> {
-    const { provider, model } = this.delegateFor(params.model.id);
+    const { provider, model } = this.delegateFor(params.model.id, "image_to_video");
     return this.absorbing(provider, () =>
-      provider.imageToVideo(images, {
+      provider.imageToVideo(image, {
         ...params,
         model: { ...params.model, id: model, provider: provider.provider }
       })
     );
+  }
+
+  override async referenceToVideo(inputs: ReferenceToVideoInputs, params: ReferenceToVideoParams): Promise<Uint8Array> {
+    const { provider, model } = this.delegateFor(params.model.id, "reference_to_video");
+    return this.absorbing(provider, () => provider.referenceToVideo(inputs, {
+      ...params,
+      model: { ...params.model, id: model, provider: provider.provider }
+    }));
   }
 
   override async textToSpeechEncoded(args: {

--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -2316,10 +2316,9 @@ export class OpenAIProvider extends BaseProvider {
   }
 
   async imageToVideo(
-    images: Uint8Array[],
+    image: Uint8Array,
     params: ImageToVideoParams
   ): Promise<Uint8Array> {
-    const image = images[0];
     if (!image || image.length === 0) {
       throw new Error("The input image cannot be empty.");
     }

--- a/packages/runtime/src/providers/python-provider.ts
+++ b/packages/runtime/src/providers/python-provider.ts
@@ -314,13 +314,13 @@ export class PythonProvider extends BaseProvider {
   }
 
   async imageToVideo(
-    images: Uint8Array[],
+    image: Uint8Array,
     params: ImageToVideoParams
   ): Promise<Uint8Array> {
     const { signal, ...wireParams } = params;
     return this._bridge.providerImageToVideo(
       this._pythonProviderId,
-      images[0] ?? new Uint8Array(),
+      image,
       { ...wireParams, model: params.model.id },
       this._secrets,
       signal

--- a/packages/runtime/src/providers/replicate-provider.ts
+++ b/packages/runtime/src/providers/replicate-provider.ts
@@ -5,6 +5,7 @@ import { BaseProvider } from "./base-provider.js";
 import { safeFetch } from "./safe-url.js";
 import { withReplicateRetry } from "./replicate-retry.js";
 import { sniffAudioMime } from "./audio-mime.js";
+import { sniffVideoMime } from "./video-mime.js";
 import { detectImageMime } from "./image-mime.js";
 import type {
   ASRModel,
@@ -34,6 +35,9 @@ import type {
 } from "./types.js";
 import {
   getModelImageInputs,
+  getModelReferenceInputs,
+  getModelInputFields,
+  validateReferenceInputs,
   getModelInputNames,
   loadImageModels,
   loadMusicModels,
@@ -41,6 +45,7 @@ import {
   selectMaskImageInput,
   selectPrimaryImageInput
 } from "./manifest-models.js";
+import type { ReferenceToVideoInputs, ReferenceToVideoParams } from "./types.js";
 
 const log = createLogger("nodetool.runtime.providers.replicate");
 
@@ -209,10 +214,15 @@ export class ReplicateProvider extends BaseProvider {
   /** Create a prediction, waiting out the low-credit throttle. */
   private runModel(
     modelId: string,
-    input: Record<string, unknown>
+    input: Record<string, unknown>,
+    signal?: AbortSignal
   ): Promise<unknown> {
+    signal?.throwIfAborted();
+    const options: { input: Record<string, unknown>; signal?: AbortSignal } = { input };
+    if (signal) options.signal = signal;
     return withReplicateRetry(modelId, () =>
-      this._client.run(modelId as `${string}/${string}`, { input })
+      this._client.run(modelId as `${string}/${string}`, options),
+      signal
     );
   }
 
@@ -875,7 +885,8 @@ export class ReplicateProvider extends BaseProvider {
   // Image / Video / Audio capabilities
   // ---------------------------------------------------------------------------
 
-  private async _fetchOutputBytes(output: unknown): Promise<Uint8Array> {
+  private async _fetchOutputBytes(output: unknown, signal?: AbortSignal): Promise<Uint8Array> {
+    signal?.throwIfAborted();
     const target = decodeReplicateOutput(output);
     if (!target) {
       throw new Error(
@@ -885,12 +896,12 @@ export class ReplicateProvider extends BaseProvider {
     }
     return target.kind === "stream"
       ? drainStream(target.stream)
-      : this._fetchUrlBytes(target.url);
+      : this._fetchUrlBytes(target.url, signal);
   }
 
-  private async _fetchUrlBytes(url: string): Promise<Uint8Array> {
+  private async _fetchUrlBytes(url: string, signal?: AbortSignal): Promise<Uint8Array> {
     if (url.startsWith("data:")) return decodeDataUri(url);
-    const res = await safeFetch(url);
+    const res = await safeFetch(url, signal ? { signal } : undefined);
     if (!res.ok) throw new Error(`Failed to fetch output: ${res.status}`);
     return new Uint8Array(await res.arrayBuffer());
   }
@@ -988,12 +999,17 @@ export class ReplicateProvider extends BaseProvider {
   }
 
   async imageToVideo(
-    images: Uint8Array[],
+    image: Uint8Array,
     params: ImageToVideoParams
   ): Promise<Uint8Array> {
+    const model = (await this.getAvailableVideoModels()).find((item) => item.id === params.model.id);
+    if (model && !model.supportedTasks?.includes("image_to_video")) {
+      throw new Error(`Replicate model ${params.model.id} does not support image_to_video`);
+    }
+    if (image.length === 0) throw new Error("Replicate image_to_video requires a start image");
     const input: Record<string, unknown> = this.imageInput(
       params.model.id,
-      images
+      [image]
     );
     if (params.prompt) input.prompt = params.prompt;
     if (params.negativePrompt) input.negative_prompt = params.negativePrompt;
@@ -1006,6 +1022,59 @@ export class ReplicateProvider extends BaseProvider {
     log.debug("imageToVideo", { model: params.model.id });
     const output = await this.runModel(params.model.id, input);
     return this._fetchOutputBytes(output);
+  }
+
+  async referenceToVideo(
+    inputs: ReferenceToVideoInputs,
+    params: ReferenceToVideoParams
+  ): Promise<Uint8Array> {
+    const modelId = params.model.id;
+    const model = (await this.getAvailableVideoModels()).find((item) => item.id === modelId);
+    if (!model?.supportedTasks?.includes("reference_to_video")) {
+      throw new Error(`Replicate model ${modelId} does not support reference_to_video`);
+    }
+    const fields = getModelReferenceInputs("@nodetool-ai/replicate-nodes", "replicate-manifest.json", modelId);
+    const references = {
+      images: inputs.images.filter((bytes) => bytes.length > 0),
+      videos: inputs.videos.filter((bytes) => bytes.length > 0)
+    };
+    validateReferenceInputs("Replicate", modelId, references, fields);
+    const declared = getModelInputFields("@nodetool-ai/replicate-nodes", "replicate-manifest.json", modelId);
+    const hasField = (name: string): boolean => declared.some((field) => field.name === name);
+    if (params.useReferenceVideoAudio === true && (!hasField("use_reference_video_audio") || references.videos.length === 0)) {
+      throw new Error(`Replicate model ${modelId} does not support reference video audio for these inputs`);
+    }
+    const input: Record<string, unknown> = {};
+    for (const field of fields) {
+      const buffers = field.kind === "image" ? references.images : references.videos;
+      if (buffers.length === 0) continue;
+      const urls = buffers.map((bytes) => field.kind === "image"
+        ? this.imageDataUri(bytes)
+        : this.dataUri(bytes, sniffVideoMime(bytes)));
+      input[field.apiName] = field.isList ? urls : urls[0];
+    }
+    const options: Record<string, unknown> = {
+      prompt: params.prompt,
+      negative_prompt: params.negativePrompt,
+      duration: params.durationSeconds,
+      aspect_ratio: params.aspectRatio,
+      resolution: params.resolution,
+      num_frames: params.numFrames,
+      guidance_scale: params.guidanceScale,
+      seed: params.seed,
+      use_reference_video_audio: params.useReferenceVideoAudio
+    };
+    for (const [name, value] of Object.entries(options)) {
+      if (value != null && hasField(name)) input[name] = value;
+    }
+    const timeout = params.timeoutSeconds && params.timeoutSeconds > 0
+      ? AbortSignal.timeout(params.timeoutSeconds * 1000)
+      : undefined;
+    const signal = params.signal && timeout
+      ? AbortSignal.any([params.signal, timeout])
+      : params.signal ?? timeout;
+    const output = await this.runModel(modelId, input, signal);
+    return this._fetchOutputBytes(output, signal);
   }
 
   private dataUri(bytes: Uint8Array, mimeType: string): string {

--- a/packages/runtime/src/providers/replicate-retry.ts
+++ b/packages/runtime/src/providers/replicate-retry.ts
@@ -13,8 +13,8 @@
  */
 
 import { createLogger } from "@nodetool-ai/config";
-import { setTimeout as waitForRetry } from "node:timers/promises";
 import { isFiniteNumber, isRecord, isString } from "@nodetool-ai/protocol";
+import { sleep } from "./http-transport.js";
 
 const log = createLogger("nodetool.runtime.providers.replicate");
 
@@ -101,11 +101,7 @@ export async function withReplicateRetry<T>(
         delayMs: delay,
         retryAfterMs: requested
       });
-      if (signal) {
-        await waitForRetry(delay, undefined, { signal });
-      } else {
-        await new Promise<void>((resolve) => setTimeout(resolve, delay));
-      }
+      await sleep(delay, signal);
     }
   }
 }

--- a/packages/runtime/src/providers/replicate-retry.ts
+++ b/packages/runtime/src/providers/replicate-retry.ts
@@ -13,6 +13,7 @@
  */
 
 import { createLogger } from "@nodetool-ai/config";
+import { setTimeout as waitForRetry } from "node:timers/promises";
 import { isFiniteNumber, isRecord, isString } from "@nodetool-ai/protocol";
 
 const log = createLogger("nodetool.runtime.providers.replicate");
@@ -69,10 +70,6 @@ export function replicateRetryAfterMs(error: unknown): number | null {
   return null;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 /**
  * Run a Replicate call, waiting out 429s instead of failing the node.
  *
@@ -82,9 +79,11 @@ function sleep(ms: number): Promise<void> {
  */
 export async function withReplicateRetry<T>(
   label: string,
-  run: () => Promise<T>
+  run: () => Promise<T>,
+  signal?: AbortSignal
 ): Promise<T> {
   for (let attempt = 0; ; attempt++) {
+    signal?.throwIfAborted();
     try {
       return await run();
     } catch (error) {
@@ -102,7 +101,11 @@ export async function withReplicateRetry<T>(
         delayMs: delay,
         retryAfterMs: requested
       });
-      await sleep(delay);
+      if (signal) {
+        await waitForRetry(delay, undefined, { signal });
+      } else {
+        await new Promise<void>((resolve) => setTimeout(resolve, delay));
+      }
     }
   }
 }

--- a/packages/runtime/src/providers/together-provider.ts
+++ b/packages/runtime/src/providers/together-provider.ts
@@ -778,10 +778,9 @@ export class TogetherProvider extends OpenAICompatProvider {
    * The first frame is supplied as a base64-encoded image in `frame_images`.
    */
   override async imageToVideo(
-    images: Uint8Array[],
+    image: Uint8Array,
     params: ImageToVideoParams
   ): Promise<Uint8Array> {
-    const image = images[0];
     if (!image || image.length === 0) {
       throw new Error("The input image cannot be empty.");
     }

--- a/packages/runtime/src/providers/types.ts
+++ b/packages/runtime/src/providers/types.ts
@@ -605,6 +605,16 @@ export interface ImageToVideoParams {
   signal?: AbortSignal;
 }
 
+export interface ReferenceToVideoInputs {
+  images: Uint8Array[];
+  videos: Uint8Array[];
+}
+
+export interface ReferenceToVideoParams extends TextToVideoParams {
+  /** Allow conditioning on audio tracks carried by reference videos. */
+  useReferenceVideoAudio?: boolean | null;
+}
+
 /**
  * Transform an existing video into a restyled / edited video, guided by a
  * prompt (e.g. style transfer, motion restyle). Mirrors `ImageToImageParams`

--- a/packages/runtime/src/providers/xai-provider.ts
+++ b/packages/runtime/src/providers/xai-provider.ts
@@ -389,11 +389,10 @@ export class XAIProvider extends OpenAICompatProvider {
   }
 
   override async imageToVideo(
-    images: Uint8Array[],
+    image: Uint8Array,
     params: ImageToVideoParams
   ): Promise<Uint8Array> {
-    const image = images.find((b) => b && b.length > 0);
-    if (!image) {
+    if (image.length === 0) {
       throw new Error("The input image cannot be empty.");
     }
 

--- a/packages/runtime/tests/context.test.ts
+++ b/packages/runtime/tests/context.test.ts
@@ -28,6 +28,7 @@ import {
 } from "../src/index.js";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
+const portablePath = (value: string): string => value.replace(/^\/private/, "");
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
@@ -627,8 +628,8 @@ describe("workspace path resolution", () => {
       jobId: "j1",
       workspaceDir: "/tmp/nodetool-workspace"
     });
-    expect(ctx.resolveWorkspacePath("workspace/out.json")).toBe(
-      resolve("/tmp/nodetool-workspace", "out.json")
+    expect(portablePath(ctx.resolveWorkspacePath("workspace/out.json"))).toBe(
+      portablePath(resolve("/tmp/nodetool-workspace", "out.json"))
     );
   });
 });
@@ -1322,7 +1323,7 @@ describe("ProcessingContext – asset helper methods", () => {
       });
 
       const filePath = await ctx.assetToSandbox("asset-42", "imports/a.txt");
-      expect(filePath).toBe(join(root, "imports/a.txt"));
+      expect(portablePath(filePath)).toBe(portablePath(join(root, "imports/a.txt")));
       await expect(readFile(filePath, "utf8")).resolves.toBe("downloaded");
     } finally {
       await rm(root, { recursive: true, force: true });
@@ -2170,10 +2171,10 @@ describe("ProcessingContext – dispatchCapability edge cases", () => {
   });
 
   it("dispatches image_to_video with a list of images", async () => {
-    let received: Uint8Array[] | undefined;
+    let received: Uint8Array | undefined;
     class I2VProvider extends MockProvider {
-      override async imageToVideo(images: Uint8Array[]): Promise<Uint8Array> {
-        received = images;
+      override async imageToVideo(image: Uint8Array): Promise<Uint8Array> {
+        received = image;
         return new Uint8Array([7]);
       }
     }
@@ -2186,7 +2187,31 @@ describe("ProcessingContext – dispatchCapability edge cases", () => {
       params: { images: [new Uint8Array([1])] }
     });
     expect(result).toEqual(new Uint8Array([7]));
-    expect(received).toEqual([new Uint8Array([1])]);
+    expect(received).toEqual(new Uint8Array([1]));
+  });
+
+  it("dispatches ordered reference image and video inputs and rejects empties", async () => {
+    let received: { images: Uint8Array[]; videos: Uint8Array[] } | undefined;
+    class RefProvider extends MockProvider {
+      override async referenceToVideo(inputs: { images: Uint8Array[]; videos: Uint8Array[] }): Promise<Uint8Array> {
+        received = inputs;
+        return new Uint8Array([8]);
+      }
+    }
+    const ctx = new ProcessingContext({ jobId: "j1" });
+    ctx.registerProvider("ref", new RefProvider());
+    await expect(ctx.runProviderPrediction({
+      provider: "ref", capability: "reference_to_video", model: "m",
+      params: {
+        reference_images: [new Uint8Array(), new Uint8Array([1])],
+        reference_videos: [new Uint8Array([2])]
+      }
+    })).resolves.toEqual(new Uint8Array([8]));
+    expect(received).toEqual({ images: [new Uint8Array([1])], videos: [new Uint8Array([2])] });
+    await expect(ctx.runProviderPrediction({
+      provider: "ref", capability: "reference_to_video", model: "m",
+      params: { reference_images: [new Uint8Array()], reference_videos: [] }
+    })).rejects.toThrow("requires at least one reference image or video");
   });
 
   it("dispatches automatic_speech_recognition", async () => {

--- a/packages/runtime/tests/entity-references.test.ts
+++ b/packages/runtime/tests/entity-references.test.ts
@@ -91,10 +91,10 @@ describe("applyEntityReferences", () => {
   it("does not touch the image list on imageToVideo (text-only)", () => {
     const frame = new Uint8Array([7]);
     const args = applyEntityReferences("imageToVideo", [
-      [frame],
+      frame,
       { model, prompt: "pan left", entities: [harbor] }
     ]);
-    expect(args[0]).toEqual([frame]);
+    expect(args[0]).toEqual(frame);
     expect((args[1] as { prompt: string }).prompt).toContain(
       "Consistency references:"
     );

--- a/packages/runtime/tests/providers/atlascloud-provider.test.ts
+++ b/packages/runtime/tests/providers/atlascloud-provider.test.ts
@@ -179,11 +179,9 @@ describe("AtlasCloudProvider — getAvailableVideoModels", () => {
     expect(byId.get("bytedance/seedance-2.0/image-to-video")?.supportedTasks).toEqual([
       "image_to_video"
     ]);
-    // reference-to-video is image-conditioned: it needs the reference stills,
-    // so it is not an answer to a text_to_video search.
     expect(
       byId.get("bytedance/seedance-2.0/reference-to-video")?.supportedTasks
-    ).toEqual(["image_to_video"]);
+    ).toEqual(["reference_to_video"]);
   });
 });
 
@@ -488,7 +486,7 @@ describe("AtlasCloudProvider — imageToVideo", () => {
     mockAtlasFetch({ capture });
     const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
     await p.imageToVideo(
-      [Uint8Array.from([0xff, 0xd8, 0xff])], // JPEG magic
+      Uint8Array.from([0xff, 0xd8, 0xff]), // JPEG magic
       {
         model: videoModel("bytedance/seedance-2.0/image-to-video"),
         prompt: "drift forward"
@@ -503,18 +501,18 @@ describe("AtlasCloudProvider — imageToVideo", () => {
   it("rejects models without an input image field (e.g. text-to-video)", async () => {
     const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
     await expect(
-      p.imageToVideo([Uint8Array.from([1])], {
+      p.imageToVideo(Uint8Array.from([1]), {
         model: videoModel("bytedance/seedance-2.0/text-to-video"),
         prompt: "x"
       })
-    ).rejects.toThrow("does not accept an input image");
+    ).rejects.toThrow("does not support image_to_video");
   });
 
-  it("falls back to `reference_images` on reference-to-video", async () => {
+  it("maps `reference_images` through referenceToVideo", async () => {
     const capture: { submitBody?: Record<string, unknown> } = {};
     mockAtlasFetch({ capture });
     const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
-    await p.imageToVideo([Uint8Array.from([0x89, 0x50, 0x4e, 0x47])], {
+    await p.referenceToVideo({ images: [Uint8Array.from([0x89, 0x50, 0x4e, 0x47])], videos: [] }, {
       model: videoModel("bytedance/seedance-2.0/reference-to-video"),
       prompt: "spin it"
     });
@@ -529,7 +527,7 @@ describe("AtlasCloudProvider — imageToVideo", () => {
     const capture: { submitBody?: Record<string, unknown> } = {};
     mockAtlasFetch({ capture });
     const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
-    await p.imageToVideo([Uint8Array.from([0x89, 0x50, 0x4e, 0x47])], {
+    await p.referenceToVideo({ images: [Uint8Array.from([0x89, 0x50, 0x4e, 0x47])], videos: [] }, {
       model: videoModel("minimax/h3/reference-to-video"),
       prompt: "anchor on this"
     });

--- a/packages/runtime/tests/providers/base-provider.test.ts
+++ b/packages/runtime/tests/providers/base-provider.test.ts
@@ -284,7 +284,7 @@ describe("BaseProvider – default method behaviors", () => {
 
   it("imageToVideo() throws 'does not support'", async () => {
     await expect(
-      provider.imageToVideo([new Uint8Array()], {
+      provider.imageToVideo(new Uint8Array(), {
         model: { id: "m", name: "m", provider: "test" },
         prompt: "test"
       })
@@ -320,6 +320,16 @@ describe("BaseProvider – getCapabilities", () => {
     // Music override must not imply TTS / video.
     expect(caps).not.toContain("text_to_speech");
     expect(caps).not.toContain("text_to_video");
+  });
+
+  it("advertises reference_to_video only when the method is overridden", () => {
+    class ReferenceProvider extends TestProvider {
+      override async referenceToVideo() {
+        return new Uint8Array();
+      }
+    }
+    expect(new TestProvider().getCapabilities()).not.toContain("reference_to_video");
+    expect(new ReferenceProvider().getCapabilities()).toContain("reference_to_video");
   });
 
   it("honors an explicit capability declaration (override seam)", () => {

--- a/packages/runtime/tests/providers/fal-provider-coverage.test.ts
+++ b/packages/runtime/tests/providers/fal-provider-coverage.test.ts
@@ -412,15 +412,14 @@ describe("FalProvider — video endpoints", () => {
     const params: ImageToVideoParams = {
       prompt: "animate",
       model: {
-        id: "fal-ai/unknown-i2v-model",
+        id: "fal-ai/luma-dream-machine/image-to-video",
         name: "I2V",
         provider: "fal_ai"
       }
     };
-    const out = await p.imageToVideo([new Uint8Array([1, 2, 3])], params);
+    const out = await p.imageToVideo(new Uint8Array([1, 2, 3]), params);
     expect(out).toBeInstanceOf(Uint8Array);
     expect(uploadMock).toHaveBeenCalledTimes(1);
-    // Unknown endpoint falls back to image_url.
     expect(captured.image_url).toBe("https://fal.media/img.png");
   });
 
@@ -827,7 +826,7 @@ describe("FalProvider numeric field coercion", () => {
       subscribe: subscribeMock,
       storage: { upload: uploadMock }
     };
-    await p.imageToVideo([new Uint8Array([1, 2, 3])], {
+    await p.imageToVideo(new Uint8Array([1, 2, 3]), {
       prompt: "animate",
       model: { id: modelId, name: "M", provider: "fal_ai" },
       ...params

--- a/packages/runtime/tests/providers/fal-provider.test.ts
+++ b/packages/runtime/tests/providers/fal-provider.test.ts
@@ -21,6 +21,45 @@ describe("FalProvider", () => {
     vi.clearAllMocks();
   });
 
+  it("maps ordered reference image URLs and rejects unsupported input before upload", async () => {
+    const upload = vi.fn(async (blob: Blob) => `https://fal.test/${blob.type}-${upload.mock.calls.length}`);
+    const subscribe = vi.fn().mockResolvedValue({ data: { video: { url: "https://fal.test/out.mp4" } } });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, arrayBuffer: async () => new Uint8Array([1, 2]).buffer, headers: new Headers() }));
+    const p = createProvider();
+    (p as unknown as { _client: unknown })._client = { subscribe, storage: { upload } };
+    await p.referenceToVideo({ images: [new Uint8Array([0x89, 0x50, 0x4e, 0x47]), new Uint8Array([0x89, 0x50, 0x4e, 0x47])], videos: [] }, { model: { id: "fal-ai/veo3.1/reference-to-video", name: "veo", provider: "fal_ai" }, prompt: "keep subject" });
+    expect(upload).toHaveBeenCalledTimes(2);
+    expect(subscribe.mock.calls[0]?.[1].input.image_urls).toHaveLength(2);
+    await expect(p.referenceToVideo({ images: [], videos: [] }, { model: { id: "fal-ai/veo3.1/reference-to-video", name: "veo", provider: "fal_ai" }, prompt: "x" })).rejects.toThrow("at least one");
+    expect(upload).toHaveBeenCalledTimes(2);
+    vi.unstubAllGlobals();
+  });
+
+  it("does not upload or submit a pre-aborted reference request", async () => {
+    const upload = vi.fn();
+    const subscribe = vi.fn();
+    const p = createProvider();
+    (p as unknown as { _client: unknown })._client = { subscribe, storage: { upload } };
+    const controller = new AbortController();
+    controller.abort();
+    await expect(p.referenceToVideo({ images: [new Uint8Array([1])], videos: [] }, { model: { id: "fal-ai/veo3.1/reference-to-video", name: "veo", provider: "fal_ai" }, prompt: "x", signal: controller.signal })).rejects.toThrow();
+    expect(upload).not.toHaveBeenCalled();
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
+  it("passes the combined timeout signal to submission and output download", async () => {
+    const subscribe = vi.fn().mockResolvedValue({ data: { video: { url: "https://fal.test/out.mp4" } } });
+    const upload = vi.fn().mockResolvedValue("https://fal.test/ref.png");
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, headers: new Headers(), arrayBuffer: async () => new Uint8Array([1]).buffer });
+    vi.stubGlobal("fetch", fetchMock);
+    const p = createProvider();
+    (p as unknown as { _client: unknown })._client = { subscribe, storage: { upload } };
+    await p.referenceToVideo({ images: [new Uint8Array([1])], videos: [] }, { model: { id: "fal-ai/veo3.1/reference-to-video", name: "veo", provider: "fal_ai" }, prompt: "x", timeoutSeconds: 5 });
+    expect(subscribe.mock.calls[0]?.[1].abortSignal).toBeInstanceOf(AbortSignal);
+    expect(fetchMock.mock.calls.at(-1)?.[1]).toEqual(expect.objectContaining({ signal: subscribe.mock.calls[0]?.[1].abortSignal }));
+    vi.unstubAllGlobals();
+  });
+
   // --- Construction ---
 
   // --- getAvailableImageModels ---
@@ -386,7 +425,7 @@ describe("FalProvider", () => {
       storage: { upload: uploadMock }
     };
 
-    await p.imageToVideo([new Uint8Array([1, 2, 3, 4])], {
+    await p.imageToVideo(new Uint8Array([1, 2, 3, 4]), {
       prompt: "animate",
       model: {
         id: "fal-ai/luma-dream-machine/image-to-video",

--- a/packages/runtime/tests/providers/gemini-provider-coverage.test.ts
+++ b/packages/runtime/tests/providers/gemini-provider-coverage.test.ts
@@ -1253,7 +1253,7 @@ describe("GeminiProvider – imageToVideo", () => {
   it("throws on empty image", async () => {
     const provider = new GeminiProvider({ GEMINI_API_KEY: "k" });
     await expect(
-      provider.imageToVideo([new Uint8Array(0)], {
+      provider.imageToVideo(new Uint8Array(0), {
         model: { id: "veo-2.0-generate-001", name: "test", provider: "gemini" }
       })
     ).rejects.toThrow("empty");
@@ -1262,7 +1262,7 @@ describe("GeminiProvider – imageToVideo", () => {
   it("throws for non-veo model", async () => {
     const provider = new GeminiProvider({ GEMINI_API_KEY: "k" });
     await expect(
-      provider.imageToVideo([new Uint8Array([1, 2, 3])], {
+      provider.imageToVideo(new Uint8Array([1, 2, 3]), {
         model: { id: "gemini-2.0-flash", name: "test", provider: "gemini" }
       })
     ).rejects.toThrow("not a Veo model");
@@ -1297,7 +1297,7 @@ describe("GeminiProvider – imageToVideo", () => {
       } as unknown as Response);
 
     const provider = new GeminiProvider({ GEMINI_API_KEY: "k" }, { fetchFn });
-    const result = await provider.imageToVideo([new Uint8Array([1, 2, 3])], {
+    const result = await provider.imageToVideo(new Uint8Array([1, 2, 3]), {
       model: { id: "veo-2.0-generate-001", name: "test", provider: "gemini" },
       prompt: "animate this",
       durationSeconds: 8

--- a/packages/runtime/tests/providers/gemini-veo-content-filter.test.ts
+++ b/packages/runtime/tests/providers/gemini-veo-content-filter.test.ts
@@ -56,7 +56,7 @@ describe("Veo content-filter refusals", () => {
     });
 
     const error = await provider
-      .imageToVideo([IMAGE], { model: MODEL, prompt: "a lighthouse in a storm" })
+      .imageToVideo(IMAGE, { model: MODEL, prompt: "a lighthouse in a storm" })
       .catch((err: unknown) => err);
 
     expect(isContentFilterRefusalError(error)).toBe(true);

--- a/packages/runtime/tests/providers/kie-provider.test.ts
+++ b/packages/runtime/tests/providers/kie-provider.test.ts
@@ -123,6 +123,48 @@ describe("KieProvider — imageToImage", () => {
   });
 });
 
+describe("KieProvider reference-to-video", () => {
+  afterEach(() => vi.unstubAllGlobals());
+  it("maps ordered images and videos to manifest upload names", async () => {
+    const { createdInputs } = mockKieFlow(["https://kie.test/i", "https://kie.test/v1", "https://kie.test/v2"]);
+    const provider = new KieProvider({ KIE_API_KEY: "k" });
+    await provider.referenceToVideo({ images: [new Uint8Array([1])], videos: [new Uint8Array([2]), new Uint8Array([3])] }, { model: { id: "minimax-h3/reference-to-video", name: "ref", provider: "kie" }, prompt: "keep", aspectRatio: "16:9", durationSeconds: 6, resolution: "2K" });
+    expect(createdInputs[0]).toMatchObject({ reference_image_urls: ["https://kie.test/i"], reference_video_urls: ["https://kie.test/v1", "https://kie.test/v2"], aspect_ratio: "16:9", duration: 6 });
+  });
+  it("accepts one reference video because H3's minimum is clip duration", async () => {
+    const { createdInputs } = mockKieFlow(["https://kie.test/video"]);
+    const provider = new KieProvider({ KIE_API_KEY: "k" });
+    await provider.referenceToVideo({ images: [], videos: [new Uint8Array([2])] }, {
+      model: { id: "minimax-h3/reference-to-video", name: "ref", provider: "kie" }, prompt: "keep"
+    });
+    expect(createdInputs[0].reference_video_urls).toEqual(["https://kie.test/video"]);
+    expect(createdInputs[0]).not.toHaveProperty("reference_image_urls");
+  });
+
+  it("rejects unsupported reference audio before any upload", async () => {
+    const { fetchMock } = mockKieFlow([]);
+    const provider = new KieProvider({ KIE_API_KEY: "k" });
+    await expect(provider.referenceToVideo({ images: [new Uint8Array([1])], videos: [new Uint8Array([2]), new Uint8Array([3])] }, { model: { id: "minimax-h3/reference-to-video", name: "ref", provider: "kie" }, prompt: "x", useReferenceVideoAudio: true })).rejects.toThrow("audio");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a pre-aborted reference request before fetch", async () => {
+    const { fetchMock } = mockKieFlow([]);
+    const provider = new KieProvider({ KIE_API_KEY: "k" });
+    const controller = new AbortController();
+    controller.abort();
+    await expect(provider.referenceToVideo({ images: [new Uint8Array([1])], videos: [] }, { model: { id: "minimax-h3/reference-to-video", name: "ref", provider: "kie" }, prompt: "x", signal: controller.signal })).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a reference-only model through image-to-video before fetch", async () => {
+    const { fetchMock } = mockKieFlow([]);
+    const provider = new KieProvider({ KIE_API_KEY: "k" });
+    await expect(provider.imageToVideo(new Uint8Array([1]), { model: { id: "minimax-h3/reference-to-video", name: "ref", provider: "kie" }, prompt: "x" })).rejects.toThrow("image_to_video");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("KieProvider — inpaint", () => {
   it("routes the source to the primary field and the mask to the mask field", async () => {
     const { createdInputs } = mockKieFlow([
@@ -158,7 +200,7 @@ describe("KieProvider — imageToVideo", () => {
       prompt: "pan left",
       durationSeconds: 5
     };
-    const result = await provider.imageToVideo([new Uint8Array([9])], params);
+    const result = await provider.imageToVideo(new Uint8Array([9]), params);
 
     expect(result).toEqual(new Uint8Array([7, 7, 7]));
     expect(createdInputs[0].image_url).toBe("https://kie.cdn/frame.png");
@@ -172,7 +214,7 @@ describe("KieProvider — imageToVideo", () => {
     const provider = new KieProvider({ KIE_API_KEY: "k" });
 
     // kling declares duration enum ["5","10"]; 7s is closer to 5.
-    await provider.imageToVideo([new Uint8Array([9])], {
+    await provider.imageToVideo(new Uint8Array([9]), {
       model: {
         id: "kling/v2-1-master-image-to-video",
         name: "Kling",
@@ -194,7 +236,7 @@ describe("KieProvider — imageToVideo", () => {
     mockKieFlow(["https://kie.cdn/frame.png"]);
     const provider = new KieProvider({ KIE_API_KEY: "k" });
 
-    const call = provider.imageToVideo([new Uint8Array([9])], {
+    const call = provider.imageToVideo(new Uint8Array([9]), {
       model: {
         id: "kling-2.6/image-to-video",
         name: "Kling 2.6",
@@ -211,7 +253,7 @@ describe("KieProvider — imageToVideo", () => {
     const { createdInputs } = mockKieFlow(["https://kie.cdn/frame.png"]);
     const provider = new KieProvider({ KIE_API_KEY: "k" });
 
-    await provider.imageToVideo([new Uint8Array([9])], {
+    await provider.imageToVideo(new Uint8Array([9]), {
       model: {
         id: "kling-2.6/image-to-video",
         name: "Kling 2.6",

--- a/packages/runtime/tests/providers/manifest-models-hardening.test.ts
+++ b/packages/runtime/tests/providers/manifest-models-hardening.test.ts
@@ -563,7 +563,7 @@ describe("inferVideoTasks", () => {
     ["decart/lucy-restyle", ["video_to_video"]],
     ["blackforestlabs/flux-3/first-last-frame-to-video", ["image_to_video"]],
     ["blackforestlabs/flux-3/keyframes-to-video", ["image_to_video"]],
-    ["bytedance/seedance-2.0/reference-to-video", ["image_to_video"]],
+    ["bytedance/seedance-2.0/reference-to-video", ["reference_to_video"]],
     // Still a generator: the direction is spelled out, so nothing above bites.
     ["fal-ai/ltx-2-19b/image-to-video", ["image_to_video"]],
     ["fal-ai/ltx-2-19b/distilled/image-to-video/lora", ["image_to_video"]],

--- a/packages/runtime/tests/providers/manifest-models.test.ts
+++ b/packages/runtime/tests/providers/manifest-models.test.ts
@@ -11,11 +11,97 @@ import {
   loadTTSModels,
   loadVideoModels
 } from "../../src/providers/manifest-models.js";
+import {
+  buildVideoModels,
+  getModelReferenceInputs,
+  validateReferenceInputs,
+  inferVideoTasks
+} from "../../src/providers/manifest-models.js";
 
 const FAL_PKG = "@nodetool-ai/fal-nodes";
 const FAL_MANIFEST = "fal-manifest.json";
 const KIE_PKG = "@nodetool-ai/kie-nodes";
 const KIE_MANIFEST = "kie-manifest.json";
+
+describe("reference-to-video discovery and validation", () => {
+  it("discovers shipped reference endpoints with generic media fields", () => {
+    const fal = loadVideoModels(FAL_PKG, FAL_MANIFEST, "fal_ai").find((m) => m.id === "fal-ai/veo3.1/reference-to-video");
+    const kie = loadVideoModels(KIE_PKG, KIE_MANIFEST, "kie").find((m) => m.id === "kling-3.0-omni/reference-to-video");
+    expect(fal?.supportedTasks).toContain("reference_to_video");
+    expect(kie?.supportedTasks).toContain("reference_to_video");
+  });
+
+  it("classifies reference names before image-to-video", () => {
+    expect(inferVideoTasks("Reference To Video", "model")).toEqual(["reference_to_video"]);
+    expect(inferVideoTasks("", "ref-to-video-model")).toEqual(["reference_to_video"]);
+  });
+
+  it("does not assume generic media arrays are identity references", () => {
+    const models = buildVideoModels([
+      { endpointId: "ambiguous", className: "Video Generator", outputType: "video", inputFields: [
+        { name: "images", apiParamName: "image_urls", propType: "list[image]" },
+        { name: "videos", apiParamName: "video_urls", propType: "list[video]" }
+      ] }
+    ], "test");
+    expect(models[0]?.supportedTasks).not.toContain("reference_to_video");
+  });
+
+  it("preserves start-frame catalogs and omits unsupported structured reference endpoints", () => {
+    const kie = loadVideoModels(KIE_PKG, KIE_MANIFEST, "kie");
+    expect(kie.find((m) => m.id === "kling-2.6/image-to-video")?.supportedTasks).toEqual(["image_to_video"]);
+    expect(kie.find((m) => m.id === "pixverse-v6/reference-to-video")).toBeUndefined();
+    const fal = loadVideoModels(FAL_PKG, FAL_MANIFEST, "fal_ai");
+    expect(fal.find((m) => m.id === "fal-ai/pika/v2.2/pikaframes")?.supportedTasks).not.toContain("reference_to_video");
+    const fields = getModelReferenceInputs(FAL_PKG, FAL_MANIFEST, "alibaba/wan-3.0-prime/reference-to-video");
+    expect(fields.map((field) => field.apiName).sort()).toEqual(["reference_image_urls", "reference_video_urls"]);
+  });
+
+  it("uses only matching media kinds in malformed generated fields", () => {
+    const fields = getModelReferenceInputs(FAL_PKG, FAL_MANIFEST, "wan/v2.6/reference-to-video/flash");
+    expect(fields).toEqual([expect.objectContaining({ kind: "image", apiName: "image_urls", isList: true })]);
+  });
+
+  it("rejects ambiguous reference fields instead of dropping or duplicating inputs", () => {
+    expect(() => validateReferenceInputs("test", "model", { images: [new Uint8Array([1])], videos: [] }, [
+      { kind: "image", name: "reference_images", apiName: "reference_images", isList: true },
+      { kind: "image", name: "subject_images", apiName: "subject_images", isList: true }
+    ])).toThrow("ambiguous reference image");
+  });
+
+  it("keeps video editing models with required sources out of reference generation", () => {
+    const models = loadVideoModels("@nodetool-ai/replicate-nodes", "replicate-manifest.json", "replicate");
+    for (const id of ["runwayml/gen4-aleph", "decart/lucy-edit-2", "wan-video/wan-2.7-videoedit"]) {
+      expect(models.find((model) => model.id === id)?.supportedTasks).toEqual(["video_to_video"]);
+    }
+  });
+
+  it("keeps explicit tasks authoritative and protects required reference video", () => {
+    const models = buildVideoModels([
+      { endpointId: "explicit", outputType: "video", supportedTasks: ["image_to_video", "reference_to_video"], fields: [{ name: "reference_videos", type: "list[video]", required: true }] },
+      { endpointId: "required", outputType: "video", className: "Video Generator", fields: [{ name: "reference_videos", type: "list[video]", required: true }] }
+    ], "test");
+    expect(models.find((m) => m.id === "explicit")?.supportedTasks).toEqual(["image_to_video", "reference_to_video"]);
+    expect(models.find((m) => m.id === "required")?.supportedTasks).toEqual(["reference_to_video"]);
+  });
+
+  it("validates empty, unsupported, required, and bounded references", () => {
+    const fields = getModelReferenceInputs("test", "manifest", "missing");
+    expect(fields).toEqual([]);
+    expect(() => validateReferenceInputs("test", "m", { images: [], videos: [] }, [{ kind: "video", name: "reference_videos", apiName: "reference_videos", isList: true, required: true }])).toThrow("at least one");
+    expect(() => validateReferenceInputs("test", "m", { images: [], videos: [new Uint8Array([1])] }, [{ kind: "video", name: "reference_videos", apiName: "reference_videos", isList: true, required: true }])).not.toThrow();
+    expect(() => validateReferenceInputs("test", "m", { images: [new Uint8Array([1]), new Uint8Array([2])], videos: [] }, [{ kind: "image", name: "reference_image", apiName: "reference_image", isList: true, max: 1 }])).toThrow("at most 1");
+  });
+
+  it("treats required wrapped image and video fields as one mixed requirement", () => {
+    const fields = [
+      { kind: "image" as const, name: "reference_images", apiName: "reference_images", isList: true, required: true, wrapInto: "refers" },
+      { kind: "video" as const, name: "reference_videos", apiName: "reference_videos", isList: true, required: true, wrapInto: "refers", min: 2 }
+    ];
+    expect(() => validateReferenceInputs("kie", "h3", { images: [new Uint8Array([1])], videos: [] }, fields)).not.toThrow();
+    expect(() => validateReferenceInputs("kie", "h3", { images: [], videos: [new Uint8Array([1])] }, fields)).not.toThrow();
+    expect(() => validateReferenceInputs("kie", "h3", { images: [], videos: [] }, fields)).toThrow("at least one");
+  });
+});
 
 describe("manifest-models task inference (FAL manifest)", () => {
   const images = loadImageModels(FAL_PKG, FAL_MANIFEST, "fal_ai");

--- a/packages/runtime/tests/providers/minimax-provider.test.ts
+++ b/packages/runtime/tests/providers/minimax-provider.test.ts
@@ -333,11 +333,9 @@ describe("MinimaxProvider", () => {
       name: "Subject",
       provider: "minimax"
     };
-    await provider.imageToVideo([new Uint8Array([1, 2, 3])], {
+    await provider.referenceToVideo({ images: [new Uint8Array([1, 2, 3])], videos: [] }, {
       model,
       prompt: "wave",
-      durationSeconds: 10,
-      resolution: "1080p"
     });
     const body = JSON.parse(
       (mockFetch.mock.calls[0][1] as { body: string }).body

--- a/packages/runtime/tests/providers/nodetool-provider-reference.test.ts
+++ b/packages/runtime/tests/providers/nodetool-provider-reference.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { NodetoolProvider } from "../../src/providers/nodetool-provider.js";
+
+const model = (id: string) => ({
+  id,
+  name: id,
+  provider: "nodetool" as const
+});
+
+describe("NodetoolProvider task routing", () => {
+  it("routes text-to-image through the catalog's default delegate", async () => {
+    const provider = new NodetoolProvider();
+    await expect(
+      provider.textToImage({ model: model("nodetool/flux-schnell"), prompt: "cat" })
+    ).rejects.toThrow(/missing NODETOOL_PLATFORM_FAL_KEY/);
+  });
+
+  it("rejects a video model without reference_to_video before delegation", async () => {
+    const provider = new NodetoolProvider();
+    await expect(
+      provider.referenceToVideo(
+        { images: [new Uint8Array([1])], videos: [] },
+        { model: model("nodetool/hailuo-fast"), prompt: "cat" }
+      )
+    ).rejects.toThrow(/does not support reference_to_video/);
+  });
+});

--- a/packages/runtime/tests/providers/openai-provider-coverage.test.ts
+++ b/packages/runtime/tests/providers/openai-provider-coverage.test.ts
@@ -1571,7 +1571,7 @@ describe("OpenAIProvider – imageToVideo", () => {
       { client: mockClient as any }
     );
 
-    const result = await provider.imageToVideo([png], {
+    const result = await provider.imageToVideo(png, {
       prompt: "make it move",
       model: { id: "sora", name: "sora", provider: "openai" },
       durationSeconds: 12
@@ -1607,7 +1607,7 @@ describe("OpenAIProvider – imageToVideo", () => {
         { client: mockClient as any }
       );
 
-      const result = provider.imageToVideo([png], {
+      const result = provider.imageToVideo(png, {
         model: { id: "sora", name: "sora", provider: "openai" },
         timeoutSeconds: 0.01
       });
@@ -1630,7 +1630,7 @@ describe("OpenAIProvider – imageToVideo", () => {
     );
 
     await expect(
-      provider.imageToVideo([new Uint8Array()], {
+      provider.imageToVideo(new Uint8Array(), {
         prompt: "test",
         model: { id: "sora", name: "sora", provider: "openai" }
       })
@@ -1656,7 +1656,7 @@ describe("OpenAIProvider – imageToVideo", () => {
     );
 
     await expect(
-      provider.imageToVideo([png], {
+      provider.imageToVideo(png, {
         prompt: "test",
         model: { id: "sora", name: "sora", provider: "openai" }
       })
@@ -1687,7 +1687,7 @@ describe("OpenAIProvider – imageToVideo", () => {
     );
 
     await expect(
-      provider.imageToVideo([png], {
+      provider.imageToVideo(png, {
         prompt: "test",
         model: { id: "sora", name: "sora", provider: "openai" }
       })
@@ -1719,7 +1719,7 @@ describe("OpenAIProvider – imageToVideo", () => {
       { client: mockClient as any }
     );
 
-    const result = await provider.imageToVideo([png], {
+    const result = await provider.imageToVideo(png, {
       prompt: "test",
       model: { id: "sora", name: "sora", provider: "openai" }
     });

--- a/packages/runtime/tests/providers/provider-registry-extended.test.ts
+++ b/packages/runtime/tests/providers/provider-registry-extended.test.ts
@@ -197,7 +197,7 @@ describe("provider-registry — extended coverage", () => {
       provider.textToVideo({ model, prompt: "ocean" })
     ).resolves.toEqual(new Uint8Array([1]));
     await expect(
-      provider.imageToVideo([new Uint8Array([9])], { model, prompt: "move" })
+      provider.imageToVideo(new Uint8Array([9]), { model, prompt: "move" })
     ).resolves.toEqual(new Uint8Array([2]));
     expect(textToVideo).toHaveBeenCalledWith(
       "wangp",

--- a/packages/runtime/tests/providers/reference-video-mappings.test.ts
+++ b/packages/runtime/tests/providers/reference-video-mappings.test.ts
@@ -1,0 +1,137 @@
+import Replicate from "replicate";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AtlasCloudProvider } from "../../src/providers/atlascloud-provider.js";
+import { ReplicateProvider } from "../../src/providers/replicate-provider.js";
+import { withReplicateRetry } from "../../src/providers/replicate-retry.js";
+
+const png = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+const webm = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3, 0x01]);
+const uri = (bytes: Uint8Array, mime: string): string =>
+  `data:${mime};base64,${Buffer.from(bytes).toString("base64")}`;
+const model = (provider: string, id: string) => ({ provider, id, name: id });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function atlas() {
+  const bodies: unknown[] = [];
+  const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    if (String(url).endsWith("/generateVideo")) {
+      bodies.push(JSON.parse(String(init?.body)));
+      return Response.json({ data: { id: "job" } });
+    }
+    if (String(url).includes("/prediction/job")) {
+      return Response.json({ data: { status: "completed", outputs: ["https://cdn.atlascloud.ai/result.mp4"] } });
+    }
+    return new Response(new Uint8Array([9]));
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return { bodies, fetchMock, provider: new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "test" }) };
+}
+
+describe("AtlasCloud reference video requests", () => {
+  it.each([
+    { images: [png], videos: [] },
+    { images: [], videos: [webm] },
+    { images: [png, png], videos: [webm, webm] }
+  ])("preserves separate reference arrays and video MIME: %j", async (inputs) => {
+    const { provider, bodies } = atlas();
+    await provider.referenceToVideo(inputs, {
+      model: model("atlascloud", "bytedance/seedance-2.0/reference-to-video"),
+      prompt: "Use image 1 and video 1",
+      negativePrompt: "no text"
+    });
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toMatchObject({ model: "bytedance/seedance-2.0/reference-to-video", prompt: "Use image 1 and video 1" });
+    if (inputs.images.length) expect(bodies[0]).toHaveProperty("reference_images", inputs.images.map((bytes) => uri(bytes, "image/png")));
+    else expect(bodies[0]).not.toHaveProperty("reference_images");
+    if (inputs.videos.length) expect(bodies[0]).toHaveProperty("reference_videos", inputs.videos.map((bytes) => uri(bytes, "video/webm")));
+    else expect(bodies[0]).not.toHaveProperty("reference_videos");
+    expect(bodies[0]).not.toHaveProperty("image");
+    expect(bodies[0]).not.toHaveProperty("negative_prompt");
+  });
+
+  it("groups typed references in the declared mixed array", async () => {
+    const { provider, bodies } = atlas();
+    await provider.referenceToVideo({ images: [png, png], videos: [webm] }, {
+      model: model("atlascloud", "alibaba/wan-3.0/reference-to-video"), prompt: "Keep the cast"
+    });
+    expect(bodies[0]).toHaveProperty("refers", [
+      { url: uri(png, "image/png"), type: "image" },
+      { url: uri(png, "image/png"), type: "image" },
+      { url: uri(webm, "video/webm"), type: "video" }
+    ]);
+    expect(bodies[0]).not.toHaveProperty("reference_images");
+    expect(bodies[0]).not.toHaveProperty("reference_videos");
+  });
+
+  it("maps generic images on a reference endpoint without caller task metadata", async () => {
+    const { provider, bodies } = atlas();
+    await provider.referenceToVideo({ images: [png], videos: [] }, {
+      model: model("atlascloud", "google/veo3.1/reference-to-video"), prompt: "Keep the cast"
+    });
+    expect(bodies[0]).toHaveProperty("images", [uri(png, "image/png")]);
+  });
+
+  it("rejects unsupported kind and forced start-frame calls before network", async () => {
+    const { provider, fetchMock } = atlas();
+    const selected = model("atlascloud", "google/veo3.1/reference-to-video");
+    await expect(provider.referenceToVideo({ images: [png], videos: [webm] }, { model: selected, prompt: "x" })).rejects.toThrow("reference video");
+    await expect(provider.imageToVideo(png, { model: selected, prompt: "x" })).rejects.toThrow("does not support image_to_video");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("Replicate reference video requests", () => {
+  it.each([
+    { images: [png], videos: [] },
+    { images: [], videos: [webm] },
+    { images: [png, png], videos: [webm, webm] }
+  ])("maps the full typed request without source fields: %j", async (inputs) => {
+    const run = vi.spyOn(Replicate.prototype, "run").mockResolvedValue(["data:video/mp4;base64,CQ=="]);
+    const provider = new ReplicateProvider({ REPLICATE_API_TOKEN: "test" });
+    const controller = new AbortController();
+    await expect(provider.referenceToVideo(inputs, {
+      model: model("replicate", "wan-video/wan-2.7-r2v"), prompt: "Keep the cast",
+      signal: controller.signal
+    })).resolves.toEqual(new Uint8Array([9]));
+    expect(run).toHaveBeenCalledWith("wan-video/wan-2.7-r2v", {
+      input: {
+        prompt: "Keep the cast",
+        ...(inputs.images.length ? { reference_images: inputs.images.map((bytes) => uri(bytes, "image/png")) } : {}),
+        ...(inputs.videos.length ? { reference_videos: inputs.videos.map((bytes) => uri(bytes, "video/webm")) } : {})
+      },
+      signal: expect.any(AbortSignal)
+    });
+  });
+
+  it("rejects video references for an image-only model before SDK submission", async () => {
+    const run = vi.spyOn(Replicate.prototype, "run");
+    const provider = new ReplicateProvider({ REPLICATE_API_TOKEN: "test" });
+    await expect(provider.referenceToVideo({ images: [png], videos: [webm] }, {
+      model: model("replicate", "xai/grok-imagine-r2v"), prompt: "x"
+    })).rejects.toThrow("does not support reference videos");
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("does not submit an already cancelled reference request", async () => {
+    const run = vi.spyOn(Replicate.prototype, "run");
+    const provider = new ReplicateProvider({ REPLICATE_API_TOKEN: "test" });
+    await expect(provider.referenceToVideo({ images: [png], videos: [] }, {
+      model: model("replicate", "wan-video/wan-2.7-r2v"), prompt: "x", signal: AbortSignal.abort()
+    })).rejects.toThrow();
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("cancels rate-limit waits before another billable submission", async () => {
+    const controller = new AbortController();
+    const run = vi.fn(async () => {
+      controller.abort();
+      throw { response: { status: 429 } };
+    });
+    await expect(withReplicateRetry("test", run, controller.signal)).rejects.toThrow();
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/runtime/tests/providers/replicate-provider-coverage.test.ts
+++ b/packages/runtime/tests/providers/replicate-provider-coverage.test.ts
@@ -229,7 +229,7 @@ describe("ReplicateProvider coverage", () => {
   it("imageToVideo feeds image input and optional params", async () => {
     const runMock = vi.fn().mockResolvedValue(fakeFileOutput(IMG));
     const provider = createProvider({ run: runMock });
-    const bytes = await provider.imageToVideo([IMG], {
+    const bytes = await provider.imageToVideo(IMG, {
       model: { id: "owner/unknown-i2v", name: "I2V", provider: "replicate" },
       prompt: "animate",
       negativePrompt: "static",

--- a/packages/runtime/tests/providers/replicate-retry.test.ts
+++ b/packages/runtime/tests/providers/replicate-retry.test.ts
@@ -97,6 +97,31 @@ describe("withReplicateRetry", () => {
     expect(run).toHaveBeenCalledTimes(2);
   });
 
+  it("returns a successful retry with a live cancellation signal", async () => {
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(rateLimitError())
+      .mockResolvedValue("ok");
+    const controller = new AbortController();
+    const result = withReplicateRetry("relight", run, controller.signal);
+
+    await vi.advanceTimersByTimeAsync(20_000);
+    await expect(result).resolves.toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops after cancellation during a rate-limit wait", async () => {
+    const run = vi.fn().mockRejectedValue(rateLimitError());
+    const controller = new AbortController();
+    const result = withReplicateRetry("relight", run, controller.signal);
+
+    await Promise.resolve();
+    controller.abort();
+    await expect(result).rejects.toBe(controller.signal.reason);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it("waits wider than the ~5s the server quotes", async () => {
     const run = vi
       .fn()

--- a/packages/runtime/tests/providers/together-provider.test.ts
+++ b/packages/runtime/tests/providers/together-provider.test.ts
@@ -805,7 +805,7 @@ describe("TogetherProvider", () => {
       prompt: "zoom out"
     };
 
-    const videoPromise = provider.imageToVideo([fakeImage], params);
+    const videoPromise = provider.imageToVideo(fakeImage, params);
     await vi.runAllTimersAsync();
 
     const result = await videoPromise;

--- a/packages/runtime/tests/providers/xai-provider.test.ts
+++ b/packages/runtime/tests/providers/xai-provider.test.ts
@@ -550,7 +550,7 @@ describe("XAIProvider", () => {
       { client: {} as any, fetchFn: mockFetch as any }
     );
 
-    await provider.imageToVideo([pngBytes], {
+    await provider.imageToVideo(pngBytes, {
       prompt: "animate",
       model: videoModel
     });

--- a/packages/runtime/tests/python-bridge-base-coverage.test.ts
+++ b/packages/runtime/tests/python-bridge-base-coverage.test.ts
@@ -721,6 +721,7 @@ describe("PythonBridgeBase — provider RPCs", () => {
     await expect(p).resolves.toBe(output);
   });
 
+
   it("providerTextToAudio returns the encoded audio blob", async () => {
     const output = new Uint8Array([4, 5, 6]);
     const p = bridge.providerTextToAudio("wangp", {

--- a/packages/sandbox-packs/sandbox-dsl/sandbox/generated/nodetool.video.js
+++ b/packages/sandbox-packs/sandbox-dsl/sandbox/generated/nodetool.video.js
@@ -6,6 +6,9 @@ function textToVideo(inputs) {
 function imageToVideo(inputs) {
   return createNode("nodetool.video.ImageToVideo", inputs, { outputNames: ["output"], defaultOutput: "output" });
 }
+function referenceToVideo(inputs) {
+  return createNode("nodetool.video.ReferenceToVideo", inputs, { outputNames: ["output"], defaultOutput: "output" });
+}
 function loadVideoFile(inputs) {
   return createNode("nodetool.video.LoadVideoFile", inputs, { outputNames: ["output"], defaultOutput: "output" });
 }
@@ -112,6 +115,7 @@ export {
   loadVideoAssets,
   loadVideoFile,
   overlay,
+  referenceToVideo,
   resize,
   reverse,
   rotate,

--- a/packages/storyboard/src/io/render-shots.ts
+++ b/packages/storyboard/src/io/render-shots.ts
@@ -12,7 +12,7 @@
  */
 
 import { stampRenderInputs } from "@nodetool-ai/protocol";
-import type { ClipVersion, KeyframeVersion, Shot } from "@nodetool-ai/protocol";
+import type { ClipVersion, ImageRef, KeyframeVersion, Shot } from "@nodetool-ai/protocol";
 import type { StoryboardDocument } from "../document.js";
 import type { ShotRenderPlan } from "../render-plan.js";
 
@@ -21,7 +21,7 @@ export interface RenderGenerationRequest {
   /** Minted by the caller of `runGeneration`, so a background caller has it early. */
   id: string;
   provider: string;
-  capability: "text_to_image" | "image_to_video" | "text_to_video";
+  capability: "text_to_image" | "image_to_video" | "reference_to_video" | "text_to_video";
   model: string;
   params: Record<string, unknown>;
   /** Save the result as an asset: the board can only reference persisted media. */
@@ -57,7 +57,7 @@ export interface StoryboardRenderHost {
     shotId: string;
   }): Promise<StoryboardSnapshot | null>;
   /** Read a stored still back as bytes — the seed a keyframe-mode clip animates. */
-  loadMedia?(ref: KeyframeVersion): Promise<Uint8Array | null>;
+  loadMedia?(ref: KeyframeVersion | ImageRef): Promise<Uint8Array | null>;
   /**
    * The real length of a rendered clip. A video model quantizes the duration it
    * was asked for, and assembly lays down what the ref says.
@@ -80,7 +80,7 @@ export interface ShotRenderOutcome {
   index: number;
   slug?: string;
   kind: "keyframe" | "clip";
-  mode: "keyframe" | "direct";
+  mode: "keyframe" | "direct" | "reference";
   ok: boolean;
   assetId?: string;
   assetUri?: string;
@@ -166,9 +166,11 @@ const isError = (value: unknown): value is { error: string } =>
 const capabilityFor = (plan: ShotRenderPlan): RenderGenerationRequest["capability"] =>
   plan.kind === "keyframe"
     ? "text_to_image"
-    : plan.mode === "direct"
-      ? "text_to_video"
-      : "image_to_video";
+    : plan.mode === "reference"
+      ? "reference_to_video"
+      : plan.mode === "direct"
+        ? "text_to_video"
+        : "image_to_video";
 
 /**
  * Render every plan and write each result onto its shot.
@@ -220,7 +222,22 @@ export async function renderShots(
             error: "The shot's still could not be read back from storage."
           };
         }
+        params["image"] = seed;
+        // Keep the historical serialized shape for callers that inspect the
+        // generation request. It contains exactly the one selected start frame.
         params["images"] = [seed];
+      }
+      if (capability === "reference_to_video" && !host.loadMedia) {
+        return { ...base, error: "Entity reference images cannot be read from storage." };
+      }
+      if (capability === "reference_to_video" && host.loadMedia) {
+        const references = await Promise.all(
+          plan.referenceImages.map((reference) => host.loadMedia?.(reference))
+        );
+        if (references.some((value) => !(value instanceof Uint8Array) || value.length === 0)) {
+          return { ...base, error: "A storyboard entity reference image could not be read from storage." };
+        }
+        params["reference_images"] = references;
       }
       const generationId = newId();
       const persist: RenderGenerationRequest["persist"] =

--- a/packages/storyboard/src/render-plan.ts
+++ b/packages/storyboard/src/render-plan.ts
@@ -24,6 +24,7 @@ import type {
   BoardRenderContext,
   ClipVersion,
   Entity,
+  ImageRef,
   KeyframeVersion,
   RenderInputsDraft,
   Shot
@@ -53,7 +54,9 @@ export interface ShotRenderPlan {
   model: { provider: string; model: string };
   aspectRatio: string;
   /** How a clip is produced. Always `"keyframe"` on a stills plan. */
-  mode: "keyframe" | "direct";
+  mode: "keyframe" | "direct" | "reference";
+  /** Ordered entity reference images to pass to reference_to_video. */
+  referenceImages: ImageRef[];
   /** Clip length, when the shot or its linked lines fix one. */
   durationSeconds?: number;
   /** The still a keyframe-mode clip animates. Null when there is none. */
@@ -64,6 +67,18 @@ export interface ShotRenderPlan {
   fresh: boolean;
 }
 
+function imageAssetId(image: ImageRef): string | undefined {
+  if (typeof image.asset_id === "string" && image.asset_id.length > 0) {
+    return image.asset_id;
+  }
+  if (typeof image.uri !== "string" || !image.uri.startsWith("asset://")) {
+    return undefined;
+  }
+  const locator = image.uri.slice("asset://".length);
+  const extension = locator.lastIndexOf(".");
+  return extension > 0 ? locator.slice(0, extension) : locator || undefined;
+}
+
 /** Per-call overrides. Each one is recorded, so a render made against something
  * other than the board's own settings reads stale against the board. */
 export interface ShotRenderPlanOptions {
@@ -72,7 +87,7 @@ export interface ShotRenderPlanOptions {
   style?: string;
   aspectRatio?: string;
   /** Forces every shot's clip mode for this call only. */
-  mode?: "keyframe" | "direct";
+  mode?: "keyframe" | "direct" | "reference";
   /** Linked script lines, so a clip is rendered long enough to hold its voiceover. */
   scriptLines?: Map<string, ScriptLine>;
 }
@@ -100,7 +115,11 @@ export function boardRenderContext(
       [...(doc.entityIds ?? [])].reverse().find((id) => styleIds.has(id)) ??
       null,
     style: doc.style,
-    scenes: doc.screenplay?.scenes ?? null
+    scenes: doc.screenplay?.scenes ?? null,
+    reference_asset_ids: entities
+      .filter((entity) => (doc.entityIds ?? []).includes(entity.id))
+      .flatMap((entity) => (entity.reference_images ?? []).map(imageAssetId))
+      .filter((id): id is string => typeof id === "string" && id.length > 0)
   };
 }
 
@@ -184,10 +203,17 @@ export function planShotRenders(
     const prompt =
       kind === "keyframe"
         ? keyframePrompt(shot, context)
-        : mode === "direct"
+        : mode === "direct" || mode === "reference"
           ? directClipPrompt(shot, context)
           : clipPrompt(shot);
     const applied = entitiesForShot(shot, [...entities]);
+    const shotReferenceAssetIds = applied.flatMap((entity) =>
+      (entity.reference_images ?? [])
+        .map(imageAssetId)
+        .filter((id): id is string => typeof id === "string" && id.length > 0)
+    );
+    const shotBoard = { ...board, reference_asset_ids: shotReferenceAssetIds };
+    const shotRendered = { ...rendered, reference_asset_ids: shotReferenceAssetIds };
     const version: KeyframeVersion | ClipVersion | null | undefined =
       kind === "keyframe" ? shot.keyframe : shot.clip;
     const plan: ShotRenderPlan = {
@@ -196,15 +222,28 @@ export function planShotRenders(
       kind,
       prompt,
       entities: applied.map(wireEntity),
-      referenceAssetIds: applied
-        .map((e) => e.reference_images?.[0]?.asset_id)
-        .filter((id): id is string => !!id),
+      referenceAssetIds: applied.flatMap((e) =>
+        (e.reference_images ?? [])
+          .map(imageAssetId)
+          .filter((id): id is string => typeof id === "string" && id.length > 0)
+      ),
       model,
       aspectRatio,
       mode: kind === "keyframe" ? "keyframe" : mode,
+      referenceImages:
+        mode === "reference"
+          ? applied.flatMap((entity) => entity.reference_images ?? [])
+          : [],
       sourceKeyframe: shot.keyframe ?? null,
-      renderInputs: currentRenderInputs(shot, rendered, kind),
-      fresh: !isVersionStale(version, shot, board)
+      renderInputs:
+        kind === "clip"
+          ? currentRenderInputs(
+              { ...shot, render_mode: mode },
+              shotRendered,
+              kind
+            )
+          : currentRenderInputs(shot, shotRendered, kind),
+      fresh: !isVersionStale(version, shot, shotBoard)
     };
     if (shot.slug !== undefined) plan.slug = shot.slug;
     if (kind === "clip") {

--- a/packages/storyboard/tests/render-plan.test.ts
+++ b/packages/storyboard/tests/render-plan.test.ts
@@ -139,6 +139,14 @@ describe("planShotRenders freshness", () => {
     expect(stale.size).toBe(1);
   });
 
+  it("records reference overrides with references instead of a keyframe source", () => {
+    const target = shot({ id: "s1", index: 0, keyframe: { type: "image", asset_id: "frame" } });
+    const [plan] = planShotRenders(board([target]), [style], "clip", undefined, { mode: "reference" });
+    expect(plan.renderInputs.render_mode).toBe("reference");
+    expect(plan.renderInputs.reference_asset_ids).toEqual(["ref-1"]);
+    expect(plan.renderInputs.source_version_id).toBeUndefined();
+  });
+
   it("measures freshness against the board, not against the call's override", () => {
     const doc = stillsFixture();
     const plans = planShotRenders(doc, [style], "keyframe", ["s1"], {
@@ -205,6 +213,74 @@ describe("planShotRenders composition", () => {
     });
     expect(plans[0].mode).toBe("direct");
     expect(plans[0].prompt).toBe("The hall, slow push in, moody neon");
+  });
+
+  it("plans reference clips with ordered entity images and direct clip wording", () => {
+    const entity: Entity = {
+      type: "entity",
+      id: "person-1",
+      kind: "character",
+      name: "Mara",
+      descriptor: "a runner",
+      reference_images: [
+        { type: "image", asset_id: "mara-1", uri: "asset://mara-1" },
+        { type: "image", asset_id: "mara-2", uri: "asset://mara-2" }
+      ]
+    };
+    const target = shot({ id: "s1", index: 0, render_mode: "reference", entity_ids: ["person-1"] });
+    const [plan] = planShotRenders(
+      board([target]),
+      [entity],
+      "clip"
+    );
+    expect(plan.mode).toBe("reference");
+    expect(plan.referenceImages.map((image) => image.asset_id)).toEqual([
+      "mara-1",
+      "mara-2"
+    ]);
+    expect(plan.referenceAssetIds).toEqual(["mara-1", "mara-2"]);
+    expect(plan.prompt).toBe("action 0, moody neon");
+  });
+
+  it("marks a reference clip stale when entity reference assets change", () => {
+    const entity: Entity = {
+      type: "entity",
+      id: "person-1",
+      kind: "character",
+      name: "Mara",
+      descriptor: "a runner",
+      reference_images: [{ type: "image", asset_id: "mara-1", uri: "asset://mara-1" }]
+    };
+    const target = shot({ id: "s1", index: 0, render_mode: "reference", entity_ids: ["person-1"] });
+    const doc = { ...board([target]), entityIds: ["person-1"] };
+    const boardContext = boardRenderContext(doc, [entity]);
+    const recorded = {
+      ...target,
+      clip: {
+        type: "video" as const,
+        asset_id: "clip-1",
+        uri: "asset://clip-1",
+        render_inputs: stampRenderInputs(currentRenderInputs(target, boardContext, "clip"))
+      }
+    };
+    const changed = { ...entity, reference_images: [{ type: "image" as const, asset_id: "mara-2", uri: "asset://mara-2" }] };
+    expect(planShotRenders({ ...doc, shots: [recorded] }, [changed], "clip")[0].fresh).toBe(false);
+  });
+
+  it("tracks asset ids from URI-only entity references per shot", () => {
+    const entity: Entity = {
+      type: "entity",
+      id: "person-1",
+      kind: "character",
+      name: "Mara",
+      descriptor: "a runner",
+      reference_images: [{ type: "image", uri: "asset://mara-1.png" }]
+    };
+    const target = shot({ id: "s1", index: 0, render_mode: "reference", entity_ids: ["person-1"] });
+    const doc = { ...board([target]), entityIds: ["person-1"] };
+
+    expect(boardRenderContext(doc, [entity]).reference_asset_ids).toEqual(["mara-1"]);
+    expect(planShotRenders(doc, [entity], "clip")[0].referenceAssetIds).toEqual(["mara-1"]);
   });
 
   it("resolves targets by id, index or slug and keeps the order asked for", () => {

--- a/packages/storyboard/tests/render-shots.test.ts
+++ b/packages/storyboard/tests/render-shots.test.ts
@@ -140,6 +140,41 @@ describe("renderShots", () => {
     expect(state.document.shots[0].status).toBe("rendered");
   });
 
+  it("resolves ordered reference images and dispatches reference_to_video", async () => {
+    const entity: Entity = {
+      type: "entity",
+      id: "e1",
+      kind: "character",
+      name: "Mara",
+      descriptor: "runner",
+      reference_images: [
+        { type: "image", asset_id: "r1", uri: "asset://r1" },
+        { type: "image", asset_id: "r2", uri: "asset://r2" }
+      ]
+    };
+    const doc = board([{ ...shot({ id: "s1", index: 0, entity_ids: ["e1"] }), render_mode: "reference" }]);
+    const { host, requests } = fakeHost(doc, {
+      loadMedia: vi.fn(async (ref) => (ref.asset_id === "r1" ? new Uint8Array([1]) : new Uint8Array([2])))
+    });
+    const plans = planShotRenders(doc, [entity], "clip");
+    await renderShots(host, { id: "b1" }, plans, { newId: ids() });
+    expect(requests[0].capability).toBe("reference_to_video");
+    expect(requests[0].params["reference_images"]).toEqual([new Uint8Array([1]), new Uint8Array([2])]);
+    expect(requests[0].params["image"]).toBeUndefined();
+  });
+
+  it("rejects an unreadable reference before spending", async () => {
+    const entity: Entity = {
+      type: "entity", id: "e1", kind: "character", name: "Mara", descriptor: "runner",
+      reference_images: [{ type: "image", asset_id: "r1", uri: "asset://r1" }]
+    };
+    const doc = board([{ ...shot({ id: "s1", index: 0, entity_ids: ["e1"] }), render_mode: "reference" }]);
+    const { host, requests } = fakeHost(doc, { loadMedia: vi.fn(async () => null) });
+    const outcomes = await renderShots(host, { id: "b1" }, planShotRenders(doc, [entity], "clip"));
+    expect(outcomes[0].ok).toBe(false);
+    expect(requests).toHaveLength(0);
+  });
+
   it("refuses a keyframe-mode clip with no still, and spends nothing", async () => {
     const doc = board([shot({ id: "s1", index: 0 })]);
     const { host, requests } = fakeHost(doc);

--- a/packages/video-nodes/src/nodes/storyboard.ts
+++ b/packages/video-nodes/src/nodes/storyboard.ts
@@ -325,7 +325,7 @@ function renderHost(context: ProcessingContext): StoryboardRenderHost {
       })) as StoryboardRowLike | null;
       return saved ? { document, updatedAt: saved.updatedAt } : null;
     },
-    loadMedia: async (ref: KeyframeVersion) => loadMediaRefBytes(ref, context)
+    loadMedia: async (ref: KeyframeVersion | ImageRef) => loadMediaRefBytes(ref, context)
   };
 }
 
@@ -1036,7 +1036,9 @@ export class RenderClipsNode extends BaseNode {
       doc.videoModel,
       this.video_model,
       "clip",
-      doc.shots.every((shot) => shotRenderMode(shot) === "direct")
+      doc.shots.some((shot) => shotRenderMode(shot) === "reference")
+        ? "reference_to_video"
+        : doc.shots.every((shot) => shotRenderMode(shot) === "direct")
         ? "text_to_video"
         : "image_to_video"
     );

--- a/packages/video-nodes/src/nodes/video.ts
+++ b/packages/video-nodes/src/nodes/video.ts
@@ -512,7 +512,7 @@ export class ImageToVideoNode extends BaseNode {
     default: [],
     title: "Images",
     description:
-      "Input image(s) to animate. The first image is the primary frame; additional images are used as references by providers that support multi-image input."
+      "Input image(s) to animate. Only the first non-empty image is used as the start frame. Use Reference To Video for reference media."
   })
   declare image: ImageRef[];
 
@@ -621,9 +621,17 @@ export class ImageToVideoNode extends BaseNode {
       images = [overrides.image as ImageRefLike];
     }
 
-    const bytesList = (
-      await Promise.all(images.map((img) => imageBytesAsync(img, context)))
-    ).filter((b) => b.length > 0);
+    let image: Uint8Array = new Uint8Array();
+    for (const candidate of images) {
+      const bytes = await imageBytesAsync(candidate, context);
+      if (bytes.length > 0) {
+        image = bytes;
+        break;
+      }
+    }
+    if (image.length === 0) {
+      throw new Error("A non-empty input image is required for Image To Video.");
+    }
     const { providerId, modelId } = modelConfig(this.serialize());
     if (!canUseProvider(context, providerId, modelId)) {
       throw new Error("No provider available for image-to-video generation.");
@@ -634,7 +642,7 @@ export class ImageToVideoNode extends BaseNode {
       capability: "image_to_video",
       model: modelId,
       params: {
-        images: bytesList,
+        image,
         prompt,
         negative_prompt: this.negative_prompt,
         entities: await resolveEntities(this.entities, context),
@@ -645,6 +653,117 @@ export class ImageToVideoNode extends BaseNode {
       }
     }),
       "Image To Video"
+    );
+    return { output: videoRef(output) };
+  }
+}
+
+/** Output handles ReferenceToVideoNode.process() emits. */
+type ReferenceToVideoNodeOutputs = {
+  output: VideoRef;
+};
+
+export class ReferenceToVideoNode extends BaseNode {
+  static readonly nodeType = "nodetool.video.ReferenceToVideo";
+  static readonly body = "content_card";
+  static readonly title = "Reference To Video";
+  static readonly description =
+    "Generate video using ordered image and video references for identity, style, scene, motion, or audio conditioning.\n    video, reference-to-video, r2v, generation, ai";
+  static readonly metadataOutputTypes = { output: "video" };
+  static readonly inlineFields: string[] = [];
+  static readonly inputFields: string[] = ["reference_images", "reference_videos", "prompt"];
+  static readonly autoSaveAsset = true;
+
+  @prop({
+    type: "list[image]",
+    default: [],
+    title: "Reference Images",
+    description: "Ordered identity, style, subject, or scene image references."
+  })
+  declare reference_images: ImageRef[];
+
+  @prop({
+    type: "list[video]",
+    default: [],
+    title: "Reference Videos",
+    description: "Ordered motion, scene, edit, or soundtrack video references."
+  })
+  declare reference_videos: VideoRef[];
+
+  @prop({
+    type: "video_model",
+    default: {
+      type: "video_model",
+      provider: "",
+      id: "",
+      name: "",
+      path: null,
+      supported_tasks: []
+    },
+    title: "Model",
+    description: "The reference-to-video model to use"
+  })
+  declare model: VideoModelRef;
+
+  @prop({ type: "str", default: "", title: "Prompt", description: "Describe the video using image 1, image 2, video 1, and video 2 numbering in list order." })
+  declare prompt: string;
+
+  @prop({ type: "bool", default: false, title: "Use Reference Video Audio", description: "Use audio tracks carried by reference videos where supported." })
+  declare use_reference_video_audio: boolean;
+
+  @prop({ type: "str", default: "", title: "Negative Prompt", description: "Text prompt describing what to avoid in the video" })
+  declare negative_prompt: string;
+
+  @prop({ type: "list[entity]", default: [], title: "Entities", description: "Consistency entities whose descriptors are injected into the prompt" })
+  declare entities: Entity[];
+
+  @prop({ type: "str", default: "16:9", title: "Aspect Ratio", description: "Aspect ratio for the video", values: VIDEO_ASPECT_RATIO_VALUES, json_schema_extra: { type: "media_aspect_ratio_video" } })
+  declare aspect_ratio: string;
+
+  @prop({ type: "str", default: "1080p", title: "Resolution", description: "Video resolution", values: VIDEO_RESOLUTION_VALUES, json_schema_extra: { type: "media_resolution_video" } })
+  declare resolution: string;
+
+  @prop({ type: "int", default: 5, title: "Duration", description: "Video duration in seconds", values: VIDEO_DURATION_VALUES, json_schema_extra: { type: "media_duration" } })
+  declare duration: number;
+
+  @prop({ type: "int", default: 0, title: "Timeout Seconds", description: "Timeout in seconds for API calls (0 = use provider default)", min: 0, max: 7200 })
+  declare timeout_seconds: number;
+
+  async process(context?: ProcessingContext): Promise<ReferenceToVideoNodeOutputs> {
+    const images = normalizeImageList(this.reference_images);
+    const videos = normalizeVideoList(this.reference_videos);
+    const [imageBytes, videoBytes] = await Promise.all([
+      Promise.all(images.map((image) => imageBytesAsync(image, context))),
+      Promise.all(videos.map((video) => videoBytesAsync(video, context)))
+    ]);
+    const referenceImages = imageBytes.filter((bytes) => bytes.length > 0);
+    const referenceVideos = videoBytes.filter((bytes) => bytes.length > 0);
+    if (referenceImages.length === 0 && referenceVideos.length === 0) {
+      throw new Error("Reference To Video requires at least one reference image or video.");
+    }
+    const { providerId, modelId } = modelConfig(this.serialize());
+    if (!canUseProvider(context, providerId, modelId)) {
+      throw new Error("No provider available for reference-to-video generation.");
+    }
+    const output = coerceProviderBytes(
+      await context.runProviderPrediction({
+        provider: providerId,
+        capability: "reference_to_video",
+        model: modelId,
+        params: {
+          reference_images: referenceImages,
+          reference_videos: referenceVideos,
+          prompt: String(this.prompt ?? ""),
+          use_reference_video_audio: this.use_reference_video_audio,
+          negative_prompt: this.negative_prompt,
+          entities: await resolveEntities(this.entities, context),
+          duration_seconds: Number(this.duration ?? 0) || undefined,
+          aspect_ratio: this.aspect_ratio,
+          resolution: this.resolution,
+          timeout_seconds: Number(this.timeout_seconds ?? 0) || undefined
+        }
+      }),
+      "Reference To Video"
     );
     return { output: videoRef(output) };
   }
@@ -3100,6 +3219,7 @@ export class LipSyncNode extends BaseNode {
 export const VIDEO_NODES = [
   TextToVideoNode,
   ImageToVideoNode,
+  ReferenceToVideoNode,
   LoadVideoFileNode,
   SaveVideoFileVideoNode,
   LoadVideoAssetsNode,

--- a/packages/video-nodes/tests/image-to-video-prompt-asset.test.ts
+++ b/packages/video-nodes/tests/image-to-video-prompt-asset.test.ts
@@ -24,9 +24,8 @@ describe("ImageToVideoNode — inline asset prompt mapping", () => {
     await node.process(context as never);
 
     const params = (captured.req as { params: Record<string, unknown> }).params;
-    const images = params.images as Uint8Array[];
-    expect(images).toHaveLength(1);
-    expect(Array.from(images[0])).toEqual(Array.from(assetBytes));
+    const image = params.image as Uint8Array;
+    expect(Array.from(image)).toEqual(Array.from(assetBytes));
     expect(params.prompt).toBe("animate image slowly");
   });
 
@@ -45,9 +44,8 @@ describe("ImageToVideoNode — inline asset prompt mapping", () => {
     await node.process(context as never);
 
     const params = (captured.req as { params: Record<string, unknown> }).params;
-    const images = params.images as Uint8Array[];
-    expect(images).toHaveLength(1);
-    expect(Array.from(images[0])).toEqual([5, 5, 5]);
+    const image = params.image as Uint8Array;
+    expect(Array.from(image)).toEqual([5, 5, 5]);
     expect(params.prompt).toBe("loop forever");
   });
 });

--- a/packages/video-nodes/tests/reference-to-video.test.ts
+++ b/packages/video-nodes/tests/reference-to-video.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { ImageToVideoNode, ReferenceToVideoNode } from "../src/nodes/video.js";
+
+const image = (bytes: number[]) => ({
+  type: "image",
+  data: Buffer.from(bytes).toString("base64")
+});
+
+const video = (bytes: number[]) => ({
+  type: "video",
+  data: Buffer.from(bytes).toString("base64")
+});
+
+function context() {
+  const requests: Array<Record<string, unknown>> = [];
+  return {
+    requests,
+    value: {
+      runProviderPrediction: async (request: Record<string, unknown>) => {
+        requests.push(request);
+        return new Uint8Array([9, 8, 7]);
+      }
+    }
+  };
+}
+
+describe("ReferenceToVideoNode", () => {
+  it("preserves ordered image and video references and rejects empty input", async () => {
+    const node = new ReferenceToVideoNode();
+    node.assign({
+      model: { type: "video_model", provider: "fake", id: "r2v" },
+      reference_images: [image([1]), image([2])],
+      reference_videos: [video([3]), video([4])],
+      prompt: "Use image 1 and video 2"
+    });
+    const run = context();
+    await node.process(run.value as never);
+    const params = run.requests[0].params as Record<string, unknown>;
+    expect((params.reference_images as Uint8Array[]).map((bytes) => bytes[0])).toEqual([1, 2]);
+    expect((params.reference_videos as Uint8Array[]).map((bytes) => bytes[0])).toEqual([3, 4]);
+    expect(run.requests[0].capability).toBe("reference_to_video");
+
+    const empty = new ReferenceToVideoNode();
+    empty.assign({ model: { type: "video_model", provider: "fake", id: "r2v" } });
+    await expect(empty.process(run.value as never)).rejects.toThrow(
+      "requires at least one reference image or video"
+    );
+  });
+});
+
+describe("ImageToVideoNode", () => {
+  it("keeps only the first non-empty serialized image as the start frame", async () => {
+    const node = new ImageToVideoNode();
+    node.assign({
+      model: { type: "video_model", provider: "fake", id: "i2v" },
+      image: [image([]), image([5]), image([6])]
+    });
+    const run = context();
+    await node.process(run.value as never);
+    const params = run.requests[0].params as Record<string, unknown>;
+    expect(Array.from(params.image as Uint8Array)).toEqual([5]);
+  });
+
+  it("does not resolve images after the first non-empty start frame", async () => {
+    const node = new ImageToVideoNode();
+    node.assign({
+      model: { type: "video_model", provider: "fake", id: "i2v" },
+      image: [image([5]), { type: "image", uri: "asset://unreachable" }]
+    });
+    const run = context();
+    const resolvingContext = {
+      ...run.value,
+      resolveAssetBytes: async () => {
+        throw new Error("later image should not be resolved");
+      }
+    };
+    await node.process(resolvingContext as never);
+    expect(run.requests).toHaveLength(1);
+  });
+});

--- a/packages/websocket/src/models-api.ts
+++ b/packages/websocket/src/models-api.ts
@@ -68,6 +68,7 @@ const RANKED_TASK_MODEL_TYPE: Record<string, string> = {
   image_to_image: "image_model",
   text_to_video: "video_model",
   image_to_video: "video_model",
+  reference_to_video: "video_model",
   text_to_speech: "tts_model",
   text_to_music: "music_model"
 };

--- a/packages/websocket/src/session/chat-turn.ts
+++ b/packages/websocket/src/session/chat-turn.ts
@@ -2988,7 +2988,7 @@ export class ChatTurnHandler {
                 { ...videoParams, images: [sourceBytes] },
                 { mime: "video/mp4" },
                 (abort) =>
-                  provider.imageToVideo([sourceBytes], {
+                  provider.imageToVideo(sourceBytes, {
                     model: videoModel,
                     prompt: expandedPrompt,
                     aspectRatio,
@@ -3327,7 +3327,7 @@ export class ChatTurnHandler {
           },
           { mime: "video/mp4" },
           (abort) =>
-            provider.imageToVideo([sourceBytes], { ...params, signal: abort })
+            provider.imageToVideo(sourceBytes, { ...params, signal: abort })
         );
         if (cancelled()) return;
         const assetId =

--- a/packages/websocket/src/session/commands.ts
+++ b/packages/websocket/src/session/commands.ts
@@ -827,6 +827,8 @@ export class CommandRouter {
       const audioFormat = isString(data.audio_format)
         ? (data.audio_format as string)
         : undefined;
+      const capability = data.capability === "reference_to_video" ? "reference_to_video" : undefined;
+      const referenceImages = Array.isArray(data.reference_images) ? data.reference_images : undefined;
       return this.runRpc(command, requestId, () =>
         inference.runDirectMediaGeneration({
           mode,
@@ -847,6 +849,8 @@ export class CommandRouter {
           voice,
           speed,
           audioFormat,
+          capability,
+          referenceImages,
           requestId
         })
       );

--- a/packages/websocket/src/session/inference.ts
+++ b/packages/websocket/src/session/inference.ts
@@ -36,7 +36,7 @@ import { admitSpend, releaseSpend, reserveSpend } from "../credit-gate.js";
 import { retrieveAssetBytes } from "../lib/asset-paths.js";
 import { resolveImageSize } from "../lib/media-size.js";
 import { getAssetAdapter } from "../lib/storage.js";
-import { isFiniteNumber, isString } from "../lib/wire-values.js";
+import { isFiniteNumber, isRecord, isString } from "../lib/wire-values.js";
 import type { ClientSession } from "./client-session.js";
 import {
   createGenerationRun,
@@ -73,6 +73,8 @@ export interface DirectMediaGenerationRequest {
    * a frame that was already delivered to a dead socket.
    */
   requestId?: string;
+  capability?: "reference_to_video";
+  referenceImages?: unknown[];
 }
 
 /**
@@ -663,7 +665,46 @@ export class DirectInferenceHandler {
         duration_seconds: req.durationSeconds ?? null
       };
       let generated: GenerationResult<Uint8Array>;
-      if (req.sourceAssetId) {
+      if (req.capability === "reference_to_video") {
+        const refs = req.referenceImages ?? [];
+        if (refs.length === 0) {
+          throw new Error("reference_to_video requires at least one reference image");
+        }
+        const referenceImages: Uint8Array[] = [];
+        for (const ref of refs) {
+          if (!isRecord(ref)) throw new Error("reference_to_video requires reference image objects");
+          const assetId = isString(ref.asset_id)
+            ? ref.asset_id
+            : isString(ref.uri) && ref.uri.startsWith("asset://")
+              ? ref.uri.slice("asset://".length).split(".")[0]
+              : "";
+          if (!assetId) throw new Error("reference_to_video reference image is missing an asset id");
+          const asset = await Asset.find(userId, assetId);
+          if (!asset) throw new Error(`Reference image asset ${assetId} was not found`);
+          if (!asset.content_type.startsWith("image/")) {
+            throw new Error(`Reference image asset ${assetId} is not an image`);
+          }
+          const bytes = await retrieveAssetBytes(getAssetAdapter(), userId, asset.id, asset.content_type);
+          if (!bytes || bytes.length === 0) throw new Error(`Reference image asset ${assetId} is empty`);
+          referenceImages.push(bytes);
+        }
+        generated = await generate(
+          "reference_to_video",
+          { ...videoParams, reference_images: referenceImages },
+          { mime: "video/mp4" },
+          (abort) => provider.referenceToVideo(
+            { images: referenceImages, videos: [] },
+            {
+              model: videoModel,
+              prompt,
+              durationSeconds: req.durationSeconds ?? null,
+              aspectRatio: req.aspectRatio ?? null,
+              resolution: req.resolution ?? null,
+              signal: abort
+            }
+          )
+        );
+      } else if (req.sourceAssetId) {
         // A source image turns the request into image-to-video: the image is
         // the frame the animation starts from.
         const sourceBytes = await retrieveSourceAssetBytes(
@@ -682,7 +723,7 @@ export class DirectInferenceHandler {
           { ...videoParams, images: [sourceBytes] },
           { mime: "video/mp4" },
           (abort) =>
-            provider.imageToVideo([sourceBytes], { ...i2vParams, signal: abort })
+            provider.imageToVideo(sourceBytes, { ...i2vParams, signal: abort })
         );
       } else {
         const params: TextToVideoParams = {

--- a/packages/websocket/src/trpc/routers/models.ts
+++ b/packages/websocket/src/trpc/routers/models.ts
@@ -980,7 +980,8 @@ const KIND_TO_MODALITY = {
   text_to_music: "music",
   speech_to_text: "asr",
   text_to_video: "video",
-  image_to_video: "video"
+  image_to_video: "video",
+  reference_to_video: "video"
 } satisfies Record<ModelSearchKind, RecommendedUnifiedModel["modality"]>;
 
 async function collectProviderModelsForKind(
@@ -1043,7 +1044,8 @@ async function collectProviderModelsForKind(
             return;
           }
           case "text_to_video":
-          case "image_to_video": {
+          case "image_to_video":
+          case "reference_to_video": {
             const models = await instance.getAvailableVideoModels();
             for (const m of models) {
               if (m.supportedTasks && !m.supportedTasks.includes(kind))

--- a/packages/websocket/tests/direct-inference-edges.test.ts
+++ b/packages/websocket/tests/direct-inference-edges.test.ts
@@ -544,7 +544,7 @@ describe("runDirectMediaGeneration", () => {
   it("routes video without a source through textToVideo and with one through imageToVideo", async () => {
     const sourceId = await createStoredAsset("1", "image/png", PNG_1x1);
     const calls: string[] = [];
-    let i2vInput: Uint8Array[] = [];
+    let i2vInput = new Uint8Array();
     const mp4 = new Uint8Array([0, 0, 0, 24, 102, 116, 121, 112]);
     const provider = asProvider({
       getTotalCost: () => 0,
@@ -552,9 +552,9 @@ describe("runDirectMediaGeneration", () => {
         calls.push(`t2v:${params.durationSeconds}`);
         return mp4;
       },
-      async imageToVideo(images: Uint8Array[]) {
+      async imageToVideo(image: Uint8Array) {
         calls.push("i2v");
-        i2vInput = images;
+        i2vInput = image;
         return mp4;
       }
     });
@@ -567,12 +567,57 @@ describe("runDirectMediaGeneration", () => {
       mediaReq({ mode: "video", sourceAssetId: sourceId })
     );
     expect(calls).toEqual(["t2v:5", "i2v"]);
-    expect(i2vInput).toHaveLength(1);
-    expect(Array.from(i2vInput[0])).toEqual(Array.from(PNG_1x1));
+    expect(Array.from(i2vInput)).toEqual(Array.from(PNG_1x1));
     for (const { asset_ids } of [plain, fromImage]) {
       const row = await Asset.find("1", asset_ids[0]);
       expect(row?.content_type).toBe("video/mp4");
     }
+  });
+
+  it("routes ordered owned reference images without requiring a keyframe", async () => {
+    const first = await createStoredAsset("1", "image/png", new Uint8Array([1, 2]));
+    const second = await createStoredAsset("1", "image/png", new Uint8Array([3, 4]));
+    let seen: Uint8Array[] | null = null;
+    const provider = asProvider({
+      getTotalCost: () => 0,
+      async referenceToVideo(inputs: { images: Uint8Array[] }) {
+        seen = inputs.images;
+        return new Uint8Array([0, 0, 0, 24, 102, 116, 121, 112]);
+      }
+    });
+    const { handler } = makeHandler(provider);
+    const result = await handler.runDirectMediaGeneration(
+      mediaReq({
+        mode: "video",
+        capability: "reference_to_video",
+        referenceImages: [
+          { type: "image", asset_id: first },
+          { type: "image", asset_id: second }
+        ]
+      })
+    );
+    expect(seen?.map((bytes) => bytes[0])).toEqual([1, 3]);
+    expect(result.asset_ids).toHaveLength(1);
+  });
+
+  it("rejects a reference image owned by another user", async () => {
+    const foreign = await createStoredAsset("2", "image/png", PNG_1x1);
+    const provider = asProvider({
+      getTotalCost: () => 0,
+      async referenceToVideo() {
+        throw new Error("provider must not be called");
+      }
+    });
+    const { handler } = makeHandler(provider);
+    await expect(
+      handler.runDirectMediaGeneration(
+        mediaReq({
+          mode: "video",
+          capability: "reference_to_video",
+          referenceImages: [{ type: "image", asset_id: foreign }]
+        })
+      )
+    ).rejects.toThrow(/not found|empty/);
   });
 
   it("routes video_edit through videoToVideo with the request's parameters", async () => {

--- a/packages/websocket/tests/generate-media-rpc.test.ts
+++ b/packages/websocket/tests/generate-media-rpc.test.ts
@@ -340,7 +340,7 @@ describe("generate_media RPC (entity mentions)", () => {
 describe("generate_media RPC (video modes)", () => {
   let ws: MockWebSocket;
   const t2vCalls: TextToVideoParams[] = [];
-  const i2vCalls: Array<{ images: Uint8Array[]; params: ImageToVideoParams }> =
+  const i2vCalls: Array<{ image: Uint8Array; params: ImageToVideoParams }> =
     [];
   const v2vCalls: Array<{ video: Uint8Array; params: ImageToVideoParams & { strength?: number | null } }> =
     [];
@@ -364,10 +364,10 @@ describe("generate_media RPC (video modes)", () => {
         return new Uint8Array([0x00, 0x00, 0x00, 0x18]);
       },
       async imageToVideo(
-        images: Uint8Array[],
+        image: Uint8Array,
         params: ImageToVideoParams
       ): Promise<Uint8Array> {
-        i2vCalls.push({ images, params });
+        i2vCalls.push({ image, params });
         return new Uint8Array([0x00, 0x00, 0x00, 0x18]);
       },
       async videoToVideo(
@@ -414,7 +414,7 @@ describe("generate_media RPC (video modes)", () => {
     expect(out.error).toBeUndefined();
     expect(t2vCalls).toHaveLength(0);
     expect(i2vCalls).toHaveLength(1);
-    expect(i2vCalls[0].images).toEqual([REF_BYTES["srcv-1"]]);
+    expect(i2vCalls[0].image).toEqual(REF_BYTES["srcv-1"]);
     expect(i2vCalls[0].params.prompt).toBe("slow push in");
     expect(i2vCalls[0].params.durationSeconds).toBe(5);
     expect(i2vCalls[0].params.aspectRatio).toBe("16:9");

--- a/web/src/components/properties/ModelProperty.tsx
+++ b/web/src/components/properties/ModelProperty.tsx
@@ -107,6 +107,7 @@ const ModelProperty = (props: PropertyProps) => {
     const videoTaskByNode = {
       "nodetool.video.TextToVideo": "text_to_video",
       "nodetool.video.ImageToVideo": "image_to_video",
+      "nodetool.video.ReferenceToVideo": "reference_to_video",
       "nodetool.video.VideoToVideo": "video_to_video",
       "nodetool.video.LipSync": "lip_sync"
     } as const;

--- a/web/src/components/storyboard/BoardStaleBanner.tsx
+++ b/web/src/components/storyboard/BoardStaleBanner.tsx
@@ -17,7 +17,7 @@
  */
 
 import { memo, useCallback, useMemo } from "react";
-import { staleClipShots, staleKeyframeShots } from "@nodetool-ai/protocol";
+import { isVersionStale } from "@nodetool-ai/protocol";
 
 import { boardRenderContext } from "../../lib/storyboard/boardRenderContext";
 import { useBoard } from "../../stores/storyboard/StoryboardStore";
@@ -76,17 +76,28 @@ const BoardStaleBannerImpl = ({
   const { data: allEntities } = useEntities();
   const { generateKeyframe } = useGenerateShot();
 
-  const context = useMemo(
-    () => boardRenderContext(board, allEntities ?? []),
+  const stale = useMemo(
+    () => board.shots.map((shot) => ({
+      shot,
+      context: boardRenderContext(
+        board,
+        allEntities ?? [],
+        shot
+      )
+    })),
     [board, allEntities]
   );
   const staleStills = useMemo(
-    () => staleKeyframeShots(board.shots, context),
-    [board.shots, context]
+    () => stale
+      .filter(({ shot, context }) => isVersionStale(shot.keyframe, shot, context))
+      .map(({ shot }) => shot),
+    [stale]
   );
   const staleClips = useMemo(
-    () => staleClipShots(board.shots, context),
-    [board.shots, context]
+    () => stale
+      .filter(({ shot, context }) => isVersionStale(shot.clip, shot, context))
+      .map(({ shot }) => shot),
+    [stale]
   );
 
   // One shot that cannot start records the reason on itself and is toasted, so

--- a/web/src/components/storyboard/ShotCard.tsx
+++ b/web/src/components/storyboard/ShotCard.tsx
@@ -75,7 +75,7 @@ interface ShotCardProps {
    * stale marker on the pill. Passed in from where the board's models, style
    * and scenes already are.
    */
-  renderContext?: BoardRenderContext | null;
+  renderContext?: BoardRenderContext | ((shot: Shot) => BoardRenderContext) | null;
   /** True when this card is the board's selected shot. */
   selected?: boolean;
   /** Selects (or, on the selected card, deselects) this shot. */
@@ -156,6 +156,8 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
   onDrop
 }) => {
   const theme = useTheme();
+  const shotRenderContext =
+    typeof renderContext === "function" ? renderContext(shot) : renderContext;
   // The still or clip the fullscreen viewer shows; null when it is closed.
   const [viewerMedia, setViewerMedia] = useState<ImageRef | VideoRef | null>(
     null
@@ -391,7 +393,7 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
       <Box
         sx={{
           ...mediaSx,
-          aspectRatio: (renderContext?.aspect_ratio ?? "16:9").replace(
+          aspectRatio: (shotRenderContext?.aspect_ratio ?? "16:9").replace(
             ":",
             " / "
           )
@@ -433,7 +435,7 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
         />
         <ShotStatusPill
           shot={shot}
-          renderContext={renderContext}
+          renderContext={shotRenderContext}
           sx={{
             position: "absolute",
             right: SPACING.md,

--- a/web/src/components/storyboard/ShotEditDialog.tsx
+++ b/web/src/components/storyboard/ShotEditDialog.tsx
@@ -504,6 +504,26 @@ const ShotEditDialogInner: React.FC<ShotEditDialogProps> = ({
               />
             </FlexColumn>
           </Box>
+          <Box sx={{ flex: "1 1 12rem", minWidth: 0 }}>
+            <FlexColumn gap={SPACING.xs}>
+              <Label sx={{ color: "text.secondary" }}>Render mode</Label>
+              <SelectField
+                size="small"
+                label="Render mode"
+                hideLabel
+                disabled={readOnly}
+                value={draft.renderMode}
+                onChange={(value) =>
+                  setDraft({ ...draft, renderMode: value as "keyframe" | "direct" | "reference" })
+                }
+                options={[
+                  { value: "keyframe", label: "Keyframe" },
+                  { value: "direct", label: "Direct" },
+                  { value: "reference", label: "Reference" }
+                ]}
+              />
+            </FlexColumn>
+          </Box>
           <Box sx={{ flex: "1 1 16rem", minWidth: 0 }}>
             <FlexColumn gap={SPACING.xs}>
               <Label sx={{ color: "text.secondary" }}>Lighting</Label>

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -28,6 +28,7 @@ import React, {
   useState
 } from "react";
 import { shotRenderMode } from "@nodetool-ai/protocol";
+import type { Shot } from "@nodetool-ai/protocol";
 import AddIcon from "@mui/icons-material/Add";
 import TuneIcon from "@mui/icons-material/Tune";
 
@@ -525,7 +526,7 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
     () =>
       shots.filter(
         (s) =>
-          shotRenderMode(s) !== "direct" &&
+          shotRenderMode(s) === "keyframe" &&
           !s.keyframe &&
           (s.status === "planned" || s.status === "failed")
       ),
@@ -533,14 +534,14 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   );
 
   const hasIncompleteStills = shots.some(
-    (s) => shotRenderMode(s) !== "direct" && !s.keyframe
+    (s) => shotRenderMode(s) === "keyframe" && !s.keyframe
   );
 
   const pendingClips = useMemo(
     () =>
       shots.filter(
         (s) =>
-          (!!s.keyframe || shotRenderMode(s) === "direct") &&
+          (!!s.keyframe || shotRenderMode(s) === "direct" || shotRenderMode(s) === "reference") &&
           !s.clip &&
           s.status !== "keyframe_generating" &&
           s.status !== "clip_generating"
@@ -557,6 +558,11 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
       : null;
   const stillStepActive = nextRenderStep === "stills";
   const clipStepActive = nextRenderStep === "clips";
+  const clipModelTask = shots.some((shot) => shotRenderMode(shot) === "reference")
+    ? "reference_to_video"
+    : shots.some((shot) => shotRenderMode(shot) === "direct")
+      ? "text_to_video"
+      : "image_to_video";
   const missingModelStep = stillStepActive
     ? imageModel?.id
       ? null
@@ -578,11 +584,12 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   // enqueue path stamped a version with, so it is derived once here rather
   // than per card (PRD § 7.7.4). Built from what `useBoard` already returned,
   // not a second read of the store.
-  const renderContext = useMemo(
-    () =>
+  const renderContext = useCallback(
+    (shot: Shot) =>
       boardRenderContext(
         { aspectRatio, style, entityIds, imageModel, videoModel, screenplay },
-        allEntities ?? []
+        allEntities ?? [],
+        shot
       ),
     [aspectRatio, style, entityIds, imageModel, videoModel, screenplay, allEntities]
   );
@@ -818,7 +825,7 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
                     <FormField label="Clip model" sx={modelFieldSx}>
                       <VideoModelSelect
                         value={videoModel?.id ?? ""}
-                        task="image_to_video"
+                        task={clipModelTask}
                         onChange={(value) => setVideoModel(boardId, value)}
                       />
                       {clipStepActive && !videoModel?.id && (

--- a/web/src/components/storyboard/__tests__/shotDraft.test.ts
+++ b/web/src/components/storyboard/__tests__/shotDraft.test.ts
@@ -45,6 +45,7 @@ describe("draftFromShot", () => {
     );
 
     expect(draft).toEqual({
+      renderMode: "keyframe",
       slug: "Opening",
       sceneId: null,
       lighting: "hard key",
@@ -155,6 +156,14 @@ describe("withDurationSourceToggled", () => {
 });
 
 describe("shotPatchFromDraft", () => {
+  it("persists reference mode as a shot change", () => {
+    const original = draftFromShot(shot(), null);
+    const draft = { ...original, renderMode: "reference" as const };
+    expect(hasShotFieldChanges(draft, original)).toBe(true);
+    expect(shotPatchFromDraft(draft).render_mode).toBe("reference");
+    expect(draftFromShot(shot({ render_mode: "reference" }), null).renderMode).toBe("reference");
+  });
+
   it("maps every column onto its field", () => {
     const draft = {
       ...draftFromShot(shot(), null),
@@ -171,6 +180,7 @@ describe("shotPatchFromDraft", () => {
     };
 
     expect(shotPatchFromDraft(draft)).toEqual({
+      render_mode: "keyframe",
       slug: "Opening",
       action: "A lighthouse at dawn",
       dialogue: "We are open.",

--- a/web/src/components/storyboard/shotDraft.ts
+++ b/web/src/components/storyboard/shotDraft.ts
@@ -10,7 +10,7 @@
  * decided in one testable place rather than inside the dialog's callbacks.
  */
 
-import type { Scene, Shot, ShotDurationSource } from "@nodetool-ai/protocol";
+import type { Scene, Shot, ShotDurationSource, ShotRenderMode } from "@nodetool-ai/protocol";
 
 /** The dialog's editable state. Every value is a string so an empty field and
  * an unset field are the same thing to the form. */
@@ -41,6 +41,7 @@ export interface ShotDraft {
   lens: string;
   /** Notes → `notes`. */
   notes: string;
+  renderMode: ShotRenderMode;
 }
 
 /** The draft a freshly opened dialog starts from. */
@@ -58,7 +59,8 @@ export const draftFromShot = (shot: Shot, scene: Scene | null): ShotDraft => ({
   movement: shot.camera?.movement ?? "",
   equipment: shot.camera?.equipment ?? "",
   lens: shot.camera?.lens ?? "",
-  notes: shot.notes ?? ""
+  notes: shot.notes ?? "",
+  renderMode: shot.render_mode ?? "keyframe"
 });
 
 /** Whether the creator has changed anything since the dialog opened. */
@@ -159,7 +161,8 @@ export const shotPatchFromDraft = (draft: ShotDraft): Partial<Shot> => {
     notes: orUndefined(draft.notes),
     duration_seconds: seconds ?? undefined,
     duration_source: draft.durationSource,
-    camera: hasCamera ? camera : undefined
+    camera: hasCamera ? camera : undefined,
+    render_mode: draft.renderMode
   };
 };
 

--- a/web/src/config/quickActionNodeTypes.ts
+++ b/web/src/config/quickActionNodeTypes.ts
@@ -9,6 +9,7 @@ export const QUICK_ACTION_NODE_TYPES = [
   "nodetool.image.Vectorize",
   "nodetool.video.TextToVideo",
   "nodetool.video.ImageToVideo",
+  "nodetool.video.ReferenceToVideo",
   "nodetool.video.VideoToVideo",
   "nodetool.video.LipSync",
   "nodetool.audio.TextToSpeech",

--- a/web/src/core/chat/__tests__/mediaPrediction.test.ts
+++ b/web/src/core/chat/__tests__/mediaPrediction.test.ts
@@ -8,6 +8,7 @@ describe("mediaPrediction", () => {
   it("accepts generation capabilities and rejects judge/chat calls", () => {
     expect(isMediaPredictionCapability("text_to_image")).toBe(true);
     expect(isMediaPredictionCapability("text_to_video")).toBe(true);
+    expect(isMediaPredictionCapability("reference_to_video")).toBe(true);
     expect(isMediaPredictionCapability("text_to_speech")).toBe(true);
     expect(isMediaPredictionCapability("generate_messages")).toBe(false);
     expect(isMediaPredictionCapability("generate_embedding")).toBe(false);
@@ -17,6 +18,7 @@ describe("mediaPrediction", () => {
   it("labels image, video, and audio separately", () => {
     expect(mediaPredictionLabel("text_to_image")).toBe("Generating image");
     expect(mediaPredictionLabel("image_to_video")).toBe("Generating video");
+    expect(mediaPredictionLabel("reference_to_video")).toBe("Generating video");
     expect(mediaPredictionLabel("text_to_speech")).toBe("Generating audio");
   });
 

--- a/web/src/core/chat/mediaPrediction.ts
+++ b/web/src/core/chat/mediaPrediction.ts
@@ -7,6 +7,7 @@ const MEDIA_PREDICTION_CAPABILITIES = new Set<string>([
   "image_to_image",
   "text_to_video",
   "image_to_video",
+  "reference_to_video",
   "video_to_video",
   "lip_sync",
   "text_to_speech",
@@ -34,6 +35,7 @@ export function mediaPredictionLabel(capability: string): string {
       return "Generating image";
     case "text_to_video":
     case "image_to_video":
+    case "reference_to_video":
     case "video_to_video":
     case "lip_sync":
       return "Generating video";

--- a/web/src/hooks/storyboard/__tests__/storyboardSetupBridge.test.tsx
+++ b/web/src/hooks/storyboard/__tests__/storyboardSetupBridge.test.tsx
@@ -9,7 +9,13 @@
  * is open, which is the failure this suite exists to catch.
  */
 import { renderHook, act } from "@testing-library/react";
-import type { Shot } from "@nodetool-ai/protocol";
+import {
+  currentRenderInputs,
+  stampRenderInputs
+} from "@nodetool-ai/protocol";
+import type { Entity, Shot } from "@nodetool-ai/protocol";
+
+let mockEntities: Entity[] = [];
 
 jest.mock("../useGenerateShot", () => ({
   useGenerateShot: () => ({
@@ -31,12 +37,15 @@ jest.mock("../useDirectScreenplay", () => ({
   useDirectScreenplay: () => ({ direct: jest.fn() })
 }));
 jest.mock("../../../serverState/useEntities", () => ({
-  useEntities: () => ({ data: [] })
+  useEntities: () => ({ data: mockEntities })
 }));
 
 import { FrontendToolRegistry } from "../../../lib/tools/frontendTools";
 import type { FrontendToolState } from "../../../lib/tools/frontendTools";
-import { hasStoryboardAgentHandler } from "../../../components/storyboard/storyboardAgentBridge";
+import {
+  getStoryboardAgentHandler,
+  hasStoryboardAgentHandler
+} from "../../../components/storyboard/storyboardAgentBridge";
 import {
   useStoryboardStore,
   type StoryboardBoard
@@ -82,8 +91,60 @@ const seed = (): void => {
 };
 
 beforeEach(() => {
+  mockEntities = [];
   useStoryboardStore.setState({ boards: {}, history: {} } as never);
   seed();
+});
+
+it("reports reference clips stale after a cast reference replacement", async () => {
+  const entity: Entity = {
+    type: "entity",
+    id: "actor-1",
+    kind: "character",
+    name: "Mara",
+    descriptor: "a runner",
+    reference_images: [{ type: "image", asset_id: "ref-a", uri: "asset://ref-a" }]
+  };
+  mockEntities = [entity];
+  const referenceShot: Shot = {
+    type: "shot",
+    id: "shot-1",
+    index: 0,
+    action: "runs",
+    status: "rendered",
+    render_mode: "reference",
+    entity_ids: ["actor-1"]
+  };
+  referenceShot.clip = {
+    type: "video",
+    asset_id: "clip-1",
+    uri: "asset://clip-1",
+    render_inputs: stampRenderInputs(currentRenderInputs(referenceShot, {
+      aspect_ratio: "16:9",
+      image_model: "",
+      video_model: "video-1",
+      style_entity_id: null,
+      style: "",
+      scenes: null,
+      reference_asset_ids: ["ref-a"]
+    }, "clip"))
+  };
+  useStoryboardStore.getState().loadBoard(BOARD, {
+    ...board(),
+    entityIds: ["actor-1"],
+    style: "",
+    videoModel: { type: "video_model", id: "video-1", name: "Video", provider: "fal_ai" },
+    shots: [referenceShot]
+  });
+  const bridge = renderHook(() => useStoryboardAgentBridge(BOARD));
+
+  const fresh = getStoryboardAgentHandler(BOARD).getSnapshot();
+  expect(fresh.shots[0]?.staleClip).toBe(false);
+
+  mockEntities = [{ ...entity, reference_images: [{ type: "image", asset_id: "ref-b", uri: "asset://ref-b" }] }];
+  bridge.rerender();
+  const stale = getStoryboardAgentHandler(BOARD).getSnapshot();
+  expect(stale.shots[0]?.staleClip).toBe(true);
 });
 
 describe("the agent bridge a setup host registers", () => {

--- a/web/src/hooks/storyboard/useGenerateShot.ts
+++ b/web/src/hooks/storyboard/useGenerateShot.ts
@@ -29,6 +29,7 @@ import type {
 import {
   clipPrompt,
   directClipPrompt,
+  entitiesForShot,
   injectEntities,
   keyframePrompt,
   sceneForShot,
@@ -41,7 +42,6 @@ import {
   useStoryboardStore,
   type StoryboardBoard
 } from "../../stores/storyboard/StoryboardStore";
-import { entitiesForShot } from "../../stores/storyboard/shotEntities";
 import { boardRenderContext } from "../../lib/storyboard/boardRenderContext";
 import { useEntities } from "../../serverState/useEntities";
 import { useImageModelsByProvider } from "../useModelsByProvider";
@@ -144,8 +144,12 @@ export const useGenerateShot = (): UseGenerateShotResult => {
    * so the first match is the board's style.
    */
   const renderContext = useCallback(
-    (board: StoryboardBoard | undefined): BoardRenderContext =>
-      boardRenderContext(board, allEntities ?? []),
+    (board: StoryboardBoard | undefined, shot?: Shot): BoardRenderContext =>
+      boardRenderContext(
+        board,
+        allEntities ?? [],
+        shot
+      ),
     [allEntities]
   );
 
@@ -258,7 +262,7 @@ export const useGenerateShot = (): UseGenerateShotResult => {
         shot,
         "keyframe",
         data,
-        renderContext(board)
+        renderContext(board, shot)
       );
     },
     [startDirectGeneration, boardEntities, imageModels, renderContext]
@@ -267,9 +271,10 @@ export const useGenerateShot = (): UseGenerateShotResult => {
   const generateClip = useCallback(
     async (boardId: string, shot: Shot): Promise<void> => {
       const board = useStoryboardStore.getState().getBoard(boardId);
-      const isDirect = shotRenderMode(shot) === "direct";
+      const renderMode = shotRenderMode(shot);
+      const isDirect = renderMode === "direct";
       let sourceAssetId: string | undefined;
-      if (!isDirect) {
+      if (renderMode === "keyframe") {
         if (!shot.keyframe) {
           throw new Error(
             "Shot has no keyframe to animate. Generate a still first, or set its render mode to direct."
@@ -289,21 +294,28 @@ export const useGenerateShot = (): UseGenerateShotResult => {
         board?.screenplay?.script_id,
         shot
       );
-      const prompt = isDirect
+      const prompt = isDirect || renderMode === "reference"
         ? directClipPrompt(shot, {
             scene: sceneForShot(shot, board?.screenplay?.scenes),
             style: board?.style ?? ""
           })
         : clipPrompt(shot);
+      const entities = entitiesForShot(shot, boardEntities(board?.entityIds));
       const data: Record<string, unknown> = {
         mode: "video",
-        prompt: `${prompt}${entityTokenSuffix(
-          entitiesForShot(shot, boardEntities(board?.entityIds))
-        )}`,
+        prompt: `${prompt}${entityTokenSuffix(entities)}`,
         aspect_ratio: aspectRatio,
         resolution: CLIP_RESOLUTION,
         variations: 1
       };
+      if (renderMode === "reference") {
+        const referenceImages = entities.flatMap((entity) => entity.reference_images ?? []);
+        if (referenceImages.length === 0) {
+          throw new Error("Reference mode requires at least one entity reference image.");
+        }
+        data.reference_images = referenceImages;
+        data.capability = "reference_to_video";
+      }
       if (sourceAssetId) {
         data.source_asset_id = sourceAssetId;
       }
@@ -319,7 +331,7 @@ export const useGenerateShot = (): UseGenerateShotResult => {
         shot,
         "clip",
         data,
-        renderContext(board)
+        renderContext(board, shot)
       );
     },
     [startDirectGeneration, boardEntities, renderContext]

--- a/web/src/hooks/storyboard/useStoryboardAgentBridge.ts
+++ b/web/src/hooks/storyboard/useStoryboardAgentBridge.ts
@@ -43,6 +43,7 @@ import { sceneOrder } from "../../lib/storyboard/sceneOrder";
 import { linkedScriptId } from "../../lib/scriptStoryboardLink";
 import { assetLocator } from "../../utils/mediaRef";
 import { DEFAULT_SETUP_SHOT_COUNT } from "@nodetool-ai/protocol/api-schemas/storyboards.js";
+import { boardRenderContext } from "../../lib/storyboard/boardRenderContext";
 
 /**
  * Shot count a Director run defaults to when neither the caller nor the board
@@ -55,21 +56,8 @@ const DEFAULT_SHOT_COUNT = DEFAULT_SETUP_SHOT_COUNT;
  * board's one style entity — the same id `setStylePreset` writes — so a preset
  * change is what makes a version stale, not every cast edit.
  */
-const renderContext = (board: StoryboardBoard, entities: readonly Entity[]) => {
-  const styleIds = new Set(
-    entities.filter((e) => e.kind === "style").map((e) => e.id)
-  );
-  const styleEntityId =
-    [...board.entityIds].reverse().find((id) => styleIds.has(id)) ?? null;
-  return {
-    aspect_ratio: board.aspectRatio,
-    image_model: board.imageModel?.id ?? "",
-    video_model: board.videoModel?.id ?? "",
-    style_entity_id: styleEntityId,
-    style: board.style,
-    scenes: board.screenplay?.scenes ?? null
-  };
-};
+const renderContext = (board: StoryboardBoard, entities: readonly Entity[], shot?: Shot) =>
+  boardRenderContext(board, entities, shot);
 
 const toSceneNode = (
   scene: { id: string; slugline: string; lighting?: string },
@@ -103,7 +91,7 @@ export const useStoryboardAgentBridge = (boardId: string): void => {
     };
 
     const toShotNode = (shot: Shot): StoryboardShotNode => {
-      const context = renderContext(requireBoard(), entities);
+      const context = renderContext(requireBoard(), entities, shot);
       return {
         id: shot.id,
         index: shot.index,
@@ -229,13 +217,12 @@ export const useStoryboardAgentBridge = (boardId: string): void => {
       run: (shot: Shot) => Promise<void>
     ): Promise<StoryboardRenderResult> => {
       const selected = requireShots(target);
-      const context = renderContext(requireBoard(), entities);
       const chosen = options?.staleOnly
         ? selected.filter((shot) =>
             isVersionStale(
               kind === "keyframe" ? shot.keyframe : shot.clip,
               shot,
-              context
+              renderContext(requireBoard(), entities, shot)
             )
           )
         : selected;

--- a/web/src/hooks/useModelsByProvider.ts
+++ b/web/src/hooks/useModelsByProvider.ts
@@ -237,6 +237,7 @@ export type ImageModelTask =
 export type VideoModelTask =
   | "text_to_video"
   | "image_to_video"
+  | "reference_to_video"
   | "video_to_video"
   | "lip_sync";
 
@@ -253,6 +254,7 @@ const STRICT_MODEL_TASKS = new Set<string>([
   "vectorize",
   "segment",
   "video_to_video",
+  "reference_to_video",
   "lip_sync"
 ]);
 

--- a/web/src/lib/storyboard/__tests__/boardRenderContext.test.ts
+++ b/web/src/lib/storyboard/__tests__/boardRenderContext.test.ts
@@ -1,4 +1,5 @@
-import type { Entity } from "@nodetool-ai/protocol";
+import { currentRenderInputs, isVersionStale, stampRenderInputs } from "@nodetool-ai/protocol";
+import type { Entity, Shot } from "@nodetool-ai/protocol";
 
 import { boardRenderContext } from "../boardRenderContext";
 
@@ -34,7 +35,8 @@ describe("boardRenderContext", () => {
       video_model: "fal-ai/kling/v1.6",
       style_entity_id: "style-a",
       style: "grainy 16mm",
-      scenes: []
+      scenes: [],
+      reference_asset_ids: []
     });
   });
 
@@ -59,6 +61,38 @@ describe("boardRenderContext", () => {
     expect(boardRenderContext(BOARD, []).style_entity_id).toBeNull();
   });
 
+  it("includes selected entity references, including URI-only assets", () => {
+    const library = [
+      {
+        ...entity("char-1", "character"),
+        reference_images: [
+          { type: "image" as const, asset_id: "first" },
+          { type: "image" as const, uri: "asset://second.png" }
+        ]
+      }
+    ];
+    expect(boardRenderContext(BOARD, library).reference_asset_ids).toEqual([
+      "first",
+      "second"
+    ]);
+  });
+
+  it("matches generation selection and order, and marks changed references stale", () => {
+    const shot: Shot = { type: "shot", id: "shot", index: 0, action: "char-1 walks", status: "planned", render_mode: "reference" };
+    const library: Entity[] = [
+      { ...entity("outside", "style"), reference_images: [{ type: "image", asset_id: "outside" }] },
+      { ...entity("style-a", "style"), reference_images: [{ type: "image", asset_id: "style" }] },
+      { ...entity("char-1", "character"), reference_images: [{ type: "image", asset_id: "character" }] }
+    ];
+    const context = boardRenderContext(BOARD, library, shot);
+    expect(context.reference_asset_ids).toEqual(["character", "style"]);
+    const clip = { type: "video" as const, asset_id: "clip", render_inputs: stampRenderInputs(currentRenderInputs(shot, context, "clip")) };
+    expect(isVersionStale(clip, shot, context)).toBe(false);
+    const changed = library.map((entry) => entry.id === "char-1" ? { ...entry, reference_images: [{ type: "image" as const, asset_id: "new-character" }] } : entry);
+    expect(isVersionStale(clip, shot, boardRenderContext(BOARD, changed, shot))).toBe(true);
+    expect(boardRenderContext(BOARD, library, { ...shot, entity_ids: ["style-a", "char-1"] }).reference_asset_ids).toEqual(["character", "style"]);
+  });
+
   it("falls back to 16:9 and empty models for a board that has none", () => {
     expect(boardRenderContext(undefined, LIBRARY)).toEqual({
       aspect_ratio: "16:9",
@@ -66,7 +100,8 @@ describe("boardRenderContext", () => {
       video_model: "",
       style_entity_id: null,
       style: "",
-      scenes: null
+      scenes: null,
+      reference_asset_ids: []
     });
   });
 });

--- a/web/src/lib/storyboard/boardRenderContext.ts
+++ b/web/src/lib/storyboard/boardRenderContext.ts
@@ -12,7 +12,8 @@
  * which style entity wins.
  */
 
-import type { BoardRenderContext, Entity } from "@nodetool-ai/protocol";
+import { entitiesForShot } from "@nodetool-ai/protocol";
+import type { BoardRenderContext, Entity, Shot } from "@nodetool-ai/protocol";
 
 /** The parts of a board this reads. Structural, so a partial board fits. */
 export interface RenderContextSource {
@@ -51,15 +52,36 @@ const styleEntityId = (
   return null;
 };
 
+const imageAssetId = (image: NonNullable<Entity["reference_images"]>[number]): string | undefined => {
+  if (typeof image.asset_id === "string" && image.asset_id.length > 0) {
+    return image.asset_id;
+  }
+  if (typeof image.uri !== "string" || !image.uri.startsWith("asset://")) {
+    return undefined;
+  }
+  const locator = image.uri.slice("asset://".length);
+  const extension = locator.lastIndexOf(".");
+  return extension > 0 ? locator.slice(0, extension) : locator || undefined;
+};
+
 /** Project a board and the resolved entity library onto the render inputs. */
 export const boardRenderContext = (
   board: RenderContextSource | undefined | null,
-  entities: readonly Entity[]
-): BoardRenderContext => ({
-  aspect_ratio: board?.aspectRatio ?? "16:9",
-  image_model: board?.imageModel?.id ?? "",
-  video_model: board?.videoModel?.id ?? "",
-  style_entity_id: styleEntityId(board?.entityIds, entities),
-  style: board?.style ?? "",
-  scenes: board?.screenplay?.scenes ?? null
-});
+  entities: readonly Entity[],
+  shot?: Shot
+): BoardRenderContext => {
+  const byId = new Map(entities.map((entity) => [entity.id, entity]));
+  const boardEntities = (board?.entityIds ?? []).flatMap((id) => byId.get(id) ?? []);
+  const selected = shot ? entitiesForShot(shot, boardEntities) : boardEntities;
+  return {
+    aspect_ratio: board?.aspectRatio ?? "16:9",
+    image_model: board?.imageModel?.id ?? "",
+    video_model: board?.videoModel?.id ?? "",
+    style_entity_id: styleEntityId(board?.entityIds, entities),
+    style: board?.style ?? "",
+    scenes: board?.screenplay?.scenes ?? null,
+    reference_asset_ids: selected
+      .flatMap((entity) => (entity.reference_images ?? []).map(imageAssetId))
+      .filter((id): id is string => typeof id === "string" && id.length > 0)
+  };
+};


### PR DESCRIPTION
## What changed

Adds an explicit reference-to-video operation to the existing providers and connects it to storyboard rendering. Previously, reference-conditioned models shared the image-to-video path even though a subject reference and an animation's first frame have different roles. A storyboard shot can now use **Reference** mode to generate a clip from its selected entities' reference images without requiring a keyframe.

### Provider and workflow behavior

`referenceToVideo` accepts separate image and video reference arrays. FAL, KIE, Replicate, AtlasCloud, and MiniMax map these inputs to their supported models' declared fields, with NodeTool forwarding to the selected provider. Validation rejects unsupported media, counts, and reference-audio options before submission. Cancellation and timeout signals propagate through the new requests.

Model discovery distinguishes reference-to-video from first-frame animation and video editing. The new generic `ReferenceToVideo` node is available through workflow discovery and generated DSL/sandbox wrappers, and the operation participates in execution, cost tracking, and generation records.

**Compatibility:** the provider-level `imageToVideo` API now takes one image rather than an array. Its callers are migrated. The existing workflow node retains its serialized image-list input and uses the first non-empty image. Python/WanGP reference generation is deferred.

### Storyboard behavior

The shot editor offers Reference alongside Keyframe and Direct modes. Model selection and render dispatch use the selected mode. Reference renders use each shot's ordered entity references, with ownership and image-type checks on stored assets. Render records capture the mode and reference asset IDs so replacing a reference marks the clip stale consistently in the UI and agent tools.

## Verification

- [x] `npm run test:affected` — complete run passed with `TMPDIR=/private/tmp` and `NODE_OPTIONS=--max-old-space-size=8192`.
- [x] `npm run typecheck` — passed with `NODE_OPTIONS=--max-old-space-size=8192`.
- [x] `npm run lint` — passed.
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — all 15 selfchecks passed.

`npm run build:packages` passed. The complete affected-test run passed all 127 backend build/test tasks, 1,445 web suites, 63 Electron suites, and 79 mobile suites. Workflow-runner Chromium E2E passed all 27 tests locally. Replicate retry coverage passed all 15 tests, including cancellation during rate-limit backoff with no second provider call. Provider requests were tested with mocks, not paid live generations.

CI follow-up: removed the new `node:timers/promises` import that prevented the workflow runner from loading in browsers, reusing the existing browser-safe delay helper. The Godot re-export integration test now has a 15-second budget for its two full exports after exceeding the default 5 seconds on CI; its assertions are unchanged.

The new agent-bridge regression was deliberately run without reference context and failed with `Expected: false; Received: true` for a fresh clip's `staleClip` flag. Restoring the context passed all 8 tests in `storyboardSetupBridge.test.tsx`.

## Agent capabilities

- [x] `npm run capabilities:check` passes.
- [x] Updated `find_model` and `render_storyboard_clips` contracts have generated coverage mappings to the new reference-video capability suite.

