### PR TITLE
fix: three logical bugs found auditing the last 100 commits

### DIFF
--- a/packages/models/src/project.ts
+++ b/packages/models/src/project.ts
@@ -24,8 +24,16 @@ import { Thread } from "./thread.js";
 
 /** The bucket documents land in when no project is active. */
 export const LOOSE_PROJECT_ID = "default";
+
 export const PERSONAL_PROJECT_KIND = "personal";
 export const PERSONAL_PROJECT_NAME = "Personal";
+
+/**
+ * The rows the Personal migration may claim: never assigned, or assigned to the
+ * loose bucket. An explicit project id is a user decision and is left alone.
+ */
+const LOOSE_ROW_SQL =
+  `(project_id IS NULL OR project_id = '' OR project_id = '${LOOSE_PROJECT_ID}')`;
 
 export interface PersonalMigrationReport {
   project: Project;
@@ -126,12 +134,18 @@ export class Project extends DBModel {
     const target = personal.id.replace(/'/g, "''");
     let migrated = 0;
     // Restore the legacy project.thread_id association before claiming
-    // remaining threads for Personal.
+    // remaining threads for Personal. Loose rows only, like every other
+    // statement here: a thread already assigned to a project stays there even
+    // when some project still names it as its own thread_id — that stale
+    // pointer is not authority to move a row the user placed. Two projects
+    // naming one thread is a broken legacy reference, so the oldest wins
+    // rather than whichever row the engine reaches first.
     await executeRaw(
       `UPDATE nodetool_threads SET project_id = (` +
         `SELECT p.id FROM projects p WHERE p.thread_id = nodetool_threads.id ` +
-        `AND p.user_id = nodetool_threads.user_id) ` +
-        `WHERE user_id = '${owner}' AND EXISTS (` +
+        `AND p.user_id = nodetool_threads.user_id ` +
+        `ORDER BY p.created_at, p.id LIMIT 1) ` +
+        `WHERE user_id = '${owner}' AND ${LOOSE_ROW_SQL} AND EXISTS (` +
         `SELECT 1 FROM projects p WHERE p.thread_id = nodetool_threads.id ` +
         `AND p.user_id = nodetool_threads.user_id) RETURNING id`
     );
@@ -142,8 +156,7 @@ export class Project extends DBModel {
       `UPDATE nodetool_jobs SET project_id = (` +
         `SELECT w.project_id FROM nodetool_workflows w ` +
         `WHERE w.id = nodetool_jobs.workflow_id AND w.user_id = nodetool_jobs.user_id) ` +
-        `WHERE user_id = '${owner}' AND (project_id IS NULL OR project_id = '' ` +
-        `OR project_id = 'default') AND EXISTS (` +
+        `WHERE user_id = '${owner}' AND ${LOOSE_ROW_SQL} AND EXISTS (` +
         `SELECT 1 FROM nodetool_workflows w WHERE w.id = nodetool_jobs.workflow_id ` +
         `AND w.user_id = nodetool_jobs.user_id AND w.project_id <> 'default') RETURNING id`
     );
@@ -156,8 +169,7 @@ export class Project extends DBModel {
     for (const table of tables) {
       const result = await executeRaw(
         `UPDATE ${table} SET project_id = '${target}' ` +
-          `WHERE user_id = '${owner}' AND ` +
-          `(project_id IS NULL OR project_id = '' OR project_id = 'default') RETURNING id`
+          `WHERE user_id = '${owner}' AND ${LOOSE_ROW_SQL} RETURNING id`
       );
       migrated += result.rows.length;
     }

--- a/packages/models/tests/project.test.ts
+++ b/packages/models/tests/project.test.ts
@@ -220,6 +220,44 @@ describe("Project model", () => {
     expect(await Project.listByUser("empty")).toEqual([]);
   });
 
+  it("leaves an assigned thread where it is, even when a project names it", async () => {
+    const owner = await Project.create<Project>({
+      id: "owner",
+      user_id: "u1",
+      name: "Owner"
+    });
+    const elsewhere = await Project.create<Project>({
+      id: "elsewhere",
+      user_id: "u1",
+      name: "Elsewhere"
+    });
+    // The user moved this thread to `elsewhere`; `owner` still carries the
+    // legacy pointer. The move is the decision, the stale pointer is not.
+    const moved = await Thread.create<Thread>({
+      user_id: "u1",
+      project_id: elsewhere.id,
+      title: "Moved"
+    });
+    const loose = await Thread.create<Thread>({
+      user_id: "u1",
+      project_id: LOOSE_PROJECT_ID,
+      title: "Loose"
+    });
+    await owner.update({ thread_id: moved.id });
+    const second = await Project.create<Project>({
+      id: "second-owner",
+      user_id: "u1",
+      name: "Second owner"
+    });
+    await second.update({ thread_id: loose.id });
+
+    await Project.migrateToPersonal("u1");
+
+    expect((await Thread.find("u1", moved.id))?.project_id).toBe(elsewhere.id);
+    // A loose thread a project names still gets restored to that project.
+    expect((await Thread.find("u1", loose.id))?.project_id).toBe(second.id);
+  });
+
   it("does not allow Personal to be deleted", async () => {
     const personal = await Project.ensurePersonal("u1");
     expect(await Project.deleteOwned("u1", personal.id)).toBe(false);

--- a/packages/protocol/src/render-record.ts
+++ b/packages/protocol/src/render-record.ts
@@ -27,12 +27,7 @@ import type {
 } from "./creative.js";
 import { shotRenderMode } from "./creative.js";
 import { sha256Hex } from "./sha256.js";
-import {
-  clipPrompt,
-  directClipPrompt,
-  keyframePrompt,
-  sceneForShot
-} from "./shot-prompt.js";
+import { clipPromptFor, keyframePrompt, sceneForShot } from "./shot-prompt.js";
 
 /**
  * The board settings a shot's render inputs are drawn from.
@@ -90,11 +85,7 @@ function promptHashFor(
   if (kind === "keyframe") {
     return sha256Hex(keyframePrompt(shot, context));
   }
-  return sha256Hex(
-    shotRenderMode(shot) === "direct"
-      ? directClipPrompt(shot, context)
-      : clipPrompt(shot)
-  );
+  return sha256Hex(clipPromptFor(shot, context));
 }
 
 /**

--- a/packages/protocol/src/shot-prompt.ts
+++ b/packages/protocol/src/shot-prompt.ts
@@ -24,7 +24,13 @@
  * A keyframe-mode clip animates a still that already carries framing, lens,
  * lighting and style, so repeating them in the video prompt only fights the
  * first-frame conditioning. A direct clip has no still, so it carries
- * everything.
+ * everything. A reference clip has no still either — its entity images
+ * condition the render, not a first frame — so it composes like a direct one.
+ *
+ * {@link clipPromptFor} is the one place that mapping lives: every render
+ * surface and the staleness record call it rather than branching on the mode
+ * themselves, because a surface that branched differently would render one
+ * prompt and hash another.
  *
  * `dialogue`, `notes` and `duration_seconds` never enter a prompt: the first
  * two are words for people, the third is a render parameter.
@@ -35,6 +41,7 @@
  * `entitiesForShot`.
  */
 
+import { shotRenderMode } from "./creative.js";
 import type { Scene, Shot } from "./creative.js";
 
 /** What a prompt needs beyond the shot itself. */
@@ -126,4 +133,21 @@ export function directClipPrompt(
     camera?.equipment,
     context.style
   ]);
+}
+
+/**
+ * The clip prompt for a shot in `mode` — `directClipPrompt` for a mode with no
+ * still to condition on (`direct`, `reference`), `clipPrompt` for `keyframe`.
+ *
+ * Pass `mode` when a call overrides the shot's own; omit it to read
+ * `shot.render_mode`.
+ */
+export function clipPromptFor(
+  shot: Shot,
+  context: ShotPromptContext = {},
+  mode: ReturnType<typeof shotRenderMode> = shotRenderMode(shot)
+): string {
+  return mode === "keyframe"
+    ? clipPrompt(shot)
+    : directClipPrompt(shot, context);
 }

--- a/packages/protocol/tests/render-record.test.ts
+++ b/packages/protocol/tests/render-record.test.ts
@@ -96,6 +96,21 @@ describe("currentRenderInputs", () => {
     );
   });
 
+  it("hashes a reference-mode clip the way it is rendered", () => {
+    // A reference clip has no still, so its prompt carries framing, lens,
+    // lighting and style — the same composition a direct clip uses. Hashing
+    // the keyframe-mode prompt instead left a style or framing edit invisible
+    // to staleness, and `stale_only` skipped the re-render.
+    const shot = makeShot({ render_mode: "reference" });
+    expect(currentRenderInputs(shot, BOARD, "clip").prompt_hash).toBe(
+      currentRenderInputs(
+        { ...shot, render_mode: "direct" },
+        BOARD,
+        "clip"
+      ).prompt_hash
+    );
+  });
+
   it("takes the image model for a still and the video model for a clip", () => {
     const shot = makeShot();
     expect(currentRenderInputs(shot, BOARD, "keyframe").model).toBe(
@@ -108,6 +123,26 @@ describe("currentRenderInputs", () => {
 });
 
 describe("isVersionStale", () => {
+  it("reads a reference-mode clip as stale after a style edit", () => {
+    const shot = makeShot({ render_mode: "reference" });
+    const clip = {
+      type: "video" as const,
+      asset_id: "asset-clip-1",
+      render_inputs: stampRenderInputs(
+        currentRenderInputs(shot, BOARD, "clip"),
+        "2026-01-01T00:00:00.000Z"
+      )
+    };
+    const rendered: Shot = { ...shot, clip, clip_versions: [clip] };
+    expect(isVersionStale(clip, rendered, BOARD)).toBe(false);
+    expect(
+      isVersionStale(clip, rendered, { ...BOARD, style: "high-key, clean" })
+    ).toBe(true);
+    expect(
+      isVersionStale(clip, { ...rendered, camera: { framing: "close" } }, BOARD)
+    ).toBe(true);
+  });
+
   it("reads a version rendered from today's inputs as current", () => {
     const shot = makeRenderedShot();
     expect(shotStaleness(shot, BOARD)).toEqual({

--- a/packages/storyboard/src/recast.ts
+++ b/packages/storyboard/src/recast.ts
@@ -16,11 +16,9 @@ import {
   entitiesForShot,
   injectEntities,
   keyframePrompt,
-  clipPrompt,
-  directClipPrompt,
+  clipPromptFor,
   sceneForShot,
-  sha256Hex,
-  shotRenderMode
+  sha256Hex
 } from "@nodetool-ai/protocol";
 import type { Entity, Screenplay, Shot } from "@nodetool-ai/protocol";
 import type { StoryboardDocument } from "./document.js";
@@ -272,9 +270,9 @@ const injectedPrompt = (
 /**
  * What this shot would render from, on this board, with this cast.
  *
- * The composition is the render path's own (`keyframePrompt`, `clipPrompt`,
- * `directClipPrompt`) plus `injectEntities`, and the digest is `sha256Hex`, the
- * one that writes `RenderInputs.prompt_hash`. Two of these are compared against
+ * The composition is the render path's own (`keyframePrompt`, `clipPromptFor`)
+ * plus `injectEntities`, and the digest is `sha256Hex`, the one that writes
+ * `RenderInputs.prompt_hash`. Two of these are compared against
  * each other, which is what makes a descriptor edit visible: the stored record
  * hashes the composed prompt *before* injection, so it does not cover one.
  */
@@ -292,13 +290,7 @@ function promptHashes(
       injectedPrompt(keyframePrompt(shot, context), shot, entities)
     ),
     clip: sha256Hex(
-      injectedPrompt(
-        shotRenderMode(shot) === "direct"
-          ? directClipPrompt(shot, context)
-          : clipPrompt(shot),
-        shot,
-        entities
-      )
+      injectedPrompt(clipPromptFor(shot, context), shot, entities)
     )
   };
 }

--- a/packages/storyboard/src/render-plan.ts
+++ b/packages/storyboard/src/render-plan.ts
@@ -15,8 +15,7 @@ import {
   entitiesForShot,
   isVersionStale,
   keyframePrompt,
-  clipPrompt,
-  directClipPrompt,
+  clipPromptFor,
   sceneForShot,
   shotRenderMode
 } from "@nodetool-ai/protocol";
@@ -203,9 +202,7 @@ export function planShotRenders(
     const prompt =
       kind === "keyframe"
         ? keyframePrompt(shot, context)
-        : mode === "direct" || mode === "reference"
-          ? directClipPrompt(shot, context)
-          : clipPrompt(shot);
+        : clipPromptFor(shot, context, mode);
     const applied = entitiesForShot(shot, [...entities]);
     const shotReferenceAssetIds = applied.flatMap((entity) =>
       (entity.reference_images ?? [])

--- a/packages/timeline/src/splitClip.ts
+++ b/packages/timeline/src/splitClip.ts
@@ -18,10 +18,11 @@ import type { CaptionWord, TimelineClip } from "./types.js";
  *   half: left when the delay falls before the cut, otherwise right with the
  *   delay rebased to the right half's start.
  * - A `"loop"` runs on both halves. `windowT` counts the cycle from the clip's
- *   own start, so the right half's delay is shifted to the next cycle boundary
- *   after the cut — the cycle grid carries across the cut instead of the loop
- *   restarting mid-cycle. A loop that has not started yet keeps the rest of
- *   its delay.
+ *   own start, so the right half's delay goes negative by the time already
+ *   elapsed — the compiler reads that as a phase offset and opens the right
+ *   half mid-cycle exactly where the left half left off, rather than
+ *   restarting the loop at the cut. A loop that has not started yet keeps the
+ *   rest of its delay ({@link rebaseLoopDelayMs}).
  * - A `fullClip` preset (kenBurns) ignores `delayMs` and runs once over the
  *   whole clip, and its curves are in canvas pixels that `splitClip` cannot
  *   compute, so neither half can carry a partial move: both replay the whole

--- a/web/src/hooks/storyboard/useGenerateShot.ts
+++ b/web/src/hooks/storyboard/useGenerateShot.ts
@@ -27,8 +27,7 @@ import type {
   Shot
 } from "@nodetool-ai/protocol";
 import {
-  clipPrompt,
-  directClipPrompt,
+  clipPromptFor,
   entitiesForShot,
   injectEntities,
   keyframePrompt,
@@ -288,7 +287,6 @@ export const useGenerateShot = (): UseGenerateShotResult => {
         throw new Error(message);
       }
       const renderMode = shotRenderMode(shot);
-      const isDirect = renderMode === "direct";
       let sourceAssetId: string | undefined;
       if (renderMode === "keyframe") {
         if (!shot.keyframe) {
@@ -310,12 +308,14 @@ export const useGenerateShot = (): UseGenerateShotResult => {
         board?.screenplay?.script_id,
         shot
       );
-      const prompt = isDirect || renderMode === "reference"
-        ? directClipPrompt(shot, {
-            scene: sceneForShot(shot, board?.screenplay?.scenes),
-            style: board?.style ?? ""
-          })
-        : clipPrompt(shot);
+      const prompt = clipPromptFor(
+        shot,
+        {
+          scene: sceneForShot(shot, board?.screenplay?.scenes),
+          style: board?.style ?? ""
+        },
+        renderMode
+      );
       const entities = entitiesForShot(shot, boardEntities(board?.entityIds));
       const data: Record<string, unknown> = {
         mode: "video",


### PR DESCRIPTION
## What changed

Three findings from an audit of the last 100 commits, one commit each.

**A reference-mode clip never went stale.** Both render paths compose a reference clip with `directClipPrompt` — it has no still to condition on, so the prompt carries framing, angle, lens, scene lighting and style — while `promptHashFor` in `render-record.ts` branched only on `"direct"` and hashed `clipPrompt`, which carries none of them. Editing the shot's framing or the board's style changed what was sent to the model but not the recorded `prompt_hash`, so `isVersionStale` read the clip as current and both `stale_only` gates (`capabilities/storyboards.ts`, `video-nodes/storyboard.ts`) skipped the re-render. Introduced by #5696, which added `reference_asset_ids` to the record but left the prompt branch two-way. `clipPromptFor` is now the single mode → composition mapping; the record, both render paths and the recast digest call it instead of branching themselves, so a surface cannot render one prompt and hash another again.

**The Personal migration moved threads it documents as untouchable.** `migrateToPersonal` is headed "Claim only loose legacy rows. Explicit project ids are never rewritten", and the job and bulk statements both guard on that — the thread statement did not. Any thread a project still named as its `thread_id` was reassigned regardless of where it already sat, so a thread the user had moved was pulled back by a stale legacy pointer. Two projects naming one thread also left the winner to whichever row the engine reached first. The guard is now one shared predicate across all three statements, and the subquery orders by `created_at`.

**A contradictory comment in `splitClip.ts`.** The `splitAnimations` docblock said a loop's right-half delay is shifted to the next cycle boundary; `rebaseLoopDelayMs`, twelve lines below, does the opposite and says so. Comment corrected to match the code — no behavior change.

## Verification

All 23 checks are green on `ff102a4`, the Quality Gate legs included.

Locally, before the push:

- [x] `npm run test:affected` — every selected suite passes except `@nodetool-ai/image-nodes`, whose 52 failures are all `No WebGPU adapter available (Node/Dawn)` (`vkCreateInstance failed with VK_ERROR_INCOMPATIBLE_DRIVER`). That is the missing-Vulkan-ICD case AGENTS.md names, it reproduces on unmodified `HEAD`, and `image-nodes` is selected only because `protocol`/`timeline` changed — nothing in this diff reaches it. CI, which has the driver, runs it green. Directly: `packages/protocol` 1487 passed, `packages/models` 929 passed, `packages/timeline` 1099 passed, `packages/storyboard` 47 passed, `web` `jest --findRelatedTests src/hooks/storyboard/useGenerateShot.ts` 279 passed across 19 suites.
- [x] `npm run typecheck` — web and electron clean locally; the mobile leg needs `npm --prefix mobile install` in a fresh container. Green in CI.
- [x] `npm run lint` — `oxlint` over the changed package files and `eslint` over the changed web file, both clean. Green in CI.
- [x] `npm run dev:nodetool -- harness gate --base main` — not run locally; the `harness-gate` Quality Gate leg passed on this head.

Note for whoever picks this up: several workspace links (`@nodetool-ai/storyboard`, `game-nodes`, `godot`, `godot-templates`) were missing from `node_modules` in this container, which broke `build:packages` at `game-nodes` with spurious `TS7006` errors. `npm install` restored them. CI was unaffected.

## New checks

Both new tests were inverted and observed failing.

- Relaxing `clipPromptFor` back to `mode === "direct"`:

```
 × hashes a reference-mode clip the way it is rendered
 × reads a reference-mode clip as stale after a style edit
      Tests  2 failed | 18 passed (20)
```

- Dropping the loose-row guard from the thread statement:

```
 × leaves an assigned thread where it is, even when a project names it
      Tests  1 failed | 35 passed (36)
```

Restoring each fix returns both suites to green (20/20 and 36/36). No other test moved in either direction, so each test pins its own fix.

## Agent capabilities

No capability added, and no declared contract changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUGM6L38jTHF6r43VLuX8J

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUGM6L38jTHF6r43VLuX8J)_