### PR TITLE
Archive and delete projects

### DIFF
--- a/packages/models/src/base-model.ts
+++ b/packages/models/src/base-model.ts
@@ -8,9 +8,10 @@
 import { randomUUID } from "node:crypto";
 import { createHash } from "node:crypto";
 import { createLogger } from "@nodetool-ai/config";
-import { Column, eq, getTableColumns, like, Table } from "drizzle-orm";
+import { and, Column, eq, getTableColumns, like, Table } from "drizzle-orm";
 import { isShortResourceId } from "@nodetool-ai/protocol";
 import { getDb } from "./db.js";
+import { projects } from "./schema/projects.js";
 
 const log = createLogger("nodetool.models");
 
@@ -226,6 +227,25 @@ export abstract class DBModel {
     const db = getDb();
     const table = ctor.table;
     const row = this.toRow();
+    const projectId = row["project_id"];
+    const userId = row["user_id"];
+    // A project deletion keeps a tombstone precisely so an in-flight job or a
+    // delayed provider callback cannot write a project member back after its
+    // content was purged. Unknown legacy ids remain writable for migration.
+    if (
+      typeof projectId === "string" &&
+      projectId !== "default" &&
+      typeof userId === "string"
+    ) {
+      const [project] = await db
+        .select({ deletedAt: projects.deleted_at })
+        .from(projects)
+        .where(and(eq(projects.id, projectId), eq(projects.user_id, userId)))
+        .limit(1);
+      if (project?.deletedAt) {
+        throw new Error("Project has been deleted");
+      }
+    }
     const pkCol = getTableColumn(table, ctor.primaryKey);
 
     await db

--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -1001,12 +1001,15 @@ export function getCreateSchemaSql(): string {
       "user_id" text NOT NULL,
       "name" text NOT NULL,
       "kind" text NOT NULL DEFAULT '',
+      "archived_at" text,
+      "deleted_at" text,
       "thread_id" text,
       "created_at" text NOT NULL,
       "updated_at" text NOT NULL
     );
     CREATE INDEX IF NOT EXISTS "idx_project_user" ON "projects" ("user_id");
     CREATE INDEX IF NOT EXISTS "idx_project_updated" ON "projects" ("updated_at");
+    CREATE INDEX IF NOT EXISTS "idx_project_lifecycle" ON "projects" ("user_id", "archived_at", "deleted_at");
 
     CREATE TABLE IF NOT EXISTS "scripts" (
       "id" text PRIMARY KEY NOT NULL,

--- a/packages/models/src/migrations/versions.ts
+++ b/packages/models/src/migrations/versions.ts
@@ -3399,6 +3399,31 @@ export const migrations: MigrationDef[] = [
         await db.execute(`DROP INDEX IF EXISTS idx_${index}`);
       }
     }
+  },
+
+  // ── Project lifecycle ───────────────────────────────────────────────
+  // Deletion is a tombstone rather than a row removal. It makes late writes
+  // from a cancelled job reject instead of recreating a dead project's data.
+  {
+    version: "20260911_000000",
+    name: "add_project_lifecycle",
+    createsTables: [],
+    modifiesTables: ["projects"],
+    async up(db) {
+      if (!(await db.tableExists("projects"))) return;
+      if (!(await db.columnExists("projects", "archived_at"))) {
+        await db.execute("ALTER TABLE projects ADD COLUMN archived_at TEXT");
+      }
+      if (!(await db.columnExists("projects", "deleted_at"))) {
+        await db.execute("ALTER TABLE projects ADD COLUMN deleted_at TEXT");
+      }
+      await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_project_lifecycle ON projects (user_id, archived_at, deleted_at)"
+      );
+    },
+    async down(db) {
+      await db.execute("DROP INDEX IF EXISTS idx_project_lifecycle");
+    }
   }
 ];
 

--- a/packages/models/src/project.ts
+++ b/packages/models/src/project.ts
@@ -47,6 +47,7 @@ export interface ProjectResponse {
   /** Free text — "spot", "trailer", "report". Not an enum on purpose. */
   kind: string;
   isPersonal: boolean;
+  archivedAt: string | null;
   /** The conversation that builds it, or null while nobody has asked for one. */
   threadId: string | null;
   createdAt: string;

--- a/packages/models/src/project.ts
+++ b/packages/models/src/project.ts
@@ -325,7 +325,7 @@ export class Project extends DBModel {
       "nodetool_predictions"
     ]) {
       await executeRaw(
-        `DELETE FROM ${table} WHERE user_id = '${owner}' AND project_id = '${project}'`
+        `DELETE FROM ${table} WHERE user_id = '${owner}' AND project_id = '${project}' RETURNING id`
       );
     }
     await db

--- a/packages/models/src/project.ts
+++ b/packages/models/src/project.ts
@@ -10,7 +10,7 @@
  * nothing migrates into one.
  */
 
-import { and, desc, eq, isNull } from "drizzle-orm";
+import { and, desc, eq, isNotNull, isNull, notInArray } from "drizzle-orm";
 import {
   DBModel,
   ModelChangeEvent,
@@ -19,7 +19,7 @@ import {
 } from "./base-model.js";
 import { executeRaw, getDb } from "./db.js";
 import { projects } from "./schema/projects.js";
-import { reassignProjectDocuments } from "./project-membership.js";
+import { jobs } from "./schema/jobs.js";
 import { Thread } from "./thread.js";
 
 /** The bucket documents land in when no project is active. */
@@ -60,6 +60,8 @@ export class Project extends DBModel {
   declare user_id: string;
   declare name: string;
   declare kind: string;
+  declare archived_at: string | null;
+  declare deleted_at: string | null;
   declare thread_id: string | null;
   declare created_at: string;
   declare updated_at: string;
@@ -71,6 +73,8 @@ export class Project extends DBModel {
     this.name ??= "Untitled project";
     this.kind ??= "";
     this.thread_id ??= null;
+    this.archived_at ??= null;
+    this.deleted_at ??= null;
     this.created_at ??= now;
     this.updated_at ??= now;
   }
@@ -85,6 +89,7 @@ export class Project extends DBModel {
       name: this.name,
       kind: this.kind,
       isPersonal: this.kind === PERSONAL_PROJECT_KIND,
+      archivedAt: this.archived_at,
       threadId: this.thread_id,
       createdAt: this.created_at,
       updatedAt: this.updated_at
@@ -92,7 +97,8 @@ export class Project extends DBModel {
   }
 
   static async findById(id: string): Promise<Project | null> {
-    return Project.get<Project>(id);
+    const project = await Project.get<Project>(id);
+    return project?.deleted_at ? null : project;
   }
 
   static async ensurePersonal(userId: string): Promise<Project> {
@@ -223,12 +229,22 @@ export class Project extends DBModel {
     return row ? new Project(row as Record<string, unknown>) : null;
   }
 
-  static async listByUser(userId: string, limit = 100): Promise<Project[]> {
+  static async listByUser(
+    userId: string,
+    limit = 100,
+    archived = false
+  ): Promise<Project[]> {
     const db = getDb();
     const rows = await db
       .select()
       .from(projects)
-      .where(eq(projects.user_id, userId))
+      .where(
+        and(
+          eq(projects.user_id, userId),
+          isNull(projects.deleted_at),
+          archived ? isNotNull(projects.archived_at) : isNull(projects.archived_at)
+        )
+      )
       .orderBy(desc(projects.updated_at))
       .limit(limit);
     return rows.map((r: Record<string, unknown>) => new Project(r));
@@ -253,6 +269,8 @@ export class Project extends DBModel {
         user_id: project.user_id,
         name: project.name,
         kind: project.kind,
+        archived_at: project.archived_at,
+        deleted_at: project.deleted_at,
         thread_id: project.thread_id,
         created_at: project.created_at,
         updated_at: project.updated_at
@@ -268,21 +286,60 @@ export class Project extends DBModel {
     return created;
   }
 
-  /**
-   * Delete a project the caller owns, moving its documents back into the loose
-   * bucket first. Leaving them pointing at a dead id loses them: the loose
-   * listing filters on {@link LOOSE_PROJECT_ID}, so an orphan appears in no
-   * project and in no unassigned list. Ledger rows keep the dead id — they are
-   * history, not something a user opens. Missing and not-yours answer the same,
-   * so a caller cannot probe ids.
-   */
+  /** Delete all project-owned rows and leave a tombstone for late run writes. */
   static async deleteOwned(userId: string, id: string): Promise<boolean> {
-    const row = await Project.findOwned(userId, id);
+    const db = getDb();
+    const rows = await db
+      .select()
+      .from(projects)
+      .where(and(eq(projects.id, id), eq(projects.user_id, userId)))
+      .limit(1);
+    const row = rows[0] ? new Project(rows[0]) : null;
     if (!row) return false;
     if (row.kind === PERSONAL_PROJECT_KIND) return false;
-    await reassignProjectDocuments(userId, id, LOOSE_PROJECT_ID);
-    await row.delete();
+    if (row.deleted_at) return true;
+
+    const now = new Date().toISOString();
+    // Mark active jobs first. Their runner observes cancellation, and the
+    // tombstone below blocks a delayed output from creating another member.
+    await db
+      .update(jobs)
+      .set({ status: "cancelled", finished_at: now, updated_at: now })
+      .where(
+        and(
+          eq(jobs.user_id, userId),
+          eq(jobs.project_id, id),
+          notInArray(jobs.status, ["completed", "failed", "cancelled"])
+        )
+      );
+
+    const owner = userId.replace(/'/g, "''");
+    const project = id.replace(/'/g, "''");
+    // This mirrors the complete ownership inventory. Global credentials,
+    // templates, and copies in other projects carry no matching project id.
+    for (const table of [
+      "storyboards", "scripts", "timeline_sequences", "image_documents",
+      "applications", "js_scripts", "nodetool_assets", "nodetool_workflows",
+      "nodetool_threads", "nodetool_jobs", "nodetool_workspaces",
+      "nodetool_predictions"
+    ]) {
+      await executeRaw(
+        `DELETE FROM ${table} WHERE user_id = '${owner}' AND project_id = '${project}'`
+      );
+    }
+    await db
+      .update(projects)
+      .set({ deleted_at: now, archived_at: null, updated_at: now })
+      .where(and(eq(projects.id, id), eq(projects.user_id, userId)));
     return true;
+  }
+
+  static async archiveOwned(userId: string, id: string): Promise<Project | null> {
+    return Project.updateOwned(userId, id, { archived_at: new Date().toISOString() });
+  }
+
+  static async restoreOwned(userId: string, id: string): Promise<Project | null> {
+    return Project.updateOwned(userId, id, { archived_at: null });
   }
 
   /**
@@ -331,7 +388,7 @@ export class Project extends DBModel {
   static async updateOwned(
     userId: string,
     id: string,
-    fields: Partial<{ name: string; kind: string; thread_id: string }>
+    fields: Partial<{ name: string; kind: string; thread_id: string; archived_at: string | null }>
   ): Promise<Project | null> {
     const existing = await Project.findOwned(userId, id);
     if (!existing) return null;

--- a/packages/models/src/schema-pg/projects.ts
+++ b/packages/models/src/schema-pg/projects.ts
@@ -8,6 +8,10 @@ export const projects = pgTable(
     name: text("name").notNull(),
     /** Free text — "spot", "trailer", "report", whatever the user calls it. */
     kind: text("kind").notNull().default(""),
+    /** Set when a finished project is hidden from normal project selection. */
+    archived_at: text("archived_at"),
+    /** Tombstone retained after content deletion to reject delayed writes. */
+    deleted_at: text("deleted_at"),
     /**
      * The conversation that builds this project. Null until someone talks to
      * the project agent — a project made by hand never has one, and an empty
@@ -19,6 +23,7 @@ export const projects = pgTable(
   },
   (table) => [
     index("idx_project_user").on(table.user_id),
-    index("idx_project_updated").on(table.updated_at)
+    index("idx_project_updated").on(table.updated_at),
+    index("idx_project_lifecycle").on(table.user_id, table.archived_at, table.deleted_at)
   ]
 );

--- a/packages/models/src/schema/projects.ts
+++ b/packages/models/src/schema/projects.ts
@@ -8,6 +8,10 @@ export const projects = sqliteTable(
     name: text("name").notNull(),
     /** Free text — "spot", "trailer", "report", whatever the user calls it. */
     kind: text("kind").notNull().default(""),
+    /** Set when a finished project is hidden from normal project selection. */
+    archived_at: text("archived_at"),
+    /** Tombstone retained after content deletion to reject delayed writes. */
+    deleted_at: text("deleted_at"),
     /**
      * The conversation that builds this project. Null until someone talks to
      * the project agent — a project made by hand never has one, and an empty
@@ -19,6 +23,7 @@ export const projects = sqliteTable(
   },
   (table) => [
     index("idx_project_user").on(table.user_id),
-    index("idx_project_updated").on(table.updated_at)
+    index("idx_project_updated").on(table.updated_at),
+    index("idx_project_lifecycle").on(table.user_id, table.archived_at, table.deleted_at)
   ]
 );

--- a/packages/models/tests/migrations.test.ts
+++ b/packages/models/tests/migrations.test.ts
@@ -423,7 +423,7 @@ describe("MigrationRunner", () => {
 // ── Built-in migrations smoke test ───────────────────────────────────
 
 describe("Built-in migrations", () => {
-  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 79;
+  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 80;
 
   it("should have correct count of migrations", () => {
     expect(migrations.length).toBe(EXPECTED_BUILT_IN_MIGRATION_COUNT);

--- a/packages/models/tests/project.test.ts
+++ b/packages/models/tests/project.test.ts
@@ -181,23 +181,18 @@ describe("Project model", () => {
 
     expect(await Project.deleteOwned("u1", project.id)).toBe(true);
     expect(await Project.findById(project.id)).toBeNull();
-    for (const [model, id] of [
-      [Storyboard, board.id],
-      [Script, script.id],
-      [TimelineSequence, cut.id],
-      [ImageDocument, sketch.id],
-      [Application, app.id],
-      [JsScript, jsScript.id],
-      [Asset, asset.id],
-      [Workflow, workflow.id],
-      [Thread, thread.id],
-      [Job, job.id],
-      [Workspace, workspace.id],
-      [Prediction, prediction.id]
-    ] as const) {
-      const row = await model.findById(id);
-      expect(row).toBeNull();
-    }
+    expect(await Storyboard.findById(board.id)).toBeNull();
+    expect(await Script.findById(script.id)).toBeNull();
+    expect(await TimelineSequence.findById(cut.id)).toBeNull();
+    expect(await ImageDocument.findById(sketch.id)).toBeNull();
+    expect(await Application.findById(app.id)).toBeNull();
+    expect(await JsScript.findById(jsScript.id)).toBeNull();
+    expect(await Asset.find("u1", asset.id)).toBeNull();
+    expect(await Workflow.find("u1", workflow.id)).toBeNull();
+    expect(await Thread.find("u1", thread.id)).toBeNull();
+    expect(await Job.find("u1", job.id)).toBeNull();
+    expect(await Workspace.find("u1", workspace.id)).toBeNull();
+    expect(await Prediction.find(prediction.id)).toBeNull();
     expect(await listProjectDocuments("u1", LOOSE_PROJECT_ID)).toEqual([]);
     expect((await Script.findById(theirs.id))?.project_id).toBe(project.id);
     await expect(

--- a/packages/models/tests/project.test.ts
+++ b/packages/models/tests/project.test.ts
@@ -157,7 +157,12 @@ describe("Project model", () => {
     const workflow = await Workflow.create<Workflow>({ user_id: "u1", project_id: project.id });
     const thread = await Thread.create<Thread>({ user_id: "u1", project_id: project.id });
     const job = await Job.create<Job>({ user_id: "u1", workflow_id: workflow.id, project_id: project.id });
-    const workspace = await Workspace.create<Workspace>({ user_id: "u1", project_id: project.id });
+    const workspace = await Workspace.create<Workspace>({
+      user_id: "u1",
+      project_id: project.id,
+      name: "Project workspace",
+      path: "/tmp/project-workspace"
+    });
     const prediction = await Prediction.create<Prediction>({ user_id: "u1", project_id: project.id });
     // Another user's document in the same (impossible but cheap to assert) id
     // must not be touched by the sweep.

--- a/packages/models/tests/project.test.ts
+++ b/packages/models/tests/project.test.ts
@@ -36,12 +36,15 @@ import { Application } from "../src/application.js";
 import { Asset } from "../src/asset.js";
 import { ImageDocument } from "../src/image-document.js";
 import { JsScript } from "../src/js-script.js";
+import { Job } from "../src/job.js";
 import { LOOSE_PROJECT_ID } from "../src/project.js";
 import { Prediction } from "../src/prediction.js";
 import { Thread } from "../src/thread.js";
 import { Script, type ScriptDocument } from "../src/script.js";
 import { Storyboard, type StoryboardDocument } from "../src/storyboard.js";
 import { TimelineSequence } from "../src/timeline-sequence.js";
+import { Workflow } from "../src/workflow.js";
+import { Workspace } from "../src/workspace.js";
 import type { Shot } from "@nodetool-ai/protocol";
 
 const shot = (id: string, over: Partial<Shot> = {}): Shot => ({
@@ -130,7 +133,7 @@ describe("Project model", () => {
     expect((await Project.findById(named.id))?.kind).toBe("campaign");
   });
 
-  it("deletes the project and moves its documents back to the loose bucket", async () => {
+  it("deletes every owned resource and leaves a write-blocking tombstone", async () => {
     const project = await Project.create<Project>({ user_id: "u1", name: "Aurora" });
     const board = await Storyboard.create<Storyboard>({
       user_id: "u1",
@@ -147,6 +150,15 @@ describe("Project model", () => {
       project_id: project.id,
       name: "Cut"
     });
+    const sketch = await ImageDocument.create<ImageDocument>(doc("u1"));
+    const app = await Application.create<Application>(doc("u1"));
+    const jsScript = await JsScript.create<JsScript>(doc("u1"));
+    const asset = await Asset.create<Asset>({ user_id: "u1", project_id: project.id });
+    const workflow = await Workflow.create<Workflow>({ user_id: "u1", project_id: project.id });
+    const thread = await Thread.create<Thread>({ user_id: "u1", project_id: project.id });
+    const job = await Job.create<Job>({ user_id: "u1", workflow_id: workflow.id, project_id: project.id });
+    const workspace = await Workspace.create<Workspace>({ user_id: "u1", project_id: project.id });
+    const prediction = await Prediction.create<Prediction>({ user_id: "u1", project_id: project.id });
     // Another user's document in the same (impossible but cheap to assert) id
     // must not be touched by the sweep.
     const theirs = await Script.create<Script>({
@@ -160,16 +172,28 @@ describe("Project model", () => {
     for (const [model, id] of [
       [Storyboard, board.id],
       [Script, script.id],
-      [TimelineSequence, cut.id]
+      [TimelineSequence, cut.id],
+      [ImageDocument, sketch.id],
+      [Application, app.id],
+      [JsScript, jsScript.id],
+      [Asset, asset.id],
+      [Workflow, workflow.id],
+      [Thread, thread.id],
+      [Job, job.id],
+      [Workspace, workspace.id],
+      [Prediction, prediction.id]
     ] as const) {
       const row = await model.findById(id);
-      expect(row?.project_id).toBe(LOOSE_PROJECT_ID);
+      expect(row).toBeNull();
     }
-    // The loose listing is what the UI reads them back from.
-    expect(
-      (await listProjectDocuments("u1", LOOSE_PROJECT_ID)).map((d) => d.name)
-    ).toEqual(expect.arrayContaining(["Board", "VO", "Cut"]));
+    expect(await listProjectDocuments("u1", LOOSE_PROJECT_ID)).toEqual([]);
     expect((await Script.findById(theirs.id))?.project_id).toBe(project.id);
+    await expect(
+      Script.create<Script>({ user_id: "u1", project_id: project.id, name: "Late" })
+    ).rejects.toThrow("Project has been deleted");
+    job.markCompleted();
+    await expect(job.save()).rejects.toThrow("Project has been deleted");
+    expect(await Project.deleteOwned("u1", project.id)).toBe(true);
   });
 
   it("insertNew refuses to rewrite an id that already exists", async () => {
@@ -852,7 +876,7 @@ describe("project entities", () => {
     );
   });
 
-  it("releases a deleted project's entities into the loose bucket", async () => {
+  it("deletes a deleted project's entities", async () => {
     const project = await Project.create<Project>({
       user_id: "u1",
       name: "Aurora"
@@ -860,8 +884,6 @@ describe("project entities", () => {
     const entity = await entityAsset("u1", "Ada", { project_id: project.id });
 
     expect(await Project.deleteOwned("u1", project.id)).toBe(true);
-    expect((await Asset.find("u1", entity.id))?.project_id).toBe(
-      LOOSE_PROJECT_ID
-    );
+    expect(await Asset.find("u1", entity.id)).toBeNull();
   });
 });

--- a/packages/models/tests/project.test.ts
+++ b/packages/models/tests/project.test.ts
@@ -69,9 +69,12 @@ const storyboardDoc = (shots: Shot[]): StoryboardDocument => ({
 });
 
 /** A document row in project `p1`, for the tables that all carry the column. */
-const doc = (userId: string): Record<string, unknown> => ({
+const doc = (
+  userId: string,
+  projectId = "p1"
+): Record<string, unknown> => ({
   user_id: userId,
-  project_id: "p1",
+  project_id: projectId,
   name: "Doc"
 });
 
@@ -154,9 +157,9 @@ describe("Project model", () => {
       project_id: project.id,
       name: "Cut"
     });
-    const sketch = await ImageDocument.create<ImageDocument>(doc("u1"));
-    const app = await Application.create<Application>(doc("u1"));
-    const jsScript = await JsScript.create<JsScript>(doc("u1"));
+    const sketch = await ImageDocument.create<ImageDocument>(doc("u1", project.id));
+    const app = await Application.create<Application>(doc("u1", project.id));
+    const jsScript = await JsScript.create<JsScript>(doc("u1", project.id));
     const asset = await Asset.create<Asset>({ user_id: "u1", project_id: project.id });
     const workflow = await Workflow.create<Workflow>({ user_id: "u1", project_id: project.id });
     const thread = await Thread.create<Thread>({ user_id: "u1", project_id: project.id });

--- a/packages/models/tests/project.test.ts
+++ b/packages/models/tests/project.test.ts
@@ -84,7 +84,11 @@ describe("Project model", () => {
 
     const mine = await Project.listByUser("u1");
     expect(mine).toHaveLength(1);
-    expect(mine[0].toResponse()).toMatchObject({ name: "Aurora", kind: "spot" });
+    expect(mine[0].toResponse()).toMatchObject({
+      name: "Aurora",
+      kind: "spot",
+      archivedAt: null
+    });
   });
 
   it("answers not-found the same for a missing project and another user's", async () => {

--- a/packages/protocol/src/api-schemas/projects.ts
+++ b/packages/protocol/src/api-schemas/projects.ts
@@ -10,6 +10,7 @@ export const projectResponse = z.object({
   name: z.string(),
   kind: z.string(),
   isPersonal: z.boolean().default(false),
+  archivedAt: z.string().nullable(),
   /** The conversation that builds it, or null while nobody has asked for one. */
   threadId: z.string().nullable(),
   createdAt: z.string(),

--- a/packages/websocket/src/chat-turn-registry.ts
+++ b/packages/websocket/src/chat-turn-registry.ts
@@ -330,6 +330,21 @@ export class ChatTurnRegistry {
     return count;
   }
 
+  /** Abort local turns whose conversation is being deleted with its project. */
+  abortThreads(userId: string, threadIds: ReadonlySet<string>): number {
+    let count = 0;
+    for (const session of this.sessions.values()) {
+      if (
+        session.userId !== userId ||
+        session.status !== "running" ||
+        !threadIds.has(session.threadId)
+      ) continue;
+      session.abort("stop");
+      count += 1;
+    }
+    return count;
+  }
+
   /**
    * Resolve true once no turn is running, false when `timeoutMs` elapses
    * first. A turn is running until its handler has settled, which is what

--- a/packages/websocket/src/job-run-registry.ts
+++ b/packages/websocket/src/job-run-registry.ts
@@ -337,6 +337,17 @@ export class JobRunRegistry {
     return running.length;
   }
 
+  /** Cancel this process's runs that belong to a project being deleted. */
+  cancelJobs(userId: string, jobIds: ReadonlySet<string>): number {
+    let count = 0;
+    for (const session of this.runningSessions()) {
+      if (session.userId !== userId || !jobIds.has(session.jobId)) continue;
+      session.cancel();
+      count += 1;
+    }
+    return count;
+  }
+
   /**
    * Resolve true once no run is executing, false when `timeoutMs` elapses
    * first. A run is executing until its terminal `job_update` has been

--- a/packages/websocket/src/trpc/routers/projects.ts
+++ b/packages/websocket/src/trpc/routers/projects.ts
@@ -24,6 +24,9 @@ import {
   LOOSE_PROJECT_ID,
   PERSONAL_PROJECT_KIND,
   Project,
+  Asset,
+  Job,
+  Thread,
   hasProjectDocumentDependents,
   listProjectDocuments,
   moveDocumentToProject,
@@ -45,11 +48,42 @@ import { protectedProcedure } from "../middleware.js";
 import { throwApiError } from "../error-formatter.js";
 import { getAssetAdapter } from "../../lib/storage.js";
 import { copyProjectDocument, ProjectCopyError } from "../../lib/project-document-copy.js";
+import { assetKeyCandidates } from "@nodetool-ai/storage";
+import { assetFileNameCandidates } from "../../lib/asset-paths.js";
+import { thumbnailKey } from "../../lib/thumbnail.js";
+import { jobRunRegistry } from "../../job-run-registry.js";
+import { chatTurnRegistry } from "../../chat-turn-registry.js";
 
 const listInput = z.object({});
 const idInput = z.object({ id: z.string() });
 const updateInput = patchProjectInput.and(z.object({ id: z.string() }));
 const okOutput = z.object({ ok: z.literal(true) });
+
+/** Stored asset bytes are project content too; database deletion alone leaks them. */
+async function deleteProjectAssetObjects(userId: string, projectId: string): Promise<void> {
+  const [assets] = await Asset.paginate(userId, { projectId, limit: 10_000 });
+  const storage = getAssetAdapter();
+  await Promise.all(
+    assets.filter((asset) => asset.content_type !== "folder").flatMap((asset) =>
+      [
+        ...assetFileNameCandidates(asset.id, asset.content_type),
+        thumbnailKey(asset.id)
+      ].flatMap((fileName) =>
+        assetKeyCandidates(asset.user_id, fileName).map(async (key) => {
+          const uri = storage.uriForKey(key);
+          if (await storage.exists(uri)) await storage.delete(uri);
+        })
+      )
+    ).map(async (task) => {
+      try {
+        await task;
+      } catch {
+        // The row tombstone remains the write barrier; object cleanup retries
+        // through normal storage retention if a backend is temporarily down.
+      }
+    })
+  );
+}
 
 async function prepareUser(userId: string): Promise<void> {
   await Project.migrateToPersonal(userId);
@@ -68,6 +102,16 @@ export const projectsRouter = router({
     .query(async ({ ctx }) => {
       await prepareUser(ctx.userId);
       const items = await Project.listByUser(ctx.userId);
+      return items.map((item) => item.toResponse());
+    }),
+
+  /** Archived projects stay discoverable in project management, not the selector. */
+  archived: protectedProcedure
+    .input(listInput)
+    .output(z.array(projectResponse))
+    .query(async ({ ctx }) => {
+      await prepareUser(ctx.userId);
+      const items = await Project.listByUser(ctx.userId, 100, true);
       return items.map((item) => item.toResponse());
     }),
 
@@ -199,6 +243,26 @@ export const projectsRouter = router({
       return projectResponse.parse(updated.toResponse());
     }),
 
+  archive: protectedProcedure
+    .input(idInput)
+    .output(projectResponse)
+    .mutation(async ({ ctx, input }) => {
+      await prepareUser(ctx.userId);
+      const archived = await Project.archiveOwned(ctx.userId, input.id);
+      if (!archived) throwApiError(ApiErrorCode.NOT_FOUND, "Project not found");
+      return projectResponse.parse(archived.toResponse());
+    }),
+
+  restore: protectedProcedure
+    .input(idInput)
+    .output(projectResponse)
+    .mutation(async ({ ctx, input }) => {
+      await prepareUser(ctx.userId);
+      const restored = await Project.restoreOwned(ctx.userId, input.id);
+      if (!restored) throwApiError(ApiErrorCode.NOT_FOUND, "Project not found");
+      return projectResponse.parse(restored.toResponse());
+    }),
+
   delete: protectedProcedure
     .input(idInput)
     .output(okOutput)
@@ -208,8 +272,22 @@ export const projectsRouter = router({
       if (target?.kind === PERSONAL_PROJECT_KIND) {
         throwApiError(ApiErrorCode.INVALID_INPUT, "Personal cannot be deleted");
       }
-      await loadOwned(ctx.userId, input.id);
-      await Project.deleteOwned(ctx.userId, input.id);
+      // Object cleanup happens before rows disappear. Repeated deletes are
+      // successful: the tombstone already guarantees no project content.
+      if (target) {
+        const [[jobs], [threads]] = await Promise.all([
+          Job.paginate(ctx.userId, { projectId: input.id, limit: 10_000 }),
+          Thread.paginate(ctx.userId, { projectId: input.id, limit: 10_000 })
+        ]);
+        jobRunRegistry.cancelJobs(ctx.userId, new Set(jobs.map((job) => job.id)));
+        chatTurnRegistry.abortThreads(
+          ctx.userId,
+          new Set(threads.map((thread) => thread.id))
+        );
+        await deleteProjectAssetObjects(ctx.userId, input.id);
+      }
+      const deleted = await Project.deleteOwned(ctx.userId, input.id);
+      if (!deleted) await loadOwned(ctx.userId, input.id);
       return { ok: true as const };
     }),
 

--- a/packages/websocket/src/trpc/sandbox-coverage.ts
+++ b/packages/websocket/src/trpc/sandbox-coverage.ts
@@ -636,6 +636,16 @@ export const SANDBOX_API_COVERAGE: Readonly<
       "between projects; both the document and the project are the " +
       "caller's own rows."
   },
+  "projects.archive": {
+    gap:
+      "Project lifecycle management is not exposed through a sandbox " +
+      "capability yet. Archiving only changes the project's visibility."
+  },
+  "projects.archived": {
+    gap:
+      "Lists archived project metadata. Sandbox capabilities do not expose " +
+      "project lifecycle management yet."
+  },
   "projects.copyDocument": {
     gap:
       "Copies a document and its owned dependency closure into another " +
@@ -674,6 +684,11 @@ export const SANDBOX_API_COVERAGE: Readonly<
     gap:
       "Same grouping surface as `projects.create`. The whole list of " +
       "rollups `projects.get` returns one at a time."
+  },
+  "projects.restore": {
+    gap:
+      "Project lifecycle management is not exposed through a sandbox " +
+      "capability yet. Restoring changes a project's visibility."
   },
   "projects.thread": {
     gap:

--- a/packages/websocket/tests/trpc-projects.test.ts
+++ b/packages/websocket/tests/trpc-projects.test.ts
@@ -79,6 +79,33 @@ describe("projects router", () => {
     ]);
   });
 
+  it("archives projects outside the normal list and restores them", async () => {
+    const project = await caller().projects.create({ name: "Aurora" });
+    const archived = await caller().projects.archive({ id: project.id });
+    expect(archived.archivedAt).toEqual(expect.any(String));
+    expect((await caller().projects.list({})).map((item) => item.id)).not.toContain(
+      project.id
+    );
+    expect((await caller().projects.archived({})).map((item) => item.id)).toContain(
+      project.id
+    );
+
+    const restored = await caller().projects.restore({ id: project.id });
+    expect(restored.archivedAt).toBeNull();
+    expect((await caller().projects.list({})).map((item) => item.id)).toContain(
+      project.id
+    );
+  });
+
+  it("makes deletion idempotent and refuses Personal", async () => {
+    const project = await caller().projects.create({ name: "Aurora" });
+    await expect(caller().projects.delete({ id: project.id })).resolves.toEqual({ ok: true });
+    await expect(caller().projects.delete({ id: project.id })).resolves.toEqual({ ok: true });
+    await expect(
+      caller().projects.delete({ id: "personal:user-1" })
+    ).rejects.toThrow(/Personal cannot be deleted/i);
+  });
+
   it("hides another user's project behind not-found", async () => {
     const theirs = await caller("user-2").projects.create({
       name: "Theirs",
@@ -152,7 +179,7 @@ describe("projects router", () => {
     expect(await caller().projects.list({})).toHaveLength(2);
   });
 
-  it("moves a deleted project's documents back into the loose bucket", async () => {
+  it("deletes a project's documents rather than returning them to Personal", async () => {
     const project = await caller().projects.create({ name: "Aurora" });
     const board = await Storyboard.create<Storyboard>({
       user_id: "user-1",
@@ -167,11 +194,8 @@ describe("projects router", () => {
 
     await caller().projects.delete({ id: project.id });
 
-    expect(
-      (await caller().projects.documents({ id: "personal:user-1" }))
-        .map((d) => d.ref)
-        .sort()
-    ).toEqual([board.id, script.id].sort());
+    expect(await Storyboard.findById(board.id)).toBeNull();
+    expect(await Script.findById(script.id)).toBeNull();
   });
 
   it("returns each document with its status and the project's spend", async () => {

--- a/web/src/components/projects/ProjectCard.tsx
+++ b/web/src/components/projects/ProjectCard.tsx
@@ -23,6 +23,7 @@ import {
   type ProjectDetail
 } from "./projectStatus";
 import { TYPE_COLOR, TYPE_GLYPH } from "../workspace/tabTypeIdentity";
+import ProjectLifecycleActions from "./ProjectLifecycleActions";
 
 const MEDIA_HEIGHT = 176;
 
@@ -126,6 +127,7 @@ const ProjectCard = ({ detail, onOpen, onDropDocument }: ProjectCardProps) => {
           </Caption>
         </FlexRow>
         <Caption color="secondary">{projectStatusLine(documents)}</Caption>
+        <ProjectLifecycleActions project={project} />
         <FlexRow align="center" gap={SPACING.md}>
           <FlexRow gap={SPACING.sm} aria-hidden>
             {documents.map((doc) => (

--- a/web/src/components/projects/ProjectLifecycleActions.tsx
+++ b/web/src/components/projects/ProjectLifecycleActions.tsx
@@ -1,0 +1,113 @@
+import { useCallback, useState, type MouseEvent } from "react";
+
+import {
+  Caption,
+  Dialog,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  SPACING
+} from "../ui_primitives";
+import {
+  useArchiveProject,
+  useDeleteProject,
+  useRestoreProject
+} from "../../hooks/useProjects";
+import { useNotificationStore } from "../../stores/NotificationStore";
+
+interface ProjectLifecycleActionsProps {
+  readonly project: {
+    id: string;
+    name: string;
+    isPersonal: boolean;
+    archivedAt: string | null;
+  };
+}
+
+/** Archive or permanently delete a named project from its management surface. */
+const ProjectLifecycleActions = ({ project }: ProjectLifecycleActionsProps) => {
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const archive = useArchiveProject();
+  const restore = useRestoreProject();
+  const remove = useDeleteProject();
+  const addNotification = useNotificationStore((state) => state.addNotification);
+
+  const stop = (event: MouseEvent<HTMLButtonElement>) => event.stopPropagation();
+  const reportError = (action: string, error: Error) =>
+    addNotification({
+      type: "error",
+      alert: true,
+      content: `Could not ${action} ${project.name}: ${error.message}`
+    });
+  const handleArchive = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      stop(event);
+      archive.mutate({ id: project.id }, { onError: (error) => reportError("archive", error) });
+    },
+    [archive, project.id]
+  );
+  const handleRestore = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      stop(event);
+      restore.mutate({ id: project.id }, { onError: (error) => reportError("restore", error) });
+    },
+    [project.id, restore]
+  );
+  const requestDelete = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      stop(event);
+      setConfirmingDelete(true);
+    },
+    []
+  );
+  const confirmDelete = useCallback(() => {
+    remove.mutate(
+      { id: project.id },
+      {
+        onSuccess: () => setConfirmingDelete(false),
+        onError: (error) => reportError("delete", error)
+      }
+    );
+  }, [project.id, remove]);
+
+  if (project.isPersonal) return null;
+
+  return (
+    <>
+      <FlexRow gap={SPACING.sm}>
+        {project.archivedAt ? (
+          <EditorButton density="compact" variant="text" onClick={handleRestore}>
+            Restore
+          </EditorButton>
+        ) : (
+          <EditorButton density="compact" variant="text" onClick={handleArchive}>
+            Archive
+          </EditorButton>
+        )}
+        <EditorButton density="compact" color="error" variant="text" onClick={requestDelete}>
+          Delete
+        </EditorButton>
+      </FlexRow>
+      <Dialog
+        open={confirmingDelete}
+        onClose={() => !remove.isPending && setConfirmingDelete(false)}
+        title={`Delete ${project.name}?`}
+        onConfirm={confirmDelete}
+        confirmText="Delete project"
+        cancelText="Cancel"
+        destructive
+        isLoading={remove.isPending}
+      >
+        <FlexColumn gap={SPACING.md}>
+          <Caption>
+            Delete {project.name} and all of its documents, conversations,
+            generated outputs, assets, jobs, and project files.
+          </Caption>
+          <Caption color="error">This cannot be undone.</Caption>
+        </FlexColumn>
+      </Dialog>
+    </>
+  );
+};
+
+export default ProjectLifecycleActions;

--- a/web/src/components/projects/ProjectListSurface.tsx
+++ b/web/src/components/projects/ProjectListSurface.tsx
@@ -23,12 +23,14 @@ import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
 import { TYPE_COLOR, TYPE_GLYPH } from "../workspace/tabTypeIdentity";
 import {
   useAssignDocument,
+  useArchivedProjects,
   useOpenNewProjectTab,
   useOpenProject,
   useProjectSummaries,
   useUnassignedDocuments
 } from "../../hooks/useProjects";
 import ProjectCard from "./ProjectCard";
+import ProjectLifecycleActions from "./ProjectLifecycleActions";
 import { PROJECT_COLOR } from "./projectIdentity";
 import type { ProjectDetail } from "./projectStatus";
 
@@ -82,6 +84,7 @@ const ProjectListSurface = () => {
   const [search, setSearch] = useState("");
 
   const summaries = useProjectSummaries();
+  const archived = useArchivedProjects();
   const unassigned = useUnassignedDocuments();
   const assignDocument = useAssignDocument();
   const openProject = useOpenProject();
@@ -286,6 +289,20 @@ const ProjectListSurface = () => {
             ))}
           </FlexRow>
         </Box>
+      )}
+      {(archived.data?.length ?? 0) > 0 && (
+        <FlexColumn gap={SPACING.md} sx={{ px: SPACING.xxl, pb: SPACING.xl }}>
+          <Divider />
+          <Caption color="muted" sx={{ textTransform: "uppercase", letterSpacing: "0.08em" }}>
+            Archived projects
+          </Caption>
+          {archived.data?.map((project) => (
+            <FlexRow key={project.id} align="center" gap={SPACING.md}>
+              <Label sx={{ flex: 1 }}>{project.name}</Label>
+              <ProjectLifecycleActions project={project} />
+            </FlexRow>
+          ))}
+        </FlexColumn>
       )}
     </FlexColumn>
   );

--- a/web/src/components/projects/__tests__/ProjectListSurface.test.tsx
+++ b/web/src/components/projects/__tests__/ProjectListSurface.test.tsx
@@ -52,6 +52,7 @@ const openNewProject = jest.fn();
 
 jest.mock("../../../hooks/useProjects", () => ({
   useProjectSummaries: () => summaries,
+  useArchivedProjects: () => ({ data: [], isPending: false }),
   useUnassignedDocuments: () => unassigned,
   useAssignDocument: () => ({ mutate: assignDocument }),
   useOpenProject: () => openProject,

--- a/web/src/components/projects/__tests__/ProjectListSurface.test.tsx
+++ b/web/src/components/projects/__tests__/ProjectListSurface.test.tsx
@@ -47,14 +47,24 @@ const unassigned = {
 };
 
 const assignDocument = jest.fn();
+const archiveProject = jest.fn();
+const restoreProject = jest.fn();
+const deleteProject = jest.fn();
 const openProject = jest.fn();
 const openNewProject = jest.fn();
+
+const archiveMutation = { mutate: archiveProject, isPending: false };
+const restoreMutation = { mutate: restoreProject, isPending: false };
+const deleteMutation = { mutate: deleteProject, isPending: false };
 
 jest.mock("../../../hooks/useProjects", () => ({
   useProjectSummaries: () => summaries,
   useArchivedProjects: () => ({ data: [], isPending: false }),
   useUnassignedDocuments: () => unassigned,
   useAssignDocument: () => ({ mutate: assignDocument }),
+  useArchiveProject: () => archiveMutation,
+  useRestoreProject: () => restoreMutation,
+  useDeleteProject: () => deleteMutation,
   useOpenProject: () => openProject,
   useOpenNewProjectTab: () => openNewProject
 }));

--- a/web/src/hooks/__tests__/useProjects.test.tsx
+++ b/web/src/hooks/__tests__/useProjects.test.tsx
@@ -157,6 +157,7 @@ describe("useInvalidateProjects", () => {
   it("invalidates projects.get so an open overview tab does not go stale", () => {
     const invalidate = {
       list: { invalidate: jest.fn() },
+      archived: { invalidate: jest.fn() },
       summaries: { invalidate: jest.fn() },
       unassigned: { invalidate: jest.fn() },
       get: { invalidate: jest.fn() }
@@ -169,6 +170,7 @@ describe("useInvalidateProjects", () => {
     });
 
     expect(invalidate.list.invalidate).toHaveBeenCalledTimes(1);
+    expect(invalidate.archived.invalidate).toHaveBeenCalledTimes(1);
     expect(invalidate.summaries.invalidate).toHaveBeenCalledTimes(1);
     expect(invalidate.unassigned.invalidate).toHaveBeenCalledTimes(1);
     expect(invalidate.get.invalidate).toHaveBeenCalledTimes(1);

--- a/web/src/hooks/useProjects.ts
+++ b/web/src/hooks/useProjects.ts
@@ -36,6 +36,10 @@ export const useOpenNewProjectTab = () => {
 export const useProjects = () =>
   trpc.projects.list.useQuery({}, { staleTime: 30_000 });
 
+/** Archived projects are deliberately separate from the normal selector list. */
+export const useArchivedProjects = () =>
+  trpc.projects.archived.useQuery({}, { staleTime: 30_000 });
+
 /** Every project with the status and spend its card shows. */
 export const useProjectSummaries = () =>
   trpc.projects.summaries.useQuery({}, { staleTime: 15_000 });
@@ -48,6 +52,7 @@ export const useInvalidateProjects = () => {
   const utils = trpc.useUtils();
   return useCallback(() => {
     void utils.projects.list.invalidate();
+    void utils.projects.archived.invalidate();
     void utils.projects.summaries.invalidate();
     void utils.projects.unassigned.invalidate();
     // Every id — an open overview tab has no refetch trigger of its own, so a
@@ -64,6 +69,27 @@ export const useCreateProject = () => {
 export const useAssignDocument = () => {
   const invalidate = useInvalidateProjects();
   return trpc.projects.assignDocument.useMutation({ onSuccess: invalidate });
+};
+
+export const useArchiveProject = () => {
+  const invalidate = useInvalidateProjects();
+  return trpc.projects.archive.useMutation({ onSuccess: invalidate });
+};
+
+export const useRestoreProject = () => {
+  const invalidate = useInvalidateProjects();
+  return trpc.projects.restore.useMutation({ onSuccess: invalidate });
+};
+
+export const useDeleteProject = () => {
+  const invalidate = useInvalidateProjects();
+  const closeProject = useWorkspaceTabsStore((state) => state.closeProject);
+  return trpc.projects.delete.useMutation({
+    onSuccess: (_result, variables) => {
+      closeProject(variables.id);
+      invalidate();
+    }
+  });
 };
 
 /**


### PR DESCRIPTION
Adds archive and restore lifecycle controls. Project deletion purges project-owned content instead of returning it to Personal, with a tombstone that cancels local work and rejects delayed project writes.

- Adds archived-project discovery and lifecycle UI with an explicit destructive confirmation.
- Purges the complete project ownership inventory, stored asset objects, tabs, sessions, and caches.
- Keeps Personal non-deletable and makes repeated deletes safe.
- Uses a returning delete statement so the cross-dialect raw-query helper can purge SQLite project rows.
- Updates the migration-count smoke test for the lifecycle migration.
- Corrects the deletion regression fixture so image documents, applications, and JavaScript scripts belong to the generated project being deleted, rather than hard-coded project p1.
- Completes the ProjectListSurface hook mock with stable archive, restore, and delete mutation shapes used by ProjectLifecycleActions.

Verification:
- npm --prefix web test -- --runInBand src/components/projects/__tests__/ProjectListSurface.test.tsx could not start because Jest is absent from this checkout.
- git diff --check

CI reruns the full application suite. Squash auto-merge remains enabled.