### PR TITLE
perf(storyboard): load boards from thumbnails and a SQL shot count

### DIFF
--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -210,7 +210,11 @@ export {
   StoryboardConflictError,
   emptyStoryboardDocument
 } from "./storyboard.js";
-export type { StoryboardDocument, StoryboardResponse } from "./storyboard.js";
+export type {
+  StoryboardDocument,
+  StoryboardResponse,
+  StoryboardSummary
+} from "./storyboard.js";
 export {
   Application,
   ApplicationConflictError,

--- a/packages/models/src/storyboard.ts
+++ b/packages/models/src/storyboard.ts
@@ -48,6 +48,21 @@ export interface StoryboardResponse {
   updatedAt: string;
 }
 
+/**
+ * One row as a board *listing* needs it: identity, name, and how many shots it
+ * holds. Everything else in the row is the `document` column, which carries the
+ * whole board — screenplay, every shot, every take. A listing that selects it
+ * reads (and JSON-parses) megabytes to print a number, so the count is asked of
+ * the database instead. See {@link Storyboard.listSummaries}.
+ */
+export interface StoryboardSummary {
+  id: string;
+  projectId: string;
+  name: string;
+  shotCount: number;
+  updatedAt: string;
+}
+
 export class StoryboardConflictError extends Error {
   constructor(id: string) {
     super(`Storyboard ${id} was modified concurrently`);
@@ -217,6 +232,54 @@ export class Storyboard extends DBModel {
       .limit(1);
     const row = rows[0];
     return row ? new Storyboard(row as Record<string, unknown>) : null;
+  }
+
+  /**
+   * The boards a listing shows, without reading any of their documents.
+   *
+   * `document` holds the entire board, so `listByUser(...).map(b =>
+   * b.toDocument().shots.length)` pulls every shot, take and prompt of every
+   * board out of the database and parses it — to print a shot count. The count
+   * is a property of the stored JSON, so it is computed there — written per
+   * dialect, like {@link Storyboard.findRecast}: `json_array_length` over a
+   * path in SQLite, over the cast text column in PostgreSQL. A document whose
+   * `shots` is missing or not an array counts 0 rather than failing the whole
+   * listing.
+   */
+  static async listSummaries(args: {
+    userId: string;
+    projectId?: string;
+    limit?: number;
+  }): Promise<StoryboardSummary[]> {
+    const db = getDb();
+    const postgres = getDbType() === "postgres";
+    const shots = postgres
+      ? sql<number>`CASE WHEN json_typeof((${storyboards.document}::json) -> 'shots') = 'array' THEN json_array_length((${storyboards.document}::json) -> 'shots') ELSE 0 END`
+      : sql<number>`COALESCE(json_array_length(${storyboards.document}, '$.shots'), 0)`;
+    const rows = await db
+      .select({
+        id: storyboards.id,
+        project_id: storyboards.project_id,
+        name: storyboards.name,
+        shot_count: shots,
+        updated_at: storyboards.updated_at
+      })
+      .from(storyboards)
+      .where(
+        and(
+          eq(storyboards.user_id, args.userId),
+          args.projectId ? eq(storyboards.project_id, args.projectId) : undefined
+        )
+      )
+      .orderBy(desc(storyboards.updated_at))
+      .limit(args.limit ?? 50);
+    return rows.map((row: Record<string, unknown>) => ({
+      id: row.id as string,
+      projectId: row.project_id as string,
+      name: row.name as string,
+      shotCount: Number(row.shot_count ?? 0),
+      updatedAt: row.updated_at as string
+    }));
   }
 
   static async listByProject(

--- a/packages/models/tests/storyboard-list-summaries.test.ts
+++ b/packages/models/tests/storyboard-list-summaries.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Listing boards without reading their documents.
+ *
+ * The `document` column holds the entire board — screenplay, every shot, every
+ * take. A listing that selected it and counted `shots.length` in JavaScript
+ * pulled megabytes out of the database to print one number per row.
+ * `listSummaries` asks the database for the count instead, so these tests pin
+ * both that the count is right and that the query never hands back a document.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { getDb, initTestDb } from "../src/db.js";
+import { storyboards } from "../src/schema/storyboards.js";
+import {
+  Storyboard,
+  emptyStoryboardDocument,
+  type StoryboardDocument
+} from "../src/storyboard.js";
+
+const OWNER = "u1";
+const OTHER = "u2";
+
+const shot = (index: number) => ({
+  type: "shot",
+  id: `shot_${index}`,
+  index,
+  action: "A lighthouse at dawn.",
+  status: "planned"
+});
+
+const document = (over: Partial<StoryboardDocument> = {}): string =>
+  JSON.stringify({ ...emptyStoryboardDocument(), ...over });
+
+async function seed(
+  name: string,
+  over: {
+    userId?: string;
+    projectId?: string;
+    document?: string;
+  } = {}
+): Promise<Storyboard> {
+  const board = new Storyboard({
+    user_id: over.userId ?? OWNER,
+    project_id: over.projectId ?? "default",
+    name,
+    document: over.document ?? document()
+  });
+  await board.save();
+  return board;
+}
+
+/** A row written straight to the table, past the model's write-time guards. */
+async function insertRaw(name: string, document: string): Promise<void> {
+  const now = new Date().toISOString();
+  await getDb().insert(storyboards).values({
+    id: `raw_${name}`,
+    user_id: OWNER,
+    project_id: "default",
+    name,
+    document,
+    timeline_id: null,
+    revision: 1,
+    created_at: now,
+    updated_at: now
+  });
+}
+
+describe("Storyboard.listSummaries", () => {
+  beforeEach(async () => {
+    await initTestDb();
+  });
+
+  it("counts the shots in the stored document", async () => {
+    await seed("three", {
+      document: document({
+        shots: [shot(0), shot(1), shot(2)] as StoryboardDocument["shots"]
+      })
+    });
+    await seed("empty");
+
+    const rows = await Storyboard.listSummaries({ userId: OWNER });
+
+    expect(
+      Object.fromEntries(rows.map((r) => [r.name, r.shotCount]))
+    ).toEqual({ three: 3, empty: 0 });
+  });
+
+  it("carries identity, project and update time", async () => {
+    const board = await seed("named", { projectId: "p1" });
+
+    const [row] = await Storyboard.listSummaries({ userId: OWNER });
+
+    expect(row).toEqual({
+      id: board.id,
+      projectId: "p1",
+      name: "named",
+      shotCount: 0,
+      updatedAt: board.updated_at
+    });
+  });
+
+  it("never selects the document column", async () => {
+    await seed("heavy", {
+      document: document({
+        shots: Array.from({ length: 5 }, (_, i) =>
+          shot(i)
+        ) as StoryboardDocument["shots"],
+        brief: "a brief nothing in a summary should carry"
+      })
+    });
+
+    const [row] = await Storyboard.listSummaries({ userId: OWNER });
+
+    expect(JSON.stringify(row)).not.toContain("a brief nothing");
+    expect(Object.keys(row).sort()).toEqual([
+      "id",
+      "name",
+      "projectId",
+      "shotCount",
+      "updatedAt"
+    ]);
+  });
+
+  it("counts 0 for a document whose shots key is missing or not an array", async () => {
+    // `save()` refuses such a document, so this is the shape only a row
+    // written before that guard can have. It must not fail the whole listing.
+    await insertRaw("missing", JSON.stringify({ brief: "" }));
+    await insertRaw("scalar", JSON.stringify({ shots: 7 }));
+
+    const rows = await Storyboard.listSummaries({ userId: OWNER });
+
+    expect(rows.map((r) => r.shotCount)).toEqual([0, 0]);
+  });
+
+  it("answers only the caller's own boards", async () => {
+    await seed("mine");
+    await seed("theirs", { userId: OTHER });
+
+    const rows = await Storyboard.listSummaries({ userId: OWNER });
+
+    expect(rows.map((r) => r.name)).toEqual(["mine"]);
+  });
+
+  it("filters by project when one is given", async () => {
+    await seed("in", { projectId: "p1" });
+    await seed("out", { projectId: "p2" });
+
+    const rows = await Storyboard.listSummaries({
+      userId: OWNER,
+      projectId: "p1"
+    });
+
+    expect(rows.map((r) => r.name)).toEqual(["in"]);
+  });
+
+  it("returns the most recently updated first, within the limit", async () => {
+    const first = await seed("first");
+    await seed("second");
+    // A save moves `updated_at` forward, so touching the older row reorders it.
+    first.name = "first touched";
+    await first.save();
+
+    const rows = await Storyboard.listSummaries({ userId: OWNER, limit: 1 });
+
+    expect(rows.map((r) => r.name)).toEqual(["first touched"]);
+  });
+});

--- a/packages/websocket/src/trpc/routers/storyboards.ts
+++ b/packages/websocket/src/trpc/routers/storyboards.ts
@@ -59,16 +59,6 @@ const stylePresetEntity = z.object({
   thumbnail: z.string()
 });
 
-function toListItem(board: Storyboard) {
-  return {
-    id: board.id,
-    projectId: board.project_id,
-    name: board.name,
-    shotCount: board.toDocument().shots.length,
-    updatedAt: board.updated_at
-  };
-}
-
 async function loadOwned(
   ctxUserId: string | null,
   id: string
@@ -85,12 +75,16 @@ export const storyboardsRouter = router({
   list: protectedProcedure
     .input(listInput)
     .output(z.array(storyboardListItem))
-    .query(async ({ ctx, input }) => {
-      const boards = input.projectId
-        ? await Storyboard.listByProject(input.projectId, ctx.userId)
-        : await Storyboard.listByUser(ctx.userId);
-      return boards.map(toListItem);
-    }),
+    .query(({ ctx, input }) =>
+      // Summaries, not rows: the shot count comes from the database, so a
+      // listing never reads a board's whole document to print one number.
+      input.projectId
+        ? Storyboard.listSummaries({
+            userId: ctx.userId,
+            projectId: input.projectId
+          })
+        : Storyboard.listSummaries({ userId: ctx.userId })
+    ),
 
   get: protectedProcedure
     .input(idInput)

--- a/packages/websocket/tests/trpc-storyboards-list.test.ts
+++ b/packages/websocket/tests/trpc-storyboards-list.test.ts
@@ -1,0 +1,120 @@
+/**
+ * storyboards router — the listing.
+ *
+ * Real DB, real models. The listing used to load every board in full and count
+ * `shots.length` in JavaScript, so a sidebar of boards read every shot, take
+ * and prompt the user owns. It now asks the database for the count; these
+ * tests pin the answer it gives and that the document never leaves the row.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { initTestDb, ModelObserver, Storyboard } from "@nodetool-ai/models";
+import { appRouter } from "../src/trpc/router.js";
+import { createCallerFactory } from "../src/trpc/index.js";
+import type { Context } from "../src/trpc/context.js";
+
+const createCaller = createCallerFactory(appRouter);
+
+function makeCtx(userId: string): Context {
+  return {
+    userId,
+    registry: {} as never,
+    apiOptions: { metadataRoots: [], registry: {} as never } as never,
+    pythonBridge: {} as never,
+    getPythonBridgeReady: () => false
+  } as Context;
+}
+
+const caller = (userId = "user-1") => createCaller(makeCtx(userId));
+
+const shots = (count: number) =>
+  Array.from({ length: count }, (_, index) => ({
+    type: "shot" as const,
+    id: `shot_${index}`,
+    index,
+    action: "A lighthouse at dawn.",
+    status: "planned"
+  }));
+
+async function board(args: {
+  name: string;
+  projectId?: string;
+  shotCount?: number;
+  userId?: string;
+}) {
+  const created = await caller(args.userId).storyboards.create({
+    name: args.name,
+    projectId: args.projectId ?? "default"
+  });
+  if (args.shotCount) {
+    await caller(args.userId).storyboards.update({
+      id: created.id,
+      baseUpdatedAt: created.updatedAt,
+      document: {
+        screenplay: null,
+        shots: shots(args.shotCount),
+        brief: "",
+        style: "",
+        entityIds: [],
+        aspectRatio: "16:9",
+        setupStage: "done",
+        genre: "",
+        directorModel: null,
+        imageModel: null,
+        videoModel: null
+      }
+    });
+  }
+  return created;
+}
+
+describe("storyboards.list", () => {
+  beforeEach(() => initTestDb());
+  afterEach(() => {
+    ModelObserver.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("answers with each board's shot count", async () => {
+    await board({ name: "Trailer", shotCount: 3 });
+    await board({ name: "Blank" });
+
+    const items = await caller().storyboards.list({});
+
+    expect(
+      Object.fromEntries(items.map((i) => [i.name, i.shotCount]))
+    ).toEqual({ Trailer: 3, Blank: 0 });
+  });
+
+  it("filters by project", async () => {
+    await board({ name: "In", projectId: "p1" });
+    await board({ name: "Out", projectId: "p2" });
+
+    const items = await caller().storyboards.list({ projectId: "p1" });
+
+    expect(items.map((i) => i.name)).toEqual(["In"]);
+  });
+
+  it("shows the caller only their own boards", async () => {
+    await board({ name: "Mine" });
+    await board({ name: "Theirs", userId: "user-2" });
+
+    const items = await caller().storyboards.list({});
+
+    expect(items.map((i) => i.name)).toEqual(["Mine"]);
+  });
+
+  // The whole point: a listing must not read documents. Loading the rows is
+  // what made a sidebar of boards cost megabytes.
+  it("never loads a board's document", async () => {
+    await board({ name: "Trailer", shotCount: 3 });
+    const listByUser = vi.spyOn(Storyboard, "listByUser");
+    const listByProject = vi.spyOn(Storyboard, "listByProject");
+
+    const items = await caller().storyboards.list({});
+
+    expect(items).toHaveLength(1);
+    expect(listByUser).not.toHaveBeenCalled();
+    expect(listByProject).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/storyboard/EntityStillModelWarning.tsx
+++ b/web/src/components/storyboard/EntityStillModelWarning.tsx
@@ -1,0 +1,36 @@
+/**
+ * EntityStillModelWarning
+ *
+ * Entity reference images only reach generation through an editing model, so a
+ * board cast with entities whose still model takes text alone silently drops
+ * them. This says so, next to the model picker.
+ *
+ * It is its own component because answering the question needs every image
+ * provider's model list. Asked from the board, that fan-out ran on every board
+ * open — behind collapsed settings, for a board with no entities at all. Here
+ * it runs only when the warning could actually fire.
+ */
+
+import { Caption } from "../ui_primitives";
+import { useImageModelsByProvider } from "../../hooks/useModelsByProvider";
+
+interface EntityStillModelWarningProps {
+  /** The board's selected still model, if one is chosen. */
+  modelId: string | undefined;
+}
+
+const EntityStillModelWarning = ({ modelId }: EntityStillModelWarningProps) => {
+  const { models } = useImageModelsByProvider();
+  const details = modelId ? models.find((m) => m.id === modelId) : undefined;
+  if (details?.supported_tasks?.includes("image_to_image")) {
+    return null;
+  }
+  return (
+    <Caption color="warning">
+      Entities carry reference images, but this model only takes text. Pick an
+      image-to-image model to use them.
+    </Caption>
+  );
+};
+
+export default EntityStillModelWarning;

--- a/web/src/components/storyboard/ShotCard.tsx
+++ b/web/src/components/storyboard/ShotCard.tsx
@@ -37,6 +37,7 @@ import {
   FlexColumn,
   FlexRow,
   ProgressBar,
+  ResponsiveImage,
   Text,
   TextInput,
   ToolbarIconButton,
@@ -47,7 +48,6 @@ import {
   TYPOGRAPHY,
   MOTION
 } from "../ui_primitives";
-import ImageRefPreview from "../node/ImageRefPreview";
 import ShotHoverToolbar from "./ShotHoverToolbar";
 import ShotMediaViewer from "./ShotMediaViewer";
 import ShotStatusPill, { CLIP_COLOR, isShotGenerating } from "./ShotStatusPill";
@@ -56,7 +56,10 @@ import { useStoryboardGenerationStore } from "../../stores/storyboard/Storyboard
 import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
 import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
 import { useShotDuration } from "../../hooks/storyboard/useShotDuration";
-import { useResolvedMediaUri } from "../../hooks/useResolvedMediaUri";
+import {
+  useResolvedMedia,
+  useResolvedMediaUri
+} from "../../hooks/useResolvedMediaUri";
 import { useAssetUpload } from "../../serverState/useAssetUpload";
 import { useNotificationStore } from "../../stores/NotificationStore";
 import { mediaRefFromAsset } from "../../utils/mediaRef";
@@ -202,10 +205,17 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
   // `asset://` locator, but the card renders the keyframe when it cannot.
   const clipUri = useResolvedMediaUri(shot.clip);
   // Download needs a URL, not a locator, and the still's is not otherwise
-  // resolved here — the preview primitive resolves its own.
-  const keyframeUri = useResolvedMediaUri(shot.keyframe);
+  // resolved here — the preview primitive resolves its own. Both forms of the
+  // still come off one asset lookup: the full one is what a download and the
+  // fullscreen viewer want, the thumbnail is what the card shows.
+  const keyframeMedia = useResolvedMedia(shot.keyframe);
+  const keyframeUri = keyframeMedia.url;
+  const keyframeThumbUri = keyframeMedia.thumbUrl ?? keyframeMedia.url;
   const downloadUri = clipUri ?? keyframeUri;
   const downloadKind = clipUri ? "clip" : "still";
+  // A ref with neither a locator nor an asset behind it has nothing to show:
+  // the card says so rather than waiting on a resolution that never lands.
+  const hasKeyframe = Boolean(shot.keyframe?.uri || shot.keyframe?.asset_id);
   const shotName = `${shot.index + 1}. ${shot.slug ?? "Untitled shot"}`;
   // What the preview shows is what fullscreen opens: the clip once there is
   // one, the selected still before that.
@@ -409,19 +419,28 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
         onDoubleClick={previewMedia ? handleOpenViewer : undefined}
       >
         {clipUri ? (
-          <VideoPlayer locator={shot.clip} poster={keyframeUri ?? undefined} />
-        ) : (
-          <ImageRefPreview
-            value={shot.keyframe}
-            placeholder={
-              <Caption
-                color="muted"
-                sx={{ textAlign: "center", p: SPACING.md }}
-              >
-                No still yet
-              </Caption>
-            }
+          <VideoPlayer
+            locator={shot.clip}
+            poster={keyframeThumbUri ?? undefined}
           />
+        ) : hasKeyframe ? (
+          // The card is a few hundred pixels wide and a board holds dozens of
+          // them, so it shows the asset's thumbnail, not the full still, and
+          // leaves the ones below the fold to the browser's lazy loading. The
+          // full still is one double-click away, in the viewer.
+          <ResponsiveImage
+            locator={shot.keyframe}
+            preferThumbnail
+            loading="lazy"
+            showSkeleton
+            alt={shotName}
+            fit="cover"
+            sx={{ height: "100%" }}
+          />
+        ) : (
+          <Caption color="muted" sx={{ textAlign: "center", p: SPACING.md }}>
+            No still yet
+          </Caption>
         )}
         <Box sx={shotLabelSx}>
           {duration.seconds != null

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -76,10 +76,7 @@ import {
 } from "../../stores/storyboard/StoryboardStore";
 import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
 import { useStoryboardShotFocus } from "../../hooks/storyboard/useStoryboardShotFocus";
-import {
-  useImageModelsByProvider,
-  type ImageModelTask
-} from "../../hooks/useModelsByProvider";
+import type { ImageModelTask } from "../../hooks/useModelsByProvider";
 import LanguageModelSelect from "../properties/LanguageModelSelect";
 import { useInStudio } from "../../studio/StudioContext";
 import ImageModelSelect from "../properties/ImageModelSelect";
@@ -101,6 +98,7 @@ import BoardLineageChip from "./BoardLineageChip";
 import BoardRetryFailed from "./BoardRetryFailed";
 import BoardStaleBanner from "./BoardStaleBanner";
 import BoardStyleDialog from "./BoardStyleDialog";
+import EntityStillModelWarning from "./EntityStillModelWarning";
 import SceneHeader from "./SceneHeader";
 import ScriptLinkControl from "./ScriptLinkControl";
 import ShotCard from "./ShotCard";
@@ -539,16 +537,6 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
     [insertShot, boardId]
   );
 
-  // Entity reference images only reach generation through an editing model;
-  // warn when entities are attached but the still model can't take them.
-  const { models: imageModels } = useImageModelsByProvider();
-  const stillModelDetails = imageModel?.id
-    ? imageModels.find((m) => m.id === imageModel.id)
-    : undefined;
-  const entitiesNeedEditModel =
-    entityIds.length > 0 &&
-    !stillModelDetails?.supported_tasks?.includes("image_to_image");
-
   const runDirect = useCallback(() => {
     onDirect?.(shotCount);
   }, [onDirect, shotCount]);
@@ -869,11 +857,8 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
                           Choose a still model before rendering stills.
                         </Caption>
                       )}
-                      {entitiesNeedEditModel && (
-                        <Caption color="warning">
-                          Entities carry reference images, but this model only
-                          takes text. Pick an image-to-image model to use them.
-                        </Caption>
+                      {entityIds.length > 0 && (
+                        <EntityStillModelWarning modelId={imageModel?.id} />
                       )}
                     </FormField>
                     <FormField label="Clip model" sx={modelFieldSx}>

--- a/web/src/components/storyboard/__tests__/ShotCard.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotCard.test.tsx
@@ -43,13 +43,6 @@ jest.mock("../../../trpc/client", () => ({
   trpcClient: {}
 }));
 
-jest.mock("../../node/ImageRefPreview", () => ({
-  __esModule: true,
-  default: ({ placeholder }: { placeholder?: React.ReactNode }) => (
-    <div data-testid="image-preview">{placeholder}</div>
-  )
-}));
-
 // The card's cast chips read the entity library; the actions the card offers
 // are covered in ShotCardActions.test.tsx, so here it is simply empty.
 jest.mock("../../../serverState/useEntities", () => ({
@@ -73,6 +66,13 @@ jest.mock("../../../hooks/storyboard/useGenerateShot", () => ({
 
 import ShotCard from "../ShotCard";
 import { useStoryboardGenerationStore } from "../../../stores/storyboard/StoryboardGenerationStore";
+
+// The manual mock the card sees: reaching it by its own path would hand this
+// suite a second copy, whose state the card never reads.
+const { mockAssetWithoutThumbnail, resetMockAssetContentTypes } =
+  jest.requireMock(
+    "../../../hooks/useResolvedMediaUri"
+  ) as typeof import("../../../hooks/__mocks__/useResolvedMediaUri");
 
 const makeShot = (overrides: Partial<Shot> = {}): Shot => ({
   type: "shot",
@@ -315,6 +315,54 @@ describe("ShotCard selection", () => {
       "aria-pressed",
       "true"
     );
+  });
+});
+
+describe("ShotCard still", () => {
+  const keyframe = {
+    type: "image" as const,
+    uri: "asset://img-9",
+    asset_id: "img-9"
+  };
+
+  afterEach(() => resetMockAssetContentTypes());
+
+  // A board holds dozens of cards a few hundred pixels wide, and a generated
+  // still is 300 KB–1.2 MB. The card shows the server's 512px thumbnail; the
+  // original is what fullscreen and download reach for (pinned above).
+  it("shows the asset's thumbnail, not the stored still", () => {
+    renderCard(makeShot({ status: "keyframe_ready", keyframe }));
+
+    expect(screen.getByRole("img", { name: /Opening/ })).toHaveAttribute(
+      "src",
+      "https://assets.test/img-9_thumb.jpg"
+    );
+  });
+
+  it("falls back to the still when the asset has no thumbnail", () => {
+    mockAssetWithoutThumbnail("img-9");
+    renderCard(makeShot({ status: "keyframe_ready", keyframe }));
+
+    expect(screen.getByRole("img", { name: /Opening/ })).toHaveAttribute(
+      "src",
+      "https://assets.test/img-9"
+    );
+  });
+
+  it("leaves the cards below the fold to the browser", () => {
+    renderCard(makeShot({ status: "keyframe_ready", keyframe }));
+
+    expect(screen.getByRole("img", { name: /Opening/ })).toHaveAttribute(
+      "loading",
+      "lazy"
+    );
+  });
+
+  it("says so when the shot has no still", () => {
+    renderCard(makeShot());
+
+    expect(screen.getByText("No still yet")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/components/storyboard/__tests__/ShotCardActions.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotCardActions.test.tsx
@@ -20,11 +20,6 @@ jest.mock("../../assets/AssetViewer", () => ({
   default: () => <div data-testid="asset-viewer" />
 }));
 
-jest.mock("../../node/ImageRefPreview", () => ({
-  __esModule: true,
-  default: () => <div data-testid="image-preview" />
-}));
-
 jest.mock("../../../trpc/client", () => ({
   trpc: { scripts: { get: { useQuery: () => ({ data: undefined }) } } },
   trpcClient: {}

--- a/web/src/components/ui_primitives/ResponsiveImage.tsx
+++ b/web/src/components/ui_primitives/ResponsiveImage.tsx
@@ -12,6 +12,7 @@ import BrokenImageIcon from "@mui/icons-material/BrokenImage";
 import { MOTION } from "./tokens";
 import {
   useResolvedMediaUri,
+  useResolvedThumbnailUri,
   type MediaLocator
 } from "../../hooks/useResolvedMediaUri";
 import type { ResolvedMediaUrl } from "../../utils/resolveMediaUri";
@@ -28,8 +29,17 @@ export interface ResponsiveImageProps extends Omit<BoxProps, 'onError'> {
    * Mutually exclusive with `src`.
    */
   locator?: MediaLocator;
+  /**
+   * Render the asset's 512px thumbnail rather than the stored original. For
+   * anything shown at card size — a grid, a strip, a list row — this is the
+   * difference between 60KB and a multi-megabyte still. Falls back to the
+   * original when the asset has no thumbnail. Ignored with `src`.
+   */
+  preferThumbnail?: boolean;
   /** Alt text for accessibility */
   alt: string;
+  /** Native lazy loading; `"lazy"` skips images scrolled out of view. */
+  loading?: "eager" | "lazy";
   /** Aspect ratio (e.g., "16/9", "1/1", "4/3") */
   aspectRatio?: string;
   /** How the image fits within its container */
@@ -57,6 +67,7 @@ const ResolvedImage: React.FC<
   borderRadius = 0,
   showSkeleton = false,
   showErrorFallback = true,
+  loading: loadingAttr,
   onError,
   onLoad,
   sx,
@@ -126,6 +137,8 @@ const ResolvedImage: React.FC<
         component="img"
         src={src || undefined}
         alt={alt}
+        loading={loadingAttr}
+        decoding="async"
         onLoad={handleLoad}
         onError={handleError}
         sx={{
@@ -156,6 +169,15 @@ const LocatorImage: React.FC<
 
 LocatorImage.displayName = "LocatorImage";
 
+/** The same branch, resolving to the asset's thumbnail. */
+const ThumbnailImage: React.FC<
+  Omit<ResponsiveImageProps, "src"> & { locator: MediaLocator }
+> = ({ locator, ...rest }) => (
+  <ResolvedImage {...rest} src={useResolvedThumbnailUri(locator) ?? ""} />
+);
+
+ThumbnailImage.displayName = "ThumbnailImage";
+
 /**
  * ResponsiveImage - An image with loading and error states
  *
@@ -177,12 +199,17 @@ LocatorImage.displayName = "LocatorImage";
  */
 export const ResponsiveImage: React.FC<ResponsiveImageProps> = ({
   locator,
+  preferThumbnail,
   ...rest
-}) =>
-  locator === undefined ? (
-    <ResolvedImage {...rest} />
+}) => {
+  if (locator === undefined) {
+    return <ResolvedImage {...rest} />;
+  }
+  return preferThumbnail ? (
+    <ThumbnailImage {...rest} locator={locator} />
   ) : (
     <LocatorImage {...rest} locator={locator} />
   );
+};
 
 ResponsiveImage.displayName = "ResponsiveImage";

--- a/web/src/components/ui_primitives/STRATEGY.md
+++ b/web/src/components/ui_primitives/STRATEGY.md
@@ -111,6 +111,13 @@ Two shapes, and the compiler picks between them:
 <AudioPlayback locator={content.audio} label="Generated audio" />
 ```
 
+Media shown at card size — a grid, a strip, a list row — takes
+`preferThumbnail` (and, in a long list, `loading="lazy"`). The server derives a
+512px JPEG for every raster asset it stores, and the full URL behind a
+generated still is 300 KB–1.2 MB; a storyboard of twelve pulled all of it to
+fill cards a few hundred pixels wide. `useResolvedThumbnailUri` is the hook
+form, and both fall back to the original when an asset has no thumbnail.
+
 Rendering a raw `asset://` literal into a JSX `src`/`poster`/`href` is rejected
 by `design-tokens/no-unresolved-media-src` (fixture:
 `scripts/test-media-src-rule.mjs`). The surfaces that render stored media are

--- a/web/src/hooks/__mocks__/useResolvedMediaUri.ts
+++ b/web/src/hooks/__mocks__/useResolvedMediaUri.ts
@@ -28,6 +28,21 @@ export const mockAssetUrl = (assetId: string): ResolvedMediaUrl =>
   `https://assets.test/${assetId}` as ResolvedMediaUrl;
 
 /**
+ * The asset's thumbnail URL under test. Distinct from {@link mockAssetUrl} so a
+ * suite can tell which of the two a surface renders — a grid of stills is
+ * supposed to show this one.
+ */
+export const mockAssetThumbUrl = (assetId: string): ResolvedMediaUrl =>
+  `https://assets.test/${assetId}_thumb.jpg` as ResolvedMediaUrl;
+
+/** Asset ids a test wants to have no thumbnail, as an SVG or a video has none. */
+export const mockAssetsWithoutThumbnail = new Set<string>();
+
+export const mockAssetWithoutThumbnail = (assetId: string): void => {
+  mockAssetsWithoutThumbnail.add(assetId);
+};
+
+/**
  * Asset ids a test wants to resolve to nothing — the shape of an asset whose
  * row is gone or whose object cannot be signed.
  */
@@ -89,6 +104,7 @@ export const resetMockAssetContentTypes = (): void => {
   mockAssetContentTypes.clear();
   mockMissingAssets.clear();
   mockPendingAssets.clear();
+  mockAssetsWithoutThumbnail.clear();
 };
 
 const locatorUri = (source: MediaLocator): string | undefined =>
@@ -106,14 +122,24 @@ export const useResolvedMedia = (
   source: MediaLocator
 ): {
   url: ResolvedMediaUrl | undefined;
+  thumbUrl: ResolvedMediaUrl | undefined;
   contentType: string | undefined;
   pending: boolean;
 } => {
   const uri = locatorUri(source);
   const id = assetIdOf(source);
   const pending = isPendingAsset(source);
+  const url = pending ? undefined : resolve(source);
+  // Only an asset has a thumbnail: a data/http/package locator resolves
+  // statically and carries nothing but itself, as in the app.
+  const hasThumb =
+    url !== undefined &&
+    id !== undefined &&
+    !mockAssetsWithoutThumbnail.has(id) &&
+    (uri === undefined || uri.startsWith("asset://"));
   return {
-    url: pending ? undefined : resolve(source),
+    url,
+    thumbUrl: hasThumb ? mockAssetThumbUrl(id) : undefined,
     pending,
     contentType:
       (uri ? contentTypeByLocator.get(uri) : undefined) ??
@@ -124,6 +150,13 @@ export const useResolvedMedia = (
 export const useResolvedMediaUri = (
   source: MediaLocator
 ): ResolvedMediaUrl | undefined => useResolvedMedia(source).url;
+
+export const useResolvedThumbnailUri = (
+  source: MediaLocator
+): ResolvedMediaUrl | undefined => {
+  const { url, thumbUrl } = useResolvedMedia(source);
+  return thumbUrl ?? url;
+};
 
 export const useResolvedMediaUris = (
   sources: MediaLocator[]

--- a/web/src/hooks/__tests__/useResolvedMediaUri.test.tsx
+++ b/web/src/hooks/__tests__/useResolvedMediaUri.test.tsx
@@ -3,7 +3,8 @@ import { useQuery } from "@tanstack/react-query";
 
 import {
   useResolvedMedia,
-  useResolvedMediaUri
+  useResolvedMediaUri,
+  useResolvedThumbnailUri
 } from "../useResolvedMediaUri";
 
 const mockGetAsset = jest.fn();
@@ -24,10 +25,14 @@ jest.mock("@tanstack/react-query", () => ({
 const mockUseQuery = useQuery as jest.MockedFunction<typeof useQuery>;
 
 /** The asset record the lookup resolves to, when it resolves. */
-const withAsset = (getUrl: string | undefined, contentType?: string) => {
+const withAsset = (
+  getUrl: string | undefined,
+  contentType?: string,
+  thumbUrl?: string
+) => {
   mockUseQuery.mockReturnValue({
     data: getUrl
-      ? { get_url: getUrl, content_type: contentType }
+      ? { get_url: getUrl, content_type: contentType, thumb_url: thumbUrl }
       : undefined
   } as any);
 };
@@ -130,5 +135,56 @@ describe("useResolvedMedia", () => {
       url: "https://cdn.example.com/signed/user-1/abc123.mp4?sig=x",
       contentType: "video/mp4"
     });
+  });
+
+  it("returns the asset's thumbnail alongside the full URL", () => {
+    withAsset(
+      "https://cdn.example.com/signed/user-1/abc123.png?sig=x",
+      "image/png",
+      "https://cdn.example.com/signed/user-1/abc123_thumb.jpg?sig=y"
+    );
+    const { result } = renderHook(() => useResolvedMedia("asset://abc123"));
+    expect(result.current.thumbUrl).toBe(
+      "https://cdn.example.com/signed/user-1/abc123_thumb.jpg?sig=y"
+    );
+  });
+
+  it("has no thumbnail for a locator that needs no lookup", () => {
+    const { result } = renderHook(() =>
+      useResolvedMedia("https://cdn.example.com/photo.png")
+    );
+    expect(result.current.thumbUrl).toBeUndefined();
+  });
+});
+
+describe("useResolvedThumbnailUri", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    withAsset(undefined);
+  });
+
+  it("resolves to the thumbnail, not the stored original", () => {
+    withAsset(
+      "https://cdn.example.com/signed/user-1/abc123.png?sig=x",
+      "image/png",
+      "https://cdn.example.com/signed/user-1/abc123_thumb.jpg?sig=y"
+    );
+    const { result } = renderHook(() =>
+      useResolvedThumbnailUri("asset://abc123")
+    );
+    expect(result.current).toBe(
+      "https://cdn.example.com/signed/user-1/abc123_thumb.jpg?sig=y"
+    );
+  });
+
+  // An asset whose thumbnail was never generated still has to render.
+  it("falls back to the full URL when the asset has no thumbnail", () => {
+    withAsset("https://cdn.example.com/signed/user-1/abc123.svg?sig=x");
+    const { result } = renderHook(() =>
+      useResolvedThumbnailUri("asset://abc123")
+    );
+    expect(result.current).toBe(
+      "https://cdn.example.com/signed/user-1/abc123.svg?sig=x"
+    );
   });
 });

--- a/web/src/hooks/useResolvedMediaUri.ts
+++ b/web/src/hooks/useResolvedMediaUri.ts
@@ -27,6 +27,17 @@ import {
 import type { ResolvedMediaUrl } from "../utils/resolveMediaUri";
 import { isString } from "../utils/typePredicates";
 
+/**
+ * How long a resolved asset record stays fresh.
+ *
+ * An asset row is immutable once written — the bytes never change under an id,
+ * and the signed URL the server mints outlives this many times over
+ * (`SIGNED_URL_TTL`, a week). Without a stale time every re-mount of every
+ * media element re-asks the server for rows it already holds: reopening a
+ * twelve-shot storyboard alone refetched twenty-four of them.
+ */
+const ASSET_STALE_TIME = 5 * 60 * 1000;
+
 /** Anything carrying a media locator: a bare URI or a `*Ref` with `asset_id`. */
 export type MediaLocator =
   | string
@@ -61,6 +72,14 @@ const locatorParts = (
  */
 export type ResolvedMedia = {
   url: ResolvedMediaUrl | undefined;
+  /**
+   * The 512px JPEG the server derived for this asset when it stored it, or
+   * `undefined` for a locator that has no asset row behind it (a `data:` URI,
+   * an `http` URL, a `package://` path). A grid of stills wants this: the
+   * source of a generated keyframe is a 300 KB–1.2 MB still and the card that
+   * shows it is a few hundred pixels wide.
+   */
+  thumbUrl: ResolvedMediaUrl | undefined;
   contentType: string | undefined;
   /**
    * True while the asset lookup is still in flight. A caller that renders
@@ -91,18 +110,21 @@ export function useResolvedMedia(source: MediaLocator): ResolvedMedia {
   } = useQuery({
     queryKey: ["asset", assetId],
     queryFn: () => getAsset(assetId as string),
-    enabled: needsAsset
+    enabled: needsAsset,
+    staleTime: ASSET_STALE_TIME
   });
 
   if (staticUrl !== null) {
     return {
       url: asResolvedMediaUrl(staticUrl) ?? undefined,
+      thumbUrl: undefined,
       contentType: undefined,
       pending: false
     };
   }
   return {
     url: asResolvedMediaUrl(asset?.get_url) ?? undefined,
+    thumbUrl: asResolvedMediaUrl(asset?.thumb_url) ?? undefined,
     contentType: asset?.content_type ?? undefined,
     // A disabled query reports `pending` forever, so gate on the id path.
     pending: needsAsset && isPending && !isError
@@ -113,6 +135,19 @@ export function useResolvedMediaUri(
   source: MediaLocator
 ): ResolvedMediaUrl | undefined {
   return useResolvedMedia(source).url;
+}
+
+/**
+ * The thumbnail form: the server's 512px JPEG when the asset has one, the full
+ * media URL when it does not (a `data:`/`http` locator, or an asset whose
+ * thumbnail was never generated). Use it wherever media is shown at card size —
+ * a grid of storyboard stills pulled megabytes per card through the full URL.
+ */
+export function useResolvedThumbnailUri(
+  source: MediaLocator
+): ResolvedMediaUrl | undefined {
+  const { url, thumbUrl } = useResolvedMedia(source);
+  return thumbUrl ?? url;
 }
 
 /**
@@ -132,7 +167,8 @@ export function useResolvedMediaUris(
     queries: parts.map(({ assetId }, i) => ({
       queryKey: ["asset", assetId],
       queryFn: () => getAsset(assetId as string),
-      enabled: staticUrls[i] === null && Boolean(assetId)
+      enabled: staticUrls[i] === null && Boolean(assetId),
+      staleTime: ASSET_STALE_TIME
     }))
   });
 


### PR DESCRIPTION
## What changed

Opening a storyboard downloaded every shot's full-resolution still to fill a card a few hundred pixels wide, and listing boards read every board's whole `document` out of the database to print a shot count. The board grid now renders the 512px thumbnail the server already derives for every raster asset (`preferThumbnail` on `ResponsiveImage`, lazily below the fold) while download and the fullscreen viewer keep reaching for the original off the same asset lookup; `storyboards.list` counts shots with `json_array_length` instead of selecting and parsing documents; asset records get a 5-minute `staleTime`, since a row is immutable and its signed URL lasts a week, so reopening a board no longer refetches two dozen rows it already holds; and the still-model warning moved into its own component so opening a board no longer fans out a model-list request per image provider for a warning sitting behind collapsed settings.

Measured, on this machine:

| | before | after |
|---|---|---|
| `storyboards.list`, 50 boards × 40 shots (6.2 MB of documents) | 40.2 ms | 9.1 ms |
| `storyboards.list`, 20 boards × 12 shots (0.7 MB) | 5.0 ms | 1.3 ms |
| one still over the wire (1024×576 – 1920×1080, through the repo's own thumbnail pipeline) | 331 KB – 1.2 MB | 59 – 66 KB |

## Verification

- [x] `npm run test:affected` — green except `@nodetool-ai/base-nodes`, which fails on this container with `No WebGPU adapter available (Node/Dawn)`; it fails identically on a clean tree (verified with `git stash`) and AGENTS.md documents it as a missing Vulkan driver, not a broken test. Because turbo stopped there, the web and electron suites were run directly instead: `cd web && npx jest` → 1451 suites, 15966 tests passed; `npx turbo run test --filter=@nodetool-ai/websocket --filter=@nodetool-ai/models --filter=@nodetool-ai/agents` → 58/58 tasks, all green.
- [x] `npm run typecheck` — web clean (`npx tsc --noEmit -p web/tsconfig.json`, exit 0). Mobile reports pre-existing `Cannot find module 'react-native'` / `expo/tsconfig.base` errors: `mobile/` is deliberately not a root workspace and its dependency tree is not installed in this container.
- [x] `npm run lint` — exit 0.
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — `Gate: 4/4 selfchecks passed`.

Both new assertions were inverted once and observed failing:

- The shot count: pointing the SQLite path at `'$.nope'` instead of `'$.shots'` →
  `× counts the shots in the stored document` / `Tests 1 failed | 6 passed (7)`.
- "never loads a board's document": restoring the old `listByUser(...).map(b => b.toDocument().shots.length)` body in the router →
  `× filters by project`, `× never loads a board's document` / `Tests 2 failed | 2 passed (4)`.

## Agent capabilities

No capability added or re-declared. `list_storyboards` still reads full documents — it reports per-shot keyframe and clip counts, which no column carries.

## New checks

No new rule or audit; the two inverted assertions above are tests, and their failing output is in **Verification**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZyhsqskzkMii9unueA7Fv

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZyhsqskzkMii9unueA7Fv)_