### PR TITLE
Copy project documents with independent dependencies

### DIFF
--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -291,9 +291,15 @@ export type {
 } from "./project-summary.js";
 export {
   moveDocumentToProject,
+  hasProjectDocumentDependents,
   reassignProjectDocuments
 } from "./project-membership.js";
 export type { ProjectMemberType } from "./project-membership.js";
+export {
+  persistProjectCopy,
+  type ProjectCopyAsset,
+  type ProjectCopyDocument
+} from "./project-copy.js";
 export {
   Script,
   ScriptConflictError,

--- a/packages/models/src/project-copy.ts
+++ b/packages/models/src/project-copy.ts
@@ -1,0 +1,60 @@
+import { getDb, getDbType, type DbTransaction } from "./db.js";
+import { applications } from "./schema/applications.js";
+import { assets } from "./schema/assets.js";
+import { imageDocuments } from "./schema/image-documents.js";
+import { jsScripts } from "./schema/js-scripts.js";
+import { scripts } from "./schema/scripts.js";
+import { storyboards } from "./schema/storyboards.js";
+import { timelineSequences } from "./schema/timeline-sequences.js";
+
+export type ProjectCopyAsset = typeof assets.$inferInsert;
+
+export type ProjectCopyDocument =
+  | { readonly type: "storyboard"; readonly values: typeof storyboards.$inferInsert }
+  | { readonly type: "script"; readonly values: typeof scripts.$inferInsert }
+  | { readonly type: "timeline"; readonly values: typeof timelineSequences.$inferInsert }
+  | { readonly type: "sketch"; readonly values: typeof imageDocuments.$inferInsert }
+  | { readonly type: "application"; readonly values: typeof applications.$inferInsert }
+  | { readonly type: "jsscript"; readonly values: typeof jsScripts.$inferInsert };
+
+function insertDocument(tx: DbTransaction, document: ProjectCopyDocument) {
+  switch (document.type) {
+    case "storyboard":
+      return tx.insert(storyboards).values(document.values);
+    case "script":
+      return tx.insert(scripts).values(document.values);
+    case "timeline":
+      return tx.insert(timelineSequences).values(document.values);
+    case "sketch":
+      return tx.insert(imageDocuments).values(document.values);
+    case "application":
+      return tx.insert(applications).values(document.values);
+    case "jsscript":
+      return tx.insert(jsScripts).values(document.values);
+  }
+}
+
+/** Persist a fully prepared project copy atomically. */
+export async function persistProjectCopy(args: {
+  readonly assets: readonly ProjectCopyAsset[];
+  readonly documents: readonly ProjectCopyDocument[];
+}): Promise<void> {
+  const db = getDb();
+  const writes = (tx: DbTransaction) => {
+    const statements: Array<{ run: () => void }> = [];
+    for (const asset of args.assets) statements.push(tx.insert(assets).values(asset));
+    for (const document of args.documents) {
+      statements.push(insertDocument(tx, document));
+    }
+    return statements;
+  };
+  if (getDbType() === "sqlite") {
+    db.transaction((tx: DbTransaction): void => {
+      for (const statement of writes(tx)) statement.run();
+    });
+  } else {
+    await db.transaction(async (tx: DbTransaction): Promise<void> => {
+      for (const statement of writes(tx)) await statement;
+    });
+  }
+}

--- a/packages/models/src/project-membership.ts
+++ b/packages/models/src/project-membership.ts
@@ -45,6 +45,132 @@ const DOCUMENT_TABLES = [
   assets
 ] as const;
 
+const REFERENCE_KEYS: Readonly<Record<string, ProjectMemberType>> = {
+  storyboardId: "storyboard",
+  storyboard_id: "storyboard",
+  scriptId: "script",
+  script_id: "script",
+  timelineId: "timeline",
+  timeline_id: "timeline",
+  sketchId: "sketch",
+  sketch_id: "sketch",
+  applicationId: "application",
+  application_id: "application",
+  jsScriptId: "jsscript",
+  js_script_id: "jsscript",
+  entityId: "entity",
+  entity_id: "entity",
+  entityIds: "entity",
+  entity_ids: "entity",
+  assetId: "entity",
+  asset_id: "entity",
+  assetIds: "entity",
+  asset_ids: "entity",
+  thumbnailAssetId: "entity",
+  thumbnail_asset_id: "entity",
+  referenceAssetId: "entity",
+  reference_asset_id: "entity"
+};
+
+function matchesReference(value: unknown, id: string): boolean {
+  if (typeof value === "string") {
+    return value === id;
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => matchesReference(item, id));
+  }
+  return false;
+}
+
+function valueIncludesReference(
+  value: unknown,
+  type: ProjectMemberType,
+  id: string
+): boolean {
+  if (typeof value === "string") {
+    return type === "entity" && value === `asset://${id}`;
+  }
+  if (!value || typeof value !== "object") return false;
+  if (Array.isArray(value)) {
+    return value.some((item) => valueIncludesReference(item, type, id));
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (REFERENCE_KEYS[key] === type && matchesReference(child, id)) {
+      return true;
+    }
+    if (valueIncludesReference(child, type, id)) return true;
+  }
+  return false;
+}
+
+/**
+ * Whether another project document names this member. Moves do not rewrite
+ * references, so callers must refuse a cross-project move rather than leave a
+ * document pointing into a project it no longer owns.
+ */
+export async function hasProjectDocumentDependents(
+  userId: string,
+  type: ProjectMemberType,
+  id: string
+): Promise<boolean> {
+  const db = getDb();
+  const [boardRows, scriptRows, timelineRows, sketchRows, appRows, jsRows] =
+    await Promise.all([
+      db
+        .select({ document: storyboards.document, timelineId: storyboards.timeline_id })
+        .from(storyboards)
+        .where(eq(storyboards.user_id, userId)),
+      db
+        .select({
+          document: scripts.document,
+          timelineId: scripts.timeline_id,
+          storyboardId: scripts.storyboard_id
+        })
+        .from(scripts)
+        .where(eq(scripts.user_id, userId)),
+      db
+        .select({ document: timelineSequences.document })
+        .from(timelineSequences)
+        .where(eq(timelineSequences.user_id, userId)),
+      db
+        .select({
+          document: imageDocuments.document,
+          thumbnailAssetId: imageDocuments.thumbnail_asset_id
+        })
+        .from(imageDocuments)
+        .where(eq(imageDocuments.user_id, userId)),
+      db
+        .select({ document: applications.document })
+        .from(applications)
+        .where(eq(applications.user_id, userId)),
+      db
+        .select({ document: jsScripts.document })
+        .from(jsScripts)
+        .where(eq(jsScripts.user_id, userId))
+    ]);
+  const rows = [
+    boardRows,
+    scriptRows,
+    timelineRows,
+    sketchRows,
+    appRows,
+    jsRows
+  ];
+  return rows.some((group) =>
+    group.some((row) => {
+      const values = Object.values(row);
+      return values.some((value) => {
+        if (typeof value !== "string") return valueIncludesReference(value, type, id);
+        try {
+          return valueIncludesReference(JSON.parse(value), type, id);
+        } catch {
+          return value === id;
+        }
+      });
+    })
+  );
+}
+
 /**
  * Point every document of one project at another — the bulk form of
  * {@link moveDocumentToProject}, used when a project goes away and its

--- a/packages/models/src/project-membership.ts
+++ b/packages/models/src/project-membership.ts
@@ -66,10 +66,24 @@ const REFERENCE_KEYS: Readonly<Record<string, ProjectMemberType>> = {
   asset_id: "entity",
   assetIds: "entity",
   asset_ids: "entity",
+  currentAssetId: "entity",
+  current_asset_id: "entity",
+  waveformAssetId: "entity",
+  waveform_asset_id: "entity",
   thumbnailAssetId: "entity",
   thumbnail_asset_id: "entity",
   referenceAssetId: "entity",
-  reference_asset_id: "entity"
+  reference_asset_id: "entity",
+  referenceAssetIds: "entity",
+  reference_asset_ids: "entity",
+  locationId: "entity",
+  location_id: "entity",
+  styleEntityId: "entity",
+  style_entity_id: "entity",
+  sourceAssetId: "entity",
+  source_asset_id: "entity",
+  maskAssetId: "entity",
+  mask_asset_id: "entity"
 };
 
 function matchesReference(value: unknown, id: string): boolean {

--- a/packages/protocol/src/api-schemas/projects.ts
+++ b/packages/protocol/src/api-schemas/projects.ts
@@ -82,6 +82,24 @@ export const projectDocumentRef = z.object({
 });
 export type ProjectDocumentRef = z.infer<typeof projectDocumentRef>;
 
+/** Copy one project document and its owned dependency graph into another project. */
+export const copyProjectDocumentInput = z.object({
+  type: projectDocumentType,
+  ref: z.string(),
+  destinationProjectId: z.string()
+});
+export type CopyProjectDocumentInput = z.infer<
+  typeof copyProjectDocumentInput
+>;
+
+export const copyProjectDocumentOutput = projectDocumentRef.extend({
+  copiedAssets: z.number(),
+  copiedDocuments: z.number()
+});
+export type CopyProjectDocumentOutput = z.infer<
+  typeof copyProjectDocumentOutput
+>;
+
 /**
  * Derived from the stored document on every read. A timeline reports its size
  * but not whether it has been rendered — nothing on the sequence row records

--- a/packages/websocket/src/lib/project-document-copy.ts
+++ b/packages/websocket/src/lib/project-document-copy.ts
@@ -61,6 +61,10 @@ const ASSET_KEYS = new Set([
   "asset_id",
   "assetids",
   "asset_ids",
+  "currentassetid",
+  "current_asset_id",
+  "waveformassetid",
+  "waveform_asset_id",
   "entityid",
   "entity_id",
   "entityids",
@@ -69,6 +73,12 @@ const ASSET_KEYS = new Set([
   "thumbnail_asset_id",
   "referenceassetid",
   "reference_asset_id",
+  "referenceassetids",
+  "reference_asset_ids",
+  "locationid",
+  "location_id",
+  "styleentityid",
+  "style_entity_id",
   "sourceassetid",
   "source_asset_id",
   "maskassetid",
@@ -96,14 +106,32 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function assetIdFromLocator(locator: string): string | null {
+  if (!locator.startsWith("asset://")) return null;
+  const rest = locator.slice("asset://".length).split(/[?#]/)[0];
+  const last = rest.includes("/") ? rest.slice(rest.lastIndexOf("/") + 1) : rest;
+  const id = last.replace(/\.[^.]+$/, "");
+  return id || null;
+}
+
+function remapAssetLocator(
+  locator: string,
+  ids: ReadonlyMap<string, string>
+): string {
+  const assetId = assetIdFromLocator(locator);
+  const copiedId = assetId ? ids.get(assetId) : undefined;
+  if (!copiedId) return locator;
+  const prefix = locator.slice(0, locator.lastIndexOf(assetId));
+  return `${prefix}${copiedId}${locator.slice(prefix.length + assetId.length)}`;
+}
+
 function addRef(
   value: unknown,
-  target: Set<string>,
-  kind: "asset" | "document"
+  target: Set<string>
 ): void {
   if (typeof value === "string" && value.length > 0) target.add(value);
   if (Array.isArray(value)) {
-    for (const item of value) addRef(item, target, kind);
+    for (const item of value) addRef(item, target);
   }
 }
 
@@ -116,32 +144,44 @@ interface References {
 function findReferences(value: unknown): References {
   const assetIds = new Set<string>();
   const documents: Array<{ type: ProjectDocumentType; id: string }> = [];
-  const pending: unknown[] = [value];
+  const pending: Array<{ value: unknown; path: string[] }> = [
+    { value, path: [] }
+  ];
   while (pending.length > 0) {
     const current = pending.pop();
-    if (typeof current === "string") {
-      if (current.startsWith("asset://")) assetIds.add(current.slice(8));
+    if (!current) continue;
+    if (typeof current.value === "string") {
+      const assetId = assetIdFromLocator(current.value);
+      if (assetId) assetIds.add(assetId);
       continue;
     }
-    if (Array.isArray(current)) {
-      pending.push(...current);
+    if (Array.isArray(current.value)) {
+      pending.push(
+        ...current.value.map((item) => ({ value: item, path: current.path }))
+      );
       continue;
     }
-    if (!isRecord(current)) continue;
-    for (const [key, child] of Object.entries(current)) {
-      if (WORKFLOW_KEYS.has(key) && child != null && child !== "") {
+    if (!isRecord(current.value)) continue;
+    for (const [key, child] of Object.entries(current.value)) {
+      const normalizedKey = key.toLowerCase();
+      if (
+        WORKFLOW_KEYS.has(normalizedKey) &&
+        current.path.at(-1) !== "source" &&
+        child != null &&
+        child !== ""
+      ) {
         throw new ProjectCopyError(
           `Unsupported workflow dependency at ${key}. Copy the workflow separately first.`
         );
       }
-      if (ASSET_KEYS.has(key)) addRef(child, assetIds, "asset");
-      const documentType = DOCUMENT_KEYS[key];
+      if (ASSET_KEYS.has(normalizedKey)) addRef(child, assetIds);
+      const documentType = DOCUMENT_KEYS[normalizedKey];
       if (documentType) {
         const ids = new Set<string>();
-        addRef(child, ids, "document");
+        addRef(child, ids);
         for (const id of ids) documents.push({ type: documentType, id });
       }
-      pending.push(child);
+      pending.push({ value: child, path: [...current.path, key] });
     }
   }
   return { assetIds, documents };
@@ -152,10 +192,7 @@ function cloneAndRemap(
   ids: ReadonlyMap<string, string>
 ): unknown {
   if (typeof value === "string") {
-    if (value.startsWith("asset://")) {
-      const copied = ids.get(value.slice(8));
-      return copied ? `asset://${copied}` : value;
-    }
+    if (value.startsWith("asset://")) return remapAssetLocator(value, ids);
     return ids.get(value) ?? value;
   }
   if (Array.isArray(value)) return value.map((item) => cloneAndRemap(item, ids));
@@ -163,6 +200,16 @@ function cloneAndRemap(
   return Object.fromEntries(
     Object.entries(value).map(([key, child]) => [key, cloneAndRemap(child, ids)])
   );
+}
+
+function cloneMetadata(
+  metadata: Record<string, unknown> | null,
+  ids: ReadonlyMap<string, string>
+): Record<string, unknown> | null {
+  const copied = cloneAndRemap(metadata, ids);
+  if (copied === null) return null;
+  if (!isRecord(copied)) throw new ProjectCopyError("Asset metadata was invalid");
+  return copied;
 }
 
 async function loadDocument(
@@ -345,21 +392,40 @@ export async function copyProjectDocument(args: {
   }
 
   const preparedAssets = new Map<string, PreparedAsset>();
+  const discoveredAssetIds = new Set(assetsToVisit);
   while (assetsToVisit.length > 0) {
-    const assetId = assetsToVisit.pop();
-    if (!assetId || assetIds.has(assetId)) continue;
-    const source = await Asset.find(args.userId, assetId);
-    if (!source) throw new ProjectCopyError(`Asset dependency ${assetId} is unavailable`);
-    assetIds.set(assetId, createTimeOrderedUuid());
-    const metadataRefs = findReferences(source.metadata);
-    assetsToVisit.push(...metadataRefs.assetIds);
-    const bytes = source.isFolder
-      ? null
-      : await retrieveAssetBytes(args.storage, source.user_id, source.id, source.content_type);
-    if (!source.isFolder && !bytes) {
-      throw new ProjectCopyError(`Asset dependency ${assetId} has no stored media`);
+    const batch = assetsToVisit.splice(-900);
+    const sourcesById = new Map(
+      (await Asset.findMany(args.userId, batch)).map((asset) => [asset.id, asset])
+    );
+    for (const assetId of batch) {
+      const source = sourcesById.get(assetId);
+      if (!source) {
+        throw new ProjectCopyError(`Asset dependency ${assetId} is unavailable`);
+      }
+      assetIds.set(assetId, createTimeOrderedUuid());
+      const metadataRefs = findReferences(source.metadata);
+      for (const dependencyId of metadataRefs.assetIds) {
+        if (!discoveredAssetIds.has(dependencyId)) {
+          discoveredAssetIds.add(dependencyId);
+          assetsToVisit.push(dependencyId);
+        }
+      }
+      const bytes = source.isFolder
+        ? null
+        : await retrieveAssetBytes(
+            args.storage,
+            source.user_id,
+            source.id,
+            source.content_type
+          );
+      if (!source.isFolder && !bytes) {
+        throw new ProjectCopyError(
+          `Asset dependency ${assetId} has no stored media`
+        );
+      }
+      preparedAssets.set(assetId, { source, bytes });
     }
-    preparedAssets.set(assetId, { source, bytes });
   }
 
   const ids = new Map<string, string>(assetIds);
@@ -385,7 +451,7 @@ export async function copyProjectDocument(args: {
 
     const db = getDb();
     const writes = (tx: DbTransaction) => {
-      const statements = [];
+      const statements: Array<{ run: () => void }> = [];
       const now = new Date().toISOString();
       for (const [sourceId, prepared] of preparedAssets) {
         const destinationId = assetIds.get(sourceId);
@@ -400,7 +466,7 @@ export async function copyProjectDocument(args: {
             content_type: prepared.source.content_type,
             size: prepared.bytes?.byteLength ?? prepared.source.size,
             duration: prepared.source.duration,
-            metadata: cloneAndRemap(prepared.source.metadata, ids) as Record<string, unknown> | null,
+            metadata: cloneMetadata(prepared.source.metadata, ids),
             sketch_document_id: null,
             workflow_id: null,
             node_id: null,
@@ -431,7 +497,7 @@ export async function copyProjectDocument(args: {
     if (getDbType() === "sqlite") {
       db.transaction((tx: DbTransaction): void => {
         for (const statement of writes(tx)) {
-          (statement as { run: () => void }).run();
+          statement.run();
         }
       });
     } else {

--- a/packages/websocket/src/lib/project-document-copy.ts
+++ b/packages/websocket/src/lib/project-document-copy.ts
@@ -1,0 +1,454 @@
+/**
+ * Copy a project document without retaining references to the source project.
+ *
+ * Dependency discovery is deliberately data driven: document formats evolve
+ * independently, but stored asset locators and the document link fields share
+ * stable names. A copy reserves every destination id before writing anything,
+ * which makes repeated references and document cycles resolve to one copy.
+ */
+import { createTimeOrderedUuid } from "@nodetool-ai/models";
+import {
+  Asset,
+  ImageDocument,
+  JsScript,
+  Script,
+  Storyboard,
+  TimelineSequence,
+  type ProjectDocumentType
+} from "@nodetool-ai/models";
+import {
+  applications,
+  assets,
+  getDb,
+  getDbType,
+  imageDocuments,
+  jsScripts,
+  scripts,
+  storyboards,
+  timelineSequences,
+  type DbTransaction
+} from "@nodetool-ai/models";
+import type { StorageAdapter } from "@nodetool-ai/storage";
+import { Application } from "@nodetool-ai/models";
+import { retrieveAssetBytes, getAssetStorageKey } from "./asset-paths.js";
+
+export class ProjectCopyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProjectCopyError";
+  }
+}
+
+interface DocumentSource {
+  readonly type: ProjectDocumentType;
+  readonly id: string;
+  readonly row:
+    | Storyboard
+    | Script
+    | TimelineSequence
+    | ImageDocument
+    | Application
+    | JsScript;
+}
+
+interface PreparedAsset {
+  readonly source: Asset;
+  readonly bytes: Uint8Array | null;
+}
+
+const ASSET_KEYS = new Set([
+  "assetid",
+  "asset_id",
+  "assetids",
+  "asset_ids",
+  "entityid",
+  "entity_id",
+  "entityids",
+  "entity_ids",
+  "thumbnailassetid",
+  "thumbnail_asset_id",
+  "referenceassetid",
+  "reference_asset_id",
+  "sourceassetid",
+  "source_asset_id",
+  "maskassetid",
+  "mask_asset_id"
+]);
+
+const DOCUMENT_KEYS: Readonly<Record<string, ProjectDocumentType>> = {
+  storyboardid: "storyboard",
+  storyboard_id: "storyboard",
+  scriptid: "script",
+  script_id: "script",
+  timelineid: "timeline",
+  timeline_id: "timeline",
+  sketchid: "sketch",
+  sketch_id: "sketch",
+  applicationid: "application",
+  application_id: "application",
+  jsscriptid: "jsscript",
+  js_script_id: "jsscript"
+};
+
+const WORKFLOW_KEYS = new Set(["workflowid", "workflow_id"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function addRef(
+  value: unknown,
+  target: Set<string>,
+  kind: "asset" | "document"
+): void {
+  if (typeof value === "string" && value.length > 0) target.add(value);
+  if (Array.isArray(value)) {
+    for (const item of value) addRef(item, target, kind);
+  }
+}
+
+interface References {
+  readonly assetIds: Set<string>;
+  readonly documents: Array<{ type: ProjectDocumentType; id: string }>;
+}
+
+/** Find copyable IDs without treating arbitrary nested `id` fields as refs. */
+function findReferences(value: unknown): References {
+  const assetIds = new Set<string>();
+  const documents: Array<{ type: ProjectDocumentType; id: string }> = [];
+  const pending: unknown[] = [value];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (typeof current === "string") {
+      if (current.startsWith("asset://")) assetIds.add(current.slice(8));
+      continue;
+    }
+    if (Array.isArray(current)) {
+      pending.push(...current);
+      continue;
+    }
+    if (!isRecord(current)) continue;
+    for (const [key, child] of Object.entries(current)) {
+      if (WORKFLOW_KEYS.has(key) && child != null && child !== "") {
+        throw new ProjectCopyError(
+          `Unsupported workflow dependency at ${key}. Copy the workflow separately first.`
+        );
+      }
+      if (ASSET_KEYS.has(key)) addRef(child, assetIds, "asset");
+      const documentType = DOCUMENT_KEYS[key];
+      if (documentType) {
+        const ids = new Set<string>();
+        addRef(child, ids, "document");
+        for (const id of ids) documents.push({ type: documentType, id });
+      }
+      pending.push(child);
+    }
+  }
+  return { assetIds, documents };
+}
+
+function cloneAndRemap(
+  value: unknown,
+  ids: ReadonlyMap<string, string>
+): unknown {
+  if (typeof value === "string") {
+    if (value.startsWith("asset://")) {
+      const copied = ids.get(value.slice(8));
+      return copied ? `asset://${copied}` : value;
+    }
+    return ids.get(value) ?? value;
+  }
+  if (Array.isArray(value)) return value.map((item) => cloneAndRemap(item, ids));
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [key, cloneAndRemap(child, ids)])
+  );
+}
+
+async function loadDocument(
+  userId: string,
+  type: ProjectDocumentType,
+  id: string
+): Promise<DocumentSource> {
+  const row = await (
+    {
+      storyboard: Storyboard.findById,
+      script: Script.findById,
+      timeline: TimelineSequence.findById,
+      sketch: ImageDocument.findById,
+      application: Application.findById,
+      jsscript: JsScript.findById
+    } as const
+  )[type](id);
+  if (!row || row.user_id !== userId) {
+    throw new ProjectCopyError(`${type} dependency ${id} is unavailable`);
+  }
+  return { type, id, row };
+}
+
+function documentPayload(source: DocumentSource): unknown {
+  switch (source.type) {
+    case "storyboard":
+    case "script":
+    case "timeline":
+    case "sketch":
+    case "jsscript":
+      return JSON.parse(source.row.document);
+    case "application":
+      return JSON.parse(source.row.document);
+  }
+}
+
+function directReferences(source: DocumentSource): References {
+  const found = findReferences(documentPayload(source));
+  const addDocument = (type: ProjectDocumentType, id: string | null): void => {
+    if (id) found.documents.push({ type, id });
+  };
+  switch (source.type) {
+    case "storyboard":
+      addDocument("timeline", source.row.timeline_id);
+      break;
+    case "script":
+      addDocument("timeline", source.row.timeline_id);
+      addDocument("storyboard", source.row.storyboard_id);
+      break;
+    case "timeline":
+      if (source.row.workflow_id) {
+        throw new ProjectCopyError("Unsupported workflow dependency on timeline");
+      }
+      break;
+    case "sketch":
+      if (source.row.workflow_id) {
+        throw new ProjectCopyError("Unsupported workflow dependency on sketch");
+      }
+      if (source.row.thumbnail_asset_id) found.assetIds.add(source.row.thumbnail_asset_id);
+      break;
+    case "application":
+    case "jsscript":
+      break;
+  }
+  return found;
+}
+
+function valuesForDocument(
+  source: DocumentSource,
+  destinationId: string,
+  destinationProjectId: string,
+  ids: ReadonlyMap<string, string>
+): { table: unknown; values: Record<string, unknown> } {
+  const now = new Date().toISOString();
+  const document = JSON.stringify(cloneAndRemap(documentPayload(source), ids));
+  const base = {
+    id: destinationId,
+    user_id: source.row.user_id,
+    project_id: destinationProjectId,
+    name: source.row.name,
+    document,
+    created_at: now,
+    updated_at: now
+  };
+  switch (source.type) {
+    case "storyboard":
+      return {
+        table: storyboards,
+        values: {
+          ...base,
+          timeline_id: source.row.timeline_id
+            ? ids.get(source.row.timeline_id) ?? null
+            : null,
+          revision: 0
+        }
+      };
+    case "script":
+      return {
+        table: scripts,
+        values: {
+          ...base,
+          timeline_id: source.row.timeline_id
+            ? ids.get(source.row.timeline_id) ?? null
+            : null,
+          storyboard_id: source.row.storyboard_id
+            ? ids.get(source.row.storyboard_id) ?? null
+            : null
+        }
+      };
+    case "timeline":
+      return {
+        table: timelineSequences,
+        values: {
+          ...base,
+          workflow_id: null,
+          fps: source.row.fps,
+          width: source.row.width,
+          height: source.row.height,
+          duration_ms: source.row.duration_ms,
+          revision: 0
+        }
+      };
+    case "sketch":
+      return {
+        table: imageDocuments,
+        values: {
+          ...base,
+          workflow_id: null,
+          width: source.row.width,
+          height: source.row.height,
+          background_color: source.row.background_color,
+          thumbnail_asset_id: source.row.thumbnail_asset_id
+            ? ids.get(source.row.thumbnail_asset_id) ?? null
+            : null,
+          revision: 0
+        }
+      };
+    case "application":
+      return {
+        table: applications,
+        values: { ...base, description: source.row.description }
+      };
+    case "jsscript":
+      return { table: jsScripts, values: base };
+  }
+}
+
+/**
+ * Copy a complete dependency closure. Storage is copied before the database
+ * transaction, so no incomplete copy can become a visible document. Failed
+ * transactions remove the newly stored bytes again.
+ */
+export async function copyProjectDocument(args: {
+  readonly userId: string;
+  readonly type: ProjectDocumentType;
+  readonly id: string;
+  readonly destinationProjectId: string;
+  readonly storage: StorageAdapter;
+}): Promise<{
+  readonly id: string;
+  readonly name: string;
+  readonly copiedAssets: number;
+  readonly copiedDocuments: number;
+}> {
+  const documentIds = new Map<string, string>();
+  const sources = new Map<string, DocumentSource>();
+  const assetIds = new Map<string, string>();
+  const assetsToVisit: string[] = [];
+  const documentsToVisit: Array<{ type: ProjectDocumentType; id: string }> = [
+    { type: args.type, id: args.id }
+  ];
+
+  while (documentsToVisit.length > 0) {
+    const next = documentsToVisit.pop();
+    if (!next) continue;
+    const key = `${next.type}:${next.id}`;
+    if (documentIds.has(key)) continue;
+    const source = await loadDocument(args.userId, next.type, next.id);
+    documentIds.set(key, createTimeOrderedUuid());
+    sources.set(key, source);
+    const refs = directReferences(source);
+    for (const assetId of refs.assetIds) assetsToVisit.push(assetId);
+    documentsToVisit.push(...refs.documents);
+  }
+
+  const preparedAssets = new Map<string, PreparedAsset>();
+  while (assetsToVisit.length > 0) {
+    const assetId = assetsToVisit.pop();
+    if (!assetId || assetIds.has(assetId)) continue;
+    const source = await Asset.find(args.userId, assetId);
+    if (!source) throw new ProjectCopyError(`Asset dependency ${assetId} is unavailable`);
+    assetIds.set(assetId, createTimeOrderedUuid());
+    const metadataRefs = findReferences(source.metadata);
+    assetsToVisit.push(...metadataRefs.assetIds);
+    const bytes = source.isFolder
+      ? null
+      : await retrieveAssetBytes(args.storage, source.user_id, source.id, source.content_type);
+    if (!source.isFolder && !bytes) {
+      throw new ProjectCopyError(`Asset dependency ${assetId} has no stored media`);
+    }
+    preparedAssets.set(assetId, { source, bytes });
+  }
+
+  const ids = new Map<string, string>(assetIds);
+  for (const [key, destinationId] of documentIds) {
+    ids.set(key.slice(key.indexOf(":") + 1), destinationId);
+  }
+
+  const storedUris: string[] = [];
+  try {
+    for (const [sourceId, prepared] of preparedAssets) {
+      if (!prepared.bytes) continue;
+      const destinationId = assetIds.get(sourceId);
+      if (!destinationId) throw new ProjectCopyError("Asset map was incomplete");
+      const key = getAssetStorageKey(
+        prepared.source.user_id,
+        destinationId,
+        prepared.source.content_type
+      );
+      storedUris.push(
+        await args.storage.store(key, prepared.bytes, prepared.source.content_type)
+      );
+    }
+
+    const db = getDb();
+    const writes = (tx: DbTransaction) => {
+      const statements = [];
+      const now = new Date().toISOString();
+      for (const [sourceId, prepared] of preparedAssets) {
+        const destinationId = assetIds.get(sourceId);
+        if (!destinationId) throw new ProjectCopyError("Asset map was incomplete");
+        statements.push(
+          tx.insert(assets).values({
+            id: destinationId,
+            user_id: prepared.source.user_id,
+            parent_id: null,
+            file_id: null,
+            name: prepared.source.name,
+            content_type: prepared.source.content_type,
+            size: prepared.bytes?.byteLength ?? prepared.source.size,
+            duration: prepared.source.duration,
+            metadata: cloneAndRemap(prepared.source.metadata, ids) as Record<string, unknown> | null,
+            sketch_document_id: null,
+            workflow_id: null,
+            node_id: null,
+            job_id: null,
+            timeline_id: null,
+            project_id: args.destinationProjectId,
+            created_at: now,
+            updated_at: now
+          })
+        );
+      }
+      for (const [sourceKey, source] of sources) {
+        const destinationId = documentIds.get(sourceKey);
+        if (!destinationId) throw new ProjectCopyError("Document map was incomplete");
+        const row = valuesForDocument(source, destinationId, args.destinationProjectId, ids);
+        statements.push(
+          tx.insert(row.table as typeof storyboards).values(row.values as never)
+        );
+      }
+      return statements;
+    };
+    if (getDbType() === "sqlite") {
+      db.transaction((tx: DbTransaction): void => {
+        for (const statement of writes(tx)) {
+          (statement as { run: () => void }).run();
+        }
+      });
+    } else {
+      await db.transaction(async (tx: DbTransaction): Promise<void> => {
+        for (const statement of writes(tx)) await statement;
+      });
+    }
+  } catch (error) {
+    await Promise.allSettled(storedUris.map((uri) => args.storage.delete(uri)));
+    throw error;
+  }
+
+  const root = sources.get(`${args.type}:${args.id}`);
+  const copiedId = documentIds.get(`${args.type}:${args.id}`);
+  if (!root || !copiedId) throw new ProjectCopyError("Copy root was unavailable");
+  return {
+    id: copiedId,
+    name: root.row.name,
+    copiedAssets: preparedAssets.size,
+    copiedDocuments: sources.size
+  };
+}

--- a/packages/websocket/src/lib/project-document-copy.ts
+++ b/packages/websocket/src/lib/project-document-copy.ts
@@ -6,30 +6,21 @@
  * stable names. A copy reserves every destination id before writing anything,
  * which makes repeated references and document cycles resolve to one copy.
  */
-import { createTimeOrderedUuid } from "@nodetool-ai/models";
 import {
   Asset,
+  Application,
+  createTimeOrderedUuid,
   ImageDocument,
   JsScript,
+  persistProjectCopy,
   Script,
   Storyboard,
   TimelineSequence,
+  type ProjectCopyAsset,
+  type ProjectCopyDocument,
   type ProjectDocumentType
 } from "@nodetool-ai/models";
-import {
-  applications,
-  assets,
-  getDb,
-  getDbType,
-  imageDocuments,
-  jsScripts,
-  scripts,
-  storyboards,
-  timelineSequences,
-  type DbTransaction
-} from "@nodetool-ai/models";
 import type { StorageAdapter } from "@nodetool-ai/storage";
-import { Application } from "@nodetool-ai/models";
 import { retrieveAssetBytes, getAssetStorageKey } from "./asset-paths.js";
 
 export class ProjectCopyError extends Error {
@@ -39,17 +30,13 @@ export class ProjectCopyError extends Error {
   }
 }
 
-interface DocumentSource {
-  readonly type: ProjectDocumentType;
-  readonly id: string;
-  readonly row:
-    | Storyboard
-    | Script
-    | TimelineSequence
-    | ImageDocument
-    | Application
-    | JsScript;
-}
+type DocumentSource =
+  | { readonly type: "storyboard"; readonly id: string; readonly row: Storyboard }
+  | { readonly type: "script"; readonly id: string; readonly row: Script }
+  | { readonly type: "timeline"; readonly id: string; readonly row: TimelineSequence }
+  | { readonly type: "sketch"; readonly id: string; readonly row: ImageDocument }
+  | { readonly type: "application"; readonly id: string; readonly row: Application }
+  | { readonly type: "jsscript"; readonly id: string; readonly row: JsScript };
 
 interface PreparedAsset {
   readonly source: Asset;
@@ -119,7 +106,8 @@ function remapAssetLocator(
   ids: ReadonlyMap<string, string>
 ): string {
   const assetId = assetIdFromLocator(locator);
-  const copiedId = assetId ? ids.get(assetId) : undefined;
+  if (!assetId) return locator;
+  const copiedId = ids.get(assetId);
   if (!copiedId) return locator;
   const prefix = locator.slice(0, locator.lastIndexOf(assetId));
   return `${prefix}${copiedId}${locator.slice(prefix.length + assetId.length)}`;
@@ -217,20 +205,26 @@ async function loadDocument(
   type: ProjectDocumentType,
   id: string
 ): Promise<DocumentSource> {
-  const row = await (
-    {
-      storyboard: Storyboard.findById,
-      script: Script.findById,
-      timeline: TimelineSequence.findById,
-      sketch: ImageDocument.findById,
-      application: Application.findById,
-      jsscript: JsScript.findById
-    } as const
-  )[type](id);
-  if (!row || row.user_id !== userId) {
-    throw new ProjectCopyError(`${type} dependency ${id} is unavailable`);
+  const assertOwned = <T extends { user_id: string }>(row: T | null): T => {
+    if (!row || row.user_id !== userId) {
+      throw new ProjectCopyError(`${type} dependency ${id} is unavailable`);
+    }
+    return row;
+  };
+  switch (type) {
+    case "storyboard":
+      return { type, id, row: assertOwned(await Storyboard.findById(id)) };
+    case "script":
+      return { type, id, row: assertOwned(await Script.findById(id)) };
+    case "timeline":
+      return { type, id, row: assertOwned(await TimelineSequence.findById(id)) };
+    case "sketch":
+      return { type, id, row: assertOwned(await ImageDocument.findById(id)) };
+    case "application":
+      return { type, id, row: assertOwned(await Application.findById(id)) };
+    case "jsscript":
+      return { type, id, row: assertOwned(await JsScript.findById(id)) };
   }
-  return { type, id, row };
 }
 
 function documentPayload(source: DocumentSource): unknown {
@@ -277,14 +271,13 @@ function directReferences(source: DocumentSource): References {
   return found;
 }
 
-function insertCopiedDocument(
-  tx: DbTransaction,
+function copiedDocument(
   source: DocumentSource,
   destinationId: string,
   destinationProjectId: string,
   ids: ReadonlyMap<string, string>,
   now: string
-) {
+): ProjectCopyDocument {
   const document = JSON.stringify(cloneAndRemap(documentPayload(source), ids));
   const base = {
     id: destinationId,
@@ -297,18 +290,20 @@ function insertCopiedDocument(
   };
   switch (source.type) {
     case "storyboard":
-      return tx.insert(storyboards).values(
-        {
+      return {
+        type: source.type,
+        values: {
           ...base,
           timeline_id: source.row.timeline_id
             ? ids.get(source.row.timeline_id) ?? null
             : null,
           revision: 0
         }
-      );
+      };
     case "script":
-      return tx.insert(scripts).values(
-        {
+      return {
+        type: source.type,
+        values: {
           ...base,
           timeline_id: source.row.timeline_id
             ? ids.get(source.row.timeline_id) ?? null
@@ -317,10 +312,11 @@ function insertCopiedDocument(
             ? ids.get(source.row.storyboard_id) ?? null
             : null
         }
-      );
+      };
     case "timeline":
-      return tx.insert(timelineSequences).values(
-        {
+      return {
+        type: source.type,
+        values: {
           ...base,
           workflow_id: null,
           fps: source.row.fps,
@@ -329,10 +325,11 @@ function insertCopiedDocument(
           duration_ms: source.row.duration_ms,
           revision: 0
         }
-      );
+      };
     case "sketch":
-      return tx.insert(imageDocuments).values(
-        {
+      return {
+        type: source.type,
+        values: {
           ...base,
           workflow_id: null,
           width: source.row.width,
@@ -343,13 +340,14 @@ function insertCopiedDocument(
             : null,
           revision: 0
         }
-      );
+      };
     case "application":
-      return tx
-        .insert(applications)
-        .values({ ...base, description: source.row.description });
+      return {
+        type: source.type,
+        values: { ...base, description: source.row.description }
+      };
     case "jsscript":
-      return tx.insert(jsScripts).values(base);
+      return { type: source.type, values: base };
   }
 }
 
@@ -449,62 +447,46 @@ export async function copyProjectDocument(args: {
       );
     }
 
-    const db = getDb();
-    const writes = (tx: DbTransaction) => {
-      const statements: Array<{ run: () => void }> = [];
-      const now = new Date().toISOString();
-      for (const [sourceId, prepared] of preparedAssets) {
-        const destinationId = assetIds.get(sourceId);
-        if (!destinationId) throw new ProjectCopyError("Asset map was incomplete");
-        statements.push(
-          tx.insert(assets).values({
-            id: destinationId,
-            user_id: prepared.source.user_id,
-            parent_id: null,
-            file_id: null,
-            name: prepared.source.name,
-            content_type: prepared.source.content_type,
-            size: prepared.bytes?.byteLength ?? prepared.source.size,
-            duration: prepared.source.duration,
-            metadata: cloneMetadata(prepared.source.metadata, ids),
-            sketch_document_id: null,
-            workflow_id: null,
-            node_id: null,
-            job_id: null,
-            timeline_id: null,
-            project_id: args.destinationProjectId,
-            created_at: now,
-            updated_at: now
-          })
-        );
-      }
-      for (const [sourceKey, source] of sources) {
-        const destinationId = documentIds.get(sourceKey);
-        if (!destinationId) throw new ProjectCopyError("Document map was incomplete");
-        statements.push(
-          insertCopiedDocument(
-            tx,
-            source,
-            destinationId,
-            args.destinationProjectId,
-            ids,
-            now
-          )
-        );
-      }
-      return statements;
-    };
-    if (getDbType() === "sqlite") {
-      db.transaction((tx: DbTransaction): void => {
-        for (const statement of writes(tx)) {
-          statement.run();
-        }
-      });
-    } else {
-      await db.transaction(async (tx: DbTransaction): Promise<void> => {
-        for (const statement of writes(tx)) await statement;
+    const now = new Date().toISOString();
+    const assetCopies: ProjectCopyAsset[] = [];
+    for (const [sourceId, prepared] of preparedAssets) {
+      const destinationId = assetIds.get(sourceId);
+      if (!destinationId) throw new ProjectCopyError("Asset map was incomplete");
+      assetCopies.push({
+        id: destinationId,
+        user_id: prepared.source.user_id,
+        parent_id: null,
+        file_id: null,
+        name: prepared.source.name,
+        content_type: prepared.source.content_type,
+        size: prepared.bytes?.byteLength ?? prepared.source.size,
+        duration: prepared.source.duration,
+        metadata: cloneMetadata(prepared.source.metadata, ids),
+        sketch_document_id: null,
+        workflow_id: null,
+        node_id: null,
+        job_id: null,
+        timeline_id: null,
+        project_id: args.destinationProjectId,
+        created_at: now,
+        updated_at: now
       });
     }
+    const documentCopies: ProjectCopyDocument[] = [];
+    for (const [sourceKey, source] of sources) {
+      const destinationId = documentIds.get(sourceKey);
+      if (!destinationId) throw new ProjectCopyError("Document map was incomplete");
+      documentCopies.push(
+        copiedDocument(
+          source,
+          destinationId,
+          args.destinationProjectId,
+          ids,
+          now
+        )
+      );
+    }
+    await persistProjectCopy({ assets: assetCopies, documents: documentCopies });
   } catch (error) {
     await Promise.allSettled(storedUris.map((uri) => args.storage.delete(uri)));
     throw error;

--- a/packages/websocket/src/lib/project-document-copy.ts
+++ b/packages/websocket/src/lib/project-document-copy.ts
@@ -230,13 +230,14 @@ function directReferences(source: DocumentSource): References {
   return found;
 }
 
-function valuesForDocument(
+function insertCopiedDocument(
+  tx: DbTransaction,
   source: DocumentSource,
   destinationId: string,
   destinationProjectId: string,
-  ids: ReadonlyMap<string, string>
-): { table: unknown; values: Record<string, unknown> } {
-  const now = new Date().toISOString();
+  ids: ReadonlyMap<string, string>,
+  now: string
+) {
   const document = JSON.stringify(cloneAndRemap(documentPayload(source), ids));
   const base = {
     id: destinationId,
@@ -249,20 +250,18 @@ function valuesForDocument(
   };
   switch (source.type) {
     case "storyboard":
-      return {
-        table: storyboards,
-        values: {
+      return tx.insert(storyboards).values(
+        {
           ...base,
           timeline_id: source.row.timeline_id
             ? ids.get(source.row.timeline_id) ?? null
             : null,
           revision: 0
         }
-      };
+      );
     case "script":
-      return {
-        table: scripts,
-        values: {
+      return tx.insert(scripts).values(
+        {
           ...base,
           timeline_id: source.row.timeline_id
             ? ids.get(source.row.timeline_id) ?? null
@@ -271,11 +270,10 @@ function valuesForDocument(
             ? ids.get(source.row.storyboard_id) ?? null
             : null
         }
-      };
+      );
     case "timeline":
-      return {
-        table: timelineSequences,
-        values: {
+      return tx.insert(timelineSequences).values(
+        {
           ...base,
           workflow_id: null,
           fps: source.row.fps,
@@ -284,11 +282,10 @@ function valuesForDocument(
           duration_ms: source.row.duration_ms,
           revision: 0
         }
-      };
+      );
     case "sketch":
-      return {
-        table: imageDocuments,
-        values: {
+      return tx.insert(imageDocuments).values(
+        {
           ...base,
           workflow_id: null,
           width: source.row.width,
@@ -299,14 +296,13 @@ function valuesForDocument(
             : null,
           revision: 0
         }
-      };
+      );
     case "application":
-      return {
-        table: applications,
-        values: { ...base, description: source.row.description }
-      };
+      return tx
+        .insert(applications)
+        .values({ ...base, description: source.row.description });
     case "jsscript":
-      return { table: jsScripts, values: base };
+      return tx.insert(jsScripts).values(base);
   }
 }
 
@@ -419,9 +415,15 @@ export async function copyProjectDocument(args: {
       for (const [sourceKey, source] of sources) {
         const destinationId = documentIds.get(sourceKey);
         if (!destinationId) throw new ProjectCopyError("Document map was incomplete");
-        const row = valuesForDocument(source, destinationId, args.destinationProjectId, ids);
         statements.push(
-          tx.insert(row.table as typeof storyboards).values(row.values as never)
+          insertCopiedDocument(
+            tx,
+            source,
+            destinationId,
+            args.destinationProjectId,
+            ids,
+            now
+          )
         );
       }
       return statements;

--- a/packages/websocket/src/trpc/routers/projects.ts
+++ b/packages/websocket/src/trpc/routers/projects.ts
@@ -24,6 +24,7 @@ import {
   LOOSE_PROJECT_ID,
   PERSONAL_PROJECT_KIND,
   Project,
+  hasProjectDocumentDependents,
   listProjectDocuments,
   moveDocumentToProject,
   summarizeProject
@@ -224,6 +225,14 @@ export const projectsRouter = router({
       await prepareUser(ctx.userId);
       if (input.projectId !== LOOSE_PROJECT_ID) {
         await loadOwned(ctx.userId, input.projectId);
+      }
+      if (
+        await hasProjectDocumentDependents(ctx.userId, input.type, input.ref)
+      ) {
+        throwApiError(
+          ApiErrorCode.INVALID_INPUT,
+          "Cannot move a referenced document or entity. Copy it into the destination project instead."
+        );
       }
       const moved = await moveDocumentToProject(
         ctx.userId,

--- a/packages/websocket/src/trpc/routers/projects.ts
+++ b/packages/websocket/src/trpc/routers/projects.ts
@@ -30,6 +30,8 @@ import {
 } from "@nodetool-ai/models";
 import {
   assignDocumentInput,
+  copyProjectDocumentInput,
+  copyProjectDocumentOutput,
   createProjectInput,
   patchProjectInput,
   projectDetail,
@@ -40,6 +42,8 @@ import { ApiErrorCode } from "../../error-codes.js";
 import { router } from "../index.js";
 import { protectedProcedure } from "../middleware.js";
 import { throwApiError } from "../error-formatter.js";
+import { getAssetAdapter } from "../../lib/storage.js";
+import { copyProjectDocument, ProjectCopyError } from "../../lib/project-document-copy.js";
 
 const listInput = z.object({});
 const idInput = z.object({ id: z.string() });
@@ -234,5 +238,40 @@ export const projectsRouter = router({
         );
       }
       return { ok: true as const };
+    }),
+
+  /**
+   * Make an independent copy in another project. The copier first verifies the
+   * complete resource closure and only publishes database rows after every
+   * required asset is available, so a caller never receives a broken copy.
+   */
+  copyDocument: protectedProcedure
+    .input(copyProjectDocumentInput)
+    .output(copyProjectDocumentOutput)
+    .mutation(async ({ ctx, input }) => {
+      await prepareUser(ctx.userId);
+      await loadOwned(ctx.userId, input.destinationProjectId);
+      try {
+        const copied = await copyProjectDocument({
+          userId: ctx.userId,
+          type: input.type,
+          id: input.ref,
+          destinationProjectId: input.destinationProjectId,
+          storage: getAssetAdapter()
+        });
+        return {
+          type: input.type,
+          ref: copied.id,
+          name: copied.name,
+          updatedAt: new Date().toISOString(),
+          copiedAssets: copied.copiedAssets,
+          copiedDocuments: copied.copiedDocuments
+        };
+      } catch (error) {
+        if (error instanceof ProjectCopyError) {
+          throwApiError(ApiErrorCode.INVALID_INPUT, error.message);
+        }
+        throw error;
+      }
     })
 });

--- a/packages/websocket/src/trpc/sandbox-coverage.ts
+++ b/packages/websocket/src/trpc/sandbox-coverage.ts
@@ -636,6 +636,12 @@ export const SANDBOX_API_COVERAGE: Readonly<
       "between projects; both the document and the project are the " +
       "caller's own rows."
   },
+  "projects.copyDocument": {
+    gap:
+      "Copies a document and its owned dependency closure into another " +
+      "project. The caller owns both sides, but no sandbox capability " +
+      "yet exposes the operation-wide reference remapping contract."
+  },
   "projects.create": {
     gap:
       "A project groups documents that already carry its id, and a run " +

--- a/packages/websocket/tests/project-document-copy.test.ts
+++ b/packages/websocket/tests/project-document-copy.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   Asset,
+  emptyScriptDocument,
+  Script,
   Storyboard,
+  TimelineSequence,
   initTestDb,
   type StoryboardDocument
 } from "@nodetool-ai/models";
@@ -94,9 +97,18 @@ describe("copyProjectDocument", () => {
     ]);
     const copiedAsset = await Asset.find(userId, copiedEntityId ?? "");
     expect(copiedAsset?.project_id).toBe(destinationProjectId);
+    if (!copiedAsset) throw new Error("Copied asset was not persisted");
+    copiedAsset.name = "Destination reference";
+    await copiedAsset.save();
+    expect((await Asset.find(userId, reference.id))?.name).toBe("Reference");
+    await storage.delete(
+      getAssetStorageKey(userId, reference.id, reference.content_type)
+    );
+    await reference.delete();
+    await board.delete();
     expect(
       await storage.retrieve(
-        getAssetStorageKey(userId, copiedEntityId ?? "", "image/png")
+        getAssetStorageKey(userId, copiedAsset.id, "image/png")
       )
     ).toEqual(new Uint8Array([1, 2, 3]));
   });
@@ -122,6 +134,111 @@ describe("copyProjectDocument", () => {
       })
     ).rejects.toBeInstanceOf(ProjectCopyError);
     expect((await Storyboard.listByProject(destinationProjectId, userId)).length).toBe(0);
+  });
+
+  it("rewrites an extension-bearing asset locator without requiring a second asset", async () => {
+    const storage = new InMemoryStorageAdapter();
+    const reference = await saveAsset(storage, {
+      content: new Uint8Array([4, 5, 6])
+    });
+    const document = storyboardDocument("");
+    document.shots = [
+      {
+        type: "shot",
+        id: "shot-1",
+        index: 0,
+        action: "show the reference",
+        status: "draft",
+        keyframe: { type: "image", uri: `asset://${reference.id}.png` }
+      }
+    ];
+    const board = new Storyboard({
+      user_id: userId,
+      project_id: sourceProjectId,
+      name: "URI board",
+      document: JSON.stringify(document)
+    });
+    await board.save();
+
+    const copied = await copyProjectDocument({
+      userId,
+      type: "storyboard",
+      id: board.id,
+      destinationProjectId,
+      storage
+    });
+
+    const copiedBoard = await Storyboard.findById(copied.id);
+    const keyframe = copiedBoard?.toDocument().shots[0]?.keyframe;
+    expect(keyframe?.uri).toBeDefined();
+    expect(keyframe?.uri).not.toBe(`asset://${reference.id}.png`);
+    expect(copied.copiedAssets).toBe(1);
+  });
+
+  it("rejects unsupported workflow bindings before it copies anything", async () => {
+    const storage = new InMemoryStorageAdapter();
+    const document = {
+      ...storyboardDocument(""),
+      workflowId: "workflow-1"
+    };
+    const board = new Storyboard({
+      user_id: userId,
+      project_id: sourceProjectId,
+      name: "Workflow board",
+      document: JSON.stringify(document)
+    });
+    await board.save();
+
+    await expect(
+      copyProjectDocument({
+        userId,
+        type: "storyboard",
+        id: board.id,
+        destinationProjectId,
+        storage
+      })
+    ).rejects.toBeInstanceOf(ProjectCopyError);
+    expect((await Storyboard.listByProject(destinationProjectId, userId)).length).toBe(0);
+  });
+
+  it("copies linked document cycles once and remaps both directions", async () => {
+    const storage = new InMemoryStorageAdapter();
+    const script = new Script({
+      user_id: userId,
+      project_id: sourceProjectId,
+      name: "Script",
+      document: JSON.stringify(emptyScriptDocument())
+    });
+    await script.save();
+    const timeline = new TimelineSequence({
+      user_id: userId,
+      project_id: sourceProjectId,
+      name: "Timeline",
+      document: JSON.stringify({
+        tracks: [],
+        clips: [],
+        markers: [],
+        scriptId: script.id
+      })
+    });
+    await timeline.save();
+    script.timeline_id = timeline.id;
+    await script.save();
+
+    const copied = await copyProjectDocument({
+      userId,
+      type: "script",
+      id: script.id,
+      destinationProjectId,
+      storage
+    });
+
+    expect(copied.copiedDocuments).toBe(2);
+    const copiedScript = await Script.findById(copied.id);
+    const copiedTimeline = await TimelineSequence.findById(
+      copiedScript?.timeline_id ?? ""
+    );
+    expect(copiedTimeline?.toDocument()).toMatchObject({ scriptId: copied.id });
   });
 
   it("traverses a large asset dependency graph without duplicate copies", async () => {

--- a/packages/websocket/tests/project-document-copy.test.ts
+++ b/packages/websocket/tests/project-document-copy.test.ts
@@ -102,13 +102,15 @@ describe("copyProjectDocument", () => {
     await copiedAsset.save();
     expect((await Asset.find(userId, reference.id))?.name).toBe("Reference");
     await storage.delete(
-      getAssetStorageKey(userId, reference.id, reference.content_type)
+      storage.uriForKey(
+        getAssetStorageKey(userId, reference.id, reference.content_type)
+      )
     );
     await reference.delete();
     await board.delete();
     expect(
       await storage.retrieve(
-        getAssetStorageKey(userId, copiedAsset.id, "image/png")
+        storage.uriForKey(getAssetStorageKey(userId, copiedAsset.id, "image/png"))
       )
     ).toEqual(new Uint8Array([1, 2, 3]));
   });

--- a/packages/websocket/tests/project-document-copy.test.ts
+++ b/packages/websocket/tests/project-document-copy.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  Asset,
+  Storyboard,
+  initTestDb,
+  type StoryboardDocument
+} from "@nodetool-ai/models";
+import { InMemoryStorageAdapter } from "@nodetool-ai/storage";
+import { getAssetStorageKey } from "../src/lib/asset-paths.js";
+import {
+  copyProjectDocument,
+  ProjectCopyError
+} from "../src/lib/project-document-copy.js";
+
+const userId = "copy-user";
+const sourceProjectId = "source";
+const destinationProjectId = "destination";
+
+const storyboardDocument = (entityId: string): StoryboardDocument => ({
+  screenplay: null,
+  shots: [],
+  brief: "",
+  style: "",
+  entityIds: [entityId, entityId],
+  aspectRatio: "16:9",
+  setupStage: "done",
+  genre: "",
+  directorModel: null,
+  imageModel: null,
+  videoModel: null
+});
+
+async function saveAsset(
+  storage: InMemoryStorageAdapter,
+  values: {
+    id?: string;
+    metadata?: Record<string, unknown> | null;
+    content?: Uint8Array;
+  } = {}
+): Promise<Asset> {
+  const asset = new Asset({
+    id: values.id,
+    user_id: userId,
+    project_id: sourceProjectId,
+    name: "Reference",
+    content_type: "image/png",
+    metadata: values.metadata ?? null,
+    size: values.content?.byteLength ?? null
+  });
+  await asset.save();
+  if (values.content) {
+    await storage.store(
+      getAssetStorageKey(userId, asset.id, asset.content_type),
+      values.content,
+      asset.content_type
+    );
+  }
+  return asset;
+}
+
+describe("copyProjectDocument", () => {
+  beforeEach(() => initTestDb());
+
+  it("copies repeated entity references once and gives the destination independent bytes", async () => {
+    const storage = new InMemoryStorageAdapter();
+    const reference = await saveAsset(storage, {
+      content: new Uint8Array([1, 2, 3])
+    });
+    const board = new Storyboard({
+      user_id: userId,
+      project_id: sourceProjectId,
+      name: "Board",
+      document: JSON.stringify(storyboardDocument(reference.id))
+    });
+    await board.save();
+
+    const copied = await copyProjectDocument({
+      userId,
+      type: "storyboard",
+      id: board.id,
+      destinationProjectId,
+      storage
+    });
+
+    expect(copied.copiedDocuments).toBe(1);
+    expect(copied.copiedAssets).toBe(1);
+    const copiedBoard = await Storyboard.findById(copied.id);
+    const copiedEntityId = copiedBoard?.toDocument().entityIds[0];
+    expect(copiedEntityId).toBeDefined();
+    expect(copiedEntityId).not.toBe(reference.id);
+    expect(copiedBoard?.toDocument().entityIds).toEqual([
+      copiedEntityId,
+      copiedEntityId
+    ]);
+    const copiedAsset = await Asset.find(userId, copiedEntityId ?? "");
+    expect(copiedAsset?.project_id).toBe(destinationProjectId);
+    expect(
+      await storage.retrieve(
+        getAssetStorageKey(userId, copiedEntityId ?? "", "image/png")
+      )
+    ).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  it("fails before writing a visible copy when a required asset is unavailable", async () => {
+    const storage = new InMemoryStorageAdapter();
+    const reference = await saveAsset(storage);
+    const board = new Storyboard({
+      user_id: userId,
+      project_id: sourceProjectId,
+      name: "Board",
+      document: JSON.stringify(storyboardDocument(reference.id))
+    });
+    await board.save();
+
+    await expect(
+      copyProjectDocument({
+        userId,
+        type: "storyboard",
+        id: board.id,
+        destinationProjectId,
+        storage
+      })
+    ).rejects.toBeInstanceOf(ProjectCopyError);
+    expect((await Storyboard.listByProject(destinationProjectId, userId)).length).toBe(0);
+  });
+
+  it("traverses a large asset dependency graph without duplicate copies", async () => {
+    const storage = new InMemoryStorageAdapter();
+    const count = 1_200;
+    let nextId: string | null = null;
+    for (let index = count - 1; index >= 0; index -= 1) {
+      const asset = await saveAsset(storage, {
+        metadata: nextId ? { assetId: nextId } : null,
+        content: new Uint8Array([index % 255])
+      });
+      nextId = asset.id;
+    }
+    const board = new Storyboard({
+      user_id: userId,
+      project_id: sourceProjectId,
+      name: "Large graph",
+      document: JSON.stringify(storyboardDocument(nextId ?? ""))
+    });
+    await board.save();
+
+    const copied = await copyProjectDocument({
+      userId,
+      type: "storyboard",
+      id: board.id,
+      destinationProjectId,
+      storage
+    });
+
+    expect(copied.copiedAssets).toBe(count);
+  });
+});

--- a/web/src/components/projects/CopyProjectDocumentAction.tsx
+++ b/web/src/components/projects/CopyProjectDocumentAction.tsx
@@ -1,5 +1,7 @@
-import { useCallback, useState } from "react";
+import { useState } from "react";
 
+import { trpc } from "../../trpc/client";
+import { useNotificationStore } from "../../stores/NotificationStore";
 import {
   Caption,
   Dialog,
@@ -8,7 +10,6 @@ import {
   SelectField,
   SPACING
 } from "../ui_primitives";
-import { trpc } from "../../trpc/client";
 import type { ProjectDocument } from "./projectStatus";
 
 interface CopyProjectDocumentActionProps {
@@ -27,30 +28,36 @@ const CopyProjectDocumentAction = ({
     { staleTime: 30_000 }
   );
   const utils = trpc.useUtils();
+  const addNotification = useNotificationStore((state) => state.addNotification);
+  // A project summary carries server-derived status, spend, and thumbnails;
+  // the copy response intentionally does not invent them, so an optimistic
+  // card would be incomplete. Refetching supplies the authoritative summary.
   const copy = trpc.projects.copyDocument.useMutation({
     onSuccess: () => {
       setOpen(false);
       void utils.projects.get.invalidate();
       void utils.projects.summaries.invalidate();
+    },
+    onError: (error) => {
+      addNotification({ type: "error", alert: true, content: error.message });
     }
   });
   const destinations = projects.filter((project) => project.id !== sourceProjectId);
-
-  const showDialog = useCallback(() => {
+  const showDialog = () => {
     setDestinationProjectId(destinations[0]?.id ?? "");
     setOpen(true);
-  }, [destinations]);
-  const closeDialog = useCallback(() => {
+  };
+  const closeDialog = () => {
     if (!copy.isPending) setOpen(false);
-  }, [copy.isPending]);
-  const confirmCopy = useCallback(() => {
+  };
+  const confirmCopy = () => {
     if (!destinationProjectId) return;
     copy.mutate({
       type: document.type,
       ref: document.ref,
       destinationProjectId
     });
-  }, [copy, destinationProjectId, document.ref, document.type]);
+  };
 
   return (
     <>
@@ -87,7 +94,6 @@ const CopyProjectDocumentAction = ({
             }))}
             disabled={destinations.length === 0 || copy.isPending}
           />
-          {copy.error && <Caption color="error">{copy.error.message}</Caption>}
         </FlexColumn>
       </Dialog>
     </>

--- a/web/src/components/projects/CopyProjectDocumentAction.tsx
+++ b/web/src/components/projects/CopyProjectDocumentAction.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type MouseEvent } from "react";
 
 import { trpc } from "../../trpc/client";
 import { useNotificationStore } from "../../stores/NotificationStore";
@@ -43,7 +43,8 @@ const CopyProjectDocumentAction = ({
     }
   });
   const destinations = projects.filter((project) => project.id !== sourceProjectId);
-  const showDialog = () => {
+  const showDialog = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
     setDestinationProjectId(destinations[0]?.id ?? "");
     setOpen(true);
   };

--- a/web/src/components/projects/CopyProjectDocumentAction.tsx
+++ b/web/src/components/projects/CopyProjectDocumentAction.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useState } from "react";
+
+import {
+  Caption,
+  Dialog,
+  EditorButton,
+  FlexColumn,
+  SelectField,
+  SPACING
+} from "../ui_primitives";
+import { trpc } from "../../trpc/client";
+import type { ProjectDocument } from "./projectStatus";
+
+interface CopyProjectDocumentActionProps {
+  readonly document: ProjectDocument;
+  readonly sourceProjectId: string;
+}
+
+const CopyProjectDocumentAction = ({
+  document,
+  sourceProjectId
+}: CopyProjectDocumentActionProps) => {
+  const [open, setOpen] = useState(false);
+  const [destinationProjectId, setDestinationProjectId] = useState("");
+  const { data: projects = [] } = trpc.projects.list.useQuery(
+    {},
+    { staleTime: 30_000 }
+  );
+  const utils = trpc.useUtils();
+  const copy = trpc.projects.copyDocument.useMutation({
+    onSuccess: () => {
+      setOpen(false);
+      void utils.projects.get.invalidate();
+      void utils.projects.summaries.invalidate();
+    }
+  });
+  const destinations = projects.filter((project) => project.id !== sourceProjectId);
+
+  const showDialog = useCallback(() => {
+    setDestinationProjectId(destinations[0]?.id ?? "");
+    setOpen(true);
+  }, [destinations]);
+  const closeDialog = useCallback(() => {
+    if (!copy.isPending) setOpen(false);
+  }, [copy.isPending]);
+  const confirmCopy = useCallback(() => {
+    if (!destinationProjectId) return;
+    copy.mutate({
+      type: document.type,
+      ref: document.ref,
+      destinationProjectId
+    });
+  }, [copy, destinationProjectId, document.ref, document.type]);
+
+  return (
+    <>
+      <EditorButton
+        variant="text"
+        density="compact"
+        onClick={showDialog}
+        aria-label={`Copy ${document.name} to another project`}
+      >
+        Copy
+      </EditorButton>
+      <Dialog
+        open={open}
+        onClose={closeDialog}
+        title={`Copy ${document.name}`}
+        onConfirm={confirmCopy}
+        confirmText="Copy"
+        cancelText="Cancel"
+        confirmDisabled={!destinationProjectId}
+        isLoading={copy.isPending}
+      >
+        <FlexColumn gap={SPACING.lg}>
+          <Caption color="secondary">
+            Referenced assets, entities, and supported documents are copied into
+            the destination. The source remains unchanged.
+          </Caption>
+          <SelectField
+            label="Destination project"
+            value={destinationProjectId}
+            onChange={setDestinationProjectId}
+            options={destinations.map((project) => ({
+              value: project.id,
+              label: project.name
+            }))}
+            disabled={destinations.length === 0 || copy.isPending}
+          />
+          {copy.error && <Caption color="error">{copy.error.message}</Caption>}
+        </FlexColumn>
+      </Dialog>
+    </>
+  );
+};
+
+export default CopyProjectDocumentAction;

--- a/web/src/components/projects/ProjectDocumentCard.tsx
+++ b/web/src/components/projects/ProjectDocumentCard.tsx
@@ -20,6 +20,7 @@ import {
 } from "../ui_primitives";
 import { TYPE_COLOR, TYPE_GLYPH } from "../workspace/tabTypeIdentity";
 import ProjectDocumentPreview from "./ProjectDocumentPreview";
+import CopyProjectDocumentAction from "./CopyProjectDocumentAction";
 import {
   documentProgress,
   documentStatusLine,
@@ -29,11 +30,13 @@ import {
 
 interface ProjectDocumentCardProps {
   document: ProjectDocument;
+  sourceProjectId: string;
   onOpen: (document: ProjectDocument) => void;
 }
 
 const ProjectDocumentCard = ({
   document,
+  sourceProjectId,
   onOpen
 }: ProjectDocumentCardProps) => {
   const handleOpen = useCallback(() => onOpen(document), [onOpen, document]);
@@ -74,6 +77,10 @@ const ProjectDocumentCard = ({
             {formatDocumentSpend(document)}
           </Box>
         </FlexRow>
+        <CopyProjectDocumentAction
+          document={document}
+          sourceProjectId={sourceProjectId}
+        />
       </FlexColumn>
     </Card>
   );

--- a/web/src/components/projects/ProjectOverviewSurface.tsx
+++ b/web/src/components/projects/ProjectOverviewSurface.tsx
@@ -122,6 +122,7 @@ const ProjectOverviewSurface = ({ refId }: ProjectOverviewSurfaceProps) => {
           <ProjectDocumentCard
             key={`${document.type}:${document.ref}`}
             document={document}
+            sourceProjectId={refId}
             onOpen={openDocument}
           />
         ))}

--- a/web/src/components/projects/__tests__/ProjectOverviewSurface.test.tsx
+++ b/web/src/components/projects/__tests__/ProjectOverviewSurface.test.tsx
@@ -76,8 +76,18 @@ const detail = {
 jest.mock("../../../trpc/client", () => ({
   trpc: {
     projects: {
-      get: { useQuery: () => ({ data: detail, isPending: false, error: null }) }
-    }
+      get: { useQuery: () => ({ data: detail, isPending: false, error: null }) },
+      list: { useQuery: () => ({ data: [], isPending: false, error: null }) },
+      copyDocument: {
+        useMutation: () => ({ isPending: false, mutate: jest.fn() })
+      }
+    },
+    useUtils: () => ({
+      projects: {
+        get: { invalidate: jest.fn() },
+        summaries: { invalidate: jest.fn() }
+      }
+    })
   }
 }));
 
@@ -158,6 +168,16 @@ describe("ProjectOverviewSurface", () => {
       title: "Script",
       projectId: "p1"
     });
+  });
+
+  it("opens copy selection without opening the source document", async () => {
+    renderSurface();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Copy Script to another project" })
+    );
+
+    expect(openTab).not.toHaveBeenCalled();
+    expect(screen.getByText("Copy Script")).toBeInTheDocument();
   });
 
   it("draws a script card from its stored lines", () => {


### PR DESCRIPTION
Copies now select a destination project and materialize a self-contained document closure, including referenced assets and documents. References are remapped through one operation-wide identity map, so repeated dependencies and cycles produce only one destination resource.

- Adds the `projects.copyDocument` procedure and protocol contracts.
- Discovers dependencies and copies storage bytes in websocket, while `@nodetool-ai/models` atomically persists prepared rows.
- Refuses moves with inbound references and reports unavailable or unsupported dependencies before a copy becomes visible.
- Classifies the new procedure at the sandbox boundary, fixes the project overview tRPC test mock, and prevents Copy clicks from opening the source card.

Verification:
- `git diff --check` passed.
- CI failure logs identified the missing sandbox coverage entry and the incomplete tRPC mock.
- Local `test:affected`, typecheck, lint, and harness gate could not complete because this recovery checkout has no `node_modules` (`typescript`, `tsc`, `oxlint`, and `tsx` are unavailable). The new CI run is the verification path.