### PR TITLE
fix(compute): honor the full WorkerSpec in the Vast.ai provider

### DIFF
--- a/packages/compute/src/__tests__/vast-provider.test.ts
+++ b/packages/compute/src/__tests__/vast-provider.test.ts
@@ -208,6 +208,132 @@ describe("VastProvider.provision", () => {
     const searchBody = JSON.parse((searchInit as RequestInit).body as string);
     expect(searchBody.q.disk_space).toEqual({ gte: 250 });
   });
+
+  it("constrains the offer search by the requested GPU count and vCPU floor", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ offers: [{ id: 555, gpu_name: "RTX 4090" }] })
+    );
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ success: true, new_contract: 9001 })
+    );
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ instances: readyInstance() })
+    );
+
+    const provider = new VastProvider(API_KEY);
+    await provider.provision(baseSpec({ gpuCount: 4, vcpu: 32 }));
+
+    const [, searchInit] = mockFetch.mock.calls[0];
+    const searchBody = JSON.parse((searchInit as RequestInit).body as string);
+    // Without these the cheapest offer is a single-GPU box and the spec's
+    // gpuCount/vcpu are silently dropped.
+    expect(searchBody.q.num_gpus).toEqual({ gte: 4 });
+    expect(searchBody.q.cpu_cores_effective).toEqual({ gte: 32 });
+  });
+
+  it("omits the GPU-count and vCPU filters when the spec does not ask for them", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ offers: [{ id: 555, gpu_name: "RTX 4090" }] })
+    );
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ success: true, new_contract: 9001 })
+    );
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ instances: readyInstance() })
+    );
+
+    const provider = new VastProvider(API_KEY);
+    await provider.provision(baseSpec());
+
+    const [, searchInit] = mockFetch.mock.calls[0];
+    const searchBody = JSON.parse((searchInit as RequestInit).body as string);
+    expect(searchBody.q.num_gpus).toBeUndefined();
+    expect(searchBody.q.cpu_cores_effective).toBeUndefined();
+  });
+
+  it("publishes the worker port as a Docker flag in env, not as entrypoint args", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ offers: [{ id: 555, gpu_name: "RTX 4090" }] })
+    );
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ success: true, new_contract: 9001 })
+    );
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ instances: readyInstance() })
+    );
+
+    const provider = new VastProvider(API_KEY);
+    await provider.provision(baseSpec());
+
+    const [, launchInit] = mockFetch.mock.calls[1];
+    const launchBody = JSON.parse((launchInit as RequestInit).body as string);
+    // Vast reads `-p` mappings out of env; `args` reaches the image entrypoint
+    // and would leave 7777 unpublished, so the attach URL could never resolve.
+    expect(launchBody.env["-p 7777:7777"]).toBe("1");
+    expect(launchBody.args).toBeUndefined();
+    expect(launchBody.runtype).toBe("args");
+  });
+
+  it("labels the instance with the profile name", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ offers: [{ id: 555, gpu_name: "RTX 4090" }] })
+    );
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ success: true, new_contract: 9001 })
+    );
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ instances: readyInstance() })
+    );
+
+    const provider = new VastProvider(API_KEY);
+    await provider.provision(baseSpec({ name: "sdxl-worker" }));
+
+    const [, launchInit] = mockFetch.mock.calls[1];
+    const launchBody = JSON.parse((launchInit as RequestInit).body as string);
+    expect(launchBody.label).toBe("sdxl-worker");
+  });
+
+  it("passes an ssh public key as PUBLIC_KEY and publishes port 22", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ offers: [{ id: 555, gpu_name: "RTX 4090" }] })
+    );
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ success: true, new_contract: 9001 })
+    );
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ instances: readyInstance() })
+    );
+
+    const provider = new VastProvider(API_KEY);
+    await provider.provision(
+      baseSpec({ sshPublicKey: "  ssh-ed25519 AAAAC3Nz key  " })
+    );
+
+    const [, launchInit] = mockFetch.mock.calls[1];
+    const launchBody = JSON.parse((launchInit as RequestInit).body as string);
+    expect(launchBody.env.PUBLIC_KEY).toBe("ssh-ed25519 AAAAC3Nz key");
+    expect(launchBody.env["-p 22:22"]).toBe("1");
+  });
+
+  it("leaves port 22 unpublished when the spec carries no ssh key", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ offers: [{ id: 555, gpu_name: "RTX 4090" }] })
+    );
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ success: true, new_contract: 9001 })
+    );
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ instances: readyInstance() })
+    );
+
+    const provider = new VastProvider(API_KEY);
+    await provider.provision(baseSpec());
+
+    const [, launchInit] = mockFetch.mock.calls[1];
+    const launchBody = JSON.parse((launchInit as RequestInit).body as string);
+    expect(launchBody.env.PUBLIC_KEY).toBeUndefined();
+    expect(launchBody.env["-p 22:22"]).toBeUndefined();
+  });
 });
 
 describe("VastProvider.status", () => {

--- a/packages/compute/src/providers/vast.ts
+++ b/packages/compute/src/providers/vast.ts
@@ -26,6 +26,9 @@ const VAST_API_BASE_URL = "https://console.vast.ai/api/v0";
 /** Internal port the worker serves on. */
 const WORKER_PORT = 7777;
 
+/** Internal sshd port, published only when the spec carries a public key. */
+const SSH_PORT = 22;
+
 type HttpMethod = "GET" | "PUT" | "DELETE";
 
 /** A Vast.ai instance as returned by the API (fields we read). */
@@ -181,8 +184,9 @@ export class VastProvider implements WorkerProvider {
 
   /**
    * Search the marketplace for the cheapest rentable offer matching the spec's
-   * GPU. Returns the offer id plus its `dph_total` (total dollars-per-hour), the
-   * estimated cost the cost guard records on the instance.
+   * GPU, GPU count and vCPU floor. Returns the offer id plus its `dph_total`
+   * (total dollars-per-hour), the estimated cost the cost guard records on the
+   * instance.
    */
   private async findOffer(
     spec: WorkerSpec
@@ -199,6 +203,14 @@ export class VastProvider implements WorkerProvider {
     };
     if (spec.gpu) {
       query.gpu_name = { eq: spec.gpu };
+    }
+    // A multi-GPU request must constrain the search: the cheapest offer is a
+    // single-GPU machine, so without this the launch silently under-delivers.
+    if (spec.gpuCount !== undefined) {
+      query.num_gpus = { gte: spec.gpuCount };
+    }
+    if (spec.vcpu !== undefined) {
+      query.cpu_cores_effective = { gte: spec.vcpu };
     }
     const res = await vastApi(this.apiKey, "bundles/", "PUT", {
       q: query,
@@ -222,14 +234,30 @@ export class VastProvider implements WorkerProvider {
     if (spec.token) env.NODETOOL_WORKER_TOKEN = spec.token;
     // Cache HF models on the instance disk so they survive a stop/resume.
     env.HF_HOME = WORKER_HF_HOME;
+    // Vast takes port mappings as Docker flags *inside* `env`, keyed by the
+    // flag with a dummy value — `args` goes to the image entrypoint instead and
+    // would never publish the port. Map the worker port out for the ws attach.
+    env[`-p ${WORKER_PORT}:${WORKER_PORT}`] = "1";
+
+    const sshKey = spec.sshPublicKey?.trim();
+    if (sshKey) {
+      // Same contract as RunPod: the key is an *image* convention — the worker
+      // entrypoint installs PUBLIC_KEY and starts sshd — so it carries over to
+      // Vast unchanged. Vast's account-level keys only apply to its own `ssh`
+      // runtypes, and we run the image's entrypoint (`args`).
+      env.PUBLIC_KEY = sshKey;
+      env[`-p ${SSH_PORT}:${SSH_PORT}`] = "1";
+    }
 
     const res = await vastApi(this.apiKey, `asks/${offerId}/`, "PUT", {
       image: spec.image,
+      // Names the instance in the Vast console, so a rented worker can be
+      // matched to its profile by hand during a reconcile.
+      label: spec.name,
       disk: spec.disk ?? DEFAULT_VOLUME_GB,
       env,
-      // Map the worker's internal port out for the direct ws:// attach.
+      // Run the image's own entrypoint (the worker), not Vast's ssh/jupyter.
       runtype: "args",
-      args: ["-p", `${WORKER_PORT}:${WORKER_PORT}`],
     });
     // The launch response is `{success, new_contract}` per the Vast HTTP API
     // (https://console.vast.ai/api/v0). On failure it carries `error`/`message`


### PR DESCRIPTION
## What changed

`VastProvider` implemented the `WorkerProvider` lifecycle but dropped four `WorkerSpec` fields that `RunpodPodProvider` honors, and published the worker port through the wrong Vast API field. The port bug is the significant one: Vast reads `-p` mappings out of the `env` dict as Docker flags, but the launch sent them as `args`, which reach the *image entrypoint* instead — so 7777 was never published and `provision` could only ever fail on "became running without a reachable port mapping". `gpuCount` and `vcpu` did not constrain the offer search, so a multi-GPU or high-vCPU profile landed on whatever single-GPU box was cheapest; they now filter on `num_gpus` and `cpu_cores_effective`. `sshPublicKey` was ignored, leaving a rented Vast worker reachable only through the execution bridge — `PUBLIC_KEY` is an image-entrypoint convention rather than a RunPod one, so it carries over unchanged alongside a published 22. `name` is now sent as the instance `label` so a rented worker can be matched to its profile in the Vast console during a manual reconcile.

Every field name and operator here is taken from the Vast API reference (create-instance body params, searchable fields and comparison operators), not inferred.

## Verification

- [x] `npm run test:affected` — the `packages/compute` leg passes: **94 tests, 7 files** (up from 88). The run as a whole fails on `@nodetool-ai/game-nodes#build`, which is unrelated and pre-existing: it fails identically with this diff stashed (4 × `TS2307` for missing `@nodetool-ai/godot` and `@nodetool-ai/godot-templates`).
- [x] `npm run typecheck` — `packages/compute` typechecks clean (`tsc --noEmit`, exit 0). The workspace-wide run fails on unbuilt node-package subpath exports in `web/src/lib/workflow/browserRunnerCore.ts`; also pre-existing, 24 × `TS2307` with this diff stashed.
- [x] `npm run lint` — exit 0, no findings on either changed file.
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — maps to nothing for this diff: `packages/compute/` is an explicit entry in `UNCLAIMED_PATHS` (`packages/cli/src/harness/registry.ts:1518`). The command itself cannot boot in this environment because the `game-nodes` build failure above leaves `@nodetool-ai/base-nodes/dist` missing.

## Agent capabilities

No capability added; no declared contract changed.

## New checks

Six test cases added to `vast-provider.test.ts`. Four assert new behavior and were run against the pre-change provider to confirm they go red:

```
× constrains the offer search by the requested GPU count and vCPU floor
× publishes the worker port as a Docker flag in env, not as entrypoint args
× labels the instance with the profile name
× passes an ssh public key as PUBLIC_KEY and publishes port 22
Tests  4 failed | 13 passed (17)
```

The other two are negative assertions (no `num_gpus`/`cpu_cores_effective` filter when the spec omits them; no port 22 without an SSH key) and pass in both directions by design — they pin that the new fields stay absent rather than being sent unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZvPEXitgxhv6KGWn2589n

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZvPEXitgxhv6KGWn2589n)_