### PR TITLE
perf(web): render thumb-sized images from thumbnails, not originals

### DIFF
--- a/web/src/__tests__/thumbnailRendering.test.ts
+++ b/web/src/__tests__/thumbnailRendering.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Thumb-sized surfaces render thumbnails, not originals.
+ *
+ * The server derives a 512px JPEG for every stored asset and hands it back as
+ * `thumb_url`. A generated still is 300KB-1.2MB and a rendered PDF is larger
+ * still, so a grid, strip, chip or avatar that resolves to `get_url` pulls the
+ * full original down to paint a few hundred pixels — twelve of them on one
+ * storyboard, dozens on a project list.
+ *
+ * There are three ways to reach the thumbnail, all equivalent:
+ *   - `preferThumbnail` on `ResponsiveImage` (the locator path),
+ *   - `useResolvedThumbnailUri` (the resolver path, for a raw `<img>`),
+ *   - `asset.thumb_url` ahead of `get_url` (surfaces holding the asset row).
+ *
+ * This file pins which surfaces are thumb-sized, so a new card cannot ship on
+ * the original and a migrated one cannot quietly regress. It is the bandwidth
+ * half of `mediaResolutionBoundary.test.ts`, which pins that the same surfaces
+ * resolve at all.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC = join(__dirname, "..");
+
+type Via = "preferThumbnail" | "thumbnail-hook" | "thumb-field";
+
+type ThumbSurface = {
+  /** What the user sees, and roughly how big it is drawn. */
+  surface: string;
+  file: string;
+  via: Via;
+};
+
+const INVENTORY: ThumbSurface[] = [
+  // Storyboard: shot cards and the takes strip under them.
+  { surface: "storyboard shot card", file: "components/storyboard/ShotCard.tsx", via: "preferThumbnail" },
+  { surface: "storyboard takes strip", file: "components/storyboard/ShotTakesGallery.tsx", via: "preferThumbnail" },
+  { surface: "storyboard entity avatar", file: "components/storyboard/StoryboardEntitiesField.tsx", via: "thumbnail-hook" },
+  // Script: the 44x26 keyframe chip beside a line.
+  { surface: "script shot chip", file: "components/script/ScriptShotChip.tsx", via: "preferThumbnail" },
+  // Projects: still grids on cards and document previews.
+  { surface: "project card stills", file: "components/projects/ProjectCard.tsx", via: "preferThumbnail" },
+  { surface: "project document preview", file: "components/projects/ProjectDocumentPreview.tsx", via: "preferThumbnail" },
+  // Setup wizards: reference tiles and the contact sheet.
+  { surface: "setup contact sheet", file: "components/setup/image/ContactSheet.tsx", via: "preferThumbnail" },
+  { surface: "setup image references", file: "components/setup/image/IdeaStep.tsx", via: "preferThumbnail" },
+  { surface: "setup video references", file: "components/setup/video/IdeaStep.tsx", via: "preferThumbnail" },
+  { surface: "setup entity rows", file: "components/setup/storyboard/EntitiesStep.tsx", via: "preferThumbnail" },
+  // Memory library rows.
+  { surface: "memory card", file: "components/memory/MemoryCard.tsx", via: "preferThumbnail" },
+  // Sketch layer list.
+  { surface: "sketch layer thumbnail", file: "components/sketch/LayerItem.tsx", via: "preferThumbnail" },
+  // Chat: the 18px resource chip.
+  { surface: "chat resource chip", file: "components/chat/message/ResourceChip.tsx", via: "thumbnail-hook" },
+  // Asset browser tiles and rows, which hold the asset row directly.
+  { surface: "asset grid tile", file: "components/assets/AssetItem.tsx", via: "thumb-field" },
+  { surface: "asset list row", file: "components/assets/AssetListView.tsx", via: "thumb-field" },
+  { surface: "asset search result", file: "components/assets/GlobalSearchResults.tsx", via: "thumb-field" },
+  { surface: "job output tile", file: "components/panels/jobs/JobItem.tsx", via: "thumb-field" },
+  { surface: "asset info panel", file: "components/context_menus/AssetInfoPanel.tsx", via: "thumb-field" }
+];
+
+const read = (file: string): string => readFileSync(join(SRC, file), "utf8");
+
+describe("thumb-sized surfaces render thumbnails", () => {
+  // An audit that matched nothing would pass silently. Assert it found its
+  // targets before asserting anything about them.
+  it("covers every thumb-sized surface family", () => {
+    expect(new Set(INVENTORY.map((entry) => entry.via))).toEqual(
+      new Set(["preferThumbnail", "thumbnail-hook", "thumb-field"])
+    );
+    expect(INVENTORY.length).toBeGreaterThanOrEqual(18);
+  });
+
+  it.each(INVENTORY)("$surface takes the thumbnail via $via", ({ file, via }) => {
+    const source = read(file);
+    expect(source.length).toBeGreaterThan(0);
+    if (via === "preferThumbnail") {
+      expect(source).toContain("<ResponsiveImage");
+      expect(source).toMatch(/^\s*preferThumbnail$/m);
+    } else if (via === "thumbnail-hook") {
+      expect(source).toContain("useResolvedThumbnailUri");
+    } else {
+      expect(source).toContain("thumb_url");
+    }
+  });
+
+  it("never paints a PDF tile from the document itself", () => {
+    // `get_url` on a PDF is the PDF; a browser paints no background image from
+    // it and downloads the whole file trying. The first-page JPEG is thumb_url.
+    const source = read("components/assets/AssetItem.tsx");
+    expect(source).not.toMatch(/backgroundImage: `url\(\$\{asset\.get_url\}\)`/);
+  });
+});

--- a/web/src/components/assets/AssetItem.tsx
+++ b/web/src/components/assets/AssetItem.tsx
@@ -555,11 +555,14 @@ const AssetItem: React.FC<AssetItemProps> = (props) => {
               style={{ color: `var(--c_${assetType})` }}
               titleAccess={asset.content_type || "PDF file"}
             />
-            {asset.get_url !== "/images/placeholder.png" && (
+            {asset.thumb_url && (
+              // The server renders the first page to a JPEG; `get_url` is the
+              // PDF itself, which no browser paints as a background image — it
+              // only pulls the whole document down behind an empty tile.
               <div
                 className="image"
                 style={{
-                  backgroundImage: `url(${asset.get_url})`
+                  backgroundImage: `url(${asset.thumb_url})`
                 }}
                 aria-label={asset.id}
               />

--- a/web/src/components/chat/message/ResourceChip.tsx
+++ b/web/src/components/chat/message/ResourceChip.tsx
@@ -22,7 +22,7 @@ import ViewInArOutlinedIcon from "@mui/icons-material/ViewInArOutlined";
 import { parseResourceUri, type ResourceKind, type ResourceUri } from "@nodetool-ai/protocol";
 
 import { BORDER_RADIUS, Chip, SPACING, TYPOGRAPHY, getSpacingPx } from "../../ui_primitives";
-import { useResolvedMediaUri } from "../../../hooks/useResolvedMediaUri";
+import { useResolvedThumbnailUri } from "../../../hooks/useResolvedMediaUri";
 import { canOpenResource, openResource } from "../../../lib/chat/openResource";
 
 interface ResourceChipProps {
@@ -83,7 +83,7 @@ const THUMBNAIL_SIZE = 18;
 
 const ResourceChip: React.FC<ResourceChipProps> = ({ uri, label }) => {
   const ref = useMemo(() => parseResourceUri(uri), [uri]);
-  const thumbnail = useResolvedMediaUri(thumbnailLocatorFor(ref));
+  const thumbnail = useResolvedThumbnailUri(thumbnailLocatorFor(ref));
 
   if (!ref) {
     return <>{label}</>;

--- a/web/src/components/chat/message/__tests__/ResourceChip.test.tsx
+++ b/web/src/components/chat/message/__tests__/ResourceChip.test.tsx
@@ -11,7 +11,7 @@ const openResource = jest.fn();
 // QueryClientProvider, so use the manual mock (resolution itself is covered
 // by hooks/__tests__/useResolvedMediaUri.test.tsx).
 jest.mock("../../../../hooks/useResolvedMediaUri");
-import { mockAssetUrl } from "../../../../hooks/__mocks__/useResolvedMediaUri";
+import { mockAssetThumbUrl } from "../../../../hooks/__mocks__/useResolvedMediaUri";
 
 jest.mock("../../../../lib/chat/openResource", () => ({
   __esModule: true,
@@ -60,10 +60,11 @@ describe("ResourceChip", () => {
   it("renders a thumbnail for image assets", () => {
     const { container } = renderChip("asset://as_1.png", "render.png");
 
-    // Resolved through the asset record, not by rewriting the locator.
+    // Resolved through the asset record, not by rewriting the locator, and at
+    // 18px the chip takes the server's thumbnail rather than the full render.
     expect(container.querySelector("img")).toHaveAttribute(
       "src",
-      mockAssetUrl("as_1.png")
+      mockAssetThumbUrl("as_1")
     );
   });
 

--- a/web/src/components/memory/MemoryCard.tsx
+++ b/web/src/components/memory/MemoryCard.tsx
@@ -65,6 +65,7 @@ const MemoryAssetThumb: React.FC<{ resource: Resource }> = memo(
     return (
       <ResponsiveImage
         locator={{ uri: resource.uri, asset_id: resource.id }}
+        preferThumbnail
         alt={label}
         title={label}
         fit="cover"

--- a/web/src/components/projects/ProjectCard.tsx
+++ b/web/src/components/projects/ProjectCard.tsx
@@ -87,6 +87,7 @@ const ProjectCard = ({ detail, onOpen, onDropDocument }: ProjectCardProps) => {
           <ResponsiveImage
             key={still.asset_id ?? still.uri ?? index}
             locator={still}
+            preferThumbnail
             alt=""
             fit="cover"
             sx={{

--- a/web/src/components/projects/ProjectDocumentPreview.tsx
+++ b/web/src/components/projects/ProjectDocumentPreview.tsx
@@ -71,6 +71,7 @@ const StillStrip = ({ document }: { document: ProjectDocument }) => (
         <ResponsiveImage
           key={still.asset_id ?? still.uri ?? index}
           locator={still}
+          preferThumbnail
           alt=""
           fit="cover"
           sx={{ width: "100%", height: "100%" }}

--- a/web/src/components/script/ScriptShotChip.tsx
+++ b/web/src/components/script/ScriptShotChip.tsx
@@ -59,6 +59,7 @@ const ScriptShotChipInner = ({ shot, onOpen }: ScriptShotChipProps) => {
         {uri ? (
           <ResponsiveImage
             locator={shot.keyframe}
+            preferThumbnail
             alt=""
             fit="cover"
             sx={{ width: "100%", height: "100%" }}

--- a/web/src/components/setup/image/ContactSheet.tsx
+++ b/web/src/components/setup/image/ContactSheet.tsx
@@ -276,6 +276,7 @@ const ContactSheetInternal: React.FC<ContactSheetProps> = ({
               {tile.assetId ? (
                 <ResponsiveImage
                   locator={`asset://${tile.assetId}`}
+                  preferThumbnail
                   alt={tile.label}
                   aspectRatio="1/1"
                   fit="contain"

--- a/web/src/components/setup/image/IdeaStep.tsx
+++ b/web/src/components/setup/image/IdeaStep.tsx
@@ -182,6 +182,7 @@ const IdeaStepInternal: React.FC<IdeaStepProps> = ({
                   >
                     <ResponsiveImage
                       locator={reference.uri}
+                      preferThumbnail
                       alt={reference.name}
                       aspectRatio="1/1"
                       fit="cover"

--- a/web/src/components/setup/storyboard/EntitiesStep.tsx
+++ b/web/src/components/setup/storyboard/EntitiesStep.tsx
@@ -530,6 +530,7 @@ export const EntitiesStep = ({ boardId }: EntitiesStepProps) => {
                                 {entity.reference_images?.[0] ? (
                                   <ResponsiveImage
                                     locator={entity.reference_images[0]}
+                                    preferThumbnail
                                     alt=""
                                     aspectRatio="1/1"
                                     borderRadius={BORDER_RADIUS.sm}

--- a/web/src/components/setup/video/IdeaStep.tsx
+++ b/web/src/components/setup/video/IdeaStep.tsx
@@ -289,6 +289,7 @@ const IdeaStepInternal: React.FC<IdeaStepProps> = ({
                   <ResponsiveImage
                     key={reference.uri}
                     locator={reference.uri}
+                    preferThumbnail
                     alt={reference.name ?? "Reference image"}
                     fit="cover"
                     borderRadius={BORDER_RADIUS.sm}

--- a/web/src/components/sketch/LayerItem.tsx
+++ b/web/src/components/sketch/LayerItem.tsx
@@ -290,6 +290,7 @@ const LayerItem: React.FC<LayerItemProps> = ({
               <ResponsiveImage
                 className="layer-thumbnail"
                 locator={layerImage}
+                preferThumbnail
                 alt={layer.name}
                 fit="contain"
                 draggable={false}

--- a/web/src/components/storyboard/ShotTakesGallery.tsx
+++ b/web/src/components/storyboard/ShotTakesGallery.tsx
@@ -231,6 +231,7 @@ const ShotTakesGalleryInner: React.FC<ShotTakesGalleryProps> = ({
                 {stillThumbSrcs[i] ? (
                   <ResponsiveImage
                     locator={still}
+                    preferThumbnail
                     alt=""
                     fit="cover"
                     sx={{ width: "100%", height: "100%" }}

--- a/web/src/components/storyboard/StoryboardEntitiesField.tsx
+++ b/web/src/components/storyboard/StoryboardEntitiesField.tsx
@@ -29,7 +29,7 @@ import {
   ENTITY_KIND_ICON,
   getEntityKindChipSx
 } from "../entities/entityKind";
-import { useResolvedMediaUri } from "../../hooks/useResolvedMediaUri";
+import { useResolvedThumbnailUri } from "../../hooks/useResolvedMediaUri";
 
 interface StoryboardEntitiesFieldProps {
   boardId: string;
@@ -42,8 +42,9 @@ const EntityAvatar: React.FC<{ entity: Entity; size?: number }> = ({
   size = 20
 }) => {
   // A reference image is an `asset://` locator by construction — it needs the
-  // asset's own `get_url` before an <img> can load it.
-  const thumb = useResolvedMediaUri(entity.reference_images?.[0]);
+  // asset's own URL before an <img> can load it. At 20-24px the avatar takes
+  // the server's 512px thumbnail, not the multi-megabyte reference still.
+  const thumb = useResolvedThumbnailUri(entity.reference_images?.[0]);
   const Icon = ENTITY_KIND_ICON[entity.kind];
   const frameSx = {
     width: size,


### PR DESCRIPTION
## What changed

Thirteen web surfaces drew stored media at card, chip or avatar size while resolving to the asset's `get_url`. A generated still is 300KB–1.2MB, so a project list, a storyboard takes strip or a setup contact sheet pulled full originals down to paint a few hundred pixels — twelve of them on one storyboard, dozens on a project list. The server already derives a 512px JPEG per asset and the plumbing to reach it (`preferThumbnail` on `ResponsiveImage`, `useResolvedThumbnailUri`) was already in place, with exactly one caller using it. This points the rest of the thumb-sized surfaces at it. Ten take the locator path via `preferThumbnail` (storyboard takes strip, script shot chip, project card and document preview, setup contact sheet and image/video reference tiles, setup entity rows, memory card, sketch layer thumbnail); two take the resolver path via `useResolvedThumbnailUri` (the 20–24px storyboard entity avatar, the 18px chat resource chip). Full-size viewers — `ShotEditViewer`, `SourceViewerPanel`, the entity reference/review steps, app-builder media widgets — deliberately keep the original. Separately, the asset-grid PDF tile painted `backgroundImage: url(<the PDF itself>)`, which no browser renders: it downloaded the whole document behind an empty tile, and now uses the first-page JPEG the server puts in `thumb_url`. `web/src/__tests__/thumbnailRendering.test.ts` pins the inventory of thumb-sized surfaces and which of the three paths each takes, following the existing `mediaResolutionBoundary.test.ts` pattern, so a new card cannot ship on the original and a migrated one cannot quietly regress.

## Verification

Note: `npm install` was needed first — `packages/godot` and `packages/godot-templates` existed in the tree but were not linked into `node_modules`, so `build:packages` failed on `@nodetool-ai/game-nodes` before any of the checks below could run. After install, `npm run build:packages` reported 64/64 successful.

- [x] `npm run test:affected` — 287 suites passed, 2573 tests passed, 3 skipped
- [x] `npm run typecheck` — web and electron clean (`tsc --noEmit` exit 0 in each). The root script also compiles `mobile/`, which fails on missing modules (`react-native`, `expo-*`, `@trpc/react-query`); `mobile/node_modules` does not exist in this environment, and `mobile/` is intentionally not a root workspace, so `npm install` at the root does not populate it. Unrelated to this web-only diff.
- [x] `npm run lint` — exit 0 (remaining warnings are pre-existing, in files this diff does not touch)
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — `Gate: 3/3 selfchecks passed`, 292/292 graphs validate cleanly

One existing test needed updating: `ResourceChip.test.tsx`'s case named "renders a thumbnail for image assets" asserted the full-res URL. It now asserts `mockAssetThumbUrl`, which is what the name always claimed.

### Inverting the new check

Removed `preferThumbnail` from `ProjectCard.tsx` and reverted the PDF tile to `asset.get_url`, then ran `npx jest src/__tests__/thumbnailRendering.test.ts`:

```
    ✕ project card stills takes the thumbnail via preferThumbnail (2 ms)
    ✕ never paints a PDF tile from the document itself (1 ms)
Tests:       2 failed, 18 passed, 20 total
```

Both fixes were restored and the suite returns to 20/20 passing.

## Agent capabilities

No capability added, and no capability's declared contract changed.

## New checks

- [x] The check was inverted once and observed failing; the failing output is in **Verification** above
- [x] The audit asserts it found its targets before asserting anything about them — it pins that all three `via` families are represented and that the inventory holds at least 18 rows, so it cannot pass by matching nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCnUb8yyXGubJ7YimfvFka

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCnUb8yyXGubJ7YimfvFka)_