### PR TITLE
Forward reference video generation to Python workers

### DIFF
--- a/packages/protocol/src/bridge-protocol.ts
+++ b/packages/protocol/src/bridge-protocol.ts
@@ -46,7 +46,7 @@
  *   3. Update `MIN_NODETOOL_CORE_VERSION` to that new release.
  */
 
-export const BRIDGE_PROTOCOL_VERSION = 5;
+export const BRIDGE_PROTOCOL_VERSION = 6;
 
 /**
  * Hard floor: the JS runtime rejects (at `discover`) any worker reporting a

--- a/packages/protocol/tests/error-and-protocol-coverage.test.ts
+++ b/packages/protocol/tests/error-and-protocol-coverage.test.ts
@@ -79,7 +79,7 @@ describe("error-helpers.isTRPCErrorWithCode", () => {
 
 describe("bridge-protocol constants", () => {
   it("BRIDGE_PROTOCOL_VERSION is the current speaking version", () => {
-    expect(BRIDGE_PROTOCOL_VERSION).toBe(5);
+    expect(BRIDGE_PROTOCOL_VERSION).toBe(6);
   });
 
   it("MIN_BRIDGE_PROTOCOL_VERSION is the hard floor at 1", () => {

--- a/packages/runtime/src/providers/python-provider.ts
+++ b/packages/runtime/src/providers/python-provider.ts
@@ -25,6 +25,8 @@ import type {
   TextToSpeechParams,
   TextToVideoParams,
   ImageToVideoParams,
+  ReferenceToVideoInputs,
+  ReferenceToVideoParams,
   TextToMusicParams,
   EncodedAudioResult
 } from "./types.js";
@@ -79,6 +81,7 @@ export class PythonProvider extends BaseProvider {
   private _secrets: Record<string, string>;
   private _supportsStreamingTTS = true;
   private _supportsEncodedTTS = true;
+  private _workerCapabilities = new Set<string>();
 
   constructor(
     providerId: string,
@@ -99,19 +102,26 @@ export class PythonProvider extends BaseProvider {
       this._bridge = bridge;
       this._pythonProviderId = providerIdOrOptions;
       this._secrets = secrets;
+      this.referenceToVideo = BaseProvider.prototype.referenceToVideo;
       return;
     }
 
     const { _id, _bridge, _bridgeProviderId, _capabilities, ...rawSecrets } =
       providerIdOrOptions;
     super(_id);
+    const wrappedReferenceToVideo = this.referenceToVideo;
     this._bridge = _bridge;
     this._pythonProviderId = _bridgeProviderId ?? _id;
+    this.referenceToVideo = BaseProvider.prototype.referenceToVideo;
     if (Array.isArray(_capabilities)) {
+      this._workerCapabilities = new Set(_capabilities.map(String));
       this._supportsStreamingTTS = _capabilities.includes("text_to_speech");
       this._supportsEncodedTTS = _capabilities.includes(
         "text_to_speech_encoded"
       );
+      if (this._workerCapabilities.has("reference_to_video")) {
+        this.referenceToVideo = wrappedReferenceToVideo;
+      }
     }
     this._secrets = Object.fromEntries(
       Object.entries(rawSecrets).filter(
@@ -187,10 +197,25 @@ export class PythonProvider extends BaseProvider {
     // The public provider id may be an alias (notably `huggingface-local`) so
     // selections route back through this bridge adapter instead of colliding
     // with a built-in remote provider that uses the worker's original id.
-    return models.map((model) => ({
-      ...model,
-      provider: this.provider
-    }));
+    return models.map((model) => {
+      const supportedTasks = Array.isArray(model.supportedTasks)
+        ? model.supportedTasks.map(String)
+        : Array.isArray(model.supported_tasks)
+          ? model.supported_tasks.map(String)
+          : undefined;
+      const normalizedModel: Record<string, unknown> = {
+        ...model,
+        provider: this.provider
+      };
+      if (modelType === "video" && supportedTasks) {
+        normalizedModel.supportedTasks = this._workerCapabilities.has(
+          "reference_to_video"
+        )
+          ? supportedTasks
+          : supportedTasks.filter((task) => task !== "reference_to_video");
+      }
+      return normalizedModel;
+    });
   }
 
   // ── Chat completion ───────────────────────────────────────────────
@@ -321,6 +346,47 @@ export class PythonProvider extends BaseProvider {
     return this._bridge.providerImageToVideo(
       this._pythonProviderId,
       image,
+      { ...wireParams, model: params.model.id },
+      this._secrets,
+      signal
+    );
+  }
+
+  async referenceToVideo(
+    inputs: ReferenceToVideoInputs,
+    params: ReferenceToVideoParams
+  ): Promise<Uint8Array> {
+    if (!this._workerCapabilities.has("reference_to_video")) {
+      throw new Error("Python worker does not support reference_to_video");
+    }
+    if (
+      Array.isArray(params.model.supportedTasks) &&
+      !params.model.supportedTasks.includes("reference_to_video")
+    ) {
+      throw new Error(
+        `Video model ${params.model.id} does not support reference_to_video`
+      );
+    }
+    if (!Array.isArray(params.model.supportedTasks)) {
+      const models = await this._getModels("video");
+      const model = models.find(
+        (candidate) =>
+          isRecord(candidate) && String(candidate.id ?? "") === params.model.id
+      );
+      if (
+        !isRecord(model) ||
+        !Array.isArray(model.supportedTasks) ||
+        !model.supportedTasks.includes("reference_to_video")
+      ) {
+        throw new Error(
+          `Video model ${params.model.id} does not support reference_to_video`
+        );
+      }
+    }
+    const { signal, ...wireParams } = params;
+    return this._bridge.providerReferenceToVideo(
+      this._pythonProviderId,
+      inputs,
       { ...wireParams, model: params.model.id },
       this._secrets,
       signal

--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -113,7 +113,8 @@ import type {
   BlenderEvent,
   BlenderExecuteOptions,
   BlenderExecuteResult,
-  PythonBridge
+  PythonBridge,
+  ReferenceToVideoInputs
 } from "./python-bridge-types.js";
 import {
   comfyStatusInfoSchema,
@@ -1152,6 +1153,56 @@ export abstract class PythonBridgeBase
       {
         provider: providerId,
         image,
+        params,
+        secrets: secrets ?? {}
+      },
+      signal
+    );
+    return result.blobs.video;
+  }
+
+  async providerReferenceToVideo(
+    providerId: string,
+    inputs: ReferenceToVideoInputs,
+    params: Record<string, unknown>,
+    secrets?: Record<string, string>,
+    signal?: AbortSignal
+  ): Promise<Uint8Array> {
+    const { images, videos } = inputs;
+    if (
+      !Array.isArray(images) ||
+      !Array.isArray(videos) ||
+      (images.length === 0 && videos.length === 0)
+    ) {
+      throw new Error(
+        "reference_to_video requires at least one reference image or video"
+      );
+    }
+    if (
+      [...images, ...videos].some((bytes) => !(bytes instanceof Uint8Array))
+    ) {
+      throw new Error(
+        "reference_to_video reference media must be binary buffers"
+      );
+    }
+    if ([...images, ...videos].some((bytes) => bytes.byteLength === 0)) {
+      throw new Error("reference_to_video reference media must be non-empty");
+    }
+    const totalBytes = [...images, ...videos].reduce(
+      (total, bytes) => total + bytes.byteLength,
+      0
+    );
+    if (totalBytes > 192 * 1024 * 1024) {
+      throw new Error(
+        `reference_to_video reference media is ${totalBytes} bytes, exceeding the 201326592 byte limit`
+      );
+    }
+    const result = await this._providerBlobCall(
+      "provider.reference_to_video",
+      {
+        provider: providerId,
+        reference_images: images,
+        reference_videos: videos,
         params,
         secrets: secrets ?? {}
       },

--- a/packages/runtime/src/python-bridge-types.ts
+++ b/packages/runtime/src/python-bridge-types.ts
@@ -2,6 +2,8 @@ import { EventEmitter } from "node:events";
 import { z } from "zod";
 
 import type { ASRResult } from "./providers/types.js";
+import type { ReferenceToVideoInputs } from "./providers/types.js";
+export type { ReferenceToVideoInputs } from "./providers/types.js";
 
 interface NodeMetadataProperty {
   name: string;
@@ -586,6 +588,13 @@ export interface PythonBridge extends EventEmitter {
   providerImageToVideo(
     providerId: string,
     image: Uint8Array,
+    params: Record<string, unknown>,
+    secrets?: Record<string, string>,
+    signal?: AbortSignal
+  ): Promise<Uint8Array>;
+  providerReferenceToVideo(
+    providerId: string,
+    inputs: ReferenceToVideoInputs,
     params: Record<string, unknown>,
     secrets?: Record<string, string>,
     signal?: AbortSignal

--- a/packages/runtime/src/swappable-python-bridge.ts
+++ b/packages/runtime/src/swappable-python-bridge.ts
@@ -278,6 +278,22 @@ export class SwappableBridge extends EventEmitter implements PythonBridge {
     );
   }
 
+  providerReferenceToVideo(
+    providerId: string,
+    inputs: import("./providers/types.js").ReferenceToVideoInputs,
+    params: Record<string, unknown>,
+    secrets?: Record<string, string>,
+    signal?: AbortSignal
+  ): Promise<Uint8Array> {
+    return this._target.providerReferenceToVideo(
+      providerId,
+      inputs,
+      params,
+      secrets,
+      signal
+    );
+  }
+
   providerTextToAudio(
     providerId: string,
     params: Record<string, unknown>,

--- a/packages/runtime/tests/providers/provider-registry-extended.test.ts
+++ b/packages/runtime/tests/providers/provider-registry-extended.test.ts
@@ -214,6 +214,110 @@ describe("provider-registry — extended coverage", () => {
     );
   });
 
+  it("gates reference video on worker capability and model support", async () => {
+    const oldWorkerModels = vi.fn(async () => [
+      {
+        id: "misreported",
+        name: "Misreported",
+        supported_tasks: ["image_to_video", "reference_to_video"]
+      }
+    ]);
+    const oldWorker = new PythonProvider({
+      _id: "wangp-old",
+      _bridge: { getProviderModels: oldWorkerModels }
+    } as any);
+    expect(oldWorker.getCapabilities()).not.toContain("reference_to_video");
+    await expect(oldWorker.getAvailableVideoModels()).resolves.toEqual([
+      expect.objectContaining({
+        supportedTasks: ["image_to_video"],
+        provider: "wangp-old"
+      })
+    ]);
+    await expect(
+      oldWorker.referenceToVideo(
+        { images: [new Uint8Array([1])], videos: [] },
+        {
+          model: {
+            id: "misreported",
+            name: "Misreported",
+            provider: "wangp-old"
+          }
+        }
+      )
+    ).rejects.toThrow("does not support referenceToVideo");
+
+    const referenceToVideo = vi.fn(async () => new Uint8Array([9]));
+    const models = vi.fn(async () => [
+      {
+        id: "start-only",
+        name: "Start only",
+        supportedTasks: ["image_to_video"]
+      },
+      {
+        id: "reference-model",
+        name: "Reference",
+        supportedTasks: ["reference_to_video"]
+      }
+    ]);
+    const worker = new PythonProvider({
+      _id: "wangp",
+      _capabilities: ["reference_to_video"],
+      _bridge: {
+        getProviderModels: models,
+        providerReferenceToVideo: referenceToVideo
+      },
+      API_KEY: "secret"
+    } as any);
+    expect(worker.getCapabilities()).toContain("reference_to_video");
+    await expect(
+      worker.referenceToVideo(
+        {
+          images: [new Uint8Array([1]), new Uint8Array([2])],
+          videos: [new Uint8Array([3])]
+        },
+        {
+          model: { id: "start-only", name: "Start only", provider: "wangp" },
+          prompt: "reject"
+        }
+      )
+    ).rejects.toThrow("start-only does not support reference_to_video");
+    expect(referenceToVideo).not.toHaveBeenCalled();
+
+    const signal = new AbortController().signal;
+    await expect(
+      worker.referenceToVideo(
+        {
+          images: [new Uint8Array([1]), new Uint8Array([2])],
+          videos: [new Uint8Array([3])]
+        },
+        {
+          model: {
+            id: "reference-model",
+            name: "Reference",
+            provider: "wangp"
+          },
+          prompt: "forward",
+          useReferenceVideoAudio: true,
+          signal
+        }
+      )
+    ).resolves.toEqual(new Uint8Array([9]));
+    expect(referenceToVideo).toHaveBeenCalledWith(
+      "wangp",
+      {
+        images: [new Uint8Array([1]), new Uint8Array([2])],
+        videos: [new Uint8Array([3])]
+      },
+      {
+        model: "reference-model",
+        prompt: "forward",
+        useReferenceVideoAudio: true
+      },
+      { API_KEY: "secret" },
+      signal
+    );
+  });
+
   it("discovers music and routes encoded audio through the Python bridge", async () => {
     const wav = new Uint8Array([
       0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x41, 0x56, 0x45

--- a/packages/runtime/tests/python-bridge-base-coverage.test.ts
+++ b/packages/runtime/tests/python-bridge-base-coverage.test.ts
@@ -721,6 +721,95 @@ describe("PythonBridgeBase — provider RPCs", () => {
     await expect(p).resolves.toBe(output);
   });
 
+  it("providerReferenceToVideo preserves ordered media and protocol fields", async () => {
+    const images = [new Uint8Array([1]), new Uint8Array([2])];
+    const videos = [new Uint8Array([3]), new Uint8Array([4])];
+    const output = new Uint8Array([9, 8]);
+    const p = bridge.providerReferenceToVideo(
+      "wangp",
+      { images, videos },
+      { model: "ref-1", prompt: "keep identity", aspect_ratio: "16:9" },
+      { TOKEN: "secret" }
+    );
+    const frame = bridge.sent.find(
+      (f) => f.type === "provider.reference_to_video"
+    )!;
+    expect(frame.data).toEqual({
+      provider: "wangp",
+      reference_images: images,
+      reference_videos: videos,
+      params: { model: "ref-1", prompt: "keep identity", aspect_ratio: "16:9" },
+      secrets: { TOKEN: "secret" },
+      blob_transfer: "chunked-v1"
+    });
+    bridge.handle({
+      type: "progress",
+      request_id: frame.request_id,
+      data: { progress: 0.5, message: "uploading" }
+    });
+    reply("provider.reference_to_video", { blobs: { video: output } });
+    await expect(p).resolves.toBe(output);
+  });
+
+  it("rejects invalid reference media and over-limit payloads before sending", async () => {
+    await expect(
+      bridge.providerReferenceToVideo("wangp", { images: [], videos: [] }, {})
+    ).rejects.toThrow(/at least one/);
+    await expect(
+      bridge.providerReferenceToVideo(
+        "wangp",
+        { images: [new Uint8Array([1]), new Uint8Array()], videos: [] },
+        {}
+      )
+    ).rejects.toThrow(/non-empty/);
+    expect(
+      bridge.sent.some((f) => f.type === "provider.reference_to_video")
+    ).toBe(false);
+    await expect(
+      bridge.providerReferenceToVideo(
+        "wangp",
+        { images: [new Uint8Array(192 * 1024 * 1024 + 1)], videos: [] },
+        {}
+      )
+    ).rejects.toThrow(/201326592/);
+    expect(
+      bridge.sent.some((f) => f.type === "provider.reference_to_video")
+    ).toBe(false);
+  });
+
+  it("accepts the exact reference media size limit", async () => {
+    const exactLimit = new Uint8Array(192 * 1024 * 1024);
+    const p = bridge.providerReferenceToVideo(
+      "wangp",
+      { images: [exactLimit], videos: [] },
+      { model: "ref-limit" }
+    );
+    const frame = bridge.sent.find(
+      (f) => f.type === "provider.reference_to_video"
+    )!;
+    expect(frame.data.reference_images[0]).toBe(exactLimit);
+    reply("provider.reference_to_video", {
+      blobs: { video: new Uint8Array([7]) }
+    });
+    await expect(p).resolves.toEqual(new Uint8Array([7]));
+  });
+
+  it("does not send a pre-aborted reference request", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      bridge.providerReferenceToVideo(
+        "wangp",
+        { images: [new Uint8Array([1])], videos: [] },
+        {},
+        {},
+        controller.signal
+      )
+    ).rejects.toThrow(/cancelled/);
+    expect(
+      bridge.sent.some((f) => f.type === "provider.reference_to_video")
+    ).toBe(false);
+  });
 
   it("providerTextToAudio returns the encoded audio blob", async () => {
     const output = new Uint8Array([4, 5, 6]);

--- a/packages/runtime/tests/python-bridge-models.test.ts
+++ b/packages/runtime/tests/python-bridge-models.test.ts
@@ -19,8 +19,8 @@ import {
 import type { ModelDownloadUpdate } from "../src/python-bridge-types.js";
 
 describe("bridge protocol version", () => {
-  it("is 5 (chunked result blobs)", () => {
-    expect(BRIDGE_PROTOCOL_VERSION).toBe(5);
+  it("is 6 (reference-to-video bridge calls)", () => {
+    expect(BRIDGE_PROTOCOL_VERSION).toBe(6);
   });
 });
 

--- a/packages/runtime/tests/swappable-python-bridge.test.ts
+++ b/packages/runtime/tests/swappable-python-bridge.test.ts
@@ -93,6 +93,9 @@ class FakeBridge extends EventEmitter {
   providerImageToVideo(): Promise<Uint8Array> {
     return Promise.resolve(new Uint8Array());
   }
+  providerReferenceToVideo(): Promise<Uint8Array> {
+    return Promise.resolve(new Uint8Array());
+  }
   providerTextToAudio(): Promise<Uint8Array> {
     return Promise.resolve(new Uint8Array());
   }
@@ -207,6 +210,33 @@ describe("SwappableBridge", () => {
     const audio: Uint8Array[] = [];
     for await (const a of swap.providerTTS("hf", "hi", "m")) audio.push(a);
     expect(audio).toEqual([new Uint8Array([1, 2, 3])]);
+  });
+
+  it("delegates reference video inputs and call metadata", async () => {
+    const target = makeFake();
+    const referenceToVideo = vi.spyOn(target, "providerReferenceToVideo");
+    const swap = new SwappableBridge(target);
+    const inputs = {
+      images: [new Uint8Array([1]), new Uint8Array([2])],
+      videos: [new Uint8Array([3]), new Uint8Array([4])]
+    };
+    const signal = new AbortController().signal;
+
+    await swap.providerReferenceToVideo(
+      "wangp",
+      inputs,
+      { model: "reference-model", prompt: "keep order" },
+      { TOKEN: "secret" },
+      signal
+    );
+
+    expect(referenceToVideo).toHaveBeenCalledWith(
+      "wangp",
+      inputs,
+      { model: "reference-model", prompt: "keep order" },
+      { TOKEN: "secret" },
+      signal
+    );
   });
 
   it("routes calls to the new target after swap", async () => {


### PR DESCRIPTION
Reference-capable Python workers can now receive every image and video reference from the existing ReferenceToVideo workflow and storyboard provider path. PythonProvider forwards the typed input object, model ID, generation options, secrets, and cancellation signal through the new `provider.reference_to_video` bridge operation.

The bridge preserves input order, rejects malformed or empty binary entries, and rejects combined media above 192 MiB before sending a frame. Results reuse the existing chunked video transfer and progress/cancellation paths. Worker capability discovery gates both the provider method and model tasks, so older workers do not expose reference generation. Native worker `supported_tasks` is normalized at the boundary, and forced calls to start-frame-only models fail before submission. Protocol version advances to 6 without raising its compatibility floor.

Companion changes:

- Worker staging and dispatch: https://github.com/nodetool-ai/nodetool-core/pull/1057
- WanGP metadata mapping and pinned worker revision: https://github.com/nodetool-ai/nodetool-wan2gp/pull/14

Validation: runtime build and 110 focused bridge/provider tests passed, as did root typecheck, lint, and all five selected harness selfchecks. A real TypeScript bridge → Python worker → combined WanGP adapter integration passed ordered image-only, video-only, two-video and mixed requests, soundtrack on/off, progress, chunked output, and temporary-file cleanup. A separate subprocess integration verified cancellation and adapter termination. The WanGP session was simulated rather than running a GPU model.

`npm run test:affected` is not green: the unchanged Next.js examples pull `@openclaw/fs-safe` through existing runtime/node barrels, and Turbopack cannot bundle its native module. The failure persisted after reinstalling dependencies. A correct Cloudflare fix requires a separate change to the imports used by Workers; no checks were disabled and no unrelated example changes are included here.
