### PR TITLE
Add speech and music generation to the timeline composer

### DIFF
--- a/packages/protocol/src/api-schemas/timeline.ts
+++ b/packages/protocol/src/api-schemas/timeline.ts
@@ -719,6 +719,7 @@ export const clipBindingKind = z.enum([
   "text-to-image",
   "image-to-image",
   "text-to-video",
+  "text-to-music",
   "text-to-audio"
 ]);
 export type ClipBindingKind = z.infer<typeof clipBindingKind>;

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -618,6 +618,7 @@ export type MediaGenerationMode =
   | "image_to_video"
   | "reference_to_video"
   | "audio"
+  | "music"
   | "audio_to_video"
   | "retake"
   | "extend"
@@ -639,7 +640,7 @@ export interface MediaGenerationRequest {
   resolution?: string | null;
   /** Number of variations to generate (images). */
   variations?: number | null;
-  /** Duration in seconds (video). */
+  /** Requested duration in seconds (video or music). */
   duration?: number | null;
   /** Voice id for text-to-speech. */
   voice?: string | null;

--- a/packages/protocol/src/ws-commands.ts
+++ b/packages/protocol/src/ws-commands.ts
@@ -192,7 +192,9 @@ export const generateMediaDataSchema = z
      * "inpaint" = image-to-image confined to `mask_asset_id`;
      * "video" = text-to-video; "audio" = text-to-speech.
      */
-    mode: z.enum(["image", "image_edit", "inpaint", "video", "audio"]).optional(),
+    mode: z
+      .enum(["image", "image_edit", "inpaint", "video", "audio", "music"])
+      .optional(),
     provider: z.string().optional(),
     model: z.string().optional(),
     prompt: z.string().optional(),

--- a/packages/runtime/src/providers/fal-provider.ts
+++ b/packages/runtime/src/providers/fal-provider.ts
@@ -767,6 +767,11 @@ export class FalProvider extends BaseProvider {
       b.set("duration", params.durationSeconds)
         .set("seconds_total", params.durationSeconds)
         .set("music_duration", params.durationSeconds);
+      if (b.declares("music_length_ms")) {
+        // ElevenLabs expects an integer, despite the optional field's string
+        // type in the generated manifest: https://fal.ai/models/fal-ai/elevenlabs/music/api
+        b.force("music_length_ms", Math.round(params.durationSeconds * 1000));
+      }
     }
     if (params.seed != null && params.seed !== -1) b.set("seed", params.seed);
     return b.args;

--- a/packages/runtime/tests/providers/fal-provider.test.ts
+++ b/packages/runtime/tests/providers/fal-provider.test.ts
@@ -640,6 +640,46 @@ describe("FalProvider — music", () => {
     ).toBe(true);
   });
 
+  it("sends ElevenLabs Music duration in milliseconds", async () => {
+    const subscribe = vi.fn().mockResolvedValue({
+      data: { audio: { url: "https://fal.ai/song.mp3" } }
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: new Headers(),
+        arrayBuffer: async () => new Uint8Array([0xff, 0xfb]).buffer
+      })
+    );
+    try {
+      const { createFalClient } = await import("@fal-ai/client");
+      vi.mocked(createFalClient).mockReturnValueOnce({
+        subscribe
+      } as ReturnType<typeof createFalClient>);
+      await createProvider().textToMusic({
+        model: {
+          id: "fal-ai/elevenlabs/music",
+          name: "ElevenLabs Music",
+          provider: "fal_ai"
+        },
+        prompt: "Warm ambient piano",
+        durationSeconds: 60
+      });
+      expect(subscribe).toHaveBeenCalledWith(
+        "fal-ai/elevenlabs/music",
+        expect.objectContaining({
+          input: expect.objectContaining({
+            prompt: "Warm ambient piano",
+            music_length_ms: 60000
+          })
+        })
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("textToMusic subscribes with the prompt and downloads the audio", async () => {
     const subscribeMock = vi.fn().mockResolvedValue({
       data: { audio: { url: "https://fal.ai/song.mp3" } }

--- a/packages/timeline/src/types.ts
+++ b/packages/timeline/src/types.ts
@@ -487,6 +487,7 @@ export interface TrackChromaKeyEffect {
  *     param overrides. `sourceClipId` is the input clip for i2i.
  *   - `"text-to-video"`: calls the runner's `generate_media` RPC with a video
  *     model + prompt. Returns a single `video/mp4` asset.
+ *   - `"text-to-music"`: generates music as an audio asset.
  *   - `"text-to-audio"`: calls the runner's `generate_media` RPC with a TTS
  *     model + voice + prompt text. Returns a single audio asset (wav/mp3/...).
  *
@@ -498,7 +499,8 @@ export type ClipBindingKind =
   | "text-to-image"
   | "image-to-image"
   | "text-to-video"
-  | "text-to-audio";
+  | "text-to-audio"
+  | "text-to-music";
 
 /**
  * What a clip draws. Two members carry no media of their own:

--- a/packages/websocket/src/session/chat-turn.ts
+++ b/packages/websocket/src/session/chat-turn.ts
@@ -17,7 +17,8 @@ import {
 import { storeAssetWithThumbnail } from "../lib/thumbnail.js";
 import {
   createGenerationRun,
-  generateSpeechBytes
+  generateSpeechBytes,
+  generateMusicBytes
 } from "./media-generation.js";
 import {
   attachRunCostLedger,
@@ -3179,7 +3180,7 @@ export class ChatTurnHandler {
         return;
       }
 
-      if (mode === "audio") {
+      if (mode === "audio" || mode === "music") {
         const voice = isString(mediaGeneration.voice)
           ? (mediaGeneration.voice as string)
           : undefined;
@@ -3210,30 +3211,50 @@ export class ChatTurnHandler {
           done: false
         });
 
+        const durationSeconds = isNumber(mediaGeneration.duration)
+          ? mediaGeneration.duration
+          : undefined;
         const audioGenerationId = randomUUID();
         let assetId: string | undefined;
         let audioMimeType: string | undefined;
         await generate(
-          "text_to_speech",
-          {
-            text: expandedPrompt,
-            voice,
-            speed,
-            audio_format: requestedFormat
-          },
-          null,
-          async () => {
-            const speech = await generateSpeechBytes(
-              provider,
-              {
+          mode === "music" ? "text_to_music" : "text_to_speech",
+          mode === "music"
+            ? { prompt: expandedPrompt, duration_seconds: durationSeconds }
+            : {
                 text: expandedPrompt,
-                model: modelId,
                 voice,
                 speed,
-                audioFormat: requestedFormat
+                audio_format: requestedFormat
               },
-              cancelled
-            );
+          null,
+          async () => {
+            const speech =
+              mode === "music"
+                ? await generateMusicBytes(
+                    provider,
+                    {
+                      model: {
+                        id: modelId,
+                        name: modelId,
+                        provider: providerId
+                      },
+                      prompt: expandedPrompt,
+                      durationSeconds
+                    },
+                    cancelled
+                  )
+                : await generateSpeechBytes(
+                    provider,
+                    {
+                      text: expandedPrompt,
+                      model: modelId,
+                      voice,
+                      speed,
+                      audioFormat: requestedFormat
+                    },
+                    cancelled
+                  );
             if (!speech) return null;
             assetId = await storeMediaAsset(
               speech.bytes,

--- a/packages/websocket/src/session/commands.ts
+++ b/packages/websocket/src/session/commands.ts
@@ -785,7 +785,8 @@ export class CommandRouter {
         | "inpaint"
         | "video"
         | "video_edit"
-        | "audio" =
+        | "audio"
+        | "music" =
         rawMode === "image_edit"
           ? "image_edit"
           : rawMode === "inpaint"
@@ -796,7 +797,9 @@ export class CommandRouter {
                 ? "video_edit"
                 : rawMode === "audio"
                   ? "audio"
-                  : "image";
+                  : rawMode === "music"
+                    ? "music"
+                    : "image";
       const provider = String(data.provider ?? defaults.provider);
       const model = String(data.model ?? defaults.model);
       const prompt = String(data.prompt ?? "");

--- a/packages/websocket/src/session/inference.ts
+++ b/packages/websocket/src/session/inference.ts
@@ -40,13 +40,21 @@ import { isFiniteNumber, isRecord, isString } from "../lib/wire-values.js";
 import type { ClientSession } from "./client-session.js";
 import {
   createGenerationRun,
-  generateSpeechBytes
+  generateSpeechBytes,
+  generateMusicBytes
 } from "./media-generation.js";
 
 const log = createLogger("nodetool.websocket.runner");
 
 export interface DirectMediaGenerationRequest {
-  mode: "image" | "image_edit" | "inpaint" | "video" | "video_edit" | "audio";
+  mode:
+    | "image"
+    | "image_edit"
+    | "inpaint"
+    | "video"
+    | "video_edit"
+    | "audio"
+    | "music";
   provider: string;
   model: string;
   prompt: string;
@@ -820,7 +828,7 @@ export class DirectInferenceHandler {
       return { asset_ids: [assetId] };
     }
 
-    if (req.mode === "audio") {
+    if (req.mode === "audio" || req.mode === "music") {
       const supportedFormats = new Set([
         "mp3",
         "wav",
@@ -836,22 +844,35 @@ export class DirectInferenceHandler {
 
       const audioGenerationId = randomUUID();
       const generated = await generate(
-        "text_to_speech",
-        {
-          text: prompt,
-          voice: req.voice,
-          speed: req.speed,
-          audio_format: requestedFormat
-        },
+        req.mode === "music" ? "text_to_music" : "text_to_speech",
+        req.mode === "music"
+          ? { prompt, duration_seconds: req.durationSeconds }
+          : {
+              text: prompt,
+              voice: req.voice,
+              speed: req.speed,
+              audio_format: requestedFormat
+            },
         null,
         async () => {
-          const speech = await generateSpeechBytes(provider, {
-            text: prompt,
-            model: req.model,
-            voice: req.voice,
-            speed: req.speed,
-            audioFormat: requestedFormat
-          });
+          const speech =
+            req.mode === "music"
+              ? await generateMusicBytes(provider, {
+                  model: {
+                    id: req.model,
+                    name: req.model,
+                    provider: req.provider
+                  },
+                  prompt,
+                  durationSeconds: req.durationSeconds
+                })
+              : await generateSpeechBytes(provider, {
+                  text: prompt,
+                  model: req.model,
+                  voice: req.voice,
+                  speed: req.speed,
+                  audioFormat: requestedFormat
+                });
           if (!speech) throw new Error("Provider returned no audio data");
           return storeAsset(speech.bytes, speech.mimeType, speech.ext);
         },

--- a/packages/websocket/src/session/media-generation.ts
+++ b/packages/websocket/src/session/media-generation.ts
@@ -20,7 +20,8 @@ import { ProcessingContext as GenerationContext } from "@nodetool-ai/runtime";
 import type {
   BaseProvider,
   GenerationRequest,
-  GenerationResult
+  GenerationResult,
+  TextToMusicParams
 } from "@nodetool-ai/runtime";
 import type { GenerationReceipt } from "@nodetool-ai/protocol";
 
@@ -46,7 +47,9 @@ export interface GenerationRunOptions {
   /** Overrides the node type the ledger records for these rows. */
   nodeType?: () => string;
   /** The managed-provider receipt, read once the assets are stored. */
-  receiptAfterPersist?: () => { cost: NonNullable<GenerationReceipt["cost"]> } | null;
+  receiptAfterPersist?: () => {
+    cost: NonNullable<GenerationReceipt["cost"]>;
+  } | null;
   /** Called with every generation id this run opened. */
   onGenerationId?: (id: string) => void;
 }
@@ -212,10 +215,25 @@ export interface SpeechRequest {
   audioFormat?: string | null;
 }
 
-export interface SpeechBytes {
+export interface GeneratedAudioBytes {
   bytes: Uint8Array;
   mimeType: string;
   ext: string;
+}
+
+export async function generateMusicBytes(
+  provider: BaseProvider,
+  request: TextToMusicParams,
+  cancelled?: () => boolean
+): Promise<GeneratedAudioBytes | null> {
+  const encoded = await provider.textToMusic(request);
+  if (cancelled?.()) return null;
+  if (!encoded.data.length) throw new Error("Provider returned no audio data");
+  return {
+    bytes: encoded.data,
+    mimeType: encoded.mimeType,
+    ext: ENCODED_AUDIO_MIME_TO_EXT[encoded.mimeType] ?? "flac"
+  };
 }
 
 /**
@@ -231,7 +249,7 @@ export async function generateSpeechBytes(
   provider: BaseProvider,
   request: SpeechRequest,
   cancelled?: () => boolean
-): Promise<SpeechBytes | null> {
+): Promise<GeneratedAudioBytes | null> {
   const requestedFormat = request.audioFormat ?? null;
   const providerRequest = {
     text: request.text,

--- a/packages/websocket/tests/chat-turn-handler-media.test.ts
+++ b/packages/websocket/tests/chat-turn-handler-media.test.ts
@@ -7,7 +7,7 @@
  * Assets are written through the real file storage adapter into a temp
  * directory (ASSET_FOLDER), so no module is mocked.
  */
-import { describe, it, expect, beforeEach, beforeAll } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll, vi } from "vitest";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -484,9 +484,70 @@ describe("audio generation", () => {
     );
     const [assistant] = assistantFrames(harness);
     const [block] = assistant.content as Array<Record<string, unknown>>;
-    expect((block.audio as Record<string, unknown>).mimeType).toBe(
-      "audio/pcm"
+    expect((block.audio as Record<string, unknown>).mimeType).toBe("audio/pcm");
+  });
+});
+
+describe("music generation", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+  it("sends a music prompt to the provider and returns native audio", async () => {
+    const textToMusic = vi.fn(async () => ({
+      data: new Uint8Array([1, 2, 3, 4]),
+      mimeType: "audio/mpeg"
+    }));
+    const harness = makeChatTurnHarness({
+      session: { resolveProvider: async () => fakeProvider({ textToMusic }) }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn(
+        "t-music",
+        { mode: "music", provider: "mock", model: "music-1", duration: 60 },
+        "Warm ambient piano"
+      )
     );
+    expect(harness.session.messagesOfType("error")).toHaveLength(0);
+    expect(textToMusic).toHaveBeenCalledWith({
+      model: { id: "music-1", name: "music-1", provider: "mock" },
+      prompt: "Warm ambient piano",
+      durationSeconds: 60
+    });
+    expect(assistantFrames(harness)).toHaveLength(1);
+    expect(assistantFrames(harness)[0].content).toEqual([
+      expect.objectContaining({
+        type: "audio",
+        audio: expect.objectContaining({
+          type: "audio",
+          mimeType: "audio/mpeg",
+          asset_id: expect.any(String)
+        })
+      })
+    ]);
+  });
+  it("reports empty music output without sending an audio reply", async () => {
+    const harness = makeChatTurnHarness({
+      session: {
+        resolveProvider: async () =>
+          fakeProvider({
+            textToMusic: async () => ({
+              data: new Uint8Array(),
+              mimeType: "audio/mpeg"
+            })
+          })
+      }
+    });
+    await harness.handler.handleChatMessage(
+      mediaTurn("t-music-empty", {
+        mode: "music",
+        provider: "mock",
+        model: "music-1"
+      })
+    );
+    expect(harness.session.messagesOfType("error")[0].message).toBe(
+      "Generation failed: Provider returned no audio data"
+    );
+    expect(assistantFrames(harness)).toHaveLength(0);
   });
 });
 

--- a/packages/websocket/tests/generate-media-rpc.test.ts
+++ b/packages/websocket/tests/generate-media-rpc.test.ts
@@ -909,3 +909,36 @@ describe("generate_media RPC (parameter passthrough)", () => {
     await runner.disconnect();
   });
 });
+
+describe("music generation RPC", () => {
+  it("calls textToMusic with the selected model and duration", async () => {
+    const ws = new MockWebSocket();
+    const textToMusic = vi.fn(async () => ({
+      data: new Uint8Array([1, 2, 3]),
+      mimeType: "audio/mpeg"
+    }));
+    const runner = await makeRunner(ws, () => ({ textToMusic }) as never);
+    try {
+      const out = await runOne(ws, runner, {
+        command: "generate_media",
+        request_id: "music-request",
+        data: {
+          mode: "music",
+          provider: "fake",
+          model: "music-1",
+          prompt: "Warm ambient piano",
+          duration: 60
+        }
+      });
+      expect(out.error).toBeUndefined();
+      expect(out.result).toEqual({ asset_ids: ["asset-1"] });
+      expect(textToMusic).toHaveBeenCalledWith({
+        model: { id: "music-1", name: "music-1", provider: "fake" },
+        prompt: "Warm ambient piano",
+        durationSeconds: 60
+      });
+    } finally {
+      await runner.disconnect();
+    }
+  });
+});

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -174,6 +174,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
   const referenceToVideoParams = useMediaGenerationStore(
     (s) => s.referenceToVideo
   );
+  const musicParams = useMediaGenerationStore((s) => s.music);
   const audioParams = useMediaGenerationStore((s) => s.audio);
 
   // Language-model selection from chat store (used in chat mode & forwarded
@@ -408,6 +409,14 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
           : null
       };
     }
+    if (mode === "music") {
+      return {
+        mode,
+        provider: musicParams.model?.provider ?? null,
+        model: musicParams.model?.id ?? null,
+        duration: musicParams.duration
+      };
+    }
     if (mode === "audio") {
       return {
         mode: "audio",
@@ -426,7 +435,8 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     videoParams,
     imageToVideoParams,
     referenceToVideoParams,
-    audioParams
+    audioParams,
+    musicParams
   ]);
 
   const { queuedMessage, sendMessage, cancelQueued, sendQueuedNow } =
@@ -472,6 +482,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     if (mode === "audio") {
       return "Type the text you want spoken…";
     }
+    if (mode === "music") return "Describe the music you want to generate…";
     if (mode === "audio_to_video") {
       return "Describe a scene synced to audio…";
     }
@@ -500,7 +511,8 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     mode === "video" ||
     mode === "image_to_video" ||
     mode === "reference_to_video" ||
-    mode === "audio";
+    mode === "audio" ||
+    mode === "music";
 
   const chatModel = selectedModel ?? languageModel;
 
@@ -532,6 +544,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     if (mode === "audio") {
       return { model: audioParams.model, label: "speech" };
     }
+    if (mode === "music") return { model: musicParams.model, label: "music" };
     return null;
   }, [
     mode,
@@ -541,7 +554,8 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     videoParams.model,
     imageToVideoParams.model,
     referenceToVideoParams.model,
-    audioParams.model
+    audioParams.model,
+    musicParams.model
   ]);
 
   // A send with no model picked can only fail on the server, so the composer

--- a/web/src/components/chat/composer/MediaModeMenu.tsx
+++ b/web/src/components/chat/composer/MediaModeMenu.tsx
@@ -3,6 +3,7 @@ import React, { memo, useMemo } from "react";
 import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
+import AudiotrackIcon from "@mui/icons-material/Audiotrack";
 import ImageIcon from "@mui/icons-material/Image";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import MovieIcon from "@mui/icons-material/Movie";
@@ -88,6 +89,12 @@ const MODES: ModeItem[] = [
     id: "audio",
     label: "Generate Speech",
     icon: <RecordVoiceOverIcon fontSize="small" />,
+    enabled: true
+  },
+  {
+    id: "music",
+    label: "Generate Music",
+    icon: <AudiotrackIcon fontSize="small" />,
     enabled: true
   },
   {

--- a/web/src/components/chat/composer/MediaModeMenu.tsx
+++ b/web/src/components/chat/composer/MediaModeMenu.tsx
@@ -21,6 +21,8 @@ import {
   Popover,
   Text,
   MOTION,
+  SHADOW,
+  reducedMotion,
   BORDER_RADIUS,
   SPACING,
   getSpacingPx
@@ -33,6 +35,7 @@ interface MediaModeMenuProps {
   onClose: () => void;
   value: MediaMode;
   onChange: (mode: MediaMode) => void;
+  modes?: readonly MediaMode[];
 }
 
 interface ModeItem {
@@ -126,11 +129,12 @@ const styles = (theme: Theme) =>
     ".mode-menu-item": {
       display: "flex",
       alignItems: "center",
-      gap: 8,
-      padding: theme.spacing(3, 4),
+      gap: getSpacingPx(SPACING.md),
+      padding: theme.spacing(SPACING.lg, SPACING.xl),
       cursor: "pointer",
       color: theme.vars.palette.grey[100],
       transition: MOTION.background,
+      ...reducedMotion({ transition: MOTION.none }),
       "&:hover": {
         backgroundColor: theme.vars.palette.c_overlay
       },
@@ -164,7 +168,8 @@ const MediaModeMenu: React.FC<MediaModeMenuProps> = ({
   open,
   onClose,
   value,
-  onChange
+  onChange,
+  modes
 }) => {
   const theme = useTheme();
   const cssStyles = useMemo(() => styles(theme), [theme]);
@@ -178,14 +183,14 @@ const MediaModeMenu: React.FC<MediaModeMenuProps> = ({
         backgroundColor: theme.vars.palette.grey[900],
         border: `1px solid ${theme.vars.palette.grey[800]}`,
         borderRadius: BORDER_RADIUS.sm,
-        boxShadow: `0 12px 40px ${theme.vars.palette.c_scrim}`
+        boxShadow: SHADOW(theme).lg
       }}
     >
       <div css={cssStyles} role="menu" aria-label="Generation mode">
         <Caption className="mode-menu-header" size="small">
           Mode
         </Caption>
-        {MODES.map((m) => {
+        {MODES.filter((m) => !modes || modes.includes(m.id)).map((m) => {
           const selected = m.id === value;
           return (
             <div
@@ -215,11 +220,11 @@ const MediaModeMenu: React.FC<MediaModeMenuProps> = ({
             >
               <span className="mode-menu-icon">{m.icon}</span>
               <FlexRow
-                gap={0.5}
+                gap={SPACING.micro}
                 align="center"
                 sx={{ flex: 1, minWidth: 0 }}
               >
-                <Text size="normal" weight={500} sx={{ color: "inherit" }}>
+                <Text size="small" weight={500} sx={{ color: "inherit" }}>
                   {m.label}
                 </Text>
                 {m.description && (

--- a/web/src/components/chat/composer/ModeChips.tsx
+++ b/web/src/components/chat/composer/ModeChips.tsx
@@ -6,7 +6,7 @@
  * with every menu and dialog it owned. That is what removed the composer's
  * "close everything on mode change" effect: there is nothing left to close.
  */
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import AppsIcon from "@mui/icons-material/Apps";
 import AspectRatioIcon from "@mui/icons-material/CropOriginal";
 import AudiotrackIcon from "@mui/icons-material/Audiotrack";
@@ -27,12 +27,14 @@ import useMediaGenerationStore, {
   AUDIO_FORMATS,
   AUDIO_SPEEDS,
   DEFAULT_TTS_VOICES,
+  MUSIC_DURATIONS,
   IMAGE_VARIATIONS
 } from "../../../stores/MediaGenerationStore";
 import type {
   AudioFormat,
   MediaMode
 } from "../../../stores/MediaGenerationStore";
+import type { MusicModel } from "../../../stores/ApiTypes";
 import useModelPreferencesStore from "../../../stores/ModelPreferencesStore";
 import ModelChip, { type ModelPickerHandle } from "./ModelChip";
 import OptionChip from "./OptionChip";
@@ -103,6 +105,49 @@ interface ModeChipsProps {
 
 interface ClusterProps {
   openModelPickerRef: React.Ref<ModelPickerHandle>;
+}
+
+function MusicModeChips({ openModelPickerRef }: ClusterProps) {
+  const params = useMediaGenerationStore((s) => s.music);
+  const setParams = useMediaGenerationStore((s) => s.setMusicParams);
+  const addRecentModel = useModelPreferencesStore((s) => s.addRecent);
+  const handlePickMusic = useCallback(
+    (model: MusicModel) => {
+      setParams({
+        model: {
+          type: "music_model",
+          id: model.id,
+          provider: model.provider,
+          name: model.name
+        }
+      });
+      addRecentModel(recentModelEntry(model));
+    },
+    [setParams, addRecentModel]
+  );
+  return (
+    <>
+      <ModelChip
+        openRef={openModelPickerRef}
+        icon={<AudiotrackIcon fontSize="small" />}
+        label={params.model?.name || "Select Music Model"}
+        picker={{
+          kind: "music",
+          onPick: handlePickMusic
+        }}
+      />
+      <OptionChip
+        menu="option"
+        icon={<AccessTimeIcon fontSize="small" />}
+        label={`${params.duration} Sec`}
+        header="Target Duration"
+        title={`Target duration: ${params.duration} seconds. The model may adjust or ignore this.`}
+        value={params.duration}
+        options={MUSIC_DURATIONS.map((id) => ({ id, label: `${id} Sec` }))}
+        onChange={(duration) => setParams({ duration })}
+      />
+    </>
+  );
 }
 
 function ImageModeChips({ openModelPickerRef }: ClusterProps) {
@@ -531,6 +576,8 @@ export function ModeChips({ mode, openModelPickerRef }: ModeChipsProps) {
       <ReferenceToVideoModeChips openModelPickerRef={openModelPickerRef} />
     );
   }
+  if (mode === "music")
+    return <MusicModeChips openModelPickerRef={openModelPickerRef} />;
   if (mode === "audio") {
     return <AudioModeChips openModelPickerRef={openModelPickerRef} />;
   }

--- a/web/src/components/chat/composer/ModeSelectChip.tsx
+++ b/web/src/components/chat/composer/ModeSelectChip.tsx
@@ -79,6 +79,7 @@ export function modeLabelFor(mode: MediaMode): string {
 interface ModeSelectChipProps {
   mode: MediaMode;
   onChange: (mode: MediaMode) => void;
+  modes?: readonly MediaMode[];
   /** Icon plus chevron only: the mode reads from its icon, and the label
    *  costs room the model and workspace chips need on one line. */
   compact?: boolean;
@@ -87,6 +88,7 @@ interface ModeSelectChipProps {
 export function ModeSelectChip({
   mode,
   onChange,
+  modes,
   compact = false
 }: ModeSelectChipProps) {
   const [anchor, setAnchor] = useState<HTMLButtonElement | null>(null);
@@ -109,6 +111,7 @@ export function ModeSelectChip({
         onClose={close}
         value={mode}
         onChange={onChange}
+        modes={modes}
       />
     </>
   );

--- a/web/src/components/chat/composer/ModeSelectChip.tsx
+++ b/web/src/components/chat/composer/ModeSelectChip.tsx
@@ -4,6 +4,7 @@
  * inside it.
  */
 import React, { useCallback, useState } from "react";
+import AudiotrackIcon from "@mui/icons-material/Audiotrack";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import ChatBubbleOutlineIcon from "@mui/icons-material/ChatBubbleOutline";
@@ -18,6 +19,7 @@ import MediaModeMenu from "./MediaModeMenu";
 import type { MediaMode } from "../../../stores/MediaGenerationStore";
 
 export function modeIconFor(mode: MediaMode): React.ReactNode {
+  if (mode === "music") return <AudiotrackIcon fontSize="small" />;
   if (mode === "image") {
     return <ImageIcon fontSize="small" />;
   }
@@ -43,6 +45,7 @@ export function modeIconFor(mode: MediaMode): React.ReactNode {
 }
 
 export function modeLabelFor(mode: MediaMode): string {
+  if (mode === "music") return "Music";
   if (mode === "image") {
     return "Image";
   }

--- a/web/src/components/chat/composer/ModelChip.tsx
+++ b/web/src/components/chat/composer/ModelChip.tsx
@@ -16,6 +16,7 @@ import React, {
 import MediaControlChip from "./MediaControlChip";
 import ImageModelMenuDialog from "../../model_menu/ImageModelMenuDialog";
 import VideoModelMenuDialog from "../../model_menu/VideoModelMenuDialog";
+import MusicModelMenuDialog from "../../model_menu/MusicModelMenuDialog";
 import TTSModelMenuDialog from "../../model_menu/TTSModelMenuDialog";
 import LanguageModelMenuDialog from "../../model_menu/LanguageModelMenuDialog";
 import type {
@@ -26,6 +27,7 @@ import type {
   ImageModel,
   LanguageModel,
   TTSModel,
+  MusicModel,
   VideoModel
 } from "../../../stores/ApiTypes";
 
@@ -36,6 +38,7 @@ export const MODEL_CHIP_MAX_WIDTH = 320;
 export type ModelPicker =
   | { kind: "image"; task: ImageModelTask; onPick: (model: ImageModel) => void }
   | { kind: "video"; task: VideoModelTask; onPick: (model: VideoModel) => void }
+  | { kind: "music"; onPick: (model: MusicModel) => void }
   | { kind: "tts"; onPick: (model: TTSModel) => void }
   | {
       kind: "language";
@@ -67,6 +70,14 @@ export function ModelChip({
   const anchorRef = useRef<HTMLButtonElement | null>(null);
   const [open, setOpen] = useState(false);
   const close = useCallback(() => setOpen(false), []);
+  const pickMusic = picker.kind === "music" ? picker.onPick : undefined;
+  const handleMusicChange = useCallback(
+    (model: MusicModel) => {
+      pickMusic?.(model);
+      close();
+    },
+    [pickMusic, close]
+  );
   useImperativeHandle(openRef, () => ({ open: () => setOpen(true) }), []);
 
   const chip = (
@@ -132,6 +143,20 @@ export function ModelChip({
             picker.onPick(model);
             setOpen(false);
           }}
+        />
+      </>
+    );
+  }
+
+  if (picker.kind === "music") {
+    return (
+      <>
+        {chip}
+        <MusicModelMenuDialog
+          open={open}
+          anchorEl={anchorRef.current}
+          onClose={close}
+          onModelChange={handleMusicChange}
         />
       </>
     );

--- a/web/src/components/chat/composer/__tests__/MediaChatComposer.test.tsx
+++ b/web/src/components/chat/composer/__tests__/MediaChatComposer.test.tsx
@@ -10,7 +10,7 @@ import useMediaGenerationStore from "../../../../stores/MediaGenerationStore";
 import useGlobalChatStore from "../../../../stores/GlobalChatStore";
 import { useChatDraftStore } from "../../../../stores/ChatDraftStore";
 import { useProvidersByCapability } from "../../../../hooks/useProviders";
-import type { MessageContent } from "../../../../stores/ApiTypes";
+import type { MessageContent, MusicModel } from "../../../../stores/ApiTypes";
 
 // The provider query decides whether the composer refuses a send and shows the
 // setup banner instead. Every mode here has a provider. The rest of the module
@@ -61,6 +61,29 @@ jest.mock("../../../model_menu/VideoModelMenuDialog", () => ({
   default: ({ open }: { open: boolean }) =>
     open ? <div data-testid="video-model-dialog" /> : null
 }));
+jest.mock("../../../model_menu/MusicModelMenuDialog", () => ({
+  __esModule: true,
+  default: ({
+    open,
+    onModelChange
+  }: {
+    open: boolean;
+    onModelChange: (model: MusicModel) => void;
+  }) =>
+    open ? (
+      <button
+        onClick={() =>
+          onModelChange({
+            id: "music-1",
+            name: "Test music",
+            provider: "fal_ai"
+          } as MusicModel)
+        }
+      >
+        Pick music model
+      </button>
+    ) : null
+}));
 jest.mock("../../../model_menu/TTSModelMenuDialog", () => ({
   __esModule: true,
   default: ({ open }: { open: boolean }) =>
@@ -90,6 +113,7 @@ const MEDIA_DEFAULTS = (() => {
     video: s.video,
     imageToVideo: s.imageToVideo,
     referenceToVideo: s.referenceToVideo,
+    music: s.music,
     audio: s.audio
   };
 })();
@@ -284,6 +308,36 @@ describe("MediaChatComposer", () => {
 
     expect(onSendMessage).not.toHaveBeenCalled();
     expect(screen.getByTestId("image-model-dialog")).toBeInTheDocument();
+  });
+
+  it("selects music, gates on its own model, and sends the requested duration", async () => {
+    const user = userEvent.setup();
+    const onSendMessage = jest.fn();
+    renderComposer(onSendMessage);
+    await user.click(screen.getByRole("button", { name: "Chat" }));
+    await user.click(
+      screen.getByRole("menuitemradio", { name: "Generate Music" })
+    );
+    expect(mockUseProvidersByCapability).toHaveBeenLastCalledWith(
+      "text_to_music"
+    );
+    await user.type(promptBox(), "Warm ambient piano{Enter}");
+    expect(onSendMessage).not.toHaveBeenCalled();
+    expect(promptBox()).toHaveValue("Warm ambient piano");
+    await user.click(screen.getByRole("button", { name: "Pick music model" }));
+    await user.click(
+      screen.getByRole("button", { name: "30 Sec" })
+    );
+    await user.click(screen.getByText("60 Sec"));
+    await user.click(screen.getByRole("button", { name: "Generate" }));
+    expect(onSendMessage).toHaveBeenCalledTimes(1);
+    expect(onSendMessage.mock.calls[0][2]).toEqual({
+      mode: "music",
+      provider: "fal_ai",
+      model: "music-1",
+      duration: 60
+    });
+    expect(promptBox()).toHaveValue("");
   });
 
   it("sends the media generation payload once a model is picked", async () => {

--- a/web/src/components/chat/composer/modeProviderSetup.ts
+++ b/web/src/components/chat/composer/modeProviderSetup.ts
@@ -22,6 +22,8 @@ export const capabilityForMode = (
     case "image_to_video":
     case "reference_to_video":
       return "text_to_video";
+    case "music":
+      return "text_to_music";
     case "audio":
       return "text_to_speech";
     default:
@@ -44,6 +46,8 @@ export const setupReasonForMode = (mode: MediaMode): string | null => {
       return "Animating images needs a video provider. Connect one to continue.";
     case "reference_to_video":
       return "Reference to video needs a video provider. Connect one to continue.";
+    case "music":
+      return "Generating music needs a music provider. Connect one to continue.";
     case "audio":
       return "Generating speech needs a text-to-speech provider. Connect one to continue.";
     default:

--- a/web/src/components/chat/composer/useMediaCostEstimate.ts
+++ b/web/src/components/chat/composer/useMediaCostEstimate.ts
@@ -52,12 +52,15 @@ function megapixelsFor(resolution: "1K" | "2K" | "4K", aspectRatio: string) {
   return Math.round(((width * height) / 1_000_000) * 100) / 100;
 }
 
-export function useMediaCostEstimate(mode: MediaMode): MediaCostEstimate | null {
+export function useMediaCostEstimate(
+  mode: MediaMode
+): MediaCostEstimate | null {
   const image = useMediaGenerationStore((s) => s.image);
   const imageEdit = useMediaGenerationStore((s) => s.imageEdit);
   const video = useMediaGenerationStore((s) => s.video);
   const imageToVideo = useMediaGenerationStore((s) => s.imageToVideo);
   const referenceToVideo = useMediaGenerationStore((s) => s.referenceToVideo);
+  const music = useMediaGenerationStore((s) => s.music);
   const audio = useMediaGenerationStore((s) => s.audio);
 
   return useMemo(() => {
@@ -119,6 +122,12 @@ export function useMediaCostEstimate(mode: MediaMode): MediaCostEstimate | null 
           quantity: 1
         };
       }
+      if (mode === "music")
+        return {
+          model: music.model,
+          params: { seconds: music.duration },
+          quantity: 1
+        };
       if (mode === "audio") {
         return { model: audio.model, params: {}, quantity: 1 };
       }
@@ -147,7 +156,7 @@ export function useMediaCostEstimate(mode: MediaMode): MediaCostEstimate | null 
       assumptions: price.assumptions,
       warnings: price.warnings
     };
-  }, [mode, image, imageEdit, video, imageToVideo, referenceToVideo, audio]);
+  }, [mode, image, imageEdit, video, imageToVideo, referenceToVideo, audio, music]);
 }
 
 export default useMediaCostEstimate;

--- a/web/src/components/timeline/Inspector/DirectGenClipPanel.tsx
+++ b/web/src/components/timeline/Inspector/DirectGenClipPanel.tsx
@@ -28,10 +28,12 @@ import CostEstimateLine from "../../costs/CostEstimateLine";
 import { generationCostLine } from "../../costs/costLine";
 import ImageModelSelect from "../../properties/ImageModelSelect";
 import VideoModelSelect from "../../properties/VideoModelSelect";
+import MusicModelSelect from "../../properties/MusicModelSelect";
 import TTSModelSelect from "../../properties/TTSModelSelect";
 import type {
   ImageModelValue,
-  TTSModelValue
+  TTSModelValue,
+  MusicModelValue
 } from "../../../stores/ApiTypes";
 import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
 import StopRoundedIcon from "@mui/icons-material/StopRounded";
@@ -59,6 +61,7 @@ import {
 import { useMediaOptions } from "../../../hooks/useModelsByProvider";
 
 import {
+  SPACING,
   Caption,
   CollapsibleSection,
   EditorButton,
@@ -89,7 +92,7 @@ interface DirectGenClipPanelProps {
 
 const sectionStyles = (theme: Theme) =>
   css({
-    padding: theme.spacing(1)
+    padding: theme.spacing(SPACING.sm)
   });
 
 const panelSx = {
@@ -140,12 +143,14 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
     canGenerate
   } = useGenerateClip(clipId);
 
-  const kind: "image" | "video" | "audio" =
+  const kind: "image" | "video" | "audio" | "music" =
     clip?.bindingKind === "text-to-video"
       ? "video"
-      : clip?.bindingKind === "text-to-audio"
-        ? "audio"
-        : "image";
+      : clip?.bindingKind === "text-to-music"
+        ? "music"
+        : clip?.bindingKind === "text-to-audio"
+          ? "audio"
+          : "image";
   const isImageToImage = clip?.bindingKind === "image-to-image";
 
   // What pressing Generate spends, at the model and settings picked above.
@@ -156,7 +161,7 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
   // Audio clips have no size/duration options, so their query stays disabled.
   const mediaOptions = useMediaOptions({
     provider: clip?.provider,
-    model: kind === "audio" ? null : clip?.model,
+    model: kind === "audio" || kind === "music" ? null : clip?.model,
     task: kind === "video" ? "video" : "image"
   });
 
@@ -273,6 +278,13 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
     [clipId, setClipDirectGenModel]
   );
 
+  const handleMusicModelChange = useCallback(
+    (v: MusicModelValue) => {
+      setClipDirectGenModel(clipId, v.provider, v.id);
+    },
+    [clipId, setClipDirectGenModel]
+  );
+
   const handleTTSModelChange = useCallback(
     (v: TTSModelValue) => {
       const nextVoice =
@@ -352,9 +364,11 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
   const promptPlaceholder =
     kind === "video"
       ? "Describe the video…"
-      : kind === "audio"
-        ? "Type text to speak…"
-        : "Describe the image…";
+      : kind === "music"
+        ? "Describe the music…"
+        : kind === "audio"
+          ? "Type text to speak…"
+          : "Describe the image…";
 
   const generateLabel = clip.currentAssetId ? "Regenerate" : "Generate";
 
@@ -372,7 +386,7 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
           }
           defaultOpen
         >
-          <FlexColumn gap={1} css={sectionStyles(theme)}>
+          <FlexColumn gap={SPACING.sm} css={sectionStyles(theme)}>
             {kind === "image" && (
               <ToggleGroup
                 exclusive
@@ -405,18 +419,32 @@ const DirectGenClipPanelInner: React.FC<DirectGenClipPanelProps> = ({
                 task="text_to_video"
                 onChange={handleVideoModelChange}
               />
+            ) : kind === "music" ? (
+              <MusicModelSelect
+                value={
+                  clip.model
+                    ? {
+                        type: "music_model",
+                        id: clip.model,
+                        name: clip.model,
+                        provider: clip.provider ?? ""
+                      }
+                    : ""
+                }
+                onChange={handleMusicModelChange}
+              />
             ) : kind === "audio" ? (
               <TTSModelSelect
                 value={
                   clip.model
-                    ? ({
+                    ? {
                         type: "tts_model",
                         id: clip.model,
                         provider: clip.provider ?? "",
                         name: clip.model,
                         voices: clip.voice ? [clip.voice] : [],
                         selected_voice: clip.voice ?? ""
-                      })
+                      }
                     : ""
                 }
                 onChange={handleTTSModelChange}

--- a/web/src/components/timeline/Inspector/TimelineInspector.tsx
+++ b/web/src/components/timeline/Inspector/TimelineInspector.tsx
@@ -517,7 +517,8 @@ export const TimelineInspector: React.FC = memo(() => {
       clip.bindingKind === "text-to-image" ||
       clip.bindingKind === "image-to-image" ||
       clip.bindingKind === "text-to-video" ||
-      clip.bindingKind === "text-to-audio"
+      clip.bindingKind === "text-to-audio" ||
+      clip.bindingKind === "text-to-music"
     ) {
       return <DirectGenClipPanel clipId={clip.id} />;
     }

--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -56,6 +56,7 @@ import SubtitlesOutlinedIcon from "@mui/icons-material/SubtitlesOutlined";
 import TuneOutlinedIcon from "@mui/icons-material/TuneOutlined";
 
 import { TopBar } from "./TopBar";
+import { TopBarPrompt } from "./TopBarPrompt";
 import { BottomStatusBar } from "./BottomStatusBar";
 import { PlayheadReadout } from "./PlayheadReadout";
 import { useTimelineCostEstimate } from "../../hooks/timeline/useTimelineCostEstimate";
@@ -516,6 +517,22 @@ const TimelineEditorBody: React.FC<
   const navigate = useNavigate();
   const theme = useTheme();
   const isMobile = useTimelineIsMobile();
+  const composerRef = useRef<HTMLDivElement>(null);
+  const [compactComposer, setCompactComposer] = useState(false);
+  useEffect(() => {
+    const element = composerRef.current;
+    if (!element) return;
+    const update = () => {
+      if (element.clientWidth > 0) {
+        setCompactComposer(element.clientWidth < 800);
+      }
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
 
   // Phone panel sheet (Inspector / Assistant / History / Script).
   const [panelSheetOpen, setPanelSheetOpen] = useState(false);
@@ -877,6 +894,20 @@ const TimelineEditorBody: React.FC<
           createSequenceErrorMessage={createErrorMessage}
           fullWidth={isMobile}
         />
+      </FlexRow>
+
+      <FlexRow
+        ref={composerRef}
+        fullWidth
+        sx={{
+          flexShrink: 0,
+          px: SPACING.md,
+          py: SPACING.sm,
+          backgroundColor: theme.vars.palette.background.paper,
+          borderBottom: `1px solid ${theme.vars.palette.divider}`
+        }}
+      >
+        <TopBarPrompt compact={isMobile || compactComposer} />
       </FlexRow>
 
       {/* ── Horizontal drag handle (pointer + keyboard resizable) ─── */}

--- a/web/src/components/timeline/TopBar.tsx
+++ b/web/src/components/timeline/TopBar.tsx
@@ -2,13 +2,8 @@
 /**
  * TopBar — Timeline Editor top bar.
  *
- * A single generation prompt bar (model + output settings + Generate) that
- * grows to fill, with Save / Export and an activity slot on the right. The
- * project name lives in the workspace tab, so it isn't repeated here.
- *
- * On phones the four labelled actions won't fit beside the prompt, so they
- * collapse into one overflow menu and the prompt takes the width it needs
- * (see `TopBarPrompt`'s `compact` layout).
+ * Project settings, Save / Export, and generation activity.
+ * Actions collapse into an overflow menu on narrow layouts.
  */
 
 import React, { memo, useCallback, useEffect, useState } from "react";
@@ -32,14 +27,11 @@ import SaveIcon from "@mui/icons-material/Save";
 import TuneIcon from "@mui/icons-material/Tune";
 import VideoLibraryOutlinedIcon from "@mui/icons-material/VideoLibraryOutlined";
 
-import { TopBarPrompt } from "./TopBarPrompt";
 import { useTimelineIsMobile } from "../../hooks/timeline/useTimelineIsMobile";
 
 const styles = (theme: Theme, compact: boolean) =>
   css({
-    // Phones need two rows for the prompt + chip rail; let the bar size to it.
-    height: compact ? "auto" : 48,
-    minHeight: compact ? 48 : undefined,
+    height: 48,
     borderBottom: `1px solid ${theme.vars.palette.divider}`,
     backgroundColor: theme.vars.palette.background.paper,
     padding: compact
@@ -98,13 +90,10 @@ export const TopBar: React.FC<TopBarProps> = memo(
     useEffect(() => {
       const element = barRef.current;
       if (!element) return;
-      // The prompt's model/settings rail and the four labelled actions need
-      // roughly 1,200px together. Collapse the actions before flexbox starts
-      // shrinking controls into one another, so this remains safe when a
-      // sidebar reduces the editor to an intermediate width.
+      // Collapse actions when the editor has insufficient width for labels.
       const update = () => {
         if (element.clientWidth === 0) return;
-        setIsNarrow(element.clientWidth < 1200);
+        setIsNarrow(element.clientWidth < 640);
       };
       update();
       const observer = new ResizeObserver(update);
@@ -134,12 +123,12 @@ export const TopBar: React.FC<TopBarProps> = memo(
       return (
         <FlexRow
           ref={barRef}
-          align="flex-start"
+          align="center"
+          justify="flex-end"
           gap={SPACING.sm}
           fullWidth
           css={styles(theme, true)}
         >
-          <TopBarPrompt compact />
           {activitySlot}
           {hasActions && (
             <>
@@ -214,13 +203,11 @@ export const TopBar: React.FC<TopBarProps> = memo(
       <FlexRow
         ref={barRef}
         align="center"
+        justify="flex-end"
         gap={SPACING.xs}
         fullWidth
         css={styles(theme, false)}
       >
-        {/* Quick-prompt generation bar — grows to fill */}
-        <TopBarPrompt />
-
         {/* Right: activity slot + settings / save / export */}
         {activitySlot}
 

--- a/web/src/components/timeline/TopBarPrompt.tsx
+++ b/web/src/components/timeline/TopBarPrompt.tsx
@@ -1,33 +1,28 @@
-/**
- * TopBarPrompt
- *
- * The timeline editor's quick text-to-video generation bar. Type a prompt,
- * pick a model + output settings, and Generate drops a text-to-video direct-gen
- * clip onto the first unlocked video track at the playhead (creating a video
- * track if the sequence has none). Generation starts immediately.
- *
- * Layout mirrors the image editor's generate form (`ConnectedGeneratePopover`) and
- * the media chat composer: a prompt that grows to fill, then the model + setting
- * chips, then the primary Generate action. The model / duration / resolution /
- * aspect controls are the shared `MediaControlChip` + option menus, so options
- * track the selected model's manifest.
- *
- * On phones (`compact`) that one row is 600px of content in 390px of viewport,
- * so it wraps into two: prompt + Generate on top, the setting chips below in a
- * horizontally scrollable rail.
- */
+/** Quick video or speech generation at the timeline playhead. */
 
-import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
 import { useTheme } from "@mui/material/styles";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import GraphicEqIcon from "@mui/icons-material/GraphicEq";
+import RecordVoiceOverIcon from "@mui/icons-material/RecordVoiceOver";
 import MovieIcon from "@mui/icons-material/Movie";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import AspectRatioIcon from "@mui/icons-material/CropOriginal";
 import TvIcon from "@mui/icons-material/Tv";
 
-import { useTimelineStore } from "../../stores/timeline/TimelineStore";
+import {
+  useTimelineStore,
+  useTimelineStoreApi
+} from "../../stores/timeline/TimelineStore";
 import { useTimelineUIStore } from "../../stores/timeline/TimelineUIStore";
-import { useTimelinePlaybackStore } from "../../stores/timeline/TimelinePlaybackStore";
+import { useTimelinePlaybackStoreApi } from "../../stores/timeline/TimelineInstance";
 import { useTimelineDirectGenJob } from "../../hooks/timeline/useTimelineDirectGenJob";
 import { useLastDirectGenModel } from "../../hooks/timeline/useLastDirectGenModel";
 import { useClipCostEstimate } from "../../hooks/timeline/useClipCostEstimate";
@@ -42,6 +37,10 @@ import {
   Toast,
   SPACING
 } from "../ui_primitives";
+import ModeSelectChip from "../chat/composer/ModeSelectChip";
+import OptionChip from "../chat/composer/OptionChip";
+import { audioModelPatch } from "../chat/composer/modelSelection";
+import TTSModelMenuDialog from "../model_menu/TTSModelMenuDialog";
 import MediaControlChip from "../chat/composer/MediaControlChip";
 import MediaOptionMenu from "../chat/composer/MediaOptionMenu";
 import MediaAspectRatioMenu from "../chat/composer/MediaAspectRatioMenu";
@@ -55,26 +54,21 @@ import type {
   VideoModelSelection,
   VideoResolution
 } from "../../stores/MediaGenerationStore";
-import type { VideoModel } from "../../stores/ApiTypes";
+import type { TTSModel, VideoModel } from "../../stores/ApiTypes";
 import { useInStudio } from "../../studio/StudioContext";
-import { forTasks, STUDIO_CLIP_MODELS } from "../../studio/curatedModels";
+import {
+  forTasks,
+  STUDIO_CLIP_MODELS,
+  STUDIO_VOICES,
+  STUDIO_VOICE
+} from "../../studio/curatedModels";
 
-/**
- * Resolve the video track to drop the clip onto: the first unlocked video
- * track, creating one if the sequence has none yet. Returns `undefined` only
- * if a video track exists but is locked.
- */
-function pickOrCreateVideoTrack(): string | undefined {
-  const findVideo = () =>
-    useTimelineStore.getState().tracks.find((t) => t.type === "video");
+const GENERATION_MODES = ["video", "audio"] as const;
+type GenerationMode = (typeof GENERATION_MODES)[number];
 
-  let video = findVideo();
-  if (!video) {
-    useTimelineStore.getState().addTrack("video", "Video");
-    video = findVideo();
-  }
-  if (!video || video.locked) return undefined;
-  return video.id;
+interface AudioSelection {
+  model: { id: string; provider: string; name: string; voices: string[] };
+  voice: string;
 }
 
 interface TopBarPromptProps {
@@ -85,6 +79,41 @@ interface TopBarPromptProps {
 export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false }) => {
   const theme = useTheme();
   const inStudio = useInStudio();
+  const timeline = useTimelineStoreApi();
+  const playback = useTimelinePlaybackStoreApi();
+  const [mode, setMode] = useState<GenerationMode>("video");
+  const [audioSelection, setAudioSelection] = useState<AudioSelection>();
+  const lastAudioModel = useLastDirectGenModel("audio");
+  const studioVoice =
+    STUDIO_VOICES.find(
+      (option) =>
+        option.modelId === lastAudioModel.model &&
+        option.id === lastAudioModel.voice
+    )?.value ?? STUDIO_VOICE;
+  const audio =
+    audioSelection ??
+    (inStudio
+      ? studioVoice
+        ? { model: studioVoice, voice: studioVoice.selected_voice }
+        : undefined
+      : lastAudioModel.model && lastAudioModel.provider
+        ? {
+            model: {
+              id: lastAudioModel.model,
+              provider: lastAudioModel.provider,
+              name: lastAudioModel.model,
+              // Remembered bindings have no catalog. Offer only their known voice.
+              voices: lastAudioModel.voice ? [lastAudioModel.voice] : []
+            },
+            voice: lastAudioModel.voice ?? ""
+          }
+        : undefined);
+  const audioModelAnchorRef = useRef<HTMLButtonElement>(null);
+  const [audioModelOpen, setAudioModelOpen] = useState(false);
+  const voiceOptions = (audio?.model.voices ?? []).map((id) => ({
+    id,
+    label: id
+  }));
   const [prompt, setPrompt] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -103,10 +132,11 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
   // Chip popover anchors.
   const videoModelAnchorRef = useRef<HTMLButtonElement>(null);
   const [videoModelOpen, setVideoModelOpen] = useState(false);
-  const [durationAnchor, setDurationAnchor] = useState<HTMLElement | null>(null);
-  const [resolutionAnchor, setResolutionAnchor] = useState<HTMLElement | null>(
+  const [durationAnchor, setDurationAnchor] = useState<HTMLElement | null>(
     null
   );
+  const [resolutionAnchor, setResolutionAnchor] =
+    useState<HTMLElement | null>(null);
   const [aspectAnchor, setAspectAnchor] = useState<HTMLElement | null>(null);
 
   const { durationOptions, resolutionOptions, aspectOptions } = useMemo(
@@ -136,33 +166,52 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
   const selectClip = useTimelineUIStore((s) => s.selectClip);
   const directGen = useTimelineDirectGenJob();
 
-  const canSubmit = prompt.trim().length > 0 && !!selectedModel?.id && !busy;
+  const model = mode === "audio" ? audio?.model : selectedModel;
+  const bindingKind = mode === "audio" ? "text-to-audio" : "text-to-video";
+  const canSubmit = prompt.trim().length > 0 && !!model?.id && !busy;
 
   const handleSubmit = useCallback(async () => {
-    if (!canSubmit || !selectedModel) return;
+    if (!canSubmit || !model) return;
     // Clear any prior failure toast before we attempt again — otherwise a
     // successful retry leaves the previous error visible.
     setError(null);
-    const trackId = pickOrCreateVideoTrack();
+    const tracks = timeline
+      .getState()
+      .tracks.filter((track) => track.type === mode);
+    if (tracks.length === 0) {
+      timeline
+        .getState()
+        .addTrack(mode, mode === "audio" ? "Audio" : "Video");
+    }
+    const trackId = timeline
+      .getState()
+      .tracks.find((track) => track.type === mode && !track.locked)?.id;
     if (!trackId) {
-      setError("Unlock the video track first.");
+      setError(
+        `Unlock ${mode === "audio" ? "an audio" : "a video"} track first.`
+      );
       return;
     }
-    const startMs = useTimelinePlaybackStore.getState().currentTimeMs;
+    const startMs = playback.getState().getTimeMs();
     setBusy(true);
     try {
-      const clipId = addDirectGenClip({
+      const clipOptions: Parameters<typeof addDirectGenClip>[0] = {
         trackId,
         startMs,
         durationMs: duration * 1000,
-        mediaType: "video",
-        bindingKind: "text-to-video",
+        mediaType: mode,
+        bindingKind,
         prompt: prompt.trim(),
-        provider: selectedModel.provider,
-        model: selectedModel.id,
-        aspectRatio: aspect,
-        resolution
-      });
+        provider: model.provider,
+        model: model.id
+      };
+      if (mode === "video") {
+        clipOptions.aspectRatio = aspect;
+        clipOptions.resolution = resolution;
+      } else if (audio?.voice) {
+        clipOptions.voice = audio.voice;
+      }
+      const clipId = addDirectGenClip(clipOptions);
       selectClip(clipId);
       await directGen.start(clipId);
       setPrompt("");
@@ -175,7 +224,12 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
     canSubmit,
     addDirectGenClip,
     prompt,
-    selectedModel,
+    model,
+    mode,
+    bindingKind,
+    audio?.voice,
+    timeline,
+    playback,
     aspect,
     resolution,
     duration,
@@ -227,13 +281,17 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
       onChange={(e) => setPrompt(e.target.value)}
       onKeyDown={handleKeyDown}
       placeholder={
-        compact ? "Generate a video…" : "Generate a video at the playhead…"
+        mode === "audio"
+          ? "Enter text to speak…"
+          : compact
+            ? "Generate a video…"
+            : "Generate a video at the playhead…"
       }
       compact
       fullWidth
       disabled={busy}
       inputProps={{
-        "aria-label": "Quick text-to-video prompt",
+        "aria-label": `Quick ${bindingKind} prompt`,
         "data-testid": "topbar-prompt-input"
       }}
       slotProps={{
@@ -241,7 +299,10 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
           startAdornment: (
             <AutoAwesomeIcon
               fontSize="small"
-              sx={{ mr: 0.5, color: theme.vars.palette.primary.main }}
+              sx={{
+                mr: SPACING.micro,
+                color: theme.vars.palette.primary.main
+              }}
             />
           )
         }
@@ -249,7 +310,7 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
       sx={{
         flex: 1,
         minWidth: compact ? 0 : 160,
-        "& .MuiOutlinedInput-root": { height: 34 },
+        "& .MuiOutlinedInput-root": { height: 32 },
         // Bar text at the label token (13px) so the prompt reads at the same
         // size as the setting chips beside it. The doubled parent selector
         // outranks TextInput's own body-token rule for this bar only — the
@@ -261,12 +322,11 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
     />
   );
 
-  // The bar creates a text-to-video clip with exactly these fields, so it
-  // prices through the same hook the clip inspector uses.
+  // Price the same binding that Generate will create.
   const costEstimate = useClipCostEstimate({
-    bindingKind: "text-to-video",
-    provider: selectedModel?.provider,
-    model: selectedModel?.id,
+    bindingKind,
+    provider: model?.provider,
+    model: model?.id,
     resolution,
     aspectRatio: aspect,
     durationMs: duration * 1000
@@ -295,16 +355,20 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
       data-testid="topbar-generate"
       // Icon-only on phones: the label costs ~70px the prompt needs, and the
       // sparkle plus the field's placeholder already say what it does.
-      aria-label="Generate video"
+      aria-label={mode === "audio" ? "Generate audio" : "Generate video"}
       // Native tooltip still fires on a disabled button: say why it is off.
       title={
         canSubmit ? undefined : "Type a prompt and pick a model to generate"
       }
       sx={{
         flexShrink: 0,
-        height: 34,
+        height: 32,
         ...(compact
-          ? { minWidth: 44, px: 1, "& .MuiButton-startIcon": { m: 0 } }
+          ? {
+              minWidth: 44,
+              px: SPACING.xs,
+              "& .MuiButton-startIcon": { m: 0 }
+            }
           : null)
       }}
     >
@@ -312,91 +376,174 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
     </EditorButton>
   );
 
-  const settingChips = (
+  const videoSettingChips = (
     <>
       <MediaControlChip
-          ref={videoModelAnchorRef}
-          icon={<MovieIcon fontSize="small" />}
-          label={selectedModel?.name || "Select Model"}
-          active={videoModelOpen}
-          onClick={() => setVideoModelOpen(true)}
-          truncate
-          showChevron={false}
-        />
-        {videoModelOpen &&
-          (inStudio ? (
-            <MediaOptionMenu
-              anchorEl={videoModelAnchorRef.current}
-              open
-              onClose={() => setVideoModelOpen(false)}
-              header="Video model"
-              value={selectedModel?.id ?? ""}
-              options={curatedClipOptions}
-              onChange={(id) => {
-                const picked = STUDIO_CLIP_MODELS.find((o) => o.id === id);
-                if (picked) handlePickVideoModel(picked.value);
-                setVideoModelOpen(false);
-              }}
-            />
-          ) : (
-            <VideoModelMenuDialog
-              open
-              anchorEl={videoModelAnchorRef.current}
-              onClose={() => setVideoModelOpen(false)}
-              onModelChange={handlePickVideoModel}
-              task="text_to_video"
-            />
-          ))}
+        ref={videoModelAnchorRef}
+        icon={<MovieIcon fontSize="small" />}
+        label={selectedModel?.name || "Select Model"}
+        active={videoModelOpen}
+        onClick={() => setVideoModelOpen(true)}
+        truncate
+        showChevron={false}
+      />
+      {videoModelOpen &&
+        (inStudio ? (
+          <MediaOptionMenu
+            anchorEl={videoModelAnchorRef.current}
+            open
+            onClose={() => setVideoModelOpen(false)}
+            header="Video model"
+            value={selectedModel?.id ?? ""}
+            options={curatedClipOptions}
+            onChange={(id) => {
+              const picked = STUDIO_CLIP_MODELS.find((o) => o.id === id);
+              if (picked) handlePickVideoModel(picked.value);
+              setVideoModelOpen(false);
+            }}
+          />
+        ) : (
+          <VideoModelMenuDialog
+            open
+            anchorEl={videoModelAnchorRef.current}
+            onClose={() => setVideoModelOpen(false)}
+            onModelChange={handlePickVideoModel}
+            task="text_to_video"
+          />
+        ))}
 
-        <MediaControlChip
-          icon={<AccessTimeIcon fontSize="small" />}
-          label={`${duration} Sec`}
-          active={!!durationAnchor}
-          onClick={(e) => setDurationAnchor(e.currentTarget)}
-          showChevron={false}
-        />
-        <MediaOptionMenu
-          anchorEl={durationAnchor}
-          open={!!durationAnchor}
-          onClose={() => setDurationAnchor(null)}
-          header="Duration"
-          value={duration}
-          options={durationOptions}
-          onChange={(d) => setDuration(d)}
-        />
+      <MediaControlChip
+        icon={<AccessTimeIcon fontSize="small" />}
+        label={`${duration} Sec`}
+        active={!!durationAnchor}
+        onClick={(e) => setDurationAnchor(e.currentTarget)}
+        showChevron={false}
+      />
+      <MediaOptionMenu
+        anchorEl={durationAnchor}
+        open={!!durationAnchor}
+        onClose={() => setDurationAnchor(null)}
+        header="Duration"
+        value={duration}
+        options={durationOptions}
+        onChange={(d) => setDuration(d)}
+      />
 
-        <MediaControlChip
-          icon={<TvIcon fontSize="small" />}
-          label={resolution}
-          active={!!resolutionAnchor}
-          onClick={(e) => setResolutionAnchor(e.currentTarget)}
-          showChevron={false}
-        />
-        <MediaOptionMenu
-          anchorEl={resolutionAnchor}
-          open={!!resolutionAnchor}
-          onClose={() => setResolutionAnchor(null)}
-          header="Video Resolution"
-          value={resolution}
-          options={resolutionOptions}
-          onChange={(r) => setResolution(r)}
-        />
+      <MediaControlChip
+        icon={<TvIcon fontSize="small" />}
+        label={resolution}
+        active={!!resolutionAnchor}
+        onClick={(e) => setResolutionAnchor(e.currentTarget)}
+        showChevron={false}
+      />
+      <MediaOptionMenu
+        anchorEl={resolutionAnchor}
+        open={!!resolutionAnchor}
+        onClose={() => setResolutionAnchor(null)}
+        header="Video Resolution"
+        value={resolution}
+        options={resolutionOptions}
+        onChange={(r) => setResolution(r)}
+      />
 
-        <MediaControlChip
-          icon={<AspectRatioIcon fontSize="small" />}
-          label={aspect}
-          active={!!aspectAnchor}
-          onClick={(e) => setAspectAnchor(e.currentTarget)}
-          showChevron={false}
-        />
-        <MediaAspectRatioMenu
-          anchorEl={aspectAnchor}
-          open={!!aspectAnchor}
-          onClose={() => setAspectAnchor(null)}
-          value={aspect}
-          options={aspectOptions}
+      <MediaControlChip
+        icon={<AspectRatioIcon fontSize="small" />}
+        label={aspect}
+        active={!!aspectAnchor}
+        onClick={(e) => setAspectAnchor(e.currentTarget)}
+        showChevron={false}
+      />
+      <MediaAspectRatioMenu
+        anchorEl={aspectAnchor}
+        open={!!aspectAnchor}
+        onClose={() => setAspectAnchor(null)}
+        value={aspect}
+        options={aspectOptions}
         onChange={(v) => setAspect(v)}
       />
+    </>
+  );
+
+  const handlePickAudioModel = useCallback((picked: TTSModel) => {
+    setAudioSelection(audioModelPatch(picked, ""));
+    setAudioModelOpen(false);
+  }, []);
+  const openAudioModel = useCallback(() => setAudioModelOpen(true), []);
+  const closeAudioModel = useCallback(() => setAudioModelOpen(false), []);
+
+  const audioSettingChips = (
+    <>
+      <MediaControlChip
+        ref={audioModelAnchorRef}
+        icon={<GraphicEqIcon fontSize="small" />}
+        label={
+          inStudio
+            ? (STUDIO_VOICES.find((option) => option.id === audio?.voice)
+                ?.label ?? "Voice")
+            : audio?.model.name || "Select TTS Model"
+        }
+        active={audioModelOpen}
+        onClick={openAudioModel}
+        truncate
+      />
+      {audioModelOpen &&
+        (inStudio ? (
+          <MediaOptionMenu
+            anchorEl={audioModelAnchorRef.current}
+            open
+            onClose={closeAudioModel}
+            header="Voice"
+            value={audio?.voice ?? ""}
+            options={STUDIO_VOICES.map((option) => ({
+              id: option.id,
+              label: option.label
+            }))}
+            onChange={(id) => {
+              const picked = STUDIO_VOICES.find((option) => option.id === id);
+              if (picked)
+                setAudioSelection({ model: picked.value, voice: id });
+              setAudioModelOpen(false);
+            }}
+          />
+        ) : (
+          <TTSModelMenuDialog
+            open
+            anchorEl={audioModelAnchorRef.current}
+            onClose={closeAudioModel}
+            onModelChange={handlePickAudioModel}
+          />
+        ))}
+      {!inStudio && audio && voiceOptions.length > 0 && (
+        <OptionChip
+          menu="option"
+          icon={<RecordVoiceOverIcon fontSize="small" />}
+          label={audio.voice || "Voice"}
+          header="Voice"
+          value={audio.voice}
+          options={voiceOptions}
+          onChange={(voice) => setAudioSelection({ ...audio, voice })}
+        />
+      )}
+    </>
+  );
+
+  const settingChips = (
+    <>
+      <ModeSelectChip
+        mode={mode}
+        modes={GENERATION_MODES}
+        onChange={(nextMode) => {
+          if (nextMode !== "video" && nextMode !== "audio") return;
+          setMode(nextMode);
+          setVideoModelOpen(false);
+          setAudioModelOpen(false);
+          setDurationAnchor(null);
+          setResolutionAnchor(null);
+          setAspectAnchor(null);
+          setError(null);
+        }}
+      />
+      {mode === "audio" ? audioSettingChips : videoSettingChips}
     </>
   );
 
@@ -413,7 +560,7 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
             {generateButton}
           </FlexRow>
           {/* Chip rail — scrolls horizontally rather than wrapping, so the bar
-              keeps a predictable two-row height whatever the model name is. */}
+          keeps a predictable two-row height whatever the model name is. */}
           <FlexRow
             gap={SPACING.sm}
             align="center"

--- a/web/src/components/timeline/TopBarPrompt.tsx
+++ b/web/src/components/timeline/TopBarPrompt.tsx
@@ -1,4 +1,4 @@
-/** Quick video or speech generation at the timeline playhead. */
+/** Quick video, speech, or music generation at the timeline playhead. */
 
 import React, {
   memo,
@@ -10,6 +10,9 @@ import React, {
 } from "react";
 import { useTheme } from "@mui/material/styles";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import AudiotrackIcon from "@mui/icons-material/Audiotrack";
+import ModelChip from "../chat/composer/ModelChip";
+import { MUSIC_DURATIONS } from "../../stores/MediaGenerationStore";
 import GraphicEqIcon from "@mui/icons-material/GraphicEq";
 import RecordVoiceOverIcon from "@mui/icons-material/RecordVoiceOver";
 import MovieIcon from "@mui/icons-material/Movie";
@@ -54,7 +57,7 @@ import type {
   VideoModelSelection,
   VideoResolution
 } from "../../stores/MediaGenerationStore";
-import type { TTSModel, VideoModel } from "../../stores/ApiTypes";
+import type { MusicModel, TTSModel, VideoModel } from "../../stores/ApiTypes";
 import { useInStudio } from "../../studio/StudioContext";
 import {
   forTasks,
@@ -63,7 +66,7 @@ import {
   STUDIO_VOICE
 } from "../../studio/curatedModels";
 
-const GENERATION_MODES = ["video", "audio"] as const;
+const GENERATION_MODES = ["video", "audio", "music"] as const;
 type GenerationMode = (typeof GENERATION_MODES)[number];
 
 interface AudioSelection {
@@ -83,6 +86,18 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
   const playback = useTimelinePlaybackStoreApi();
   const [mode, setMode] = useState<GenerationMode>("video");
   const [audioSelection, setAudioSelection] = useState<AudioSelection>();
+  const [musicSelection, setMusicSelection] = useState<MusicModel>();
+  const [musicDuration, setMusicDuration] = useState(30);
+  const lastMusicModel = useLastDirectGenModel("music");
+  const musicModel =
+    musicSelection ??
+    (lastMusicModel.model && lastMusicModel.provider
+      ? {
+          id: lastMusicModel.model,
+          name: lastMusicModel.model,
+          provider: lastMusicModel.provider
+        }
+      : undefined);
   const lastAudioModel = useLastDirectGenModel("audio");
   const studioVoice =
     STUDIO_VOICES.find(
@@ -166,8 +181,20 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
   const selectClip = useTimelineUIStore((s) => s.selectClip);
   const directGen = useTimelineDirectGenJob();
 
-  const model = mode === "audio" ? audio?.model : selectedModel;
-  const bindingKind = mode === "audio" ? "text-to-audio" : "text-to-video";
+  const model =
+    mode === "music"
+      ? musicModel
+      : mode === "audio"
+        ? audio?.model
+        : selectedModel;
+  const mediaType = mode === "video" ? "video" : "audio";
+  const generationDuration = mode === "music" ? musicDuration : duration;
+  const bindingKind =
+    mode === "music"
+      ? "text-to-music"
+      : mode === "audio"
+        ? "text-to-audio"
+        : "text-to-video";
   const canSubmit = prompt.trim().length > 0 && !!model?.id && !busy;
 
   const handleSubmit = useCallback(async () => {
@@ -177,18 +204,18 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
     setError(null);
     const tracks = timeline
       .getState()
-      .tracks.filter((track) => track.type === mode);
+      .tracks.filter((track) => track.type === mediaType);
     if (tracks.length === 0) {
       timeline
         .getState()
-        .addTrack(mode, mode === "audio" ? "Audio" : "Video");
+        .addTrack(mediaType, mediaType === "audio" ? "Audio" : "Video");
     }
     const trackId = timeline
       .getState()
-      .tracks.find((track) => track.type === mode && !track.locked)?.id;
+      .tracks.find((track) => track.type === mediaType && !track.locked)?.id;
     if (!trackId) {
       setError(
-        `Unlock ${mode === "audio" ? "an audio" : "a video"} track first.`
+        `Unlock ${mediaType === "audio" ? "an audio" : "a video"} track first.`
       );
       return;
     }
@@ -198,8 +225,8 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
       const clipOptions: Parameters<typeof addDirectGenClip>[0] = {
         trackId,
         startMs,
-        durationMs: duration * 1000,
-        mediaType: mode,
+        durationMs: generationDuration * 1000,
+        mediaType,
         bindingKind,
         prompt: prompt.trim(),
         provider: model.provider,
@@ -208,7 +235,7 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
       if (mode === "video") {
         clipOptions.aspectRatio = aspect;
         clipOptions.resolution = resolution;
-      } else if (audio?.voice) {
+      } else if (mode === "audio" && audio?.voice) {
         clipOptions.voice = audio.voice;
       }
       const clipId = addDirectGenClip(clipOptions);
@@ -226,13 +253,14 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
     prompt,
     model,
     mode,
+    mediaType,
     bindingKind,
     audio?.voice,
     timeline,
     playback,
     aspect,
     resolution,
-    duration,
+    generationDuration,
     selectClip,
     directGen
   ]);
@@ -281,11 +309,13 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
       onChange={(e) => setPrompt(e.target.value)}
       onKeyDown={handleKeyDown}
       placeholder={
-        mode === "audio"
-          ? "Enter text to speak…"
-          : compact
-            ? "Generate a video…"
-            : "Generate a video at the playhead…"
+        mode === "music"
+          ? "Describe the music you want to generate…"
+          : mode === "audio"
+            ? "Enter text to speak…"
+            : compact
+              ? "Generate a video…"
+              : "Generate a video at the playhead…"
       }
       compact
       fullWidth
@@ -329,7 +359,7 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
     model: model?.id,
     resolution,
     aspectRatio: aspect,
-    durationMs: duration * 1000
+    durationMs: generationDuration * 1000
   });
 
   const costLine = (
@@ -355,7 +385,7 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
       data-testid="topbar-generate"
       // Icon-only on phones: the label costs ~70px the prompt needs, and the
       // sparkle plus the field's placeholder already say what it does.
-      aria-label={mode === "audio" ? "Generate audio" : "Generate video"}
+      aria-label={`Generate ${mode}`}
       // Native tooltip still fires on a disabled button: say why it is off.
       title={
         canSubmit ? undefined : "Type a prompt and pick a model to generate"
@@ -527,13 +557,38 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
     </>
   );
 
+  const musicSettingChips = (
+    <>
+      <ModelChip
+        icon={<AudiotrackIcon fontSize="small" />}
+        label={musicModel?.name || "Select Music Model"}
+        picker={{ kind: "music", onPick: setMusicSelection }}
+      />
+      <OptionChip
+        menu="option"
+        icon={<AccessTimeIcon fontSize="small" />}
+        label={`${musicDuration} Sec`}
+        header="Target Duration"
+        title={`Target duration: ${musicDuration} seconds. The model may adjust or ignore this.`}
+        value={musicDuration}
+        options={MUSIC_DURATIONS.map((id) => ({ id, label: `${id} Sec` }))}
+        onChange={setMusicDuration}
+      />
+    </>
+  );
+
   const settingChips = (
     <>
       <ModeSelectChip
         mode={mode}
         modes={GENERATION_MODES}
         onChange={(nextMode) => {
-          if (nextMode !== "video" && nextMode !== "audio") return;
+          if (
+            nextMode !== "video" &&
+            nextMode !== "audio" &&
+            nextMode !== "music"
+          )
+            return;
           setMode(nextMode);
           setVideoModelOpen(false);
           setAudioModelOpen(false);
@@ -543,7 +598,11 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
           setError(null);
         }}
       />
-      {mode === "audio" ? audioSettingChips : videoSettingChips}
+      {mode === "music"
+        ? musicSettingChips
+        : mode === "audio"
+          ? audioSettingChips
+          : videoSettingChips}
     </>
   );
 

--- a/web/src/components/timeline/__tests__/TopBarPrompt.test.tsx
+++ b/web/src/components/timeline/__tests__/TopBarPrompt.test.tsx
@@ -4,7 +4,12 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";
-import type { Asset, TTSModel, VideoModel } from "../../../stores/ApiTypes";
+import type {
+  Asset,
+  MusicModel,
+  TTSModel,
+  VideoModel
+} from "../../../stores/ApiTypes";
 
 const mockSend = jest.fn(async (_frame: unknown) => {});
 const mockReplies = new Map<string, (message: unknown) => void>();
@@ -22,6 +27,29 @@ jest.mock("../../../lib/websocket/GlobalWebSocketManager", () => ({
 jest.mock("../../../lib/websocket/lookupGenerations", () => ({
   isSettled: (status: string) => status !== "running",
   lookupGenerations: jest.fn(async () => new Map())
+}));
+jest.mock("../../model_menu/MusicModelMenuDialog", () => ({
+  __esModule: true,
+  default: ({
+    open,
+    onModelChange
+  }: {
+    open: boolean;
+    onModelChange: (model: MusicModel) => void;
+  }) =>
+    open ? (
+      <button
+        onClick={() =>
+          onModelChange({
+            id: "music-1",
+            provider: "fal_ai",
+            name: "Test music"
+          } as MusicModel)
+        }
+      >
+        Pick music model
+      </button>
+    ) : null
 }));
 jest.mock("../../model_menu/TTSModelMenuDialog", () => ({
   __esModule: true,
@@ -90,7 +118,7 @@ function renderPrompt(compact = false) {
 
 async function chooseSpeech() {
   await userEvent.click(screen.getByRole("button", { name: "Video" }));
-  expect(screen.getAllByRole("menuitemradio")).toHaveLength(2);
+  expect(screen.getAllByRole("menuitemradio")).toHaveLength(3);
   await userEvent.click(
     screen.getByRole("menuitemradio", { name: "Generate Speech" })
   );
@@ -118,6 +146,80 @@ afterEach(() => {
 });
 
 describe("TopBarPrompt", () => {
+  it.each([false, true])(
+    "generates music on an audio track and fits the result (compact=%s)",
+    async (compact) => {
+      renderPrompt(compact);
+      act(() => instance.playback.getState().setTimeMs(2500));
+      await userEvent.click(screen.getByRole("button", { name: "Video" }));
+      await userEvent.click(
+        screen.getByRole("menuitemradio", { name: "Generate Music" })
+      );
+      await userEvent.type(
+        screen.getByRole("textbox", { name: "Quick text-to-music prompt" }),
+        "Warm ambient piano"
+      );
+      expect(
+        screen.getByRole("button", { name: "Generate music" })
+      ).toBeDisabled();
+      await userEvent.click(
+        screen.getByRole("button", { name: "Select Music Model" })
+      );
+      await userEvent.click(
+        screen.getByRole("button", { name: "Pick music model" })
+      );
+      await userEvent.click(
+        screen.getByRole("button", { name: "30 Sec" })
+      );
+      await userEvent.click(screen.getByText("60 Sec"));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Generate music" })
+      );
+      const clip = instance.doc.getState().clips[0];
+      expect(clip).toMatchObject({
+        mediaType: "audio",
+        bindingKind: "text-to-music",
+        startMs: 2500,
+        durationMs: 60000,
+        model: "music-1",
+        provider: "fal_ai",
+        status: "generating"
+      });
+      expect(useLastModelStore.getState().byKind.music).toMatchObject({
+        model: "music-1"
+      });
+      expect(useLastModelStore.getState().byKind.audio).toBeUndefined();
+      const frame = mockSend.mock.calls[0][0] as {
+        request_id: string;
+        data: Record<string, unknown>;
+      };
+      expect(frame.data).toMatchObject({
+        mode: "music",
+        prompt: "Warm ambient piano",
+        duration: 60,
+        model: "music-1"
+      });
+      expect(frame.data.voice).toBeUndefined();
+      expect(frame.data.aspect_ratio).toBeUndefined();
+      jest
+        .spyOn(useAssetStore.getState(), "get")
+        .mockResolvedValue({ id: "music-asset", duration: 58.5 } as Asset);
+      act(() =>
+        mockReplies.get(frame.request_id)?.({
+          type: "rpc_response",
+          result: { asset_ids: ["music-asset"] }
+        })
+      );
+      await waitFor(() =>
+        expect(instance.doc.getState().clips[0]).toMatchObject({
+          status: "generated",
+          currentAssetId: "music-asset",
+          durationMs: 58500
+        })
+      );
+    }
+  );
+
   it.each([false, true])(
     "generates speech at the playhead and fits its duration (compact=%s)",
     async (compact) => {

--- a/web/src/components/timeline/__tests__/TopBarPrompt.test.tsx
+++ b/web/src/components/timeline/__tests__/TopBarPrompt.test.tsx
@@ -1,0 +1,314 @@
+/** @jest-environment jsdom */
+import React from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import type { Asset, TTSModel, VideoModel } from "../../../stores/ApiTypes";
+
+const mockSend = jest.fn(async (_frame: unknown) => {});
+const mockReplies = new Map<string, (message: unknown) => void>();
+jest.mock("../../../lib/websocket/GlobalWebSocketManager", () => ({
+  globalWebSocketManager: {
+    ensureConnection: jest.fn(async () => {}),
+    send: (frame: unknown) => mockSend(frame),
+    subscribe: (id: string, reply: (message: unknown) => void) => {
+      mockReplies.set(id, reply);
+      return () => mockReplies.delete(id);
+    },
+    setResumeJobIdProvider: jest.fn()
+  }
+}));
+jest.mock("../../../lib/websocket/lookupGenerations", () => ({
+  isSettled: (status: string) => status !== "running",
+  lookupGenerations: jest.fn(async () => new Map())
+}));
+jest.mock("../../model_menu/TTSModelMenuDialog", () => ({
+  __esModule: true,
+  default: ({
+    onModelChange
+  }: {
+    onModelChange: (model: TTSModel) => void;
+  }) => (
+    <button
+      onClick={() =>
+        onModelChange({
+          id: "tts-1",
+          provider: "openai",
+          name: "Test speech",
+          voices: ["nova", "alloy"]
+        } as TTSModel)
+      }
+    >
+      Pick speech model
+    </button>
+  )
+}));
+jest.mock("../../model_menu/VideoModelMenuDialog", () => ({
+  __esModule: true,
+  default: ({
+    onModelChange
+  }: {
+    onModelChange: (model: VideoModel) => void;
+  }) => (
+    <button
+      onClick={() =>
+        onModelChange({
+          id: "video-test",
+          provider: "fal_ai",
+          name: "Test video"
+        } as VideoModel)
+      }
+    >
+      Pick video model
+    </button>
+  )
+}));
+
+import { landDirectGen } from "../../../hooks/timeline/useTimelineDirectGenJob";
+import { TopBarPrompt } from "../TopBarPrompt";
+import {
+  createTimelineInstance,
+  TimelineProvider,
+  type TimelineInstance
+} from "../../../stores/timeline/TimelineInstance";
+import { useLastModelStore } from "../../../stores/lastModelStore";
+import { useAssetStore } from "../../../stores/AssetStore";
+import { __resetGenerationWatchesForTests } from "../../../lib/websocket/generationWatch";
+
+let instance: TimelineInstance;
+
+function renderPrompt(compact = false) {
+  return render(
+    <ThemeProvider theme={mockTheme}>
+      <TimelineProvider instance={instance}>
+        <TopBarPrompt compact={compact} />
+      </TimelineProvider>
+    </ThemeProvider>
+  );
+}
+
+async function chooseSpeech() {
+  await userEvent.click(screen.getByRole("button", { name: "Video" }));
+  expect(screen.getAllByRole("menuitemradio")).toHaveLength(2);
+  await userEvent.click(
+    screen.getByRole("menuitemradio", { name: "Generate Speech" })
+  );
+}
+
+async function pickSpeechModel() {
+  await userEvent.click(
+    screen.getByRole("button", { name: "Select TTS Model" })
+  );
+  await userEvent.click(
+    screen.getByRole("button", { name: "Pick speech model" })
+  );
+}
+
+beforeEach(() => {
+  instance = createTimelineInstance();
+  useLastModelStore.setState({ byKind: {} });
+  mockSend.mockClear();
+  mockReplies.clear();
+});
+
+afterEach(() => {
+  __resetGenerationWatchesForTests();
+  jest.restoreAllMocks();
+});
+
+describe("TopBarPrompt", () => {
+  it.each([false, true])(
+    "generates speech at the playhead and fits its duration (compact=%s)",
+    async (compact) => {
+      renderPrompt(compact);
+      act(() => instance.playback.getState().setTimeMs(2500));
+      await chooseSpeech();
+      expect(
+        screen.queryByRole("button", { name: "720p" })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "4 Sec" })
+      ).not.toBeInTheDocument();
+      const prompt = screen.getByRole("textbox", {
+        name: "Quick text-to-audio prompt"
+      });
+      await userEvent.type(prompt, "Read the whole sentence aloud.");
+      expect(
+        screen.getByRole("button", { name: "Generate audio" })
+      ).toBeDisabled();
+      await pickSpeechModel();
+      await userEvent.click(screen.getByRole("button", { name: "nova" }));
+      await userEvent.click(screen.getByText("alloy"));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Generate audio" })
+      );
+
+      const clip = instance.doc.getState().clips[0];
+      expect(clip).toMatchObject({
+        mediaType: "audio",
+        bindingKind: "text-to-audio",
+        startMs: 2500,
+        provider: "openai",
+        model: "tts-1",
+        voice: "alloy",
+        status: "generating"
+      });
+      expect(
+        instance.doc
+          .getState()
+          .tracks.find((track) => track.id === clip.trackId)?.type
+      ).toBe("audio");
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const frame = mockSend.mock.calls[0][0] as {
+        request_id: string;
+        data: Record<string, unknown>;
+      };
+      expect(frame.data).toMatchObject({
+        mode: "audio",
+        provider: "openai",
+        model: "tts-1",
+        voice: "alloy",
+        prompt: "Read the whole sentence aloud.",
+        variations: 1
+      });
+      expect(frame.data).not.toHaveProperty("duration");
+      expect(frame.data).not.toHaveProperty("aspect_ratio");
+      expect(frame.data).not.toHaveProperty("resolution");
+      jest
+        .spyOn(useAssetStore.getState(), "get")
+        .mockResolvedValue({ id: "speech-asset", duration: 12.5 } as Asset);
+      act(() =>
+        mockReplies.get(frame.request_id)?.({
+          type: "rpc_response",
+          result: { asset_ids: ["speech-asset"] }
+        })
+      );
+      await waitFor(() =>
+        expect(instance.doc.getState().clips[0]).toMatchObject({
+          status: "generated",
+          currentAssetId: "speech-asset",
+          durationMs: 12500
+        })
+      );
+      expect(prompt).toHaveValue("");
+    }
+  );
+
+  it("keeps a remembered provider's voice instead of offering unrelated defaults", async () => {
+    useLastModelStore.getState().remember("audio", {
+      provider: "gemini",
+      model: "gemini-2.5-flash-preview-tts",
+      voice: "Puck"
+    });
+    renderPrompt();
+    await chooseSpeech();
+    await userEvent.click(screen.getByRole("button", { name: "Puck" }));
+    expect(screen.queryByText("alloy")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Puck").length).toBeGreaterThan(0);
+  });
+
+  it("uses the provider default when the remembered audio model has no voice", async () => {
+    useLastModelStore.getState().remember("audio", {
+      provider: "gemini",
+      model: "gemini-2.5-flash-preview-tts"
+    });
+    renderPrompt();
+    await chooseSpeech();
+    await userEvent.type(screen.getByRole("textbox"), "Hello{enter}");
+    const frame = mockSend.mock.calls[0][0] as { data: { voice?: string } };
+    expect(frame.data.voice).toBeUndefined();
+  });
+
+  it("does not fit retimed audio to its raw source length", async () => {
+    instance.doc.getState().addTrack("audio", "Speech");
+    const clipId = instance.doc.getState().addDirectGenClip({
+      trackId: instance.doc.getState().tracks[0].id,
+      startMs: 0,
+      durationMs: 16000,
+      mediaType: "audio",
+      bindingKind: "text-to-audio",
+      prompt: "Hello",
+      provider: "openai",
+      model: "tts-1"
+    });
+    instance.doc.getState().patchClip(clipId, { speedMultiplier: 0.5 });
+    jest
+      .spyOn(useAssetStore.getState(), "get")
+      .mockResolvedValue({ id: "slow-speech", duration: 8 } as Asset);
+    await act(async () =>
+      landDirectGen(instance.doc, clipId, "request", null, {
+        assetIds: ["slow-speech"],
+        errored: false
+      })
+    );
+    expect(instance.doc.getState().clips[0]).toMatchObject({
+      currentAssetId: "slow-speech",
+      durationMs: 16000,
+      speedMultiplier: 0.5
+    });
+  });
+
+  it("preserves each mode's model and uses the video generation path after switching back", async () => {
+    renderPrompt();
+    await userEvent.click(screen.getByRole("button", { name: "Select Model" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Pick video model" })
+    );
+    await chooseSpeech();
+    await pickSpeechModel();
+    await userEvent.click(screen.getByRole("button", { name: "Speech" }));
+    await userEvent.click(
+      screen.getByRole("menuitemradio", { name: "Generate Videos" })
+    );
+    expect(
+      screen.getByRole("button", { name: "Test video" })
+    ).toBeInTheDocument();
+    await userEvent.type(screen.getByRole("textbox"), "An ocean wave{enter}");
+    expect(instance.doc.getState().clips[0]).toMatchObject({
+      mediaType: "video",
+      bindingKind: "text-to-video",
+      model: "video-test",
+      aspectRatio: "16:9",
+      resolution: "720p",
+      durationMs: 4000
+    });
+    await chooseSpeech();
+    expect(
+      screen.getByRole("button", { name: "Test speech" })
+    ).toBeInTheDocument();
+  });
+
+  it("uses an unlocked audio track and refuses generation when all audio tracks are locked", async () => {
+    instance.doc.getState().addTrack("audio", "Locked");
+    const locked = instance.doc
+      .getState()
+      .tracks.find((track) => track.type === "audio")!;
+    instance.doc.setState({
+      tracks: instance.doc
+        .getState()
+        .tracks.map((track) => ({ ...track, locked: true }))
+    });
+    renderPrompt();
+    await chooseSpeech();
+    await pickSpeechModel();
+    await userEvent.type(screen.getByRole("textbox"), "Hello");
+    await userEvent.click(
+      screen.getByRole("button", { name: "Generate audio" })
+    );
+    expect(mockSend).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("Unlock an audio track first.")
+    ).toBeInTheDocument();
+    act(() => instance.doc.getState().addTrack("audio", "Unlocked"));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Generate audio" })
+    );
+    const clip = instance.doc.getState().clips[0];
+    expect(clip.trackId).not.toBe(locked.id);
+    expect(
+      instance.doc.getState().tracks.find((track) => track.id === clip.trackId)
+        ?.name
+    ).toBe("Unlocked");
+  });
+});

--- a/web/src/hooks/timeline/useClipCostEstimate.ts
+++ b/web/src/hooks/timeline/useClipCostEstimate.ts
@@ -44,9 +44,11 @@ export function clipGenerationSpec(
   const kind =
     clip.bindingKind === "text-to-video"
       ? "video"
-      : clip.bindingKind === "text-to-audio"
-        ? "audio"
-        : "image";
+      : clip.bindingKind === "text-to-music"
+        ? "music"
+        : clip.bindingKind === "text-to-audio"
+          ? "audio"
+          : "image";
   return {
     kind,
     provider: clip.provider ?? null,
@@ -58,7 +60,7 @@ export function clipGenerationSpec(
     // The direct-gen job derives the requested duration from the clip's own
     // length on the timeline, so a per-second model is priced for that.
     seconds:
-      kind === "video"
+      kind === "video" || kind === "music"
         ? Math.max(1, Math.round((clip.durationMs ?? 4000) / 1000))
         : null
   };

--- a/web/src/hooks/timeline/useGenerateClip.ts
+++ b/web/src/hooks/timeline/useGenerateClip.ts
@@ -57,7 +57,8 @@ const isDirectGenKind = (kind: string | undefined): boolean =>
   kind === "text-to-image" ||
   kind === "image-to-image" ||
   kind === "text-to-video" ||
-  kind === "text-to-audio";
+  kind === "text-to-audio" ||
+  kind === "text-to-music";
 
 /**
  * Compute the non-generating clip status from current clip fields. Used by

--- a/web/src/hooks/timeline/useLastDirectGenModel.ts
+++ b/web/src/hooks/timeline/useLastDirectGenModel.ts
@@ -27,17 +27,16 @@ interface LastDirectGenModel {
   voice: string | undefined;
 }
 
-export type DirectGenMediaKind = "image" | "video" | "audio";
+export type DirectGenMediaKind = "image" | "video" | "audio" | "music";
 
 const matchesKind = (
   bindingKind: string | undefined,
   kind: DirectGenMediaKind
 ): boolean => {
   if (kind === "video") return bindingKind === "text-to-video";
+  if (kind === "music") return bindingKind === "text-to-music";
   if (kind === "audio") return bindingKind === "text-to-audio";
-  return (
-    bindingKind === "text-to-image" || bindingKind === "image-to-image"
-  );
+  return bindingKind === "text-to-image" || bindingKind === "image-to-image";
 };
 
 export const useLastDirectGenModel = (

--- a/web/src/hooks/timeline/useTimelineDirectGenJob.ts
+++ b/web/src/hooks/timeline/useTimelineDirectGenJob.ts
@@ -29,6 +29,9 @@ import {
   lookupGenerations
 } from "../../lib/websocket/lookupGenerations";
 import { watchGeneration } from "../../lib/websocket/generationWatch";
+import { useAssetStore } from "../../stores/AssetStore";
+import { getAssetUrl } from "../../utils/assetHelpers";
+import { probeMediaDurationMs } from "../../utils/probeMediaDuration";
 
 interface DirectGenRpcResponse extends WebSocketMessage {
   type: "rpc_response";
@@ -59,6 +62,43 @@ const clearInFlight = (clipId: string): void => {
 
 function fail(timeline: TimelineStoreApi, clipId: string): void {
   timeline.getState().patchClip(clipId, { status: "failed" });
+}
+
+async function fitGeneratedAudio(
+  timeline: TimelineStoreApi,
+  clip: TimelineClip,
+  assetId: string
+): Promise<void> {
+  try {
+    const asset = await useAssetStore.getState().get(assetId);
+    const url = getAssetUrl(asset);
+    const durationMs =
+      asset.duration && asset.duration > 0
+        ? Math.round(asset.duration * 1000)
+        : url
+          ? await probeMediaDurationMs(url, "audio")
+          : null;
+    const current = timeline
+      .getState()
+      .clips.find((item) => item.id === clip.id);
+    // A late probe must not undo a trim, lock, or subsequent generation.
+    if (
+      durationMs &&
+      current &&
+      !current.locked &&
+      current.currentAssetId === assetId &&
+      current.status === "generated" &&
+      (current.speedMultiplier ?? 1) === 1 &&
+      !current.timeRemap &&
+      current.durationMs === clip.durationMs &&
+      current.inPointMs === undefined &&
+      current.outPointMs === undefined
+    ) {
+      timeline.getState().patchClip(clip.id, { durationMs });
+    }
+  } catch {
+    // Keep the generated asset and editable placeholder length if metadata is unavailable.
+  }
 }
 
 /** One request's outcome, however it was learned. */
@@ -142,6 +182,9 @@ export function landDirectGen(
     patch.outPointMs = undefined;
   }
   store.patchClip(clipId, patch);
+  if (current.bindingKind === "text-to-audio" && !current.locked) {
+    void fitGeneratedAudio(timeline, current, first);
+  }
 }
 
 /**

--- a/web/src/hooks/timeline/useTimelineDirectGenJob.ts
+++ b/web/src/hooks/timeline/useTimelineDirectGenJob.ts
@@ -182,7 +182,11 @@ export function landDirectGen(
     patch.outPointMs = undefined;
   }
   store.patchClip(clipId, patch);
-  if (current.bindingKind === "text-to-audio" && !current.locked) {
+  if (
+    (current.bindingKind === "text-to-audio" ||
+      current.bindingKind === "text-to-music") &&
+    !current.locked
+  ) {
     void fitGeneratedAudio(timeline, current, first);
   }
 }
@@ -370,7 +374,8 @@ export function useTimelineDirectGenJob(): UseTimelineDirectGenJobApi {
         kind !== "text-to-image" &&
         kind !== "image-to-image" &&
         kind !== "text-to-video" &&
-        kind !== "text-to-audio"
+        kind !== "text-to-audio" &&
+        kind !== "text-to-music"
       ) {
         return null;
       }
@@ -437,11 +442,11 @@ export function useTimelineDirectGenJob(): UseTimelineDirectGenJobApi {
       // them through when set. Video additionally derives its requested duration
       // from the clip's timeline length (width & height are ignored for video).
       const framingParams: FramingParams = {};
-      if (kind !== "text-to-audio") {
+      if (kind !== "text-to-audio" && kind !== "text-to-music") {
         framingParams.aspect_ratio = clip.aspectRatio;
         framingParams.resolution = clip.resolution;
       }
-      if (kind === "text-to-video") {
+      if (kind === "text-to-video" || kind === "text-to-music") {
         framingParams.duration = clip.durationMs
           ? Math.round(clip.durationMs / 1000)
           : undefined;
@@ -459,7 +464,9 @@ export function useTimelineDirectGenJob(): UseTimelineDirectGenJobApi {
                   ? "image_edit"
                   : kind === "text-to-video"
                     ? "video"
-                    : "audio",
+                    : kind === "text-to-music"
+                      ? "music"
+                      : "audio",
             provider: clip.provider,
             model: clip.model,
             prompt,

--- a/web/src/stores/MediaGenerationStore.ts
+++ b/web/src/stores/MediaGenerationStore.ts
@@ -9,7 +9,12 @@
  */
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import type { ImageModelValue, Message, TTSModelValue } from "./ApiTypes";
+import type {
+  ImageModelValue,
+  Message,
+  MusicModelValue,
+  TTSModelValue
+} from "./ApiTypes";
 
 /**
  * Media-generation request metadata that can be attached to outgoing chat
@@ -57,6 +62,7 @@ export type MediaMode =
   | "image_to_video"
   | "reference_to_video"
   | "audio"
+  | "music"
   | "audio_to_video"
   | "retake"
   | "extend"
@@ -104,6 +110,7 @@ export const VIDEO_RESOLUTIONS: VideoResolution[] = [
   "1440p",
   "4K"
 ];
+export const MUSIC_DURATIONS = [15, 30, 60, 120];
 export const VIDEO_DURATIONS: number[] = [2, 3, 4, 5, 6, 8, 10, 12, 15];
 export const IMAGE_VARIATIONS: number[] = [1, 2, 4, 6, 8];
 
@@ -168,6 +175,11 @@ interface VideoGenerationParams {
   duration: number;
 }
 
+interface MusicGenerationParams {
+  model: MusicModelValue | null;
+  duration: number;
+}
+
 interface AudioGenerationParams {
   model: TTSModelValue | null;
   voice: string;
@@ -209,6 +221,8 @@ interface MediaGenerationState {
   imageToVideo: ImageToVideoGenerationParams;
   referenceToVideo: ReferenceToVideoGenerationParams;
   audio: AudioGenerationParams;
+  music: MusicGenerationParams;
+  setMusicParams: (params: Partial<MusicGenerationParams>) => void;
   setMode: (mode: MediaMode) => void;
   setImageParams: (params: Partial<ImageGenerationParams>) => void;
   setImageEditParams: (params: Partial<ImageEditParams>) => void;
@@ -276,6 +290,9 @@ const useMediaGenerationStore = create<MediaGenerationState>()(
       imageToVideo: DEFAULT_IMAGE_TO_VIDEO_PARAMS,
       referenceToVideo: DEFAULT_REFERENCE_TO_VIDEO_PARAMS,
       audio: DEFAULT_AUDIO_PARAMS,
+      music: { model: null, duration: 30 },
+      setMusicParams: (params) =>
+        set((state) => ({ music: { ...state.music, ...params } })),
       setMode: (mode) => set({ mode }),
       setImageParams: (params) =>
         set((state) => ({ image: { ...state.image, ...params } })),

--- a/web/src/stores/lastModelStore.ts
+++ b/web/src/stores/lastModelStore.ts
@@ -11,7 +11,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-export type ModelKind = "image" | "video" | "audio";
+export type ModelKind = "image" | "video" | "audio" | "music";
 
 interface RememberedModel {
   provider?: string;
@@ -72,6 +72,8 @@ export function modelKindForBinding(
   switch (bindingKind) {
     case "text-to-video":
       return "video";
+    case "text-to-music":
+      return "music";
     case "text-to-audio":
       return "audio";
     case "text-to-image":

--- a/web/src/stores/timeline/TimelineStore.ts
+++ b/web/src/stores/timeline/TimelineStore.ts
@@ -778,7 +778,8 @@ export interface TimelineStoreState {
       | "text-to-image"
       | "image-to-image"
       | "text-to-video"
-      | "text-to-audio";
+      | "text-to-audio"
+      | "text-to-music";
     prompt: string;
     provider?: string;
     model?: string;
@@ -3063,9 +3064,11 @@ export const createTimelineStore = (
                 ? "Image-to-Image"
                 : bindingKind === "text-to-video"
                   ? "Text-to-Video"
-                  : bindingKind === "text-to-audio"
-                    ? "Text-to-Audio"
-                    : "Text-to-Image";
+                  : bindingKind === "text-to-music"
+                    ? "Text-to-Music"
+                    : bindingKind === "text-to-audio"
+                      ? "Text-to-Audio"
+                      : "Text-to-Image";
 
           const clip = makeClip({
             id: createTimeOrderedUuid(),

--- a/web/src/utils/generationCostEstimate.ts
+++ b/web/src/utils/generationCostEstimate.ts
@@ -25,7 +25,7 @@ import {
 /** What a surface states about the generation it is about to start. */
 export interface GenerationSpec {
   /** "image" prices a still, "video" a clip, "audio" a spoken take. */
-  kind: "image" | "video" | "audio";
+  kind: "image" | "video" | "audio" | "music";
   provider?: string | null;
   model?: string | null;
   /** The rung in the catalog's own spelling: "1K", "720p". */
@@ -78,7 +78,7 @@ function priceParams(spec: GenerationSpec): ModelPriceParams {
   if (spec.resolution) {
     params.resolution = spec.resolution;
   }
-  if (spec.kind === "video") {
+  if (spec.kind === "video" || spec.kind === "music") {
     if (spec.seconds != null && spec.seconds > 0) {
       params.seconds = spec.seconds;
     }


### PR DESCRIPTION
## What changed

Add Speech and Music modes to the timeline generation composer, and Music mode to the chat composer. Move the timeline composer below the preview and above the tracks, with a compact layout for narrow panels. Generated audio lands on an audio track and fits its actual duration, with separate remembered speech and music models and inspector regeneration support. Fix ElevenLabs Music on FAL dropping the requested duration by sending integer milliseconds.

## Verification

After applying the three feature commits to the latest main and resolving overlaps with reference-to-video, the four composer/timeline suites passed: 40 tests. Conflict-resolution review found no issues.

Before rebasing:
- Focused FAL provider suites: 66 tests passed.
- Chat and direct-generation RPC suites: 32 tests passed.
- Typecheck and lint passed.
- Harness gate: 10/10 selfchecks passed.

The broad affected run was not green: runtime tests failed on macOS path canonicalization (`/tmp` versus `/private/tmp`), and a narrower backend run encountered live reliability-driver failures. Web suites that failed under the broad run passed when rerun separately.

The duration regression was observed failing before the fix: a 60-second ElevenLabs request contained only `prompt`, with the expected `music_length_ms: 60000` absent. The same test passed after the fix.

- [x] `npm run test:affected` with explicit composer/timeline test files
- [x] `npm run typecheck` (before rebase)
- [x] `npm run lint` (before rebase)
- [x] `npm run dev:nodetool -- harness gate --base origin/main` (before rebase)
