### PR TITLE
fix(storyboard): widen the board cast to its shots' entities on load

### DIFF
--- a/packages/models/src/storyboard.ts
+++ b/packages/models/src/storyboard.ts
@@ -1,4 +1,5 @@
 import { eq, desc, and, sql } from "drizzle-orm";
+import { boardEntityIdsWithShots } from "@nodetool-ai/protocol";
 import type { Screenplay, Shot } from "@nodetool-ai/protocol";
 import type { StoryboardSetupStage } from "@nodetool-ai/protocol/api-schemas/storyboards.js";
 import {
@@ -122,6 +123,10 @@ export class Storyboard extends DBModel {
     doc.entityIds ??= [];
     doc.setupStage ??= "done";
     doc.genre ??= "";
+    // A shot can name an entity the board was never cast with — agents write
+    // shots one at a time and forget the board. Reconcile on read so the cast
+    // holds everything the shots reference.
+    doc.entityIds = [...boardEntityIdsWithShots(doc.entityIds, doc.shots ?? [])];
     return doc;
   }
 

--- a/packages/models/tests/storyboard-entity-cast.test.ts
+++ b/packages/models/tests/storyboard-entity-cast.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Every server read of a board goes through `toDocument`, so that is where a
+ * shot-only entity joins the board's cast. Without it, an agent that sets
+ * `entity_ids` on a shot leaves the board's cast — the list the prompt
+ * seasoning and the editor's pickers read — without that entity.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  Storyboard,
+  emptyStoryboardDocument,
+  type StoryboardDocument
+} from "../src/storyboard.js";
+import type { Shot } from "@nodetool-ai/protocol";
+
+const shot = (id: string, entityIds?: string[]): Shot => {
+  const s: Shot = {
+    type: "shot",
+    id,
+    index: 0,
+    action: `${id} action`,
+    status: "planned"
+  };
+  if (entityIds) {
+    s.entity_ids = entityIds;
+  }
+  return s;
+};
+
+const board = (over: Partial<StoryboardDocument>): Storyboard =>
+  new Storyboard({
+    user_id: "u1",
+    project_id: "p1",
+    name: "board",
+    document: JSON.stringify({ ...emptyStoryboardDocument(), ...over })
+  });
+
+describe("Storyboard.toDocument entity cast", () => {
+  it("adds entities a shot names but the board was never cast with", () => {
+    const doc = board({
+      entityIds: ["e_style"],
+      shots: [shot("s1", ["e_style", "e_hero"]), shot("s2", ["e_prop"])]
+    }).toDocument();
+    expect(doc.entityIds).toEqual(["e_style", "e_hero", "e_prop"]);
+  });
+
+  it("leaves an already-consistent cast alone", () => {
+    const doc = board({
+      entityIds: ["e_a", "e_b"],
+      shots: [shot("s1", ["e_b"]), shot("s2")]
+    }).toDocument();
+    expect(doc.entityIds).toEqual(["e_a", "e_b"]);
+  });
+
+  it("still defaults a row persisted before entityIds existed", () => {
+    const row = new Storyboard({
+      user_id: "u1",
+      project_id: "p1",
+      name: "board",
+      document: JSON.stringify({ shots: [shot("s1", ["e_hero"])] })
+    });
+    expect(row.toDocument().entityIds).toEqual(["e_hero"]);
+  });
+});

--- a/packages/protocol/src/creative.ts
+++ b/packages/protocol/src/creative.ts
@@ -632,6 +632,37 @@ export function entitiesForShot(shot: Shot, boardEntities: Entity[]): Entity[] {
   });
 }
 
+/**
+ * The board's cast, widened to hold every entity its shots reference.
+ *
+ * A shot's `entity_ids` is a selection out of the board's cast:
+ * {@link entitiesForShot} filters the board's entities by it, so an id cast on
+ * a shot but never on the board resolves to nothing — the chip is on the shot,
+ * the entity is not in the board's library, and the prompt is not seasoned with
+ * it. Agents writing shots hit this routinely. Reconciling on read keeps the
+ * two in step: board cast first, in order, then each shot's unseen ids in shot
+ * order.
+ *
+ * Returns `entityIds` itself when nothing is missing, so a caller can compare
+ * by identity and skip a write.
+ */
+export function boardEntityIdsWithShots(
+  entityIds: readonly string[],
+  shots: readonly Shot[]
+): readonly string[] {
+  const seen = new Set(entityIds);
+  const added: string[] = [];
+  for (const shot of shots) {
+    for (const id of shot.entity_ids ?? []) {
+      if (!seen.has(id)) {
+        seen.add(id);
+        added.push(id);
+      }
+    }
+  }
+  return added.length === 0 ? entityIds : [...entityIds, ...added];
+}
+
 // ---------------------------------------------------------------------------
 // Cost governance
 // ---------------------------------------------------------------------------

--- a/packages/protocol/tests/board-entity-cast.test.ts
+++ b/packages/protocol/tests/board-entity-cast.test.ts
@@ -1,0 +1,63 @@
+/**
+ * A shot's entity selection is read against the board's cast, so an id cast on
+ * a shot but missing from the board resolves to nothing. Agents write shots
+ * without touching the board, so the two have to be reconciled on read.
+ */
+
+import { describe, expect, it } from "vitest";
+import { boardEntityIdsWithShots, entitiesForShot } from "../src/creative.js";
+import type { Entity, Shot } from "../src/creative.js";
+
+const shot = (id: string, entityIds?: string[]): Shot => {
+  const s: Shot = {
+    type: "shot",
+    id,
+    index: 0,
+    action: `${id} action`,
+    status: "planned"
+  };
+  if (entityIds) {
+    s.entity_ids = entityIds;
+  }
+  return s;
+};
+
+const entity = (id: string): Entity => ({
+  type: "entity",
+  id,
+  name: id,
+  kind: "character",
+  descriptor: `${id} descriptor`
+});
+
+describe("boardEntityIdsWithShots", () => {
+  it("appends shot entity ids the board is missing, in shot order", () => {
+    expect(
+      boardEntityIdsWithShots(
+        ["a"],
+        [shot("s1", ["a", "b"]), shot("s2", ["c", "b"])]
+      )
+    ).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns the same array when every shot id is already cast", () => {
+    const cast = ["a", "b"];
+    expect(boardEntityIdsWithShots(cast, [shot("s1", ["b"])])).toBe(cast);
+  });
+
+  it("ignores shots with no explicit selection", () => {
+    const cast = ["a"];
+    expect(boardEntityIdsWithShots(cast, [shot("s1")])).toBe(cast);
+  });
+
+  it("is what makes a shot-only entity reach the shot's prompt", () => {
+    const s = shot("s1", ["a", "b"]);
+    const library = [entity("a"), entity("b")];
+    const boardOnly = library.filter((e) => ["a"].includes(e.id));
+    expect(entitiesForShot(s, boardOnly).map((e) => e.id)).toEqual(["a"]);
+
+    const widened = boardEntityIdsWithShots(["a"], [s]);
+    const cast = library.filter((e) => widened.includes(e.id));
+    expect(entitiesForShot(s, cast).map((e) => e.id)).toEqual(["a", "b"]);
+  });
+});

--- a/web/src/stores/storyboard/StoryboardStore.ts
+++ b/web/src/stores/storyboard/StoryboardStore.ts
@@ -26,6 +26,7 @@ import type {
   ShotStatus,
   VideoRef
 } from "@nodetool-ai/protocol";
+import { boardEntityIdsWithShots } from "@nodetool-ai/protocol";
 import {
   pushHistory,
   undoHistory,
@@ -639,10 +640,14 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
   loadBoard: (id, board, options) =>
     set((state) => {
       const prev = state.boards[id];
+      const merged = { ...emptyBoard(id), ...board };
       const next = {
-        ...emptyBoard(id),
-        ...board,
+        ...merged,
         id,
+        // A shot can carry an entity the board was never cast with — agents
+        // write shots one at a time and forget the board. Widen the cast on
+        // load so the chips, the pickers and the prompts agree.
+        entityIds: [...boardEntityIdsWithShots(merged.entityIds, merged.shots)],
         shots: board.shots.map((s) =>
           s.status === "keyframe_generating"
             ? { ...s, status: "planned" as const }
@@ -739,7 +744,12 @@ export const useStoryboardStore = create<StoryboardStoreState>((set, get) => ({
         // The screenplay's cast becomes the board's cast: `entityIds` is what
         // seasons every shot prompt, and a screenplay that names entities the
         // board does not carry would generate them out.
-        entityIds: screenplay.entity_ids ?? board.entityIds,
+        entityIds: [
+          ...boardEntityIdsWithShots(
+            screenplay.entity_ids ?? board.entityIds,
+            shots
+          )
+        ],
         // An explicit `brief` wins. A logline fills an empty brief only — the
         // editor directs *from* the brief, so a returned logline must never
         // overwrite what the user wrote.

--- a/web/src/stores/storyboard/__tests__/boardEntityCast.test.ts
+++ b/web/src/stores/storyboard/__tests__/boardEntityCast.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment node
+ *
+ * The board's cast holds every entity its shots reference. `entitiesForShot`
+ * filters the board's entities by the shot's `entity_ids`, so an id an agent
+ * put on a shot without casting it on the board resolves to nothing — the chip
+ * shows, the picker does not list it, and the prompt is not seasoned with it.
+ * Loading a board reconciles the two.
+ */
+
+import type { Screenplay, Shot } from "@nodetool-ai/protocol";
+import { useStoryboardStore } from "../StoryboardStore";
+
+const BOARD = "board-entity-cast";
+
+const shot = (id: string, index: number, entityIds?: string[]): Shot => {
+  const s: Shot = {
+    type: "shot",
+    id,
+    index,
+    action: `${id} action`,
+    status: "planned"
+  };
+  if (entityIds) {
+    s.entity_ids = entityIds;
+  }
+  return s;
+};
+
+const load = (entityIds: string[], shots: Shot[]): void => {
+  useStoryboardStore.getState().loadBoard(BOARD, {
+    screenplay: null,
+    shots,
+    title: "Fixture",
+    brief: "",
+    style: "",
+    entityIds,
+    aspectRatio: "16:9",
+    setupStage: "done",
+    genre: "",
+    directorModel: null,
+    imageModel: null,
+    videoModel: null,
+    activeShotId: null,
+    timelineId: null
+  });
+};
+
+afterEach(() => {
+  useStoryboardStore.getState().removeBoard(BOARD);
+});
+
+describe("board cast on load", () => {
+  it("adds shot entities the board is missing", () => {
+    load(["e_style"], [shot("s1", 0, ["e_style", "e_hero"]), shot("s2", 1, ["e_prop"])]);
+    expect(useStoryboardStore.getState().getBoard(BOARD)?.entityIds).toEqual([
+      "e_style",
+      "e_hero",
+      "e_prop"
+    ]);
+  });
+
+  it("leaves an already-consistent cast alone", () => {
+    load(["e_a", "e_b"], [shot("s1", 0, ["e_b"]), shot("s2", 1)]);
+    expect(useStoryboardStore.getState().getBoard(BOARD)?.entityIds).toEqual([
+      "e_a",
+      "e_b"
+    ]);
+  });
+
+  it("keeps shot entities when a screenplay replaces the cast", () => {
+    const shots = [shot("s1", 0, ["e_hero"])];
+    load([], shots);
+    const screenplay: Screenplay = {
+      type: "screenplay",
+      id: "play-1",
+      title: "Fixture",
+      shots,
+      entity_ids: ["e_style"]
+    };
+    useStoryboardStore.getState().setScreenplay(BOARD, screenplay);
+    expect(useStoryboardStore.getState().getBoard(BOARD)?.entityIds).toEqual([
+      "e_style",
+      "e_hero"
+    ]);
+  });
+});


### PR DESCRIPTION
## What changed

An entity linked to a shot but not to the board resolved to nothing: `entitiesForShot` filters the board's entities by the shot's `entity_ids`, so the chip showed on the shot while the prompt was never seasoned with it and the board's pickers never listed it. Agents write shots one at a time without touching the board, so the two drifted apart routinely. New pure helper `boardEntityIdsWithShots` in `@nodetool-ai/protocol` returns the board's cast widened with every shot-referenced id it is missing (board order first, then shot order; same array back when nothing is missing). It is applied on the read paths: `Storyboard.toDocument` — which every server read of a board goes through, so the widened cast persists on the next write — and the web store's `loadBoard` and `setScreenplay`.

## Verification

- [x] `npm run test:affected` — the suites reached by this diff pass: protocol 1482, models 925, storyboard 47, agents 4508, websocket 2924, web storyboard suites 340. Two failures are pre-existing on `main` and unrelated: `packages/image-nodes` (`No WebGPU adapter available` — no Vulkan driver in this container) and `packages/video-nodes/tests/timeline-time-remap-decode.test.ts` (hook timeout), both reproduced on a stashed tree.
- [x] `npm run typecheck` — one pre-existing error, reproduced on a stashed tree: `web/src/components/projects/__tests__/projectStarters.test.ts(43,3)` missing `isPersonal`.
- [x] `npm run lint`
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — `Gate: 5/5 selfchecks passed`

Both new checks were inverted and observed failing. With the `toDocument` line removed:

```
 ❯ tests/storyboard-entity-cast.test.ts (3 tests | 2 failed)
     × adds entities a shot names but the board was never cast with
     × still defaults a row persisted before entityIds existed
```

With the two store call sites reverted:

```
FAIL src/stores/storyboard/__tests__/boardEntityCast.test.ts
    ✕ adds shot entities the board is missing
    ✕ keeps shot entities when a screenplay replaces the cast
```

## Agent capabilities

No capability added or re-declared.

## New checks

- [x] Each new test was inverted once and observed failing; the failing output is in **Verification** above
- [x] No audit added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEyJkUv8eeENdJiMhgnWXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEyJkUv8eeENdJiMhgnWXU)_