### PR TITLE
[T-20260910-0002] Expose project ownership on legacy resource APIs

### DIFF
--- a/packages/models/src/job.ts
+++ b/packages/models/src/job.ts
@@ -321,15 +321,17 @@ export class Job extends DBModel {
       limit?: number;
       status?: JobStatus;
       workflowId?: string;
+      projectId?: string;
     } = {}
   ): Promise<[Job[], string]> {
-    const { limit = 50, status, workflowId } = opts;
+    const { limit = 50, status, workflowId, projectId } = opts;
     const startKey = opts.startKey ?? opts.cursor;
     const db = getDb();
 
     const conditions = [eq(jobs.user_id, userId)];
     if (status) conditions.push(eq(jobs.status, status));
     if (workflowId) conditions.push(eq(jobs.workflow_id, workflowId));
+    if (projectId !== undefined) conditions.push(eq(jobs.project_id, projectId));
     if (startKey) {
       const cursorRow = await Job.get<Job>(startKey);
       if (cursorRow && cursorRow.user_id === userId) {

--- a/packages/models/src/thread.ts
+++ b/packages/models/src/thread.ts
@@ -55,13 +55,17 @@ export class Thread extends DBModel {
       startKey?: string;
       reverse?: boolean;
       workflowId?: string;
+      projectId?: string;
     } = {}
   ): Promise<[Thread[], string]> {
-    const { limit = 50, reverse = true, workflowId, startKey } = opts;
+    const { limit = 50, reverse = true, workflowId, projectId, startKey } = opts;
     const db = getDb();
     const conditions = [eq(threads.user_id, userId)];
     if (workflowId !== undefined) {
       conditions.push(eq(threads.workflow_id, workflowId));
+    }
+    if (projectId !== undefined) {
+      conditions.push(eq(threads.project_id, projectId));
     }
     // Seek past the cursor row so following `next` advances the page. Without
     // this the same first page was returned forever while still advertising a

--- a/packages/models/src/workflow.ts
+++ b/packages/models/src/workflow.ts
@@ -268,13 +268,17 @@ export class Workflow extends DBModel {
       access?: AccessLevel;
       runMode?: WorkflowRunMode | string;
       tag?: string;
+      projectId?: string;
       startKey?: string;
     } = {}
   ): Promise<[Workflow[], string]> {
-    const { limit = 50, access, runMode, tag, startKey } = opts;
+    const { limit = 50, access, runMode, tag, projectId, startKey } = opts;
     const db = getDb();
 
     const conditions = [eq(workflows.user_id, userId)];
+    if (projectId !== undefined) {
+      conditions.push(eq(workflows.project_id, projectId));
+    }
     if (access) conditions.push(eq(workflows.access, access));
     if (runMode) {
       conditions.push(eq(workflows.run_mode, runMode));
@@ -336,11 +340,14 @@ export class Workflow extends DBModel {
    */
   static async paginateSummaries(
     userId: string,
-    opts: { limit?: number; startKey?: string } = {}
+    opts: { limit?: number; projectId?: string; startKey?: string } = {}
   ): Promise<[WorkflowSummary[], string]> {
-    const { limit = 50, startKey } = opts;
+    const { limit = 50, projectId, startKey } = opts;
     const db = getDb();
     const conditions = [eq(workflows.user_id, userId)];
+    if (projectId !== undefined) {
+      conditions.push(eq(workflows.project_id, projectId));
+    }
 
     if (startKey) {
       const [cursor] = await db
@@ -444,14 +451,17 @@ export class Workflow extends DBModel {
 
   static async paginateTools(
     userId: string,
-    opts: { limit?: number; startKey?: string } = {}
+    opts: { limit?: number; projectId?: string; startKey?: string } = {}
   ): Promise<[Workflow[], string]> {
-    const { limit = 50, startKey } = opts;
+    const { limit = 50, projectId, startKey } = opts;
     const db = getDb();
     const conditions = [
       eq(workflows.user_id, userId),
       eq(workflows.run_mode, "tool")
     ];
+    if (projectId !== undefined) {
+      conditions.push(eq(workflows.project_id, projectId));
+    }
     if (startKey) {
       const cursor = await Workflow.get<Workflow>(startKey);
       if (cursor && cursor.user_id === userId) {

--- a/packages/models/src/workspace.ts
+++ b/packages/models/src/workspace.ts
@@ -90,14 +90,18 @@ export class Workspace extends DBModel {
 
   static async paginate(
     userId: string,
-    opts: { limit?: number; startKey?: string } = {}
+    opts: { limit?: number; projectId?: string; startKey?: string } = {}
   ): Promise<[Workspace[], string]> {
-    const { limit = 50 } = opts;
+    const { limit = 50, projectId } = opts;
     const db = getDb();
+    const conditions = [eq(workspaces.user_id, userId)];
+    if (projectId !== undefined) {
+      conditions.push(eq(workspaces.project_id, projectId));
+    }
     const rows = await db
       .select()
       .from(workspaces)
-      .where(eq(workspaces.user_id, userId))
+      .where(and(...conditions))
       .limit(limit + 1);
 
     const items = rows.map((r: Record<string, unknown>) => new Workspace(r));

--- a/packages/models/tests/migrations.test.ts
+++ b/packages/models/tests/migrations.test.ts
@@ -530,6 +530,15 @@ describe("Built-in migrations", () => {
     expect(await adapter.tableExists("nodetool_workflow_shares")).toBe(true);
     expect(await adapter.tableExists("projects")).toBe(true);
 
+    for (const table of [
+      "nodetool_workflows",
+      "nodetool_threads",
+      "nodetool_jobs",
+      "nodetool_workspaces"
+    ]) {
+      expect(await adapter.columnExists(table, "project_id")).toBe(true);
+    }
+
     // Ledger rows carry the project (and document) they were spent on.
     expect(
       await adapter.columnExists("nodetool_predictions", "project_id")

--- a/packages/models/tests/models.test.ts
+++ b/packages/models/tests/models.test.ts
@@ -6,6 +6,7 @@ import { Workflow } from "../src/workflow.js";
 import { Asset } from "../src/asset.js";
 import { Message } from "../src/message.js";
 import { Thread } from "../src/thread.js";
+import { Workspace } from "../src/workspace.js";
 
 // ── Setup ────────────────────────────────────────────────────────────
 
@@ -339,6 +340,69 @@ describe("Workflow model", () => {
     expect(JSON.stringify([...firstPage, ...secondPage])).not.toContain(
       "x".repeat(100)
     );
+  });
+
+  it("scopes workflow pages by project without changing the legacy default", async () => {
+    await Workflow.create<Workflow>({
+      user_id: "u1",
+      project_id: "p1",
+      name: "One",
+      graph: { nodes: [], edges: [] }
+    });
+    await Workflow.create<Workflow>({
+      user_id: "u1",
+      project_id: "p2",
+      name: "Two",
+      graph: { nodes: [], edges: [] }
+    });
+
+    const [all] = await Workflow.paginate("u1");
+    const [one] = await Workflow.paginate("u1", { projectId: "p1" });
+    const [summaries] = await Workflow.paginateSummaries("u1", {
+      projectId: "p1"
+    });
+    const [tools] = await Workflow.paginateTools("u1", {
+      projectId: "p1"
+    });
+
+    expect(all).toHaveLength(2);
+    expect(one.map((workflow) => workflow.project_id)).toEqual(["p1"]);
+    expect(summaries.map((workflow) => workflow.id)).toEqual([one[0].id]);
+    expect(tools).toEqual([]);
+  });
+
+  it("scopes job and thread pages by project", async () => {
+    await Job.create<Job>({ user_id: "u1", workflow_id: "w1", project_id: "p1" });
+    await Job.create<Job>({ user_id: "u1", workflow_id: "w2", project_id: "p2" });
+    await Thread.create<Thread>({ user_id: "u1", project_id: "p1", title: "One" });
+    await Thread.create<Thread>({ user_id: "u1", project_id: "p2", title: "Two" });
+
+    const [jobs] = await Job.paginate("u1", { projectId: "p1" });
+    const [threads] = await Thread.paginate("u1", { projectId: "p1" });
+
+    expect(jobs.map((job) => job.project_id)).toEqual(["p1"]);
+    expect(threads.map((thread) => thread.project_id)).toEqual(["p1"]);
+  });
+
+  it("scopes workspace pages by project", async () => {
+    await Workspace.create<Workspace>({
+      user_id: "u1",
+      project_id: "p1",
+      name: "One",
+      path: "/tmp/one"
+    });
+    await Workspace.create<Workspace>({
+      user_id: "u1",
+      project_id: "p2",
+      name: "Two",
+      path: "/tmp/two"
+    });
+
+    const [workspaces] = await Workspace.paginate("u1", {
+      projectId: "p2"
+    });
+
+    expect(workspaces.map((workspace) => workspace.project_id)).toEqual(["p2"]);
   });
 
   it("paginate with access filter", async () => {

--- a/packages/protocol/src/api-schemas/jobs.ts
+++ b/packages/protocol/src/api-schemas/jobs.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 export const jobResponse = z.object({
   id: z.string(),
   user_id: z.string(),
+  project_id: z.string().optional(),
   job_type: z.literal("workflow"),
   status: z.string(),
   name: z.string().nullable(),
@@ -24,6 +25,7 @@ export type JobResponse = z.infer<typeof jobResponse>;
 // `/running/all` and the cancel endpoint response.
 export const backgroundJobResponse = z.object({
   job_id: z.string(),
+  project_id: z.string().optional(),
   status: z.string(),
   workflow_id: z.string(),
   created_at: z.string().nullable(),
@@ -36,6 +38,7 @@ export type BackgroundJobResponse = z.infer<typeof backgroundJobResponse>;
 export const listInput = z.object({
   limit: z.number().int().min(1).max(500).default(100),
   workflow_id: z.string().optional(),
+  project_id: z.string().optional(),
   include_outputs: z.boolean().default(false),
   // Cursor from a previous response's next_start_key. Without this the returned
   // cursor could never be submitted, so pagination past the first page was

--- a/packages/protocol/src/api-schemas/threads.ts
+++ b/packages/protocol/src/api-schemas/threads.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 export const threadResponse = z.object({
   id: z.string(),
   user_id: z.string(),
+  project_id: z.string().optional(),
   workflow_id: z.string().nullable().optional(),
   title: z.string().nullable(),
   created_at: z.string(),
@@ -20,7 +21,8 @@ export const listInput = z.object({
   limit: z.number().int().min(1).max(500).default(10),
   cursor: z.string().optional(),
   reverse: z.boolean().optional(),
-  workflow_id: z.string().optional()
+  workflow_id: z.string().optional(),
+  project_id: z.string().optional()
 });
 export type ListInput = z.infer<typeof listInput>;
 
@@ -40,7 +42,8 @@ export type GetInput = z.infer<typeof getInput>;
 // `title` is optional; defaults to "New Thread" server-side.
 export const createInput = z.object({
   title: z.string().optional(),
-  workflow_id: z.string().nullable().optional()
+  workflow_id: z.string().nullable().optional(),
+  project_id: z.string().default("default")
 });
 export type CreateInput = z.infer<typeof createInput>;
 

--- a/packages/protocol/src/api-schemas/workflows.ts
+++ b/packages/protocol/src/api-schemas/workflows.ts
@@ -116,6 +116,8 @@ export type Graph = z.infer<typeof graph>;
 
 export const workflowResponse = z.object({
   id: z.string(),
+  /** Project ownership. Optional for clients during the rollout. */
+  project_id: z.string().optional(),
   access: z.string(),
   created_at: z.string().nullable().optional(),
   updated_at: z.string().nullable().optional(),
@@ -251,6 +253,7 @@ export const listInput = z.object({
   run_mode: z.string().optional(),
   mediaOutput: z.boolean().optional(),
   tag: z.string().optional(),
+  project_id: z.string().optional(),
   cursor: z.string().optional()
 });
 export type ListInput = z.infer<typeof listInput>;
@@ -277,6 +280,7 @@ export type GetInput = z.infer<typeof getInput>;
 
 export const workflowBody = z.object({
   name: z.string().min(1),
+  project_id: z.string().default("default"),
   tool_name: z.string().nullable().optional(),
   package_name: z.string().nullable().optional(),
   path: z.string().nullable().optional(),

--- a/packages/protocol/src/api-schemas/workspace.ts
+++ b/packages/protocol/src/api-schemas/workspace.ts
@@ -50,6 +50,7 @@ export type GetInput = z.infer<typeof getInput>;
 export const createInput = z.object({
   name: z.string().min(1),
   path: z.string().min(1),
+  project_id: z.string().optional(),
   is_default: z.boolean().default(false)
 });
 export type CreateInput = z.infer<typeof createInput>;

--- a/packages/protocol/src/api-schemas/workspace.ts
+++ b/packages/protocol/src/api-schemas/workspace.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 export const workspaceResponse = z.object({
   id: z.string(),
   user_id: z.string(),
+  project_id: z.string().optional(),
   name: z.string(),
   path: z.string(),
   is_default: z.boolean(),
@@ -18,7 +19,8 @@ export type WorkspaceResponse = z.infer<typeof workspaceResponse>;
 
 // ── list (GET /api/workspaces) ───────────────────────────────────
 export const listInput = z.object({
-  limit: z.number().int().min(1).max(500).default(50)
+  limit: z.number().int().min(1).max(500).default(50),
+  project_id: z.string().optional()
 });
 export type ListInput = z.infer<typeof listInput>;
 

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -432,6 +432,7 @@ export interface WorkflowGraph {
 export interface Workflow {
   id: string;
   user_id?: string;
+  project_id?: string;
   name: string;
   tool_name?: string | null;
   description: string;
@@ -470,6 +471,7 @@ export interface WorkflowList {
 
 export interface WorkflowRequest {
   name: string;
+  project_id?: string;
   tool_name?: string | null;
   package_name?: string | null;
   path?: string | null;
@@ -510,6 +512,7 @@ export interface WorkflowToolList {
 export interface Thread {
   id: string;
   user_id: string;
+  project_id?: string;
   /** Workflow this conversation belongs to, or null for global chat. */
   workflow_id?: string | null;
   title: string | null;
@@ -526,6 +529,7 @@ export interface ThreadList {
 export interface ThreadCreateRequest {
   title?: string;
   workflow_id?: string | null;
+  project_id?: string;
 }
 
 export interface ThreadUpdateRequest {
@@ -955,6 +959,7 @@ export interface Graph {
 export interface JobResponse {
   id: string;
   user_id: string;
+  project_id?: string;
   job_type: string;
   workflow_id: string;
   status: string | null;
@@ -982,6 +987,7 @@ export interface RunJobRequest {
   job_type?: string;
   execution_strategy?: string;
   workflow_id: string;
+  project_id?: string | null;
   user_id?: string;
   auth_token?: string;
   api_url?: string | null;
@@ -1595,6 +1601,7 @@ export interface CollectionCreate {
 export interface WorkspaceResponse {
   id: string;
   user_id: string;
+  project_id?: string;
   name: string;
   path: string;
   is_default?: boolean;
@@ -1612,6 +1619,7 @@ export interface WorkspaceListResponse {
 export interface WorkspaceCreateRequest {
   name: string;
   description?: string;
+  project_id?: string;
 }
 
 export interface WorkspaceUpdateRequest {

--- a/packages/protocol/tests/api-schemas-workspace.test.ts
+++ b/packages/protocol/tests/api-schemas-workspace.test.ts
@@ -93,6 +93,13 @@ describe("workspace.createInput", () => {
     expect(createInput.parse({ name: "n", path: "/p" }).is_default).toBe(false);
   });
 
+  it("accepts an optional project id", () => {
+    expect(
+      createInput.parse({ name: "n", path: "/p", project_id: "project-1" })
+        .project_id
+    ).toBe("project-1");
+  });
+
   it("rejects empty name", () => {
     expect(createInput.safeParse({ name: "", path: "/p" }).success).toBe(false);
   });

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -502,6 +502,7 @@ async function parseBody<S extends z.ZodType>(
 export function toWorkflowResponse(workflow: Workflow) {
   return {
     id: workflow.id,
+    project_id: workflow.project_id,
     access: workflow.access,
     created_at: workflow.created_at,
     updated_at: workflow.updated_at,
@@ -1271,11 +1272,13 @@ export async function handleWorkflowsRoot(
   if (request.method === "GET") {
     const limit = parseLimit(url, 100);
     const runMode = url.searchParams.get("run_mode")?.trim() ?? undefined;
+    const projectId = url.searchParams.get("project_id")?.trim() || undefined;
     const startKey = url.searchParams.get("cursor")?.trim() || undefined;
     // columns is Python-specific (column selection) and is ignored here.
     const [workflows, cursor] = await Workflow.paginate(userId, {
       limit,
       runMode,
+      projectId,
       startKey
     });
     return jsonResponse({
@@ -1408,6 +1411,7 @@ export function toJobResponse(job: Job) {
   return {
     id: job.id,
     user_id: job.user_id,
+    project_id: job.project_id,
     job_type: "workflow",
     status: job.status,
     workflow_id: job.workflow_id,

--- a/packages/websocket/src/http-body-schemas.ts
+++ b/packages/websocket/src/http-body-schemas.ts
@@ -116,6 +116,7 @@ export const workflowsExportBundleBodySchema = z.object({
 /** `POST /api/workflows` and `PUT /api/workflows/:id` */
 export const workflowRequestBodySchema = z.object({
   name: lenientString(),
+  project_id: unchecked<string>(),
   tool_name: unchecked<string | null>(),
   package_name: unchecked<string | null>(),
   path: unchecked<string | null>(),

--- a/packages/websocket/src/lib/workflow-service.ts
+++ b/packages/websocket/src/lib/workflow-service.ts
@@ -58,6 +58,7 @@ export interface WorkflowGraphInput {
 /** The fields both writers accept. Absent means "leave alone" on update. */
 export interface WorkflowWriteInput {
   name?: string;
+  project_id?: string;
   tool_name?: string | null;
   package_name?: string | null;
   path?: string | null;
@@ -141,6 +142,7 @@ function createRow(
     settings: input.settings ?? null,
     run_mode: input.run_mode ?? "workflow",
     workspace_id: input.workspace_id ?? null,
+    project_id: input.project_id ?? "default",
     html_app: input.html_app ?? null,
     app_doc: appDoc
   };

--- a/packages/websocket/src/trpc/routers/jobs.ts
+++ b/packages/websocket/src/trpc/routers/jobs.ts
@@ -30,6 +30,7 @@ function toJobResponse(job: JobModel, includeOutputs: boolean): JobResponse {
   return {
     id: job.id,
     user_id: job.user_id,
+    project_id: job.project_id,
     job_type: "workflow" as const,
     status: job.status,
     name: job.name ?? null,
@@ -45,6 +46,7 @@ function toJobResponse(job: JobModel, includeOutputs: boolean): JobResponse {
 function toBackgroundJobResponse(job: JobModel): BackgroundJobResponse {
   return {
     job_id: job.id,
+    project_id: job.project_id,
     status: job.status,
     workflow_id: job.workflow_id,
     created_at: job.started_at ?? null,
@@ -130,11 +132,13 @@ export const jobsRouter = router({
     .input(listInput)
     .output(listOutput)
     .query(async ({ ctx, input }) => {
-      const [jobs, nextStartKey] = await Job.paginate(ctx.userId, {
+      const page: Parameters<typeof Job.paginate>[1] = {
         limit: input.limit,
         workflowId: input.workflow_id,
         startKey: input.start_key
-      });
+      };
+      if (input.project_id !== undefined) page.projectId = input.project_id;
+      const [jobs, nextStartKey] = await Job.paginate(ctx.userId, page);
       return {
         jobs: jobs.map((j) => toJobResponse(j, input.include_outputs)),
         next_start_key: nextStartKey || null

--- a/packages/websocket/src/trpc/routers/threads.ts
+++ b/packages/websocket/src/trpc/routers/threads.ts
@@ -39,6 +39,7 @@ function toThreadResponse(thread: ThreadModel): ThreadResponse {
   return {
     id: thread.id,
     user_id: thread.user_id,
+    project_id: thread.project_id,
     workflow_id: thread.workflow_id ?? null,
     title: thread.title,
     created_at: thread.created_at,
@@ -97,6 +98,7 @@ export const threadsRouter = router({
         startKey: input.cursor,
         reverse: input.reverse
       };
+      if (input.project_id !== undefined) page.projectId = input.project_id;
       if (input.workflow_id !== undefined) {
         page.workflowId = input.workflow_id;
       }

--- a/packages/websocket/src/trpc/routers/workflows.ts
+++ b/packages/websocket/src/trpc/routers/workflows.ts
@@ -244,6 +244,7 @@ function recordAutosave(workflowId: string, now: number): void {
 function toWorkflowResponse(workflow: WorkflowModel): WorkflowResponse {
   return {
     id: workflow.id,
+    project_id: workflow.project_id,
     access: workflow.access,
     created_at: (workflow.created_at as string | undefined) ?? null,
     updated_at: (workflow.updated_at as string | undefined) ?? null,
@@ -455,6 +456,7 @@ export const workflowsRouter = router({
         limit: input.limit,
         runMode: input.run_mode,
         tag: input.tag,
+        projectId: input.project_id,
         startKey: input.cursor
       });
       let filtered = workflows;

--- a/packages/websocket/src/trpc/routers/workspace.ts
+++ b/packages/websocket/src/trpc/routers/workspace.ts
@@ -206,15 +206,16 @@ export const workspaceRouter = router({
         await Workspace.unsetOtherDefaults(ctx.userId);
       }
 
-      const ws = (await Workspace.create({
+      const workspaceInput: Record<string, unknown> = {
         user_id: ctx.userId,
         name: input.name,
         path: input.path,
-        is_default: input.is_default,
-        ...(input.project_id === undefined
-          ? {}
-          : { project_id: input.project_id })
-      })) as Workspace;
+        is_default: input.is_default
+      };
+      if (input.project_id !== undefined) {
+        workspaceInput.project_id = input.project_id;
+      }
+      const ws = (await Workspace.create(workspaceInput)) as Workspace;
 
       return toWorkspaceResponse(ws);
     }),

--- a/packages/websocket/src/trpc/routers/workspace.ts
+++ b/packages/websocket/src/trpc/routers/workspace.ts
@@ -48,6 +48,7 @@ function toWorkspaceResponse(ws: Workspace): WorkspaceResponse {
   return {
     id: ws.id,
     user_id: ws.user_id,
+    project_id: ws.project_id,
     name: ws.name,
     path: ws.path,
     is_default: ws.is_default,
@@ -178,9 +179,11 @@ export const workspaceRouter = router({
       // editor never has to render a "no workspace" state and a run always has
       // somewhere to write.
       await Workspace.ensureDefault(ctx.userId);
-      const [items] = await Workspace.paginate(ctx.userId, {
+      const page: Parameters<typeof Workspace.paginate>[1] = {
         limit: input.limit
-      });
+      };
+      if (input.project_id !== undefined) page.projectId = input.project_id;
+      const [items] = await Workspace.paginate(ctx.userId, page);
       const readable = canManageWorkspaces()
         ? items
         : items.filter((ws) => ws.isManaged());
@@ -207,7 +210,8 @@ export const workspaceRouter = router({
         user_id: ctx.userId,
         name: input.name,
         path: input.path,
-        is_default: input.is_default
+        is_default: input.is_default,
+        project_id: input.project_id
       })) as Workspace;
 
       return toWorkspaceResponse(ws);

--- a/packages/websocket/src/trpc/routers/workspace.ts
+++ b/packages/websocket/src/trpc/routers/workspace.ts
@@ -211,7 +211,9 @@ export const workspaceRouter = router({
         name: input.name,
         path: input.path,
         is_default: input.is_default,
-        project_id: input.project_id
+        ...(input.project_id === undefined
+          ? {}
+          : { project_id: input.project_id })
       })) as Workspace;
 
       return toWorkspaceResponse(ws);

--- a/packages/websocket/tests/trpc-workspace.test.ts
+++ b/packages/websocket/tests/trpc-workspace.test.ts
@@ -241,6 +241,32 @@ describe("workspace router", () => {
       expect(result.id).toBe("new-ws");
     });
 
+    it("forwards project ownership when provided", async () => {
+      (existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      (stat as ReturnType<typeof vi.fn>).mockResolvedValue({
+        isDirectory: () => true
+      });
+      (access as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+      (Workspace.create as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeWorkspace({ id: "project-ws" })
+      );
+
+      const caller = createCaller(makeCtx());
+      await caller.workspace.create({
+        name: "Project workspace",
+        path: "/home/user/project-ws",
+        project_id: "project-1"
+      });
+
+      expect(Workspace.create).toHaveBeenCalledWith({
+        user_id: "user-1",
+        name: "Project workspace",
+        path: "/home/user/project-ws",
+        is_default: false,
+        project_id: "project-1"
+      });
+    });
+
     it("unsets other defaults when is_default is true", async () => {
       (existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
       (stat as ReturnType<typeof vi.fn>).mockResolvedValue({


### PR DESCRIPTION
Completes the remaining ownership boundary for legacy workflow, job, thread, and workspace APIs. Database-backed project ownership is now available through compatible protocol fields and explicit project-scoped list operations, while omitted filters retain existing behavior.

- Add project ownership fields to workflow, job, thread, and workspace protocol contracts and response mappings.
- Add project-scoped pagination to all four model families and wire the filters through REST/tRPC workflow, tRPC job/thread/workspace surfaces.
- Carry project ownership through workflow creation and verify SQLite migration coverage.
- Add regression tests for mixed-project pagination.

Verification:
- `git diff --check` passed.
- `npm run test:affected` was attempted but package builds are blocked because `node_modules/typescript/bin/tsc` is absent.
- `npm run typecheck`, `npm run lint`, and the harness gate were attempted and are blocked by missing `tsc`, `oxlint`, and `tsx` binaries.
- Focused Vitest execution was unavailable because `vitest` is not installed.