### PR TITLE
feat(storyboard): edit a shot underneath its card

### DIFF
--- a/docs/creation-flows/prd.md
+++ b/docs/creation-flows/prd.md
@@ -23,8 +23,8 @@ editor that already exists for that document, with the generated work in place.
 The storyboard flow (E1) is specified in full, modeled on the reference. It
 also reshapes the board and the shot editor: scene-grouped shot cards with a
 hover toolbar and an insert point, a genre chip and Change Style, and a
-full-screen Edit Shot dialog with the still, its versions and one shot-table
-row. The other four flows (E2–E5) are specified to the level their phases
+shot editor that opens underneath the card being edited, with the still, its
+versions and one shot-table row. The other four flows (E2–E5) are specified to the level their phases
 need: steps, plan shape, presets, generate action, landing, data fields and
 reuse.
 
@@ -105,7 +105,7 @@ buttons, Video Count toggle) are not part of any flow. See § 4.3.
 5. Genre, screenplay review, scenes with one ordering contract, prompt
    composition for every camera field, per-version render record and derived
    staleness, twelve shipped style presets and `Change Style`, board card
-   changes, the Edit Shot dialog with draft-then-save, PDF/DOCX/FDX and CSV
+   changes, the inline shot editor with draft-then-save, PDF/DOCX/FDX and CSV
    imports through a server extraction route.
 
 **E2–E5 (§ 8–§ 11), to phase level**
@@ -371,11 +371,12 @@ Batch jobs are server jobs. A board closed mid-batch reattaches on open: the
 generation store reconciles each shot's pending job by id and lands completed
 assets as versions, the same path the queue overlay uses today.
 
-### 7.5 Edit Shot dialog
+### 7.5 Edit Shot panel
 
-Full-screen dialog, `Edit your shot`. Replaces the docked inspector. The
-selection footer from Phase 0 keeps only `Edit`, `Iterate`, `Regenerate`,
-`Delete`.
+`Edit your shot`, opened directly underneath the card being edited as a
+full-width row of the shot grid, so the shot stays on screen while its fields
+are edited. The selection footer from Phase 0 keeps only `Edit`, `Iterate`,
+`Regenerate`, `Delete`; its `Edit` opens the same panel under the shot's card.
 
 - **Left.** Still or clip viewer with pan, flip horizontal, zoom in, zoom out,
   `Open in image editor`. Flip and image-editor edits each add a version, never
@@ -404,7 +405,8 @@ changes?" with `Save` and `Discard`. Version selection, deletion, flip and
 upload are not draft state. They commit immediately, as they do today.
 
 Keyboard: `Esc` closes (with the confirm above when dirty), `←`/`→` step
-versions, `Cmd/Ctrl+S` saves.
+versions, `Cmd/Ctrl+S` saves. `Previous shot` / `Next shot` move the panel under
+the shot they step to, asking about an unsaved draft first.
 
 ### 7.6 Imports
 
@@ -628,7 +630,7 @@ never changes under a user.
 - **D10 — Imported dialogue is deterministic.** FDX dialogue and scene order
   come from the parser. The Director fills camera and motion. A post-check
   restores drift. (Resolves F3.)
-- **D11 — Edit dialog replaces the docked inspector, draft-then-save.** § 7.5.
+- **D11 — The editor opens under the shot's card, draft-then-save.** § 7.5.
   (Resolves F8.)
 - **D12 — Style change never renders.** Stills and clips are marked stale.
   Stills re-render from the banner, clips from `Render clips`. (Resolves Q2.)
@@ -1243,7 +1245,7 @@ Copy follows [BRAND.md § Lexicon](../BRAND.md#5-lexicon): no billing terms, no
 | E1 review notice (FDX) | Restored the dialogue of shots 3 and 7 to your script. |
 | E1 step 3 | Choose your aspect ratio and art style · Set the look with a preset or your own references. You can change it later. · Generate your storyboard |
 | E1 board | Edit · Iterate · Retry N failed · Style changed. N stills and M clips are stale. · Re-render stills |
-| E1 dialog | Edit your shot · Save · Regenerate · Discard changes? · Save · Discard |
+| E1 shot editor | Edit your shot · Save · Regenerate · Discard changes? · Save · Discard |
 | E1 scanned PDF | No text found in this PDF. Paste the script, or upload a DOCX or FDX. |
 | E2 | What's the video? · Choose your format · Plan the beats · Re-plan · Continue to look · Choose your look · Generate your video · cost unknown until the first clip returns |
 | E3 | What's the script about? · Choose your format · Write the script · Rewrite · Continue to voices · Choose the voices · Voice your script |

--- a/docs/creation-flows/tasks.md
+++ b/docs/creation-flows/tasks.md
@@ -203,11 +203,11 @@ of each other. Inside a phase, tasks are listed in dependency order.
       exists. Test: no record, no text (criterion 13). (PRD D14)
 - [ ] **Next-steps strip.** `Extract script`, `Assemble timeline`.
 
-## P4 — Storyboard Edit Shot dialog
+## P4 — Storyboard Edit Shot panel
 
-- [ ] **Dialog shell.** `web/src/components/storyboard/ShotEditDialog.tsx`,
-      full-screen, opened from `Edit`, the dialogue icon and the selection
-      footer. Draft state for the table and header rows; `Save` commits one
+- [ ] **Panel shell.** `web/src/components/storyboard/ShotEditPanel.tsx`,
+      opened from `Edit`, the dialogue icon and the selection footer as a
+      full-width row of the shot grid, directly under the card it edits. Draft state for the table and header rows; `Save` commits one
       store update and one undo entry; `Regenerate` saves then renders;
       dirty close asks. Keyboard: `Esc`, `←`/`→`, `Cmd/Ctrl+S`. Tests:
       criterion 14. (PRD § 7.5, D11)
@@ -229,7 +229,7 @@ of each other. Inside a phase, tasks are listed in dependency order.
 - [ ] **Remove inspector fields.** Shrink the selection footer to `Edit`,
       `Iterate`, `Regenerate`, `Delete`. Delete the field editors from
       `ShotInspector.tsx` only after every field, the cost line, entity chips
-      and the duration toggle exist in the dialog (R2). Update
+      and the duration toggle exist in the panel (R2). Update
       `web/src/components/storyboard/__tests__/`.
 
 ## P5 — Storyboard imports and custom style

--- a/web/src/components/storyboard/ShotCard.tsx
+++ b/web/src/components/storyboard/ShotCard.tsx
@@ -11,8 +11,9 @@
  * footer (Edit, Iterate, Regenerate, Upload). Both swallow their clicks, so
  * reaching for an action never also selects the card.
  *
- * `Edit` and the dialogue icon both open {@link ShotEditDialog}; the icon
- * opens it on the dialogue cell (PRD § 7.5).
+ * `Edit` and the dialogue icon both ask the board to open the shot's editor
+ * directly under this card ({@link ShotEditPanel}); the icon opens it on the
+ * dialogue cell (PRD § 7.5).
  */
 
 import React, { memo, useCallback, useState } from "react";
@@ -47,7 +48,6 @@ import {
   MOTION
 } from "../ui_primitives";
 import ImageRefPreview from "../node/ImageRefPreview";
-import ShotEditDialog from "./ShotEditDialog";
 import ShotHoverToolbar from "./ShotHoverToolbar";
 import ShotMediaViewer from "./ShotMediaViewer";
 import ShotStatusPill, { CLIP_COLOR, isShotGenerating } from "./ShotStatusPill";
@@ -91,6 +91,12 @@ interface ShotCardProps {
   onDragEnd?: () => void;
   /** Fired on the card a drag was released on. */
   onDrop?: (shotId: string) => void;
+  /**
+   * Opens this shot's editor. The board owns it, because it renders it under
+   * this card's row — the card cannot place a panel outside its own cell.
+   * Without it the card shows no edit affordances.
+   */
+  onEdit?: (shotId: string, focus: "fields" | "dialogue") => void;
 }
 
 /** The thumbnail: a fixed 16:9 media area every card in the grid shares. */
@@ -153,7 +159,8 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
   onDragStart,
   onDragEnter,
   onDragEnd,
-  onDrop
+  onDrop,
+  onEdit
 }) => {
   const theme = useTheme();
   const shotRenderContext =
@@ -165,10 +172,6 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [iterateOpen, setIterateOpen] = useState(false);
   const [iterateText, setIterateText] = useState("");
-  // Null while the Edit dialog is closed; `dialogue` opens it on that cell.
-  const [editFocus, setEditFocus] = useState<"fields" | "dialogue" | null>(
-    null
-  );
 
   // Why the last still or clip failed. Kept on the shot's job state until the
   // next attempt registers, so the card can say more than "failed".
@@ -265,9 +268,14 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
     removeShot(boardId, shot.id);
   }, [removeShot, boardId, shot.id]);
 
-  const handleEdit = useCallback(() => setEditFocus("fields"), []);
-  const handleEditDialogue = useCallback(() => setEditFocus("dialogue"), []);
-  const handleCloseEdit = useCallback(() => setEditFocus(null), []);
+  const handleEdit = useCallback(
+    () => onEdit?.(shot.id, "fields"),
+    [onEdit, shot.id]
+  );
+  const handleEditDialogue = useCallback(
+    () => onEdit?.(shot.id, "dialogue"),
+    [onEdit, shot.id]
+  );
 
   const handleRegenerate = useCallback(() => {
     void generateKeyframe(boardId, shot).catch(() => undefined);
@@ -503,9 +511,11 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
             borderRadius: BORDER_RADIUS.sm
           }}
         >
-          <EditorButton size="small" onClick={handleEdit} sx={footerButtonSx}>
-            Edit
-          </EditorButton>
+          {onEdit && (
+            <EditorButton size="small" onClick={handleEdit} sx={footerButtonSx}>
+              Edit
+            </EditorButton>
+          )}
           <EditorButton
             size="small"
             onClick={handleOpenIterate}
@@ -533,20 +543,22 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
             multiple={false}
           />
           <Box sx={{ flex: 1 }} />
-          <ToolbarIconButton
-            icon={
-              hasDialogue ? (
-                <ChatBubbleIcon sx={{ fontSize: "1em" }} />
-              ) : (
-                <ChatBubbleOutlineIcon sx={{ fontSize: "1em" }} />
-              )
-            }
-            tooltip={hasDialogue ? "Edit the dialogue" : "Add dialogue"}
-            ariaLabel={hasDialogue ? "Edit dialogue" : "Add dialogue"}
-            data-testid="shot-dialogue-icon"
-            data-filled={hasDialogue ? "true" : undefined}
-            onClick={handleEditDialogue}
-          />
+          {onEdit && (
+            <ToolbarIconButton
+              icon={
+                hasDialogue ? (
+                  <ChatBubbleIcon sx={{ fontSize: "1em" }} />
+                ) : (
+                  <ChatBubbleOutlineIcon sx={{ fontSize: "1em" }} />
+                )
+              }
+              tooltip={hasDialogue ? "Edit the dialogue" : "Add dialogue"}
+              ariaLabel={hasDialogue ? "Edit dialogue" : "Add dialogue"}
+              data-testid="shot-dialogue-icon"
+              data-filled={hasDialogue ? "true" : undefined}
+              onClick={handleEditDialogue}
+            />
+          )}
         </FlexRow>
       )}
 
@@ -555,19 +567,6 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
         media={viewerMedia}
         onClose={handleCloseViewer}
       />
-
-      {/* The dialog is its own surface: its clicks must not reach the card's
-          selection handler through the React tree. */}
-      <Box onClick={swallowClick}>
-        <ShotEditDialog
-          boardId={boardId}
-          shotId={shot.id}
-          open={editFocus !== null}
-          onClose={handleCloseEdit}
-          focusDialogue={editFocus === "dialogue"}
-          readOnly={readOnly}
-        />
-      </Box>
 
       {/* Both dialogs sit inside the card, so their clicks would bubble into
           its selection handler through the React tree. */}

--- a/web/src/components/storyboard/ShotEditPanel.tsx
+++ b/web/src/components/storyboard/ShotEditPanel.tsx
@@ -1,10 +1,11 @@
 /**
- * ShotEditDialog
+ * ShotEditPanel
  *
- * `Edit your shot` — the full-screen editor that replaces the docked inspector
- * (PRD § 7.5, D11). The viewer and the takes gallery sit side by side, the
- * § 7.7.2 table row and the scene header row sit under them, and the linked
- * script's lines sit under that.
+ * `Edit your shot` — the editor the board opens **directly underneath the card
+ * being edited**, spanning the grid's full width, rather than over the board in
+ * a dialog: the shot stays on screen while its fields are edited. The viewer and
+ * the takes gallery sit side by side, the § 7.7.2 table row and the scene header
+ * row sit under them, and the linked script's lines sit under that.
  *
  * The two rows are a **draft**. Nothing typed here reaches the board until
  * `Save`, which writes the whole shot in one `updateShot` — one store update,
@@ -39,6 +40,7 @@ import {
   Box,
   Caption,
   Chip,
+  CloseButton,
   Dialog,
   Divider,
   EditorButton,
@@ -47,6 +49,7 @@ import {
   FlexColumn,
   FlexRow,
   Label,
+  Panel,
   ScrollArea,
   SelectField,
   Text,
@@ -82,12 +85,17 @@ import { getEntityChipSx, getEntityKindDotSx } from "../entities/entityKind";
 import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
 import { requestDocumentFocus } from "../../stores/DocumentFocusStore";
 
-interface ShotEditDialogProps {
+interface ShotEditPanelProps {
   boardId: string;
-  /** The shot the dialog opens on; `←`/`→` step from here. */
+  /** The shot the panel edits — the card it sits under. */
   shotId: string;
-  open: boolean;
   onClose: () => void;
+  /**
+   * Asks the board to move the panel under another shot. The panel cannot move
+   * itself: where it sits is the board's grid placement, not its own state.
+   * Without it, `Previous shot`/`Next shot` are not offered.
+   */
+  onShotChange?: (shotId: string) => void;
   /** Opens with the dialogue cell focused, for the card's dialogue icon. */
   focusDialogue?: boolean;
   readOnly?: boolean;
@@ -126,17 +134,16 @@ const shotNumberSx = {
   flexShrink: 0
 } as const;
 
-const ShotEditDialogInner: React.FC<ShotEditDialogProps> = ({
+const ShotEditPanelInner: React.FC<ShotEditPanelProps> = ({
   boardId,
   shotId,
-  open,
   onClose,
+  onShotChange,
   focusDialogue,
   readOnly,
   onOpenBoardSettings
 }) => {
-  const [currentId, setCurrentId] = useState(shotId);
-  // What the dialog is waiting on an answer for: a close, or a step to another
+  // What the panel is waiting on an answer for: a close, or a step to another
   // shot. Null while there is nothing pending.
   const [pending, setPending] = useState<{ shotId?: string } | null>(null);
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
@@ -167,33 +174,27 @@ const ShotEditDialogInner: React.FC<ShotEditDialogProps> = ({
   const { generateKeyframe, generateClip } = useGenerateShot();
   const { data: allEntities } = useEntities();
 
-  const shot = shots.find((s) => s.id === currentId);
+  const shot = shots.find((s) => s.id === shotId);
   const scene = useMemo(
     () => scenes.find((s) => s.id === shot?.scene_id) ?? null,
     [scenes, shot?.scene_id]
   );
 
-  // The draft, reset whenever the dialog opens on a different shot. Keyed on
-  // the shot id rather than the object so a store write behind the dialog (a
+  // The draft, reset whenever the panel moves to a different shot. Keyed on
+  // the shot id rather than the object so a store write behind the panel (a
   // landed render) does not wipe what is being typed.
   const [draft, setDraft] = useState<ShotDraft | null>(null);
   const [original, setOriginal] = useState<ShotDraft | null>(null);
   const draftedFor = useRef<string | null>(null);
   useEffect(() => {
-    if (!open || !shot || draftedFor.current === shot.id) {
+    if (!shot || draftedFor.current === shot.id) {
       return;
     }
     const next = draftFromShot(shot, scene);
     draftedFor.current = shot.id;
     setDraft(next);
     setOriginal(next);
-  }, [open, shot, scene]);
-  useEffect(() => {
-    if (!open) {
-      draftedFor.current = null;
-      setCurrentId(shotId);
-    }
-  }, [open, shotId]);
+  }, [shot, scene]);
 
   const dirty = !!draft && !!original && isDraftDirty(draft, original);
 
@@ -218,7 +219,7 @@ const ShotEditDialogInner: React.FC<ShotEditDialogProps> = ({
     () => sceneOrder(shots, scenes).flatMap((group) => group.shots),
     [shots, scenes]
   );
-  const position = ordered.findIndex((s) => s.id === currentId);
+  const position = ordered.findIndex((s) => s.id === shotId);
   const numbering = shot
     ? displayNumber(shot, shots)
     : { scene: 0, shot: 0 };
@@ -328,12 +329,12 @@ const ShotEditDialogInner: React.FC<ShotEditDialogProps> = ({
       }
       if (target.shotId) {
         draftedFor.current = null;
-        setCurrentId(target.shotId);
+        onShotChange?.(target.shotId);
       } else {
         onClose();
       }
     },
-    [dirty, onClose]
+    [dirty, onClose, onShotChange]
   );
 
   const runPending = useCallback(
@@ -348,12 +349,12 @@ const ShotEditDialogInner: React.FC<ShotEditDialogProps> = ({
       }
       if (target.shotId) {
         draftedFor.current = null;
-        setCurrentId(target.shotId);
+        onShotChange?.(target.shotId);
       } else {
         onClose();
       }
     },
-    [pending, commit, onClose]
+    [pending, commit, onClose, onShotChange]
   );
 
   const handleClose = useCallback(() => leave({}), [leave]);
@@ -368,22 +369,26 @@ const ShotEditDialogInner: React.FC<ShotEditDialogProps> = ({
     [ordered, position, leave]
   );
 
-  // `Cmd/Ctrl+S` saves. `←`/`→` step versions and are handled by the viewer,
-  // which owns the still/clip toggle and the pager index (PRD § 7.5).
+  // `Cmd/Ctrl+S` saves, `Esc` closes — the panel is not a dialog, so it listens
+  // for both itself. `←`/`→` step versions and are handled by the viewer, which
+  // owns the still/clip toggle and the pager index (PRD § 7.5).
   useEffect(() => {
-    if (!open) {
-      return;
-    }
     const onKeyDown = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
         event.preventDefault();
         handleSave();
         return;
       }
+      // While the discard question is up it owns Escape: answering it is what
+      // closes the panel.
+      if (event.key === "Escape" && pending === null) {
+        event.preventDefault();
+        handleClose();
+      }
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [open, handleSave]);
+  }, [handleSave, handleClose, pending]);
 
   const handleEditInScript = useCallback(() => {
     if (!scriptId || !shot) {
@@ -408,65 +413,49 @@ const ShotEditDialogInner: React.FC<ShotEditDialogProps> = ({
     leave({});
   }, [scriptId, shot, scriptLines, openTab, leave]);
 
-  if (!open || !shot || !draft) {
+  if (!shot || !draft) {
     return null;
   }
 
-  const canStepBack = position > 0;
-  const canStepForward = position >= 0 && position < ordered.length - 1;
+  const canStep = !!onShotChange;
+  const canStepBack = canStep && position > 0;
+  const canStepForward =
+    canStep && position >= 0 && position < ordered.length - 1;
 
   return (
-    <Dialog
-      open={open}
-      onClose={handleClose}
-      fullScreen
-      title="Edit your shot"
-      className="shot-edit-dialog"
-      actions={
-        <FlexRow align="center" gap={SPACING.sm} fullWidth wrap>
-          <ShotCostLine estimate={costEstimate} />
-          <Box sx={{ flex: 1 }} />
-          {!readOnly && (
-            <>
-              <ToolbarIconButton
-                icon={<MoreHorizIcon sx={{ fontSize: "1em" }} />}
-                tooltip="More actions"
-                ariaLabel="More shot actions"
-                onClick={(event) => setMenuAnchor(event.currentTarget)}
-              />
-              <EditorButton onClick={handleRegenerate}>Regenerate</EditorButton>
-              <EditorButton
-                variant="contained"
-                color="primary"
-                onClick={handleSave}
-                disabled={!dirty}
-              >
-                Save
-              </EditorButton>
-            </>
-          )}
-        </FlexRow>
-      }
+    <Panel
+      padding={SPACING.xl}
+      className="shot-edit-panel"
+      data-testid="shot-edit-panel"
+      data-shot-id={shot.id}
+      sx={{ minWidth: 0 }}
     >
       <FlexColumn gap={SPACING.xl} sx={{ minWidth: 0 }}>
         <FlexRow align="center" gap={SPACING.md} wrap>
+          <Text size="big">Edit your shot</Text>
           <Box sx={shotNumberSx}>
             {`SH ${String(shot.index + 1).padStart(2, "0")}`}
           </Box>
-          <EditorButton
-            onClick={() => stepShot(-1)}
-            disabled={!canStepBack}
-            title="Previous shot (←)"
-          >
-            Previous shot
-          </EditorButton>
-          <EditorButton
-            onClick={() => stepShot(1)}
-            disabled={!canStepForward}
-            title="Next shot (→)"
-          >
-            Next shot
-          </EditorButton>
+          {canStep && (
+            <>
+              <EditorButton
+                onClick={() => stepShot(-1)}
+                disabled={!canStepBack}
+                title="Previous shot"
+              >
+                Previous shot
+              </EditorButton>
+              <EditorButton
+                onClick={() => stepShot(1)}
+                disabled={!canStepForward}
+                title="Next shot"
+              >
+                Next shot
+              </EditorButton>
+            </>
+          )}
+          <Box sx={{ flex: 1 }} />
+          <CloseButton onClick={handleClose} />
         </FlexRow>
 
         <Box sx={columnsSx}>
@@ -608,6 +597,32 @@ const ShotEditDialogInner: React.FC<ShotEditDialogProps> = ({
         )}
 
         <ShotScriptPanel boardId={boardId} shot={shot} readOnly={readOnly} />
+
+        <Divider />
+
+        <FlexRow align="center" gap={SPACING.sm} wrap>
+          <ShotCostLine estimate={costEstimate} />
+          <Box sx={{ flex: 1 }} />
+          {!readOnly && (
+            <>
+              <ToolbarIconButton
+                icon={<MoreHorizIcon sx={{ fontSize: "1em" }} />}
+                tooltip="More actions"
+                ariaLabel="More shot actions"
+                onClick={(event) => setMenuAnchor(event.currentTarget)}
+              />
+              <EditorButton onClick={handleRegenerate}>Regenerate</EditorButton>
+              <EditorButton
+                variant="contained"
+                color="primary"
+                onClick={handleSave}
+                disabled={!dirty}
+              >
+                Save
+              </EditorButton>
+            </>
+          )}
+        </FlexRow>
       </FlexColumn>
 
       <EditorMenu
@@ -653,11 +668,11 @@ const ShotEditDialogInner: React.FC<ShotEditDialogProps> = ({
           Version choices, deletions, flips and uploads are already saved.
         </Caption>
       </Dialog>
-    </Dialog>
+    </Panel>
   );
 };
 
-export const ShotEditDialog = memo(ShotEditDialogInner);
-ShotEditDialog.displayName = "ShotEditDialog";
+export const ShotEditPanel = memo(ShotEditPanelInner);
+ShotEditPanel.displayName = "ShotEditPanel";
 
-export default ShotEditDialog;
+export default ShotEditPanel;

--- a/web/src/components/storyboard/ShotInspector.tsx
+++ b/web/src/components/storyboard/ShotInspector.tsx
@@ -6,9 +6,10 @@
  * the four actions PRD § 7.5 leaves here — `Edit`, `Iterate`, `Regenerate`,
  * `Delete`.
  *
- * Every field this used to edit now lives in {@link ShotEditDialog}, which
- * `Edit` opens. The cross-document chips stay because nothing else on the
- * board says where a shot landed in the script and in the cut.
+ * Every field this used to edit now lives in {@link ShotEditPanel}, which the
+ * board opens under the shot's card when `Edit` is taken here. The
+ * cross-document chips stay because nothing else on the board says where a shot
+ * landed in the script and in the cut.
  */
 
 import React, { memo, useCallback, useMemo, useState } from "react";
@@ -23,7 +24,6 @@ import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
 import { useBoardScriptLines } from "../../hooks/storyboard/useShotDuration";
 import { useShotTimelineLink } from "../../hooks/storyboard/useShotTimelineLink";
 import ShotActionText from "./ShotActionText";
-import ShotEditDialog from "./ShotEditDialog";
 import { isShotGenerating } from "./ShotStatusPill";
 import {
   Box,
@@ -52,6 +52,12 @@ interface ShotInspectorProps {
   readOnly?: boolean;
   /** Clears the board's selection. */
   onClose?: () => void;
+  /**
+   * Opens the shot's editor. The board renders it under the shot's card, so the
+   * footer asks rather than opening a surface of its own. Without it `Edit` is
+   * not offered.
+   */
+  onEdit?: (shotId: string) => void;
 }
 
 /** Sky — the app's colour for anything script- or voice-shaped. */
@@ -84,7 +90,8 @@ const ShotInspectorInner: React.FC<ShotInspectorProps> = ({
   boardId,
   shot,
   readOnly,
-  onClose
+  onClose,
+  onEdit
 }) => {
   const removeShot = useStoryboardStore((state) => state.removeShot);
   const boardEntityIds = useStoryboardStore(
@@ -97,7 +104,6 @@ const ShotInspectorInner: React.FC<ShotInspectorProps> = ({
   const { generateKeyframe, generateRevisedClip } = useGenerateShot();
   const { data: allEntities } = useEntities();
 
-  const [editOpen, setEditOpen] = useState(false);
   const [iterateOpen, setIterateOpen] = useState(false);
   const [iterateText, setIterateText] = useState("");
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -218,14 +224,16 @@ const ShotInspectorInner: React.FC<ShotInspectorProps> = ({
         )}
         {!readOnly && (
           <>
-            <EditorButton
-              variant="contained"
-              color="primary"
-              onClick={() => setEditOpen(true)}
-              title="Open this shot's fields, takes and script lines"
-            >
-              Edit
-            </EditorButton>
+            {onEdit && (
+              <EditorButton
+                variant="contained"
+                color="primary"
+                onClick={() => onEdit(shot.id)}
+                title="Open this shot's fields, takes and script lines under its card"
+              >
+                Edit
+              </EditorButton>
+            )}
             <EditorButton
               onClick={() => setIterateOpen(true)}
               disabled={isGenerating || !shot.clip}
@@ -260,14 +268,6 @@ const ShotInspectorInner: React.FC<ShotInspectorProps> = ({
           <CloseButton onClick={onClose} tooltip="Clear shot selection" />
         )}
       </FlexRow>
-
-      <ShotEditDialog
-        boardId={boardId}
-        shotId={shot.id}
-        open={editOpen}
-        onClose={() => setEditOpen(false)}
-        readOnly={readOnly}
-      />
 
       <Dialog
         open={iterateOpen}

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -17,6 +17,10 @@
  *
  * Selecting a card opens the selection footer under the grid and scrolls it
  * into view; the arrow keys walk the selection along the grid.
+ *
+ * `Edit` on a card opens {@link ShotEditPanel} as a full-width row of the grid
+ * placed immediately after that card, so the editor sits directly underneath
+ * the shot it edits rather than over the board.
  */
 
 import React, {
@@ -100,6 +104,7 @@ import BoardStyleDialog from "./BoardStyleDialog";
 import SceneHeader from "./SceneHeader";
 import ScriptLinkControl from "./ScriptLinkControl";
 import ShotCard from "./ShotCard";
+import ShotEditPanel from "./ShotEditPanel";
 import ShotInsertPoint, { SHOT_INSERT_POINT_CLASS } from "./ShotInsertPoint";
 import ShotInspector from "./ShotInspector";
 import StoryboardEntitiesField from "./StoryboardEntitiesField";
@@ -167,6 +172,16 @@ const shotGridSx = {
   "@media (max-width: 600px)": {
     gridTemplateColumns: "minmax(0, 1fr)"
   }
+} as const;
+
+/**
+ * The editor's row: the full width of the grid, directly under the card whose
+ * shot it edits. The panel inside it spans the row the same way, so a narrow
+ * viewport that drops the grid to one column needs no second rule.
+ */
+const editRowSx = {
+  gridColumn: "1 / -1",
+  minWidth: 0
 } as const;
 
 /**
@@ -335,6 +350,31 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   const openStyle = useCallback(() => setStyleOpen(true), []);
   const closeStyle = useCallback(() => setStyleOpen(false), []);
 
+  // Which shot's editor is open, and which cell it opened on. The board holds
+  // this rather than the card, because the panel is a row of this grid: a card
+  // cannot place a surface outside its own cell.
+  const [editing, setEditing] = useState<{
+    shotId: string;
+    focus: "fields" | "dialogue";
+  } | null>(null);
+  const handleEditShot = useCallback(
+    (shotId: string, focus: "fields" | "dialogue" = "fields") => {
+      setEditing({ shotId, focus });
+    },
+    []
+  );
+  const handleEditShotFields = useCallback(
+    (shotId: string) => handleEditShot(shotId, "fields"),
+    [handleEditShot]
+  );
+  const closeEditing = useCallback(() => setEditing(null), []);
+  // Stepping from the panel moves it under the shot it steps to; the focus goes
+  // back to the fields, since the dialogue cell was this shot's request.
+  const handleEditingShotChange = useCallback(
+    (shotId: string) => setEditing({ shotId, focus: "fields" }),
+    []
+  );
+
   // The one grouping pass the render needs: the headers, the cards under each,
   // the captions, and the scene a drop resolves against all read it.
   const scenes = screenplay?.scenes;
@@ -351,6 +391,7 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
     []
   );
   const closeSettings = useCallback(() => setSettingsOpen(false), []);
+  const openSettings = useCallback(() => setSettingsOpen(true), []);
   const settingsPanelId = `storyboard-board-settings-${boardId}`;
 
   // The inspector docks under the grid, so on a board of more than a row or
@@ -359,6 +400,7 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   // not, because that already centres the card.
   const gridRef = useRef<HTMLDivElement>(null);
   const inspectorRef = useRef<HTMLDivElement>(null);
+  const editPanelRef = useRef<HTMLDivElement>(null);
   const revealInspector = useRef(false);
   useEffect(() => {
     if (!revealInspector.current) {
@@ -371,6 +413,19 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
       behavior: "smooth"
     });
   }, [activeShotId]);
+
+  // The editor opens under the card, which on a tall card is partly below the
+  // fold; bring it into view on open and whenever it moves to another shot.
+  useEffect(() => {
+    if (!editing) {
+      return;
+    }
+    // `scrollIntoView` is absent under jsdom, so the call is guarded.
+    editPanelRef.current?.scrollIntoView?.({
+      block: "nearest",
+      behavior: "smooth"
+    });
+  }, [editing]);
 
   // Clicking the selected card deselects it (the card's aria-pressed
   // contract); the store's selectShot stays idempotent for programmatic
@@ -399,7 +454,10 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
       const target = event.target as HTMLElement;
       if (
         !gridRef.current?.contains(target) ||
-        target.closest("input, textarea, [contenteditable=true]")
+        target.closest("input, textarea, [contenteditable=true]") ||
+        // The editor is a row of this grid, so its keys arrive here too. It owns
+        // them: Escape closes it, and nothing in it should move the selection.
+        target.closest(".shot-edit-panel")
       ) {
         return;
       }
@@ -960,30 +1018,48 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
                   slugline={group.scene?.slugline || undefined}
                 />
                 {group.shots.map((shot) => (
-                  <Box key={shot.id} sx={shotSlotSx}>
-                    <ShotCard
-                      boardId={boardId}
-                      shot={shot}
-                      caption={captions.get(shot.id)}
-                      renderContext={renderContext}
-                      selected={shot.id === activeShotId}
-                      onSelect={handleSelectShot}
-                      readOnly={readOnly}
-                      draggable={!readOnly && !directing}
-                      dropTarget={shot.id === dropTargetId}
-                      onDragStart={handleDragStart}
-                      onDragEnter={handleDragEnter}
-                      onDragEnd={handleDragEnd}
-                      onDrop={handleDrop}
-                    />
-                    {!readOnly && !directing && (
-                      <ShotInsertPoint
-                        afterShotId={shot.id}
-                        label={`after ${captions.get(shot.id) ?? ""}`}
-                        onInsert={handleInsertShot}
+                  <React.Fragment key={shot.id}>
+                    <Box sx={shotSlotSx}>
+                      <ShotCard
+                        boardId={boardId}
+                        shot={shot}
+                        caption={captions.get(shot.id)}
+                        renderContext={renderContext}
+                        selected={shot.id === activeShotId}
+                        onSelect={handleSelectShot}
+                        readOnly={readOnly}
+                        draggable={!readOnly && !directing}
+                        dropTarget={shot.id === dropTargetId}
+                        onDragStart={handleDragStart}
+                        onDragEnter={handleDragEnter}
+                        onDragEnd={handleDragEnd}
+                        onDrop={handleDrop}
+                        onEdit={readOnly ? undefined : handleEditShot}
                       />
+                      {!readOnly && !directing && (
+                        <ShotInsertPoint
+                          afterShotId={shot.id}
+                          label={`after ${captions.get(shot.id) ?? ""}`}
+                          onInsert={handleInsertShot}
+                        />
+                      )}
+                    </Box>
+                    {/* Directly under the card: a full-width row of this same
+                        grid, so the shot stays on screen while it is edited. */}
+                    {editing?.shotId === shot.id && (
+                      <Box ref={editPanelRef} sx={editRowSx}>
+                        <ShotEditPanel
+                          boardId={boardId}
+                          shotId={shot.id}
+                          focusDialogue={editing.focus === "dialogue"}
+                          readOnly={readOnly}
+                          onClose={closeEditing}
+                          onShotChange={handleEditingShotChange}
+                          onOpenBoardSettings={openSettings}
+                        />
+                      </Box>
                     )}
-                  </Box>
+                  </React.Fragment>
                 ))}
               </React.Fragment>
             ))}
@@ -1021,6 +1097,7 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
               shot={activeShot}
               readOnly={readOnly}
               onClose={clearSelection}
+              onEdit={readOnly ? undefined : handleEditShotFields}
             />
           </Box>
         )}

--- a/web/src/components/storyboard/__tests__/ShotCardActions.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotCardActions.test.tsx
@@ -45,24 +45,6 @@ jest.mock("../../../serverState/useAssetUpload", () => ({
     selector({ uploadAsset: mockUploadAsset })
 }));
 
-// The dialog has its own suite; here only which surface the card opens matters.
-jest.mock("../ShotEditDialog", () => ({
-  __esModule: true,
-  default: ({
-    open,
-    focusDialogue
-  }: {
-    open: boolean;
-    focusDialogue?: boolean;
-  }) =>
-    open ? (
-      <div
-        data-testid="shot-edit-dialog"
-        data-focus-dialogue={focusDialogue ? "true" : undefined}
-      />
-    ) : null
-}));
-
 jest.mock("../../../hooks/storyboard/useGenerateShot", () => ({
   useGenerateShot: () => ({
     generateKeyframe: jest.fn(async () => undefined),
@@ -110,11 +92,14 @@ const renderCard = (
 ) =>
   render(
     <ThemeProvider theme={mockTheme}>
-      <ShotCard boardId={BOARD} shot={shot} {...props} />
+      <ShotCard boardId={BOARD} shot={shot} onEdit={onEdit} {...props} />
     </ThemeProvider>
   );
 
+const onEdit = jest.fn();
+
 beforeEach(() => {
+  onEdit.mockClear();
   mockUploadAsset.mockReset();
 });
 
@@ -235,27 +220,32 @@ describe("ShotCard edit affordances", () => {
     );
   });
 
-  it("opens the Edit dialog on the dialogue cell, without selecting the card", async () => {
+  // The editor opens under the card, which is the board's grid, so both
+  // affordances ask the board and name the cell to open on.
+  it("asks for the dialogue cell from the dialogue icon, without selecting the card", async () => {
     const onSelect = jest.fn();
     renderCard(seedShot({ dialogue: "Keep it lit." }), { onSelect });
 
     await userEvent.click(screen.getByTestId("shot-dialogue-icon"));
-    expect(screen.getByTestId("shot-edit-dialog")).toHaveAttribute(
-      "data-focus-dialogue",
-      "true"
-    );
+    expect(onEdit).toHaveBeenCalledWith("shot-1", "dialogue");
     expect(onSelect).not.toHaveBeenCalled();
   });
 
-  it("opens the Edit dialog on the fields from Edit", async () => {
+  it("asks for the fields from Edit, without selecting the card", async () => {
     const onSelect = jest.fn();
     renderCard(seedShot(), { onSelect });
 
     await userEvent.click(screen.getByRole("button", { name: "Edit" }));
-    expect(screen.getByTestId("shot-edit-dialog")).not.toHaveAttribute(
-      "data-focus-dialogue"
-    );
+    expect(onEdit).toHaveBeenCalledWith("shot-1", "fields");
     expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("hides both when the board offers no editor", () => {
+    renderCard(seedShot({ dialogue: "Keep it lit." }), { onEdit: undefined });
+    expect(
+      screen.queryByRole("button", { name: "Edit" })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("shot-dialogue-icon")).not.toBeInTheDocument();
   });
 
   it("keeps the scene and shot caption as the card title", () => {

--- a/web/src/components/storyboard/__tests__/ShotEditPanel.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotEditPanel.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Criterion 14, against the real storyboard store: the dialog edits every
+ * Criterion 14, against the real storyboard store: the panel edits every
  * field in § 7.7.2, `Save` is one undo step, closing dirty asks, `Regenerate`
  * renders from the saved values, dialogue is read-only on a linked board, and
  * the ERT chip toggles `duration_source`.
@@ -93,7 +93,7 @@ jest.mock("../ShotEditViewer", () => stub("shot-edit-viewer"));
 jest.mock("../ShotTakesGallery", () => stub("takes-gallery"));
 jest.mock("../ShotScriptPanel", () => stub("script-panel"));
 
-import ShotEditDialog from "../ShotEditDialog";
+import ShotEditPanel from "../ShotEditPanel";
 import { useStoryboardStore } from "../../../stores/storyboard/StoryboardStore";
 
 const BOARD = "board-edit";
@@ -158,17 +158,18 @@ const storedShot = (id = "shot-1"): Shot => {
 };
 
 const onClose = jest.fn();
+const onShotChange = jest.fn();
 
-const renderDialog = (
-  props: Partial<React.ComponentProps<typeof ShotEditDialog>> = {}
+const renderPanel = (
+  props: Partial<React.ComponentProps<typeof ShotEditPanel>> = {}
 ) =>
   render(
     <ThemeProvider theme={mockTheme}>
-      <ShotEditDialog
+      <ShotEditPanel
         boardId={BOARD}
         shotId="shot-1"
-        open
         onClose={onClose}
+        onShotChange={onShotChange}
         {...props}
       />
     </ThemeProvider>
@@ -192,6 +193,7 @@ const typeInto = async (label: string, text: string) => {
 
 beforeEach(() => {
   onClose.mockClear();
+  onShotChange.mockClear();
   generateKeyframeMock.mockClear();
   generateClipMock.mockClear();
   lineIsVoiced = true;
@@ -201,10 +203,10 @@ afterEach(() => {
   useStoryboardStore.getState().removeBoard(BOARD);
 });
 
-describe("ShotEditDialog fields (criterion 14)", () => {
+describe("ShotEditPanel fields (criterion 14)", () => {
   it("shows the derived numbering and the board's aspect ratio read-only", () => {
     seed([baseShot(), baseShot({ id: "shot-2", index: 1, scene_id: "sc2" })]);
-    renderDialog();
+    renderPanel();
 
     // Scene 1, Shot 1 — both derived from `shot.index`, neither editable.
     expect(screen.getByTestId("cell-scene")).toHaveTextContent("1");
@@ -217,7 +219,7 @@ describe("ShotEditDialog fields (criterion 14)", () => {
   it("links to the board's settings form when the caller can open one", () => {
     seed([baseShot()]);
     const onOpenBoardSettings = jest.fn();
-    renderDialog({ onOpenBoardSettings });
+    renderPanel({ onOpenBoardSettings });
     expect(
       screen.getByRole("button", { name: "Board settings" })
     ).toBeEnabled();
@@ -225,14 +227,14 @@ describe("ShotEditDialog fields (criterion 14)", () => {
 
   it("numbers a shot by its scene, not by its position on the board", () => {
     seed([baseShot(), baseShot({ id: "shot-2", index: 1, scene_id: "sc2" })]);
-    renderDialog({ shotId: "shot-2" });
+    renderPanel({ shotId: "shot-2" });
     expect(screen.getByTestId("cell-scene")).toHaveTextContent("2");
     expect(screen.getByTestId("cell-shot")).toHaveTextContent("1");
   });
 
   it("edits every § 7.7.2 field and saves them in one write", async () => {
     seed([baseShot()]);
-    renderDialog();
+    renderPanel();
 
     await typeInto("Description", "A lighthouse at dawn");
     await typeInto("Dialogue", "We are open.");
@@ -269,7 +271,7 @@ describe("ShotEditDialog fields (criterion 14)", () => {
 
   it("puts every edited field back with a single undo", async () => {
     seed([baseShot()]);
-    renderDialog();
+    renderPanel();
 
     await typeInto("Description", "A lighthouse at dawn");
     await choose("Size", "wide");
@@ -286,7 +288,7 @@ describe("ShotEditDialog fields (criterion 14)", () => {
 
   it("moves the shot to the chosen scene and writes that scene's lighting", async () => {
     seed([baseShot(), baseShot({ id: "shot-2", index: 1, scene_id: "sc2" })]);
-    renderDialog();
+    renderPanel();
 
     await choose("Slugline", "INT. LAMP ROOM — NIGHT");
     await typeInto("Scene lighting", "sodium wash");
@@ -299,7 +301,7 @@ describe("ShotEditDialog fields (criterion 14)", () => {
   });
 });
 
-describe("ShotEditDialog overflow actions", () => {
+describe("ShotEditPanel overflow actions", () => {
   const openOverflow = async () => {
     await userEvent.click(
       screen.getByRole("button", { name: "More shot actions" })
@@ -311,7 +313,7 @@ describe("ShotEditDialog overflow actions", () => {
       baseShot(),
       baseShot({ id: "shot-2", index: 1, slug: "Second", action: "The lamp" })
     ]);
-    renderDialog({ shotId: "shot-2" });
+    renderPanel({ shotId: "shot-2" });
 
     await openOverflow();
     await userEvent.click(
@@ -329,7 +331,7 @@ describe("ShotEditDialog overflow actions", () => {
         keyframe: { type: "image", uri: "asset://still-1", asset_id: "still-1" }
       })
     ]);
-    renderDialog();
+    renderPanel();
 
     await typeInto("Description", "A lighthouse at dawn");
     await openOverflow();
@@ -345,10 +347,10 @@ describe("ShotEditDialog overflow actions", () => {
   });
 });
 
-describe("ShotEditDialog save semantics", () => {
+describe("ShotEditPanel save semantics", () => {
   it("asks before closing with unsaved edits, and discards on Discard", async () => {
     seed([baseShot()]);
-    renderDialog();
+    renderPanel();
 
     await typeInto("Description", "A lighthouse at dawn");
     await userEvent.click(screen.getByRole("button", { name: "Close" }));
@@ -368,7 +370,7 @@ describe("ShotEditDialog save semantics", () => {
 
   it("saves and closes when the confirm's Save is taken", async () => {
     seed([baseShot()]);
-    renderDialog();
+    renderPanel();
 
     await typeInto("Description", "A lighthouse at dawn");
     await userEvent.click(screen.getByRole("button", { name: "Close" }));
@@ -386,7 +388,7 @@ describe("ShotEditDialog save semantics", () => {
 
   it("closes without asking when nothing was edited", async () => {
     seed([baseShot()]);
-    renderDialog();
+    renderPanel();
     await userEvent.click(screen.getByRole("button", { name: "Close" }));
     expect(onClose).toHaveBeenCalled();
     expect(screen.queryByText("Discard changes?")).not.toBeInTheDocument();
@@ -394,7 +396,7 @@ describe("ShotEditDialog save semantics", () => {
 
   it("renders from the saved values, not the ones on screen before Save", async () => {
     seed([baseShot()]);
-    renderDialog();
+    renderPanel();
 
     await typeInto("Description", "A lighthouse at dawn");
     await userEvent.click(screen.getByRole("button", { name: "Regenerate" }));
@@ -407,10 +409,10 @@ describe("ShotEditDialog save semantics", () => {
   });
 });
 
-describe("ShotEditDialog keyboard", () => {
+describe("ShotEditPanel keyboard", () => {
   it("saves on Cmd/Ctrl+S", async () => {
     seed([baseShot()]);
-    renderDialog();
+    renderPanel();
 
     await typeInto("Description", "A lighthouse at dawn");
     await userEvent.keyboard("{Control>}s{/Control}");
@@ -431,7 +433,7 @@ describe("ShotEditDialog keyboard", () => {
         action: "The lamp turns"
       })
     ]);
-    renderDialog();
+    renderPanel();
 
     expect(screen.getByLabelText("Description")).toHaveValue(
       "A lighthouse at dusk"
@@ -450,7 +452,7 @@ describe("ShotEditDialog keyboard", () => {
 
   it("closes on Esc, asking when dirty", async () => {
     seed([baseShot()]);
-    renderDialog();
+    renderPanel();
 
     await userEvent.keyboard("{Escape}");
     expect(onClose).toHaveBeenCalled();
@@ -463,7 +465,7 @@ describe("ShotEditDialog keyboard", () => {
   });
 });
 
-describe("ShotEditDialog on a linked board (PRD D9)", () => {
+describe("ShotEditPanel on a linked board (PRD D9)", () => {
   const linked = () =>
     seed(
       [baseShot({ script_line_ids: ["line-1"], dialogue: "We are closed." })],
@@ -472,7 +474,7 @@ describe("ShotEditDialog on a linked board (PRD D9)", () => {
 
   it("shows the dialogue read-only with a way into the script", () => {
     linked();
-    renderDialog();
+    renderPanel();
 
     expect(screen.queryByLabelText("Dialogue")).not.toBeInTheDocument();
     expect(screen.getByTestId("shot-dialogue-readonly")).toHaveTextContent(
@@ -485,7 +487,7 @@ describe("ShotEditDialog on a linked board (PRD D9)", () => {
 
   it("pins the length when one is typed, and unpins from the chip", async () => {
     linked();
-    renderDialog();
+    renderPanel();
 
     // 3400 ms + 250 ms of silence, rounded up — the takes' own duration.
     expect(
@@ -510,5 +512,50 @@ describe("ShotEditDialog on a linked board (PRD D9)", () => {
     expect(
       screen.getByLabelText("Estimated running time in seconds")
     ).toHaveValue(9);
+  });
+});
+
+describe("ShotEditPanel placement (it is a row of the board, not a dialog)", () => {
+  it("asks the board to move it rather than swapping the shot under itself", async () => {
+    seed([
+      baseShot(),
+      baseShot({ id: "shot-2", index: 1, slug: "Second", action: "The lamp" })
+    ]);
+    renderPanel();
+
+    await userEvent.click(screen.getByRole("button", { name: "Next shot" }));
+
+    expect(onShotChange).toHaveBeenCalledWith("shot-2");
+    // Still on shot-1: where the panel sits is the board's call.
+    expect(screen.getByLabelText("Description")).toHaveValue(
+      "A lighthouse at dusk"
+    );
+  });
+
+  it("asks about an unsaved draft before stepping away", async () => {
+    seed([baseShot(), baseShot({ id: "shot-2", index: 1, slug: "Second" })]);
+    renderPanel();
+
+    await typeInto("Description", "A lighthouse at dawn");
+    await userEvent.click(screen.getByRole("button", { name: "Next shot" }));
+
+    expect(onShotChange).not.toHaveBeenCalled();
+    const confirm = await screen.findByText("Discard changes?");
+    await userEvent.click(
+      within(confirm.closest("[role='dialog']") as HTMLElement).getByRole(
+        "button",
+        { name: "Discard" }
+      )
+    );
+    expect(onShotChange).toHaveBeenCalledWith("shot-2");
+    expect(storedShot().action).toBe("A lighthouse at dusk");
+  });
+
+  it("offers no stepping when the board cannot move it", () => {
+    seed([baseShot(), baseShot({ id: "shot-2", index: 1, slug: "Second" })]);
+    renderPanel({ onShotChange: undefined });
+    expect(
+      screen.queryByRole("button", { name: "Next shot" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/storyboard/__tests__/ShotInspector.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotInspector.test.tsx
@@ -1,7 +1,7 @@
 /**
  * The selection footer after P4: the selected shot's description, four actions
  * (`Edit`, `Iterate`, `Regenerate`, `Delete`), and cross-document chips. Every
- * editable field is asserted in `ShotEditDialog.test.tsx`.
+ * editable field is asserted in `ShotEditPanel.test.tsx`.
  */
 import React from "react";
 import { render, screen, within } from "@testing-library/react";
@@ -109,13 +109,6 @@ jest.mock("../../../trpc/client", () => ({
   trpcClient: {}
 }));
 
-// The dialog has its own suite and reaches much further into the board.
-jest.mock("../ShotEditDialog", () => ({
-  __esModule: true,
-  default: ({ open }: { open: boolean }) =>
-    open ? <div data-testid="shot-edit-dialog" /> : null
-}));
-
 import ShotInspector from "../ShotInspector";
 import { useWorkspaceTabsStore } from "../../../stores/WorkspaceTabsStore";
 import { useDocumentFocusStore } from "../../../stores/DocumentFocusStore";
@@ -136,11 +129,19 @@ const renderInspector = (
 ) =>
   render(
     <ThemeProvider theme={mockTheme}>
-      <ShotInspector boardId="board-1" shot={shot} {...props} />
+      <ShotInspector
+        boardId="board-1"
+        shot={shot}
+        onEdit={onEdit}
+        {...props}
+      />
     </ThemeProvider>
   );
 
+const onEdit = jest.fn();
+
 beforeEach(() => {
+  onEdit.mockClear();
   removeShotMock.mockClear();
   generateKeyframeMock.mockClear();
   generateRevisedClipMock.mockClear();
@@ -188,7 +189,7 @@ describe("ShotInspector selection footer (PRD § 7.5)", () => {
     for (const name of ["Edit", "Iterate", "Regenerate", "Delete"]) {
       expect(screen.getByRole("button", { name })).toBeInTheDocument();
     }
-    // The field editors moved into the dialog; none of them is here.
+    // The field editors moved into the panel under the card; none is here.
     expect(screen.queryByLabelText("Shot description")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Framing")).not.toBeInTheDocument();
     expect(
@@ -199,11 +200,19 @@ describe("ShotInspector selection footer (PRD § 7.5)", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("opens the Edit dialog from Edit", async () => {
+  // The editor belongs under the shot's card, which only the board can place,
+  // so Edit asks the board rather than opening a surface of its own.
+  it("asks the board to open the editor from Edit", async () => {
     renderInspector(makeShot());
-    expect(screen.queryByTestId("shot-edit-dialog")).not.toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Edit" }));
-    expect(screen.getByTestId("shot-edit-dialog")).toBeInTheDocument();
+    expect(onEdit).toHaveBeenCalledWith("shot-1");
+  });
+
+  it("hides Edit when the board offers no editor", () => {
+    renderInspector(makeShot(), { onEdit: undefined });
+    expect(
+      screen.queryByRole("button", { name: "Edit" })
+    ).not.toBeInTheDocument();
   });
 
   it("renders a new still from Regenerate", async () => {

--- a/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
+++ b/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
@@ -189,6 +189,7 @@ jest.mock("../ShotCard", () => ({
     onDragStart,
     onDragEnter,
     onDrop,
+    onEdit,
     renderContext
   }: {
     shot: Shot;
@@ -201,6 +202,7 @@ jest.mock("../ShotCard", () => ({
     onDragStart?: (id: string) => void;
     onDragEnter?: (id: string) => void;
     onDrop?: (id: string) => void;
+    onEdit?: (id: string, focus: "fields" | "dialogue") => void;
   }) => (
     <div
       data-testid="shot-card"
@@ -226,7 +228,44 @@ jest.mock("../ShotCard", () => ({
       onDragStart={() => onDragStart?.(shot.id)}
       onDragEnter={() => onDragEnter?.(shot.id)}
       onDrop={() => onDrop?.(shot.id)}
-    />
+    >
+      {onEdit && (
+        // The real card swallows its footer's clicks, so reaching for Edit
+        // never also selects the card.
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onEdit(shot.id, "fields");
+          }}
+        >
+          {`Edit ${shot.id}`}
+        </button>
+      )}
+    </div>
+  )
+}));
+// The editor has its own suite (ShotEditPanel.test.tsx); here only where the
+// board puts it, and which shot it is given, matter.
+jest.mock("../ShotEditPanel", () => ({
+  __esModule: true,
+  default: ({
+    shotId,
+    onClose,
+    onShotChange
+  }: {
+    shotId: string;
+    onClose: () => void;
+    onShotChange?: (id: string) => void;
+  }) => (
+    <div data-testid="shot-edit-panel" data-shot-id={shotId}>
+      <button type="button" onClick={onClose}>
+        Close editor
+      </button>
+      <button type="button" onClick={() => onShotChange?.("s2")}>
+        Step to s2
+      </button>
+    </div>
   )
 }));
 // The inspector reads the real store, the entity library and the linked
@@ -957,5 +996,72 @@ describe("StoryboardBoard selection", () => {
     renderBoard(jest.fn());
     expect(screen.getAllByTestId("shot-inspector").length).toBeGreaterThan(0);
     activeShot = null;
+  });
+});
+
+// The editor is a row of the shot grid, placed right after the card it edits.
+// Nothing else enforces that: as a dialog it worked from anywhere, so a
+// regression would only show as the panel drifting away from its shot.
+describe("StoryboardBoard shot editing placement", () => {
+  const editCard = async (shotId: string) => {
+    await userEvent.click(
+      screen.getByRole("button", { name: `Edit ${shotId}` })
+    );
+  };
+
+  /** The grid cell holding a card, i.e. what the editor must follow. */
+  const cellOf = (shotId: string): HTMLElement =>
+    screen.getByLabelText(shotId).parentElement as HTMLElement;
+
+  it("opens the editor directly under the edited card, inside the grid", async () => {
+    mockShots = [makeShot("s1"), makeShot("s2"), makeShot("s3")];
+    renderBoard(jest.fn());
+    expect(screen.queryByTestId("shot-edit-panel")).not.toBeInTheDocument();
+
+    await editCard("s2");
+
+    const panel = screen.getByTestId("shot-edit-panel");
+    expect(panel).toHaveAttribute("data-shot-id", "s2");
+    const cell = cellOf("s2");
+    const row = cell.nextElementSibling as HTMLElement;
+    expect(row).toContainElement(panel);
+    // Same parent as the card's cell — a row of the grid, not a layer over it.
+    expect(row.parentElement).toBe(cell.parentElement);
+  });
+
+  it("closes the editor without touching the selection", async () => {
+    mockShots = [makeShot("s1"), makeShot("s2")];
+    mockSelectShot.mockClear();
+    renderBoard(jest.fn());
+
+    await editCard("s1");
+    await userEvent.click(screen.getByRole("button", { name: "Close editor" }));
+
+    expect(screen.queryByTestId("shot-edit-panel")).not.toBeInTheDocument();
+    expect(mockSelectShot).not.toHaveBeenCalled();
+  });
+
+  it("moves the editor under the shot it steps to", async () => {
+    mockShots = [makeShot("s1"), makeShot("s2")];
+    renderBoard(jest.fn());
+
+    await editCard("s1");
+    await userEvent.click(screen.getByRole("button", { name: "Step to s2" }));
+
+    const panel = screen.getByTestId("shot-edit-panel");
+    expect(panel).toHaveAttribute("data-shot-id", "s2");
+    expect(cellOf("s2").nextElementSibling).toContainElement(panel);
+  });
+
+  it("offers no editor on a read-only board", () => {
+    mockShots = [makeShot("s1")];
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <StoryboardBoard boardId="board-1" readOnly />
+      </ThemeProvider>
+    );
+    expect(
+      screen.queryByRole("button", { name: "Edit s1" })
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What changed

Editing a storyboard shot now happens directly underneath the shot. The editor was a full-screen dialog over the board, which hid the very shot being edited along with every other card; it is now `ShotEditPanel`, a full-width row of the shot grid placed immediately after the edited card, opened from the card's `Edit`, its dialogue icon, or the selection footer's `Edit`. The board owns which shot is open, because placing the panel is grid placement and a card cannot render a surface outside its own cell — `ShotCard` and `ShotInspector` take an `onEdit` callback and show no edit affordance without one, so a read-only board offers none. Everything the dialog did is unchanged: draft-then-save in one `updateShot` and one undo step, `Regenerate` rendering from the saved values, the dirty-close question, `Cmd/Ctrl+S`, and `Esc` (which the panel now listens for itself, since it is no longer a dialog). `Previous shot`/`Next shot` ask the board to move the panel under the shot they step to, behind the same unsaved-draft question, and keys typed in the panel no longer reach the grid's selection navigation. PRD § 7.5 and its task list describe the panel rather than a dialog.

## Verification

- [x] `npm run test:affected` — 9 suites, 134 tests passed. The placement is pinned by new cases in `StoryboardBoard.test.tsx` (the panel is the next sibling of the edited card's cell, inside the grid; closing and stepping), `ShotEditPanel.test.tsx` (stepping asks the board, and asks about a dirty draft first) and the card/inspector suites (`Edit` asks the board and is hidden without `onEdit`).
- [x] `npm run lint` — exit 0.
- [~] `npm run typecheck` — 49 pre-existing errors, identical with and without this diff (verified by stashing): `@nodetool-ai/video-nodes`, `code-nodes`, `audio-nodes`, `image-nodes` and `storyboard` have no `dist`, because `npm run build:packages` fails on `@nodetool-ai/game-nodes` (`src/project.ts` implicit `any`s) on `origin/main` too. No error names a file in this diff.
- [~] `npm run dev:nodetool -- harness gate --base origin/main` — cannot start in this checkout: the CLI imports `@nodetool-ai/base-nodes/dist/index.js`, missing for the same pre-existing build failure. The suites the `storyboard` area's entries name were run by hand instead, all green: `packages/protocol -- script-link shot-prompt render-record creative-scenes screenplay-authoring api-schemas-storyboards` (113), `packages/timeline -- script-link linked storyboard` (55), `packages/execution -- linked-timeline-validate` (1), `web -- src/lib/storyboard src/components/setup` (529).

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KufEpXrTXVLTgsoR6oUPbx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KufEpXrTXVLTgsoR6oUPbx)_