### PR TITLE
refactor(projects): thin out the new-project page

### DIFF
--- a/web/src/components/projects/NewProjectSurface.tsx
+++ b/web/src/components/projects/NewProjectSurface.tsx
@@ -1250,45 +1250,31 @@ const NewProjectSurface = () => {
     <ScrollArea fullHeight>
       <FlexColumn align="center" sx={{ minHeight: "100%", px: SPACING.xl }}>
         <FlexColumn
-          gap={SPACING.xl}
+          gap={SPACING.xxl}
           sx={{ width: "100%", maxWidth: `${COLUMN_WIDTH}px`, pt: SPACING.xxxl }}
         >
+          {/* The getting-started steps read as a thin bar above the page rather
+              than a block wedged between the composer and the footer. */}
+          {showOnboarding && (
+            <GettingStartedChecklist
+              hasConfiguredProvider={hasConfiguredProvider}
+              onConnectProvider={handleConnectProvider}
+              onOpenTemplates={handleOpenTemplates}
+              onCreateWorkflow={() => void handleCreateNewWorkflow()}
+            />
+          )}
+
           <FlexColumn gap={SPACING.md} align="center">
             <Text size="big">What do you want to make?</Text>
             <Caption
               color="secondary"
               sx={{ maxWidth: "560px", textAlign: "center" }}
             >
-              An agent plans the documents — a board, a script, a cut — and
-              builds them while you watch. Everything it makes stays editable.
+              An agent plans the documents and builds them while you watch.
+              Everything it makes stays editable.
             </Caption>
           </FlexColumn>
 
-          <FlexColumn
-            gap={SPACING.md}
-            sx={{
-              "& button": { bgcolor: "common.black" },
-              "& button:not([aria-disabled=\"true\"]):hover": {
-                bgcolor: "common.black",
-                borderColor: "primary.main"
-              },
-              "& img": { opacity: 0.6 }
-            }}
-          >
-            <Caption color="muted">Start with a guided flow</Caption>
-            <OptionCardGrid
-              label="Guided creation flows"
-              options={entryOptions}
-              onSelect={handleEntryCard}
-              minColumnWidth={240}
-              variant="media"
-              // These cards route to a flow, they do not pick one of a set:
-              // no pressed state, and each is its own tab stop.
-              mode="navigation"
-            />
-          </FlexColumn>
-
-          <Caption color="muted">Or describe what you want to make</Caption>
           <FlexColumn
             gap={SPACING.lg}
             sx={{
@@ -1399,7 +1385,7 @@ const NewProjectSurface = () => {
           </FlexColumn>
 
           {starters.length > 0 && (
-            <FlexColumn gap={SPACING.md} align="center">
+            <FlexColumn gap={SPACING.md} align="center" sx={{ mt: -SPACING.lg }}>
               <FlexRow
                 justify="center"
                 gap={SPACING.sm}
@@ -1462,48 +1448,47 @@ const NewProjectSurface = () => {
             </FlexColumn>
           )}
 
-          {showOnboarding && (
-            <Box sx={{ pt: SPACING.lg }}>
-              <GettingStartedChecklist
-                hasConfiguredProvider={hasConfiguredProvider}
-                onConnectProvider={handleConnectProvider}
-                onOpenTemplates={handleOpenTemplates}
-                onCreateWorkflow={() => void handleCreateNewWorkflow()}
-              />
-            </Box>
-          )}
-
-          <FlexRow justify="center" align="center" gap={SPACING.md}>
-            <Caption color="muted">Not sure where to begin?</Caption>
-            <EditorButton
-              variant="outlined"
-              density="compact"
-              onClick={handleOpenTemplates}
-            >
-              Browse examples
-            </EditorButton>
-            <EditorButton
-              variant="outlined"
-              density="compact"
-              onClick={handleOpenTutorials}
-            >
-              Tutorials
-            </EditorButton>
-          </FlexRow>
+          <FlexColumn
+            gap={SPACING.md}
+            sx={{
+              "& button": { bgcolor: "common.black" },
+              "& button:not([aria-disabled=\"true\"]):hover": {
+                bgcolor: "common.black",
+                borderColor: "primary.main"
+              },
+              "& img": { opacity: 0.6 }
+            }}
+          >
+            <Caption color="muted">Or start with a guided flow</Caption>
+            <OptionCardGrid
+              label="Guided creation flows"
+              options={entryOptions}
+              onSelect={handleEntryCard}
+              minColumnWidth={240}
+              variant="media"
+              // These cards route to a flow, they do not pick one of a set:
+              // no pressed state, and each is its own tab stop.
+              mode="navigation"
+            />
+          </FlexColumn>
         </FlexColumn>
 
         <Box sx={{ flex: 1, minHeight: SPACING.xxxl }} />
 
+        {/* One quiet footer: the blank documents and the two places to go when
+            nothing above fits, rather than two rows competing for the same
+            "where else can I start" question. */}
         <FlexColumn
           gap={SPACING.md}
           sx={{
             width: "100%",
             maxWidth: `${COLUMN_WIDTH}px`,
+            pt: SPACING.xxl,
             pb: SPACING.xxl
           }}
         >
           <Divider />
-          <FlexRow align="baseline" gap={SPACING.md}>
+          <FlexRow align="baseline" gap={SPACING.md} wrap>
             <Caption
               color="muted"
               sx={{ textTransform: "uppercase", letterSpacing: "0.08em" }}
@@ -1513,6 +1498,21 @@ const NewProjectSurface = () => {
             <Caption color="muted">
               — opens as a loose tab, outside any project
             </Caption>
+            <Box sx={{ flex: 1 }} />
+            <EditorButton
+              variant="text"
+              density="compact"
+              onClick={handleOpenTemplates}
+            >
+              Browse examples
+            </EditorButton>
+            <EditorButton
+              variant="text"
+              density="compact"
+              onClick={handleOpenTutorials}
+            >
+              Tutorials
+            </EditorButton>
           </FlexRow>
           <Box
             sx={{

--- a/web/src/components/projects/NewProjectSurface.tsx
+++ b/web/src/components/projects/NewProjectSurface.tsx
@@ -1276,8 +1276,38 @@ const NewProjectSurface = () => {
           </FlexColumn>
 
           <FlexColumn
+            gap={SPACING.md}
+            sx={{
+              "& button": { bgcolor: "common.black" },
+              "& button:not([aria-disabled=\"true\"]):hover": {
+                bgcolor: "common.black",
+                borderColor: "primary.main"
+              },
+              "& img": { opacity: 0.6 }
+            }}
+          >
+            <Caption color="muted">Start with a guided flow</Caption>
+            <OptionCardGrid
+              label="Guided creation flows"
+              options={entryOptions}
+              onSelect={handleEntryCard}
+              minColumnWidth={240}
+              variant="media"
+              // These cards route to a flow, they do not pick one of a set:
+              // no pressed state, and each is its own tab stop.
+              mode="navigation"
+            />
+          </FlexColumn>
+
+          {/* The composer sits below the cards, not above them: its `/` and `@`
+              menus open upward from the box's top edge
+              (`useTextareaSkillMention`), so it needs the page above it as
+              headroom. */}
+          <Caption color="muted">Or describe what you want to make</Caption>
+          <FlexColumn
             gap={SPACING.lg}
             sx={{
+              mt: -SPACING.lg,
               bgcolor: "background.paper",
               border: "1px solid",
               borderColor: "primary.main",
@@ -1448,29 +1478,6 @@ const NewProjectSurface = () => {
             </FlexColumn>
           )}
 
-          <FlexColumn
-            gap={SPACING.md}
-            sx={{
-              "& button": { bgcolor: "common.black" },
-              "& button:not([aria-disabled=\"true\"]):hover": {
-                bgcolor: "common.black",
-                borderColor: "primary.main"
-              },
-              "& img": { opacity: 0.6 }
-            }}
-          >
-            <Caption color="muted">Or start with a guided flow</Caption>
-            <OptionCardGrid
-              label="Guided creation flows"
-              options={entryOptions}
-              onSelect={handleEntryCard}
-              minColumnWidth={240}
-              variant="media"
-              // These cards route to a flow, they do not pick one of a set:
-              // no pressed state, and each is its own tab stop.
-              mode="navigation"
-            />
-          </FlexColumn>
         </FlexColumn>
 
         <Box sx={{ flex: 1, minHeight: SPACING.xxxl }} />


### PR DESCRIPTION
## What changed

The new-project page stacked eight sections down one 860px column — title, guided-flow cards, a second "or describe what you want" label, the composer, starter pills, the getting-started checklist, an examples/tutorials row, and the blank-document strip — so nothing led and everything read as crowded. It now reads in four blocks: the getting-started strip as a thin bar above the title, the guided-flow card grid, the composer with its starter pills pulled up under it so they read as part of the box, and one footer carrying both the blank documents and the examples/tutorials links. Section gaps went from 16px to 24px, so fewer blocks sit further apart.

The composer stays below the cards on purpose. Its `/` and `@` menus position with `bottom: window.innerHeight - rect.top + 6` (`useTextareaSkillMention.tsx`), so they open upward from the box's top edge and need the page above them as headroom — an earlier revision of this branch put the composer first and left them nowhere to draw.

No behaviour, flow copy, or accessible names changed; the 38 existing tests pass unmodified.

## Verification

- [x] `npm run test:affected` — 2 suites, 39 tests passed
- [x] `npm run typecheck` — 42 errors locally, identical to the same run with the change stashed; all are unbuilt-package resolution failures from `build:packages` failing in this container on `@nodetool-ai/game-nodes` (it cannot resolve `@nodetool-ai/godot` / `@nodetool-ai/godot-templates`). None name a changed file. The Quality Gate `typecheck` job is green on this head.
- [x] `npm run lint` — passes, including the design-token rules
- [x] `npm run dev:nodetool -- harness gate --base main` — could not run locally (the CLI loads `@nodetool-ai/base-nodes/dist`, unbuilt for the same reason). The Quality Gate `harness-gate` job is green on this head.

All 22 checks pass on `0e2b74b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KTmnnEHCbtkHgZVUw8oKK