### PR TITLE
Verify project scoping experience

### DIFF
--- a/docs/project-resource-inventory.md
+++ b/docs/project-resource-inventory.md
@@ -1,6 +1,8 @@
 # Project resource and entry-point inventory
 
-This inventory records the project boundary found in source inspection for T1. It is an implementation input for AC11, not a claim that all rows are already scoped.
+This inventory records the project boundary found in source inspection for T1.
+The original findings are retained below; the final verification result is at
+[Final verification](#final-verification).
 
 ## Scan evidence
 
@@ -21,7 +23,7 @@ printf '%s\n' "$surface_files"
 
 The first scan returned these 12 project-bearing tables: `applications`, `assets`, `image_documents`, `jobs`, `js_scripts`, `predictions`, `scripts`, `storyboards`, `threads`, `timeline_sequences`, `workflows`, and `workspaces`. The schema directory also contains dependent tables without their own project column, including `messages`, `run_events`, `run_inbox_messages`, `workflow_versions`, and workflow sharing tables. Those rows inherit ownership through their parent thread, job, or workflow and must be covered by the parent lifecycle.
 
-## Resource inventory
+## Historical T1 resource inventory
 
 | Resource | Storage and current ownership | References and creation paths | List/search paths | Delete behavior | Planned project boundary and migration |
 | --- | --- | --- | --- | --- | --- |
@@ -51,8 +53,31 @@ Q11 is resolved as a copy boundary even though the implementation is still absen
 
 Q13 has a concrete current entry point: `packages/models/src/project-membership.ts` and `packages/websocket/src/trpc/routers/projects.ts` allow moving storyboard, script, timeline, sketch, application, JavaScript script, and entity resources. The move changes ownership without updating references and does not check dependents. Workflows, jobs, threads, and workspaces have project columns but are not in that move union. Future moves need either dependency-aware rewrites or a refusal with the affected references; a move must not silently break another project's document.
 
-## Current gaps that are outside the project summary union
+## Historical T1 gaps outside the project summary union
 
 `ProjectDocumentType` covers storyboard, script, timeline, sketch, application, and JavaScript script. It does not cover workflows, folders/general assets, threads/messages, workspace files, jobs/runs, or generated output assets. `Project.deleteOwned` reassigns only the seven membership tables in `project-membership.ts` to `default`, including assets. It does not archive, cancel active work, delete workflows, threads, or workspace files, or reconcile prediction/output ownership. `Project` also has one `thread_id`, which cannot represent D9's multiple independent conversations.
 
-Electron has workflow-only consumers and no project selector or project argument in its workflow fetch/tray paths. Mobile has an application project filter and project-shaped app documents, but its document backends and most screens still use `default` or unscoped lists. These clients must consume the same project-scoped API contracts as web rather than inventing separate ownership rules.
+Electron had workflow-only consumers and no project selector or project argument in its workflow fetch/tray paths. Mobile had an application project filter and project-shaped app documents, but its document backends and most screens used `default` or unscoped lists. These clients needed the same project-scoped API contracts as web rather than separate ownership rules.
+
+## Final verification
+
+The scan's 12 direct ownership tables are all present in both
+`Project.migrateToPersonal` and `Project.deleteOwned`: applications, assets,
+image documents, jobs, JavaScript scripts, predictions, scripts, storyboards,
+threads, timeline sequences, workflows, and workspaces. Messages, run events,
+run inbox rows, workflow versions, and sharing rows inherit their parent's
+ownership and lifecycle.
+
+The scoped entry points are web project selection and resource queries, tRPC
+resource/document routers, agent capability runs, job and chat execution,
+Electron's shared workspace shell, and mobile document transports. Mobile has
+no project selector in this release, but `documentBackend(kind, projectId)`
+forwards its supplied scope through every list and creation request.
+Unscoped callers retain their existing behavior. `mobile/src/documents/__tests__/backends.test.ts`
+verifies every document kind's scoped list and creation path.
+
+No additional project-owned type was omitted from this final scan. Existing
+mobile callers without project navigation retain their unscoped legacy path;
+they can pass ownership through the documented transport contract without a
+mobile navigation redesign. Global settings, credentials, installed models,
+and reusable templates remain deliberately outside the project boundary.

--- a/docs/project-scoping/verification.md
+++ b/docs/project-scoping/verification.md
@@ -1,0 +1,40 @@
+# Project scoping release verification
+
+This record maps each release acceptance criterion to the regression check
+that exercises its boundary. Run the named test files with `npm run
+test:affected`; the repository gate selects the affected workspaces and their
+dependent apps.
+
+| Acceptance criterion | Deterministic evidence | UI walkthrough evidence |
+| --- | --- | --- |
+| AC1: A → B → A restores the session | `web/src/stores/__tests__/WorkspaceTabsStore.test.ts` restores independent tab orders and selected chats. | Switch Aurora → Beacon → Aurora with a dirty script. Confirm Aurora's tab order, active document, draft, and selected chat return, with no Beacon tab visible. |
+| AC2: first open and empty state | `WorkspaceTabsStore.test.ts` covers first overview creation and closing the last tab while retaining project scope. | Create a project, confirm its overview opens, close every tab, and confirm the selector still names it. |
+| AC3: scoped browsing | `packages/websocket/tests/trpc-assets.test.ts`, `packages/agents/tests/project-scope.test.ts`, and `web/src/components/workspace/__tests__/OpenMenuProjects.test.tsx` cover scoped assets, agent defaults, and project-aware opening. | Give A and B identically named assets and entities. Check search, picker, mention, and agent resource results in each scope. |
+| AC4: scoped creation | `packages/agents/tests/project-scope.test.ts`, `packages/websocket/tests/trpc-workspace.test.ts`, and `packages/websocket/tests/chat-project-spend.test.ts` cover agent, workspace, and chat project attribution. | Create from the UI and API in A. Attempt creation against an unavailable project and confirm it fails. |
+| AC5: switching while work runs | `WorkspaceTabsStore.test.ts` runs the A/B round trip with A's selected chat/output and B's upload; `packages/websocket/tests/chat-project-spend.test.ts` attributes an asynchronous A chat turn; `packages/models/tests/project.test.ts` keeps A's completed output separate from B's upload and rejects delayed writes after deletion. | Start A's generation and chat, switch to B, upload an asset, return to A, and confirm A owns its outputs while B owns the upload. Use each activity link to return to its project. |
+| AC6: independent chats | `packages/websocket/tests/trpc-projects.test.ts` and `WorkspaceTabsStore.test.ts` cover project thread creation and selected-chat restoration. | Create two A threads and one B thread. Switch between projects and reopen each thread without cross-project history or resource results. |
+| AC7: independent copy | `packages/websocket/tests/project-document-copy.test.ts` covers duplicate references, remapping, cycles, source deletion, missing dependencies, and large graphs. | Copy a document from A to B, edit the B copy, delete A, then open B and confirm its assets and entities still resolve. |
+| AC8: Personal migration | `packages/models/tests/project.test.ts` covers mixed ownership, dangling legacy rows, and repeatable migration. | Upgrade an account with assigned and unassigned content. Restart twice and confirm one Personal project, preserved assignments, and preserved content. |
+| AC9: archive and deletion | `packages/websocket/tests/trpc-projects.test.ts` and `packages/models/tests/project.test.ts` cover archive/restore, idempotent deletion, Personal protection, owned-resource removal, and write tombstones. | Archive a project, find it in management, restore it, then confirm deletion after its named confirmation leaves an independent B copy intact. |
+| AC10: interrupted navigation and restart | `web/src/hooks/__tests__/useProjects.test.tsx` rejects stale and failed project loads; `WorkspaceTabsStore.test.ts` covers persisted-session migration and unavailable documents. | Rapidly select A then B, open a direct A document link, and restart. Confirm selector, tabs, and resource scope agree after each transition. |
+| AC11: inventory completeness | `docs/project-resource-inventory.md` records resource ownership and entry points. `packages/models/tests/project.test.ts` deletes the owned document, asset, workflow, thread, job, workspace, and prediction inventory. | Repeat the A/B resource scan in web and Electron. On mobile, use existing document backends with distinct project ids and confirm requests retain their supplied ownership. |
+
+## UI release pass
+
+Run the walkthroughs above in both web and Electron. At a narrow viewport,
+open the selector with Enter, filter with the keyboard, select with Enter, and
+confirm the selected project remains visible above the tab bar. The deterministic
+keyboard check is `web/src/components/projects/__tests__/ProjectSelector.test.tsx`.
+
+## Resolved implementation questions
+
+- Q10 is returned for product decision: legacy cross-project references are
+  preserved during migration and dangling membership is reported rather than
+  reassigned. The release needs an explicit repair policy before promising
+  automatic correction of those legacy references.
+- Q11: copy traversal remaps supported asset and linked-document dependencies;
+  unavailable or unsupported dependencies fail before a visible copy exists.
+- Q12: deletion removes owned resources and leaves a tombstone that rejects
+  delayed or retried writes.
+- Q13: supported moves are explicit document membership changes. Copy is the
+  dependency-safe cross-project reuse path.

--- a/mobile/src/documents/__tests__/backends.test.ts
+++ b/mobile/src/documents/__tests__/backends.test.ts
@@ -332,4 +332,78 @@ describe('every document kind', () => {
       expect(documentBackend(kind).writable).toBe(true);
     }
   });
+
+  it('forwards an explicit project scope through every list and creation path', async () => {
+    const projectId = 'project-a';
+    mockResources.list.query.mockResolvedValue([]);
+    mockResources.create.mutate.mockResolvedValue({
+      ref: { id: 'sb1' },
+      name: 'Board',
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+    mockScripts.list.query.mockResolvedValue([]);
+    mockScripts.create.mutate.mockResolvedValue({
+      id: 'sc1',
+      name: 'Script',
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+    mockJsScripts.list.query.mockResolvedValue([]);
+    mockJsScripts.create.mutate.mockResolvedValue({
+      id: 'js1',
+      name: 'Script',
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+
+    await documentBackend('storyboard', projectId).list(10);
+    await documentBackend('storyboard', projectId).create('Board');
+    await documentBackend('timeline', projectId).list(10);
+    await documentBackend('timeline', projectId).create('Timeline');
+    await documentBackend('sketch', projectId).list(10);
+    await documentBackend('sketch', projectId).create('Sketch');
+    await documentBackend('script', projectId).list(10);
+    await documentBackend('script', projectId).create('Script');
+    await documentBackend('jsscript', projectId).list(10);
+    await documentBackend('jsscript', projectId).create('Script');
+
+    expect(mockResources.list.query).toHaveBeenCalledWith({
+      kind: 'storyboard',
+      limit: 10,
+      projectId,
+    });
+    expect(mockResources.create.mutate).toHaveBeenCalledWith({
+      kind: 'storyboard',
+      name: 'Board',
+      projectId,
+    });
+    expect(mockResources.list.query).toHaveBeenCalledWith({
+      kind: 'timeline',
+      limit: 10,
+      projectId,
+    });
+    expect(mockResources.create.mutate).toHaveBeenCalledWith({
+      kind: 'timeline',
+      name: 'Timeline',
+      projectId,
+    });
+    expect(mockResources.list.query).toHaveBeenCalledWith({
+      kind: 'sketch',
+      limit: 10,
+      projectId,
+    });
+    expect(mockResources.create.mutate).toHaveBeenCalledWith({
+      kind: 'sketch',
+      name: 'Sketch',
+      projectId,
+    });
+    expect(mockScripts.list.query).toHaveBeenCalledWith({ projectId });
+    expect(mockScripts.create.mutate).toHaveBeenCalledWith({
+      name: 'Script',
+      projectId,
+    });
+    expect(mockJsScripts.list.query).toHaveBeenCalledWith({ projectId });
+    expect(mockJsScripts.create.mutate).toHaveBeenCalledWith({
+      name: 'Script',
+      projectId,
+    });
+  });
 });

--- a/mobile/src/documents/backends.ts
+++ b/mobile/src/documents/backends.ts
@@ -54,14 +54,16 @@ export interface DocumentBackend<Doc = unknown> {
 }
 
 /** The `resources.*` envelope: token is the row's numeric revision. */
-function resourcesBackend(kind: ResourceDocumentKind): DocumentBackend {
+function resourcesBackend(
+  kind: ResourceDocumentKind,
+  projectId: string | undefined
+): DocumentBackend {
   return {
     writable: true,
     list: async (limit) => {
-      const summaries = await createMobileTRPCClient().resources.list.query({
-        kind,
-        limit,
-      });
+      const summaries = await createMobileTRPCClient().resources.list.query(
+        projectId === undefined ? { kind, limit } : { kind, limit, projectId }
+      );
       return summaries.map((summary) => ({
         id: summary.ref.id,
         name: summary.name,
@@ -72,7 +74,7 @@ function resourcesBackend(kind: ResourceDocumentKind): DocumentBackend {
       const detail = await createMobileTRPCClient().resources.create.mutate({
         kind,
         name,
-        projectId: 'default',
+        projectId: projectId ?? 'default',
       });
       return {
         id: detail.ref.id,
@@ -125,11 +127,13 @@ function resourcesBackend(kind: ResourceDocumentKind): DocumentBackend {
 }
 
 /** The `scripts.*` router: token is `updated_at`, sent back as `baseUpdatedAt`. */
-function scriptsBackend(): DocumentBackend {
+function scriptsBackend(projectId: string | undefined): DocumentBackend {
   return {
     writable: true,
     list: async () => {
-      const scripts = await createMobileTRPCClient().scripts.list.query({});
+      const scripts = await createMobileTRPCClient().scripts.list.query(
+        projectId === undefined ? {} : { projectId }
+      );
       return scripts.map((script) => ({
         id: script.id,
         name: script.name,
@@ -140,7 +144,7 @@ function scriptsBackend(): DocumentBackend {
     create: async (name) => {
       const script = await createMobileTRPCClient().scripts.create.mutate({
         name,
-        projectId: 'default',
+        projectId: projectId ?? 'default',
       });
       return {
         id: script.id,
@@ -186,14 +190,16 @@ function scriptsBackend(): DocumentBackend {
  * The `jsScripts.*` router: same `baseUpdatedAt` scheme as `scripts.*`, and a
  * different table again — a JS script is a body with declared ports, not lines.
  */
-function jsScriptsBackend(): DocumentBackend {
+function jsScriptsBackend(projectId: string | undefined): DocumentBackend {
   const portSummary = (inputs: number, outputs: number): string =>
     `${inputs} in · ${outputs} out`;
 
   return {
     writable: true,
     list: async () => {
-      const scripts = await createMobileTRPCClient().jsScripts.list.query({});
+      const scripts = await createMobileTRPCClient().jsScripts.list.query(
+        projectId === undefined ? {} : { projectId }
+      );
       return scripts.map((script) => ({
         id: script.id,
         name: script.name,
@@ -204,7 +210,7 @@ function jsScriptsBackend(): DocumentBackend {
     create: async (name) => {
       const script = await createMobileTRPCClient().jsScripts.create.mutate({
         name,
-        projectId: 'default',
+        projectId: projectId ?? 'default',
       });
       return {
         id: script.id,
@@ -249,13 +255,20 @@ function jsScriptsBackend(): DocumentBackend {
 }
 
 const backends = {
-  timeline: resourcesBackend('timeline'),
-  storyboard: resourcesBackend('storyboard'),
-  sketch: resourcesBackend('sketch'),
-  script: scriptsBackend(),
-  jsscript: jsScriptsBackend(),
-} satisfies Record<DocumentKind, DocumentBackend>;
+  timeline: (projectId?: string) => resourcesBackend('timeline', projectId),
+  storyboard: (projectId?: string) => resourcesBackend('storyboard', projectId),
+  sketch: (projectId?: string) => resourcesBackend('sketch', projectId),
+  script: (projectId?: string) => scriptsBackend(projectId),
+  jsscript: (projectId?: string) => jsScriptsBackend(projectId),
+} satisfies Record<DocumentKind, (projectId?: string) => DocumentBackend>;
 
-export function documentBackend<Doc>(kind: DocumentKind): DocumentBackend<Doc> {
-  return backends[kind] as DocumentBackend<Doc>;
+/**
+ * Supplying a scope keeps list and creation requests in that project. Existing
+ * mobile callers remain unscoped until mobile gains its own project selector.
+ */
+export function documentBackend<Doc>(
+  kind: DocumentKind,
+  projectId?: string
+): DocumentBackend<Doc> {
+  return backends[kind](projectId) as DocumentBackend<Doc>;
 }

--- a/packages/models/tests/project.test.ts
+++ b/packages/models/tests/project.test.ts
@@ -203,6 +203,28 @@ describe("Project model", () => {
     expect(await Project.deleteOwned("u1", project.id)).toBe(true);
   });
 
+  it("keeps a project's completed output separate from another project's upload", async () => {
+    const projectA = await Project.create<Project>({ user_id: "u1", name: "A" });
+    const projectB = await Project.create<Project>({ user_id: "u1", name: "B" });
+    const output = await Prediction.create<Prediction>({
+      user_id: "u1",
+      project_id: projectA.id
+    });
+    const upload = await Asset.create<Asset>({
+      user_id: "u1",
+      project_id: projectB.id,
+      name: "B upload"
+    });
+
+    const [storedOutput, storedUpload] = await Promise.all([
+      Prediction.find(output.id),
+      Asset.find("u1", upload.id)
+    ]);
+    expect(storedOutput?.project_id).toBe(projectA.id);
+    expect(storedUpload?.project_id).toBe(projectB.id);
+    expect(storedOutput?.project_id).not.toBe(storedUpload?.project_id);
+  });
+
   it("insertNew refuses to rewrite an id that already exists", async () => {
     const mine = await Project.create<Project>({
       id: "shared-id",

--- a/web/src/components/projects/__tests__/ProjectSelector.test.tsx
+++ b/web/src/components/projects/__tests__/ProjectSelector.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * The selector is the top-level project boundary. These checks use the real
+ * tab store so keyboard selection proves the selected scope changes before a
+ * caller starts loading the project's saved session.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+
+import mockTheme from "../../../__mocks__/themeMock";
+import { useWorkspaceTabsStore } from "../../../stores/WorkspaceTabsStore";
+
+const projects = {
+  data: [
+    { id: "a", name: "Aurora" },
+    { id: "b", name: "Beacon" }
+  ],
+  isPending: false,
+  error: null
+};
+
+const documentsQuery = jest.fn();
+jest.mock("../../../trpc/client", () => ({
+  trpc: {
+    projects: {
+      list: { useQuery: () => ({ ...projects }) }
+    }
+  },
+  trpcClient: {
+    projects: {
+      documents: { query: (...args: unknown[]) => documentsQuery(...args) }
+    }
+  }
+}));
+
+jest.mock("../../timeline/ActivityIndicator", () => ({
+  ActivityIndicator: () => null
+}));
+
+import ProjectSelector from "../ProjectSelector";
+
+const renderSelector = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ProjectSelector />
+    </ThemeProvider>
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  documentsQuery.mockResolvedValue([
+    { type: "script", ref: "a-script", name: "Aurora script" }
+  ]);
+  useWorkspaceTabsStore.setState({
+    tabs: [],
+    activeTabId: null,
+    activeProjectId: null,
+    projectSessions: {}
+  });
+});
+
+describe("ProjectSelector", () => {
+  it("opens and selects a project with the keyboard", async () => {
+    const user = userEvent.setup();
+    renderSelector();
+
+    const trigger = screen.getByRole("button", {
+      name: "Selected project: Personal"
+    });
+    trigger.focus();
+    await user.keyboard("{Enter}");
+
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Selected project: Aurora" })
+      ).toBeInTheDocument()
+    );
+    expect(documentsQuery).toHaveBeenCalledWith({ id: "a" });
+    expect(screen.queryByRole("textbox", { name: "Find a project" })).not.toBeInTheDocument();
+  });
+
+  it("keeps the selected project named above the tabs", () => {
+    useWorkspaceTabsStore.getState().setActiveProjectId("b");
+    renderSelector();
+
+    expect(
+      screen.getByRole("button", { name: "Selected project: Beacon" })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/projects/__tests__/ProjectSelector.test.tsx
+++ b/web/src/components/projects/__tests__/ProjectSelector.test.tsx
@@ -70,7 +70,9 @@ describe("ProjectSelector", () => {
     trigger.focus();
     await user.keyboard("{Enter}");
 
-    await user.keyboard("{ArrowDown}{Enter}");
+    const aurora = await screen.findByRole("menuitem", { name: "Aurora" });
+    aurora.focus();
+    await user.keyboard("{Enter}");
 
     await waitFor(() =>
       expect(

--- a/web/src/stores/__tests__/WorkspaceTabsStore.test.ts
+++ b/web/src/stores/__tests__/WorkspaceTabsStore.test.ts
@@ -246,6 +246,55 @@ describe("creationProjectId", () => {
 });
 
 describe("openProject", () => {
+  it("keeps A's chat and output session separate from B's upload through a round trip", () => {
+    const store = useWorkspaceTabsStore.getState();
+    store.openProject({
+      id: "a",
+      name: "Aurora",
+      documents: [
+        { type: "chat", ref: "a-chat", title: "A chat" },
+        { type: "script", ref: "a-script", title: "A script" }
+      ]
+    });
+    store.setActiveTab("chat:a-chat");
+    store.openTab({
+      type: "image",
+      ref: "a-output",
+      title: "A output",
+      projectId: "a"
+    });
+
+    store.openProject({ id: "b", name: "Beacon" });
+    store.openTab({
+      type: "image",
+      ref: "b-upload",
+      title: "B upload",
+      projectId: "b"
+    });
+
+    store.openProject({ id: "a", name: "Aurora" });
+
+    const state = useWorkspaceTabsStore.getState();
+    expect(state.activeProjectId).toBe("a");
+    expect(state.projectSessions.a.selectedChatThreadId).toBe("a-chat");
+    expect(state.projectSessions.a.tabIds).toEqual([
+      "project:a",
+      "chat:a-chat",
+      "script:a-script",
+      "image:a-output"
+    ]);
+    expect(state.projectSessions.b.tabIds).toEqual([
+      "project:b",
+      "image:b-upload"
+    ]);
+    expect(state.tabs.find((tab) => tab.id === "image:a-output")?.projectId).toBe(
+      "a"
+    );
+    expect(state.tabs.find((tab) => tab.id === "image:b-upload")?.projectId).toBe(
+      "b"
+    );
+  });
+
   it("opens the overview first and a tab per document, all in the group", () => {
     useWorkspaceTabsStore.getState().openProject({
       id: "p1",


### PR DESCRIPTION
Completes release verification coverage for project scoping and records the AC1–AC11 evidence map. It also gives mobile document transports an explicit project scope without adding mobile project navigation.\n\n- Adds deterministic A/B session, output/upload ownership, and keyboard selector coverage.\n- Covers scoped mobile list/create requests for every document kind.\n- Records the final inventory, UI walkthrough procedure, and the Q10 product decision.\n\nVerification attempted:\n- npm run test:affected (blocked: local TypeScript dependency missing)\n- npm run typecheck (blocked: tsc missing)\n- npm run lint (blocked: oxlint missing)\n- npm run dev:nodetool -- harness gate --base origin/main (blocked: tsx missing)\n\nCaveat: browser and Electron narrow-layout walkthroughs are documented but could not run because this checkout has no dependencies.