### PR TITLE
Bolt: Optimize array filtering allocations in count aggregations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-11-20 - O(4*N) filtering optimization in job queues
 **Learning:** Multiple array `.filter(...)` statements over the same array to partition items by disjoint conditions caused an O(K*N) performance bottleneck and unnecessary intermediate array allocations.
 **Action:** Replace multiple `.filter(...)` lines with a single manual `for` loop that iterates the array once and sorts the items into different target arrays concurrently (O(N) pass).
+## 2024-11-20 - O(N*M) array filtering inside metric calculations
+**Learning:** Multiple array `.filter(...).length` statements create O(N*M) performance bottlenecks and intermediate array allocations when calculating totals or counts.
+**Action:** Replace multiple `.filter(...).length` lines with a single manual `for` loop that iterates the array once and tallies multiple metrics concurrently (O(N) pass, O(1) space).

--- a/web/src/components/chat/message/parsePlanDocument.ts
+++ b/web/src/components/chat/message/parsePlanDocument.ts
@@ -121,8 +121,14 @@ export const parsePlanDocument = (
       : record["executed"] === true
         ? true
         : null;
+  let parallelizableCount = 0;
+  for (let i = 0; i < tasks.length; i++) {
+    if (tasks[i].dependsOn.length === 0) {
+      parallelizableCount++;
+    }
+  }
   const parallelizable = isFiniteNumber(record["parallelizable"])
     ? record["parallelizable"]
-    : tasks.filter((task) => task.dependsOn.length === 0).length;
+    : parallelizableCount;
   return { title, tasks, executed, parallelizable };
 };

--- a/web/src/components/packages/usePackageManager.ts
+++ b/web/src/components/packages/usePackageManager.ts
@@ -318,25 +318,24 @@ export function usePackageManager(params: {
       });
     }
 
+    let langCount = 0;
+    let mediaCount = 0;
+    let aiCount = 0;
+    if (isSoftware) {
+      for (let i = 0; i < statuses.length; i++) {
+        const group = runtimeGroup(statuses[i].id);
+        if (group === "language") langCount++;
+        else if (group === "media") mediaCount++;
+        else if (group === "ai") aiCount++;
+      }
+    }
+
     const categories: PMCount[] = isSoftware
       ? [
           { id: "all", label: "All runtimes", count: statuses.length },
-          {
-            id: "language",
-            label: "Languages",
-            count: statuses.filter((p) => runtimeGroup(p.id) === "language")
-              .length
-          },
-          {
-            id: "media",
-            label: "Media & docs",
-            count: statuses.filter((p) => runtimeGroup(p.id) === "media").length
-          },
-          {
-            id: "ai",
-            label: "AI runtimes",
-            count: statuses.filter((p) => runtimeGroup(p.id) === "ai").length
-          }
+          { id: "language", label: "Languages", count: langCount },
+          { id: "media", label: "Media & docs", count: mediaCount },
+          { id: "ai", label: "AI runtimes", count: aiCount }
         ]
       : [
           { id: "included", label: "Included", count: includedItems.length },


### PR DESCRIPTION
## What
Replaced multiple array `.filter(...).length` checks with a single O(N) loop to compute category counts in `usePackageManager` and dependent task counts in `parsePlanDocument`.

## Why
When extracting metrics or counts from arrays, iterating via `.filter(...)` creates an intermediate array solely to read its length. When done multiple times over the same array (e.g., getting counts for different status categories), it creates an O(K*N) performance bottleneck and scales poorly due to garbage collection pressure from intermediate array allocations.

## Impact
Reduces the time complexity of category counting in package manager from O(3*N) to O(N) and prevents unnecessary array allocations on high-frequency UI updates. Similarly reduces task processing overhead when parsing plan documents.

## Verification
Ran `npm run test` targeting the affected packages `src/components/chat/message/` and `src/components/packages/`. Verified that `parsePlanDocument` and `usePackageManager` pass all behavior tests. Ran `npm run typecheck` and `npm run lint:design`.

---
*PR created automatically by Jules for task [5615517030902977173](https://jules.google.com/task/5615517030902977173) started by @georgi*