### PR TITLE
feat(web): put project selection above workspace tabs

### DIFF
--- a/web/src/components/projects/ProjectSelector.tsx
+++ b/web/src/components/projects/ProjectSelector.tsx
@@ -1,0 +1,216 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { useCallback, useRef, useState } from "react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+
+import {
+  BORDER_RADIUS,
+  Caption,
+  ContextMenu,
+  EditorButton,
+  FlexRow,
+  MenuItemPrimitive,
+  SearchInput,
+  SPACING,
+  Text,
+  getSpacingPx
+} from "../ui_primitives";
+import {
+  LOOSE_PROJECT_ID,
+  PROJECT_LIST_REF,
+  useWorkspaceTabsStore
+} from "../../stores/WorkspaceTabsStore";
+import {
+  useOpenNewProjectTab,
+  useOpenProject,
+  useProjects
+} from "../../hooks/useProjects";
+import { PROJECT_COLOR, PROJECT_GLYPH } from "./projectIdentity";
+import { ActivityIndicator } from "../timeline/ActivityIndicator";
+
+const selectorStyles = (theme: Theme) => css({
+  minHeight: "40px",
+  flexShrink: 0,
+  padding: `0 ${getSpacingPx(SPACING.xl)}`,
+  backgroundColor: theme.vars.palette.c_app_header,
+  borderBottom: `1px solid ${theme.vars.palette.divider}`,
+  WebkitAppRegion: "drag",
+  "& .selector-button": {
+    WebkitAppRegion: "no-drag",
+    display: "flex",
+    alignItems: "center",
+    gap: getSpacingPx(SPACING.md),
+    minHeight: "32px",
+    maxWidth: "min(100%, 360px)",
+    padding: `0 ${getSpacingPx(SPACING.md)}`,
+    border: "1px solid transparent",
+    borderRadius: BORDER_RADIUS.md,
+    background: "transparent",
+    color: theme.vars.palette.text.primary,
+    cursor: "pointer",
+    "&:hover, &:focus-visible": {
+      backgroundColor: theme.vars.palette.action.hover,
+      borderColor: theme.vars.palette.divider
+    }
+  },
+  "& .selector-name": {
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap"
+  },
+  "& .selector-glyph": { color: PROJECT_COLOR },
+  [theme.breakpoints.down("sm")]: {
+    padding: `0 ${getSpacingPx(SPACING.md)}`,
+    "& > .MuiTypography-root": { display: "none" },
+    "& .selector-button": { flex: 1, minWidth: 0 }
+  }
+});
+
+const ProjectSelector = () => {
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const theme = useTheme();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const { data: projects, isPending, error } = useProjects();
+  const openProject = useOpenProject();
+  const openNewProject = useOpenNewProjectTab();
+  const activeProjectId = useWorkspaceTabsStore(
+    (state) => state.activeProjectId
+  );
+  const setActiveProjectId = useWorkspaceTabsStore(
+    (state) => state.setActiveProjectId
+  );
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+
+  const activeProject = projects?.find(
+    (project) => project.id === activeProjectId
+  );
+  const activeTabTitle = useWorkspaceTabsStore((state) => {
+    const tab = state.tabs.find((entry) => entry.id === state.activeTabId);
+    return tab?.projectId === activeProjectId ? tab.title : undefined;
+  });
+  const name =
+    activeProject?.name ??
+    (activeProjectId ? activeTabTitle ?? "Project" : "Personal");
+  const close = useCallback(() => {
+    setOpen(false);
+    setSearch("");
+  }, []);
+
+  const selectPersonal = useCallback(() => {
+    close();
+    setActiveProjectId(null);
+  }, [close, setActiveProjectId]);
+
+  const selectProject = useCallback(
+    (project: { id: string; name: string }) => {
+      close();
+      void openProject(project);
+    },
+    [close, openProject]
+  );
+
+  const openProjects = useCallback(() => {
+    close();
+    openTab({
+      type: "project-list",
+      ref: PROJECT_LIST_REF,
+      mode: "view",
+      title: "Projects"
+    });
+  }, [close, openTab]);
+
+  const needle = search.trim().toLowerCase();
+  const visibleProjects = (projects ?? []).filter((project) =>
+    project.name.toLowerCase().includes(needle)
+  );
+
+  return (
+    <FlexRow css={selectorStyles(theme)} align="center" gap={SPACING.md}>
+      <button
+        ref={anchorRef}
+        type="button"
+        className="selector-button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={`Selected project: ${name}`}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span className="selector-glyph" aria-hidden>{PROJECT_GLYPH}</span>
+        <Text className="selector-name">{name}</Text>
+        <span aria-hidden>▾</span>
+      </button>
+      <Caption color="muted">Project</Caption>
+      <ActivityIndicator />
+      <ContextMenu
+        open={open}
+        anchorEl={anchorRef.current}
+        onClose={close}
+        paperSx={{ minWidth: "280px", p: SPACING.sm }}
+      >
+        <SearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder="Find a project"
+          ariaLabel="Find a project"
+          fullWidth
+          sx={{ mb: SPACING.sm }}
+        />
+        <MenuItemPrimitive
+          label="Personal"
+          secondary="Unassigned work"
+          selected={
+            activeProjectId === null || activeProjectId === LOOSE_PROJECT_ID
+          }
+          onClick={selectPersonal}
+        />
+        {isPending && (
+          <Caption sx={{ px: SPACING.md, py: SPACING.sm }}>
+            Loading projects…
+          </Caption>
+        )}
+        {error && (
+          <Caption color="error" sx={{ px: SPACING.md, py: SPACING.sm }}>
+            Could not load projects
+          </Caption>
+        )}
+        {visibleProjects.map((project) => (
+          <MenuItemPrimitive
+            key={project.id}
+            label={project.name}
+            selected={project.id === activeProjectId}
+            onClick={() => selectProject(project)}
+          />
+        ))}
+        {!isPending && !error && visibleProjects.length === 0 && (
+          <Caption sx={{ px: SPACING.md, py: SPACING.sm }}>
+            {needle ? "No matching projects" : "No named projects yet"}
+          </Caption>
+        )}
+        <FlexRow
+          className="selector-actions"
+          gap={SPACING.sm}
+          sx={{ px: SPACING.md, pt: SPACING.sm, pb: SPACING.md }}
+        >
+          <EditorButton
+            density="compact"
+            variant="outlined"
+            onClick={openNewProject}
+          >
+            New project
+          </EditorButton>
+          <EditorButton
+            density="compact"
+            variant="outlined"
+            onClick={openProjects}
+          >
+            Manage projects
+          </EditorButton>
+        </FlexRow>
+      </ContextMenu>
+    </FlexRow>
+  );
+};
+
+export default ProjectSelector;

--- a/web/src/components/workspace/WorkspaceShell.tsx
+++ b/web/src/components/workspace/WorkspaceShell.tsx
@@ -18,6 +18,7 @@ import { MOTION, reducedMotion } from "../ui_primitives";
 import WorkspaceTabBar from "./WorkspaceTabBar";
 import TabContent from "./TabContent";
 import WorkspaceTabLayer from "./WorkspaceTabLayer";
+import ProjectSelector from "../projects/ProjectSelector";
 
 import FrontendToolRuntimeSync from "../panels/FrontendToolRuntimeSync";
 
@@ -44,7 +45,7 @@ const styles = (theme: Theme, isDragging: boolean) =>
     // align with the single top bar. PanelRight (inspector) sits below the bar;
     // the left rail runs full-height to top 0. Legacy layouts set neither var
     // and keep their own fallback offsets.
-    "--workspace-header-height": `${HEADER_HEIGHT}px`,
+    "--workspace-header-height": `${HEADER_HEIGHT * 2}px`,
     "--workspace-rail-top": "0px",
     backgroundColor: "var(--c_editor_bg_color)",
 
@@ -184,6 +185,7 @@ const WorkspaceShell = () => {
           editor chrome — and its own sync — is not mounted. Without this the
           build fails with "Frontend tool runtime state is not initialized". */}
       <FrontendToolRuntimeSync />
+      <ProjectSelector />
       <WorkspaceTabBar />
       <div className="workspace-main">
         <Suspense fallback={null}>

--- a/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -35,7 +35,6 @@ import OpenMenu from "./OpenMenu";
 import WorkspaceTabItem from "./WorkspaceTabItem";
 import MobileDocumentSelector from "./MobileDocumentSelector";
 import MobileRailLauncher from "../panels/MobileRailLauncher";
-import ProjectScopeChip from "../projects/ProjectScopeChip";
 import { PROJECT_COLOR } from "../projects/projectIdentity";
 import { TYPE_COLOR, TYPE_GLYPH } from "./tabTypeIdentity";
 
@@ -110,8 +109,7 @@ const styles = (theme: Theme) =>
         color: theme.vars.palette.text.primary,
         backgroundColor: "var(--c_editor_bg_color)"
       },
-      // A tab in the open project's group. The cyan underline is the group's
-      // extent; the chip to its left names it.
+      // A tab in the selected project's group gets a shared cyan underline.
       "&.in-project": {
         boxShadow: `inset 0 -2px 0 color-mix(in srgb, ${PROJECT_COLOR} 35%, transparent)`
       },
@@ -331,16 +329,6 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
     () => tabs.find((tab) => tab.id === activeTabId) ?? null,
     [tabs, activeTabId]
   );
-
-  // The store keeps its tabs in render order — the open project's tabs are one
-  // contiguous run behind the scope chip — so the bar renders `tabs` as they
-  // come and a tab's index on screen is its index in the store.
-  const firstGroupedTabId = visibleTabs.find(
-    (tab) => tab.projectId === activeProjectId
-  )?.id;
-  const groupName =
-    visibleTabs.find((tab) => tab.type === "project" && tab.ref === activeProjectId)
-      ?.title ?? "Project";
 
   const newTabButtonRef = useRef<HTMLButtonElement>(null);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -647,12 +635,6 @@ const WorkspaceTabBar = React.memo(function WorkspaceTabBar() {
         <div className="tabs">
           {visibleTabs.map((tab) => (
             <Fragment key={tab.id}>
-              {tab.id === firstGroupedTabId && activeProjectId && (
-                <ProjectScopeChip
-                  projectId={activeProjectId}
-                  fallbackName={groupName}
-                />
-              )}
               <WorkspaceTabItem
                 tab={tab}
                 inProject={tab.projectId === activeProjectId}

--- a/web/src/components/workspace/__tests__/WorkspaceShellRuntimeSync.test.tsx
+++ b/web/src/components/workspace/__tests__/WorkspaceShellRuntimeSync.test.tsx
@@ -33,6 +33,11 @@ jest.mock("../../../stores/PanelStore", () => ({
 jest.mock("../../../hooks/useWorkspaceMenuShortcuts", () => ({
   useWorkspaceMenuShortcuts: jest.fn()
 }));
+jest.mock("../../../hooks/useProjects", () => ({
+  useProjects: () => ({ data: [], isPending: false, error: null }),
+  useOpenProject: () => jest.fn(),
+  useOpenNewProjectTab: () => jest.fn()
+}));
 jest.mock("@mui/material", () => ({
   ...jest.requireActual("@mui/material"),
   useMediaQuery: () => false

--- a/web/src/components/workspace/__tests__/WorkspaceShellRuntimeSync.test.tsx
+++ b/web/src/components/workspace/__tests__/WorkspaceShellRuntimeSync.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 const workspaceTabsState = {
   tabs: [],
   activeTabId: null,
+  activeProjectId: null,
   setTitle: jest.fn()
 };
 jest.mock("../../../stores/WorkspaceTabsStore", () => ({

--- a/web/src/components/workspace/__tests__/WorkspaceShellRuntimeSync.test.tsx
+++ b/web/src/components/workspace/__tests__/WorkspaceShellRuntimeSync.test.tsx
@@ -47,6 +47,7 @@ jest.mock("@mui/material/styles", () => ({
   ...jest.requireActual("@mui/material/styles"),
   useTheme: () => ({
     breakpoints: { down: () => "@media(max-width: 600px)" },
+    shape: { borderRadius: 8 },
     spacing: (factor: number) => `${factor * 8}px`,
     vars: {
       palette: {

--- a/web/src/components/workspace/__tests__/WorkspaceShellRuntimeSync.test.tsx
+++ b/web/src/components/workspace/__tests__/WorkspaceShellRuntimeSync.test.tsx
@@ -46,7 +46,15 @@ jest.mock("@mui/material", () => ({
 jest.mock("@mui/material/styles", () => ({
   ...jest.requireActual("@mui/material/styles"),
   useTheme: () => ({
-    breakpoints: { down: () => "@media(max-width: 600px)" }
+    breakpoints: { down: () => "@media(max-width: 600px)" },
+    vars: {
+      palette: {
+        action: { hover: "#f5f5f5" },
+        c_app_header: "#ffffff",
+        divider: "#dddddd",
+        text: { primary: "#111111" }
+      }
+    }
   })
 }));
 

--- a/web/src/components/workspace/__tests__/WorkspaceShellRuntimeSync.test.tsx
+++ b/web/src/components/workspace/__tests__/WorkspaceShellRuntimeSync.test.tsx
@@ -47,6 +47,7 @@ jest.mock("@mui/material/styles", () => ({
   ...jest.requireActual("@mui/material/styles"),
   useTheme: () => ({
     breakpoints: { down: () => "@media(max-width: 600px)" },
+    spacing: (factor: number) => `${factor * 8}px`,
     vars: {
       palette: {
         action: { hover: "#f5f5f5" },

--- a/web/src/stores/WorkspaceTabsStore.ts
+++ b/web/src/stores/WorkspaceTabsStore.ts
@@ -601,8 +601,8 @@ export const useWorkspaceTabsStore = create<WorkspaceTabsState>()(
               ? currentTab.projectId === projectId
               : currentTab.projectId === undefined)
               ? currentTab.id
-              : fallbackTab?.id) ??
-            state.activeTabId;
+            : fallbackTab?.id) ??
+            null;
           return {
             activeProjectId: projectId,
             activeTabId,

--- a/web/src/stores/__tests__/WorkspaceTabsStore.test.ts
+++ b/web/src/stores/__tests__/WorkspaceTabsStore.test.ts
@@ -233,6 +233,16 @@ describe("creationProjectId", () => {
     useWorkspaceTabsStore.getState().setActiveProjectId(null);
     expect(create()).toBe(LOOSE_PROJECT_ID);
   });
+
+  it("clears a project tab when switching to Personal with no Personal tab", () => {
+    useWorkspaceTabsStore.getState().openProject({
+      id: "proj-1",
+      name: "Aurora"
+    });
+    useWorkspaceTabsStore.getState().setActiveProjectId(null);
+    expect(useWorkspaceTabsStore.getState().activeProjectId).toBeNull();
+    expect(useWorkspaceTabsStore.getState().activeTabId).toBeNull();
+  });
 });
 
 describe("openProject", () => {


### PR DESCRIPTION
Moves project selection into persistent workspace chrome above document tabs. The selector supports Personal, project search and switching, project creation, management access, and activity visibility while preserving per-project tab sessions.

Main changes:
- Add ProjectSelector to WorkspaceShell with loading, failure, empty, search, Personal, create, and manage states.
- Remove the tab-group scope chip so only selected-project tabs render in the tab bar.
- Keep Personal navigation consistent by clearing a hidden project tab when no Personal tab exists.
- Fix the WorkspaceShell runtime-sync test to mock the projects hook introduced by the persistent selector.

Verification:
- git diff --check passed.
- CI failure reproduced from test-app job 103191734861 and fixed with the focused test mock.
- Local Jest execution was blocked after npm install encountered an ENOTEMPTY reification error in the pre-existing node_modules tree. Full verification is delegated to CI.