### PR TITLE
feat(chat): add reference-to-video mode and agent capability

### DIFF
--- a/docs/global-chat.md
+++ b/docs/global-chat.md
@@ -60,9 +60,16 @@ The same composer generates more than text. Click the mode chip to switch betwee
 | **Edit Images** | Image-to-image edits on a dropped image |
 | **Generate Videos** | Text-to-video |
 | **Animate Image** | Turn a still image into a clip |
+| **Reference to Video** | One clip from several attached images and videos — a character plus a garment, a product plus a location, a clip whose motion the new shot follows |
 | **Generate Speech** | Text-to-speech with a voice picker |
 
 Each mode swaps in its own controls — resolution, aspect ratio, duration, voice — and attaches them to the message so the server routes to the right provider call.
+
+Reference to Video takes every image and video on the message, plus the
+reference image of any `@`-mentioned entity, so the prompt describes the action
+and the camera rather than the subjects. Its audio chip chooses between what the
+model scores and the first reference video's own track; only some models accept
+the second, and one that does not rejects the request.
 
 ---
 

--- a/packages/agents/src/capabilities/media.specs.ts
+++ b/packages/agents/src/capabilities/media.specs.ts
@@ -227,6 +227,50 @@ export const ANIMATE_IMAGE_SCHEMA: JsonSchema = {
   required: ["provider", "model", "input_file"]
 };
 
+export const VIDEO_FROM_REFERENCES_SCHEMA: JsonSchema = {
+  type: "object" as const,
+  properties: {
+    background: {
+      type: "boolean" as const,
+      description:
+        "Return at once with a generation_id while the provider works; collect the result with await_generation. At most 16 open per run.",
+      default: false
+    },
+    provider: { type: "string" as const },
+    model: { type: "string" as const },
+    reference_files: {
+      type: "array" as const,
+      items: { type: "string" as const },
+      description:
+        "The references that condition the clip — workspace-relative paths or asset:// URIs. Images and videos may be mixed; each is routed by its own type. At least one is required."
+    },
+    output_file: {
+      type: "string" as const,
+      description: "Optional workspace-relative path to also write the result."
+    },
+    prompt: {
+      type: "string" as const,
+      description:
+        "What happens in the shot. The references say who and what is in it, so describe the action and the camera rather than re-describing the subject."
+    },
+    use_reference_video_audio: {
+      type: "boolean" as const,
+      description:
+        "Keep the audio of the first reference video instead of what the model would synthesize. Only some models accept it; one that does not rejects the call."
+    },
+    negative_prompt: { type: "string" as const },
+    num_frames: { type: "number" as const },
+    duration_seconds: {
+      type: "number" as const,
+      description:
+        "Requested clip length. Models honour this loosely, clamp it to the lengths they support, and some ignore it — measure the result with analyze_video before cutting to it."
+    },
+    aspect_ratio: { type: "string" as const },
+    resolution: { type: "string" as const }
+  },
+  required: ["provider", "model", "reference_files"]
+};
+
 export const GENERATE_SPEECH_SCHEMA: JsonSchema = {
   type: "object" as const,
   properties: {
@@ -520,6 +564,22 @@ export const animateImageSpec: CapabilitySpec = {
     `Animating image with ${String(params["provider"])}:${String(params["model"])}`
 };
 
+export const videoFromReferencesSpec: CapabilitySpec = {
+  name: "generate_video_from_references",
+  description:
+    "Generate a video conditioned on a set of reference images and/or videos, " +
+    "using a provider+model selected via find_model " +
+    "(capability=reference_to_video). Reach for this instead of animate_image " +
+    "when more than one reference defines the shot — a character sheet plus a " +
+    "garment, a product plus a location, a clip whose motion the new shot " +
+    "should follow. `prompt` then describes the action and the camera, not the " +
+    "subjects. Result is saved as an asset.",
+  inputSchema: VIDEO_FROM_REFERENCES_SCHEMA,
+  category: "write",
+  userMessage: (params) =>
+    `Generating video from references with ${String(params["provider"])}:${String(params["model"])}`
+};
+
 export const generateSpeechSpec: CapabilitySpec = {
   name: "generate_speech",
   description:
@@ -783,6 +843,7 @@ export const mediaSpecs: readonly CapabilitySpec[] = [
   segmentImageSpec,
   generateVideoSpec,
   animateImageSpec,
+  videoFromReferencesSpec,
   generateSpeechSpec,
   generateMusicSpec,
   transcribeAudioSpec,

--- a/packages/agents/src/capabilities/media.ts
+++ b/packages/agents/src/capabilities/media.ts
@@ -57,7 +57,7 @@ import {
   assertResolvedHostAllowed
 } from "../network-guard.js";
 import { encodeBase64 as encodeMediaBase64 } from "../sandbox-bytes.js";
-import { imagePixelSize } from "../sandbox-media.js";
+import { imagePixelSize, sniffImageFormat } from "../sandbox-media.js";
 import {
   DEFAULT_MIME,
   MAX_MEDIA_REF_BYTES,
@@ -95,6 +95,7 @@ import {
   segmentImageSpec,
   generateVideoSpec,
   animateImageSpec,
+  videoFromReferencesSpec,
   generateSpeechSpec,
   generateMusicSpec,
   transcribeAudioSpec,
@@ -734,6 +735,133 @@ const animateImage: CapabilityExport = {
       namePrefix: "animated-video",
       mime: "video/mp4",
       params: { image, prompt: params["prompt"], ...shape }
+    });
+  }
+};
+
+/** Extensions that state a reference's kind without reading its bytes. */
+const IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "bmp",
+  "webp",
+  "avif",
+  "heic",
+  "heif",
+  "tif",
+  "tiff"
+]);
+const VIDEO_EXTENSIONS = new Set([
+  "mp4",
+  "m4v",
+  "mov",
+  "webm",
+  "mkv",
+  "avi",
+  "mpeg",
+  "mpg",
+  "wmv"
+]);
+
+/**
+ * Whether a reference is an image or a video. The provider takes the two in
+ * separate lists — a video handed over as an image is rejected with an opaque
+ * provider error — so the kind has to be settled here.
+ *
+ * The extension decides when it says anything, because it is what the caller
+ * stated. Otherwise the bytes do: the image sniffer first (it owns the
+ * `ftyp`-based AVIF/HEIC cases), then the three video containers. A reference
+ * neither names nor looks like either is null, and the call refuses it rather
+ * than guessing.
+ */
+export function classifyReferenceMedia(
+  file: string,
+  bytes: Uint8Array
+): "image" | "video" | null {
+  const dot = file.lastIndexOf(".");
+  const ext = dot > -1 ? file.slice(dot + 1).toLowerCase() : "";
+  if (IMAGE_EXTENSIONS.has(ext)) return "image";
+  if (VIDEO_EXTENSIONS.has(ext)) return "video";
+  if (sniffImageFormat(bytes) !== "unknown") return "image";
+  const at = (i: number): number => bytes[i] ?? -1;
+  const tag = (offset: number, text: string): boolean =>
+    [...text].every((ch, i) => at(offset + i) === ch.charCodeAt(0));
+  if (tag(4, "ftyp")) return "video";
+  // Matroska / WebM EBML header.
+  if (at(0) === 0x1a && at(1) === 0x45 && at(2) === 0xdf && at(3) === 0xa3) {
+    return "video";
+  }
+  if (tag(0, "RIFF") && tag(8, "AVI ")) return "video";
+  return null;
+}
+
+const videoFromReferences: CapabilityExport = {
+  spec: videoFromReferencesSpec,
+  impl: async (run, params) => {
+    const context = run.context;
+    const m = parseModelArgs(params);
+    if ("error" in m) return m;
+    const referenceFiles = params["reference_files"];
+    if (!Array.isArray(referenceFiles)) {
+      return { error: "reference_files must be an array of strings" };
+    }
+    const files = referenceFiles.filter(isNonEmptyString);
+    if (files.length === 0) {
+      return { error: "reference_files must name at least one reference" };
+    }
+    const images: Uint8Array[] = [];
+    const videos: Uint8Array[] = [];
+    for (const file of files) {
+      let bytes: Uint8Array;
+      try {
+        bytes = await readWorkspaceOrAssetFile(context, file);
+      } catch (e) {
+        return predictionError("reference_to_video", m, e);
+      }
+      const kind = classifyReferenceMedia(file, bytes);
+      if (kind === null) {
+        return {
+          error: `${file} is neither an image nor a video — reference_to_video takes only those`
+        };
+      }
+      (kind === "image" ? images : videos).push(bytes);
+    }
+    const useReferenceVideoAudio = aliased(
+      params,
+      "use_reference_video_audio",
+      "useReferenceVideoAudio"
+    );
+    if (useReferenceVideoAudio === true && videos.length === 0) {
+      return {
+        error:
+          "use_reference_video_audio needs a reference video to take the audio from"
+      };
+    }
+    const shape = videoShapeParams(params);
+    // Same reasoning as animate_image: a vertical reference rendered at the
+    // provider's default lands 16:9 and the crop is found at the cut. The
+    // first image reference states the intended shape when the call does not.
+    if (shape.aspect_ratio === undefined && images.length > 0) {
+      const size = imagePixelSize(images[0]!);
+      const derived = size ? nearestAspectRatio(size.width, size.height) : null;
+      if (derived) shape.aspect_ratio = derived;
+    }
+    return runMediaGeneration(run, params, {
+      capability: "reference_to_video",
+      m,
+      type: "video",
+      namePrefix: "reference-video",
+      mime: "video/mp4",
+      params: {
+        reference_images: images,
+        reference_videos: videos,
+        prompt: params["prompt"],
+        negative_prompt: aliased(params, "negative_prompt", "negativePrompt"),
+        use_reference_video_audio: useReferenceVideoAudio,
+        ...shape
+      }
     });
   }
 };
@@ -2385,6 +2513,7 @@ export const MEDIA_CAPABILITIES: readonly CapabilityExport[] = [
   segmentImage,
   generateVideo,
   animateImage,
+  videoFromReferences,
   generateSpeech,
   generateMusic,
   transcribeAudio,
@@ -2410,6 +2539,7 @@ export {
   segmentImage,
   generateVideo,
   animateImage,
+  videoFromReferences,
   generateSpeech,
   generateMusic,
   transcribeAudio,

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -51,6 +51,7 @@ export const NODETOOL_API_NAMESPACE_TOOLS: Record<string, readonly string[]> = {
     "edit_image",
     "generate_video",
     "animate_image",
+    "generate_video_from_references",
     "generate_speech",
     "generate_music",
     "transcribe_audio",
@@ -880,6 +881,13 @@ const nodetool = (() => {
         __need("animate_image")(
           __merge(opts, __merge(__model(model), { input_file: inputFile }))
         ),
+      videoFromReferences: (referenceFiles, model, opts) =>
+        __need("generate_video_from_references")(
+          __merge(
+            opts,
+            __merge(__model(model), { reference_files: referenceFiles })
+          )
+        ),
       speak: (text, model, opts) =>
         __need("generate_speech")(
           __merge(opts, __merge(__model(model), { text: text }))
@@ -1591,7 +1599,10 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   \`generateImage(prompt, model, {width, height, output_file})\`,
   \`editImage(inputFile, prompt, model, {reference_files})\`,
   \`generateVideo(prompt, model)\`,
-  \`animateImage(inputFile, model)\`, \`speak(text, model, {voice})\`,
+  \`animateImage(inputFile, model)\`,
+  \`videoFromReferences(referenceFiles, model, {prompt})\` — one clip from several
+  image/video references, when more than one reference defines the shot,
+  \`speak(text, model, {voice})\`,
   \`generateMusic(prompt, model, {lyrics, duration_seconds})\`,
   \`transcribe(inputFile, model)\`, \`embed(text, model)\`. Results are saved as
   assets (\`asset://\` URI); pass \`output_file\` for a workspace copy too.

--- a/packages/agents/src/evals/codeact-api-core.ts
+++ b/packages/agents/src/evals/codeact-api-core.ts
@@ -241,7 +241,7 @@ const MODEL_CATALOG: readonly ModelEntry[] = [
     provider: "fal_ai",
     model_id: "fal-ai/ltx-video",
     type: "video",
-    capabilities: ["text_to_video", "image_to_video"]
+    capabilities: ["text_to_video", "image_to_video", "reference_to_video"]
   },
   {
     provider: "openai",
@@ -1197,6 +1197,48 @@ export function createCoreApiTools(recorder: CodeActToolRecorder): Tool[] {
         );
         return {
           asset_uri: asset.uri,
+          provider: model.provider,
+          model: model.model_id
+        };
+      }
+    ),
+    tool(
+      "generate_video_from_references",
+      "Generate a video conditioned on a set of image/video references.",
+      { provider: s, model: s, reference_files: { type: "array" }, prompt: s },
+      (params) => {
+        const model = world.model(
+          params["provider"],
+          params["model"],
+          "reference_to_video"
+        );
+        const files = Array.isArray(params["reference_files"])
+          ? params["reference_files"]
+          : [];
+        if (files.length === 0) {
+          throw new Error(
+            "reference_files must name at least one image or video reference."
+          );
+        }
+        // Every reference contributes to the clip, so the saved content carries
+        // all of them plus the prompt — that is what the adherence checks read.
+        const sources = files.map((file) => world.asset(file));
+        const prompt = str(params["prompt"]);
+        const content = [
+          ...sources.map((a) => a.prompt ?? a.content),
+          prompt
+        ]
+          .filter((part) => part.length > 0)
+          .join(" ");
+        const asset = world.saveAsset(
+          `reference-clip-${str(world.assets.size + 1)}`,
+          content,
+          "video/mp4",
+          content
+        );
+        return {
+          asset_uri: asset.uri,
+          asset_id: asset.id,
           provider: model.provider,
           model: model.model_id
         };

--- a/packages/agents/src/task-planner.ts
+++ b/packages/agents/src/task-planner.ts
@@ -120,7 +120,9 @@ const TOOL_ENABLED_PLANNING_SECTIONS = `
   generate_embedding) and pass the resulting \`provider\` + \`model\` to the
   generation tool.
 - Generation tools: \`generate_image\`, \`edit_image\`, \`generate_video\`,
-  \`animate_image\`, \`generate_speech\`, \`transcribe_audio\`, \`embed_text\`.
+  \`animate_image\`, \`generate_video_from_references\` (several image/video
+  references condition one clip), \`generate_speech\`, \`transcribe_audio\`,
+  \`embed_text\`.
 - These tools save outputs as ASSETS automatically — the result includes
   \`asset_id\` and \`asset_uri\` ("asset://<id>.<ext>"). Reference those in
   later steps and in the final response so the chat UI can show them.

--- a/packages/agents/src/tools/builtin-tools.ts
+++ b/packages/agents/src/tools/builtin-tools.ts
@@ -197,6 +197,7 @@ export const BUILTIN_TOOL_NAMES: readonly string[] = [
   "edit_image",
   "generate_video",
   "animate_image",
+  "generate_video_from_references",
   "generate_speech",
   "generate_music",
   "transcribe_audio",

--- a/packages/agents/src/tools/mcp-tools.ts
+++ b/packages/agents/src/tools/mcp-tools.ts
@@ -168,8 +168,9 @@ export interface GetAllMcpToolsOptions {
    * - `find_model` — pick a `{provider, model_id}` for any capability.
    * - `list_models` — browse everything the configured providers offer.
    * - `generate_image` / `edit_image` / `generate_video` / `animate_image` /
-   *   `generate_speech` / `transcribe_audio` / `embed_text` — direct
-   *   provider-backed media generation tools usable from any agent loop.
+   *   `generate_video_from_references` / `generate_speech` /
+   *   `transcribe_audio` / `embed_text` — direct provider-backed media
+   *   generation tools usable from any agent loop.
    *
    * Independent of `registry`: the multi-task planner doesn't need a
    * registry but still benefits from these tools.

--- a/packages/agents/tests/capabilities-media.test.ts
+++ b/packages/agents/tests/capabilities-media.test.ts
@@ -39,6 +39,8 @@ import {
   scoreImageAdherence,
   transcribeAudio,
   understandVideo,
+  videoFromReferences,
+  classifyReferenceMedia,
   ffmpeg,
   ytDlp
 } from "../src/capabilities/media.js";
@@ -87,6 +89,7 @@ describe("the media capability module", () => {
       "segment_image",
       "generate_video",
       "animate_image",
+      "generate_video_from_references",
       "generate_speech",
       "generate_music",
       "transcribe_audio",
@@ -115,6 +118,10 @@ describe("wire identity: a Tool built from the spec", () => {
     [editImage, toolForCapabilityName("edit_image")],
     [generateVideo, toolForCapabilityName("generate_video")],
     [animateImage, toolForCapabilityName("animate_image")],
+    [
+      videoFromReferences,
+      toolForCapabilityName("generate_video_from_references")
+    ],
     [generateSpeech, toolForCapabilityName("generate_speech")],
     [transcribeAudio, toolForCapabilityName("transcribe_audio")],
     [embedText, toolForCapabilityName("embed_text")],
@@ -900,5 +907,126 @@ describe("animate_image takes its shape from the still", () => {
       input_file: "still.bin"
     });
     expect(sentParams(context)["aspect_ratio"]).toBeUndefined();
+  });
+});
+
+/**
+ * reference_to_video takes two lists — images and videos — and a provider
+ * rejects a video handed over as an image with an opaque error, so the split
+ * is the contract worth pinning.
+ */
+describe("generate_video_from_references", () => {
+  /** A PNG header, and an MP4 `ftyp` box. Nothing decodes either. */
+  const PNG = new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a
+  ]);
+  const MP4 = new Uint8Array([
+    0, 0, 0, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d
+  ]);
+
+  function contextFor(files: Record<string, Uint8Array>): ProcessingContext {
+    return withGenerationSeam({
+      userId: "user-1",
+      runProviderPrediction: vi.fn(async () => new Uint8Array([1, 2, 3])),
+      workspace: {
+        localDir: null,
+        write: async () => {},
+        read: async (path: string) => {
+          const bytes = files[path];
+          if (!bytes) throw new Error(`no such file: ${path}`);
+          return bytes;
+        },
+        key: (p: string) => p
+      }
+    }) as unknown as ProcessingContext;
+  }
+
+  const sentParams = (context: ProcessingContext): Record<string, unknown> =>
+    (
+      (
+        context.runProviderPrediction as unknown as ReturnType<typeof vi.fn>
+      ).mock.calls[0][0] as Record<string, unknown>
+    )["params"] as Record<string, unknown>;
+
+  const sentCapability = (context: ProcessingContext): unknown =>
+    (
+      (
+        context.runProviderPrediction as unknown as ReturnType<typeof vi.fn>
+      ).mock.calls[0][0] as Record<string, unknown>
+    )["capability"];
+
+  it("routes each reference into the list its own kind belongs in", async () => {
+    const context = contextFor({ "hero.png": PNG, "motion.mp4": MP4 });
+    await asTool(videoFromReferences).process(context, {
+      provider: "fal_ai",
+      model: "minimax/h3/reference-to-video",
+      reference_files: ["hero.png", "motion.mp4"],
+      prompt: "she walks into frame",
+      duration_seconds: 6
+    });
+    expect(sentCapability(context)).toBe("reference_to_video");
+    const params = sentParams(context);
+    expect(params["reference_images"]).toEqual([PNG]);
+    expect(params["reference_videos"]).toEqual([MP4]);
+    expect(params["duration_seconds"]).toBe(6);
+  });
+
+  it("classifies by content when the path carries no extension", () => {
+    expect(classifyReferenceMedia("hero.png", PNG)).toBe("image");
+    expect(classifyReferenceMedia("clip.mov", MP4)).toBe("video");
+    // No extension: the bytes decide.
+    expect(classifyReferenceMedia("hero", PNG)).toBe("image");
+    expect(classifyReferenceMedia("clip", MP4)).toBe("video");
+    // Neither, so the call has to refuse rather than guess.
+    expect(classifyReferenceMedia("notes.txt", new Uint8Array([1, 2, 3]))).toBeNull();
+  });
+
+  it("refuses a reference that is neither an image nor a video", async () => {
+    const context = contextFor({ "notes.bin": new Uint8Array([1, 2, 3]) });
+    const result = (await asTool(videoFromReferences).process(context, {
+      provider: "fal_ai",
+      model: "minimax/h3/reference-to-video",
+      reference_files: ["notes.bin"]
+    })) as Record<string, unknown>;
+    expect(String(result["error"])).toContain("notes.bin");
+    expect(context.runProviderPrediction).not.toHaveBeenCalled();
+  });
+
+  it("refuses an empty reference list", async () => {
+    const context = contextFor({});
+    const result = (await asTool(videoFromReferences).process(context, {
+      provider: "fal_ai",
+      model: "minimax/h3/reference-to-video",
+      reference_files: []
+    })) as Record<string, unknown>;
+    expect(String(result["error"])).toContain("at least one reference");
+    expect(context.runProviderPrediction).not.toHaveBeenCalled();
+  });
+
+  it("refuses reference audio when no reference video was given", async () => {
+    const context = contextFor({ "hero.png": PNG });
+    const result = (await asTool(videoFromReferences).process(context, {
+      provider: "fal_ai",
+      model: "minimax/h3/reference-to-video",
+      reference_files: ["hero.png"],
+      use_reference_video_audio: true
+    })) as Record<string, unknown>;
+    expect(String(result["error"])).toContain("reference video");
+    expect(context.runProviderPrediction).not.toHaveBeenCalled();
+  });
+
+  it("takes its aspect from the first image reference when none is named", async () => {
+    const vertical = new Uint8Array(33);
+    vertical.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    vertical.set([0x49, 0x48, 0x44, 0x52], 12);
+    new DataView(vertical.buffer).setUint32(16, 720, false);
+    new DataView(vertical.buffer).setUint32(20, 1280, false);
+    const context = contextFor({ "hero.png": vertical });
+    await asTool(videoFromReferences).process(context, {
+      provider: "fal_ai",
+      model: "minimax/h3/reference-to-video",
+      reference_files: ["hero.png"]
+    });
+    expect(sentParams(context)["aspect_ratio"]).toBe("9:16");
   });
 });

--- a/packages/agents/tests/capabilities-registry.test.ts
+++ b/packages/agents/tests/capabilities-registry.test.ts
@@ -132,6 +132,7 @@ const CAPABILITY_CATEGORY_SNAPSHOT: Record<string, PermissionCategory> = {
   generate_speech: "write",
   generate_music: "write",
   generate_video: "write",
+  generate_video_from_references: "write",
   get_apify_actor: "read",
   get_apify_actor_schema: "read",
   get_apify_dataset_items: "read",

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -419,6 +419,16 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     ],
   },
   {
+    name: "generate_video_from_references",
+    module: "media",
+    impl: "packages/agents/src/capabilities/media.ts",
+    contract: "dea82ea56a14",
+    selfcheck: "capability-suites",
+    suites: [
+      "packages/agents/tests/capabilities-media.test.ts",
+    ],
+  },
+  {
     name: "generate_speech",
     module: "media",
     impl: "packages/agents/src/capabilities/media.ts",

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -33,6 +33,7 @@ export const ALWAYS_ENABLED_TOOLS: readonly string[] = [
   "edit_image",
   "generate_video",
   "animate_image",
+  "generate_video_from_references",
   "generate_speech",
   "transcribe_audio",
   "read_media_bytes"

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -612,6 +612,7 @@ export type MediaGenerationMode =
   | "image_edit"
   | "video"
   | "image_to_video"
+  | "reference_to_video"
   | "audio"
   | "audio_to_video"
   | "retake"
@@ -648,6 +649,12 @@ export interface MediaGenerationRequest {
   num_inference_steps?: number | null;
   /** Source image asset id (image_edit / image_to_video). */
   source_asset_id?: string | null;
+  /**
+   * Keep the audio of the first reference *video* instead of whatever the
+   * model would synthesize (reference_to_video). Only some models take it;
+   * the provider rejects the request when the selected one does not.
+   */
+  use_reference_video_audio?: boolean | null;
   /** Extra provider-specific params. */
   extras?: Record<string, unknown> | null;
 }

--- a/packages/websocket/src/session/chat-turn.ts
+++ b/packages/websocket/src/session/chat-turn.ts
@@ -373,6 +373,16 @@ export interface ChatTurnDeps {
     mediaGeneration: Record<string, unknown>,
     userId: string
   ) => Promise<Uint8Array | null>;
+  /**
+   * Every image and video the user attached, for the reference-to-video mode
+   * — which takes a set of references rather than the one source image
+   * {@link resolveSourceImageBytes} returns.
+   */
+  resolveReferenceMediaBytes: (
+    data: Record<string, unknown>,
+    mediaGeneration: Record<string, unknown>,
+    userId: string
+  ) => Promise<{ images: Uint8Array[]; videos: Uint8Array[] }>;
 }
 
 /**
@@ -3035,6 +3045,124 @@ export class ChatTurnHandler {
                 asset_id: assetId,
                 format: "mp4",
                 duration: duration
+              }
+            }
+          ],
+          thread_id: threadId,
+          workflow_id: workflowId,
+          provider: providerId,
+          model: modelId,
+          media_generation: mediaGeneration
+        };
+        // Re-check: cancellation may have landed while the asset was persisting.
+        if (cancelled()) return;
+        await this.saveMessageToDb(assistantMsgData);
+        await this.session.send(assistantMsgData);
+        return;
+      }
+
+      if (mode === "reference_to_video") {
+        // The whole set of attachments conditions one clip, so every image
+        // and video on the message reaches the provider — plus the reference
+        // images of any `@`-mentioned entity, which is the same kind of input
+        // arriving by a different route.
+        const references = await this.deps.resolveReferenceMediaBytes(
+          data,
+          mediaGeneration,
+          userId
+        );
+        const referenceImages = [...references.images, ...entityImageBytes];
+        const referenceVideos = references.videos;
+        if (referenceImages.length === 0 && referenceVideos.length === 0) {
+          await this.session.send({
+            type: "error",
+            message:
+              "Reference to video needs at least one reference — attach an image or a video first",
+            thread_id: threadId
+          });
+          return;
+        }
+
+        const aspectRatio = isString(mediaGeneration.aspect_ratio)
+          ? (mediaGeneration.aspect_ratio as string)
+          : null;
+        const resolution = isString(mediaGeneration.resolution)
+          ? (mediaGeneration.resolution as string)
+          : null;
+        const duration = isNumber(mediaGeneration.duration)
+          ? (mediaGeneration.duration as number)
+          : null;
+        // Only some models take it, and a model that does not rejects the
+        // request rather than silently dropping the audio, so the flag is
+        // forwarded only when the composer set it.
+        const useReferenceVideoAudio =
+          typeof mediaGeneration.use_reference_video_audio === "boolean"
+            ? (mediaGeneration.use_reference_video_audio as boolean)
+            : undefined;
+        const r2vModel: ProviderVideoModel = {
+          id: modelId,
+          name: modelId,
+          provider: providerId
+        };
+
+        await this.session.send({
+          type: "chunk",
+          thread_id: threadId,
+          content: "",
+          content_type: "text",
+          content_metadata: { media_generation: mediaGeneration },
+          done: false
+        });
+
+        const generated = await generate(
+          "reference_to_video",
+          {
+            prompt: expandedPrompt,
+            aspect_ratio: aspectRatio,
+            resolution,
+            duration_seconds: duration,
+            reference_images: referenceImages,
+            reference_videos: referenceVideos,
+            use_reference_video_audio: useReferenceVideoAudio
+          },
+          { mime: "video/mp4" },
+          (abort) =>
+            provider.referenceToVideo(
+              { images: referenceImages, videos: referenceVideos },
+              {
+                model: r2vModel,
+                prompt: expandedPrompt,
+                aspectRatio,
+                resolution,
+                durationSeconds: duration,
+                useReferenceVideoAudio,
+                signal: abort
+              }
+            )
+        );
+        if (cancelled()) return;
+        const assetId =
+          seamAssetId(generated) ??
+          (await storeMediaAsset(generated.output, "video/mp4", "mp4"));
+
+        await this.session.send({
+          type: "chunk",
+          thread_id: threadId,
+          content: "",
+          done: true
+        });
+
+        const assistantMsgData: Record<string, unknown> = {
+          type: "message",
+          role: "assistant",
+          content: [
+            {
+              type: "video",
+              video: {
+                type: "video",
+                asset_id: assetId,
+                format: "mp4",
+                duration
               }
             }
           ],

--- a/packages/websocket/src/websocket-client-session.ts
+++ b/packages/websocket/src/websocket-client-session.ts
@@ -601,7 +601,9 @@ export class WebSocketClientSession implements ClientSession {
       entityRefResolver,
       resolveEntityReferenceImages,
       resolveSourceImageBytes: (data, mediaGeneration, userId) =>
-        this.resolveSourceImageBytes(data, mediaGeneration, userId)
+        this.resolveSourceImageBytes(data, mediaGeneration, userId),
+      resolveReferenceMediaBytes: (data, mediaGeneration, userId) =>
+        this.resolveReferenceMediaBytes(data, mediaGeneration, userId)
     });
     this.commands = new CommandRouter({
       session: this,
@@ -1077,6 +1079,112 @@ export class WebSocketClientSession implements ClientSession {
   }
 
   /**
+   * Bytes behind one media content block, whatever form the client used to
+   * name them: a stored `asset_id`, an `asset://<id>.<ext>` uri written by the
+   * `@`-mention picker, an inline `data:` uri, an http(s) url, or a bare
+   * base64 `data` field. Returns null when none of them resolves.
+   */
+  private async resolveMediaRefBytes(
+    ref: Record<string, unknown>,
+    userId: string
+  ): Promise<Uint8Array | null> {
+    const assetId = isString(ref.asset_id) ? (ref.asset_id as string) : null;
+    if (assetId) {
+      const bytes = await this.loadAssetBytes(userId, assetId);
+      if (bytes && bytes.length > 0) return bytes;
+    }
+    const uri = isString(ref.uri) ? (ref.uri as string) : null;
+    if (uri) {
+      if (uri.startsWith("asset://")) {
+        // `@`-mentioned or library-dragged asset: `asset://<id>.<ext>`.
+        const withoutScheme = uri.slice("asset://".length);
+        const dotIdx = withoutScheme.lastIndexOf(".");
+        const mentionedId =
+          dotIdx > -1 ? withoutScheme.slice(0, dotIdx) : withoutScheme;
+        const bytes = await this.loadAssetBytes(userId, mentionedId);
+        if (bytes && bytes.length > 0) return bytes;
+      } else if (uri.startsWith("data:")) {
+        const commaIdx = uri.indexOf(",");
+        if (commaIdx > -1) {
+          const b64 = uri.slice(commaIdx + 1);
+          try {
+            return new Uint8Array(Buffer.from(b64, "base64"));
+          } catch {
+            /* fall through to the `data` field below */
+          }
+        }
+      } else if (uri.startsWith("http://") || uri.startsWith("https://")) {
+        // A chat client picked this uri, so the media-ref egress policy
+        // decides — including on every redirect hop, which the predicate
+        // this replaced never saw.
+        try {
+          const resp = await fetchExternalMedia(uri);
+          if (resp.ok) {
+            return new Uint8Array(await resp.arrayBuffer());
+          }
+        } catch (err) {
+          log.warn("resolveMediaRefBytes: fetch failed", {
+            uri,
+            error: err instanceof Error ? err.message : String(err)
+          });
+        }
+      }
+    }
+    const data64 = isString(ref.data) ? (ref.data as string) : null;
+    if (data64) {
+      try {
+        return new Uint8Array(Buffer.from(data64, "base64"));
+      } catch {
+        /* ignore */
+      }
+    }
+    return null;
+  }
+
+  /** One asset's bytes, or null when it is gone or unreadable. */
+  private async loadAssetBytes(
+    userId: string,
+    assetId: string
+  ): Promise<Uint8Array | null> {
+    if (!assetId) return null;
+    try {
+      const asset = await Asset.find(userId, assetId);
+      if (!asset) return null;
+      return await retrieveAssetBytes(
+        getAssetAdapter(),
+        userId,
+        assetId,
+        asset.content_type
+      );
+    } catch (err) {
+      log.warn("loadAssetBytes: asset load failed", {
+        assetId,
+        error: err instanceof Error ? err.message : String(err)
+      });
+      return null;
+    }
+  }
+
+  /** The inner ref record of every `image_url` / `video` block on a message. */
+  private mediaRefsOnMessage(
+    data: Record<string, unknown>,
+    blockType: "image_url" | "video"
+  ): Array<Record<string, unknown>> {
+    const content = data.content;
+    if (!Array.isArray(content)) return [];
+    const field = blockType === "image_url" ? "image" : "video";
+    const refs: Array<Record<string, unknown>> = [];
+    for (const c of content) {
+      if (!isObjectLike(c)) continue;
+      const block = c as Record<string, unknown>;
+      if (block.type !== blockType) continue;
+      const ref = block[field];
+      refs.push(isObjectLike(ref) ? (ref as Record<string, unknown>) : {});
+    }
+    return refs;
+  }
+
+  /**
    * Resolve the source image bytes for image-edit / image-to-video calls.
    * Searches in priority order:
    *   1. `media_generation.source_asset_id`  → load from Asset storage
@@ -1089,98 +1197,54 @@ export class WebSocketClientSession implements ClientSession {
     mediaGeneration: Record<string, unknown>,
     userId: string
   ): Promise<Uint8Array | null> {
-    const tryLoadAsset = async (
-      assetId: string
-    ): Promise<Uint8Array | null> => {
-      if (!assetId) return null;
-      try {
-        const asset = await Asset.find(userId, assetId);
-        if (!asset) return null;
-        return await retrieveAssetBytes(
-          getAssetAdapter(),
-          userId,
-          assetId,
-          asset.content_type
-        );
-      } catch (err) {
-        log.warn("resolveSourceImageBytes: asset load failed", {
-          assetId,
-          error: err instanceof Error ? err.message : String(err)
-        });
-        return null;
-      }
-    };
-
     const explicitId = isString(mediaGeneration.source_asset_id)
       ? (mediaGeneration.source_asset_id as string)
       : null;
     if (explicitId) {
-      const fromAsset = await tryLoadAsset(explicitId);
+      const fromAsset = await this.loadAssetBytes(userId, explicitId);
       if (fromAsset && fromAsset.length > 0) return fromAsset;
     }
-
-    const content = data.content;
-    if (Array.isArray(content)) {
-      for (const c of content) {
-        if (!isObjectLike(c)) continue;
-        const block = c as Record<string, unknown>;
-        if (block.type !== "image_url") continue;
-        const image = (block.image ?? {}) as Record<string, unknown>;
-        const assetId = isString(image.asset_id)
-          ? (image.asset_id as string)
-          : null;
-        if (assetId) {
-          const bytes = await tryLoadAsset(assetId);
-          if (bytes && bytes.length > 0) return bytes;
-        }
-        const uri = isString(image.uri) ? (image.uri as string) : null;
-        if (uri) {
-          if (uri.startsWith("asset://")) {
-            // `@`-mentioned or library-dragged asset: `asset://<id>.<ext>`.
-            const withoutScheme = uri.slice("asset://".length);
-            const dotIdx = withoutScheme.lastIndexOf(".");
-            const mentionedId =
-              dotIdx > -1 ? withoutScheme.slice(0, dotIdx) : withoutScheme;
-            const bytes = await tryLoadAsset(mentionedId);
-            if (bytes && bytes.length > 0) return bytes;
-          } else if (uri.startsWith("data:")) {
-            const commaIdx = uri.indexOf(",");
-            if (commaIdx > -1) {
-              const b64 = uri.slice(commaIdx + 1);
-              try {
-                return new Uint8Array(Buffer.from(b64, "base64"));
-              } catch {
-                /* fall through */
-              }
-            }
-          } else if (uri.startsWith("http://") || uri.startsWith("https://")) {
-            // A chat client picked this uri, so the media-ref egress policy
-            // decides — including on every redirect hop, which the predicate
-            // this replaced never saw.
-            try {
-              const resp = await fetchExternalMedia(uri);
-              if (resp.ok) {
-                return new Uint8Array(await resp.arrayBuffer());
-              }
-            } catch (err) {
-              log.warn("resolveSourceImageBytes: fetch failed", {
-                uri,
-                error: err instanceof Error ? err.message : String(err)
-              });
-            }
-          }
-        }
-        const data64 = isString(image.data) ? (image.data as string) : null;
-        if (data64) {
-          try {
-            return new Uint8Array(Buffer.from(data64, "base64"));
-          } catch {
-            /* ignore */
-          }
-        }
-      }
+    for (const ref of this.mediaRefsOnMessage(data, "image_url")) {
+      const bytes = await this.resolveMediaRefBytes(ref, userId);
+      if (bytes && bytes.length > 0) return bytes;
     }
     return null;
+  }
+
+  /**
+   * Every reference the user attached, for reference-to-video: *all* the
+   * image and video blocks on the message rather than the first one, because
+   * the whole point of the mode is that several references describe one shot
+   * (a character, a garment, a location). `source_asset_id` joins the images
+   * so a surface that names one explicitly still reaches the model. A block
+   * whose bytes do not resolve drops rather than failing the turn — the
+   * caller refuses only when nothing at all resolved.
+   */
+  private async resolveReferenceMediaBytes(
+    data: Record<string, unknown>,
+    mediaGeneration: Record<string, unknown>,
+    userId: string
+  ): Promise<{ images: Uint8Array[]; videos: Uint8Array[] }> {
+    const collect = async (
+      blockType: "image_url" | "video"
+    ): Promise<Uint8Array[]> => {
+      const out: Uint8Array[] = [];
+      for (const ref of this.mediaRefsOnMessage(data, blockType)) {
+        const bytes = await this.resolveMediaRefBytes(ref, userId);
+        if (bytes && bytes.length > 0) out.push(bytes);
+      }
+      return out;
+    };
+    const images = await collect("image_url");
+    const videos = await collect("video");
+    const explicitId = isString(mediaGeneration.source_asset_id)
+      ? (mediaGeneration.source_asset_id as string)
+      : null;
+    if (explicitId) {
+      const bytes = await this.loadAssetBytes(userId, explicitId);
+      if (bytes && bytes.length > 0) images.unshift(bytes);
+    }
+    return { images, videos };
   }
 
   async handleCommand(

--- a/packages/websocket/tests/chat-turn-handler-media.test.ts
+++ b/packages/websocket/tests/chat-turn-handler-media.test.ts
@@ -1,7 +1,8 @@
 /**
  * handleMediaGenerationMessage: the image / video / audio / image_edit /
- * image_to_video routes a `chat_message` with a `media_generation` payload
- * takes, their refusal branches, cancellation, and the provider-failure catch.
+ * image_to_video / reference_to_video routes a `chat_message` with a
+ * `media_generation` payload takes, their refusal branches, cancellation, and
+ * the provider-failure catch.
  *
  * Assets are written through the real file storage adapter into a temp
  * directory (ASSET_FOLDER), so no module is mocked.
@@ -486,5 +487,110 @@ describe("audio generation", () => {
     expect((block.audio as Record<string, unknown>).mimeType).toBe(
       "audio/pcm"
     );
+  });
+});
+
+describe("reference_to_video", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("refuses a turn with no reference attached", async () => {
+    const harness = makeChatTurnHarness({
+      session: { resolveProvider: async () => fakeProvider({}) }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-r2v-empty", {
+        mode: "reference_to_video",
+        provider: "mock",
+        model: "vid-1"
+      })
+    );
+    const [err] = harness.session.messagesOfType("error");
+    expect(String(err.message)).toContain("at least one reference");
+    expect(assistantFrames(harness)).toHaveLength(0);
+  });
+
+  it("passes every attached image and video, plus entity references", async () => {
+    const imageA = new Uint8Array([1, 1, 1]);
+    const imageB = new Uint8Array([2, 2, 2]);
+    const clip = new Uint8Array([3, 3, 3]);
+    const entityImage = new Uint8Array([4, 4, 4]);
+    let inputs: { images: Uint8Array[]; videos: Uint8Array[] } | null = null;
+    let params: Record<string, unknown> | null = null;
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            referenceToVideo: async (i, p) => {
+              inputs = i as { images: Uint8Array[]; videos: Uint8Array[] };
+              params = p as Record<string, unknown>;
+              return PNG;
+            },
+            textToVideo: async () => {
+              throw new Error("must not fall back to text-to-video");
+            }
+          })
+      },
+      deps: {
+        resolveReferenceMediaBytes: async () => ({
+          images: [imageA, imageB],
+          videos: [clip]
+        }),
+        resolveEntityReferenceImages: async () => [entityImage]
+      }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-r2v", {
+        mode: "reference_to_video",
+        provider: "mock",
+        model: "vid-1",
+        duration: 6,
+        aspect_ratio: "9:16",
+        use_reference_video_audio: true
+      })
+    );
+    expect(inputs).toEqual({
+      images: [imageA, imageB, entityImage],
+      videos: [clip]
+    });
+    expect(params?.durationSeconds).toBe(6);
+    expect(params?.aspectRatio).toBe("9:16");
+    expect(params?.useReferenceVideoAudio).toBe(true);
+    const [assistant] = assistantFrames(harness);
+    const [block] = assistant.content as Array<Record<string, unknown>>;
+    expect(block.type).toBe("video");
+    expect((block.video as Record<string, unknown>).duration).toBe(6);
+  });
+
+  it("states nothing about reference audio when the composer left it off", async () => {
+    let params: Record<string, unknown> | null = null;
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            referenceToVideo: async (_i, p) => {
+              params = p as Record<string, unknown>;
+              return PNG;
+            }
+          })
+      },
+      deps: {
+        resolveReferenceMediaBytes: async () => ({
+          images: [],
+          videos: [new Uint8Array([7, 7])]
+        })
+      }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-media-r2v-audio-off", {
+        mode: "reference_to_video",
+        provider: "mock",
+        model: "vid-1",
+        use_reference_video_audio: null
+      })
+    );
+    expect(params?.useReferenceVideoAudio).toBeUndefined();
+    expect(assistantFrames(harness)).toHaveLength(1);
   });
 });

--- a/packages/websocket/tests/chat-turn-test-harness.ts
+++ b/packages/websocket/tests/chat-turn-test-harness.ts
@@ -135,6 +135,7 @@ export function makeChatTurnHarness(
     entityRefResolver: () => ({ getAssetInfo: async () => null }),
     resolveEntityReferenceImages: async () => [],
     resolveSourceImageBytes: async () => null,
+    resolveReferenceMediaBytes: async () => ({ images: [], videos: [] }),
     ...overrides.deps
   };
   const handler = new ChatTurnHandler(session, deps);
@@ -158,6 +159,7 @@ export interface FakeProviderShape {
   imageToImages?: (...args: unknown[]) => Promise<Uint8Array[]>;
   textToVideo?: (...args: unknown[]) => Promise<Uint8Array>;
   imageToVideo?: (...args: unknown[]) => Promise<Uint8Array>;
+  referenceToVideo?: (...args: unknown[]) => Promise<Uint8Array>;
   textToSpeechEncoded?: (
     ...args: unknown[]
   ) => Promise<{ data: Uint8Array; mimeType: string } | null>;

--- a/packages/websocket/tests/session-media-references.test.ts
+++ b/packages/websocket/tests/session-media-references.test.ts
@@ -1,0 +1,150 @@
+/**
+ * The session's own media-reference resolvers.
+ *
+ * `resolveSourceImageBytes` (image_edit / image_to_video) and
+ * `resolveReferenceMediaBytes` (reference_to_video) share one per-block loader,
+ * so the two shapes are pinned together: the first usable image for the one,
+ * every image and video for the other. The chat-turn suite stubs these as
+ * dependencies, which leaves the block walking itself untested — this covers
+ * the forms a client actually sends: an inline `data:` uri, a bare base64
+ * `data` field, and an unresolvable reference that must drop rather than fail
+ * the turn.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { initTestDb } from "@nodetool-ai/models";
+import { WebSocketClientSession } from "../src/websocket-client-session.js";
+
+const noopExecutor = () => ({
+  async process() {
+    return {};
+  }
+});
+
+/** The two resolvers are private; the tests drive them by name. */
+interface Resolvers {
+  resolveSourceImageBytes: (
+    data: Record<string, unknown>,
+    mediaGeneration: Record<string, unknown>,
+    userId: string
+  ) => Promise<Uint8Array | null>;
+  resolveReferenceMediaBytes: (
+    data: Record<string, unknown>,
+    mediaGeneration: Record<string, unknown>,
+    userId: string
+  ) => Promise<{ images: Uint8Array[]; videos: Uint8Array[] }>;
+}
+
+function resolvers(): Resolvers {
+  const session = new WebSocketClientSession({
+    resolveExecutor: noopExecutor
+  });
+  return session as unknown as Resolvers;
+}
+
+const b64 = (bytes: number[]): string =>
+  Buffer.from(new Uint8Array(bytes)).toString("base64");
+
+const imageBlock = (ref: Record<string, unknown>) => ({
+  type: "image_url",
+  image: { type: "image", ...ref }
+});
+const videoBlock = (ref: Record<string, unknown>) => ({
+  type: "video",
+  video: { type: "video", ...ref }
+});
+
+describe("resolveReferenceMediaBytes", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("collects every image and video block, in message order", async () => {
+    const result = await resolvers().resolveReferenceMediaBytes(
+      {
+        content: [
+          { type: "text", text: "she walks into frame" },
+          imageBlock({ uri: `data:image/png;base64,${b64([1, 1])}` }),
+          videoBlock({ uri: `data:video/mp4;base64,${b64([3, 3])}` }),
+          imageBlock({ data: b64([2, 2]) })
+        ]
+      },
+      {},
+      "user-1"
+    );
+    expect(result.images).toEqual([
+      new Uint8Array([1, 1]),
+      new Uint8Array([2, 2])
+    ]);
+    expect(result.videos).toEqual([new Uint8Array([3, 3])]);
+  });
+
+  it("drops a reference whose bytes cannot be reached, keeping the rest", async () => {
+    const result = await resolvers().resolveReferenceMediaBytes(
+      {
+        content: [
+          // An asset id no row exists for: the turn must still run on what
+          // did resolve rather than fail on the one that did not.
+          imageBlock({ asset_id: "does-not-exist" }),
+          imageBlock({ uri: `data:image/png;base64,${b64([7])}` })
+        ]
+      },
+      {},
+      "user-1"
+    );
+    expect(result.images).toEqual([new Uint8Array([7])]);
+    expect(result.videos).toEqual([]);
+  });
+
+  it("answers with empty lists when the message carries no media", async () => {
+    const result = await resolvers().resolveReferenceMediaBytes(
+      { content: "just text" },
+      {},
+      "user-1"
+    );
+    expect(result).toEqual({ images: [], videos: [] });
+  });
+});
+
+describe("resolveSourceImageBytes", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("takes the first image block and ignores the videos", async () => {
+    const bytes = await resolvers().resolveSourceImageBytes(
+      {
+        content: [
+          videoBlock({ uri: `data:video/mp4;base64,${b64([9])}` }),
+          imageBlock({ uri: `data:image/png;base64,${b64([1, 2])}` }),
+          imageBlock({ uri: `data:image/png;base64,${b64([3, 4])}` })
+        ]
+      },
+      {},
+      "user-1"
+    );
+    expect(bytes).toEqual(new Uint8Array([1, 2]));
+  });
+
+  it("skips a block it cannot resolve rather than answering null", async () => {
+    const bytes = await resolvers().resolveSourceImageBytes(
+      {
+        content: [
+          imageBlock({ asset_id: "does-not-exist" }),
+          imageBlock({ data: b64([5, 6]) })
+        ]
+      },
+      {},
+      "user-1"
+    );
+    expect(bytes).toEqual(new Uint8Array([5, 6]));
+  });
+
+  it("answers null when nothing resolves", async () => {
+    const bytes = await resolvers().resolveSourceImageBytes(
+      { content: [imageBlock({ asset_id: "does-not-exist" })] },
+      {},
+      "user-1"
+    );
+    expect(bytes).toBeNull();
+  });
+});

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -171,6 +171,9 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
   const imageEditParams = useMediaGenerationStore((s) => s.imageEdit);
   const videoParams = useMediaGenerationStore((s) => s.video);
   const imageToVideoParams = useMediaGenerationStore((s) => s.imageToVideo);
+  const referenceToVideoParams = useMediaGenerationStore(
+    (s) => s.referenceToVideo
+  );
   const audioParams = useMediaGenerationStore((s) => s.audio);
 
   // Language-model selection from chat store (used in chat mode & forwarded
@@ -390,6 +393,21 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
         num_inference_steps: imageToVideoParams.numInferenceSteps
       };
     }
+    if (mode === "reference_to_video") {
+      return {
+        mode: "reference_to_video",
+        provider: referenceToVideoParams.model?.provider ?? null,
+        model: referenceToVideoParams.model?.id ?? null,
+        aspect_ratio: referenceToVideoParams.aspectRatio,
+        resolution: referenceToVideoParams.resolution,
+        duration: referenceToVideoParams.duration,
+        // Only sent when on: a model that cannot take it rejects the request,
+        // so an off toggle must not state anything.
+        use_reference_video_audio: referenceToVideoParams.useReferenceVideoAudio
+          ? true
+          : null
+      };
+    }
     if (mode === "audio") {
       return {
         mode: "audio",
@@ -407,6 +425,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     imageEditParams,
     videoParams,
     imageToVideoParams,
+    referenceToVideoParams,
     audioParams
   ]);
 
@@ -445,6 +464,11 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
         ? "Describe the animation…"
         : "Describe how the dropped image should animate…";
     }
+    if (mode === "reference_to_video") {
+      return isMobile
+        ? "Describe the shot…"
+        : "Describe the shot — the attached images and videos are the references…";
+    }
     if (mode === "audio") {
       return "Type the text you want spoken…";
     }
@@ -475,6 +499,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     mode === "image_edit" ||
     mode === "video" ||
     mode === "image_to_video" ||
+    mode === "reference_to_video" ||
     mode === "audio";
 
   const chatModel = selectedModel ?? languageModel;
@@ -498,6 +523,12 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     if (mode === "image_to_video") {
       return { model: imageToVideoParams.model, label: "image to video" };
     }
+    if (mode === "reference_to_video") {
+      return {
+        model: referenceToVideoParams.model,
+        label: "reference to video"
+      };
+    }
     if (mode === "audio") {
       return { model: audioParams.model, label: "speech" };
     }
@@ -509,6 +540,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     imageEditParams.model,
     videoParams.model,
     imageToVideoParams.model,
+    referenceToVideoParams.model,
     audioParams.model
   ]);
 

--- a/web/src/components/chat/composer/MediaModeMenu.tsx
+++ b/web/src/components/chat/composer/MediaModeMenu.tsx
@@ -7,6 +7,7 @@ import ImageIcon from "@mui/icons-material/Image";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import MovieIcon from "@mui/icons-material/Movie";
 import MovieFilterIcon from "@mui/icons-material/MovieFilter";
+import BurstModeIcon from "@mui/icons-material/BurstMode";
 import GraphicEqIcon from "@mui/icons-material/GraphicEq";
 import RecordVoiceOverIcon from "@mui/icons-material/RecordVoiceOver";
 import ReplayIcon from "@mui/icons-material/Replay";
@@ -71,6 +72,13 @@ const MODES: ModeItem[] = [
     id: "image_to_video",
     label: "Animate Image",
     icon: <MovieFilterIcon fontSize="small" />,
+    enabled: true
+  },
+  {
+    id: "reference_to_video",
+    label: "Reference to Video",
+    description: "several references, one shot",
+    icon: <BurstModeIcon fontSize="small" />,
     enabled: true
   },
   {

--- a/web/src/components/chat/composer/ModeChips.tsx
+++ b/web/src/components/chat/composer/ModeChips.tsx
@@ -10,6 +10,8 @@ import React, { useMemo } from "react";
 import AppsIcon from "@mui/icons-material/Apps";
 import AspectRatioIcon from "@mui/icons-material/CropOriginal";
 import AudiotrackIcon from "@mui/icons-material/Audiotrack";
+import BurstModeIcon from "@mui/icons-material/BurstMode";
+import VolumeUpIcon from "@mui/icons-material/VolumeUp";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import DisplaySettingsIcon from "@mui/icons-material/Tv";
@@ -76,6 +78,22 @@ const AUDIO_FORMAT_OPTIONS: MediaOption<AudioFormat>[] = AUDIO_FORMATS.map(
 
 const { strengthOptions: STRENGTH_OPTIONS, stepsOptions: STEPS_OPTIONS } =
   buildImageEditOptions();
+
+/** Whether the first reference video's own audio survives into the result. */
+const REFERENCE_AUDIO_OPTIONS: MediaOption<string>[] = [
+  {
+    id: "off",
+    label: "Model audio",
+    description: "let the model score the clip",
+    icon: <VolumeUpIcon fontSize="small" />
+  },
+  {
+    id: "on",
+    label: "Reference audio",
+    description: "keep the reference video's track",
+    icon: <VolumeUpIcon fontSize="small" />
+  }
+];
 
 interface ModeChipsProps {
   mode: MediaMode;
@@ -365,6 +383,71 @@ function ImageToVideoModeChips({ openModelPickerRef }: ClusterProps) {
   );
 }
 
+function ReferenceToVideoModeChips({ openModelPickerRef }: ClusterProps) {
+  const params = useMediaGenerationStore((s) => s.referenceToVideo);
+  const setParams = useMediaGenerationStore((s) => s.setReferenceToVideoParams);
+  const addRecentModel = useModelPreferencesStore((s) => s.addRecent);
+  const { durationOptions, resolutionOptions, aspectOptions } = useMemo(
+    () => buildVideoModelOptions(params.model),
+    [params.model]
+  );
+
+  return (
+    <>
+      <ModelChip
+        openRef={openModelPickerRef}
+        icon={<BurstModeIcon fontSize="small" />}
+        label={params.model?.name || "Select Reference Model"}
+        picker={{
+          kind: "video",
+          task: "reference_to_video",
+          onPick: (model) => {
+            setParams(videoModelPatch(model, params));
+            addRecentModel(recentModelEntry(model));
+          }
+        }}
+      />
+      <OptionChip
+        menu="option"
+        icon={<AccessTimeIcon fontSize="small" />}
+        label={`${params.duration} Sec`}
+        header="Clip Duration"
+        value={params.duration}
+        options={durationOptions}
+        onChange={(duration) => setParams({ duration })}
+      />
+      <OptionChip
+        menu="option"
+        icon={<DisplaySettingsIcon fontSize="small" />}
+        label={params.resolution}
+        header="Video Resolution"
+        value={params.resolution}
+        options={resolutionOptions}
+        onChange={(resolution) => setParams({ resolution })}
+      />
+      <OptionChip
+        menu="aspect"
+        icon={<AspectRatioIcon fontSize="small" />}
+        label={params.aspectRatio}
+        value={params.aspectRatio}
+        options={aspectOptions}
+        onChange={(aspectRatio) => setParams({ aspectRatio })}
+      />
+      <OptionChip
+        menu="option"
+        icon={<VolumeUpIcon fontSize="small" />}
+        label={params.useReferenceVideoAudio ? "Reference audio" : "Model audio"}
+        header="Audio Source"
+        value={params.useReferenceVideoAudio ? "on" : "off"}
+        options={REFERENCE_AUDIO_OPTIONS}
+        onChange={(value) =>
+          setParams({ useReferenceVideoAudio: value === "on" })
+        }
+      />
+    </>
+  );
+}
+
 function AudioModeChips({ openModelPickerRef }: ClusterProps) {
   const params = useMediaGenerationStore((s) => s.audio);
   const setParams = useMediaGenerationStore((s) => s.setAudioParams);
@@ -442,6 +525,11 @@ export function ModeChips({ mode, openModelPickerRef }: ModeChipsProps) {
   }
   if (mode === "image_to_video") {
     return <ImageToVideoModeChips openModelPickerRef={openModelPickerRef} />;
+  }
+  if (mode === "reference_to_video") {
+    return (
+      <ReferenceToVideoModeChips openModelPickerRef={openModelPickerRef} />
+    );
   }
   if (mode === "audio") {
     return <AudioModeChips openModelPickerRef={openModelPickerRef} />;

--- a/web/src/components/chat/composer/ModeSelectChip.tsx
+++ b/web/src/components/chat/composer/ModeSelectChip.tsx
@@ -8,6 +8,7 @@ import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import ChatBubbleOutlineIcon from "@mui/icons-material/ChatBubbleOutline";
 import ImageIcon from "@mui/icons-material/Image";
+import BurstModeIcon from "@mui/icons-material/BurstMode";
 import MovieFilterIcon from "@mui/icons-material/MovieFilter";
 import RecordVoiceOverIcon from "@mui/icons-material/RecordVoiceOver";
 import VideocamIcon from "@mui/icons-material/Videocam";
@@ -28,6 +29,9 @@ export function modeIconFor(mode: MediaMode): React.ReactNode {
   }
   if (mode === "image_to_video") {
     return <MovieFilterIcon fontSize="small" />;
+  }
+  if (mode === "reference_to_video") {
+    return <BurstModeIcon fontSize="small" />;
   }
   if (mode === "audio") {
     return <RecordVoiceOverIcon fontSize="small" />;
@@ -50,6 +54,9 @@ export function modeLabelFor(mode: MediaMode): string {
   }
   if (mode === "image_to_video") {
     return "Image→Video";
+  }
+  if (mode === "reference_to_video") {
+    return "Refs→Video";
   }
   if (mode === "audio") {
     return "Speech";

--- a/web/src/components/chat/composer/__tests__/MediaChatComposer.test.tsx
+++ b/web/src/components/chat/composer/__tests__/MediaChatComposer.test.tsx
@@ -89,6 +89,7 @@ const MEDIA_DEFAULTS = (() => {
     imageEdit: s.imageEdit,
     video: s.video,
     imageToVideo: s.imageToVideo,
+    referenceToVideo: s.referenceToVideo,
     audio: s.audio
   };
 })();
@@ -313,5 +314,74 @@ describe("MediaChatComposer", () => {
       provider: "fal_ai",
       model: "flux"
     });
+  });
+
+  it("sends reference-to-video with the shot params, and the audio flag only when on", async () => {
+    const user = userEvent.setup();
+    const onSendMessage = jest.fn();
+    const setMode = (useReferenceVideoAudio: boolean) =>
+      useMediaGenerationStore.setState({
+        mode: "reference_to_video",
+        referenceToVideo: {
+          ...MEDIA_DEFAULTS.referenceToVideo,
+          model: {
+            type: "video_model",
+            id: "minimax/h3/reference-to-video",
+            provider: "fal_ai",
+            name: "Minimax H3"
+          },
+          duration: 6,
+          resolution: "1080p",
+          aspectRatio: "9:16",
+          useReferenceVideoAudio
+        }
+      });
+
+    setMode(false);
+    const off = renderComposer(onSendMessage);
+    await user.click(promptBox());
+    await user.keyboard("she walks into frame");
+    await user.click(screen.getByRole("button", { name: "Generate" }));
+
+    expect(onSendMessage.mock.calls[0][2]).toEqual({
+      mode: "reference_to_video",
+      provider: "fal_ai",
+      model: "minimax/h3/reference-to-video",
+      aspect_ratio: "9:16",
+      resolution: "1080p",
+      duration: 6,
+      // A model that cannot take reference audio rejects the request, so an
+      // off toggle must state nothing rather than `false`.
+      use_reference_video_audio: null
+    });
+    off.unmount();
+
+    onSendMessage.mockClear();
+    setMode(true);
+    renderComposer(onSendMessage);
+    await user.click(promptBox());
+    await user.keyboard("she walks into frame");
+    await user.click(screen.getByRole("button", { name: "Generate" }));
+
+    expect(onSendMessage.mock.calls[0][2]).toMatchObject({
+      use_reference_video_audio: true
+    });
+  });
+
+  it("opens the video picker instead of sending when no reference model is picked", async () => {
+    const user = userEvent.setup();
+    const onSendMessage = jest.fn();
+    useMediaGenerationStore.setState({
+      mode: "reference_to_video",
+      referenceToVideo: { ...MEDIA_DEFAULTS.referenceToVideo, model: null }
+    });
+    renderComposer(onSendMessage);
+
+    await user.click(promptBox());
+    await user.keyboard("she walks into frame");
+    await user.click(screen.getByRole("button", { name: "Generate" }));
+
+    expect(onSendMessage).not.toHaveBeenCalled();
+    expect(screen.getByTestId("video-model-dialog")).toBeInTheDocument();
   });
 });

--- a/web/src/components/chat/composer/__tests__/useMediaCostEstimate.test.ts
+++ b/web/src/components/chat/composer/__tests__/useMediaCostEstimate.test.ts
@@ -33,7 +33,30 @@ const setImage = (patch: Parameters<
     useMediaGenerationStore.getState().setImageParams(patch);
   });
 
+const setReferenceToVideo = (patch: Parameters<
+  ReturnType<typeof useMediaGenerationStore.getState>["setReferenceToVideoParams"]
+>[0]) =>
+  act(() => {
+    useMediaGenerationStore.getState().setReferenceToVideoParams(patch);
+  });
+
 describe("useMediaCostEstimate", () => {
+  it("prices a reference-to-video clip off its own duration and rung", () => {
+    setReferenceToVideo({
+      model: VIDEO_MODEL,
+      duration: 5,
+      resolution: "720p"
+    });
+    const { result, rerender } = renderHook(() =>
+      useMediaCostEstimate("reference_to_video")
+    );
+    expect(result.current?.total).toBeCloseTo(0.5, 10);
+
+    setReferenceToVideo({ duration: 10 });
+    rerender();
+    expect(result.current?.total).toBeCloseTo(1, 10);
+  });
+
   it("returns nothing while no model is picked", () => {
     setVideo({ model: null });
     const { result } = renderHook(() => useMediaCostEstimate("video"));

--- a/web/src/components/chat/composer/__tests__/useModeProviderSetup.test.tsx
+++ b/web/src/components/chat/composer/__tests__/useModeProviderSetup.test.tsx
@@ -37,6 +37,7 @@ describe("capabilityForMode", () => {
     expect(capabilityForMode("image_edit")).toBe("text_to_image");
     expect(capabilityForMode("video")).toBe("text_to_video");
     expect(capabilityForMode("image_to_video")).toBe("text_to_video");
+    expect(capabilityForMode("reference_to_video")).toBe("text_to_video");
     expect(capabilityForMode("audio")).toBe("text_to_speech");
   });
 
@@ -54,6 +55,7 @@ describe("capabilityForMode", () => {
       "image_edit",
       "video",
       "image_to_video",
+      "reference_to_video",
       "audio"
     ] as const) {
       expect(setupReasonForMode(mode)).toEqual(expect.any(String));

--- a/web/src/components/chat/composer/modeProviderSetup.ts
+++ b/web/src/components/chat/composer/modeProviderSetup.ts
@@ -20,6 +20,7 @@ export const capabilityForMode = (
       return "text_to_image";
     case "video":
     case "image_to_video":
+    case "reference_to_video":
       return "text_to_video";
     case "audio":
       return "text_to_speech";
@@ -41,6 +42,8 @@ export const setupReasonForMode = (mode: MediaMode): string | null => {
       return "Generating videos needs a video provider. Connect one to continue.";
     case "image_to_video":
       return "Animating images needs a video provider. Connect one to continue.";
+    case "reference_to_video":
+      return "Reference to video needs a video provider. Connect one to continue.";
     case "audio":
       return "Generating speech needs a text-to-speech provider. Connect one to continue.";
     default:

--- a/web/src/components/chat/composer/useMediaCostEstimate.ts
+++ b/web/src/components/chat/composer/useMediaCostEstimate.ts
@@ -57,6 +57,7 @@ export function useMediaCostEstimate(mode: MediaMode): MediaCostEstimate | null 
   const imageEdit = useMediaGenerationStore((s) => s.imageEdit);
   const video = useMediaGenerationStore((s) => s.video);
   const imageToVideo = useMediaGenerationStore((s) => s.imageToVideo);
+  const referenceToVideo = useMediaGenerationStore((s) => s.referenceToVideo);
   const audio = useMediaGenerationStore((s) => s.audio);
 
   return useMemo(() => {
@@ -108,6 +109,16 @@ export function useMediaCostEstimate(mode: MediaMode): MediaCostEstimate | null 
           quantity: 1
         };
       }
+      if (mode === "reference_to_video") {
+        return {
+          model: referenceToVideo.model,
+          params: {
+            resolution: referenceToVideo.resolution,
+            seconds: referenceToVideo.duration
+          },
+          quantity: 1
+        };
+      }
       if (mode === "audio") {
         return { model: audio.model, params: {}, quantity: 1 };
       }
@@ -136,7 +147,7 @@ export function useMediaCostEstimate(mode: MediaMode): MediaCostEstimate | null 
       assumptions: price.assumptions,
       warnings: price.warnings
     };
-  }, [mode, image, imageEdit, video, imageToVideo, audio]);
+  }, [mode, image, imageEdit, video, imageToVideo, referenceToVideo, audio]);
 }
 
 export default useMediaCostEstimate;

--- a/web/src/stores/MediaGenerationStore.ts
+++ b/web/src/stores/MediaGenerationStore.ts
@@ -34,6 +34,8 @@ export interface MediaGenerationRequest {
   strength?: number | null;
   num_inference_steps?: number | null;
   source_asset_id?: string | null;
+  /** Keep the first reference video's audio (reference_to_video). */
+  use_reference_video_audio?: boolean | null;
   extras?: Record<string, unknown> | null;
 }
 
@@ -53,6 +55,7 @@ export type MediaMode =
   | "image_edit"
   | "video"
   | "image_to_video"
+  | "reference_to_video"
   | "audio"
   | "audio_to_video"
   | "retake"
@@ -189,18 +192,31 @@ interface ImageToVideoGenerationParams {
   numInferenceSteps: number;
 }
 
+interface ReferenceToVideoGenerationParams {
+  model: VideoModelSelection | null;
+  resolution: VideoResolution;
+  aspectRatio: string;
+  duration: number;
+  /** Keep the audio of the first reference video instead of synthesizing. */
+  useReferenceVideoAudio: boolean;
+}
+
 interface MediaGenerationState {
   mode: MediaMode;
   image: ImageGenerationParams;
   imageEdit: ImageEditParams;
   video: VideoGenerationParams;
   imageToVideo: ImageToVideoGenerationParams;
+  referenceToVideo: ReferenceToVideoGenerationParams;
   audio: AudioGenerationParams;
   setMode: (mode: MediaMode) => void;
   setImageParams: (params: Partial<ImageGenerationParams>) => void;
   setImageEditParams: (params: Partial<ImageEditParams>) => void;
   setVideoParams: (params: Partial<VideoGenerationParams>) => void;
   setImageToVideoParams: (params: Partial<ImageToVideoGenerationParams>) => void;
+  setReferenceToVideoParams: (
+    params: Partial<ReferenceToVideoGenerationParams>
+  ) => void;
   setAudioParams: (params: Partial<AudioGenerationParams>) => void;
 }
 
@@ -242,6 +258,14 @@ const DEFAULT_IMAGE_TO_VIDEO_PARAMS: ImageToVideoGenerationParams = {
   numInferenceSteps: 30
 };
 
+const DEFAULT_REFERENCE_TO_VIDEO_PARAMS: ReferenceToVideoGenerationParams = {
+  model: null,
+  resolution: "1080p",
+  aspectRatio: "16:9",
+  duration: 5,
+  useReferenceVideoAudio: false
+};
+
 const useMediaGenerationStore = create<MediaGenerationState>()(
   persist(
     (set) => ({
@@ -250,6 +274,7 @@ const useMediaGenerationStore = create<MediaGenerationState>()(
       imageEdit: DEFAULT_IMAGE_EDIT_PARAMS,
       video: DEFAULT_VIDEO_PARAMS,
       imageToVideo: DEFAULT_IMAGE_TO_VIDEO_PARAMS,
+      referenceToVideo: DEFAULT_REFERENCE_TO_VIDEO_PARAMS,
       audio: DEFAULT_AUDIO_PARAMS,
       setMode: (mode) => set({ mode }),
       setImageParams: (params) =>
@@ -262,16 +287,20 @@ const useMediaGenerationStore = create<MediaGenerationState>()(
         set((state) => ({
           imageToVideo: { ...state.imageToVideo, ...params }
         })),
+      setReferenceToVideoParams: (params) =>
+        set((state) => ({
+          referenceToVideo: { ...state.referenceToVideo, ...params }
+        })),
       setAudioParams: (params) =>
         set((state) => ({ audio: { ...state.audio, ...params } }))
     }),
     {
       name: "nodetool-media-generation",
-      version: 2,
+      version: 3,
       migrate: (persistedState, version) => {
-        const state = (persistedState ?? {}) as Partial<MediaGenerationState>;
+        let state = (persistedState ?? {}) as Partial<MediaGenerationState>;
         if (version < 2) {
-          return {
+          state = {
             ...state,
             audio: { ...DEFAULT_AUDIO_PARAMS, ...(state.audio ?? {}) },
             imageEdit: {
@@ -282,7 +311,16 @@ const useMediaGenerationStore = create<MediaGenerationState>()(
               ...DEFAULT_IMAGE_TO_VIDEO_PARAMS,
               ...(state.imageToVideo ?? {})
             }
-          } as MediaGenerationState;
+          };
+        }
+        if (version < 3) {
+          state = {
+            ...state,
+            referenceToVideo: {
+              ...DEFAULT_REFERENCE_TO_VIDEO_PARAMS,
+              ...(state.referenceToVideo ?? {})
+            }
+          };
         }
         return state as MediaGenerationState;
       }


### PR DESCRIPTION
## What changed

The runtime already carried `reference_to_video` end to end — provider methods, the capability dispatch in `ProcessingContext`, and the `generate_media` RPC the storyboard shot path uses — but neither the chat composer nor the agent toolbelt could reach it, so a set of references defining one shot had no route that did not go through a storyboard. This adds both. **Chat mode:** a `reference_to_video` entry in `MediaGenerationMode` with its own chip cluster (model, duration, resolution, aspect, audio source) and its branch in the chat turn, which sends every image and video on the message plus the reference images of any `@`-mentioned entity, so the prompt describes the action and the camera rather than the subjects; the reference-audio flag is forwarded only when the composer set it, because a model that cannot take it rejects the request rather than dropping the audio. `resolveSourceImageBytes` grew a sibling for this and the two now share one per-block loader — the first usable image for `image_edit`/`image_to_video`, every image and video for `reference_to_video`; a reference whose bytes cannot be reached drops, and the turn refuses only when nothing at all resolved. **Agent capability:** `generate_video_from_references` takes `reference_files` of mixed workspace paths and asset URIs and routes each by its own kind — the extension when the caller stated one, magic bytes otherwise, and a refusal rather than a guess when it is neither — and, like `animate_image`, takes its aspect from the first image reference when the call names none.

## Verification

- [x] `npm run test:affected` — 101/102 tasks green. The one failure is `@nodetool-ai/image-nodes#test`: `No WebGPU adapter available (Node/Dawn)`, the missing-Vulkan-driver case AGENTS.md names explicitly. Suites for the packages this diff touches all pass: `packages/agents` 76 (capabilities-media + capabilities-registry), `packages/websocket` 25 (chat-turn-handler-media + the new session-media-references), `packages/cli` 790, `web` 2153 across composer/stores/chat-core.
- [x] `npm run typecheck` — electron clean; web reports one error, `src/components/projects/__tests__/projectStarters.test.ts(43,3)` (`isPersonal` missing), which reproduces identically with this diff stashed. Mobile cannot run here: `mobile/node_modules` does not exist and this diff touches no mobile file.
- [x] `npm run lint` — exit 0.
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — **Gate: 7/7 selfchecks passed**. It first failed `capability-suites` on the checked-in name → category snapshot in `capabilities-registry.test.ts`, which the new capability had to join.

Both new behaviors were inverted once and observed failing:

- Dropping `entityImageBytes` from the chat turn's reference list:
  `AssertionError: expected { images: [ …(2) ], videos: [ …(1) ] } to deeply equal { images: [ …(3) ], videos: [ …(1) ] }`
- `break`ing out of the reference collect loop after the first hit:
  `AssertionError: expected [ Uint8Array[ 1, 1 ] ] to deeply equal [ Uint8Array[ 1, 1 ], …(1) ]`

## Agent capabilities

- [x] `npm run capabilities:check` passes (`capability table is current (282 capabilities)`).
- [x] `generate_video_from_references` is listed in `packages/cli/src/harness/capability-table.ts` with `selfcheck: capability-suites` naming `packages/agents/tests/capabilities-media.test.ts` — covered, not a gap. That suite pins the image/video split, the three refusals (unclassifiable reference, empty list, reference audio with no reference video), and the derived aspect ratio.

## New checks

No new rule or audit — the added checks are ordinary test suites, and the two inversions above are in **Verification**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aAod917Z4AmXFMrhP4U8N

---
_Generated by [Claude Code](https://claude.ai/code/session_013aAod917Z4AmXFMrhP4U8N)_