### PR TITLE
[T-20260910-0002] T2 — Complete project ownership and Personal migration

### DIFF
--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -208,6 +208,16 @@ export function getRawDb(): Database.Database {
   return _sqlite;
 }
 
+/** Execute dynamic SQL against the active database connection. */
+export async function executeRaw(sql: string): Promise<{ rows: unknown[] }> {
+  if (_dbType === "postgres") {
+    if (!_pgClient) throw new Error("PostgreSQL database not initialized.");
+    return { rows: await _pgClient.unsafe(sql) };
+  }
+  if (!_sqlite) throw new Error("SQLite database not initialized.");
+  return { rows: _sqlite.prepare(sql).all() as unknown[] };
+}
+
 /**
  * Verify the database connection is alive with a lightweight query.
  * Dialect-aware: runs `select 1` over the active client. Throws if the

--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -424,6 +424,7 @@ export function getCreateSchemaSql(): string {
       "path" text,
       "run_mode" text,
       "workspace_id" text,
+      "project_id" text NOT NULL DEFAULT 'default',
       "html_app" text,
       "app_doc" text,
       "receive_clipboard" integer,
@@ -433,12 +434,14 @@ export function getCreateSchemaSql(): string {
     );
     CREATE INDEX IF NOT EXISTS "idx_workflows_user_id" ON "nodetool_workflows" ("user_id");
     CREATE INDEX IF NOT EXISTS "idx_workflows_access" ON "nodetool_workflows" ("access");
+    CREATE INDEX IF NOT EXISTS "idx_workflows_user_project" ON "nodetool_workflows" ("user_id", "project_id");
 
     CREATE TABLE IF NOT EXISTS "nodetool_jobs" (
       "id" text PRIMARY KEY NOT NULL,
       "user_id" text NOT NULL,
       "job_type" text NOT NULL DEFAULT '',
       "workflow_id" text NOT NULL,
+      "project_id" text NOT NULL DEFAULT 'default',
       "status" text NOT NULL DEFAULT 'scheduled',
       "name" text DEFAULT '',
       "graph" text,
@@ -468,6 +471,7 @@ export function getCreateSchemaSql(): string {
     CREATE INDEX IF NOT EXISTS "idx_jobs_worker_id" ON "nodetool_jobs" ("worker_id");
     CREATE INDEX IF NOT EXISTS "idx_jobs_heartbeat_at" ON "nodetool_jobs" ("heartbeat_at");
     CREATE INDEX IF NOT EXISTS "idx_jobs_recovery" ON "nodetool_jobs" ("status", "heartbeat_at");
+    CREATE INDEX IF NOT EXISTS "idx_jobs_user_project" ON "nodetool_jobs" ("user_id", "project_id");
 
     CREATE TABLE IF NOT EXISTS "nodetool_messages" (
       "id" text PRIMARY KEY NOT NULL,
@@ -502,12 +506,14 @@ export function getCreateSchemaSql(): string {
       "id" text PRIMARY KEY NOT NULL,
       "user_id" text NOT NULL,
       "workflow_id" text,
+      "project_id" text NOT NULL DEFAULT 'default',
       "title" text NOT NULL DEFAULT '',
       "created_at" text NOT NULL,
       "updated_at" text NOT NULL
     );
     CREATE INDEX IF NOT EXISTS "idx_threads_user_id" ON "nodetool_threads" ("user_id");
     CREATE INDEX IF NOT EXISTS "idx_threads_user_workflow" ON "nodetool_threads" ("user_id", "workflow_id");
+    CREATE INDEX IF NOT EXISTS "idx_threads_user_project" ON "nodetool_threads" ("user_id", "project_id");
 
     CREATE TABLE IF NOT EXISTS "nodetool_assets" (
       "id" text PRIMARY KEY NOT NULL,
@@ -548,11 +554,13 @@ export function getCreateSchemaSql(): string {
       "user_id" text NOT NULL,
       "name" text NOT NULL DEFAULT '',
       "path" text NOT NULL DEFAULT '',
+      "project_id" text NOT NULL DEFAULT 'default',
       "is_default" integer DEFAULT 0,
       "created_at" text NOT NULL,
       "updated_at" text NOT NULL
     );
     CREATE INDEX IF NOT EXISTS "idx_workspaces_user_id" ON "nodetool_workspaces" ("user_id");
+    CREATE INDEX IF NOT EXISTS "idx_workspaces_user_project" ON "nodetool_workspaces" ("user_id", "project_id");
 
     CREATE TABLE IF NOT EXISTS "nodetool_workflow_versions" (
       "id" text PRIMARY KEY NOT NULL,

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -255,8 +255,13 @@ export type {
   ReserveInput
 } from "./application-budget.js";
 export { ApplicationDeployment } from "./application-deployment.js";
-export { Project, LOOSE_PROJECT_ID } from "./project.js";
-export type { ProjectResponse } from "./project.js";
+export {
+  Project,
+  LOOSE_PROJECT_ID,
+  PERSONAL_PROJECT_KIND,
+  PERSONAL_PROJECT_NAME
+} from "./project.js";
+export type { PersonalMigrationReport, ProjectResponse } from "./project.js";
 export {
   listProjectDocuments,
   listProjectEntities,

--- a/packages/models/src/job.ts
+++ b/packages/models/src/job.ts
@@ -26,6 +26,7 @@ export class Job extends DBModel {
   declare user_id: string;
   declare job_type: string;
   declare workflow_id: string;
+  declare project_id: string;
   declare status: JobStatus;
   declare name: string;
   declare graph: Record<string, unknown> | null;
@@ -61,6 +62,7 @@ export class Job extends DBModel {
     this.id ??= createTimeOrderedUuid();
     this.job_type ??= "";
     this.status ??= "scheduled";
+    this.project_id ??= "default";
     this.retry_count ??= 0;
     this.max_retries ??= 3;
     this.version ??= 0;

--- a/packages/models/src/migrations/versions.ts
+++ b/packages/models/src/migrations/versions.ts
@@ -3354,6 +3354,51 @@ export const migrations: MigrationDef[] = [
       // The column stays: dropping one is unsafe across dialects and versions,
       // and its value is a bucket id nothing else reads.
     }
+  },
+
+  // ── Add ownership to legacy resource containers ────────────────────
+  // `default` is a compatibility value. Authenticated startup resolves a
+  // user's Personal project and moves only rows carrying that value.
+  {
+    version: "20260910_000000",
+    name: "add_project_ownership_to_legacy_resources",
+    createsTables: [],
+    modifiesTables: [
+      "nodetool_workflows",
+      "nodetool_threads",
+      "nodetool_jobs",
+      "nodetool_workspaces"
+    ],
+    async up(db) {
+      const tables = [
+        "nodetool_workflows",
+        "nodetool_threads",
+        "nodetool_jobs",
+        "nodetool_workspaces"
+      ];
+      for (const table of tables) {
+        if (!(await db.tableExists(table))) continue;
+        if (!(await db.columnExists(table, "project_id"))) {
+          await db.execute(
+            `ALTER TABLE ${table} ADD COLUMN project_id TEXT NOT NULL DEFAULT 'default'`
+          );
+        }
+        await db.execute(
+          `CREATE INDEX IF NOT EXISTS idx_${table.replace("nodetool_", "")}_user_project ` +
+            `ON ${table} (user_id, project_id)`
+        );
+      }
+    },
+    async down(db) {
+      for (const index of [
+        "workflows_user_project",
+        "threads_user_project",
+        "jobs_user_project",
+        "workspaces_user_project"
+      ]) {
+        await db.execute(`DROP INDEX IF EXISTS idx_${index}`);
+      }
+    }
   }
 ];
 

--- a/packages/models/src/project.ts
+++ b/packages/models/src/project.ts
@@ -17,7 +17,7 @@ import {
   ModelObserver,
   createTimeOrderedUuid
 } from "./base-model.js";
-import { getDb } from "./db.js";
+import { executeRaw, getDb } from "./db.js";
 import { projects } from "./schema/projects.js";
 import { reassignProjectDocuments } from "./project-membership.js";
 import { Thread } from "./thread.js";
@@ -122,26 +122,25 @@ export class Project extends DBModel {
   /** Claim only loose legacy rows. Explicit project ids are never rewritten. */
   static async migrateToPersonal(userId: string): Promise<PersonalMigrationReport> {
     const personal = await Project.ensurePersonal(userId);
-    const db = getDb();
     const owner = userId.replace(/'/g, "''");
     const target = personal.id.replace(/'/g, "''");
     let migrated = 0;
     // Restore the legacy project.thread_id association before claiming
     // remaining threads for Personal.
-    await db.execute(
+    await executeRaw(
       sql.raw(
         `UPDATE nodetool_threads SET project_id = (` +
           `SELECT p.id FROM projects p WHERE p.thread_id = nodetool_threads.id ` +
           `AND p.user_id = nodetool_threads.user_id) ` +
           `WHERE user_id = '${owner}' AND EXISTS (` +
           `SELECT 1 FROM projects p WHERE p.thread_id = nodetool_threads.id ` +
-          `AND p.user_id = nodetool_threads.user_id)`
+          `AND p.user_id = nodetool_threads.user_id) RETURNING id`
       )
     );
     // Runs created from an already-assigned workflow inherit that ownership.
     // Jobs without a project column were otherwise indistinguishable from
     // genuinely unassigned runs.
-    await db.execute(
+    await executeRaw(
       sql.raw(
         `UPDATE nodetool_jobs SET project_id = (` +
           `SELECT w.project_id FROM nodetool_workflows w ` +
@@ -149,7 +148,7 @@ export class Project extends DBModel {
           `WHERE user_id = '${owner}' AND (project_id IS NULL OR project_id = '' ` +
           `OR project_id = 'default') AND EXISTS (` +
           `SELECT 1 FROM nodetool_workflows w WHERE w.id = nodetool_jobs.workflow_id ` +
-          `AND w.user_id = nodetool_jobs.user_id AND w.project_id <> 'default')`
+          `AND w.user_id = nodetool_jobs.user_id AND w.project_id <> 'default') RETURNING id`
       )
     );
     const tables = [
@@ -159,21 +158,20 @@ export class Project extends DBModel {
       "nodetool_predictions"
     ];
     for (const table of tables) {
-      const result = await db.execute(
+      const result = await executeRaw(
         sql.raw(
           `UPDATE ${table} SET project_id = '${target}' ` +
             `WHERE user_id = '${owner}' AND ` +
-            `(project_id IS NULL OR project_id = '' OR project_id = 'default')`
+            `(project_id IS NULL OR project_id = '' OR project_id = 'default') RETURNING id`
         )
       );
-      const changes = (result as { changes?: unknown }).changes;
-      if (typeof changes === "number") migrated += changes;
+      migrated += result.rows.length;
     }
     // Dangling non-default ids are intentionally left in place. They need a
     // repair decision, and moving them would hide a broken legacy reference.
     let dangling = 0;
     for (const table of tables) {
-      const result = await db.execute(
+      const result = await executeRaw(
         sql.raw(
           `SELECT COUNT(*) AS count FROM ${table} r ` +
             `WHERE r.user_id = '${owner}' AND r.project_id IS NOT NULL ` +
@@ -182,9 +180,7 @@ export class Project extends DBModel {
             `WHERE p.id = r.project_id AND p.user_id = r.user_id)`
         )
       );
-      const rows = Array.isArray(result)
-        ? result
-        : ((result as { rows?: unknown[] }).rows ?? []);
+      const rows = result.rows;
       const count = (rows[0] as { count?: unknown } | undefined)?.count;
       dangling += Number(count ?? 0);
     }

--- a/packages/models/src/project.ts
+++ b/packages/models/src/project.ts
@@ -314,6 +314,18 @@ export class Project extends DBModel {
     id: string,
     fields: Partial<{ name: string; kind: string; thread_id: string }>
   ): Promise<Project | null> {
+    const existing = await Project.findOwned(userId, id);
+    if (!existing) return null;
+    // Personal is a permanent account space. Keep its marker immutable, and
+    // do not let a named project be converted into the reserved kind.
+    if (
+      fields.kind !== undefined &&
+      fields.kind !== existing.kind &&
+      (existing.kind === PERSONAL_PROJECT_KIND ||
+        fields.kind === PERSONAL_PROJECT_KIND)
+    ) {
+      return null;
+    }
     const db = getDb();
     const rows = await db
       .update(projects)

--- a/packages/models/src/project.ts
+++ b/packages/models/src/project.ts
@@ -10,7 +10,7 @@
  * nothing migrates into one.
  */
 
-import { and, desc, eq, isNull } from "drizzle-orm";
+import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import {
   DBModel,
   ModelChangeEvent,
@@ -24,12 +24,21 @@ import { Thread } from "./thread.js";
 
 /** The bucket documents land in when no project is active. */
 export const LOOSE_PROJECT_ID = "default";
+export const PERSONAL_PROJECT_KIND = "personal";
+export const PERSONAL_PROJECT_NAME = "Personal";
+
+export interface PersonalMigrationReport {
+  project: Project;
+  migrated: number;
+  dangling: number;
+}
 
 export interface ProjectResponse {
   id: string;
   name: string;
   /** Free text — "spot", "trailer", "report". Not an enum on purpose. */
   kind: string;
+  isPersonal: boolean;
   /** The conversation that builds it, or null while nobody has asked for one. */
   threadId: string | null;
   createdAt: string;
@@ -67,6 +76,7 @@ export class Project extends DBModel {
       id: this.id,
       name: this.name,
       kind: this.kind,
+      isPersonal: this.kind === PERSONAL_PROJECT_KIND,
       threadId: this.thread_id,
       createdAt: this.created_at,
       updatedAt: this.updated_at
@@ -75,6 +85,110 @@ export class Project extends DBModel {
 
   static async findById(id: string): Promise<Project | null> {
     return Project.get<Project>(id);
+  }
+
+  static async ensurePersonal(userId: string): Promise<Project> {
+    const db = getDb();
+    const existing = await db
+      .select()
+      .from(projects)
+      .where(
+        and(eq(projects.user_id, userId), eq(projects.kind, PERSONAL_PROJECT_KIND))
+      )
+      .orderBy(projects.created_at)
+      .limit(1);
+    if (existing[0]) return new Project(existing[0]);
+
+    const created = await Project.insertNew({
+      id: `personal:${userId}`,
+      user_id: userId,
+      name: PERSONAL_PROJECT_NAME,
+      kind: PERSONAL_PROJECT_KIND
+    });
+    if (created) return created;
+
+    const resolved = await db
+      .select()
+      .from(projects)
+      .where(
+        and(eq(projects.user_id, userId), eq(projects.kind, PERSONAL_PROJECT_KIND))
+      )
+      .orderBy(projects.created_at)
+      .limit(1);
+    if (!resolved[0]) throw new Error("Unable to resolve Personal project");
+    return new Project(resolved[0]);
+  }
+
+  /** Claim only loose legacy rows. Explicit project ids are never rewritten. */
+  static async migrateToPersonal(userId: string): Promise<PersonalMigrationReport> {
+    const personal = await Project.ensurePersonal(userId);
+    const db = getDb();
+    const owner = userId.replace(/'/g, "''");
+    const target = personal.id.replace(/'/g, "''");
+    let migrated = 0;
+    // Restore the legacy project.thread_id association before claiming
+    // remaining threads for Personal.
+    await db.execute(
+      sql.raw(
+        `UPDATE nodetool_threads SET project_id = (` +
+          `SELECT p.id FROM projects p WHERE p.thread_id = nodetool_threads.id ` +
+          `AND p.user_id = nodetool_threads.user_id) ` +
+          `WHERE user_id = '${owner}' AND EXISTS (` +
+          `SELECT 1 FROM projects p WHERE p.thread_id = nodetool_threads.id ` +
+          `AND p.user_id = nodetool_threads.user_id)`
+      )
+    );
+    // Runs created from an already-assigned workflow inherit that ownership.
+    // Jobs without a project column were otherwise indistinguishable from
+    // genuinely unassigned runs.
+    await db.execute(
+      sql.raw(
+        `UPDATE nodetool_jobs SET project_id = (` +
+          `SELECT w.project_id FROM nodetool_workflows w ` +
+          `WHERE w.id = nodetool_jobs.workflow_id AND w.user_id = nodetool_jobs.user_id) ` +
+          `WHERE user_id = '${owner}' AND (project_id IS NULL OR project_id = '' ` +
+          `OR project_id = 'default') AND EXISTS (` +
+          `SELECT 1 FROM nodetool_workflows w WHERE w.id = nodetool_jobs.workflow_id ` +
+          `AND w.user_id = nodetool_jobs.user_id AND w.project_id <> 'default')`
+      )
+    );
+    const tables = [
+      "storyboards", "scripts", "timeline_sequences", "image_documents",
+      "applications", "js_scripts", "nodetool_assets", "nodetool_workflows",
+      "nodetool_threads", "nodetool_jobs", "nodetool_workspaces",
+      "nodetool_predictions"
+    ];
+    for (const table of tables) {
+      const result = await db.execute(
+        sql.raw(
+          `UPDATE ${table} SET project_id = '${target}' ` +
+            `WHERE user_id = '${owner}' AND ` +
+            `(project_id IS NULL OR project_id = '' OR project_id = 'default')`
+        )
+      );
+      const changes = (result as { changes?: unknown }).changes;
+      if (typeof changes === "number") migrated += changes;
+    }
+    // Dangling non-default ids are intentionally left in place. They need a
+    // repair decision, and moving them would hide a broken legacy reference.
+    let dangling = 0;
+    for (const table of tables) {
+      const result = await db.execute(
+        sql.raw(
+          `SELECT COUNT(*) AS count FROM ${table} r ` +
+            `WHERE r.user_id = '${owner}' AND r.project_id IS NOT NULL ` +
+            `AND r.project_id <> 'default' AND r.project_id <> '${target}' ` +
+            `AND NOT EXISTS (SELECT 1 FROM projects p ` +
+            `WHERE p.id = r.project_id AND p.user_id = r.user_id)`
+        )
+      );
+      const rows = Array.isArray(result)
+        ? result
+        : ((result as { rows?: unknown[] }).rows ?? []);
+      const count = (rows[0] as { count?: unknown } | undefined)?.count;
+      dangling += Number(count ?? 0);
+    }
+    return { project: personal, migrated, dangling };
   }
 
   static async findOwned(userId: string, id: string): Promise<Project | null> {
@@ -158,6 +272,7 @@ export class Project extends DBModel {
   static async deleteOwned(userId: string, id: string): Promise<boolean> {
     const row = await Project.findOwned(userId, id);
     if (!row) return false;
+    if (row.kind === PERSONAL_PROJECT_KIND) return false;
     await reassignProjectDocuments(userId, id, LOOSE_PROJECT_ID);
     await row.delete();
     return true;
@@ -182,7 +297,8 @@ export class Project extends DBModel {
 
     const thread = await Thread.create<Thread>({
       user_id: userId,
-      title: project.name
+      title: project.name,
+      project_id: project.id
     });
     const db = getDb();
     const rows = await db

--- a/packages/models/src/project.ts
+++ b/packages/models/src/project.ts
@@ -10,7 +10,7 @@
  * nothing migrates into one.
  */
 
-import { and, desc, eq, isNull, sql } from "drizzle-orm";
+import { and, desc, eq, isNull } from "drizzle-orm";
 import {
   DBModel,
   ModelChangeEvent,
@@ -128,28 +128,24 @@ export class Project extends DBModel {
     // Restore the legacy project.thread_id association before claiming
     // remaining threads for Personal.
     await executeRaw(
-      sql.raw(
-        `UPDATE nodetool_threads SET project_id = (` +
-          `SELECT p.id FROM projects p WHERE p.thread_id = nodetool_threads.id ` +
-          `AND p.user_id = nodetool_threads.user_id) ` +
-          `WHERE user_id = '${owner}' AND EXISTS (` +
-          `SELECT 1 FROM projects p WHERE p.thread_id = nodetool_threads.id ` +
-          `AND p.user_id = nodetool_threads.user_id) RETURNING id`
-      )
+      `UPDATE nodetool_threads SET project_id = (` +
+        `SELECT p.id FROM projects p WHERE p.thread_id = nodetool_threads.id ` +
+        `AND p.user_id = nodetool_threads.user_id) ` +
+        `WHERE user_id = '${owner}' AND EXISTS (` +
+        `SELECT 1 FROM projects p WHERE p.thread_id = nodetool_threads.id ` +
+        `AND p.user_id = nodetool_threads.user_id) RETURNING id`
     );
     // Runs created from an already-assigned workflow inherit that ownership.
     // Jobs without a project column were otherwise indistinguishable from
     // genuinely unassigned runs.
     await executeRaw(
-      sql.raw(
-        `UPDATE nodetool_jobs SET project_id = (` +
-          `SELECT w.project_id FROM nodetool_workflows w ` +
-          `WHERE w.id = nodetool_jobs.workflow_id AND w.user_id = nodetool_jobs.user_id) ` +
-          `WHERE user_id = '${owner}' AND (project_id IS NULL OR project_id = '' ` +
-          `OR project_id = 'default') AND EXISTS (` +
-          `SELECT 1 FROM nodetool_workflows w WHERE w.id = nodetool_jobs.workflow_id ` +
-          `AND w.user_id = nodetool_jobs.user_id AND w.project_id <> 'default') RETURNING id`
-      )
+      `UPDATE nodetool_jobs SET project_id = (` +
+        `SELECT w.project_id FROM nodetool_workflows w ` +
+        `WHERE w.id = nodetool_jobs.workflow_id AND w.user_id = nodetool_jobs.user_id) ` +
+        `WHERE user_id = '${owner}' AND (project_id IS NULL OR project_id = '' ` +
+        `OR project_id = 'default') AND EXISTS (` +
+        `SELECT 1 FROM nodetool_workflows w WHERE w.id = nodetool_jobs.workflow_id ` +
+        `AND w.user_id = nodetool_jobs.user_id AND w.project_id <> 'default') RETURNING id`
     );
     const tables = [
       "storyboards", "scripts", "timeline_sequences", "image_documents",
@@ -159,11 +155,9 @@ export class Project extends DBModel {
     ];
     for (const table of tables) {
       const result = await executeRaw(
-        sql.raw(
-          `UPDATE ${table} SET project_id = '${target}' ` +
-            `WHERE user_id = '${owner}' AND ` +
-            `(project_id IS NULL OR project_id = '' OR project_id = 'default') RETURNING id`
-        )
+        `UPDATE ${table} SET project_id = '${target}' ` +
+          `WHERE user_id = '${owner}' AND ` +
+          `(project_id IS NULL OR project_id = '' OR project_id = 'default') RETURNING id`
       );
       migrated += result.rows.length;
     }
@@ -172,13 +166,11 @@ export class Project extends DBModel {
     let dangling = 0;
     for (const table of tables) {
       const result = await executeRaw(
-        sql.raw(
-          `SELECT COUNT(*) AS count FROM ${table} r ` +
-            `WHERE r.user_id = '${owner}' AND r.project_id IS NOT NULL ` +
-            `AND r.project_id <> 'default' AND r.project_id <> '${target}' ` +
-            `AND NOT EXISTS (SELECT 1 FROM projects p ` +
-            `WHERE p.id = r.project_id AND p.user_id = r.user_id)`
-        )
+        `SELECT COUNT(*) AS count FROM ${table} r ` +
+          `WHERE r.user_id = '${owner}' AND r.project_id IS NOT NULL ` +
+          `AND r.project_id <> 'default' AND r.project_id <> '${target}' ` +
+          `AND NOT EXISTS (SELECT 1 FROM projects p ` +
+          `WHERE p.id = r.project_id AND p.user_id = r.user_id)`
       );
       const rows = result.rows;
       const count = (rows[0] as { count?: unknown } | undefined)?.count;

--- a/packages/models/src/schema-pg/jobs.ts
+++ b/packages/models/src/schema-pg/jobs.ts
@@ -8,6 +8,7 @@ export const jobs = pgTable(
     user_id: text("user_id").notNull(),
     job_type: text("job_type").notNull().default(""),
     workflow_id: text("workflow_id").notNull(),
+    project_id: text("project_id").notNull().default("default"),
     status: text("status").notNull().default("scheduled"),
     name: text("name").default(""),
     graph: jsonText<Record<string, unknown>>()("graph"),
@@ -39,6 +40,7 @@ export const jobs = pgTable(
     index("idx_jobs_updated_at").on(table.updated_at),
     index("idx_jobs_worker_id").on(table.worker_id),
     index("idx_jobs_heartbeat_at").on(table.heartbeat_at),
-    index("idx_jobs_recovery").on(table.status, table.heartbeat_at)
+    index("idx_jobs_recovery").on(table.status, table.heartbeat_at),
+    index("idx_jobs_user_project").on(table.user_id, table.project_id)
   ]
 );

--- a/packages/models/src/schema-pg/threads.ts
+++ b/packages/models/src/schema-pg/threads.ts
@@ -9,12 +9,14 @@ export const threads = pgTable(
     // threads (e.g. the global chat). Lets the node editor scope its thread
     // list to the open workflow.
     workflow_id: text("workflow_id"),
+    project_id: text("project_id").notNull().default("default"),
     title: text("title").notNull().default(""),
     created_at: text("created_at").notNull(),
     updated_at: text("updated_at").notNull()
   },
   (table) => [
     index("idx_threads_user_id").on(table.user_id),
-    index("idx_threads_user_workflow").on(table.user_id, table.workflow_id)
+    index("idx_threads_user_workflow").on(table.user_id, table.workflow_id),
+    index("idx_threads_user_project").on(table.user_id, table.project_id)
   ]
 );

--- a/packages/models/src/schema-pg/workflows.ts
+++ b/packages/models/src/schema-pg/workflows.ts
@@ -21,6 +21,7 @@ export const workflows = pgTable(
     path: text("path"),
     run_mode: text("run_mode"),
     workspace_id: text("workspace_id"),
+    project_id: text("project_id").notNull().default("default"),
     html_app: text("html_app"),
     app_doc: jsonText<Record<string, unknown>>()("app_doc"),
     receive_clipboard: integer("receive_clipboard"),
@@ -30,6 +31,7 @@ export const workflows = pgTable(
   },
   (table) => [
     index("idx_workflows_user_id").on(table.user_id),
+    index("idx_workflows_user_project").on(table.user_id, table.project_id),
     index("idx_workflows_access").on(table.access)
   ]
 );

--- a/packages/models/src/schema-pg/workspaces.ts
+++ b/packages/models/src/schema-pg/workspaces.ts
@@ -7,9 +7,13 @@ export const workspaces = pgTable(
     user_id: text("user_id").notNull(),
     name: text("name").notNull().default(""),
     path: text("path").notNull().default(""),
+    project_id: text("project_id").notNull().default("default"),
     is_default: integer("is_default").default(0),
     created_at: text("created_at").notNull(),
     updated_at: text("updated_at").notNull()
   },
-  (table) => [index("idx_workspaces_user_id").on(table.user_id)]
+  (table) => [
+    index("idx_workspaces_user_id").on(table.user_id),
+    index("idx_workspaces_user_project").on(table.user_id, table.project_id)
+  ]
 );

--- a/packages/models/src/schema/jobs.ts
+++ b/packages/models/src/schema/jobs.ts
@@ -14,6 +14,7 @@ export const jobs = sqliteTable(
     user_id: text("user_id").notNull(),
     job_type: text("job_type").notNull().default(""),
     workflow_id: text("workflow_id").notNull(),
+    project_id: text("project_id").notNull().default("default"),
     status: text("status").notNull().default("scheduled"),
     name: text("name").default(""),
     graph: jsonText<Record<string, unknown>>()("graph"),
@@ -45,6 +46,7 @@ export const jobs = sqliteTable(
     index("idx_jobs_updated_at").on(table.updated_at),
     index("idx_jobs_worker_id").on(table.worker_id),
     index("idx_jobs_heartbeat_at").on(table.heartbeat_at),
-    index("idx_jobs_recovery").on(table.status, table.heartbeat_at)
+    index("idx_jobs_recovery").on(table.status, table.heartbeat_at),
+    index("idx_jobs_user_project").on(table.user_id, table.project_id)
   ]
 );

--- a/packages/models/src/schema/threads.ts
+++ b/packages/models/src/schema/threads.ts
@@ -9,12 +9,14 @@ export const threads = sqliteTable(
     // threads (e.g. the global chat). Lets the node editor scope its thread
     // list to the open workflow.
     workflow_id: text("workflow_id"),
+    project_id: text("project_id").notNull().default("default"),
     title: text("title").notNull().default(""),
     created_at: text("created_at").notNull(),
     updated_at: text("updated_at").notNull()
   },
   (table) => [
     index("idx_threads_user_id").on(table.user_id),
-    index("idx_threads_user_workflow").on(table.user_id, table.workflow_id)
+    index("idx_threads_user_workflow").on(table.user_id, table.workflow_id),
+    index("idx_threads_user_project").on(table.user_id, table.project_id)
   ]
 );

--- a/packages/models/src/schema/workflows.ts
+++ b/packages/models/src/schema/workflows.ts
@@ -21,6 +21,7 @@ export const workflows = sqliteTable(
     path: text("path"),
     run_mode: text("run_mode"),
     workspace_id: text("workspace_id"),
+    project_id: text("project_id").notNull().default("default"),
     html_app: text("html_app"),
     app_doc: jsonText<Record<string, unknown>>()("app_doc"),
     receive_clipboard: integer("receive_clipboard", { mode: "boolean" }),
@@ -30,6 +31,7 @@ export const workflows = sqliteTable(
   },
   (table) => [
     index("idx_workflows_user_id").on(table.user_id),
+    index("idx_workflows_user_project").on(table.user_id, table.project_id),
     index("idx_workflows_access").on(table.access)
   ]
 );

--- a/packages/models/src/schema/workspaces.ts
+++ b/packages/models/src/schema/workspaces.ts
@@ -7,9 +7,13 @@ export const workspaces = sqliteTable(
     user_id: text("user_id").notNull(),
     name: text("name").notNull().default(""),
     path: text("path").notNull().default(""),
+    project_id: text("project_id").notNull().default("default"),
     is_default: integer("is_default", { mode: "boolean" }).default(false),
     created_at: text("created_at").notNull(),
     updated_at: text("updated_at").notNull()
   },
-  (table) => [index("idx_workspaces_user_id").on(table.user_id)]
+  (table) => [
+    index("idx_workspaces_user_id").on(table.user_id),
+    index("idx_workspaces_user_project").on(table.user_id, table.project_id)
+  ]
 );

--- a/packages/models/src/thread.ts
+++ b/packages/models/src/thread.ts
@@ -15,6 +15,7 @@ export class Thread extends DBModel {
   declare id: string;
   declare user_id: string;
   declare workflow_id: string | null;
+  declare project_id: string;
   declare title: string;
   declare created_at: string;
   declare updated_at: string;
@@ -24,6 +25,7 @@ export class Thread extends DBModel {
     const now = new Date().toISOString();
     this.id ??= createTimeOrderedUuid();
     this.workflow_id ??= null;
+    this.project_id ??= "default";
     this.title ??= "";
     this.created_at ??= now;
     this.updated_at ??= now;

--- a/packages/models/src/workflow.ts
+++ b/packages/models/src/workflow.ts
@@ -86,6 +86,7 @@ export class Workflow extends DBModel {
   declare path: string | null;
   declare run_mode: string | null;
   declare workspace_id: string | null;
+  declare project_id: string;
   declare html_app: string | null;
   declare app_doc: Record<string, unknown> | null;
   declare receive_clipboard: boolean | null;
@@ -109,6 +110,7 @@ export class Workflow extends DBModel {
     this.path ??= null;
     this.run_mode ??= "workflow";
     this.workspace_id ??= null;
+    this.project_id ??= "default";
     this.html_app ??= null;
     this.app_doc ??= null;
     this.access ??= "private";

--- a/packages/models/src/workspace.ts
+++ b/packages/models/src/workspace.ts
@@ -24,6 +24,7 @@ export class Workspace extends DBModel {
   declare user_id: string;
   declare name: string;
   declare path: string;
+  declare project_id: string;
   declare is_default: boolean;
   declare created_at: string;
   declare updated_at: string;
@@ -32,6 +33,7 @@ export class Workspace extends DBModel {
     super(data);
     const now = new Date().toISOString();
     this.id ??= createTimeOrderedUuid();
+    this.project_id ??= "default";
     // Handle raw integer booleans from legacy data. The column is declared
     // `boolean`, so the legacy integer only shows through a widened read.
     const rawIsDefault: unknown = this.is_default;

--- a/packages/models/tests/migrations.test.ts
+++ b/packages/models/tests/migrations.test.ts
@@ -423,7 +423,7 @@ describe("MigrationRunner", () => {
 // ── Built-in migrations smoke test ───────────────────────────────────
 
 describe("Built-in migrations", () => {
-  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 78;
+  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 79;
 
   it("should have correct count of migrations", () => {
     expect(migrations.length).toBe(EXPECTED_BUILT_IN_MIGRATION_COUNT);

--- a/packages/models/tests/project.test.ts
+++ b/packages/models/tests/project.test.ts
@@ -108,6 +108,28 @@ describe("Project model", () => {
     expect(updated!.updated_at > "2020-01-01T00:00:00.000Z").toBe(true);
   });
 
+  it("keeps Personal permanently personal", async () => {
+    const personal = await Project.ensurePersonal("u1");
+    expect(
+      await Project.updateOwned("u1", personal.id, { kind: "campaign" })
+    ).toBeNull();
+    expect((await Project.findById(personal.id))?.kind).toBe(
+      PERSONAL_PROJECT_KIND
+    );
+
+    const named = await Project.create<Project>({
+      user_id: "u1",
+      name: "Campaign",
+      kind: "campaign"
+    });
+    expect(
+      await Project.updateOwned("u1", named.id, {
+        kind: PERSONAL_PROJECT_KIND
+      })
+    ).toBeNull();
+    expect((await Project.findById(named.id))?.kind).toBe("campaign");
+  });
+
   it("deletes the project and moves its documents back to the loose bucket", async () => {
     const project = await Project.create<Project>({ user_id: "u1", name: "Aurora" });
     const board = await Storyboard.create<Storyboard>({

--- a/packages/models/tests/project.test.ts
+++ b/packages/models/tests/project.test.ts
@@ -9,7 +9,11 @@
 
 import { describe, it, expect, beforeEach } from "vitest";
 import { initTestDb } from "../src/db.js";
-import { Project } from "../src/project.js";
+import {
+  PERSONAL_PROJECT_KIND,
+  PERSONAL_PROJECT_NAME,
+  Project
+} from "../src/project.js";
 import {
   listProjectDocuments,
   listProjectEntities,
@@ -159,6 +163,45 @@ describe("Project model", () => {
     expect(row?.user_id).toBe("u1");
     expect(row?.name).toBe("Mine");
     expect(row?.id).toBe(mine.id);
+  });
+
+  it("migrates loose resources to one Personal project and is restartable", async () => {
+    const assigned = await Project.create<Project>({
+      id: "assigned",
+      user_id: "u1",
+      name: "Assigned"
+    });
+    const loose = await Script.create<Script>({
+      user_id: "u1",
+      project_id: LOOSE_PROJECT_ID,
+      name: "Loose"
+    });
+    const kept = await Script.create<Script>({
+      user_id: "u1",
+      project_id: assigned.id,
+      name: "Kept"
+    });
+    await Script.create<Script>({
+      user_id: "u1",
+      project_id: "missing-project",
+      name: "Dangling"
+    });
+
+    const first = await Project.migrateToPersonal("u1");
+    const second = await Project.migrateToPersonal("u1");
+    expect(first.project.name).toBe(PERSONAL_PROJECT_NAME);
+    expect(first.project.kind).toBe(PERSONAL_PROJECT_KIND);
+    expect(second.project.id).toBe(first.project.id);
+    expect(first.dangling).toBe(1);
+    expect((await Script.findById(loose.id))?.project_id).toBe(first.project.id);
+    expect((await Script.findById(kept.id))?.project_id).toBe(assigned.id);
+    expect(await Project.listByUser("empty")).toEqual([]);
+  });
+
+  it("does not allow Personal to be deleted", async () => {
+    const personal = await Project.ensurePersonal("u1");
+    expect(await Project.deleteOwned("u1", personal.id)).toBe(false);
+    expect(await Project.findById(personal.id)).not.toBeNull();
   });
 });
 

--- a/packages/protocol/fixtures/sdk-v1/http-get-workflow-interface.json
+++ b/packages/protocol/fixtures/sdk-v1/http-get-workflow-interface.json
@@ -122,7 +122,7 @@
       "response": {
         "body": {
           "diagnostics": [],
-          "etag": "e77c846cf9f74bfab94dc2ee810b5f56",
+          "etag": "cb330249a9200ced1822bd4617451fa9",
           "inputs": [
             {
               "default": "hello",

--- a/packages/protocol/fixtures/sdk-v1/http-post-workflow-interfaces.json
+++ b/packages/protocol/fixtures/sdk-v1/http-post-workflow-interfaces.json
@@ -123,7 +123,7 @@
           "interfaces": [
             {
               "diagnostics": [],
-              "etag": "e77c846cf9f74bfab94dc2ee810b5f56",
+              "etag": "cb330249a9200ced1822bd4617451fa9",
               "inputs": [
                 {
                   "default": "hello",
@@ -159,7 +159,7 @@
             },
             {
               "diagnostics": [],
-              "etag": "cb250715545e8bee3f6669eedfdb536e",
+              "etag": "bae74feecd84b4fb975c1cd27410631f",
               "inputs": [
                 {
                   "default": "hello",

--- a/packages/protocol/src/api-schemas/projects.ts
+++ b/packages/protocol/src/api-schemas/projects.ts
@@ -9,6 +9,7 @@ export const projectResponse = z.object({
   id: z.string(),
   name: z.string(),
   kind: z.string(),
+  isPersonal: z.boolean().default(false),
   /** The conversation that builds it, or null while nobody has asked for one. */
   threadId: z.string().nullable(),
   createdAt: z.string(),

--- a/packages/websocket/src/trpc/routers/projects.ts
+++ b/packages/websocket/src/trpc/routers/projects.ts
@@ -22,6 +22,7 @@
 import { z } from "zod";
 import {
   LOOSE_PROJECT_ID,
+  PERSONAL_PROJECT_KIND,
   Project,
   listProjectDocuments,
   moveDocumentToProject,
@@ -45,6 +46,10 @@ const idInput = z.object({ id: z.string() });
 const updateInput = patchProjectInput.and(z.object({ id: z.string() }));
 const okOutput = z.object({ ok: z.literal(true) });
 
+async function prepareUser(userId: string): Promise<void> {
+  await Project.migrateToPersonal(userId);
+}
+
 async function loadOwned(userId: string, id: string): Promise<Project> {
   const project = await Project.findOwned(userId, id);
   if (!project) throwApiError(ApiErrorCode.NOT_FOUND, "Project not found");
@@ -56,6 +61,7 @@ export const projectsRouter = router({
     .input(listInput)
     .output(z.array(projectResponse))
     .query(async ({ ctx }) => {
+      await prepareUser(ctx.userId);
       const items = await Project.listByUser(ctx.userId);
       return items.map((item) => item.toResponse());
     }),
@@ -69,6 +75,7 @@ export const projectsRouter = router({
     .input(listInput)
     .output(z.array(projectDetail))
     .query(async ({ ctx }) => {
+      await prepareUser(ctx.userId);
       const projects = await Project.listByUser(ctx.userId);
       return Promise.all(
         projects.map(async (project) => {
@@ -88,6 +95,7 @@ export const projectsRouter = router({
     .input(idInput)
     .output(projectDetail)
     .query(async ({ ctx, input }) => {
+      await prepareUser(ctx.userId);
       const project = await loadOwned(ctx.userId, input.id);
       const summary = await summarizeProject(ctx.userId, project.id);
       return projectDetail.parse({
@@ -103,6 +111,7 @@ export const projectsRouter = router({
     .input(idInput)
     .output(z.array(projectDocumentRef))
     .query(async ({ ctx, input }) => {
+      await prepareUser(ctx.userId);
       await loadOwned(ctx.userId, input.id);
       return listProjectDocuments(ctx.userId, input.id);
     }),
@@ -115,7 +124,10 @@ export const projectsRouter = router({
   unassigned: protectedProcedure
     .input(listInput)
     .output(z.array(projectDocumentRef))
-    .query(({ ctx }) => listProjectDocuments(ctx.userId, LOOSE_PROJECT_ID)),
+    .query(async ({ ctx }) => {
+      await prepareUser(ctx.userId);
+      return listProjectDocuments(ctx.userId, LOOSE_PROJECT_ID);
+    }),
 
   /**
    * The project's agent thread, created on first ask. A mutation rather than a
@@ -126,6 +138,7 @@ export const projectsRouter = router({
     .input(idInput)
     .output(z.object({ threadId: z.string() }))
     .mutation(async ({ ctx, input }) => {
+      await prepareUser(ctx.userId);
       await loadOwned(ctx.userId, input.id);
       const threadId = await Project.ensureThread(ctx.userId, input.id);
       if (!threadId) throwApiError(ApiErrorCode.NOT_FOUND, "Project not found");
@@ -136,6 +149,7 @@ export const projectsRouter = router({
     .input(createProjectInput)
     .output(projectResponse)
     .mutation(async ({ ctx, input }) => {
+      await prepareUser(ctx.userId);
       // The insert never rewrites an existing row: the primary key is
       // install-global, so an upsert here could hand one user's project to
       // another. A conflict is re-read instead — the caller's own id answers
@@ -170,6 +184,7 @@ export const projectsRouter = router({
     .input(updateInput)
     .output(projectResponse)
     .mutation(async ({ ctx, input }) => {
+      await prepareUser(ctx.userId);
       await loadOwned(ctx.userId, input.id);
       const fields: { name?: string; kind?: string } = {};
       if (input.name !== undefined) fields.name = input.name;
@@ -183,6 +198,11 @@ export const projectsRouter = router({
     .input(idInput)
     .output(okOutput)
     .mutation(async ({ ctx, input }) => {
+      await prepareUser(ctx.userId);
+      const target = await Project.findOwned(ctx.userId, input.id);
+      if (target?.kind === PERSONAL_PROJECT_KIND) {
+        throwApiError(ApiErrorCode.INVALID_INPUT, "Personal cannot be deleted");
+      }
       await loadOwned(ctx.userId, input.id);
       await Project.deleteOwned(ctx.userId, input.id);
       return { ok: true as const };
@@ -197,6 +217,7 @@ export const projectsRouter = router({
     .input(assignDocumentInput)
     .output(okOutput)
     .mutation(async ({ ctx, input }) => {
+      await prepareUser(ctx.userId);
       if (input.projectId !== LOOSE_PROJECT_ID) {
         await loadOwned(ctx.userId, input.projectId);
       }

--- a/packages/websocket/src/trpc/routers/resources.ts
+++ b/packages/websocket/src/trpc/routers/resources.ts
@@ -17,6 +17,8 @@ import { z } from "zod";
 import {
   Asset,
   ImageDocument,
+  LOOSE_PROJECT_ID,
+  Project,
   Storyboard,
   TimelineSequence
 } from "@nodetool-ai/models";
@@ -173,12 +175,12 @@ function documentProvider(
  * metadata, and there is no revision to conflict on.
  */
 const assetProvider: ResourceProvider = {
-  async list(userId, _projectId, limit) {
-    const [assets] = await Asset.paginate(userId, { limit });
+  async list(userId, projectId, limit) {
+    const [assets] = await Asset.paginate(userId, { projectId, limit });
     return assets.map((asset) => ({
       ref: { kind: "asset" as const, id: asset.id },
       name: asset.name,
-      projectId: null,
+      projectId: asset.project_id,
       contentType: asset.content_type,
       updatedAt: asset.updated_at
     }));
@@ -189,7 +191,7 @@ const assetProvider: ResourceProvider = {
     return {
       ref: { kind: "asset", id: asset.id },
       name: asset.name,
-      projectId: null,
+      projectId: asset.project_id,
       contentType: asset.content_type,
       updatedAt: asset.updated_at,
       document: asset.metadata ?? {}
@@ -210,7 +212,7 @@ const assetProvider: ResourceProvider = {
     return {
       ref: { kind: "asset", id: asset.id },
       name: asset.name,
-      projectId: null,
+      projectId: asset.project_id,
       contentType: asset.content_type,
       updatedAt: asset.updated_at,
       document: asset.metadata ?? {}
@@ -237,7 +239,7 @@ const providers = {
   )
 } satisfies Record<ResourceKind, ResourceProvider>;
 
-const notFound = (kind: ResourceKind): never =>
+const notFound = (kind: string): never =>
   throwApiError(ApiErrorCode.NOT_FOUND, `${kind} resource not found`);
 
 const conflict = (kind: ResourceKind): never =>
@@ -246,13 +248,28 @@ const conflict = (kind: ResourceKind): never =>
     `${kind} resource was modified since it was read (optimistic concurrency conflict)`
   );
 
+async function resolveProjectScope(
+  userId: string,
+  projectId: string
+): Promise<string> {
+  await Project.migrateToPersonal(userId);
+  if (projectId === LOOSE_PROJECT_ID) {
+    return (await Project.ensurePersonal(userId)).id;
+  }
+  if (!(await Project.findOwned(userId, projectId))) return notFound("project");
+  return projectId;
+}
+
 export const resourcesRouter = router({
   list: protectedProcedure
     .input(listResourcesInput)
     .output(z.array(resourceSummary))
-    .query(({ ctx, input }) =>
-      providers[input.kind].list(ctx.userId, input.projectId, input.limit)
-    ),
+    .query(async ({ ctx, input }) => {
+      const projectId = input.projectId
+        ? await resolveProjectScope(ctx.userId, input.projectId)
+        : undefined;
+      return providers[input.kind].list(ctx.userId, projectId, input.limit);
+    }),
 
   read: protectedProcedure
     .input(readResourceInput)
@@ -268,9 +285,10 @@ export const resourcesRouter = router({
   create: protectedProcedure
     .input(createResourceInput)
     .output(resourceDetail)
-    .mutation(({ ctx, input }) =>
-      providers[input.kind].create(ctx.userId, input.name, input.projectId)
-    ),
+    .mutation(async ({ ctx, input }) => {
+      const projectId = await resolveProjectScope(ctx.userId, input.projectId);
+      return providers[input.kind].create(ctx.userId, input.name, projectId);
+    }),
 
   update: protectedProcedure
     .input(updateResourceInput)

--- a/packages/websocket/tests/trpc-projects.test.ts
+++ b/packages/websocket/tests/trpc-projects.test.ts
@@ -62,9 +62,9 @@ describe("projects router", () => {
     });
     expect(created.name).toBe("Aurora Launch Spot");
 
-    expect((await caller().projects.list({})).map((p) => p.id)).toEqual([
-      created.id
-    ]);
+    expect((await caller().projects.list({})).map((p) => p.id)).toEqual(
+      expect.arrayContaining([created.id, "personal:user-1"])
+    );
 
     const renamed = await caller().projects.update({
       id: created.id,
@@ -74,7 +74,9 @@ describe("projects router", () => {
     expect(renamed.kind).toBe("spot");
 
     await caller().projects.delete({ id: created.id });
-    expect(await caller().projects.list({})).toEqual([]);
+    expect((await caller().projects.list({})).map((p) => p.id)).toEqual([
+      "personal:user-1"
+    ]);
   });
 
   it("hides another user's project behind not-found", async () => {
@@ -104,7 +106,9 @@ describe("projects router", () => {
       caller().projects.create({ id: "   ", name: "Whitespace" })
     ).rejects.toThrow();
     // Nothing was written under the reserved id.
-    expect(await caller().projects.list({})).toEqual([]);
+    expect((await caller().projects.list({})).map((p) => p.id)).toEqual([
+      "personal:user-1"
+    ]);
 
     const theirs = await caller("user-2").projects.create({
       id: "shared-id",
@@ -119,7 +123,9 @@ describe("projects router", () => {
     expect(
       (await caller("user-2").projects.get({ id: theirs.id })).project.name
     ).toBe("Theirs");
-    expect(await caller().projects.list({})).toEqual([]);
+    expect((await caller().projects.list({})).map((p) => p.id)).toEqual([
+      "personal:user-1"
+    ]);
   });
 
   it("answers a repeated create of the caller's own id with the same project", async () => {
@@ -143,7 +149,7 @@ describe("projects router", () => {
     expect(
       (await caller().projects.create({ id: "padded", name: "Again" })).id
     ).toBe("padded");
-    expect(await caller().projects.list({})).toHaveLength(1);
+    expect(await caller().projects.list({})).toHaveLength(2);
   });
 
   it("moves a deleted project's documents back into the loose bucket", async () => {
@@ -162,7 +168,9 @@ describe("projects router", () => {
     await caller().projects.delete({ id: project.id });
 
     expect(
-      (await caller().projects.unassigned({})).map((d) => d.ref).sort()
+      (await caller().projects.documents({ id: "personal:user-1" }))
+        .map((d) => d.ref)
+        .sort()
     ).toEqual([board.id, script.id].sort());
   });
 
@@ -249,7 +257,8 @@ describe("projects router", () => {
     const summaries = await caller().projects.summaries({});
     expect(summaries.map((s) => s.project.name).sort()).toEqual([
       "Aurora",
-      "Meridian"
+      "Meridian",
+      "Personal"
     ]);
     const auroraSummary = summaries.find((s) => s.project.id === aurora.id);
     expect(auroraSummary?.documents.map((d) => d.name)).toEqual(["Board"]);
@@ -263,9 +272,7 @@ describe("projects router", () => {
     });
     await Script.create<Script>({ user_id: "user-2", name: "Theirs" });
 
-    expect((await caller().projects.unassigned({})).map((d) => d.ref)).toEqual([
-      loose.id
-    ]);
+    expect(await caller().projects.unassigned({})).toEqual([]);
 
     await caller().projects.assignDocument({
       projectId: project.id,
@@ -282,9 +289,7 @@ describe("projects router", () => {
       type: "script",
       ref: loose.id
     });
-    expect((await caller().projects.unassigned({})).map((d) => d.ref)).toEqual([
-      loose.id
-    ]);
+    expect(await caller().projects.unassigned({})).toEqual([]);
   });
 
   it("refuses a move into a project the caller does not own, and of a document they do not own", async () => {


### PR DESCRIPTION
Implemented and committed as `473a8d1d`.

- Added ownership fields across workflows, threads, jobs, and workspaces.
- Added deterministic Personal project creation and restartable migration.
- Preserved assigned resources and legacy project threads.
- Added dangling-membership protection and scoped resource validation.
- Protected Personal from deletion.
- Added migration and ownership tests.

Verification was blocked by missing tools after `npm install` hung: `vitest`, `tsc`, `oxlint`, and `tsx` were unavailable.

---

Closes task **T-20260910-0002**: T2 — Complete project ownership and Personal migration.

### Acceptance criteria
- [x] AC8 is satisfied.
- [x] The ownership portions of AC4 and AC11 are satisfied.