### PR TITLE
feat(compute): add the Verda worker provisioning target

### DIFF
--- a/docs/worker-deployment.md
+++ b/docs/worker-deployment.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Worker Deployment"
-description: "Rent a GPU on RunPod or Vast.ai, attach it to NodeTool, and run Python nodes remotely — with a cost guard that tears it down."
+description: "Rent a GPU on RunPod, Vast.ai or Verda, attach it to NodeTool, and run Python nodes remotely — with a cost guard that tears it down."
 ---
 
 NodeTool runs most graphs on your machine. When a node needs a GPU you don't
@@ -41,7 +41,10 @@ tables live in NodeTool's SQLite DB so the UI and CLI share one source of truth.
 ## Prerequisites
 
 - A **RunPod** account and API key ([runpod.io console → settings](https://www.runpod.io/console/user/settings)),
-  or a **Vast.ai** account and API key.
+  a **Vast.ai** account and API key, or a **Verda** cloud API client id and
+  secret ([API credentials](https://docs.verda.com/welcome-to-verda/api-credentials/)).
+  Verda's cloud credentials are separate from its inference key, and are deleted
+  when the team member who created them is removed from the project.
 - A worker container image — the published NodeTool worker image, or your own
   built from a NodeTool Python package. It must run `python -m nodetool.worker`
   on port 7777 (msgpack RPC, bearer-token auth).
@@ -67,10 +70,12 @@ Store the API key in the secret store so the manager can read it:
 ```bash
 nodetool secrets store RUNPOD_API_KEY      # prompts for the value
 nodetool secrets store VAST_API_KEY        # for Vast.ai
+nodetool secrets store VERDA_CLIENT_ID     # for Verda (both are required)
+nodetool secrets store VERDA_CLIENT_SECRET
 ```
 
 If the secret store is unreachable (headless/sandboxed), the manager falls back
-to the `RUNPOD_API_KEY` / `VAST_API_KEY` environment variables.
+to the environment variables of the same names.
 
 ---
 
@@ -80,11 +85,46 @@ to the `RUNPOD_API_KEY` / `VAST_API_KEY` environment variables.
 |--------|----------|----------|----------|
 | `runpod` | RunPod **pod** (REST `rest.runpod.io/v1/pods`) | `wss://<podid>-7777.proxy.runpod.net` | deletes the pod |
 | `vast` | Vast.ai instance | `ws://<ip>:<port>` | destroys the instance |
+| `verda` | Verda **VM** (REST `api.verda.com/v1`) | `ws://<ip>:7777` | deletes the instance and permanently deletes its OS volume |
 
-Both run the **same worker image** — there is no per-provider image work. Local
+All three run the **same worker image** — there is no per-provider image work. Local
 or LAN workers are also supported, but unmanaged: run the worker container
 yourself and point `NODETOOL_WORKER_URL` (and `NODETOOL_WORKER_TOKEN`) at it.
 There is no provisioning provider for local Docker — you start and stop it.
+
+### Verda
+
+Verda rents **virtual machines**, not containers, so a Verda profile needs two
+images: the guest OS (`osImage`, a CUDA + Docker image from `GET /v1/images`)
+and the worker container (`image`, as on every target). Leave `osImage` unset
+and the provider picks a CUDA+Docker image from the live catalog.
+
+Its `gpu` field is a Verda **instance type** — `1H100.80S.30V`, not a GPU name.
+List the live ids with `GET /v1/instance-types`; availability is per-location,
+and a type absent from every location has no capacity right now.
+
+Three behaviours differ from RunPod and Vast, all of them cost-relevant:
+
+- **Verda bills a shut-down instance at the full rate**, and removed its
+  hibernate action for that reason. So NodeTool's pause does **not** shut the
+  machine down: it deletes the instance and retains the OS volume, which ends
+  the GPU charge while keeping the model cache. Resuming boots a **new machine**
+  from that volume, so its IP — and its provider handle — change.
+- **Terminate deletes the OS volume permanently.** A trashed volume still holds
+  storage quota and can be restored for a charge covering the deleted interval,
+  which is not what teardown promises. The cached models are gone for good.
+- **Only Pay As You Go is used.** Long-term contracts are prepaid, and spot
+  instances can be discontinued mid-workflow; neither is chosen for you.
+
+A Verda worker publishes port 7777 on a public IP, and Verda's own [security
+guide](https://docs.verda.com/cpu-and-gpu-instances/securing-your-instance/)
+warns that a UFW rule does not block a Docker-published port. The provider
+therefore refuses to launch a worker with no bearer token — keep
+`token_policy` on `generate` unless you have a specific reason not to.
+
+Pay As You Go bills in prepaid ten-minute increments, and running out of balance
+can discontinue instances and delete volumes. A low balance is not harmless
+billing metadata.
 
 ---
 
@@ -131,7 +171,7 @@ only the token so it pipes cleanly into `NODETOOL_WORKER_TOKEN`.
 ### CLI reference
 
 ```bash
-nodetool worker profile add <name> --target <runpod|vast> --image <img> \
+nodetool worker profile add <name> --target <runpod|vast|verda> --image <img> \
     [--gpu <type>] [--vcpu <n>] \
     [--token-policy <generate|fixed>] \
     [--idle-timeout <minutes>] [--max-lifetime <minutes>]
@@ -195,7 +235,7 @@ from. A profile that sets neither opts its instances out of the reaper entirely
 ## How provisioning works
 
 1. `WorkerManager.provision(profileName)` looks up the profile and resolves the
-   target's provider (RunPod or Vast).
+   target's provider (RunPod, Vast or Verda).
 2. If the profile's `token_policy` is `generate`, it mints a high-entropy bearer
    token for the worker.
 3. The provider launches the image on the chosen GPU/spec, polls until the box

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -31,7 +31,7 @@ import { getDefaultDbPath } from "@nodetool-ai/config";
 import { registerWorkerModelsCommands } from "./worker-models.js";
 import { printTable, asJson } from "./output.js";
 
-const SUPPORTED_TARGETS = ["runpod", "vast"] as const;
+const SUPPORTED_TARGETS = ["runpod", "vast", "verda"] as const;
 type SupportedTarget = (typeof SUPPORTED_TARGETS)[number];
 const TOKEN_POLICIES = ["generate", "fixed"] as const satisfies readonly TokenPolicy[];
 

--- a/packages/compute/src/__tests__/manager.test.ts
+++ b/packages/compute/src/__tests__/manager.test.ts
@@ -147,6 +147,9 @@ class FakeProvider implements WorkerProvider {
   public costUsd: number | undefined;
   /** ws URL resume() reports back (defaults to a fresh one). */
   public resumeWsUrl = "wss://pod-resumed-7777.proxy.runpod.net";
+  /** Handle resume() reports back. Verda hands back a NEW one: it releases the
+   * machine on stop and boots a fresh one from the retained disk. */
+  public resumeProviderRef: string | null = null;
 
   async provision(spec: WorkerSpec): Promise<ProvisionResult> {
     this.provisioned.push(spec);
@@ -170,7 +173,7 @@ class FakeProvider implements WorkerProvider {
   async resume(ref: string): Promise<ProvisionResult> {
     this.resumed.push(ref);
     return {
-      providerRef: ref,
+      providerRef: this.resumeProviderRef ?? ref,
       wsUrl: this.resumeWsUrl,
       status: "running",
       costUsd: this.costUsd,
@@ -411,6 +414,29 @@ describe("WorkerManager — resume / terminate", () => {
     );
   });
 
+  it("resume adopts a provider handle that changed across the pause", async () => {
+    // A Verda pause DELETES the machine and keeps its disk, so resuming boots
+    // a new instance with a new handle. Dropping it would leave the registry
+    // pointing at a dead machine while the live one billed untracked, and a
+    // later stop/terminate would act on nothing.
+    const { manager, models, provider } = makeManager();
+    provider.resumeProviderRef = "verda:new-handle";
+    await manager.createProfile(PROFILE_INPUT);
+    const instance = await manager.provision("hf-a40");
+    await manager.stop(instance.id);
+
+    const resumed = await manager.resume(instance.id);
+
+    expect(resumed.provider_ref).toBe("verda:new-handle");
+    expect(models.instances.get(instance.id)?.provider_ref).toBe(
+      "verda:new-handle"
+    );
+
+    // The teardown that follows must target the NEW machine.
+    await manager.terminate(instance.id);
+    expect(provider.terminated).toEqual(["verda:new-handle"]);
+  });
+
   it("terminate destroys the provider resource and marks the instance terminated", async () => {
     const { manager, models, provider } = makeManager();
     await manager.createProfile(PROFILE_INPUT);
@@ -491,7 +517,9 @@ describe("WorkerManager — API key resolution", () => {
     await manager.provision("hf-a40");
 
     expect(getSecret).toHaveBeenCalledWith("RUNPOD_API_KEY", expect.anything());
-    expect(factory).toHaveBeenCalledWith("runpod", "secret-runpod-key");
+    expect(factory).toHaveBeenCalledWith("runpod", {
+      RUNPOD_API_KEY: "secret-runpod-key",
+    });
   });
 
   it("falls back to the environment when the secret store has no key", async () => {
@@ -505,7 +533,9 @@ describe("WorkerManager — API key resolution", () => {
 
       await manager.provision("hf-a40");
 
-      expect(factory).toHaveBeenCalledWith("runpod", "env-runpod-key");
+      expect(factory).toHaveBeenCalledWith("runpod", {
+        RUNPOD_API_KEY: "env-runpod-key",
+      });
     } finally {
       if (prev === undefined) {
         delete process.env.RUNPOD_API_KEY;
@@ -795,6 +825,7 @@ describe("WorkerManager — reconcile", () => {
       await expect(manager.apiKeyStatus()).resolves.toEqual({
         runpod: true,
         vast: true,
+        verda: true,
       });
     });
 

--- a/packages/compute/src/__tests__/verda-provider.test.ts
+++ b/packages/compute/src/__tests__/verda-provider.test.ts
@@ -1,0 +1,538 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { VerdaProvider } from "../providers/verda.js";
+import { VerdaApiClient, assertSafeId } from "../providers/verda-api.js";
+import type { WorkerSpec } from "../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// Setup — mock the global fetch the Verda transport uses. Every test drives the
+// provider through recorded response shapes taken from the published OpenAPI
+// schema (https://api.verda.com/v1/openapi.json), so no live calls are made.
+// ---------------------------------------------------------------------------
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function response(
+  body: unknown,
+  status = 200,
+  headers: Record<string, string> = {}
+): Response {
+  const text = typeof body === "string" ? body : JSON.stringify(body ?? "");
+  const partial: Pick<Response, "ok" | "status" | "json" | "text" | "headers"> =
+    {
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(body === null ? "" : text),
+      headers: new Headers(headers),
+    };
+  // SAFETY: the code under test reads only ok/status/json/text/headers.
+  return partial as Response;
+}
+
+const CREDENTIALS = { clientId: "client-id", clientSecret: "client-secret" };
+
+/** The token every authenticated call is preceded by. */
+function tokenResponse(): Response {
+  return response({
+    access_token: "access-token",
+    token_type: "Bearer",
+    expires_in: 3600,
+    refresh_token: "refresh-token",
+    scope: "cloud-api-v1",
+  });
+}
+
+const OS_IMAGES = [
+  { id: "img-1", image_type: "ubuntu-22.04", name: "Ubuntu 22.04" },
+  {
+    id: "img-2",
+    image_type: "ubuntu-24.04-cuda-12.8-docker",
+    name: "Ubuntu 24.04 + CUDA 12.8 + Docker",
+  },
+];
+
+const AVAILABILITY = [
+  { location_code: "FIN-01", availabilities: ["1H100.80S.30V"] },
+  { location_code: "ICE-01", availabilities: ["1H100.80S.30V", "1V100.6V"] },
+];
+
+function runningInstance(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    ip: "203.0.113.9",
+    status: "running",
+    hostname: "hf-worker",
+    instance_type: "1H100.80S.30V",
+    location: "FIN-01",
+    os_volume_id: "22222222-2222-2222-2222-222222222222",
+    volume_ids: [],
+    ssh_key_ids: [],
+    startup_script_id: "33333333-3333-3333-3333-333333333333",
+    price_per_hour: 2.45,
+    ...overrides,
+  };
+}
+
+function baseSpec(overrides: Partial<WorkerSpec> = {}): WorkerSpec {
+  return {
+    name: "HF Worker",
+    image: "ghcr.io/nodetool-ai/nodetool-worker:0.7.3",
+    target: "verda",
+    gpu: "1H100.80S.30V",
+    token: "worker-secret",
+    ...overrides,
+  };
+}
+
+/**
+ * Queue the responses a successful provision consumes, in order:
+ * token, images, availability, script create, instance create, then the poll.
+ */
+function queueProvision(instance = runningInstance()): void {
+  mockFetch
+    .mockResolvedValueOnce(tokenResponse())
+    .mockResolvedValueOnce(response(OS_IMAGES))
+    .mockResolvedValueOnce(response(AVAILABILITY))
+    .mockResolvedValueOnce(response({ id: instance.startup_script_id }, 201))
+    .mockResolvedValueOnce(response({ id: instance.id }, 202))
+    .mockResolvedValueOnce(response(instance));
+}
+
+/** Every request body sent to a given path, parsed. */
+function bodiesFor(path: string): Array<Record<string, unknown>> {
+  return mockFetch.mock.calls
+    .filter(([url]) => String(url).endsWith(path))
+    .map(([, init]) => JSON.parse(String(init?.body ?? "{}")));
+}
+
+function newProvider(): VerdaProvider {
+  return new VerdaProvider(CREDENTIALS);
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+
+describe("VerdaProvider.provision", () => {
+  it("creates an instance with an explicit location and a CUDA+Docker image", async () => {
+    queueProvision();
+    const result = await newProvider().provision(baseSpec());
+
+    const [create] = bodiesFor("/v1/instances");
+    // Since March 2026 a create without location_code is rejected outright.
+    expect(create.location_code).toBe("FIN-01");
+    expect(create.instance_type).toBe("1H100.80S.30V");
+    // The guest OS image is a VM image, NOT the worker's Docker image.
+    expect(create.image).toBe("ubuntu-24.04-cuda-12.8-docker");
+    expect(create.contract).toBe("PAY_AS_YOU_GO");
+    // Dynamic pricing is removed from the API; never offer it.
+    expect(create.pricing).toBeUndefined();
+    expect(result.wsUrl).toBe("ws://203.0.113.9:7777");
+    expect(result.costUsd).toBe(2.45);
+    expect(result.status).toBe("running");
+  });
+
+  it("refuses to launch a worker with no bearer token", async () => {
+    // The bootstrap publishes 7777 with Docker, which a UFW rule does not
+    // block — an unauthenticated worker would be exposed on a public IP.
+    await expect(
+      newProvider().provision(baseSpec({ token: undefined }))
+    ).rejects.toThrow(/bearer token is required/i);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("requires an instance type rather than guessing one", async () => {
+    await expect(
+      newProvider().provision(baseSpec({ gpu: undefined }))
+    ).rejects.toThrow(/instance type/i);
+  });
+
+  it("rejects a region where the instance type has no capacity", async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce(response(OS_IMAGES))
+      .mockResolvedValueOnce(response(AVAILABILITY));
+
+    await expect(
+      newProvider().provision(baseSpec({ region: "USA-01" }))
+    ).rejects.toThrow(/not available in "USA-01"/);
+  });
+
+  it("rejects an OS image that is not in the live catalog", async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce(response(OS_IMAGES))
+      .mockResolvedValueOnce(response(AVAILABILITY));
+
+    await expect(
+      newProvider().provision(baseSpec({ osImage: "ubuntu-99.04" }))
+    ).rejects.toThrow(/not in the catalog/);
+  });
+
+  it("reports no capacity distinctly when the create is refused with 503", async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce(response(OS_IMAGES))
+      .mockResolvedValueOnce(response(AVAILABILITY))
+      .mockResolvedValueOnce(response({ id: "script-1" }, 201))
+      // The transport retries 503 before giving up; answer every attempt.
+      // `retry-after: 0` keeps the real backoff from dominating the test.
+      .mockResolvedValue(response("no capacity", 503, { "retry-after": "0" }));
+
+    await expect(newProvider().provision(baseSpec())).rejects.toThrow(
+      /no capacity/i
+    );
+  });
+
+  it("destroys the instance and its new volume when readiness fails", async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce(response(OS_IMAGES))
+      .mockResolvedValueOnce(response(AVAILABILITY))
+      .mockResolvedValueOnce(response({ id: "script-1" }, 201))
+      .mockResolvedValueOnce(response({ id: "inst-1" }, 202))
+      .mockResolvedValueOnce(response(runningInstance({ status: "error" })))
+      // The teardown re-reads the instance to learn which volumes to delete.
+      .mockResolvedValueOnce(
+        response(
+          runningInstance({
+            id: "inst-1",
+            status: "error",
+            volume_ids: ["66666666-6666-6666-6666-666666666666"],
+          })
+        )
+      )
+      .mockResolvedValueOnce(response(null, 202));
+
+    await expect(newProvider().provision(baseSpec())).rejects.toThrow(
+      /terminal status/
+    );
+
+    // A create that is never persisted must not leave a billing resource: the
+    // failed machine AND the volumes it just created are destroyed rather than
+    // left for the reconcile scan, which never sees an unrecorded ref.
+    const deletes = bodiesFor("/v1/instances").filter(
+      (body) => body.action === "delete"
+    );
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0].id).toBe("inst-1");
+    // An EMPTY list here would retain every disk — a silent billing leak.
+    expect(deletes[0].volume_ids).toEqual([
+      "22222222-2222-2222-2222-222222222222",
+      "66666666-6666-6666-6666-666666666666",
+    ]);
+    expect(deletes[0].delete_permanently).toBe(true);
+  });
+
+  it("writes a rerun-safe bootstrap script that publishes the worker port", async () => {
+    queueProvision();
+    await newProvider().provision(baseSpec({ env: { EXTRA: "value" } }));
+
+    const [script] = bodiesFor("/v1/scripts");
+    const body = String(script.script);
+    // Verda runs the script on EVERY boot, including after a resume.
+    expect(body).toContain("docker inspect nodetool-worker");
+    expect(body).toContain("docker start nodetool-worker");
+    expect(body).toContain("-p 7777:7777");
+    expect(body).toContain("HF_HOME=/workspace/huggingface");
+    expect(body).toContain("EXTRA=value");
+    expect(body).toContain("NODETOOL_WORKER_TOKEN=worker-secret");
+  });
+});
+
+describe("VerdaProvider.stop", () => {
+  it("releases compute while retaining every volume", async () => {
+    queueProvision();
+    const provider = newProvider();
+    const { providerRef } = await provider.provision(baseSpec());
+
+    mockFetch.mockResolvedValueOnce(response(null, 202));
+    await provider.stop(providerRef);
+
+    const [action] = bodiesFor("/v1/instances").filter(
+      (body) => body.action === "delete"
+    );
+    expect(action.id).toBe("11111111-1111-1111-1111-111111111111");
+    // An EMPTY list retains all volumes; OMITTING the field would delete the
+    // OS volume and with it the cached models.
+    expect(action.volume_ids).toEqual([]);
+    expect(action.delete_permanently).toBeUndefined();
+  });
+
+  it("refuses to pause a worker with no retained volume to resume from", async () => {
+    queueProvision(runningInstance({ os_volume_id: "" }));
+    const provider = newProvider();
+    const { providerRef } = await provider.provision(baseSpec());
+
+    await expect(provider.stop(providerRef)).rejects.toThrow(
+      /no recorded OS volume/
+    );
+  });
+});
+
+describe("VerdaProvider.resume", () => {
+  it("boots a new machine from the retained OS volume and returns its new ref", async () => {
+    queueProvision();
+    const provider = newProvider();
+    const original = await provider.provision(baseSpec());
+
+    const resumed = runningInstance({
+      id: "44444444-4444-4444-4444-444444444444",
+      ip: "203.0.113.20",
+    });
+    mockFetch
+      // The old instance is gone after the pause.
+      .mockResolvedValueOnce(response(runningInstance({ status: "notfound" })))
+      .mockResolvedValueOnce(response({ id: resumed.id }, 202))
+      .mockResolvedValueOnce(response(resumed));
+
+    const result = await provider.resume(original.providerRef);
+
+    const create = bodiesFor("/v1/instances").at(-1);
+    // The retained OS volume id stands in for an image type: the machine boots
+    // the old disk, model cache and all.
+    expect(create?.image).toBe("22222222-2222-2222-2222-222222222222");
+    expect(create?.location_code).toBe("FIN-01");
+    expect(create?.os_volume).toBeUndefined();
+    expect(result.wsUrl).toBe("ws://203.0.113.20:7777");
+    // The handle CHANGED — the manager must persist it or lose the live machine.
+    expect(result.providerRef).not.toBe(original.providerRef);
+  });
+
+  it("keeps the retained volume when the resumed machine fails to come up", async () => {
+    queueProvision();
+    const provider = newProvider();
+    const original = await provider.provision(baseSpec());
+
+    mockFetch
+      .mockResolvedValueOnce(response(runningInstance({ status: "notfound" })))
+      .mockResolvedValueOnce(response({ id: "inst-2" }, 202))
+      .mockResolvedValueOnce(
+        response(runningInstance({ id: "inst-2", status: "error" }))
+      )
+      .mockResolvedValueOnce(response(null, 202));
+
+    await expect(provider.resume(original.providerRef)).rejects.toThrow(
+      /terminal status/
+    );
+
+    const cleanup = bodiesFor("/v1/instances").at(-1);
+    // The volume predates this attempt and holds the user's models.
+    expect(cleanup?.volume_ids).toEqual([]);
+    expect(cleanup?.delete_permanently).toBeUndefined();
+  });
+});
+
+describe("VerdaProvider.terminate", () => {
+  it("names every attached volume and deletes them permanently", async () => {
+    queueProvision(
+      runningInstance({ volume_ids: ["55555555-5555-5555-5555-555555555555"] })
+    );
+    const provider = newProvider();
+    const { providerRef } = await provider.provision(baseSpec());
+
+    mockFetch
+      .mockResolvedValueOnce(
+        response(
+          runningInstance({
+            volume_ids: ["55555555-5555-5555-5555-555555555555"],
+          })
+        )
+      )
+      .mockResolvedValueOnce(response(null, 202));
+
+    await provider.terminate(providerRef);
+
+    const action = bodiesFor("/v1/instances").at(-1);
+    // Omitting a volume would only DETACH it, leaving it billable.
+    expect(action?.volume_ids).toEqual([
+      "22222222-2222-2222-2222-222222222222",
+      "55555555-5555-5555-5555-555555555555",
+    ]);
+    // Trashed volumes still hold quota and can be restored at a charge.
+    expect(action?.delete_permanently).toBe(true);
+  });
+
+  it("deletes the retained volume when compute was already released", async () => {
+    queueProvision();
+    const provider = newProvider();
+    const { providerRef } = await provider.provision(baseSpec());
+
+    mockFetch
+      .mockResolvedValueOnce(response(runningInstance({ status: "notfound" })))
+      .mockResolvedValueOnce(response(null, 202));
+
+    await provider.terminate(providerRef);
+
+    const [volumeAction] = bodiesFor("/v1/volumes");
+    expect(volumeAction).toMatchObject({
+      action: "delete",
+      id: "22222222-2222-2222-2222-222222222222",
+      is_permanent: true,
+    });
+  });
+});
+
+describe("VerdaProvider.status and list", () => {
+  it("reports a released worker as stopped, not missing", async () => {
+    queueProvision();
+    const provider = newProvider();
+    const { providerRef } = await provider.provision(baseSpec());
+
+    mockFetch.mockResolvedValueOnce(response("not found", 404));
+    expect(await provider.status(providerRef)).toBe("stopped");
+  });
+
+  it("maps an unknown provider state to error rather than progress", async () => {
+    queueProvision();
+    const provider = newProvider();
+    const { providerRef } = await provider.provision(baseSpec());
+
+    mockFetch.mockResolvedValueOnce(
+      response(runningInstance({ status: "installation_failed" }))
+    );
+    expect(await provider.status(providerRef)).toBe("error");
+  });
+
+  it("encodes the same handle in list() as in provision(), so reconcile matches", async () => {
+    queueProvision();
+    const provider = newProvider();
+    const provisioned = await provider.provision(baseSpec());
+
+    mockFetch.mockResolvedValueOnce(response([runningInstance()]));
+    const listed = await provider.list();
+
+    // A mismatch here would make the manager treat every tracked Verda worker
+    // as an orphan and mark the live one dead.
+    expect(listed).toEqual([
+      { providerRef: provisioned.providerRef, status: "running" },
+    ]);
+  });
+});
+
+describe("Verda input safety", () => {
+  it.each([
+    "../../v1/instances",
+    "abc/def",
+    "id?query=1",
+    "id with space",
+  ])("rejects the traversal-shaped id %s", (id) => {
+    expect(() => assertSafeId(id, "instance id")).toThrow(/Unsafe Verda/);
+  });
+
+  it("accepts a normal uuid", () => {
+    expect(
+      assertSafeId("11111111-1111-1111-1111-111111111111", "instance id")
+    ).toBe("11111111-1111-1111-1111-111111111111");
+  });
+
+  it("rejects a handle that is not a Verda handle", async () => {
+    await expect(newProvider().status("runpod-pod-id")).rejects.toThrow(
+      /Not a Verda worker handle/
+    );
+  });
+});
+
+describe("VerdaApiClient", () => {
+  it("mints one token for concurrent calls and reuses it", async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValue(response([]));
+
+    const client = new VerdaApiClient(CREDENTIALS);
+    await Promise.all([
+      client.request("GET", "/v1/locations"),
+      client.request("GET", "/v1/images"),
+    ]);
+    await client.request("GET", "/v1/instances");
+
+    const tokenCalls = mockFetch.mock.calls.filter(([url]) =>
+      String(url).endsWith("/v1/oauth2/token")
+    );
+    expect(tokenCalls).toHaveLength(1);
+  });
+
+  it("never echoes the client secret when authentication fails", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({ message: "bad client_secret=client-secret" }, 401)
+    );
+    const client = new VerdaApiClient(CREDENTIALS);
+    await expect(client.request("GET", "/v1/instances")).rejects.toThrow(
+      /Check VERDA_CLIENT_ID and VERDA_CLIENT_SECRET/
+    );
+    const [[, init]] = mockFetch.mock.calls;
+    expect(String(init?.body)).toContain("client_credentials");
+  });
+
+  it("retries a rate-limited call after Retry-After and then succeeds", async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce(response("slow down", 429, { "retry-after": "0" }))
+      .mockResolvedValueOnce(response([{ code: "FIN-01" }]));
+
+    const client = new VerdaApiClient(CREDENTIALS);
+    const { status, body } = await client.request("GET", "/v1/locations");
+    expect(status).toBe(200);
+    expect(body).toEqual([{ code: "FIN-01" }]);
+  });
+
+  it("re-authenticates once after a 401 on an authenticated call", async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce(response("expired", 401))
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce(response([]));
+
+    const client = new VerdaApiClient(CREDENTIALS);
+    await client.request("GET", "/v1/instances");
+
+    const tokenCalls = mockFetch.mock.calls.filter(([url]) =>
+      String(url).endsWith("/v1/oauth2/token")
+    );
+    expect(tokenCalls).toHaveLength(2);
+  });
+
+  it("returns 204 as an already-satisfied action, not an error", async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenResponse())
+      .mockResolvedValueOnce(response(null, 204));
+
+    const client = new VerdaApiClient(CREDENTIALS);
+    const { status, body } = await client.request("PUT", "/v1/instances", {
+      action: "delete",
+      id: "inst-1",
+    });
+    expect(status).toBe(204);
+    expect(body).toBeNull();
+  });
+
+  it("surfaces a partially failed bulk action (207) as a failure", async () => {
+    queueProvision();
+    const provider = newProvider();
+    const { providerRef } = await provider.provision(baseSpec());
+
+    mockFetch.mockResolvedValueOnce(
+      response(
+        [{ instanceId: "inst-1", status: "error", message: "still deploying" }],
+        207
+      )
+    );
+    await expect(provider.stop(providerRef)).rejects.toThrow(
+      /still deploying/
+    );
+  });
+
+  it("requires both halves of the credential pair", () => {
+    expect(
+      () => new VerdaApiClient({ clientId: "id", clientSecret: "" })
+    ).toThrow(/VERDA_CLIENT_ID and VERDA_CLIENT_SECRET/);
+  });
+});

--- a/packages/compute/src/index.ts
+++ b/packages/compute/src/index.ts
@@ -19,9 +19,13 @@ export type {
 export type { ReaperDeps, ReaperHandle, ReaperManager } from "./reaper.js";
 export { RunpodPodProvider } from "./providers/runpod.js";
 export { VastProvider } from "./providers/vast.js";
+export { VerdaProvider } from "./providers/verda.js";
+export { VerdaApiClient, VerdaApiError } from "./providers/verda-api.js";
+export type { VerdaCredentials } from "./providers/verda-api.js";
 export type {
   ProviderInstance,
   ProvisionResult,
+  WorkerCredentials,
   WorkerProvider,
   WorkerSpec,
   WorkerStatus,

--- a/packages/compute/src/manager.ts
+++ b/packages/compute/src/manager.ts
@@ -36,7 +36,9 @@ import {
 
 import { RunpodPodProvider } from "./providers/runpod.js";
 import { VastProvider } from "./providers/vast.js";
+import { VerdaProvider } from "./providers/verda.js";
 import type {
+  WorkerCredentials,
   WorkerProvider,
   WorkerSpec,
   WorkerStatus,
@@ -55,11 +57,17 @@ const LOCAL_USER_ID = "1";
  */
 const ACTIVE_WORKER_KEY = "active_worker_instance_id";
 
-/** Secret-store key holding each target's API key. */
-const API_KEY_SECRET = {
-  runpod: "RUNPOD_API_KEY",
-  vast: "VAST_API_KEY",
-} satisfies Record<WorkerTarget, string>;
+/**
+ * Secret-store keys each target authenticates with. Most targets take a single
+ * API key; Verda takes an OAuth2 client id AND secret, so this is a list per
+ * target rather than one name. A target is usable only when EVERY listed
+ * secret resolves.
+ */
+const CREDENTIAL_SECRETS = {
+  runpod: ["RUNPOD_API_KEY"],
+  vast: ["VAST_API_KEY"],
+  verda: ["VERDA_CLIENT_ID", "VERDA_CLIENT_SECRET"],
+} satisfies Record<WorkerTarget, readonly string[]>;
 
 /**
  * The connection info a caller applies to the Python bridge when attaching to
@@ -93,13 +101,18 @@ export interface ReconcileSummary {
 /** Construct the concrete provider for a target. */
 function defaultProviderFactory(
   target: WorkerTarget,
-  apiKey: string
+  credentials: WorkerCredentials
 ): WorkerProvider {
   switch (target) {
     case "runpod":
-      return new RunpodPodProvider(apiKey);
+      return new RunpodPodProvider(credentials.RUNPOD_API_KEY);
     case "vast":
-      return new VastProvider(apiKey);
+      return new VastProvider(credentials.VAST_API_KEY);
+    case "verda":
+      return new VerdaProvider({
+        clientId: credentials.VERDA_CLIENT_ID,
+        clientSecret: credentials.VERDA_CLIENT_SECRET,
+      });
     default:
       throw new Error(`Unsupported worker target: ${target}`);
   }
@@ -136,7 +149,10 @@ export interface WorkerManagerDeps {
   getSetting: (key: string) => Promise<string | null>;
   setSetting: (key: string, value: string) => Promise<void>;
   deleteSetting: (key: string) => Promise<void>;
-  providerFactory: (target: WorkerTarget, apiKey: string) => WorkerProvider;
+  providerFactory: (
+    target: WorkerTarget,
+    credentials: WorkerCredentials
+  ) => WorkerProvider;
 }
 
 function defaultDeps(): WorkerManagerDeps {
@@ -272,6 +288,11 @@ export class WorkerManager {
     const result = await provider.resume(instance.provider_ref);
     return this.deps.updateWorkerInstance(instance.id, {
       status: "running",
+      // A resume can hand back a DIFFERENT provider handle: Verda releases the
+      // machine on stop and boots a new one from the retained disk. Dropping
+      // the new ref would leave the registry pointing at a dead instance and
+      // the live one billing untracked.
+      provider_ref: result.providerRef,
       ws_url: result.wsUrl,
       estimated_cost_usd: result.costUsd ?? instance.estimated_cost_usd,
       // Resuming is activity — reset the idle clock so the reaper doesn't
@@ -481,8 +502,8 @@ export class WorkerManager {
   }
 
   private async resolveProvider(target: WorkerTarget): Promise<WorkerProvider> {
-    const apiKey = await this.loadApiKey(target);
-    return this.deps.providerFactory(target, apiKey);
+    const credentials = await this.loadCredentials(target);
+    return this.deps.providerFactory(target, credentials);
   }
 
   /**
@@ -492,48 +513,66 @@ export class WorkerManager {
    * env-provided key.
    */
   async apiKeyStatus(): Promise<Record<WorkerTarget, boolean>> {
-    const targets = Object.keys(API_KEY_SECRET) as WorkerTarget[];
+    const targets = Object.keys(CREDENTIAL_SECRETS) as WorkerTarget[];
     const entries = await Promise.all(
       targets.map(
         async (target) =>
-          [target, (await this.resolveApiKey(target)) !== null] as const
+          [target, (await this.missingSecrets(target)).length === 0] as const
       )
     );
     return Object.fromEntries(entries) as Record<WorkerTarget, boolean>;
   }
 
   /**
-   * Load a target's API key from the secret store, falling back to the
-   * environment when the keychain is unreachable (headless/sandboxed). Mirrors
-   * the resolution the deleted `runpod-worker.ts` script used.
+   * Load every secret a target authenticates with, from the secret store and
+   * falling back to the environment when the keychain is unreachable
+   * (headless/sandboxed). Throws naming ALL missing secrets, so a Verda user
+   * fixing one credential is not sent back for the second.
    */
-  private async loadApiKey(target: WorkerTarget): Promise<string> {
-    const key = await this.resolveApiKey(target);
-    if (key !== null) {
-      return key;
+  private async loadCredentials(
+    target: WorkerTarget
+  ): Promise<WorkerCredentials> {
+    const missing = await this.missingSecrets(target);
+    if (missing.length > 0) {
+      throw new Error(
+        `${missing.join(" and ")} not found in the secret store or ` +
+          `environment. Store with: ` +
+          `${missing.map((name) => `nodetool secrets store ${name}`).join("; ")}`
+      );
     }
-    const secretName = API_KEY_SECRET[target];
-    throw new Error(
-      `${secretName} not found in the secret store or environment. ` +
-        `Store it with: nodetool secrets store ${secretName}`
+    const names = CREDENTIAL_SECRETS[target];
+    const entries = await Promise.all(
+      names.map(
+        async (name) => [name, (await this.resolveSecret(name)) ?? ""] as const
+      )
     );
+    return Object.fromEntries(entries);
+  }
+
+  /** The target's secrets that resolve nowhere. Empty means it is usable. */
+  private async missingSecrets(target: WorkerTarget): Promise<string[]> {
+    const names = CREDENTIAL_SECRETS[target];
+    if (!names) {
+      throw new Error(`No credential mapping for worker target: ${target}`);
+    }
+    const resolved = await Promise.all(
+      names.map(
+        async (name) => [name, await this.resolveSecret(name)] as const
+      )
+    );
+    return resolved.filter(([, value]) => value === null).map(([name]) => name);
   }
 
   /**
-   * Resolve a target's API key from the secret store, then the environment.
-   * Returns `null` when neither has it (no throw) — shared by `loadApiKey` (which
-   * throws) and `apiKeyStatus` (which reports).
+   * Resolve one secret from the secret store, then the environment. Returns
+   * `null` when neither has it (no throw).
    */
-  private async resolveApiKey(target: WorkerTarget): Promise<string | null> {
-    const key = API_KEY_SECRET[target];
-    if (!key) {
-      throw new Error(`No API key mapping for worker target: ${target}`);
-    }
-    const fromStore = await this.deps.getSecret(key, LOCAL_USER_ID);
+  private async resolveSecret(name: string): Promise<string | null> {
+    const fromStore = await this.deps.getSecret(name, LOCAL_USER_ID);
     if (fromStore) {
       return fromStore;
     }
-    return process.env[key] ?? null;
+    return process.env[name] ?? null;
   }
 }
 
@@ -549,6 +588,8 @@ function specFromProfile(
     image: profile.image,
     target,
     gpu: typeof spec.gpu === "string" ? spec.gpu : undefined,
+    region: typeof spec.region === "string" ? spec.region : undefined,
+    osImage: typeof spec.osImage === "string" ? spec.osImage : undefined,
     vcpu: typeof spec.vcpu === "number" ? spec.vcpu : undefined,
     disk: typeof spec.disk === "number" ? spec.disk : undefined,
     env: isStringRecord(spec.env) ? spec.env : undefined,

--- a/packages/compute/src/providers/types.ts
+++ b/packages/compute/src/providers/types.ts
@@ -6,7 +6,15 @@
 // persistence and identity (profiles, instances) live above it in the manager.
 
 /** Provisioning target a profile/spec runs on. */
-export type WorkerTarget = "runpod" | "vast";
+export type WorkerTarget = "runpod" | "vast" | "verda";
+
+/**
+ * The resolved secrets a provider authenticates with, keyed by secret name
+ * (e.g. `{ RUNPOD_API_KEY: "..." }`). A target needs one entry per name in the
+ * manager's `CREDENTIAL_SECRETS` list — Verda takes a client id AND secret, so
+ * a single key string cannot express every target's credentials.
+ */
+export type WorkerCredentials = Readonly<Record<string, string>>;
 
 /**
  * Lifecycle status of a worker, shared by instances and provider results.
@@ -47,8 +55,21 @@ export interface WorkerSpec {
   image: string;
   /** Provisioning target. */
   target: WorkerTarget;
-  /** Provider-shaped GPU selector (e.g. "A40"). */
+  /** Provider-shaped GPU selector (e.g. "A40", or a Verda `instance_type`). */
   gpu?: string;
+  /**
+   * Provider-shaped region/datacenter selector. Verda REQUIRES a
+   * `location_code` on every create; when this is unset the provider resolves
+   * one from live availability. Ignored by targets that pick a region
+   * themselves (RunPod, Vast).
+   */
+  region?: string;
+  /**
+   * Guest OS image for VM targets (Verda `image_type`). Distinct from `image`,
+   * which is the Docker image the guest RUNS — a VM target needs both. Unset
+   * lets the provider choose a CUDA+Docker image from the live catalog.
+   */
+  osImage?: string;
   /** Number of GPUs to request (GPU targets only). Defaults to 1. */
   gpuCount?: number;
   /** vCPU count. */

--- a/packages/compute/src/providers/verda-api.ts
+++ b/packages/compute/src/providers/verda-api.ts
@@ -1,0 +1,270 @@
+// Verda cloud API transport — authentication, retries, and response decoding.
+//
+// Split from `verda.ts` so the provider reads as lifecycle logic while the
+// awkward parts of the wire protocol live here:
+//
+//   * OAuth2 client-credentials tokens (`POST /v1/oauth2/token`) with a single
+//     in-flight refresh per client, refreshed before expiry.
+//   * The documented rate limits (500 authenticated req/min per project, 60/min
+//     per method+path) surface as 429 + `Retry-After`, honoured with bounded
+//     retries.
+//   * Verda answers instance actions asynchronously: 202 (accepted), 204 (the
+//     single action was already satisfied), 207 (a bulk action partly failed).
+//     Callers get the status code, not a decoded resource, so they can tell
+//     "accepted" from "done".
+//
+// Credentials are injected by the caller (the `WorkerManager` sources them from
+// the secret store); this module never reads `process.env`.
+
+/** Production base URL. The rendered API reference advertises localhost in its
+ * `servers` block, so it is pinned here rather than taken from a generator. */
+const VERDA_API_BASE_URL = "https://api.verda.com";
+
+/** Refresh a token this long before it expires, to cover clock skew + latency. */
+const TOKEN_REFRESH_SKEW_MS = 60_000;
+
+/** Cap on retries of a 429/503 before the call fails. */
+const MAX_RETRIES = 3;
+
+/** Fallback backoff when a 429 carries no usable `Retry-After`. */
+const DEFAULT_RETRY_DELAY_MS = 2_000;
+
+export type VerdaMethod = "GET" | "POST" | "PUT" | "DELETE";
+
+/** A decoded Verda response: the HTTP status plus the parsed body (if any). */
+export interface VerdaResponse<T = unknown> {
+  status: number;
+  body: T;
+}
+
+/** Verda cloud API credentials — distinct from the separate inference key. */
+export interface VerdaCredentials {
+  clientId: string;
+  clientSecret: string;
+}
+
+/**
+ * A Verda API failure carrying the HTTP status, so callers can tell apart the
+ * failures the brief requires be handled distinctly: no capacity (503),
+ * authentication (401/403), quota/funds (402/422) and malformed input (400).
+ */
+export class VerdaApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly path: string
+  ) {
+    super(message);
+    this.name = "VerdaApiError";
+  }
+
+  /** The provider reported no capacity for the requested configuration. */
+  get isNoCapacity(): boolean {
+    return this.status === 503;
+  }
+
+  /** The credentials were rejected — retrying with the same token cannot help. */
+  get isAuth(): boolean {
+    return this.status === 401 || this.status === 403;
+  }
+}
+
+/**
+ * Reject a resource identifier that would escape its intended API path.
+ *
+ * The Verda Python SDK shipped a path-traversal fix in 1.24.1 (a crafted
+ * resource name or id could redirect an authenticated request to a different
+ * endpoint). NodeTool interpolates ids into paths too — a `provider_ref` read
+ * back from the registry, a volume id from a provider response — so the same
+ * check is enforced here rather than trusted to the far side.
+ */
+export function assertSafeId(id: string, label: string): string {
+  if (!/^[A-Za-z0-9._-]+$/.test(id)) {
+    throw new Error(
+      `Unsafe Verda ${label} ${JSON.stringify(id)}: ids may contain only ` +
+        `letters, digits, dot, underscore and hyphen`
+    );
+  }
+  return id;
+}
+
+/** Parse `Retry-After` (delta-seconds or HTTP-date) into milliseconds. */
+function retryAfterMs(header: string | null): number {
+  if (!header) return DEFAULT_RETRY_DELAY_MS;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds * 1_000;
+  }
+  const date = Date.parse(header);
+  if (!Number.isNaN(date)) {
+    return Math.max(0, date - Date.now());
+  }
+  return DEFAULT_RETRY_DELAY_MS;
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Authenticated Verda REST client. One instance per credential pair holds that
+ * pair's access token; refresh is serialized so a burst of concurrent calls
+ * mints one token rather than racing.
+ */
+export class VerdaApiClient {
+  private accessToken: string | null = null;
+  private expiresAt = 0;
+  /** In-flight refresh, shared by every caller that arrives during it. */
+  private pending: Promise<string> | null = null;
+
+  constructor(
+    private readonly credentials: VerdaCredentials,
+    private readonly baseUrl: string = VERDA_API_BASE_URL
+  ) {
+    if (!credentials.clientId || !credentials.clientSecret) {
+      throw new Error(
+        "Verda requires both VERDA_CLIENT_ID and VERDA_CLIENT_SECRET"
+      );
+    }
+  }
+
+  /**
+   * Call an authenticated endpoint. Retries 429/503 with backoff, and retries
+   * ONCE after a 401 with a freshly minted token (a token can expire mid-flight);
+   * a second 401 is a credential problem and is surfaced.
+   */
+  async request<T = unknown>(
+    method: VerdaMethod,
+    path: string,
+    body?: Record<string, unknown>
+  ): Promise<VerdaResponse<T>> {
+    let reauthed = false;
+    for (let attempt = 0; ; attempt++) {
+      const token = await this.token();
+      const response = await this.send(method, path, token, body);
+
+      if (response.status === 401 && !reauthed) {
+        // The token was rejected — drop it and mint a new one exactly once.
+        reauthed = true;
+        this.invalidate();
+        continue;
+      }
+
+      if (
+        (response.status === 429 || response.status === 503) &&
+        attempt < MAX_RETRIES
+      ) {
+        await sleep(retryAfterMs(response.headers.get("retry-after")));
+        continue;
+      }
+
+      return this.decode<T>(response, method, path);
+    }
+  }
+
+  /** Drop the cached token, forcing the next call to mint a fresh one. */
+  invalidate(): void {
+    this.accessToken = null;
+    this.expiresAt = 0;
+  }
+
+  // --- Internals ----------------------------------------------------------
+
+  private async send(
+    method: VerdaMethod,
+    path: string,
+    token: string,
+    body?: Record<string, unknown>
+  ): Promise<Response> {
+    const init: RequestInit = {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      signal: AbortSignal.timeout(60_000),
+    };
+    if (body && method !== "GET") {
+      init.body = JSON.stringify(body);
+    }
+    return fetch(`${this.baseUrl}${path}`, init);
+  }
+
+  private async decode<T>(
+    response: Response,
+    method: VerdaMethod,
+    path: string
+  ): Promise<VerdaResponse<T>> {
+    const text = await response.text().catch(() => "");
+    if (!response.ok) {
+      // Response bodies can echo request fields; include only the provider's
+      // message, never the request body, which carries the worker token.
+      throw new VerdaApiError(
+        `Verda ${method} ${path} failed (${response.status}): ${text.slice(0, 500)}`,
+        response.status,
+        path
+      );
+    }
+    // 202/204 legitimately carry no body — an action was accepted, not applied.
+    let parsed: unknown = null;
+    if (text) {
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        // Some creates answer with a bare id rather than JSON; keep the text.
+        parsed = text;
+      }
+    }
+    return { status: response.status, body: parsed as T };
+  }
+
+  /** Return a live access token, refreshing when absent or near expiry. */
+  private token(): Promise<string> {
+    if (this.accessToken && Date.now() < this.expiresAt - TOKEN_REFRESH_SKEW_MS) {
+      return Promise.resolve(this.accessToken);
+    }
+    // Serialize: concurrent callers share one refresh rather than each minting
+    // a token (and burning the per-path rate limit on /oauth2/token).
+    this.pending ??= this.refresh().finally(() => {
+      this.pending = null;
+    });
+    return this.pending;
+  }
+
+  private async refresh(): Promise<string> {
+    const response = await fetch(`${this.baseUrl}/v1/oauth2/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({
+        grant_type: "client_credentials",
+        client_id: this.credentials.clientId,
+        client_secret: this.credentials.clientSecret,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) {
+      // Never echo the body: the request carried the client secret and a
+      // provider error may quote it back.
+      throw new VerdaApiError(
+        `Verda authentication failed (${response.status}). Check ` +
+          `VERDA_CLIENT_ID and VERDA_CLIENT_SECRET.`,
+        response.status,
+        "/v1/oauth2/token"
+      );
+    }
+
+    const token = (await response.json()) as {
+      access_token?: string;
+      expires_in?: number;
+    };
+    if (!token.access_token) {
+      throw new Error("Verda token response contained no access_token");
+    }
+    this.accessToken = token.access_token;
+    // Treat a missing expires_in conservatively rather than caching forever.
+    const ttl = typeof token.expires_in === "number" ? token.expires_in : 300;
+    this.expiresAt = Date.now() + ttl * 1_000;
+    return token.access_token;
+  }
+}

--- a/packages/compute/src/providers/verda.ts
+++ b/packages/compute/src/providers/verda.ts
@@ -1,0 +1,722 @@
+// Verda-backed `WorkerProvider` (https://api.verda.com/v1).
+//
+// Verda rents VIRTUAL MACHINES, not containers. The NodeTool worker image is
+// something the guest RUNS, so provisioning is two-layered: pick a CUDA+Docker
+// OS image for the machine, then hand Verda a startup script that runs the
+// worker image on it. `WorkerSpec.osImage` names the former, `WorkerSpec.image`
+// the latter.
+//
+// Lifecycle deliberately does NOT mirror RunPod/Vast, because Verda's does not:
+//
+//   * Verda bills a SHUT-DOWN instance at the full rate, and removed its
+//     hibernate action for exactly that reason. Mapping `stop` to `shutdown`
+//     would make the idle reaper stop workers while saving nothing, so `stop`
+//     instead DELETES the instance while retaining its OS volume — the
+//     "release compute, keep disks" operation. The model cache survives; the
+//     GPU bill ends.
+//   * `resume` therefore CREATES A NEW MACHINE from the retained OS volume. It
+//     returns a new `providerRef`, which the manager persists.
+//   * `terminate` deletes compute AND permanently deletes the OS volume, so no
+//     billable storage is left behind in the 96-hour trash window.
+//
+// Because `stop` destroys the instance record, everything `resume` needs to
+// rebuild the machine is encoded in the provider ref (see `encodeRef`).
+//
+// Credentials are injected by the `WorkerManager`; this provider never reads
+// `process.env`.
+
+import {
+  DEFAULT_VOLUME_GB,
+  WORKER_HF_HOME,
+  WORKER_VOLUME_MOUNT,
+  type ProviderInstance,
+  type ProvisionResult,
+  type WorkerProvider,
+  type WorkerSpec,
+  type WorkerStatus,
+} from "./types.js";
+import {
+  assertSafeId,
+  VerdaApiClient,
+  VerdaApiError,
+  type VerdaCredentials,
+} from "./verda-api.js";
+
+/** Port the worker serves on, published from the container to the VM. */
+const WORKER_PORT = 7777;
+
+/** Pay-as-you-go only. Long-term contracts are prepaid and are never chosen
+ * on the user's behalf; spot instances can be discontinued mid-workflow. */
+const CONTRACT = "PAY_AS_YOU_GO";
+
+/** Name of the container the startup script runs, used for idempotent reruns. */
+const CONTAINER_NAME = "nodetool-worker";
+
+/** A Verda instance as returned by `GET /v1/instances` (fields we read). */
+interface VerdaInstance {
+  id?: string;
+  ip?: string;
+  status?: string;
+  hostname?: string;
+  description?: string;
+  instance_type?: string;
+  location?: string;
+  os_volume_id?: string;
+  volume_ids?: string[];
+  ssh_key_ids?: string[];
+  startup_script_id?: string;
+  price_per_hour?: number;
+}
+
+/** An OS image from `GET /v1/images`. */
+interface VerdaOsImage {
+  id?: string;
+  image_type?: string;
+  name?: string;
+  details?: string[];
+}
+
+/**
+ * The create plan carried inside a provider ref. `stop` destroys the instance,
+ * so `resume` cannot read these back from the API — they travel with the handle.
+ */
+interface VerdaRef {
+  /** Instance id. Empty once the instance has been released by `stop`. */
+  i: string;
+  /** Retained OS volume id — the model cache, and `resume`'s boot disk. */
+  v: string;
+  /** Instance type, re-requested on resume. */
+  t: string;
+  /** Location code, re-requested on resume. */
+  l: string;
+  /** Startup script id. */
+  s?: string;
+  /** SSH key ids. */
+  k?: string[];
+  /** Hostname. */
+  h?: string;
+}
+
+/**
+ * Encode a create plan as an opaque provider handle.
+ *
+ * `provision` and `list` both build this from the SAME `GET` representation, so
+ * a live instance encodes to the identical string in both paths and the
+ * manager's orphan reconcile matches it by equality.
+ */
+function encodeRef(ref: VerdaRef): string {
+  const ordered: VerdaRef = {
+    i: ref.i,
+    v: ref.v,
+    t: ref.t,
+    l: ref.l,
+    s: ref.s,
+    k: ref.k,
+    h: ref.h,
+  };
+  return `verda:${Buffer.from(JSON.stringify(ordered)).toString("base64url")}`;
+}
+
+/** Decode a provider handle produced by `encodeRef`. */
+function decodeRef(ref: string): VerdaRef {
+  if (!ref.startsWith("verda:")) {
+    throw new Error(`Not a Verda worker handle: ${JSON.stringify(ref)}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(
+      Buffer.from(ref.slice("verda:".length), "base64url").toString("utf8")
+    );
+  } catch {
+    throw new Error(`Corrupt Verda worker handle: ${JSON.stringify(ref)}`);
+  }
+  const plan = parsed as VerdaRef;
+  if (typeof plan?.v !== "string" || typeof plan?.t !== "string") {
+    throw new Error(`Incomplete Verda worker handle: ${JSON.stringify(ref)}`);
+  }
+  return plan;
+}
+
+/** Build the handle for an instance as the API currently reports it. */
+function refFromInstance(instance: VerdaInstance): string {
+  return encodeRef({
+    i: instance.id ?? "",
+    v: instance.os_volume_id ?? "",
+    t: instance.instance_type ?? "",
+    l: instance.location ?? "",
+    s: instance.startup_script_id || undefined,
+    k: instance.ssh_key_ids?.length ? instance.ssh_key_ids : undefined,
+    h: instance.hostname || undefined,
+  });
+}
+
+/**
+ * Map Verda's instance status onto the shared `WorkerStatus`.
+ *
+ * Unknown states map to `error`, not to a hopeful `provisioning`: a state this
+ * code does not recognise must not read as progress to the poll loop.
+ */
+function mapInstanceStatus(status: string | undefined): WorkerStatus {
+  switch (status) {
+    case "running":
+      return "running";
+    case "provisioning":
+    case "ordered":
+    case "new":
+    case "validating":
+    case "deploying":
+      return "provisioning";
+    case "offline":
+      // Shut down but still allocated — and still billed. Not our paused state.
+      return "stopped";
+    case "deleting":
+      return "stopping";
+    case "discontinued":
+    case "notfound":
+      return "terminated";
+    default:
+      // error, no_capacity, installation_failed, unknown, and anything new.
+      return "error";
+  }
+}
+
+/** Single-quote a value for safe interpolation into the bootstrap script. */
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export class VerdaProvider implements WorkerProvider {
+  private readonly api: VerdaApiClient;
+
+  constructor(credentials: VerdaCredentials, api?: VerdaApiClient) {
+    this.api = api ?? new VerdaApiClient(credentials);
+  }
+
+  async provision(spec: WorkerSpec): Promise<ProvisionResult> {
+    // The startup script publishes 7777 with Docker, and Verda's own guide
+    // warns that a UFW rule does NOT block a Docker-published port. The worker
+    // is therefore reachable from the internet the moment it boots, so refuse
+    // to launch one that accepts unauthenticated requests.
+    if (!spec.token) {
+      throw new Error(
+        "Verda workers publish port 7777 on a public IP, so a bearer token is " +
+          "required. Use a profile with token_policy 'generate' or 'fixed'."
+      );
+    }
+    const instanceType = spec.gpu?.trim();
+    if (!instanceType) {
+      throw new Error(
+        "Verda requires an instance type (e.g. \"1H100.80S.30V\"). Set the " +
+          "profile's gpu field to a type from GET /v1/instance-types."
+      );
+    }
+
+    const [osImage, locationCode] = await Promise.all([
+      this.resolveOsImage(spec.osImage),
+      this.resolveLocation(instanceType, spec.region),
+    ]);
+
+    const sshKeyIds = spec.sshPublicKey
+      ? [await this.ensureSshKey(spec.name, spec.sshPublicKey)]
+      : [];
+    const scriptId = await this.createStartupScript(spec);
+
+    const hostname = sanitizeHostname(spec.name);
+    const create: Record<string, unknown> = {
+      instance_type: instanceType,
+      image: osImage,
+      location_code: locationCode,
+      hostname,
+      description: `NodeTool worker (${spec.name})`,
+      contract: CONTRACT,
+      startup_script_id: scriptId,
+      os_volume: {
+        name: `${hostname}-os`,
+        size: spec.disk ?? DEFAULT_VOLUME_GB,
+      },
+    };
+    if (sshKeyIds.length > 0) {
+      create.ssh_key_ids = sshKeyIds;
+    }
+
+    // `POST /v1/instances` answers 202 (accepted) — the machine does not exist
+    // yet. Persist nothing until the id is known, then treat every later
+    // failure as owning a billing resource that must be torn down.
+    const instanceId = await this.createInstance(create);
+
+    try {
+      const instance = await this.waitForReady(instanceId);
+      if (!instance.ip) {
+        throw new Error(
+          `Verda instance ${instanceId} became running without an IP address`
+        );
+      }
+      return {
+        providerRef: refFromInstance(instance),
+        wsUrl: `ws://${instance.ip}:${WORKER_PORT}`,
+        token: spec.token,
+        status: "running",
+        costUsd: instance.price_per_hour,
+      };
+    } catch (err) {
+      // Destroy compute AND the just-created OS volume: nothing here is worth
+      // retaining, and an orphan would bill until a reconcile scan found it.
+      // The volumes must be NAMED — an empty list retains every one of them.
+      await this.destroyWithVolumes(instanceId).catch(() => {
+        // Best-effort teardown; the provision failure below is the real error.
+      });
+      throw err;
+    }
+  }
+
+  async status(ref: string): Promise<WorkerStatus> {
+    const plan = decodeRef(ref);
+    if (!plan.i) {
+      // Compute was released by `stop`; only the retained volume remains.
+      return "stopped";
+    }
+    const instance = await this.getInstance(plan.i);
+    if (!instance) {
+      // The machine is gone but the OS volume was retained — this is the state
+      // `stop` leaves behind, and it is resumable.
+      return "stopped";
+    }
+    return mapInstanceStatus(instance.status);
+  }
+
+  /**
+   * Pause: release the GPU compute, retain the OS volume and its model cache.
+   *
+   * This DELETES the Verda instance. A `shutdown` would keep billing the full
+   * instance rate (Verda removed hibernate for the same reason), so it is not
+   * the operation the cost guard needs.
+   */
+  async stop(ref: string): Promise<void> {
+    const plan = decodeRef(ref);
+    if (!plan.i) {
+      return;
+    }
+    if (!plan.v) {
+      throw new Error(
+        "Refusing to pause a Verda worker with no recorded OS volume: " +
+          "releasing its compute would destroy the machine with nothing to " +
+          "resume from. Terminate it instead."
+      );
+    }
+    // `volume_ids: []` is the documented "retain ALL attached volumes" form.
+    // Omitting the field deletes the OS volume instead, so it is always sent.
+    await this.deleteInstance(plan.i, { volumeIds: [], permanent: false });
+  }
+
+  /**
+   * Resume: create a NEW machine that boots from the retained OS volume.
+   *
+   * Returns a new provider ref (the instance id changed). Verda can refuse for
+   * lack of capacity, which surfaces as a distinct error rather than a retry.
+   */
+  async resume(ref: string): Promise<ProvisionResult> {
+    const plan = decodeRef(ref);
+    if (plan.i) {
+      const existing = await this.getInstance(plan.i);
+      if (existing && mapInstanceStatus(existing.status) === "running") {
+        // Already live (a stop that failed after the caller gave up, say).
+        return this.resultFor(existing);
+      }
+    }
+    if (!plan.v) {
+      throw new Error(
+        "This Verda worker has no retained OS volume to resume from."
+      );
+    }
+
+    const create: Record<string, unknown> = {
+      instance_type: plan.t,
+      // A customized OS volume id stands in for an image type: the machine
+      // boots the retained disk, model cache and all.
+      image: assertSafeId(plan.v, "volume id"),
+      location_code: plan.l,
+      hostname: plan.h ?? CONTAINER_NAME,
+      description: "NodeTool worker (resumed)",
+      contract: CONTRACT,
+    };
+    if (plan.s) create.startup_script_id = plan.s;
+    if (plan.k?.length) create.ssh_key_ids = plan.k;
+
+    const instanceId = await this.createInstance(create);
+    try {
+      const instance = await this.waitForReady(instanceId);
+      if (!instance.ip) {
+        throw new Error(
+          `Verda instance ${instanceId} resumed without an IP address`
+        );
+      }
+      return this.resultFor(instance);
+    } catch (err) {
+      // Release the failed machine but KEEP the volume: it is the user's model
+      // cache and predates this resume attempt.
+      await this.deleteInstance(instanceId, {
+        volumeIds: [],
+        permanent: false,
+      }).catch(() => {
+        // Best-effort; surface the resume failure below.
+      });
+      throw err;
+    }
+  }
+
+  /**
+   * Destroy the worker AND its OS volume — the real teardown that ends every
+   * charge. The volume is deleted PERMANENTLY: a trashed volume still occupies
+   * the storage quota and can be restored (at a charge for the deleted
+   * interval), which is not what "terminate" promises. The model cache is gone.
+   */
+  async terminate(ref: string): Promise<void> {
+    const plan = decodeRef(ref);
+    if (plan.i) {
+      const destroyed = await this.destroyWithVolumes(plan.i, plan.v);
+      if (destroyed) {
+        return;
+      }
+    }
+    // Compute is already released; the retained volume is what still bills.
+    if (plan.v) {
+      await this.api.request("PUT", "/v1/volumes", {
+        action: "delete",
+        id: assertSafeId(plan.v, "volume id"),
+        is_permanent: true,
+      });
+    }
+  }
+
+  async list(): Promise<ProviderInstance[]> {
+    const { body } = await this.api.request<VerdaInstance[]>(
+      "GET",
+      "/v1/instances"
+    );
+    const instances = Array.isArray(body) ? body : [];
+    return instances.map((instance) => ({
+      providerRef: refFromInstance(instance),
+      status: mapInstanceStatus(instance.status),
+    }));
+  }
+
+  // --- Internals ----------------------------------------------------------
+
+  private resultFor(instance: VerdaInstance): ProvisionResult {
+    return {
+      providerRef: refFromInstance(instance),
+      wsUrl: `ws://${instance.ip}:${WORKER_PORT}`,
+      status: "running",
+      costUsd: instance.price_per_hour,
+    };
+  }
+
+  /**
+   * Pick the guest OS image. An explicit `osImage` is validated against the
+   * live catalog (a typo would otherwise fail deep inside provisioning); with
+   * none set, prefer an image that ships CUDA and Docker, which the bootstrap
+   * script needs.
+   */
+  private async resolveOsImage(requested?: string): Promise<string> {
+    const { body } = await this.api.request<VerdaOsImage[]>(
+      "GET",
+      "/v1/images"
+    );
+    const images = Array.isArray(body) ? body : [];
+    const types = images
+      .map((image) => image.image_type)
+      .filter((type): type is string => Boolean(type));
+
+    if (requested) {
+      if (!types.includes(requested)) {
+        throw new Error(
+          `Verda OS image "${requested}" is not in the catalog. ` +
+            `Available: ${types.join(", ")}`
+        );
+      }
+      return requested;
+    }
+
+    const describes = (image: VerdaOsImage): string =>
+      [image.image_type, image.name, ...(image.details ?? [])]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+    const preferred = images.find((image) => {
+      const text = describes(image);
+      return text.includes("cuda") && text.includes("docker");
+    });
+    const fallback = images.find((image) => describes(image).includes("docker"));
+    const chosen = (preferred ?? fallback)?.image_type;
+    if (!chosen) {
+      throw new Error(
+        "No Verda OS image with CUDA and Docker found. Set the profile's " +
+          `osImage explicitly. Available: ${types.join(", ")}`
+      );
+    }
+    return chosen;
+  }
+
+  /**
+   * Resolve the required `location_code` against LIVE availability — a catalog
+   * entry is not a reservation, so this is re-read immediately before each create.
+   * An explicit region is verified rather than trusted.
+   */
+  private async resolveLocation(
+    instanceType: string,
+    requested?: string
+  ): Promise<string> {
+    const { body } = await this.api.request<
+      Array<{ location_code?: string; availabilities?: string[] }>
+    >("GET", "/v1/instance-availability");
+    const rows = Array.isArray(body) ? body : [];
+    const withType = rows.filter((row) =>
+      (row.availabilities ?? []).includes(instanceType)
+    );
+
+    if (requested) {
+      const match = withType.find((row) => row.location_code === requested);
+      if (!match) {
+        throw new Error(
+          `Verda instance type "${instanceType}" is not available in ` +
+            `"${requested}". Available in: ` +
+            `${withType.map((r) => r.location_code).join(", ") || "no location"}`
+        );
+      }
+      return requested;
+    }
+
+    const first = withType[0]?.location_code;
+    if (!first) {
+      throw new Error(
+        `No Verda location currently has capacity for instance type ` +
+          `"${instanceType}".`
+      );
+    }
+    return first;
+  }
+
+  /** Register the spec's public key, reusing an identical existing key. */
+  private async ensureSshKey(name: string, publicKey: string): Promise<string> {
+    const key = publicKey.trim();
+    const { body } = await this.api.request<
+      Array<{ id?: string; key?: string }>
+    >("GET", "/v1/sshkeys");
+    const existing = Array.isArray(body)
+      ? body.find((entry) => entry.key?.trim() === key)
+      : undefined;
+    if (existing?.id) {
+      return existing.id;
+    }
+    const created = await this.api.request<unknown>("POST", "/v1/sshkeys", {
+      name: `nodetool-${sanitizeHostname(name)}`,
+      key,
+    });
+    return extractId(created.body, "SSH key");
+  }
+
+  /**
+   * Create the startup script that turns a bare VM into a NodeTool worker.
+   *
+   * The script is idempotent: Verda runs it on every boot, including after a
+   * resume, and it must not fail on a machine that already has the container.
+   */
+  private async createStartupScript(spec: WorkerSpec): Promise<string> {
+    const env: Record<string, string> = { ...(spec.env ?? {}) };
+    if (spec.token) {
+      env.NODETOOL_WORKER_TOKEN = spec.token;
+    }
+    // Cache HF models on the OS volume so they survive a pause/resume.
+    env.HF_HOME = WORKER_HF_HOME;
+
+    const envFlags = Object.entries(env)
+      .map(([key, value]) => `  -e ${shellQuote(`${key}=${value}`)} \\`)
+      .join("\n");
+
+    const script = `#!/bin/bash
+# NodeTool worker bootstrap. Rerun-safe: Verda runs it on every boot.
+set -euo pipefail
+
+mkdir -p ${WORKER_HF_HOME}
+
+# Reuse the container across reboots; only pull and create it when absent.
+if docker inspect ${CONTAINER_NAME} >/dev/null 2>&1; then
+  docker start ${CONTAINER_NAME}
+  exit 0
+fi
+
+docker pull ${shellQuote(spec.image)}
+docker run -d \\
+  --name ${CONTAINER_NAME} \\
+  --restart unless-stopped \\
+  --gpus all \\
+  -p ${WORKER_PORT}:${WORKER_PORT} \\
+  -v ${WORKER_VOLUME_MOUNT}:${WORKER_VOLUME_MOUNT} \\
+${envFlags}
+  ${shellQuote(spec.image)}
+`;
+
+    const created = await this.api.request<unknown>("POST", "/v1/scripts", {
+      name: `nodetool-${sanitizeHostname(spec.name)}-${Date.now()}`,
+      script,
+    });
+    return extractId(created.body, "startup script");
+  }
+
+  /** `POST /v1/instances`, returning the accepted instance id. */
+  private async createInstance(create: Record<string, unknown>): Promise<string> {
+    try {
+      const { body } = await this.api.request<unknown>(
+        "POST",
+        "/v1/instances",
+        create
+      );
+      return extractId(body, "instance");
+    } catch (err) {
+      if (err instanceof VerdaApiError && err.isNoCapacity) {
+        throw new Error(
+          `Verda has no capacity for instance type ` +
+            `"${String(create.instance_type)}" in "${String(create.location_code)}".`
+        );
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Delete an instance together with every volume attached to it, permanently.
+   *
+   * The volume ids are read back from the instance and NAMED explicitly: an
+   * empty `volume_ids` retains them all, and omitting the field deletes only
+   * the OS volume while detaching the rest — both leave billable storage
+   * behind. Returns false when the instance no longer exists.
+   */
+  private async destroyWithVolumes(
+    instanceId: string,
+    extraVolumeId?: string
+  ): Promise<boolean> {
+    const instance = await this.getInstance(instanceId);
+    if (!instance) {
+      return false;
+    }
+    const volumeIds = [
+      ...new Set(
+        [
+          instance.os_volume_id,
+          ...(instance.volume_ids ?? []),
+          extraVolumeId,
+        ].filter((id): id is string => Boolean(id))
+      ),
+    ];
+    await this.deleteInstance(instanceId, { volumeIds, permanent: true });
+    return true;
+  }
+
+  /**
+   * `PUT /v1/instances` delete. `volumeIds: []` retains every attached volume;
+   * a non-empty list deletes exactly those.
+   */
+  private async deleteInstance(
+    instanceId: string,
+    opts: { volumeIds: string[]; permanent: boolean }
+  ): Promise<void> {
+    const body: Record<string, unknown> = {
+      action: "delete",
+      id: assertSafeId(instanceId, "instance id"),
+      volume_ids: opts.volumeIds.map((id) => assertSafeId(id, "volume id")),
+    };
+    if (opts.permanent && opts.volumeIds.length > 0) {
+      body.delete_permanently = true;
+    }
+    const { status, body: result } = await this.api.request<
+      Array<{ status?: string; message?: string }>
+    >("PUT", "/v1/instances", body);
+
+    // 204 means the action was already satisfied. 202 accepted it. 207 means a
+    // bulk action partly failed — with a single id, that is a failure.
+    if (status === 207) {
+      const failure = Array.isArray(result)
+        ? result.find((entry) => entry.status === "error")
+        : undefined;
+      throw new Error(
+        `Verda refused to delete instance ${instanceId}: ` +
+          `${failure?.message ?? "unknown error"}`
+      );
+    }
+  }
+
+  /** `GET /v1/instances/{id}`, or null when it no longer exists. */
+  private async getInstance(id: string): Promise<VerdaInstance | null> {
+    try {
+      const { body } = await this.api.request<VerdaInstance>(
+        "GET",
+        `/v1/instances/${assertSafeId(id, "instance id")}`
+      );
+      // A deleted instance can answer 200 with the `notfound` status rather
+      // than a 404, so both shapes are treated as gone.
+      if (!body || body.status === "notfound") {
+        return null;
+      }
+      return body;
+    } catch (err) {
+      if (err instanceof VerdaApiError && err.status === 404) {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  /** Poll until the instance reports `running`, or fail on a terminal state. */
+  private async waitForReady(
+    id: string,
+    opts: { timeoutMs?: number; intervalMs?: number } = {}
+  ): Promise<VerdaInstance> {
+    const deadline = Date.now() + (opts.timeoutMs ?? 600_000);
+    const intervalMs = opts.intervalMs ?? 10_000;
+    let last: string | undefined;
+    while (Date.now() < deadline) {
+      const instance = await this.getInstance(id);
+      last = instance?.status;
+      const status = mapInstanceStatus(instance?.status);
+      if (instance && status === "running") {
+        return instance;
+      }
+      if (status === "error" || status === "terminated") {
+        throw new Error(
+          `Verda instance ${id} reached terminal status ` +
+            `"${instance?.status ?? "deleted"}"`
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+    throw new Error(
+      `Verda instance ${id} did not become ready within the timeout ` +
+        `(last status: ${last ?? "unknown"})`
+    );
+  }
+}
+
+/** Pull a resource id out of a create response, which may be a bare string. */
+function extractId(body: unknown, label: string): string {
+  if (typeof body === "string" && body.trim()) {
+    return body.trim().replace(/^"|"$/g, "");
+  }
+  if (body && typeof body === "object") {
+    const id = (body as { id?: unknown }).id;
+    if (typeof id === "string" && id) {
+      return id;
+    }
+  }
+  throw new Error(`Verda ${label} creation returned no id`);
+}
+
+/** Reduce a profile name to a valid hostname label. */
+function sanitizeHostname(name: string): string {
+  const cleaned = name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 60);
+  return cleaned || "nodetool-worker";
+}

--- a/packages/config/src/setting-catalog.ts
+++ b/packages/config/src/setting-catalog.ts
@@ -456,6 +456,16 @@ sec(
   "Vast.ai API key for renting marketplace GPUs to run NodeTool workers. Get yours at https://cloud.vast.ai/manage-keys/"
 );
 sec(
+  "VERDA_CLIENT_ID",
+  "Verda",
+  "Verda cloud API client id for renting GPU instances to run NodeTool workers. Create credentials at https://cloud.verda.com/ (distinct from the inference key)."
+);
+sec(
+  "VERDA_CLIENT_SECRET",
+  "Verda",
+  "Verda cloud API client secret, paired with VERDA_CLIENT_ID. Credentials are tied to the team member who created them and are deleted when that member is removed."
+);
+sec(
   "NODE_SUPABASE_KEY",
   "NodeSupabase",
   "Supabase service key for user-provided nodes"

--- a/packages/config/tests/setting-catalog.test.ts
+++ b/packages/config/tests/setting-catalog.test.ts
@@ -11,7 +11,9 @@ const PROVIDER_CREDENTIALS: Array<[envVar: string, readBy: string]> = [
   ["JINA_API_KEY", "packages/runtime/src/providers/jina-provider.ts"],
   ["VOYAGE_API_KEY", "packages/runtime/src/providers/voyage-provider.ts"],
   ["EVOLINK_API_KEY", "packages/runtime/src/providers/evolink-provider.ts"],
-  ["VAST_API_KEY", "packages/compute/src/manager.ts"]
+  ["VAST_API_KEY", "packages/compute/src/manager.ts"],
+  ["VERDA_CLIENT_ID", "packages/compute/src/manager.ts"],
+  ["VERDA_CLIENT_SECRET", "packages/compute/src/manager.ts"]
 ];
 
 describe("setting catalog", () => {

--- a/packages/models/src/worker-instances.ts
+++ b/packages/models/src/worker-instances.ts
@@ -20,7 +20,7 @@ import { createTimeOrderedUuid } from "./base-model.js";
 import { getDb } from "./db.js";
 import { workerInstances } from "./schema/workers.js";
 
-export type WorkerTarget = "runpod" | "vast";
+export type WorkerTarget = "runpod" | "vast" | "verda";
 
 /**
  * Salt for worker-token encryption. Worker tokens are not user-scoped (the

--- a/packages/models/src/worker-profiles.ts
+++ b/packages/models/src/worker-profiles.ts
@@ -12,7 +12,7 @@ import { createTimeOrderedUuid } from "./base-model.js";
 import { getDb } from "./db.js";
 import { workerProfiles } from "./schema/workers.js";
 
-export type WorkerTarget = "runpod" | "vast";
+export type WorkerTarget = "runpod" | "vast" | "verda";
 export type TokenPolicy = "generate" | "fixed";
 
 export interface WorkerProfile {

--- a/packages/websocket/src/trpc/routers/worker.ts
+++ b/packages/websocket/src/trpc/routers/worker.ts
@@ -22,7 +22,7 @@ import type { RepointPythonBridge, ProbeWorkerHealth } from "../context.js";
 import { router } from "../index.js";
 import { protectedProcedure } from "../middleware.js";
 
-const targetSchema = z.enum(["runpod", "vast"]);
+const targetSchema = z.enum(["runpod", "vast", "verda"]);
 
 const profileCreateInput = z.object({
   name: z.string().min(1),
@@ -78,7 +78,8 @@ const workerInstanceOutput = z.object({
 const okOutput = z.object({ ok: z.literal(true) });
 const apiKeyStatusOutput = z.object({
   runpod: z.boolean(),
-  vast: z.boolean()
+  vast: z.boolean(),
+  verda: z.boolean()
 });
 const connectionOutput = z.object({
   wsUrl: z.string(),

--- a/packages/websocket/tests/trpc-worker.test.ts
+++ b/packages/websocket/tests/trpc-worker.test.ts
@@ -225,7 +225,7 @@ describe("worker router", () => {
   // ── lifecycle / status procedures ────────────────────────────────
   describe("apiKeyStatus / resume / terminate / health", () => {
     it("apiKeyStatus delegates to manager.apiKeyStatus", async () => {
-      const status = { runpod: true, vast: false };
+      const status = { runpod: true, vast: false, verda: true };
       manager.apiKeyStatus.mockResolvedValue(status);
       const caller = createCaller(makeCtx(manager, repoint));
       await expect(caller.worker.apiKeyStatus()).resolves.toEqual(status);

--- a/web/src/components/menus/providerCatalog.ts
+++ b/web/src/components/menus/providerCatalog.ts
@@ -454,6 +454,20 @@ export const PROVIDER_META: ProviderMeta[] = [
     docsUrl: "https://docs.vast.ai/"
   },
   {
+    key: "VERDA_CLIENT_ID",
+    name: "Verda",
+    description: "Cloud API client id for renting GPU instances as workers.",
+    section: "compute",
+    docsUrl: "https://docs.verda.com/welcome-to-verda/api-credentials/"
+  },
+  {
+    key: "VERDA_CLIENT_SECRET",
+    name: "Verda (secret)",
+    description: "Cloud API client secret, paired with the Verda client id.",
+    section: "compute",
+    docsUrl: "https://docs.verda.com/welcome-to-verda/api-credentials/"
+  },
+  {
     key: "LLAMA_API_KEY",
     providerId: PROVIDER_IDS.LLAMA_CPP,
     name: "llama.cpp",

--- a/web/src/components/workers/WorkerProfilesDialog.tsx
+++ b/web/src/components/workers/WorkerProfilesDialog.tsx
@@ -22,11 +22,13 @@ import type {
   TokenPolicy
 } from "../../hooks/useWorkers";
 
-// The secret each provider's API needs before a worker can be provisioned.
-const API_KEY_BY_TARGET = {
-  runpod: "RUNPOD_API_KEY",
-  vast: "VAST_API_KEY"
-} satisfies Record<WorkerTarget, string>;
+// The secrets each provider's API needs before a worker can be provisioned.
+// Verda authenticates with an OAuth2 client id AND secret, so this is a list.
+const API_KEYS_BY_TARGET = {
+  runpod: ["RUNPOD_API_KEY"],
+  vast: ["VAST_API_KEY"],
+  verda: ["VERDA_CLIENT_ID", "VERDA_CLIENT_SECRET"]
+} satisfies Record<WorkerTarget, readonly string[]>;
 
 // A profile is a reusable template (target, image, GPU spec, token policy,
 // lifecycle limits); provisioning rents a GPU box from it.
@@ -56,7 +58,8 @@ const CUSTOM_GPU = "__custom__";
 
 const TARGET_OPTIONS = [
   { value: "runpod", label: "RunPod" },
-  { value: "vast", label: "Vast" }
+  { value: "vast", label: "Vast" },
+  { value: "verda", label: "Verda" }
 ] as const;
 
 // GPU ids are PROVIDER-NATIVE and differ per target: RunPod wants the full
@@ -96,11 +99,20 @@ const VAST_GPU_OPTIONS = [
   { value: CUSTOM_GPU, label: "Other (enter GPU id)…" }
 ] as const;
 
-// Default GPU per target: a solid mid-range card for RunPod, and "Any cheapest"
-// for Vast.
+// Verda rents whole machines, so its selector is an INSTANCE TYPE
+// ("1H100.80S.30V" = 1x H100 80GB, 30 vCPU), not a GPU name. The catalog is
+// account- and region-specific, so it is entered rather than picked from a
+// list that could go stale: `GET /v1/instance-types` lists the live ids.
+const VERDA_INSTANCE_TYPE_OPTIONS = [
+  { value: CUSTOM_GPU, label: "Enter instance type…" }
+] as const;
+
+// Default GPU per target: a solid mid-range card for RunPod, "Any cheapest"
+// for Vast, and a typed instance type for Verda.
 const DEFAULT_GPU = {
   runpod: "NVIDIA A40",
-  vast: ""
+  vast: "",
+  verda: CUSTOM_GPU
 } satisfies Record<WorkerTarget, string>;
 
 // vCPU choices for a CPU-only RunPod pod. The provider passes this as the pod's
@@ -166,10 +178,15 @@ const WorkerProfilesDialog: React.FC<WorkerProfilesDialogProps> = ({
   // provider's API key isn't available yet — provisioning would fail without it.
   // `apiKeyStatus` reflects store OR env (the same resolution provisioning uses),
   // so an env-provided key does NOT false-warn. Only warn on an explicit false.
-  const apiKeyName = API_KEY_BY_TARGET[target];
+  const apiKeyName = API_KEYS_BY_TARGET[target].join(" and ");
   const apiKeyMissing = apiKeyStatus?.[target] === false;
 
-  const gpuOptions = target === "runpod" ? RUNPOD_GPU_OPTIONS : VAST_GPU_OPTIONS;
+  const gpuOptions =
+    target === "runpod"
+      ? RUNPOD_GPU_OPTIONS
+      : target === "verda"
+        ? VERDA_INSTANCE_TYPE_OPTIONS
+        : VAST_GPU_OPTIONS;
   // The provider-native GPU id we'll actually submit ("" means "any/none").
   const resolvedGpu = gpu === CUSTOM_GPU ? customGpu.trim() : gpu;
   // RunPod CPU-only pod: the curated "CPU only" entry (empty id) on RunPod.

--- a/web/src/components/workers/__tests__/WorkerProfilesDialog.test.tsx
+++ b/web/src/components/workers/__tests__/WorkerProfilesDialog.test.tsx
@@ -66,7 +66,7 @@ describe("WorkerProfilesDialog", () => {
   });
 
   it("warns when the selected provider's API key is unavailable", async () => {
-    setup({ profiles: [], apiKeyStatus: { runpod: false, vast: false } });
+    setup({ profiles: [], apiKeyStatus: { runpod: false, vast: false, verda: false } });
 
     expect(screen.getByText(/No RUNPOD_API_KEY configured/i)).toBeInTheDocument();
 
@@ -77,7 +77,7 @@ describe("WorkerProfilesDialog", () => {
   });
 
   it("does not warn when the provider key is available (e.g. via env)", () => {
-    setup({ profiles: [], apiKeyStatus: { runpod: true, vast: true } });
+    setup({ profiles: [], apiKeyStatus: { runpod: true, vast: true, verda: true } });
     expect(screen.queryByText(/configured/i)).not.toBeInTheDocument();
   });
 

--- a/web/src/components/workers/__tests__/WorkersPanel.test.tsx
+++ b/web/src/components/workers/__tests__/WorkersPanel.test.tsx
@@ -70,7 +70,7 @@ const makeHookValue = (
   instancesQuery: { isLoading: false } as ReturnType<
     typeof useWorkers
   >["instancesQuery"],
-  apiKeyStatus: { runpod: true, vast: true },
+  apiKeyStatus: { runpod: true, vast: true, verda: true },
   createProfile: jest.fn(async () => makeProfile()),
   deleteProfile: jest.fn(async () => undefined),
   provision: jest.fn(async () => makeInstance()),

--- a/web/src/hooks/useWorkers.ts
+++ b/web/src/hooks/useWorkers.ts
@@ -13,7 +13,7 @@ import { trpcClient, type RouterOutputs } from "../trpc/client";
  * affected query after every lifecycle action so the panel stays current.
  */
 
-export type WorkerTarget = "runpod" | "vast";
+export type WorkerTarget = "runpod" | "vast" | "verda";
 export type TokenPolicy = "generate" | "fixed";
 type WorkerStatus =
   | "provisioning"


### PR DESCRIPTION
## What changed

Adds `verda` alongside `runpod` and `vast` as a `WorkerProvider`, implemented against the live OpenAPI schema (`api.verda.com/v1/openapi.json`) rather than the SDK's introductory examples — the schema confirmed that `location_code` is required on every create, that `pricing` is deprecated, and the exact `volume_ids` semantics on delete. Verda rents virtual machines rather than containers, so provisioning is two-layered: a CUDA+Docker guest OS image (`osImage`, new on `WorkerSpec`) plus the worker image the guest runs (`image`), started by a rerun-safe Docker startup script.

The lifecycle deliberately diverges from the other targets, because Verda's does. Verda bills a shut-down instance at the full rate and removed its hibernate action for exactly that reason, so mapping `stop` to `shutdown` would have the idle reaper stop workers while saving nothing. Instead `stop` deletes the instance and retains the OS volume — ending the GPU charge while keeping the model cache — and `resume` boots a new machine from that volume. Because `stop` destroys the instance record, the create plan `resume` needs travels inside the provider ref; `provision` and `list` build that ref from the same `GET` representation so orphan reconcile still matches by equality.

Two supporting changes the target could not be correct without: `WorkerManager.resume` now persists a provider ref that changed across the pause (dropping it left the registry pointing at a dead machine while the live one billed untracked), and credentials now resolve per target as a *list* of secrets rather than one key, because Verda authenticates with an OAuth2 client id and secret (`VERDA_CLIENT_ID` + `VERDA_CLIENT_SECRET`). Teardown names every attached volume explicitly and deletes it permanently: an empty `volume_ids` retains all disks and an omitted one only detaches them, both leaving billable storage behind. Because the bootstrap publishes 7777 with Docker — which a UFW rule does not block — provisioning refuses a worker with no bearer token, and resource ids are validated before interpolation into API paths, matching the traversal fix the Verda SDK shipped in 1.24.1. Only Pay As You Go is used.

## Verification

- [x] `npm run test:affected` — all packages touched by this diff pass: `compute` 125, `models` 70 files, `config` 130. The turbo run also reports failures in `image-nodes` and (intermittently) `blender-nodes`/`core-nodes`; these are environmental, not from this diff. `image-nodes` is the documented missing-Vulkan-ICD case (`No WebGPU adapter available (Node/Dawn)`, which AGENTS.md notes CI installs lavapipe for); the others pass standalone (`blender-nodes` 103 passed/37 skipped) and fail only under parallel load. None depend on `packages/compute` — they are swept in because this diff touches `models` and `config`.
- [x] `npm run typecheck` — clean except one pre-existing error in `web/src/components/projects/__tests__/projectStarters.test.ts` (`isPersonal` missing), confirmed present at HEAD with the change stashed.
- [x] `npm run lint` — exit 0, no findings in the changed files.
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — `Gate: 2/2 selfchecks passed`.

Note for reviewers: this environment's `node_modules` predated the `godot`, `game-nodes` and `websocket` workspaces, so builds and several suites failed until `npm install` relinked them. `package-lock.json` is unchanged.

## Agent capabilities

Not applicable — no capability added, and no capability's declared contract changed.

## New checks

- [x] The checks were inverted and observed failing. Three inversions, each restored afterwards:
  - Making `stop` omit `volume_ids` (the silent model-cache-destroying bug) → `2 failed | 28 passed`: *releases compute while retaining every volume*, *keeps the retained volume when the resumed machine fails to come up*.
  - Making `list()` encode a handle differently from `provision()` → `1 failed | 29 passed`: *encodes the same handle in list() as in provision(), so reconcile matches*.
  - Reintroducing the provision-failure volume leak (`volumeIds: []`, which retains disks) → `1 failed | 29 passed`: *destroys the instance and its new volume when readiness fails*. This one was a real bug found while self-reviewing the diff: the failure path passed an empty list with a comment claiming it destroyed the volume. Fixed, and the test that had passed while the bug was live now asserts the named volume ids and `delete_permanently`.
- [x] No file-scanning audit was added, so there is no match-nothing failure mode to guard.

## Not done

Per the brief, this ships the instance backend only. Serverless containers, batch jobs and a separate data volume (the OS volume carries the model cache today) are out of scope. No live smoke test was run — that needs credentials plus an approved spending and destruction policy — so every test here runs against recorded schema shapes, and no claim is made about provider behavior beyond what the published schema and docs specify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xh17NgumHqdHiYTxCMPqU5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xh17NgumHqdHiYTxCMPqU5)_