### PR TITLE
feat: scope resource browsing to active project

### DIFF
--- a/packages/models/src/asset.ts
+++ b/packages/models/src/asset.ts
@@ -305,9 +305,14 @@ export class Asset extends DBModel {
   static async getChildren(
     userId: string,
     parentId: string,
-    limit = 100
+    limit = 100,
+    projectId?: string
   ): Promise<Asset[]> {
-    const [assetList] = await Asset.paginate(userId, { parentId, limit });
+    const [assetList] = await Asset.paginate(userId, {
+      parentId,
+      projectId,
+      limit
+    });
     return assetList;
   }
 
@@ -320,11 +325,12 @@ export class Asset extends DBModel {
     query: string,
     opts: {
       contentType?: string;
+      projectId?: string;
       limit?: number;
       cursor?: string;
     } = {}
   ): Promise<[Asset[], string, Array<Record<string, string>>]> {
-    const { contentType, limit = 100, cursor: startKey } = opts;
+    const { contentType, projectId, limit = 100, cursor: startKey } = opts;
     // Escape LIKE special characters to prevent pattern injection
     const sanitized = query.trim().replace(/[%_\\]/g, "\\$&");
     const db = getDb();
@@ -336,6 +342,9 @@ export class Asset extends DBModel {
     if (contentType) {
       const sanitizedType = contentType.replace(/[%_\\]/g, "\\$&");
       conditions.push(like(assets.content_type, `${sanitizedType}%`));
+    }
+    if (projectId) {
+      conditions.push(eq(assets.project_id, projectId));
     }
     if (startKey) {
       const cursorAsset = await Asset.get<Asset>(startKey);
@@ -467,10 +476,13 @@ export class Asset extends DBModel {
    */
   static async getAssetsRecursive(
     userId: string,
-    folderId: string
+    folderId: string,
+    projectId?: string
   ): Promise<{ assets: Record<string, unknown>[] }> {
     const folder = await Asset.find(userId, folderId);
-    if (!folder) return { assets: [] };
+    if (!folder || (projectId !== undefined && folder.project_id !== projectId)) {
+      return { assets: [] };
+    }
 
     // Guards against cyclic parent links: without it the descent never
     // terminates, and since better-sqlite3 is synchronous it starves the
@@ -484,6 +496,7 @@ export class Asset extends DBModel {
       visited.add(currentFolderId);
       const [assetList] = await Asset.paginate(userId, {
         parentId: currentFolderId,
+        projectId,
         limit: 10000
       });
       const result: Record<string, unknown>[] = [];

--- a/packages/models/tests/asset-find.test.ts
+++ b/packages/models/tests/asset-find.test.ts
@@ -86,6 +86,26 @@ describe("Asset.paginate – additional filters", () => {
     expect(results[0].name).toBe("a.txt");
   });
 
+  it("filters identical asset names by project", async () => {
+    const projectA = await Asset.create<Asset>({
+      user_id: "u1",
+      name: "same-name.png",
+      content_type: "image/png",
+      project_id: "project-a"
+    });
+    await Asset.create<Asset>({
+      user_id: "u1",
+      name: "same-name.png",
+      content_type: "image/png",
+      project_id: "project-b"
+    });
+
+    const [results] = await Asset.paginate("u1", {
+      projectId: "project-a"
+    });
+    expect(results.map((asset) => asset.id)).toEqual([projectA.id]);
+  });
+
   it("filters by nodeId", async () => {
     await Asset.create<Asset>({
       user_id: "u1",
@@ -233,6 +253,26 @@ describe("Asset.searchAssetsGlobal", () => {
       contentType: "image"
     });
     expect(results).toHaveLength(2);
+  });
+
+  it("filters identical search matches by project", async () => {
+    const projectA = await Asset.create<Asset>({
+      user_id: "u1",
+      name: "same-name.png",
+      content_type: "image/png",
+      project_id: "project-a"
+    });
+    await Asset.create<Asset>({
+      user_id: "u1",
+      name: "same-name.png",
+      content_type: "image/png",
+      project_id: "project-b"
+    });
+
+    const [results] = await Asset.searchAssetsGlobal("u1", "same-name", {
+      projectId: "project-a"
+    });
+    expect(results.map((asset) => asset.id)).toEqual([projectA.id]);
   });
 
   it("returns empty for no matches", async () => {

--- a/packages/protocol/src/api-schemas/assets.ts
+++ b/packages/protocol/src/api-schemas/assets.ts
@@ -31,6 +31,8 @@ export type AssetResponse = z.infer<typeof assetResponse>;
 // home folder if none are specified.
 export const listInput = z.object({
   parent_id: z.string().optional(),
+  /** Restrict browsing to one project; omitted keeps the explicit global view. */
+  project_id: z.string().optional(),
   content_type: z.string().optional(),
   workflow_id: z.string().optional(),
   node_id: z.string().optional(),
@@ -48,7 +50,9 @@ export type ListOutput = z.infer<typeof listOutput>;
 
 // ── get (GET /api/assets/:id) ────────────────────────────────────
 export const getInput = z.object({
-  id: z.string().min(1)
+  id: z.string().min(1),
+  /** Restrict a folder lookup to one project when it is used for navigation. */
+  project_id: z.string().optional()
 });
 export type GetInput = z.infer<typeof getInput>;
 
@@ -176,7 +180,9 @@ export type ChildrenOutput = z.infer<typeof childrenOutput>;
 // ── recursive (GET /api/assets/:id/recursive) ────────────────────
 // Flat list of every asset under the folder, including nested sub-folders.
 export const recursiveInput = z.object({
-  id: z.string().min(1)
+  id: z.string().min(1),
+  /** Restrict the recursive folder walk to one project. */
+  project_id: z.string().optional()
 });
 export type RecursiveInput = z.infer<typeof recursiveInput>;
 
@@ -190,6 +196,8 @@ export type RecursiveOutput = z.infer<typeof recursiveOutput>;
 // the `@`-mention typeahead show a list of assets before the user narrows it.
 export const searchInput = z.object({
   query: z.string(),
+  /** Restrict search results to one project; omitted is the explicit global search. */
+  project_id: z.string().optional(),
   content_type: z.string().optional(),
   page_size: z.number().int().min(1).max(10000).default(200),
   cursor: z.string().optional(),

--- a/packages/protocol/src/api-schemas/projects.ts
+++ b/packages/protocol/src/api-schemas/projects.ts
@@ -213,6 +213,8 @@ export const projectEntitySummary = z.object({
     .array(z.object({ name: z.string().optional(), hex: z.string() }))
     .nullable()
     .optional(),
+  /** Reference image when the entity marker points at a separate asset. */
+  reference_asset_id: z.string().optional(),
   updatedAt: z.string()
 });
 export type ProjectEntitySummary = z.infer<typeof projectEntitySummary>;

--- a/packages/protocol/tests/api-schemas-assets.test.ts
+++ b/packages/protocol/tests/api-schemas-assets.test.ts
@@ -30,4 +30,10 @@ describe("assets.searchInput", () => {
     const result = searchInput.parse({ query: "cat" });
     expect(result.page_size).toBe(200);
   });
+
+  it("accepts a project scope for searches", () => {
+    expect(
+      searchInput.parse({ query: "same", project_id: "project-a" }).project_id
+    ).toBe("project-a");
+  });
 });

--- a/packages/websocket/src/trpc/routers/assets.ts
+++ b/packages/websocket/src/trpc/routers/assets.ts
@@ -206,7 +206,8 @@ export const assetsRouter = router({
         !input.workflow_id &&
         !input.node_id &&
         !input.job_id &&
-        !input.timeline_id
+        !input.timeline_id &&
+        input.project_id === undefined
           ? ctx.userId
           : input.parent_id;
 

--- a/packages/websocket/src/trpc/routers/assets.ts
+++ b/packages/websocket/src/trpc/routers/assets.ts
@@ -210,18 +210,22 @@ export const assetsRouter = router({
           ? ctx.userId
           : input.parent_id;
 
-      const [assets, cursor] = await Asset.paginate(ctx.userId, {
+      const paginateOptions: Parameters<typeof Asset.paginate>[1] = {
         parentId: effectiveParentId,
-        ...(input.project_id !== undefined
-          ? { projectId: input.project_id }
-          : {}),
         contentType: input.content_type,
         workflowId: input.workflow_id,
         nodeId: input.node_id,
         jobId: input.job_id,
         timelineId: input.timeline_id,
         limit: input.page_size
-      });
+      };
+      if (input.project_id !== undefined) {
+        paginateOptions.projectId = input.project_id;
+      }
+      const [assets, cursor] = await Asset.paginate(
+        ctx.userId,
+        paginateOptions
+      );
       return {
         assets: await Promise.all(assets.map((a) => toAssetResponse(a))),
         next: cursor || null

--- a/packages/websocket/src/trpc/routers/assets.ts
+++ b/packages/websocket/src/trpc/routers/assets.ts
@@ -134,17 +134,28 @@ async function deleteFolderRecursive(
 async function getAllAssetsRecursive(
   userId: string,
   folderId: string,
+  projectId?: string,
   visited: Set<string> = new Set()
 ): Promise<AssetModel[]> {
   if (visited.has(folderId)) return [];
   visited.add(folderId);
 
+  if (projectId !== undefined) {
+    const folder = await Asset.find(userId, folderId);
+    if (!folder || folder.project_id !== projectId) return [];
+  }
+
   const collected: AssetModel[] = [];
-  const children = await Asset.getChildren(userId, folderId, 10000);
+  const children = await Asset.getChildren(userId, folderId, 10000, projectId);
   for (const child of children) {
     collected.push(child);
     if (child.content_type === "folder") {
-      const subAssets = await getAllAssetsRecursive(userId, child.id, visited);
+      const subAssets = await getAllAssetsRecursive(
+        userId,
+        child.id,
+        projectId,
+        visited
+      );
       collected.push(...subAssets);
     }
   }
@@ -201,6 +212,9 @@ export const assetsRouter = router({
 
       const [assets, cursor] = await Asset.paginate(ctx.userId, {
         parentId: effectiveParentId,
+        ...(input.project_id !== undefined
+          ? { projectId: input.project_id }
+          : {}),
         contentType: input.content_type,
         workflowId: input.workflow_id,
         nodeId: input.node_id,
@@ -242,6 +256,12 @@ export const assetsRouter = router({
 
       const asset = await Asset.find(ctx.userId, input.id);
       if (!asset) {
+        throwApiError(ApiErrorCode.NOT_FOUND, "Asset not found");
+      }
+      if (
+        input.project_id !== undefined &&
+        asset.project_id !== input.project_id
+      ) {
         throwApiError(ApiErrorCode.NOT_FOUND, "Asset not found");
       }
       return toAssetResponse(asset);
@@ -480,7 +500,11 @@ export const assetsRouter = router({
     .input(recursiveInput)
     .output(recursiveOutput)
     .query(async ({ ctx, input }) => {
-      const assets = await getAllAssetsRecursive(ctx.userId, input.id);
+      const assets = await getAllAssetsRecursive(
+        ctx.userId,
+        input.id,
+        input.project_id
+      );
       return {
         assets: await Promise.all(assets.map((a) => toAssetResponse(a)))
       };
@@ -499,6 +523,9 @@ export const assetsRouter = router({
       };
       if (input.content_type) {
         searchOptions.contentType = input.content_type;
+      }
+      if (input.project_id !== undefined) {
+        searchOptions.projectId = input.project_id;
       }
       if (input.cursor) {
         searchOptions.cursor = input.cursor;

--- a/packages/websocket/tests/trpc-assets.test.ts
+++ b/packages/websocket/tests/trpc-assets.test.ts
@@ -66,6 +66,7 @@ function makeAsset(opts: {
   workflow_id?: string | null;
   node_id?: string | null;
   job_id?: string | null;
+  project_id?: string;
   created_at?: string;
   updated_at?: string;
   duration?: number | null;
@@ -81,6 +82,7 @@ function makeAsset(opts: {
     workflow_id: opts.workflow_id ?? null,
     node_id: opts.node_id ?? null,
     job_id: opts.job_id ?? null,
+    project_id: opts.project_id,
     created_at: opts.created_at ?? "2026-04-17T00:00:00Z",
     updated_at: opts.updated_at ?? "2026-04-17T00:00:00Z",
     duration: opts.duration ?? null,
@@ -132,6 +134,24 @@ describe("assets router", () => {
         workflowId: undefined,
         nodeId: undefined,
         jobId: undefined,
+        limit: 10000
+      });
+    });
+
+    it("forwards project scope to asset pagination", async () => {
+      (Asset.paginate as ReturnType<typeof vi.fn>).mockResolvedValue([[], ""]);
+
+      const caller = createCaller(makeCtx());
+      await caller.assets.list({ project_id: "project-a" });
+
+      expect(Asset.paginate).toHaveBeenCalledWith("user-1", {
+        parentId: undefined,
+        projectId: "project-a",
+        contentType: undefined,
+        workflowId: undefined,
+        nodeId: undefined,
+        jobId: undefined,
+        timelineId: undefined,
         limit: 10000
       });
     });
@@ -377,6 +397,32 @@ describe("assets router", () => {
       const result = await caller.assets.recursive({ id: "root" });
       expect(result.assets.map((a) => a.id)).toEqual(["c1", "f1", "gc"]);
     });
+
+    it("walks only descendants from the requested project", async () => {
+      const childA = makeAsset({ id: "a", project_id: "project-a" });
+      const childB = makeAsset({ id: "b", project_id: "project-b" });
+      (Asset.find as ReturnType<typeof vi.fn>).mockResolvedValue(
+        makeAsset({ id: "root", content_type: "folder", project_id: "project-a" })
+      );
+      (Asset.getChildren as ReturnType<typeof vi.fn>).mockImplementation(
+        (_userId: string, _folderId: string, _limit: number, projectId?: string) =>
+          Promise.resolve(projectId === "project-a" ? [childA] : [childB])
+      );
+
+      const caller = createCaller(makeCtx());
+      const result = await caller.assets.recursive({
+        id: "root",
+        project_id: "project-a"
+      });
+
+      expect(result.assets.map((a) => a.id)).toEqual(["a"]);
+      expect(Asset.getChildren).toHaveBeenCalledWith(
+        "user-1",
+        "root",
+        10000,
+        "project-a"
+      );
+    });
   });
 
   // ── search ──────────────────────────────────────────────────────
@@ -416,6 +462,20 @@ describe("assets router", () => {
       expect(Asset.searchAssetsGlobal).toHaveBeenCalledWith("user-1", "cat", {
         contentType: "image",
         limit: 24
+      });
+    });
+
+    it("forwards project scope to asset search", async () => {
+      (
+        Asset.searchAssetsGlobal as ReturnType<typeof vi.fn>
+      ).mockResolvedValue([[], "", []]);
+
+      const caller = createCaller(makeCtx());
+      await caller.assets.search({ query: "same", project_id: "project-a" });
+
+      expect(Asset.searchAssetsGlobal).toHaveBeenCalledWith("user-1", "same", {
+        projectId: "project-a",
+        limit: 200
       });
     });
 

--- a/web/src/components/assets/AssetTree.tsx
+++ b/web/src/components/assets/AssetTree.tsx
@@ -20,6 +20,10 @@ import { Asset } from "../../stores/ApiTypes";
 import { IconForType } from "../../config/IconForType";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
+import {
+  LOOSE_PROJECT_ID,
+  useWorkspaceTabsStore
+} from "../../stores/WorkspaceTabsStore";
 
 const styles = (_theme: Theme) =>
   css({
@@ -47,6 +51,8 @@ const AssetTree: React.FC<AssetTreeProps> = ({
   const [isLoading, setIsLoading] = useState(true);
   const [closedFolders, setClosedFolders] = useState<string[]>([]);
   const getAssetsRecursive = useAssetStore((state) => state.getAssetsRecursive);
+  const projectId =
+    useWorkspaceTabsStore((state) => state.activeProjectId) ?? LOOSE_PROJECT_ID;
 
   const folderIcon = useMemo(() => <IconForType iconName="folder" />, []);
   const imageIcon = useMemo(() => <IconForType iconName="image" />, []);
@@ -105,7 +111,7 @@ const AssetTree: React.FC<AssetTreeProps> = ({
       setIsLoading(true);
       onLoading(true);
       try {
-        const result = await getAssetsRecursive(folderId);
+        const result = await getAssetsRecursive(folderId, projectId);
         const treeWithTotals = processAssetTree(result);
         setAssetTree(treeWithTotals);
         const total = treeWithTotals.reduce(
@@ -129,7 +135,8 @@ const AssetTree: React.FC<AssetTreeProps> = ({
     getAssetsRecursive,
     processAssetTree,
     onTotalAssetsCalculated,
-    onLoading
+    onLoading,
+    projectId
   ]);
 
   const handleToggleFolder = useCallback((assetId: string) => {

--- a/web/src/components/entities/EntityAssetPickerDialog.tsx
+++ b/web/src/components/entities/EntityAssetPickerDialog.tsx
@@ -20,11 +20,17 @@ import {
 import type { Asset } from "../../stores/ApiTypes";
 import { trpcClient } from "../../trpc/client";
 import ImageRefPreview from "../node/ImageRefPreview";
+import {
+  LOOSE_PROJECT_ID,
+  useWorkspaceTabsStore
+} from "../../stores/WorkspaceTabsStore";
 
 interface EntityAssetPickerDialogProps {
   readonly open: boolean;
   readonly onClose: () => void;
   readonly onPick: (assetId: string) => void;
+  /** Project whose image assets may back the entity. Defaults to the active project. */
+  readonly projectId?: string;
   /** Dialog heading. Defaults to the "tag a new entity" wording. */
   readonly title?: string;
   /** When given, only these asset ids are offered — e.g. entities already tagged. */
@@ -42,6 +48,7 @@ const EntityAssetPickerDialogInternal: React.FC<
   open,
   onClose,
   onPick,
+  projectId,
   title = "Pick a reference image",
   assetIds,
   excludedAssetIds,
@@ -49,14 +56,18 @@ const EntityAssetPickerDialogInternal: React.FC<
   emptyDescription = "Generate or upload an image first."
 }) => {
   const theme = useTheme();
+  const activeProjectId =
+    useWorkspaceTabsStore((state) => state.activeProjectId) ?? LOOSE_PROJECT_ID;
+  const scopedProjectId = projectId ?? activeProjectId;
   const allowed = assetIds ? new Set(assetIds) : null;
   const excluded = excludedAssetIds ? new Set(excludedAssetIds) : null;
   const { data, isLoading } = useQuery({
-    queryKey: ["entity-asset-picker"],
+    queryKey: ["entity-asset-picker", scopedProjectId],
     queryFn: async (): Promise<Asset[]> => {
       const result = await trpcClient.assets.search.query({
         query: "",
-        page_size: 500
+        page_size: 500,
+        project_id: scopedProjectId
       });
       return (result.assets as Asset[]).filter((a) =>
         (a.content_type ?? "").startsWith("image/")

--- a/web/src/components/entities/EntityEditorDialog.tsx
+++ b/web/src/components/entities/EntityEditorDialog.tsx
@@ -219,6 +219,7 @@ const EntityEditorDialogInternal: React.FC<EntityEditorDialogProps> = ({
         open={pickerOpen}
         onClose={() => setPickerOpen(false)}
         onPick={handlePickImage}
+        projectId={projectId}
       />
     </Dialog>
   );

--- a/web/src/components/entities/EntityLibrary.tsx
+++ b/web/src/components/entities/EntityLibrary.tsx
@@ -26,8 +26,14 @@ import {
 import EntityCard from "./EntityCard";
 import EntityEditorDialog from "./EntityEditorDialog";
 import EntitySetupHost from "../setup/entity/EntitySetupHost";
+import {
+  LOOSE_PROJECT_ID,
+  useWorkspaceTabsStore
+} from "../../stores/WorkspaceTabsStore";
 
 const EntityLibraryInternal: React.FC = () => {
+  const projectId =
+    useWorkspaceTabsStore((state) => state.activeProjectId) ?? LOOSE_PROJECT_ID;
   const { data: entities, isLoading } = useEntities();
   const deleteEntity = useDeleteEntity();
 
@@ -126,6 +132,7 @@ const EntityLibraryInternal: React.FC = () => {
           onClose={() => setEditorOpen(false)}
           assetId={editorAssetId}
           entity={editingEntity}
+          projectId={projectId}
         />
       )}
     </FlexColumn>

--- a/web/src/components/entities/EntityListPanel.tsx
+++ b/web/src/components/entities/EntityListPanel.tsx
@@ -24,9 +24,15 @@ import {
 import EntityAssetPickerDialog from "./EntityAssetPickerDialog";
 import EntityCard from "./EntityCard";
 import EntityEditorDialog from "./EntityEditorDialog";
+import {
+  LOOSE_PROJECT_ID,
+  useWorkspaceTabsStore
+} from "../../stores/WorkspaceTabsStore";
 
 /** Picks an image asset, then opens the editor to describe it. */
 export const CreateEntityButton = memo(function CreateEntityButton() {
+  const projectId =
+    useWorkspaceTabsStore((state) => state.activeProjectId) ?? LOOSE_PROJECT_ID;
   const [pickerOpen, setPickerOpen] = useState(false);
   const [assetId, setAssetId] = useState<string | null>(null);
 
@@ -49,12 +55,14 @@ export const CreateEntityButton = memo(function CreateEntityButton() {
         open={pickerOpen}
         onClose={() => setPickerOpen(false)}
         onPick={handlePick}
+        projectId={projectId}
       />
       {assetId && (
         <EntityEditorDialog
           open
           onClose={() => setAssetId(null)}
           assetId={assetId}
+          projectId={projectId}
         />
       )}
     </>
@@ -62,6 +70,8 @@ export const CreateEntityButton = memo(function CreateEntityButton() {
 });
 
 const EntityListPanelInternal: React.FC = () => {
+  const projectId =
+    useWorkspaceTabsStore((state) => state.activeProjectId) ?? LOOSE_PROJECT_ID;
   const { data: entities, isLoading } = useEntities();
   const deleteEntity = useDeleteEntity();
   const [editing, setEditing] = useState<Entity | null>(null);
@@ -116,6 +126,7 @@ const EntityListPanelInternal: React.FC = () => {
           onClose={() => setEditing(null)}
           assetId={editing.id}
           entity={editing}
+          projectId={projectId}
         />
       )}
     </>

--- a/web/src/components/node_types/editing/promptComposer/useAssetMentionSearch.ts
+++ b/web/src/components/node_types/editing/promptComposer/useAssetMentionSearch.ts
@@ -5,6 +5,10 @@ import { useAssetStore } from "../../../../stores/AssetStore";
 import { useRecentAssetsStore } from "../../../../stores/RecentAssetsStore";
 import { useEntities } from "../../../../serverState/useEntities";
 import type { Asset } from "../../../../stores/ApiTypes";
+import {
+  LOOSE_PROJECT_ID,
+  useWorkspaceTabsStore
+} from "../../../../stores/WorkspaceTabsStore";
 
 export type MentionTab = "recent" | "saved";
 
@@ -77,6 +81,8 @@ export const useAssetMentionSearch = (
   const search = useAssetStore((state) => state.search);
   const updateAsset = useAssetStore((state) => state.update);
   const { data: allEntities } = useEntities();
+  const activeProjectId =
+    useWorkspaceTabsStore((state) => state.activeProjectId) ?? LOOSE_PROJECT_ID;
   const recentAssets = useRecentAssetsStore((state) => state.recentAssets);
   const renameRecentAsset = useRecentAssetsStore(
     (state) => state.renameRecentAsset
@@ -107,7 +113,11 @@ export const useAssetMentionSearch = (
     }
     let active = true;
     const handle = setTimeout(() => {
-      search({ query: queryString, page_size: PAGE_SIZE })
+      search({
+        query: queryString,
+        page_size: PAGE_SIZE,
+        project_id: activeProjectId
+      })
         .then((result) => {
           if (active && queryTokenRef.current === token) {
             // Folders aren't attachable — the mention picker is for files only.
@@ -128,7 +138,7 @@ export const useAssetMentionSearch = (
       active = false;
       clearTimeout(handle);
     };
-  }, [queryString, search]);
+  }, [queryString, search, activeProjectId]);
 
   const loadMoreSaved = useCallback(() => {
     if (!savedCursor || queryString === null || loadingMoreRef.current) {
@@ -137,7 +147,12 @@ export const useAssetMentionSearch = (
     const cursor = savedCursor;
     const token = queryTokenRef.current;
     loadingMoreRef.current = true;
-    search({ query: queryString, page_size: PAGE_SIZE, cursor })
+    search({
+      query: queryString,
+      page_size: PAGE_SIZE,
+      cursor,
+      project_id: activeProjectId
+    })
       .then((result) => {
         if (queryTokenRef.current !== token) {
           return;
@@ -158,17 +173,25 @@ export const useAssetMentionSearch = (
           loadingMoreRef.current = false;
         }
       });
-  }, [savedCursor, queryString, search]);
+  }, [savedCursor, queryString, search, activeProjectId]);
+
+  const scopedRecentAssets = useMemo(
+    () =>
+      recentAssets.filter(
+        (asset) => (asset.project_id ?? LOOSE_PROJECT_ID) === activeProjectId
+      ),
+    [recentAssets, activeProjectId]
+  );
 
   const filteredRecent = useMemo(() => {
     const q = (queryString ?? "").trim().toLowerCase();
     if (!q) {
-      return recentAssets;
+      return scopedRecentAssets;
     }
-    return recentAssets.filter((a) =>
+    return scopedRecentAssets.filter((a) =>
       (a.name || a.id).toLowerCase().includes(q)
     );
-  }, [recentAssets, queryString]);
+  }, [scopedRecentAssets, queryString]);
 
   const displayedAssets = activeTab === "recent" ? filteredRecent : savedAssets;
 

--- a/web/src/components/projects/ProjectEntitiesSection.tsx
+++ b/web/src/components/projects/ProjectEntitiesSection.tsx
@@ -47,7 +47,11 @@ const toEntity = (row: ProjectEntitySummary): Entity => ({
   lora: row.lora ?? null,
   palette: row.palette ?? null,
   reference_images: [
-    { type: "image", asset_id: row.id, uri: `asset://${row.id}` }
+    {
+      type: "image",
+      asset_id: row.reference_asset_id ?? row.id,
+      uri: `asset://${row.reference_asset_id ?? row.id}`
+    }
   ],
   updated_at: row.updatedAt
 });
@@ -119,6 +123,7 @@ const ProjectEntitiesSectionInternal = ({
         open={pickerOpen}
         onClose={() => setPickerOpen(false)}
         onPick={handlePick}
+        projectId={projectId}
       />
 
       {editorAssetId && (

--- a/web/src/components/properties/FolderProperty.tsx
+++ b/web/src/components/properties/FolderProperty.tsx
@@ -20,6 +20,10 @@ import dialogStyles from "../../styles/DialogStyles";
 import isEqual from "../../utils/isEqual";
 import Select from "../inputs/Select";
 import { FlexRow, DialogActionButtons } from "../ui_primitives";
+import {
+  LOOSE_PROJECT_ID,
+  useWorkspaceTabsStore
+} from "../../stores/WorkspaceTabsStore";
 
 interface FolderValue {
   type: "folder";
@@ -30,15 +34,18 @@ const FolderProperty = (props: PropertyProps<FolderValue | null>) => {
   const id = `folder-${props.property.name}-${props.propertyIndex}`;
   const load = useAssetStore((state) => state.load);
   const createFolder = useAssetStore((state) => state.createFolder);
+  const projectId =
+    useWorkspaceTabsStore((state) => state.activeProjectId) ?? LOOSE_PROJECT_ID;
   const addNotification = useNotificationStore(
     (state) => state.addNotification
   );
   const fetchFolders = async () => {
-    return await load({ content_type: "folder" });
+    return await load({ content_type: "folder", project_id: projectId });
   };
   const { data, error, isLoading, refetch } = useQuery<AssetList, Error>({
-    queryKey: ["assets", { content_type: "folder" }],
-    queryFn: fetchFolders
+    queryKey: ["assets", { content_type: "folder", project_id: projectId }],
+    queryFn: fetchFolders,
+    staleTime: 30_000
   });
 
   // Validate that the selected value exists in the options

--- a/web/src/lib/tools/builtin/entities.ts
+++ b/web/src/lib/tools/builtin/entities.ts
@@ -4,6 +4,7 @@ import { FrontendToolRegistry } from "../frontendTools";
 import { trpcClient } from "../../../trpc/client";
 import { assetToEntity } from "../../../serverState/useEntities";
 import type { Asset } from "../../../stores/ApiTypes";
+import { creationProjectId } from "../../../stores/WorkspaceTabsStore";
 
 /**
  * Agent tools for the reusable-entity ("ingredients") library. Entities are
@@ -12,10 +13,11 @@ import type { Asset } from "../../../stores/ApiTypes";
  * cross-shot consistency.
  */
 
-async function fetchEntities(): Promise<Entity[]> {
+async function fetchEntities(projectId = creationProjectId()): Promise<Entity[]> {
   const result = await trpcClient.assets.search.query({
     query: "",
-    page_size: 1000
+    page_size: 1000,
+    project_id: projectId
   });
   const entities: Entity[] = [];
   for (const asset of result.assets) {

--- a/web/src/serverState/__tests__/useFolderTree.test.tsx
+++ b/web/src/serverState/__tests__/useFolderTree.test.tsx
@@ -35,7 +35,7 @@ describe("useFolderTree", () => {
     const { result } = renderHook(() => useFolderTree());
     expect(useQuery).toHaveBeenCalledWith(
       expect.objectContaining({
-        queryKey: ["folderTree", "name"]
+        queryKey: ["folderTree", "name", "default"]
       })
     );
     expect(result.current.data).toEqual(mockFolderTree);
@@ -45,7 +45,7 @@ describe("useFolderTree", () => {
     renderHook(() => useFolderTree("updated_at"));
     expect(useQuery).toHaveBeenCalledWith(
       expect.objectContaining({
-        queryKey: ["folderTree", "updated_at"]
+        queryKey: ["folderTree", "updated_at", "default"]
       })
     );
   });
@@ -61,6 +61,6 @@ describe("useFolderTree", () => {
     renderHook(() => useFolderTree("name"));
     
     await capturedQueryFn?.();
-    expect(mockLoadFolderTree).toHaveBeenCalledWith("name");
+    expect(mockLoadFolderTree).toHaveBeenCalledWith("name", "default");
   });
 });

--- a/web/src/serverState/useAssets.ts
+++ b/web/src/serverState/useAssets.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAssetStore } from "../stores/AssetStore";
 import { Asset } from "../stores/ApiTypes";
@@ -13,6 +13,10 @@ import { getAssetCategory } from "../components/assets/assetGridUtils";
 import { trpcClient } from "../trpc/client";
 import { normalizeAssetList } from "../utils/normalizeAsset";
 import { useNotificationStore } from "../stores/NotificationStore";
+import {
+  LOOSE_PROJECT_ID,
+  useWorkspaceTabsStore
+} from "../stores/WorkspaceTabsStore";
 
 type FilterOptions = {
   searchTerm: string;
@@ -61,6 +65,12 @@ export const useAssets = () => {
   const sizeFilter = useAssetGridStore((state) => state.sizeFilter);
   const typeFilter = useAssetGridStore((state) => state.typeFilter);
   const workflowFilter = useAssetGridStore((state) => state.workflowFilter);
+  const gridScopeProjectId = useAssetGridStore(
+    (state) => state.scopeProjectId
+  );
+  const resetForProject = useAssetGridStore((state) => state.resetForProject);
+  const activeProjectId =
+    useWorkspaceTabsStore((state) => state.activeProjectId) ?? LOOSE_PROJECT_ID;
   const addNotification = useNotificationStore(
     (state) => state.addNotification
   );
@@ -69,72 +79,97 @@ export const useAssets = () => {
     throw new Error("User not logged");
   }
 
+  const projectScopeReady = gridScopeProjectId === activeProjectId;
+
+  useEffect(() => {
+    if (!projectScopeReady) {
+      resetForProject(activeProjectId);
+    }
+  }, [activeProjectId, projectScopeReady, resetForProject]);
+
   const fetchAssets = useCallback(async () => {
     const result = await load({
-      parent_id: currentFolderId || currentUser?.id
+      parent_id: currentFolderId || currentUser.id,
+      project_id: activeProjectId
     });
     return result;
-  }, [load, currentFolderId, currentUser?.id]);
+  }, [load, currentFolderId, currentUser.id, activeProjectId]);
 
   const {
     data: currentFolderAssets,
     error: currentFolderError,
     isLoading: isLoadingCurrentFolder
   } = useQuery({
-    queryKey: ["assets", { parent_id: currentFolderId }],
+    queryKey: [
+      "assets",
+      { parent_id: currentFolderId, project_id: activeProjectId }
+    ],
     queryFn: fetchAssets,
-    enabled: !!currentFolderId && !workflowFilter
+    enabled: projectScopeReady && !!currentFolderId && !workflowFilter,
+    staleTime: 30_000
   });
 
   // Fetch assets filtered by workflow_id when workflowFilter is active
   const fetchWorkflowAssets = useCallback(async () => {
     const data = await trpcClient.assets.list.query({
-      workflow_id: workflowFilter!
+      workflow_id: workflowFilter!,
+      project_id: activeProjectId
     });
     return {
       ...data,
       assets: normalizeAssetList(data.assets)
     };
-  }, [workflowFilter]);
+  }, [workflowFilter, activeProjectId]);
 
   const {
     data: workflowFilteredAssets,
     error: workflowFilterError,
     isLoading: isLoadingWorkflowAssets
   } = useQuery({
-    queryKey: ["assets", { workflow_id: workflowFilter }],
+    queryKey: [
+      "assets",
+      { workflow_id: workflowFilter, project_id: activeProjectId }
+    ],
     queryFn: fetchWorkflowAssets,
-    enabled: !!workflowFilter,
+    enabled: projectScopeReady && !!workflowFilter,
     staleTime: 30000
   });
 
   const refetchAssets = useCallback(() => {
     if (workflowFilter) {
       return queryClient.invalidateQueries({
-        queryKey: ["assets", { workflow_id: workflowFilter }]
+        queryKey: [
+          "assets",
+          { workflow_id: workflowFilter, project_id: activeProjectId }
+        ]
       });
     }
     return queryClient.invalidateQueries({
-      queryKey: ["assets", { parent_id: currentFolderId }]
+      queryKey: [
+        "assets",
+        { parent_id: currentFolderId, project_id: activeProjectId }
+      ]
     });
-  }, [queryClient, currentFolderId, workflowFilter]);
+  }, [queryClient, currentFolderId, workflowFilter, activeProjectId]);
 
   const fetchAllFolders = useCallback(async () => {
-    return await loadFolderTree(settings.assetsOrder);
-  }, [loadFolderTree, settings.assetsOrder]);
+    return await loadFolderTree(settings.assetsOrder, activeProjectId);
+  }, [loadFolderTree, settings.assetsOrder, activeProjectId]);
 
   const {
     data: folderTree,
     error: folderTreeError,
     isLoading: isLoadingFolderTree
   } = useQuery({
-    queryKey: ["folderTree", settings.assetsOrder],
+    queryKey: ["folderTree", settings.assetsOrder, activeProjectId],
     queryFn: fetchAllFolders
   });
 
   const refetchFolders = useCallback(() => {
-    return queryClient.invalidateQueries({ queryKey: ["folderTree"] });
-  }, [queryClient]);
+    return queryClient.invalidateQueries({
+      queryKey: ["folderTree", settings.assetsOrder, activeProjectId]
+    });
+  }, [queryClient, settings.assetsOrder, activeProjectId]);
 
   const refetchAssetsAndFolders = useCallback(() => {
     refetchAssets();
@@ -230,15 +265,21 @@ export const useAssets = () => {
   // to refresh the folder tree and the workflow-filtered list.
   const invalidateAssetSiblings = useCallback(() => {
     queryClient.invalidateQueries({
-      queryKey: ["assets", { parent_id: currentFolderId }]
+      queryKey: [
+        "assets",
+        { parent_id: currentFolderId, project_id: activeProjectId }
+      ]
     });
     if (workflowFilter) {
       queryClient.invalidateQueries({
-        queryKey: ["assets", { workflow_id: workflowFilter }]
+        queryKey: [
+          "assets",
+          { workflow_id: workflowFilter, project_id: activeProjectId }
+        ]
       });
     }
     queryClient.invalidateQueries({ queryKey: ["folderTree"] });
-  }, [queryClient, currentFolderId, workflowFilter]);
+  }, [queryClient, currentFolderId, workflowFilter, activeProjectId]);
 
   const notifyMutationError = useCallback(
     (content: string) => (err: Error) => {
@@ -279,7 +320,7 @@ export const useAssets = () => {
         setCurrentFolderId(folder.id || currentUser?.id || "");
         setCurrentFolder(folder || null);
         setSelectedAssetIds([]);
-        loadCurrentFolder(gridStore);
+        loadCurrentFolder(gridStore, activeProjectId);
       }
     },
     [
@@ -290,13 +331,14 @@ export const useAssets = () => {
       setCurrentFolder,
       setSelectedAssetIds,
       loadCurrentFolder,
-      gridStore
+      gridStore,
+      activeProjectId
     ]
   );
   const navigateToFolderId = useCallback(
     async (folderId: string | null) => {
       const getAsset = useAssetStore.getState().get;
-      const folder: Asset = await getAsset(folderId || "");
+      const folder: Asset = await getAsset(folderId || "", activeProjectId);
 
       if (folder) {
         setSelectedFolderId(folderId);
@@ -304,7 +346,7 @@ export const useAssets = () => {
         setCurrentFolderId(folderId || currentUser?.id || "");
         setCurrentFolder(folder || null);
         setSelectedAssetIds([]);
-        loadCurrentFolder(gridStore);
+        loadCurrentFolder(gridStore, activeProjectId);
       }
     },
     [
@@ -315,7 +357,8 @@ export const useAssets = () => {
       setCurrentFolder,
       setSelectedAssetIds,
       loadCurrentFolder,
-      gridStore
+      gridStore,
+      activeProjectId
     ]
   );
 
@@ -330,11 +373,12 @@ export const useAssets = () => {
     async (folderId: string) => {
       const result = await load({
         parent_id: folderId,
+        project_id: activeProjectId,
         recursive: true
       });
       return result;
     },
-    [load]
+    [load, activeProjectId]
   );
 
   return {

--- a/web/src/serverState/useEntities.ts
+++ b/web/src/serverState/useEntities.ts
@@ -26,6 +26,10 @@ import type { Asset } from "../stores/ApiTypes";
 import { mediaRefFromAsset } from "../utils/mediaRef";
 import { trpcClient } from "../trpc/client";
 import { isObjectLike, isString } from "../utils/typePredicates";
+import {
+  LOOSE_PROJECT_ID,
+  useWorkspaceTabsStore
+} from "../stores/WorkspaceTabsStore";
 
 /** The Entity-without-images object stored on `metadata.nodetool_entity`. */
 interface EntityMarker {
@@ -56,7 +60,7 @@ const invalidateProjectQueries = (client: QueryClient): void => {
     }
   });
 };
-const ENTITIES_QUERY_KEY = ["entities"] as const;
+const entityQueryKey = (projectId: string) => ["entities", projectId] as const;
 const VALID_KINDS: ReadonlySet<string> = new Set([
   "character",
   "location",
@@ -125,13 +129,19 @@ export function assetToEntity(asset: Asset): Entity | null {
 }
 
 /** Fetch all assets tagged as entities, mapped to {@link Entity} objects. */
-export function useEntities(): UseQueryResult<Entity[], Error> {
+export function useEntities(
+  projectId?: string
+): UseQueryResult<Entity[], Error> {
+  const activeProjectId =
+    useWorkspaceTabsStore((state) => state.activeProjectId) ?? LOOSE_PROJECT_ID;
+  const scopedProjectId = projectId ?? activeProjectId;
   return useQuery({
-    queryKey: ENTITIES_QUERY_KEY,
+    queryKey: entityQueryKey(scopedProjectId),
     queryFn: async (): Promise<Entity[]> => {
       const result = await trpcClient.assets.search.query({
         query: "",
-        page_size: 1000
+        page_size: 1000,
+        project_id: scopedProjectId
       });
       const entities: Entity[] = [];
       for (const asset of result.assets) {
@@ -179,9 +189,15 @@ export function useSaveEntity(): UseMutationResult<
   SaveEntityInput
 > {
   const queryClient = useQueryClient();
+  const activeProjectId =
+    useWorkspaceTabsStore((state) => state.activeProjectId) ?? LOOSE_PROJECT_ID;
   return useMutation({
     mutationFn: async (input: SaveEntityInput): Promise<Entity | null> => {
-      const asset = await trpcClient.assets.get.query({ id: input.assetId });
+      const projectId = input.projectId ?? activeProjectId;
+      const asset = await trpcClient.assets.get.query({
+        id: input.assetId,
+        project_id: projectId
+      });
       if (input.createOnly && readEntityMarker(asset.metadata)) {
         throw new Error("That image is already used by another entity.");
       }
@@ -210,21 +226,21 @@ export function useSaveEntity(): UseMutationResult<
       // Membership is the projects router's write, not the asset's: it is the
       // one path that checks the project is the caller's before filing
       // anything into it.
-      if (input.projectId && input.projectId !== updated.project_id) {
+      if (projectId !== updated.project_id) {
         await trpcClient.projects.assignDocument.mutate({
-          projectId: input.projectId,
+          projectId,
           type: "entity",
           ref: input.assetId
         });
         return assetToEntity({
           ...updated,
-          project_id: input.projectId
+          project_id: projectId
         } as Asset);
       }
       return assetToEntity(updated as Asset);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ENTITIES_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: ["entities"] });
       invalidateProjectQueries(queryClient);
     }
   });
@@ -233,9 +249,14 @@ export function useSaveEntity(): UseMutationResult<
 /** Remove the entity marker from an asset. The asset itself is left intact. */
 export function useDeleteEntity(): UseMutationResult<void, Error, string> {
   const queryClient = useQueryClient();
+  const activeProjectId =
+    useWorkspaceTabsStore((state) => state.activeProjectId) ?? LOOSE_PROJECT_ID;
   return useMutation({
     mutationFn: async (assetId: string): Promise<void> => {
-      const asset = await trpcClient.assets.get.query({ id: assetId });
+      const asset = await trpcClient.assets.get.query({
+        id: assetId,
+        project_id: activeProjectId
+      });
       const nextMetadata = {
         ...(asset.metadata ?? {})
       } satisfies Record<string, unknown>;
@@ -246,7 +267,7 @@ export function useDeleteEntity(): UseMutationResult<void, Error, string> {
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ENTITIES_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: ["entities"] });
       invalidateProjectQueries(queryClient);
     }
   });

--- a/web/src/serverState/useFolderTree.ts
+++ b/web/src/serverState/useFolderTree.ts
@@ -1,11 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAssetStore } from "../stores/AssetStore";
+import {
+  LOOSE_PROJECT_ID,
+  useWorkspaceTabsStore
+} from "../stores/WorkspaceTabsStore";
 
 export function useFolderTree(sortBy: "name" | "updated_at" = "name") {
   const loadFolderTree = useAssetStore((state) => state.loadFolderTree);
+  const activeProjectId =
+    useWorkspaceTabsStore((state) => state.activeProjectId) ?? LOOSE_PROJECT_ID;
 
   return useQuery({
-    queryKey: ["folderTree", sortBy],
-    queryFn: async () => await loadFolderTree(sortBy)
+    queryKey: ["folderTree", sortBy, activeProjectId],
+    queryFn: async () => await loadFolderTree(sortBy, activeProjectId),
+    staleTime: 30_000
   });
 }

--- a/web/src/stores/AssetGridStore.ts
+++ b/web/src/stores/AssetGridStore.ts
@@ -79,6 +79,9 @@ interface AssetGridState {
 
   // Workflow filter
   workflowFilter: string | null;
+  /** Project whose folder and selection state this explorer currently represents. */
+  scopeProjectId: string | null;
+  resetForProject: (projectId: string) => void;
   setWorkflowFilter: (workflowId: string | null) => void;
 }
 
@@ -207,6 +210,26 @@ const createAssetGridStore = (
 
   // Workflow filter
   workflowFilter: null,
+  scopeProjectId: null,
+  resetForProject: (projectId) =>
+    set({
+      scopeProjectId: projectId,
+      assetSearchTerm: null,
+      currentAudioAsset: null,
+      currentFolder: null,
+      currentFolderId: null,
+      globalSearchResults: [],
+      globalSearchQuery: "",
+      isGlobalSearchActive: false,
+      isGlobalSearchMode: false,
+      openAsset: null,
+      parentFolder: null,
+      selectedAssetIds: [],
+      selectedAssets: [],
+      selectedFolderId: null,
+      selectedFolderIds: [],
+      workflowFilter: null
+    }),
   setWorkflowFilter: (workflowId) => set({ workflowFilter: workflowId })
 }),
       {

--- a/web/src/stores/AssetStore.ts
+++ b/web/src/stores/AssetStore.ts
@@ -299,10 +299,9 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
   },
 
   get: async (id: string, project_id?: string) => {
-    const raw = await trpcClient.assets.get.query({
-      id,
-      ...(project_id !== undefined ? { project_id } : {})
-    });
+    const getInput: Parameters<typeof trpcClient.assets.get.query>[0] = { id };
+    if (project_id !== undefined) getInput.project_id = project_id;
+    const raw = await trpcClient.assets.get.query(getInput);
     const data = normalizeAssetUrls(raw);
     get().add(data);
     return data;
@@ -323,12 +322,13 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
       if (!query.parent_id) {
         throw new Error("Recursive asset queries require a parent_id");
       }
-      const data = await trpcClient.assets.recursive.query({
-        id: query.parent_id,
-        ...(query.project_id !== undefined
-          ? { project_id: query.project_id }
-          : {})
-      });
+      const recursiveInput: Parameters<
+        typeof trpcClient.assets.recursive.query
+      >[0] = { id: query.parent_id };
+      if (query.project_id !== undefined) {
+        recursiveInput.project_id = query.project_id;
+      }
+      const data = await trpcClient.assets.recursive.query(recursiveInput);
       const normalized = normalizeAssetList(data.assets ?? []);
       for (const asset of normalized) {
         get().add(asset);
@@ -352,10 +352,11 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
 
   loadFolderTree: async (sortBy?: string, project_id?: string) => {
     // Fallback implementation: fetch all folders via tRPC and build tree locally
-    const data = await trpcClient.assets.list.query({
-      content_type: "folder",
-      ...(project_id !== undefined ? { project_id } : {})
-    });
+    const listInput: Parameters<typeof trpcClient.assets.list.query>[0] = {
+      content_type: "folder"
+    };
+    if (project_id !== undefined) listInput.project_id = project_id;
+    const data = await trpcClient.assets.list.query(listInput);
     return buildFolderTree(
       normalizeAssetList(data.assets),
       sortBy === "updated_at" ? "updated_at" : "name"
@@ -395,10 +396,9 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
           });
       }
     }
-    return get().load({
-      parent_id: requestedFolderId,
-      ...(project_id !== undefined ? { project_id } : {})
-    });
+    const assetQuery: AssetQuery = { parent_id: requestedFolderId };
+    if (project_id !== undefined) assetQuery.project_id = project_id;
+    return get().load(assetQuery);
   },
 
   search: async (query: AssetSearchQuery): Promise<AssetSearchResult> => {
@@ -645,10 +645,11 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
     folderId: string,
     project_id?: string
   ): Promise<AssetTreeNode[]> => {
-    const data = await trpcClient.assets.recursive.query({
-      id: folderId,
-      ...(project_id !== undefined ? { project_id } : {})
-    });
+    const recursiveInput: Parameters<
+      typeof trpcClient.assets.recursive.query
+    >[0] = { id: folderId };
+    if (project_id !== undefined) recursiveInput.project_id = project_id;
+    const data = await trpcClient.assets.recursive.query(recursiveInput);
     // The tRPC `recursive` procedure returns a flat array — convert it to the
     // tree shape expected by downstream code.
     return normalizeAssetList((data.assets ?? []) as AssetTreeNode[]);

--- a/web/src/stores/AssetStore.ts
+++ b/web/src/stores/AssetStore.ts
@@ -177,6 +177,7 @@ type AssetQuery = {
   workflow_id?: string | null;
   parent_id?: string | null;
   content_type?: string | null;
+  project_id?: string;
   recursive?: boolean;
 };
 
@@ -185,6 +186,7 @@ type AssetSearchQuery = {
   content_type?: string;
   page_size?: number;
   cursor?: string;
+  project_id?: string;
 };
 
 export type AssetUpdate = {
@@ -204,8 +206,8 @@ export interface AssetStore {
   setQueryClient: (queryClient: QueryClient) => void;
   add: (asset: Asset) => void;
   invalidateQueries: (queryKey: QueryKey) => void;
-  get: (id: string) => Promise<Asset>;
-  getAllAssetsInFolder: (folderId: string) => Promise<Asset[]>;
+  get: (id: string, project_id?: string) => Promise<Asset>;
+  getAllAssetsInFolder: (folderId: string, project_id?: string) => Promise<Asset[]>;
   createFolder: (parent_id: string | null, name: string) => Promise<Asset>;
   createAsset: (
     file: File,
@@ -215,13 +217,13 @@ export interface AssetStore {
     source?: UploadSource
   ) => Promise<Asset>;
   load: (query: AssetQuery) => Promise<AssetList>;
-  loadFolderTree: (sortBy?: string) => Promise<FolderTree>;
-  loadCurrentFolder: (gridStore: AssetGridStoreApi) => Promise<AssetList>;
+  loadFolderTree: (sortBy?: string, project_id?: string) => Promise<FolderTree>;
+  loadCurrentFolder: (gridStore: AssetGridStoreApi, project_id?: string) => Promise<AssetList>;
   search: (query: AssetSearchQuery) => Promise<AssetSearchResult>;
   update: (asset: AssetUpdate) => Promise<Asset>;
   delete: (id: string) => Promise<string[]>;
   download: (ids: string[]) => Promise<boolean>;
-  getAssetsRecursive: (folderId: string) => Promise<AssetTreeNode[]>;
+  getAssetsRecursive: (folderId: string, project_id?: string) => Promise<AssetTreeNode[]>;
 }
 
 export type FolderTree = Record<string, AssetTreeNode>;
@@ -296,9 +298,10 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
     get().queryClient?.setQueryData(["asset", asset.id], asset);
   },
 
-  get: async (id: string) => {
+  get: async (id: string, project_id?: string) => {
     const raw = await trpcClient.assets.get.query({
-      id
+      id,
+      ...(project_id !== undefined ? { project_id } : {})
     });
     const data = normalizeAssetUrls(raw);
     get().add(data);
@@ -321,7 +324,10 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
         throw new Error("Recursive asset queries require a parent_id");
       }
       const data = await trpcClient.assets.recursive.query({
-        id: query.parent_id
+        id: query.parent_id,
+        ...(query.project_id !== undefined
+          ? { project_id: query.project_id }
+          : {})
       });
       const normalized = normalizeAssetList(data.assets ?? []);
       for (const asset of normalized) {
@@ -335,6 +341,7 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
     }
     if (query.content_type) listInput.content_type = query.content_type;
     if (query.workflow_id) listInput.workflow_id = query.workflow_id;
+    if (query.project_id !== undefined) listInput.project_id = query.project_id;
     const data = await trpcClient.assets.list.query(listInput);
     const normalized = normalizeAssetList(data.assets);
     for (const asset of normalized) {
@@ -343,10 +350,11 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
     return { ...data, assets: normalized };
   },
 
-  loadFolderTree: async (sortBy?: string) => {
+  loadFolderTree: async (sortBy?: string, project_id?: string) => {
     // Fallback implementation: fetch all folders via tRPC and build tree locally
     const data = await trpcClient.assets.list.query({
-      content_type: "folder"
+      content_type: "folder",
+      ...(project_id !== undefined ? { project_id } : {})
     });
     return buildFolderTree(
       normalizeAssetList(data.assets),
@@ -357,7 +365,10 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
   /**
    * Load the current folder and its parent folder.
    */
-  loadCurrentFolder: async (gridStore: AssetGridStoreApi) => {
+  loadCurrentFolder: async (
+    gridStore: AssetGridStoreApi,
+    project_id?: string
+  ) => {
     const currentFolderId = gridStore.getState().currentFolderId;
     const setCurrentFolder = gridStore.getState().setCurrentFolder;
     const setParentFolder = gridStore.getState().setParentFolder;
@@ -368,7 +379,7 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
       gridStore.getState().currentFolderId === requestedFolderId;
 
     if (requestedFolderId) {
-      const asset = await get().get(requestedFolderId);
+      const asset = await get().get(requestedFolderId, project_id);
       if (!isStillActive()) {
         const empty: AssetList = { next: "", assets: [] };
         return empty;
@@ -376,7 +387,7 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
       setCurrentFolder(asset);
       if (asset?.parent_id) {
         get()
-          .get(asset.parent_id)
+          .get(asset.parent_id, project_id)
           .then((parent) => {
             if (isStillActive()) {
               setParentFolder(parent);
@@ -384,7 +395,10 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
           });
       }
     }
-    return get().load({ parent_id: requestedFolderId });
+    return get().load({
+      parent_id: requestedFolderId,
+      ...(project_id !== undefined ? { project_id } : {})
+    });
   },
 
   search: async (query: AssetSearchQuery): Promise<AssetSearchResult> => {
@@ -394,6 +408,7 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
       if (query.content_type) searchInput.content_type = query.content_type;
       if (query.page_size) searchInput.page_size = query.page_size;
       if (query.cursor) searchInput.cursor = query.cursor;
+      if (query.project_id !== undefined) searchInput.project_id = query.project_id;
       const data = await trpcClient.assets.search.query(searchInput);
       const result = data as AssetSearchResult;
       return { ...result, assets: normalizeAssetList(result.assets) };
@@ -438,8 +453,11 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
       throw normalizeAssetError(error, "Failed to create folder");
     }
   },
-  getAllAssetsInFolder: async (folderId: string): Promise<Asset[]> => {
-    const tree = await get().getAssetsRecursive(folderId);
+  getAllAssetsInFolder: async (
+    folderId: string,
+    project_id?: string
+  ): Promise<Asset[]> => {
+    const tree = await get().getAssetsRecursive(folderId, project_id);
 
     const flatten = (nodes: AssetTreeNode[]): Asset[] => {
       let result: Asset[] = [];
@@ -623,8 +641,14 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
     }
   },
 
-  getAssetsRecursive: async (folderId: string): Promise<AssetTreeNode[]> => {
-    const data = await trpcClient.assets.recursive.query({ id: folderId });
+  getAssetsRecursive: async (
+    folderId: string,
+    project_id?: string
+  ): Promise<AssetTreeNode[]> => {
+    const data = await trpcClient.assets.recursive.query({
+      id: folderId,
+      ...(project_id !== undefined ? { project_id } : {})
+    });
     // The tRPC `recursive` procedure returns a flat array — convert it to the
     // tree shape expected by downstream code.
     return normalizeAssetList((data.assets ?? []) as AssetTreeNode[]);


### PR DESCRIPTION
## Summary

Scope asset browsing, entity selection, and asset mentions to the active project while preserving intentional global asset search.

- Thread `project_id` through asset list, search, folder, and recursive routes and model queries.
- Include active-project identity in asset/entity query keys, picker requests, mentions, and folder navigation; reset explorer selection/navigation on project changes.
- Add A/B fixture coverage for identically named assets and project-filtered queries.
- Preserve project-root asset browsing by treating `project_id` as a filter, preventing the user-home-folder fallback from overriding the selected project.

## Verification

- CI failure: `tests/trpc-assets.test.ts` expected a scoped list to forward `parentId: undefined`; CI received `parentId: "user-1"`.
- `git diff --check` passed.
- Focused test could not start because this checkout has no `node_modules` (`vitest: not found`). CI will run the installed-toolchain suite.