### PR TITLE
feat(chat): support multiple project chat threads

### DIFF
--- a/packages/websocket/src/session/chat-turn.ts
+++ b/packages/websocket/src/session/chat-turn.ts
@@ -527,13 +527,18 @@ export class ChatTurnHandler {
 
   private async ensureThreadExists(
     threadId?: string,
-    workflowId?: string | null
+    workflowId?: string | null,
+    projectId?: string
   ): Promise<string> {
     const userId = this.session.requireUserId();
     if (!threadId) {
+      if (projectId && projectId !== "default") {
+        await Project.requireOwned(userId, projectId);
+      }
       const thread = await Thread.create({
         user_id: userId,
         workflow_id: workflowId ?? null,
+        project_id: projectId ?? "default",
         title: ""
       });
       return thread.id;
@@ -544,6 +549,7 @@ export class ChatTurnHandler {
       id: threadId,
       user_id: userId,
       workflow_id: workflowId ?? null,
+      project_id: projectId ?? "default",
       title: ""
     });
     return thread.id;
@@ -1136,7 +1142,8 @@ export class ChatTurnHandler {
       : null;
     const threadId = await this.ensureThreadExists(
       isString(data.thread_id) ? data.thread_id : undefined,
-      messageWorkflowId
+      messageWorkflowId,
+      isString(data.project_id) ? data.project_id : undefined
     );
     data.thread_id = threadId;
 

--- a/packages/websocket/src/trpc/routers/threads.ts
+++ b/packages/websocket/src/trpc/routers/threads.ts
@@ -6,7 +6,7 @@
  * to Message.delete() in batches of 100, mirroring the legacy behavior.
  */
 
-import { Thread, Message, Memory } from "@nodetool-ai/models";
+import { Thread, Message, Memory, Project } from "@nodetool-ai/models";
 import type { Thread as ThreadModel } from "@nodetool-ai/models";
 import { ApiErrorCode } from "../../error-codes.js";
 import { router } from "../index.js";
@@ -15,6 +15,7 @@ import { throwApiError } from "../error-formatter.js";
 import {
   listInput,
   listOutput,
+  createInput,
   getInput,
   threadResponse,
   updateInput,
@@ -89,6 +90,22 @@ async function deriveThreadTitle(threadId: string): Promise<string> {
 }
 
 export const threadsRouter = router({
+  create: protectedProcedure
+    .input(createInput)
+    .output(threadResponse)
+    .mutation(async ({ ctx, input }) => {
+      if (input.project_id !== "default") {
+        await Project.requireOwned(ctx.userId, input.project_id);
+      }
+      const thread = await Thread.create({
+        user_id: ctx.userId,
+        project_id: input.project_id,
+        workflow_id: input.workflow_id ?? null,
+        title: input.title ?? ""
+      });
+      return toThreadResponse(thread);
+    }),
+
   list: protectedProcedure
     .input(listInput)
     .output(listOutput)

--- a/packages/websocket/src/trpc/sandbox-coverage.ts
+++ b/packages/websocket/src/trpc/sandbox-coverage.ts
@@ -865,6 +865,12 @@ export const SANDBOX_API_COVERAGE: Readonly<
   "memories.delete": { capability: "memory_delete" },
   "memories.list": { capability: "memory_list" },
   "memories.search": { capability: "memory_search" },
+  "threads.create": {
+    withheld:
+      "Creating chat history is not a sandbox capability. Runs may read " +
+      "threads for context, while the chat module remains read-only so a " +
+      "run cannot create or alter transcript records outside its turn."
+  },
   "threads.delete": {
     withheld:
       "Chat history is the record of what a run was asked to do and " +

--- a/web/src/components/chat/ChatListPanel.tsx
+++ b/web/src/components/chat/ChatListPanel.tsx
@@ -30,12 +30,13 @@ const useOpenThreadTab = () => {
   const location = useLocation();
 
   return useCallback(
-    (threadId: string, title?: string) => {
+    (threadId: string, title?: string, projectId?: string) => {
       openTab({
         type: "chat",
         ref: threadId,
         mode: "view",
-        title: title || "New chat"
+        title: title || "New chat",
+        projectId
       });
       if (!location.pathname.startsWith("/workspace")) {
         navigate("/workspace");
@@ -47,6 +48,9 @@ const useOpenThreadTab = () => {
 
 export const CreateChatButton = memo(function CreateChatButton() {
   const createNewThread = useGlobalChatStore((state) => state.createNewThread);
+  const activeProjectId = useWorkspaceTabsStore(
+    (state) => state.activeProjectId
+  );
   const addNotification = useNotificationStore(
     (state) => state.addNotification
   );
@@ -54,8 +58,11 @@ export const CreateChatButton = memo(function CreateChatButton() {
 
   const handleCreate = useCallback(async () => {
     try {
-      const threadId = await createNewThread();
-      openThreadTab(threadId);
+      const projectId = activeProjectId ?? "default";
+      const threadId = await createNewThread(undefined, undefined, {
+        projectId
+      });
+      openThreadTab(threadId, undefined, projectId);
     } catch (error) {
       console.error("Failed to create new chat thread:", error);
       addNotification({
@@ -63,7 +70,7 @@ export const CreateChatButton = memo(function CreateChatButton() {
         content: "Could not start a new conversation. Please try again."
       });
     }
-  }, [createNewThread, openThreadTab, addNotification]);
+  }, [createNewThread, openThreadTab, addNotification, activeProjectId]);
 
   return (
     <Tooltip title="New chat" placement="right-start">
@@ -108,6 +115,9 @@ const ChatListPanel = () => {
   );
   const setVisibility = usePanelStore((state) => state.setVisibility);
   const activeTabId = useWorkspaceTabsStore((state) => state.activeTabId);
+  const activeProjectId = useWorkspaceTabsStore(
+    (state) => state.activeProjectId
+  );
   const openThreadTab = useOpenThreadTab();
 
   const activeThreadId = activeTabId?.startsWith("chat:")
@@ -122,10 +132,14 @@ const ChatListPanel = () => {
     [threads, messageCache]
   );
 
+  const projectId = activeProjectId ?? "default";
   const threadsWithMessages = useMemo<Record<string, ThreadInfo>>(() => {
     const needle = filterValue.trim().toLowerCase();
     const result: Record<string, ThreadInfo> = {};
     for (const [id, thread] of Object.entries(threads)) {
+      if ((thread.project_id ?? "default") !== projectId) {
+        continue;
+      }
       const preview = threadPreview(thread.title, messageCache[id]);
       if (needle && !preview.toLowerCase().includes(needle)) {
         continue;
@@ -138,11 +152,15 @@ const ChatListPanel = () => {
       };
     }
     return result;
-  }, [threads, messageCache, filterValue]);
+  }, [threads, messageCache, filterValue, projectId]);
 
   const handleSelectThread = useCallback(
     (id: string) => {
-      openThreadTab(id, threads[id]?.title ?? undefined);
+      openThreadTab(
+        id,
+        threads[id]?.title ?? undefined,
+        threads[id]?.project_id ?? "default"
+      );
       setVisibility(false);
     },
     [openThreadTab, threads, setVisibility]
@@ -164,11 +182,14 @@ const ChatListPanel = () => {
   const createNewThread = useGlobalChatStore((state) => state.createNewThread);
   const handleNewThread = useCallback(async () => {
     try {
-      openThreadTab(await createNewThread());
+      const threadId = await createNewThread(undefined, undefined, {
+        projectId
+      });
+      openThreadTab(threadId, undefined, projectId);
     } catch (error) {
       console.error("Failed to create new chat thread:", error);
     }
-  }, [createNewThread, openThreadTab]);
+  }, [createNewThread, openThreadTab, projectId]);
 
   const isEmpty = Object.keys(threadsWithMessages).length === 0;
 

--- a/web/src/components/chat/__tests__/ChatListPanel.test.tsx
+++ b/web/src/components/chat/__tests__/ChatListPanel.test.tsx
@@ -82,7 +82,8 @@ describe("ChatListPanel", () => {
       type: "chat",
       ref: "thread-1",
       mode: "view",
-      title: "Fixing the encoder"
+      title: "Fixing the encoder",
+      projectId: "default"
     });
   });
 
@@ -110,7 +111,8 @@ describe("ChatListPanel", () => {
       type: "chat",
       ref: "thread-new",
       mode: "view",
-      title: "New chat"
+      title: "New chat",
+      projectId: "default"
     });
   });
 });

--- a/web/src/components/chat/containers/ChatPanelHeader.tsx
+++ b/web/src/components/chat/containers/ChatPanelHeader.tsx
@@ -36,6 +36,8 @@ interface ChatPanelHeaderProps {
   docsTopic?: DocsTopic;
   /** Name the help icon's tooltip uses. */
   docsLabel?: string;
+  /** Limit the conversation picker to one project's threads. */
+  projectId?: string;
 }
 
 /**
@@ -49,7 +51,8 @@ const ChatPanelHeader: React.FC<ChatPanelHeaderProps> = ({
   threadId,
   title,
   docsTopic = "agents",
-  docsLabel = "Chat & agents"
+  docsLabel = "Chat & agents",
+  projectId
 }) => {
   const navigate = useNavigate();
   const openTab = useWorkspaceTabsStore((state) => state.openTab);
@@ -82,17 +85,23 @@ const ChatPanelHeader: React.FC<ChatPanelHeaderProps> = ({
   const threadsWithMessages: Record<string, ThreadInfo> = useMemo(() => {
     if (!threads) return {};
     return Object.fromEntries(
-      Object.entries(threads).map(([id, thread]) => [
-        id,
-        {
-          id: thread.id,
-          title: thread.title ?? undefined,
-          updatedAt: thread.updated_at,
-          messages: messageCache[id] || []
-        }
-      ])
+      Object.entries(threads)
+        .filter(
+          ([, thread]) =>
+            projectId === undefined ||
+            (thread.project_id ?? "default") === projectId
+        )
+        .map(([id, thread]) => [
+          id,
+          {
+            id: thread.id,
+            title: thread.title ?? undefined,
+            updatedAt: thread.updated_at,
+            messages: messageCache[id] || []
+          }
+        ])
     );
-  }, [threads, messageCache]);
+  }, [threads, messageCache, projectId]);
 
   const handleSelectThread = useCallback(
     (id: string) => {

--- a/web/src/components/projects/ProjectAgentPanel.tsx
+++ b/web/src/components/projects/ProjectAgentPanel.tsx
@@ -91,7 +91,7 @@ const ProjectAgentPanel = ({
     return thread && (thread.project_id ?? "default") === projectId
       ? selectedChatCandidate
       : null;
-  );
+  });
   const setSelectedChatThread = useWorkspaceTabsStore(
     (state) => state.setSelectedChatThread
   );
@@ -111,7 +111,8 @@ const ProjectAgentPanel = ({
       loadMessages: state.loadMessages,
       sendMessage: state.sendMessage,
       trySendMessage: state.trySendMessage,
-      stopGeneration: state.stopGeneration
+      stopGeneration: state.stopGeneration,
+      createNewThread: state.createNewThread
     }))
   );
   const messages = useGlobalChatStore((state) =>

--- a/web/src/components/projects/ProjectAgentPanel.tsx
+++ b/web/src/components/projects/ProjectAgentPanel.tsx
@@ -24,6 +24,8 @@ import {
   getSpacingPx
 } from "../ui_primitives";
 import ChatView from "../chat/containers/ChatView";
+import ChatPanelHeader from "../chat/containers/ChatPanelHeader";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
 import useGlobalChatStore, {
   useThreadRuntime
 } from "../../stores/GlobalChatStore";
@@ -79,6 +81,20 @@ const ProjectAgentPanel = ({
   const [historyLoaded, setHistoryLoaded] = useState(false);
   const ensureThread = trpc.projects.thread.useMutation();
   const ensureThreadAsync = ensureThread.mutateAsync;
+  const selectedChatCandidate = useWorkspaceTabsStore(
+    (state) => state.projectSessions[projectId]?.selectedChatThreadId ?? null
+  );
+  const selectedChatThreadId = useGlobalChatStore((state) => {
+    const thread = selectedChatCandidate
+      ? state.threads?.[selectedChatCandidate]
+      : undefined;
+    return thread && (thread.project_id ?? "default") === projectId
+      ? selectedChatCandidate
+      : null;
+  );
+  const setSelectedChatThread = useWorkspaceTabsStore(
+    (state) => state.setSelectedChatThread
+  );
 
   const {
     connect,
@@ -86,7 +102,8 @@ const ProjectAgentPanel = ({
     loadMessages,
     sendMessage,
     trySendMessage,
-    stopGeneration
+    stopGeneration,
+    createNewThread
   } = useGlobalChatStore(
     useShallow((state) => ({
       connect: state.connect,
@@ -135,9 +152,11 @@ const ProjectAgentPanel = ({
     // Nothing to do when the incoming id is the thread this panel already
     // bound — including the null → id flip, which is the cache catching up
     // with the thread we created ourselves.
+    const preferredThreadId = selectedChatThreadId ?? boundThreadId;
     if (
       bound.current?.projectId === projectId &&
-      (boundThreadId === null || boundThreadId === bound.current.threadId)
+      (preferredThreadId === null ||
+        preferredThreadId === bound.current.threadId)
     ) {
       return;
     }
@@ -154,13 +173,15 @@ const ProjectAgentPanel = ({
       // A project that already names its thread needs no write; only the
       // first visit creates one.
       const id =
-        boundThreadId ?? (await ensureThreadAsync({ id: projectId })).threadId;
+        preferredThreadId ??
+        (await ensureThreadAsync({ id: projectId })).threadId;
       if (!active || !mounted.current) return;
       // Claimed before the awaits below, so the cache catching up mid-load
       // cannot start a second bind of the same thread.
       const claim = { projectId, threadId: id };
       bound.current = claim;
       setThreadId(id);
+      setSelectedChatThread(projectId, id);
       // The row exists on the server, so a fetch registers it with the store
       // rather than guessing at a local one.
       await fetchThread(id);
@@ -175,7 +196,33 @@ const ProjectAgentPanel = ({
     return () => {
       active = false;
     };
-  }, [projectId, boundThreadId, ensureThreadAsync, fetchThread, loadMessages]);
+  }, [
+    projectId,
+    boundThreadId,
+    selectedChatThreadId,
+    ensureThreadAsync,
+    fetchThread,
+    loadMessages,
+    setSelectedChatThread
+  ]);
+
+  const handleNewChat = useCallback(async () => {
+    const id = await createNewThread(undefined, undefined, {
+      projectId
+    });
+    setSelectedChatThread(projectId, id);
+    setHistoryLoaded(false);
+    setThreadId(id);
+  }, [createNewThread, projectId, setSelectedChatThread]);
+
+  const handleSelectThread = useCallback(
+    (id: string) => {
+      setSelectedChatThread(projectId, id);
+      setHistoryLoaded(false);
+      setThreadId(id);
+    },
+    [projectId, setSelectedChatThread]
+  );
 
   const systemPrompt = useMemo(
     () => projectSystemPrompt(projectName, projectId),
@@ -274,34 +321,43 @@ const ProjectAgentPanel = ({
         Project agent
       </Caption>
       {threadId ? (
-        <ChatView
-          status={chatStatus}
-          messages={messages}
-          progress={runtime.progress.current}
-          total={runtime.progress.total}
-          progressMessage={runtime.statusMessage}
-          model={selectedModel}
-          onModelChange={setSelectedModel}
-          sendMessage={handleSend}
-          onStop={handleStop}
-          threadId={threadId}
-          systemPrompt={systemPrompt}
-          chatSource="workspace_chat"
-          currentPlanningUpdate={runtime.planningUpdate}
-          currentTaskUpdate={runtime.taskUpdate}
-          currentLogUpdate={runtime.logUpdate}
-          runningToolCallId={runtime.runningToolCallId}
-          hideModePicker
-          composerPlaceholder="Ask for a change to this project…"
-          noMessagesPlaceholder={
-            <FlexColumn sx={{ flex: 1, px: SPACING.lg, pt: SPACING.lg }}>
-              <Caption color="muted">
-                Nothing here yet. Ask for a change and the agent builds it into
-                this project.
-              </Caption>
-            </FlexColumn>
-          }
-        />
+        <>
+          <ChatPanelHeader
+            projectId={projectId}
+            threadId={threadId}
+            onNewChat={() => void handleNewChat()}
+            onSelectThread={handleSelectThread}
+            title="Project conversations"
+          />
+          <ChatView
+            status={chatStatus}
+            messages={messages}
+            progress={runtime.progress.current}
+            total={runtime.progress.total}
+            progressMessage={runtime.statusMessage}
+            model={selectedModel}
+            onModelChange={setSelectedModel}
+            sendMessage={handleSend}
+            onStop={handleStop}
+            threadId={threadId}
+            systemPrompt={systemPrompt}
+            chatSource="workspace_chat"
+            currentPlanningUpdate={runtime.planningUpdate}
+            currentTaskUpdate={runtime.taskUpdate}
+            currentLogUpdate={runtime.logUpdate}
+            runningToolCallId={runtime.runningToolCallId}
+            hideModePicker
+            composerPlaceholder="Ask for a change to this project…"
+            noMessagesPlaceholder={
+              <FlexColumn sx={{ flex: 1, px: SPACING.lg, pt: SPACING.lg }}>
+                <Caption color="muted">
+                  Nothing here yet. Ask for a change and the agent builds it into
+                  this project.
+                </Caption>
+              </FlexColumn>
+            }
+          />
+        </>
       ) : (
         <LoadingSpinner />
       )}

--- a/web/src/components/projects/__tests__/ProjectAgentPanel.test.tsx
+++ b/web/src/components/projects/__tests__/ProjectAgentPanel.test.tsx
@@ -5,6 +5,7 @@
  */
 import { render, screen, waitFor } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
+import { MemoryRouter } from "react-router-dom";
 import mockTheme from "../../../__mocks__/themeMock";
 
 const ensureThread = jest.fn(async () => ({ threadId: "t1" }));
@@ -79,7 +80,9 @@ import {
 
 const panel = (threadId: string | null) => (
   <ThemeProvider theme={mockTheme}>
-    <ProjectAgentPanel projectId="p1" projectName="Aurora" threadId={threadId} />
+    <MemoryRouter>
+      <ProjectAgentPanel projectId="p1" projectName="Aurora" threadId={threadId} />
+    </MemoryRouter>
   </ThemeProvider>
 );
 

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -59,6 +59,7 @@ import {
   type ThreadRuntime
 } from "../core/chat/threadRuntime";
 import { isObjectLike, isString } from "../utils/typePredicates";
+import { creationProjectId } from "./WorkspaceTabsStore";
 
 // Include additional runtime statuses used during message streaming
 type ChatStatus =
@@ -371,13 +372,14 @@ export interface GlobalChatState {
     options?: {
       title?: string;
       workflowId?: string | null;
+      projectId?: string | null;
       makeCurrent?: boolean;
     }
   ) => void;
   createNewThread: (
     title?: string,
     workflowId?: string | null,
-    options?: { makeCurrent?: boolean }
+    options?: { makeCurrent?: boolean; projectId?: string | null }
   ) => Promise<string>;
   switchThread: (threadId: string) => void;
   deleteThread: (threadId: string) => Promise<void>;
@@ -1061,7 +1063,9 @@ const useGlobalChatStore = create<GlobalChatState>()(
         // Ensure we have a thread
         let threadId = targetThreadId ?? currentThreadId;
         if (!threadId) {
-          threadId = await get().createNewThread();
+          threadId = await get().createNewThread(undefined, undefined, {
+            projectId: creationProjectId()
+          });
         }
         const tid = threadId;
 
@@ -1099,6 +1103,8 @@ const useGlobalChatStore = create<GlobalChatState>()(
             get().threadWorkflowId[tid] ??
             null)
           : (workflowId ?? null);
+        const boundProjectId =
+          get().threads[tid]?.project_id ?? creationProjectId();
         set((state) => ({
           threadWorkflowId: {
             ...state.threadWorkflowId,
@@ -1132,6 +1138,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
         const chatMessageData = {
           ...messageWithoutTools,
           workflow_id: message.workflow_id ?? boundWorkflowId,
+          project_id: boundProjectId,
           thread_id: threadId,
           permission_mode: get().getPermissionMode(threadId),
           model: isMediaGeneration
@@ -1303,6 +1310,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
           options?.workflowId !== undefined
             ? options.workflowId
             : (get().workflowId ?? null);
+        const boundProjectId = options?.projectId ?? creationProjectId();
 
         ensureThreadSubscription(threadId, set, get);
 
@@ -1310,6 +1318,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
         const localThread: Thread = {
           id: threadId,
           user_id: "",
+          project_id: boundProjectId,
           workflow_id: boundWorkflowId,
           title: safeTitle || "New conversation",
           created_at: now,
@@ -1357,12 +1366,16 @@ const useGlobalChatStore = create<GlobalChatState>()(
       createNewThread: async (
         title?: string,
         workflowId?: string | null,
-        options?: { makeCurrent?: boolean }
+        options?: { makeCurrent?: boolean; projectId?: string | null }
       ) => {
         const id = crypto.randomUUID();
         get().ensureLocalThread(id, {
           title: isString(title) ? title : undefined,
           workflowId,
+          projectId:
+            options?.projectId !== undefined
+              ? options.projectId
+              : creationProjectId(),
           makeCurrent: options?.makeCurrent !== false
         });
         return id;

--- a/web/src/stores/WorkspaceTabsStore.ts
+++ b/web/src/stores/WorkspaceTabsStore.ts
@@ -136,6 +136,7 @@ interface WorkspaceTabsState {
   moveTab: (id: string, toIndex: number) => void;
   getActiveTab: () => WorkspaceTab | null;
   setActiveProjectId: (projectId: string | null) => void;
+  setSelectedChatThread: (projectId: string | null, threadId: string) => void;
   /**
    * Make `input.id` the active project: open its overview tab, adopt or open a
    * tab per document, and gather the group into one contiguous run. Documents
@@ -609,6 +610,15 @@ export const useWorkspaceTabsStore = create<WorkspaceTabsState>()(
             tabs: gatherProjectTabs(state.tabs, projectId)
           };
         }),
+
+      setSelectedChatThread: (projectId, threadId) =>
+        set((state) => ({
+          projectSessions: updateSession(
+            state.projectSessions,
+            projectId ?? undefined,
+            (session) => ({ ...session, selectedChatThreadId: threadId })
+          )
+        })),
 
       openProject: ({ id, name, documents }) =>
         set((state) => {

--- a/web/src/stores/__tests__/GlobalChatStore.test.ts
+++ b/web/src/stores/__tests__/GlobalChatStore.test.ts
@@ -349,6 +349,7 @@ describe("GlobalChatStore", () => {
         data: {
           ...msg,
           workflow_id: null,
+          project_id: "default",
           thread_id: threadId,
           model: "gpt-5.4-mini",
           provider: "openai",
@@ -1202,6 +1203,7 @@ describe("GlobalChatStore", () => {
         data: {
           ...message,
           workflow_id: "test-workflow",
+          project_id: "default",
           thread_id: threadId,
           model: "gpt-5.4-mini",
           provider: "openai",


### PR DESCRIPTION
## Summary
Project chat now supports multiple independent conversation threads per project. New threads inherit the active project, thread history remains isolated, and the selected project conversation is restored through the existing project session state.

## Main changes
- Add project-scoped thread creation and ownership validation to tRPC and chat-turn creation.
- Preserve project identity in client-created threads and outgoing background turns.
- Filter workspace and embedded project conversation pickers by project.
- Add project conversation selection/creation and persist the selected thread in `WorkspaceTabsStore`.

## Verification
- `git diff --check` passed.
- `npm run test:affected` could not complete because the checkout has no usable npm toolchain and `npx turbo` stalled during dependency installation.
- `npm run typecheck` failed before compilation: `tsc: not found`.
- `npm run lint` failed before linting: `oxlint: not found`.
- `npm run dev:nodetool -- harness gate --base origin/main --dry-run` failed before execution: `tsx: not found`.
