### PR TITLE
Choose storyboard render models at render time

### DIFF
--- a/packages/protocol/src/api-schemas/storyboards.ts
+++ b/packages/protocol/src/api-schemas/storyboards.ts
@@ -20,6 +20,12 @@ const mediaRef = z
   })
   .passthrough();
 
+const shotModelRef = z.object({
+  id: z.string(),
+  provider: z.string(),
+  name: z.string().optional()
+});
+
 export const storyboardShot = z
   .object({
     type: z.literal("shot"),
@@ -32,6 +38,8 @@ export const storyboardShot = z
     duration_seconds: z.number().optional(),
     keyframe: mediaRef.nullable().optional(),
     clip: mediaRef.nullable().optional(),
+    still_model: shotModelRef.optional(),
+    clip_model: shotModelRef.optional(),
     /** Ordered ids of the linked script's lines this shot covers. */
     script_line_ids: z.array(z.string()).optional(),
     /** Linked line texts as last projected, joined "\n" — drift only. */

--- a/packages/protocol/src/creative.ts
+++ b/packages/protocol/src/creative.ts
@@ -17,7 +17,7 @@
 
 import { z } from "zod";
 
-import type { ImageRef, VideoRef } from "./api-types.js";
+import type { ImageRef, Provider, VideoRef } from "./api-types.js";
 import { ENTITY_METADATA_KEY } from "./style-presets.js";
 
 // ---------------------------------------------------------------------------
@@ -364,6 +364,13 @@ export type VersionRef<T> = T & { render_inputs?: RenderInputs };
 export type KeyframeVersion = VersionRef<ImageRef>;
 export type ClipVersion = VersionRef<VideoRef>;
 
+/** A render model remembered on one shot for fast re-renders. */
+export interface ShotModelRef {
+  id: string;
+  provider: Provider;
+  name?: string;
+}
+
 /**
  * Field-by-field equality of two render records, ignoring `recorded_at` — a
  * timestamp is not an input, and every re-render would otherwise read as
@@ -419,6 +426,10 @@ export interface Shot {
   clip?: ClipVersion | null;
   /** Every rendered take for this shot, oldest first. `clip` is one of them. */
   clip_versions?: ClipVersion[];
+  /** Model used for this shot's latest still render. */
+  still_model?: ShotModelRef;
+  /** Model used for this shot's latest clip render. */
+  clip_model?: ShotModelRef;
   status: ShotStatus;
   /** Estimated cost to render this shot's clip, for the gate. */
   cost_estimate?: number | null;

--- a/packages/protocol/tests/api-schemas-storyboards.test.ts
+++ b/packages/protocol/tests/api-schemas-storyboards.test.ts
@@ -279,6 +279,57 @@ describe("setup stage and genre", () => {
   });
 });
 
+describe("per-shot render models", () => {
+  const legacyDocument = {
+    screenplay: null,
+    shots: [
+      {
+        type: "shot",
+        id: "shot-1",
+        index: 0,
+        action: "A lighthouse at dawn",
+        status: "planned"
+      }
+    ],
+    brief: "A keeper's last night",
+    style: "noir",
+    entityIds: [],
+    aspectRatio: "16:9",
+    directorModel: null,
+    imageModel: null,
+    videoModel: null
+  };
+
+  it("preserves model refs and still accepts legacy shots without them", () => {
+    const withModels = storyboardDocument.parse({
+      ...legacyDocument,
+      shots: [
+        {
+          ...legacyDocument.shots[0],
+          still_model: {
+            id: "atlas/still",
+            provider: "atlascloud",
+            name: "Atlas Still"
+          },
+          clip_model: {
+            id: "atlas/clip",
+            provider: "atlascloud",
+            name: "Atlas Clip"
+          }
+        }
+      ]
+    });
+
+    expect(withModels.shots[0]).toMatchObject({
+      still_model: { id: "atlas/still", provider: "atlascloud" },
+      clip_model: { id: "atlas/clip", provider: "atlascloud" }
+    });
+    expect(storyboardDocument.parse(legacyDocument).shots[0].still_model).toBe(
+      undefined
+    );
+  });
+});
+
 describe("scenes", () => {
   /** A screenplay saved before scenes existed. */
   const legacyScreenplay = {

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -31,8 +31,11 @@ import React, {
   useRef,
   useState
 } from "react";
-import { shotRenderMode, requiredVideoTasksForShots } from "@nodetool-ai/protocol";
-import type { Shot } from "@nodetool-ai/protocol";
+import {
+  shotRenderMode,
+  requiredVideoTasksForShots
+} from "@nodetool-ai/protocol";
+import type { Shot, ShotModelRef } from "@nodetool-ai/protocol";
 import AddIcon from "@mui/icons-material/Add";
 import TuneIcon from "@mui/icons-material/Tune";
 
@@ -76,7 +79,14 @@ import {
 } from "../../stores/storyboard/StoryboardStore";
 import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
 import { useStoryboardShotFocus } from "../../hooks/storyboard/useStoryboardShotFocus";
-import type { ImageModelTask } from "../../hooks/useModelsByProvider";
+import {
+  useImageModelsByProvider,
+  useVideoModelsByProvider,
+  type ImageModelTask,
+  type VideoModelTask
+} from "../../hooks/useModelsByProvider";
+import { modelMatchesTask } from "../../hooks/modelTaskMatching";
+import type { ImageModelValue, VideoModelValue } from "../../stores/ApiTypes";
 import LanguageModelSelect from "../properties/LanguageModelSelect";
 import { useInStudio } from "../../studio/StudioContext";
 import ImageModelSelect from "../properties/ImageModelSelect";
@@ -108,6 +118,10 @@ import ShotInspector from "./ShotInspector";
 import StoryboardEntitiesField from "./StoryboardEntitiesField";
 import { sceneDropTarget } from "./sceneDrop";
 import { isShotNavigationKey, navigateShots } from "./shotOrder";
+import {
+  getRememberedModel,
+  getRememberedModelForTask
+} from "../../stores/lastModelStore";
 
 // The preview mounts the timeline compositor; keep it out of the board bundle.
 const LazyStoryboardPreview = React.lazy(() => import("./StoryboardPreview"));
@@ -137,6 +151,38 @@ const SHOT_COUNT_OPTIONS = [3, 4, 5, 6, 8, 10, 12].map((n) => ({
 // Stills can come from a plain generator or an editing model; the latter can
 // take entity reference images, so the picker offers both.
 const STILL_MODEL_TASKS: ImageModelTask[] = ["text_to_image", "image_to_image"];
+
+const clipTaskForShot = (shot: Shot): VideoModelTask => {
+  const mode = shotRenderMode(shot);
+  return mode === "reference"
+    ? "reference_to_video"
+    : mode === "direct"
+      ? "text_to_video"
+      : "image_to_video";
+};
+
+const CLIP_TASK_LABELS: Record<VideoModelTask, string> = {
+  image_to_video: "Animate stills",
+  text_to_video: "Generate from prompts",
+  reference_to_video: "Use entity references",
+  video_to_video: "Revise clips",
+  lip_sync: "Lip sync"
+};
+
+const imageValue = (model: ShotModelRef): ImageModelValue => ({
+  type: "image_model",
+  id: model.id,
+  provider: model.provider,
+  name: model.name ?? model.id,
+  path: ""
+});
+
+const videoValue = (model: ShotModelRef): VideoModelValue => ({
+  type: "video_model",
+  id: model.id,
+  provider: model.provider,
+  name: model.name ?? model.id
+});
 
 // The model pickers are custom buttons, not InputBase controls; hold them at
 // the shared form-control height. Scoped to the picker's own class so no
@@ -290,6 +336,37 @@ const RenderBatchButton: React.FC<RenderBatchButtonProps> = ({
   );
 };
 
+const RenderCostSummary: React.FC<{
+  estimate: RenderBatchCostEstimate;
+}> = ({ estimate }) => {
+  const { shotCount, cost, pricedCount, reasons, notes } = estimate;
+  const priced = pricedCount > 0 && cost > 0;
+  return (
+    <FlexColumn gap={SPACING.micro}>
+      <Text size="small">
+        {priced
+          ? `Estimated cost: about ${formatUsd(cost)}${
+              pricedCount < shotCount
+                ? ` (${pricedCount} of ${shotCount} shots priced)`
+                : ""
+            }`
+          : "Select a priced model to see the batch estimate."}
+      </Text>
+      {reasons.map((reason) => (
+        <Caption key={reason} color="secondary">
+          {reason}
+        </Caption>
+      ))}
+      {priced &&
+        notes.map((note) => (
+          <Caption key={note} color="secondary">
+            {note}
+          </Caption>
+        ))}
+    </FlexColumn>
+  );
+};
+
 const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   boardId,
   readOnly,
@@ -347,6 +424,17 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   const [styleOpen, setStyleOpen] = useState(false);
   const openStyle = useCallback(() => setStyleOpen(true), []);
   const closeStyle = useCallback(() => setStyleOpen(false), []);
+  const [renderDialog, setRenderDialog] = useState<"stills" | "clips" | null>(
+    null
+  );
+  const [stillSelection, setStillSelection] = useState<ImageModelValue | null>(
+    null
+  );
+  const [clipSelections, setClipSelections] = useState<
+    Partial<Record<VideoModelTask, VideoModelValue>>
+  >({});
+  const { models: imageModels } = useImageModelsByProvider();
+  const { models: videoModels } = useVideoModelsByProvider();
 
   // Which shot's editor is open, and which cell it opened on. The board holds
   // this rather than the card, because the panel is a row of this grid: a card
@@ -587,7 +675,9 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
     () =>
       shots.filter(
         (s) =>
-          (!!s.keyframe || shotRenderMode(s) === "direct" || shotRenderMode(s) === "reference") &&
+          (!!s.keyframe ||
+            shotRenderMode(s) === "direct" ||
+            shotRenderMode(s) === "reference") &&
           !s.clip &&
           s.status !== "keyframe_generating" &&
           s.status !== "clip_generating"
@@ -604,19 +694,7 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
       : null;
   const stillStepActive = nextRenderStep === "stills";
   const clipStepActive = nextRenderStep === "clips";
-  const clipModelTask = requiredVideoTasksForShots(shots);
-  const missingModelStep = stillStepActive
-    ? imageModel?.id
-      ? null
-      : "stills"
-    : clipStepActive && !videoModel?.id
-      ? "clips"
-      : null;
-  useEffect(() => {
-    if (missingModelStep) {
-      setSettingsOpen(true);
-    }
-  }, [missingModelStep]);
+  const clipModelTasks = requiredVideoTasksForShots(pendingClips);
   const settingsVisible = settingsOpen;
 
   // The toolbar's one-line summary: how big the board is, how it looks, and
@@ -633,7 +711,15 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
         allEntities ?? [],
         shot
       ),
-    [aspectRatio, style, entityIds, imageModel, videoModel, screenplay, allEntities]
+    [
+      aspectRatio,
+      style,
+      entityIds,
+      imageModel,
+      videoModel,
+      screenplay,
+      allEntities
+    ]
   );
   const summary = useMemo(() => {
     const entityNames = (allEntities ?? [])
@@ -650,26 +736,171 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   }, [shots.length, style, entityIds, allEntities]);
 
   const { generateKeyframe, generateClip } = useGenerateShot();
+  const resolveImageModel = useCallback(
+    (value: ShotModelRef | null | undefined): ImageModelValue | null => {
+      if (!value) {
+        return null;
+      }
+      const model = imageModels.find(
+        (candidate) =>
+          candidate.id === value.id && candidate.provider === value.provider
+      );
+      return model ? imageValue(model) : null;
+    },
+    [imageModels]
+  );
+  const findRememberedImageModel = useCallback((): ImageModelValue | null => {
+    const remembered = getRememberedModel("image");
+    if (!remembered?.model || !remembered.provider) {
+      return null;
+    }
+    return resolveImageModel({
+      id: remembered.model,
+      provider: remembered.provider
+    });
+  }, [resolveImageModel]);
+
+  const resolveVideoModel = useCallback(
+    (
+      value: ShotModelRef | null | undefined,
+      task: VideoModelTask
+    ): VideoModelValue | null => {
+      if (!value) {
+        return null;
+      }
+      const model = videoModels.find(
+        (candidate) =>
+          candidate.id === value.id &&
+          candidate.provider === value.provider &&
+          modelMatchesTask(candidate.supported_tasks, task)
+      );
+      return model ? videoValue(model) : null;
+    },
+    [videoModels]
+  );
+
+  const findRememberedVideoModel = useCallback(
+    (task: VideoModelTask): VideoModelValue | null => {
+      const remembered =
+        getRememberedModelForTask("video", task) ?? getRememberedModel("video");
+      if (!remembered?.model || !remembered.provider) {
+        return null;
+      }
+      return resolveVideoModel(
+        { id: remembered.model, provider: remembered.provider },
+        task
+      );
+    },
+    [resolveVideoModel]
+  );
+
+  const defaultStillSelection = useMemo(
+    () =>
+      findRememberedImageModel() ??
+      [...shots]
+        .reverse()
+        .map((shot) => resolveImageModel(shot.still_model))
+        .find((model): model is ImageModelValue => model !== null) ??
+      resolveImageModel(imageModel),
+    [findRememberedImageModel, shots, resolveImageModel, imageModel]
+  );
+
+  const defaultClipSelections = useMemo(() => {
+    const selections: Partial<Record<VideoModelTask, VideoModelValue>> = {};
+    for (const task of clipModelTasks) {
+      const shotModel = [...shots]
+        .reverse()
+        .filter((shot) => clipTaskForShot(shot) === task)
+        .map((shot) => resolveVideoModel(shot.clip_model, task))
+        .find((model): model is VideoModelValue => model !== null);
+      const selected =
+        findRememberedVideoModel(task) ??
+        shotModel ??
+        resolveVideoModel(videoModel, task);
+      if (selected) {
+        selections[task] = selected;
+      }
+    }
+    return selections;
+  }, [
+    clipModelTasks,
+    shots,
+    findRememberedVideoModel,
+    resolveVideoModel,
+    videoModel
+  ]);
+
+  const openStillRenderDialog = useCallback(() => {
+    setStillSelection(defaultStillSelection);
+    setRenderDialog("stills");
+  }, [defaultStillSelection]);
+
+  const openClipRenderDialog = useCallback(() => {
+    setClipSelections(defaultClipSelections);
+    setRenderDialog("clips");
+  }, [defaultClipSelections]);
+
   // A shot that cannot start records the reason on itself (its card shows it,
   // and it is toasted), so one failure must not stop the rest of the batch.
   const handleGenerateAllStills = useCallback(() => {
+    if (!stillSelection) {
+      return;
+    }
+    setImageModel(boardId, stillSelection);
+    setRenderDialog(null);
     for (const shot of pendingStills) {
-      void generateKeyframe(boardId, shot).catch(() => undefined);
+      void generateKeyframe(boardId, shot, stillSelection).catch(
+        () => undefined
+      );
     }
-  }, [pendingStills, generateKeyframe, boardId]);
+  }, [pendingStills, generateKeyframe, boardId, stillSelection, setImageModel]);
   const handleGenerateAllClips = useCallback(() => {
-    for (const shot of pendingClips) {
-      void generateClip(boardId, shot).catch(() => undefined);
+    if (clipModelTasks.some((task) => !clipSelections[task])) {
+      return;
     }
-  }, [pendingClips, generateClip, boardId]);
+    const lastModel = clipSelections[clipModelTasks.at(-1) as VideoModelTask];
+    if (lastModel) {
+      setVideoModel(boardId, lastModel);
+    }
+    setRenderDialog(null);
+    for (const shot of pendingClips) {
+      const model = clipSelections[clipTaskForShot(shot)];
+      void generateClip(boardId, shot, model).catch(() => undefined);
+    }
+  }, [
+    pendingClips,
+    generateClip,
+    boardId,
+    clipModelTasks,
+    clipSelections,
+    setVideoModel
+  ]);
 
   // What each batch button is about to spend, over exactly the shots it loops.
+  const effectiveStillSelection =
+    renderDialog === "stills" ? stillSelection : defaultStillSelection;
+  const stillModelForShot = useCallback(
+    () => effectiveStillSelection,
+    [effectiveStillSelection]
+  );
+  const effectiveClipSelections =
+    renderDialog === "clips" ? clipSelections : defaultClipSelections;
+  const clipModelForShot = useCallback(
+    (shot: Shot) => effectiveClipSelections[clipTaskForShot(shot)] ?? null,
+    [effectiveClipSelections]
+  );
   const stillsCost = useRenderBatchCostEstimate(
     boardId,
     pendingStills,
-    "still"
+    "still",
+    stillModelForShot
   );
-  const clipsCost = useRenderBatchCostEstimate(boardId, pendingClips, "clip");
+  const clipsCost = useRenderBatchCostEstimate(
+    boardId,
+    pendingClips,
+    "clip",
+    clipModelForShot
+  );
 
   // The archive is packed server-side from the saved board, so a download
   // shows what the server holds — the local edits an in-flight save has not
@@ -760,20 +991,16 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
               <RenderBatchButton
                 label="Render stills"
                 estimate={stillsCost}
-                disabled={
-                  pendingStills.length === 0 || !imageModel?.id || !!directing
-                }
-                highlighted={stillStepActive && !!imageModel?.id}
-                onClick={handleGenerateAllStills}
+                disabled={pendingStills.length === 0 || !!directing}
+                highlighted={stillStepActive}
+                onClick={openStillRenderDialog}
               />
               <RenderBatchButton
                 label="Render clips"
                 estimate={clipsCost}
-                disabled={
-                  pendingClips.length === 0 || !videoModel?.id || !!directing
-                }
-                highlighted={clipStepActive && !!videoModel?.id}
-                onClick={handleGenerateAllClips}
+                disabled={pendingClips.length === 0 || !!directing}
+                highlighted={clipStepActive}
+                onClick={openClipRenderDialog}
               />
             </FlexRow>
           )}
@@ -851,33 +1078,6 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
                         />
                       </FormField>
                     )}
-                    <FormField label="Still model" sx={modelFieldSx}>
-                      <ImageModelSelect
-                        value={imageModel?.id ?? ""}
-                        task={STILL_MODEL_TASKS}
-                        onChange={(value) => setImageModel(boardId, value)}
-                      />
-                      {stillStepActive && !imageModel?.id && (
-                        <Caption color="warning" role="alert">
-                          Choose a still model before rendering stills.
-                        </Caption>
-                      )}
-                      {entityIds.length > 0 && (
-                        <EntityStillModelWarning modelId={imageModel?.id} />
-                      )}
-                    </FormField>
-                    <FormField label="Clip model" sx={modelFieldSx}>
-                      <VideoModelSelect
-                        value={videoModel?.id ?? ""}
-                        task={clipModelTask}
-                        onChange={(value) => setVideoModel(boardId, value)}
-                      />
-                      {clipStepActive && !videoModel?.id && (
-                        <Caption color="warning" role="alert">
-                          Choose a clip model before rendering clips.
-                        </Caption>
-                      )}
-                    </FormField>
                     <FormField label="Aspect ratio">
                       <SelectField
                         label="Aspect ratio"
@@ -931,6 +1131,76 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
             </Panel>
           </Collapse>
         )}
+
+        <Dialog
+          open={renderDialog === "stills"}
+          onClose={() => setRenderDialog(null)}
+          title="Render stills"
+          onConfirm={handleGenerateAllStills}
+          confirmText={`Render stills${
+            stillsCost.pricedCount > 0 && stillsCost.cost > 0
+              ? ` · ~${formatUsd(stillsCost.cost)}`
+              : ""
+          }`}
+          confirmDisabled={!stillSelection}
+        >
+          <FlexColumn gap={SPACING.md}>
+            <Caption color="secondary">
+              Pick the model for this batch. The choice is remembered on every
+              shot for one-click regeneration.
+            </Caption>
+            <FormField label="Still model" sx={modelFieldSx}>
+              <ImageModelSelect
+                value={stillSelection?.id ?? ""}
+                task={STILL_MODEL_TASKS}
+                onChange={setStillSelection}
+              />
+              {entityIds.length > 0 && (
+                <EntityStillModelWarning modelId={stillSelection?.id} />
+              )}
+            </FormField>
+            <RenderCostSummary estimate={stillsCost} />
+          </FlexColumn>
+        </Dialog>
+
+        <Dialog
+          open={renderDialog === "clips"}
+          onClose={() => setRenderDialog(null)}
+          title="Render clips"
+          onConfirm={handleGenerateAllClips}
+          confirmText={`Render clips${
+            clipsCost.pricedCount > 0 && clipsCost.cost > 0
+              ? ` · ~${formatUsd(clipsCost.cost)}`
+              : ""
+          }`}
+          confirmDisabled={clipModelTasks.some((task) => !clipSelections[task])}
+        >
+          <FlexColumn gap={SPACING.md}>
+            <Caption color="secondary">
+              Pick a model for each kind of clip in this batch. Each shot keeps
+              its choice for fast re-renders.
+            </Caption>
+            {clipModelTasks.map((task) => (
+              <FormField
+                key={task}
+                label={CLIP_TASK_LABELS[task]}
+                sx={modelFieldSx}
+              >
+                <VideoModelSelect
+                  value={clipSelections[task]?.id ?? ""}
+                  task={task}
+                  onChange={(value) =>
+                    setClipSelections((current) => ({
+                      ...current,
+                      [task]: value
+                    }))
+                  }
+                />
+              </FormField>
+            ))}
+            <RenderCostSummary estimate={clipsCost} />
+          </FlexColumn>
+        </Dialog>
 
         <Dialog
           open={confirmRedirect}

--- a/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
+++ b/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from "@mui/material/styles";
 import type { Entity, Scene, Shot } from "@nodetool-ai/protocol";
 import { isVersionStale } from "@nodetool-ai/protocol";
 import mockTheme from "../../../__mocks__/themeMock";
+import { useLastModelStore } from "../../../stores/lastModelStore";
 
 jest.mock("../../../hooks/useResolvedMediaUri");
 
@@ -34,6 +35,8 @@ const mockInsertShot = jest.fn();
 const mockMoveShot = jest.fn();
 const mockSetSetup = jest.fn();
 const mockSetStylePreset = jest.fn();
+const mockSetImageModel = jest.fn();
+const mockSetVideoModel = jest.fn();
 jest.mock("../../../stores/storyboard/StoryboardStore", () => ({
   useBoard: () => ({
     title: "My film",
@@ -82,8 +85,8 @@ jest.mock("../../../stores/storyboard/StoryboardStore", () => ({
       setStyle: jest.fn(),
       setAspectRatio: jest.fn(),
       setDirectorModel: jest.fn(),
-      setImageModel: jest.fn(),
-      setVideoModel: jest.fn(),
+      setImageModel: mockSetImageModel,
+      setVideoModel: mockSetVideoModel,
       undo: jest.fn(),
       redo: jest.fn(),
       selectShot: mockSelectShot,
@@ -124,6 +127,10 @@ jest.mock("../ScriptLinkControl", () => ({
 
 const mockGenerateKeyframe = jest.fn(async () => undefined);
 const mockGenerateClip = jest.fn(async () => undefined);
+let mockImageSelection = {
+  id: "fal-ai/flux/schnell",
+  provider: "fal_ai"
+};
 jest.mock("../../../hooks/storyboard/useGenerateShot", () => ({
   useGenerateShot: () => ({
     generateKeyframe: mockGenerateKeyframe,
@@ -132,7 +139,34 @@ jest.mock("../../../hooks/storyboard/useGenerateShot", () => ({
 }));
 
 jest.mock("../../../hooks/useModelsByProvider", () => ({
-  useImageModelsByProvider: () => ({ models: [] })
+  useImageModelsByProvider: () => ({
+    models: [
+      {
+        id: "fal-ai/flux/schnell",
+        provider: "fal_ai",
+        name: "Flux Schnell"
+      },
+      {
+        id: "fal-ai/flux/premium",
+        provider: "fal_ai",
+        name: "Flux Premium"
+      }
+    ]
+  }),
+  useVideoModelsByProvider: () => ({
+    models: [
+      {
+        id: "pixverse/720p",
+        provider: "fal_ai",
+        supported_tasks: ["image_to_video"]
+      },
+      {
+        id: "atlas/direct-v1",
+        provider: "atlascloud",
+        supported_tasks: ["text_to_video"]
+      }
+    ]
+  })
 }));
 
 // The toolbar's summary line names the board's entities, and the style dialog
@@ -163,14 +197,35 @@ const stub = (name: string) => ({
 jest.mock("../../properties/LanguageModelSelect", () => stub("lang-model"));
 jest.mock("../../properties/ImageModelSelect", () => ({
   __esModule: true,
-  default: () => (
-    <div role="combobox" aria-label="Still model" data-testid="image-model" />
+  default: ({ onChange }: { onChange: (value: unknown) => void }) => (
+    <button
+      aria-label="Still model"
+      onClick={() => onChange(mockImageSelection)}
+    >
+      Still model
+    </button>
   )
 }));
 jest.mock("../../properties/VideoModelSelect", () => ({
   __esModule: true,
-  default: () => (
-    <div role="combobox" aria-label="Clip model" data-testid="video-model" />
+  default: ({
+    onChange,
+    task
+  }: {
+    onChange: (value: unknown) => void;
+    task: string;
+  }) => (
+    <button
+      aria-label={`Clip model for ${task}`}
+      onClick={() =>
+        onChange({
+          id: task === "text_to_video" ? "atlas/direct-v1" : "pixverse/720p",
+          provider: task === "text_to_video" ? "atlascloud" : "fal_ai"
+        })
+      }
+    >
+      Clip model
+    </button>
   )
 }));
 // The card's own behaviour has its own suite (ShotCard.test.tsx); this stub
@@ -314,6 +369,15 @@ beforeEach(() => {
     imageModel: { id: "fal-ai/flux/schnell", provider: "fal_ai" },
     videoModel: { id: "pixverse/720p", provider: "fal_ai" }
   };
+  mockSetImageModel.mockClear();
+  mockSetVideoModel.mockClear();
+  mockGenerateKeyframe.mockClear();
+  mockGenerateClip.mockClear();
+  mockImageSelection = {
+    id: "fal-ai/flux/schnell",
+    provider: "fal_ai"
+  };
+  useLastModelStore.setState({ byKind: {}, byTask: {} });
 });
 
 const renderBoard = (onDirect: (n: number) => void) =>
@@ -424,12 +488,14 @@ describe("StoryboardBoard preview", () => {
 });
 
 describe("StoryboardBoard model fields", () => {
-  it("offers still and clip models but no screenplay model in Studio", () => {
+  it("keeps all model pickers out of settings in Studio", () => {
     mockShots = [];
     renderBoardInStudio();
 
-    expect(screen.getByTestId("image-model")).toBeInTheDocument();
-    expect(screen.getByTestId("video-model")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Still model" })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Clip model")).not.toBeInTheDocument();
     expect(screen.queryByTestId("lang-model")).not.toBeInTheDocument();
   });
 
@@ -502,22 +568,18 @@ describe("StoryboardBoard toolbar", () => {
     ).toHaveAttribute("aria-expanded", "false");
   });
 
-  it("lets the user close settings after a missing model reveals them", async () => {
+  it("does not put render model pickers in board settings", async () => {
     boardModels = { imageModel: null, videoModel: null };
     mockShots = [makeShot("s1")];
     const user = userEvent.setup();
     renderBoard(jest.fn());
 
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      "Choose a still model before rendering stills."
-    );
-    await user.click(
-      screen.getByRole("button", { name: "Close board settings" })
-    );
+    await user.click(screen.getByRole("button", { name: /Board settings/ }));
 
     expect(
-      screen.queryByRole("combobox", { name: "Still model" })
+      screen.queryByRole("button", { name: "Still model" })
     ).not.toBeInTheDocument();
+    expect(screen.queryByText("Clip model")).not.toBeInTheDocument();
   });
 
   it("renders the render actions on the toolbar", () => {
@@ -597,23 +659,45 @@ describe("StoryboardBoard toolbar", () => {
     ).not.toHaveAttribute("aria-current");
   });
 
-  it("opens the still model picker and asks for a model before rendering", () => {
+  it("asks for a still model when rendering, then renders with that choice", async () => {
     boardModels = { imageModel: null, videoModel: null };
     mockShots = [makeShot("s1")];
+    const user = userEvent.setup();
     renderBoard(jest.fn());
 
     expect(
-      screen.getByRole("combobox", { name: "Still model" })
-    ).toBeInTheDocument();
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      "Choose a still model before rendering stills."
-    );
+      screen.queryByRole("button", { name: "Still model" })
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Render stills (1)" }));
     expect(
-      screen.getByRole("button", { name: "Render stills (1)" })
-    ).toBeDisabled();
+      screen.getByRole("dialog", { name: /Render stills/ })
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Still model" }));
+    await user.click(screen.getByRole("button", { name: "Render stills" }));
+
+    expect(mockGenerateKeyframe).toHaveBeenCalledWith(
+      "board-1",
+      mockShots[0],
+      expect.objectContaining({ id: "fal-ai/flux/schnell" })
+    );
   });
 
-  it("opens the clip model picker and asks for a model before rendering", () => {
+  it("prefills the last still model so a repeat batch only needs confirmation", async () => {
+    mockShots = [makeShot("s1")];
+    const user = userEvent.setup();
+    renderBoard(jest.fn());
+
+    await user.click(screen.getByRole("button", { name: "Render stills (1)" }));
+    await user.click(screen.getByRole("button", { name: "Render stills" }));
+
+    expect(mockGenerateKeyframe).toHaveBeenCalledWith(
+      "board-1",
+      mockShots[0],
+      expect.objectContaining(boardModels.imageModel as Record<string, unknown>)
+    );
+  });
+
+  it("asks for separate clip models when pending shots need different tasks", async () => {
     boardModels = {
       imageModel: { id: "fal-ai/flux/schnell", provider: "fal_ai" },
       videoModel: null
@@ -623,19 +707,117 @@ describe("StoryboardBoard toolbar", () => {
         ...makeShot("s1"),
         status: "keyframe_ready",
         keyframe: { type: "image", asset_id: "still-1" }
-      }
+      },
+      { ...makeShot("s2"), render_mode: "direct" }
     ];
+    const user = userEvent.setup();
     renderBoard(jest.fn());
 
+    await user.click(screen.getByRole("button", { name: "Render clips (2)" }));
     expect(
-      screen.getByRole("combobox", { name: "Clip model" })
+      screen.getByRole("dialog", { name: /Render clips/ })
     ).toBeInTheDocument();
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      "Choose a clip model before rendering clips."
+    await user.click(
+      screen.getByRole("button", { name: "Clip model for image_to_video" })
     );
+    await user.click(
+      screen.getByRole("button", { name: "Clip model for text_to_video" })
+    );
+    await user.click(screen.getByRole("button", { name: "Render clips" }));
+
+    expect(mockGenerateClip).toHaveBeenNthCalledWith(
+      1,
+      "board-1",
+      mockShots[0],
+      expect.objectContaining({ id: "pixverse/720p" })
+    );
+    expect(mockGenerateClip).toHaveBeenNthCalledWith(
+      2,
+      "board-1",
+      mockShots[1],
+      expect.objectContaining({ id: "atlas/direct-v1" })
+    );
+  });
+
+  it("does not prefill a remembered clip model after the shot mode changes", async () => {
+    boardModels = { imageModel: null, videoModel: null };
+    mockShots = [
+      {
+        ...makeShot("s1"),
+        render_mode: "direct",
+        clip_model: { id: "pixverse/720p", provider: "fal_ai" }
+      }
+    ];
+    const user = userEvent.setup();
+    renderBoard(jest.fn());
+
+    await user.click(screen.getByRole("button", { name: "Render clips (1)" }));
+
+    expect(screen.getByRole("button", { name: "Render clips" })).toBeDisabled();
+  });
+
+  it("remembers separate model choices for each clip task", async () => {
+    boardModels = { imageModel: null, videoModel: null };
+    mockShots = [
+      {
+        ...makeShot("s1"),
+        status: "keyframe_ready",
+        keyframe: { type: "image", asset_id: "still-1" }
+      },
+      { ...makeShot("s2"), render_mode: "direct" }
+    ];
+    useLastModelStore.getState().rememberForTask("video", "image_to_video", {
+      provider: "fal_ai",
+      model: "pixverse/720p"
+    });
+    useLastModelStore.getState().rememberForTask("video", "text_to_video", {
+      provider: "atlascloud",
+      model: "atlas/direct-v1"
+    });
+    const user = userEvent.setup();
+    renderBoard(jest.fn());
+
+    await user.click(screen.getByRole("button", { name: "Render clips (2)" }));
+    await user.click(screen.getByRole("button", { name: "Render clips" }));
+
+    expect(mockGenerateClip).toHaveBeenNthCalledWith(
+      1,
+      "board-1",
+      mockShots[0],
+      expect.objectContaining({ id: "pixverse/720p" })
+    );
+    expect(mockGenerateClip).toHaveBeenNthCalledWith(
+      2,
+      "board-1",
+      mockShots[1],
+      expect.objectContaining({ id: "atlas/direct-v1" })
+    );
+  });
+
+  it("updates the confirmation price when the batch model changes", async () => {
+    mockShots = [makeShot("s1"), makeShot("s2")];
+    mockImageSelection = {
+      id: "fal-ai/flux/premium",
+      provider: "fal_ai"
+    };
+    mockPrice.mockImplementation((model: unknown) => ({
+      unit_price:
+        (model as { id?: string }).id === "fal-ai/flux/premium" ? 1 : 0.01,
+      billing_unit: "images",
+      currency: "USD",
+      source: "bundle"
+    }));
+    const user = userEvent.setup();
+    renderBoard(jest.fn());
+
+    await user.click(
+      screen.getByRole("button", { name: "Render stills (2) · ~$0.02" })
+    );
+    await user.click(screen.getByRole("button", { name: "Still model" }));
+
     expect(
-      screen.getByRole("button", { name: "Render clips (1)" })
-    ).toBeDisabled();
+      screen.getByRole("button", { name: "Render stills · ~$2" })
+    ).toBeEnabled();
   });
 
   it("puts each batch's price on its own button", () => {
@@ -824,9 +1006,7 @@ describe("StoryboardBoard scene headers", () => {
     const headings = screen.getAllByRole("heading", { level: 3 });
     expect(headings).toHaveLength(1);
     expect(headings[0]).toHaveTextContent("Scene 1");
-    expect(
-      screen.queryByText(/INT\.|EXT\./)
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/INT\.|EXT\./)).not.toBeInTheDocument();
   });
 
   it("groups the cards under one header per scene, in derived order", () => {
@@ -879,7 +1059,9 @@ describe("StoryboardBoard insert point", () => {
     renderBoard(jest.fn());
 
     await user.click(
-      screen.getByRole("button", { name: "Insert a shot after Scene 1 | Shot 1" })
+      screen.getByRole("button", {
+        name: "Insert a shot after Scene 1 | Shot 1"
+      })
     );
 
     expect(mockInsertShot).toHaveBeenCalledWith("board-1", "s1");

--- a/web/src/hooks/modelTaskMatching.ts
+++ b/web/src/hooks/modelTaskMatching.ts
@@ -1,0 +1,22 @@
+const STRICT_MODEL_TASKS = new Set<string>([
+  "inpainting",
+  "upscale",
+  "remove_background",
+  "relight",
+  "vectorize",
+  "segment",
+  "video_to_video",
+  "reference_to_video",
+  "lip_sync"
+]);
+
+/** Match the model picker: undeclared tasks pass only for basic generation. */
+export const modelMatchesTask = (
+  supportedTasks: string[] | null | undefined,
+  task: string
+): boolean => {
+  if (!supportedTasks || supportedTasks.length === 0) {
+    return !STRICT_MODEL_TASKS.has(task);
+  }
+  return supportedTasks.includes(task);
+};

--- a/web/src/hooks/storyboard/__tests__/useGenerateShot.test.tsx
+++ b/web/src/hooks/storyboard/__tests__/useGenerateShot.test.tsx
@@ -21,7 +21,11 @@ jest.mock("../../../lib/websocket/GlobalWebSocketManager", () => ({
 // these arrays per scenario.
 const mockEntities: unknown[] = [];
 const mockImageModels: Array<{ id: string; supported_tasks?: string[] }> = [];
-const mockVideoModels: Array<{ id: string; provider: string; supported_tasks?: string[] }> = [];
+const mockVideoModels: Array<{
+  id: string;
+  provider: string;
+  supported_tasks?: string[];
+}> = [];
 jest.mock("../../../serverState/useEntities", () => ({
   useEntities: () => ({ data: mockEntities })
 }));
@@ -34,10 +38,15 @@ jest.mock("../../useModelsByProvider", () => ({
 const scriptQuery = jest.fn();
 jest.mock("../../../trpc/client", () => ({
   trpc: {},
-  trpcClient: { scripts: { get: { query: (input: { id: string }) => scriptQuery(input) } } }
+  trpcClient: {
+    scripts: { get: { query: (input: { id: string }) => scriptQuery(input) } }
+  }
 }));
 
-import { useGenerateShot, __resetStartingShotsForTests } from "../useGenerateShot";
+import {
+  useGenerateShot,
+  __resetStartingShotsForTests
+} from "../useGenerateShot";
 import { useStoryboardStore } from "../../../stores/storyboard/StoryboardStore";
 import { useStoryboardGenerationStore } from "../../../stores/storyboard/StoryboardGenerationStore";
 import {
@@ -80,9 +89,19 @@ beforeEach(() => {
 
 describe("mixed-mode clip generation", () => {
   const boardId = "mixed-modes";
-  const videoModel = { type: "video_model" as const, id: "mixed-model", provider: "fal_ai" as const, name: "Mixed" };
+  const videoModel = {
+    type: "video_model" as const,
+    id: "mixed-model",
+    provider: "fal_ai" as const,
+    name: "Mixed"
+  };
   const shots: Shot[] = [
-    { ...shot, id: "mixed-keyframe", render_mode: "keyframe", keyframe: { type: "image", asset_id: "start" } },
+    {
+      ...shot,
+      id: "mixed-keyframe",
+      render_mode: "keyframe",
+      keyframe: { type: "image", asset_id: "start" }
+    },
     { ...shot, id: "mixed-direct", render_mode: "direct" },
     { ...shot, id: "mixed-reference", render_mode: "reference" }
   ];
@@ -99,31 +118,94 @@ describe("mixed-mode clip generation", () => {
     }
   });
 
-  it.each([undefined, ["reference_to_video"], ["text_to_video", "image_to_video"]])(
-    "refuses the whole mixed board before sending any shot with tasks %j", async (supported_tasks) => {
-      mockVideoModels.push({ id: videoModel.id, provider: videoModel.provider, supported_tasks });
-      const { result } = renderHook(() => useGenerateShot());
-      await act(async () => {
-        for (const value of shots) {
-          await expect(result.current.generateClip(boardId, value)).rejects.toThrow("every shot mode");
-        }
-      });
-      expect(send).not.toHaveBeenCalled();
-    }
-  );
-
-  it("sends each shot through its own task when the model supports all three", async () => {
-    mockVideoModels.push({ id: videoModel.id, provider: videoModel.provider, supported_tasks: ["text_to_video", "image_to_video", "reference_to_video"] });
+  it("uses and stores a different compatible model for each shot mode", async () => {
+    const models = {
+      keyframe: {
+        id: "image-video",
+        provider: "atlascloud",
+        name: "Image video"
+      },
+      direct: { id: "text-video", provider: "atlascloud", name: "Text video" },
+      reference: {
+        id: "reference-video",
+        provider: "atlascloud",
+        name: "Reference video"
+      }
+    } as const;
+    mockVideoModels.push(
+      { ...models.keyframe, supported_tasks: ["image_to_video"] },
+      { ...models.direct, supported_tasks: ["text_to_video"] },
+      { ...models.reference, supported_tasks: ["reference_to_video"] }
+    );
     const { result } = renderHook(() => useGenerateShot());
     await act(async () => {
-      for (const value of shots) await result.current.generateClip(boardId, value);
+      await result.current.generateClip(boardId, shots[0], models.keyframe);
+      await result.current.generateClip(boardId, shots[1], models.direct);
+      await result.current.generateClip(boardId, shots[2], models.reference);
     });
     expect(send).toHaveBeenCalledTimes(3);
-    expect(send.mock.calls[0][0].data).toMatchObject({ source_asset_id: "start" });
-    expect(send.mock.calls[1][0].data.source_asset_id).toBeUndefined();
-    expect(send.mock.calls[1][0].data.capability).toBeUndefined();
-    expect(send.mock.calls[2][0].data).toMatchObject({ capability: "reference_to_video", reference_images: location.reference_images });
+    expect(send.mock.calls[0][0].data).toMatchObject({
+      model: "image-video",
+      source_asset_id: "start"
+    });
+    expect(send.mock.calls[1][0].data).toMatchObject({ model: "text-video" });
+    expect(send.mock.calls[2][0].data).toMatchObject({
+      model: "reference-video",
+      capability: "reference_to_video"
+    });
+
+    const stored = useStoryboardStore.getState().getBoard(boardId)?.shots;
+    expect(stored?.[0].clip_model).toEqual(models.keyframe);
+    expect(stored?.[1].clip_model).toEqual(models.direct);
+    expect(stored?.[2].clip_model).toEqual(models.reference);
   });
+});
+
+it("reuses the model remembered on a shot when regenerating", async () => {
+  const model = {
+    id: "atlas/still-v1",
+    provider: "atlascloud" as const,
+    name: "Atlas Still"
+  };
+  const { result } = renderHook(() => useGenerateShot());
+
+  await act(async () => {
+    await result.current.generateKeyframe(BOARD, shot, model);
+  });
+  useStoryboardGenerationStore.getState().clear(shot.id);
+  const remembered = useStoryboardStore
+    .getState()
+    .getBoard(BOARD)
+    ?.shots.find((value) => value.id === shot.id);
+
+  await act(async () => {
+    await result.current.generateKeyframe(BOARD, remembered ?? shot);
+  });
+
+  expect(send).toHaveBeenCalledTimes(2);
+  expect(send.mock.calls[1][0].data).toMatchObject({
+    provider: "atlascloud",
+    model: "atlas/still-v1"
+  });
+});
+
+it("rejects a remembered clip model that is no longer in the catalog", async () => {
+  const unavailable: Shot = {
+    ...shot,
+    render_mode: "direct",
+    clip_model: {
+      id: "atlas/removed",
+      provider: "atlascloud",
+      name: "Removed Atlas model"
+    }
+  };
+  useStoryboardStore.getState().upsertShot(BOARD, unavailable);
+  const { result } = renderHook(() => useGenerateShot());
+
+  await expect(
+    act(() => result.current.generateClip(BOARD, unavailable))
+  ).rejects.toThrow("is no longer available");
+  expect(send).not.toHaveBeenCalled();
 });
 
 it("starts exactly one generation for concurrent generateKeyframe calls", async () => {
@@ -326,6 +408,12 @@ describe("clip generation on a script-linked board", () => {
     useStoryboardGenerationStore.getState().clear(linkedShot.id);
     shotToSeed = linkedShot;
     mockEntities.length = 0;
+    mockVideoModels.length = 0;
+    mockVideoModels.push({
+      id: "vid-1",
+      provider: "vprov",
+      supported_tasks: ["image_to_video", "text_to_video"]
+    });
   });
 
   const videoModel = {
@@ -416,17 +504,17 @@ describe("a start that fails", () => {
     const { result } = renderHook(() => useGenerateShot());
 
     await act(async () => {
-      await expect(result.current.generateKeyframe(BOARD, shot)).rejects.toThrow(
-        "No image model configured"
-      );
+      await expect(
+        result.current.generateKeyframe(BOARD, shot)
+      ).rejects.toThrow("No image model configured");
     });
 
     const job = useStoryboardGenerationStore.getState().shotJobs[shot.id];
     expect(job?.status).toBe("failed");
     expect(job?.errorMessage).toBe("No image model configured");
-    expect(
-      useStoryboardStore.getState().getBoard(BOARD)?.shots[0].status
-    ).toBe("failed");
+    expect(useStoryboardStore.getState().getBoard(BOARD)?.shots[0].status).toBe(
+      "failed"
+    );
   });
 
   it("records a reason when a clip's request fails to send", async () => {
@@ -551,7 +639,9 @@ describe("prompts come from the shared shot-prompt module", () => {
     await act(async () => {
       await result.current.generateClip(boardId, direct);
     });
-    expect(promptSent()).toBe(directClipPrompt(direct, { scene, style: STYLE }));
+    expect(promptSent()).toBe(
+      directClipPrompt(direct, { scene, style: STYLE })
+    );
   });
 });
 

--- a/web/src/hooks/storyboard/__tests__/useRenderBatchCostEstimate.test.tsx
+++ b/web/src/hooks/storyboard/__tests__/useRenderBatchCostEstimate.test.tsx
@@ -121,6 +121,33 @@ describe("useRenderBatchCostEstimate", () => {
     expect(result.current.pricedCount).toBe(3);
   });
 
+  it("prices remembered shot models instead of the board fallback", () => {
+    mockPrice.mockImplementation((model: { id: string }) => ({
+      unit_price: model.id === "atlas/direct" ? 0.2 : 0.1,
+      billing_unit: "video",
+      currency: "USD",
+      source: "bundle"
+    }));
+    selectClipModel();
+    const perShot = [
+      {
+        ...shots[0],
+        clip_model: { id: "atlas/direct", provider: "atlascloud" }
+      },
+      shots[1]
+    ];
+
+    const { result } = renderHook(() =>
+      useRenderBatchCostEstimate(BOARD, perShot, "clip")
+    );
+
+    expect(mockPrice).toHaveBeenCalledWith(
+      { id: "atlas/direct", provider: "atlascloud" },
+      expect.objectContaining({ resolution: CLIP_RESOLUTION })
+    );
+    expect(result.current.cost).toBeCloseTo(0.3, 9);
+  });
+
   it("says why a batch has no figure instead of quoting zero", () => {
     const { result } = renderHook(() =>
       useRenderBatchCostEstimate(BOARD, shots, "clip")
@@ -139,15 +166,16 @@ describe("useRenderBatchCostEstimate", () => {
   });
 
   it("counts only the shots that priced when the catalog answers for some", () => {
-    mockPrice.mockImplementation((_model: unknown, params: { seconds?: number }) =>
-      params.seconds === 6
-        ? null
-        : {
-            unit_price: 0.5,
-            billing_unit: "video",
-            currency: "USD",
-            source: "bundle"
-          }
+    mockPrice.mockImplementation(
+      (_model: unknown, params: { seconds?: number }) =>
+        params.seconds === 6
+          ? null
+          : {
+              unit_price: 0.5,
+              billing_unit: "video",
+              currency: "USD",
+              source: "bundle"
+            }
     );
     selectClipModel();
 

--- a/web/src/hooks/storyboard/useGenerateShot.ts
+++ b/web/src/hooks/storyboard/useGenerateShot.ts
@@ -7,8 +7,8 @@
  *   - `generateKeyframe(boardId, shot)` — mode `image`, prompt from the shot
  *     action + board style. Entity mentions travel as `entity://<id>` tokens
  *     the server expands at generation time (name inline, descriptor block,
- *     reference image routed into the provider inputs); when the board's still
- *     model cannot edit, descriptors are seasoned client-side instead.
+ *     reference image routed into the provider inputs); when the selected
+ *     still model cannot edit, descriptors are seasoned client-side instead.
  *   - `generateClip(boardId, shot)` — mode `video` with the shot's keyframe as
  *     `source_asset_id` (image-to-video), timed to the linked script's takes.
  *   - `generateRevisedClip(boardId, shot, instruction)` — mode `video_edit`
@@ -24,7 +24,8 @@ import { useCallback } from "react";
 import type {
   BoardRenderContext,
   Entity,
-  Shot
+  Shot,
+  ShotModelRef
 } from "@nodetool-ai/protocol";
 import {
   clipPromptFor,
@@ -32,12 +33,9 @@ import {
   injectEntities,
   keyframePrompt,
   sceneForShot,
-  requiredVideoTasksForShots,
   shotRenderMode
 } from "@nodetool-ai/protocol";
-import {
-  globalWebSocketManager
-} from "../../lib/websocket/GlobalWebSocketManager";
+import { globalWebSocketManager } from "../../lib/websocket/GlobalWebSocketManager";
 import {
   useStoryboardStore,
   type StoryboardBoard
@@ -48,6 +46,7 @@ import {
   useImageModelsByProvider,
   useVideoModelsByProvider
 } from "../useModelsByProvider";
+import { modelMatchesTask } from "../modelTaskMatching";
 import {
   PENDING_JOB_TTL_MS,
   subscribeDirectShotJob,
@@ -58,6 +57,7 @@ import {
 import { fetchShotDurationSeconds } from "./useShotDuration";
 import { CLIP_RESOLUTION, STILL_RESOLUTION } from "./renderSpec";
 import { getErrorMessage } from "../../utils/errorHandling";
+import { useLastModelStore } from "../../stores/lastModelStore";
 
 /**
  * Shots with a start in flight, before `registerJob` marks them active in the
@@ -103,8 +103,16 @@ const hasReferenceImage = (entities: Entity[]): boolean =>
   entities.some((e) => (e.reference_images?.length ?? 0) > 0);
 
 interface UseGenerateShotResult {
-  generateKeyframe: (boardId: string, shot: Shot) => Promise<void>;
-  generateClip: (boardId: string, shot: Shot) => Promise<void>;
+  generateKeyframe: (
+    boardId: string,
+    shot: Shot,
+    model?: ShotModelRef
+  ) => Promise<void>;
+  generateClip: (
+    boardId: string,
+    shot: Shot,
+    model?: ShotModelRef
+  ) => Promise<void>;
   generateRevisedClip: (
     boardId: string,
     shot: Shot,
@@ -121,7 +129,7 @@ export const useGenerateShot = (): UseGenerateShotResult => {
   );
   // Library entities; a board's `entityIds` picks which ones season prompts.
   const { data: allEntities } = useEntities();
-  // Model catalog, for checking whether the still model can take entity
+  // Model catalogs, for checking whether the selected model can take entity
   // reference images (image_to_image support).
   const { models: imageModels } = useImageModelsByProvider();
   const { models: videoModels } = useVideoModelsByProvider();
@@ -149,11 +157,7 @@ export const useGenerateShot = (): UseGenerateShotResult => {
    */
   const renderContext = useCallback(
     (board: StoryboardBoard | undefined, shot?: Shot): BoardRenderContext =>
-      boardRenderContext(
-        board,
-        allEntities ?? [],
-        shot
-      ),
+      boardRenderContext(board, allEntities ?? [], shot),
     [allEntities]
   );
 
@@ -223,8 +227,13 @@ export const useGenerateShot = (): UseGenerateShotResult => {
   );
 
   const generateKeyframe = useCallback(
-    async (boardId: string, shot: Shot): Promise<void> => {
+    async (
+      boardId: string,
+      shot: Shot,
+      modelOverride?: ShotModelRef
+    ): Promise<void> => {
       const board = useStoryboardStore.getState().getBoard(boardId);
+      const model = modelOverride ?? shot.still_model ?? board?.imageModel;
       const style = board?.style ?? "";
       const aspectRatio = board?.aspectRatio ?? "16:9";
       const entities = entitiesForShot(shot, boardEntities(board?.entityIds));
@@ -233,8 +242,8 @@ export const useGenerateShot = (): UseGenerateShotResult => {
       // board's still model can edit — the server expands them into prompt
       // text and routes the reference images into the provider call.
       // Otherwise season descriptors client-side only.
-      const stillModel = board?.imageModel?.id
-        ? imageModels.find((m) => m.id === board.imageModel?.id)
+      const stillModel = model?.id
+        ? imageModels.find((candidate) => candidate.id === model.id)
         : undefined;
       const useEditModel =
         hasReferenceImage(entities) &&
@@ -257,36 +266,61 @@ export const useGenerateShot = (): UseGenerateShotResult => {
         resolution: STILL_RESOLUTION,
         variations: 1
       };
-      if (board?.imageModel) {
-        data.provider = board.imageModel.provider;
-        data.model = board.imageModel.id;
+      if (model) {
+        data.provider = model.provider;
+        data.model = model.id;
+        useStoryboardStore
+          .getState()
+          .updateShot(boardId, shot.id, { still_model: model });
+        useLastModelStore.getState().remember("image", {
+          provider: model.provider,
+          model: model.id
+        });
       }
+      const renderShot = model ? { ...shot, still_model: model } : shot;
       await startDirectGeneration(
         boardId,
-        shot,
+        renderShot,
         "keyframe",
         data,
-        renderContext(board, shot)
+        renderContext(board, renderShot)
       );
     },
     [startDirectGeneration, boardEntities, imageModels, renderContext]
   );
 
   const generateClip = useCallback(
-    async (boardId: string, shot: Shot): Promise<void> => {
+    async (
+      boardId: string,
+      shot: Shot,
+      modelOverride?: ShotModelRef
+    ): Promise<void> => {
       const board = useStoryboardStore.getState().getBoard(boardId);
-      const requiredTasks = requiredVideoTasksForShots(board?.shots ?? [shot]);
-      const selectedModel = videoModels.find((model) =>
-        model.id === board?.videoModel?.id && model.provider === board.videoModel.provider
+      const model = modelOverride ?? shot.clip_model ?? board?.videoModel;
+      const renderMode = shotRenderMode(shot);
+      const requiredTask =
+        renderMode === "reference"
+          ? "reference_to_video"
+          : renderMode === "direct"
+            ? "text_to_video"
+            : "image_to_video";
+      const selectedModel = videoModels.find(
+        (candidate) =>
+          candidate.id === model?.id && candidate.provider === model.provider
       );
-      const supportedTasks = selectedModel?.supported_tasks;
-      if ((requiredTasks.length > 1 && !supportedTasks?.length) ||
-          (supportedTasks?.length && requiredTasks.some((task) => !supportedTasks.includes(task)))) {
-        const message = "Choose a clip model that supports every shot mode on this board before rendering.";
+      if (model && !selectedModel) {
+        const message = `The remembered clip model ${model.name ?? model.id} is no longer available. Choose another model.`;
         recordStartFailure(shot.id, boardId, "clip", message);
         throw new Error(message);
       }
-      const renderMode = shotRenderMode(shot);
+      if (
+        selectedModel &&
+        !modelMatchesTask(selectedModel.supported_tasks, requiredTask)
+      ) {
+        const message = `Choose a clip model that supports ${requiredTask.replaceAll("_", " ")} for this shot.`;
+        recordStartFailure(shot.id, boardId, "clip", message);
+        throw new Error(message);
+      }
       let sourceAssetId: string | undefined;
       if (renderMode === "keyframe") {
         if (!shot.keyframe) {
@@ -325,9 +359,13 @@ export const useGenerateShot = (): UseGenerateShotResult => {
         variations: 1
       };
       if (renderMode === "reference") {
-        const referenceImages = entities.flatMap((entity) => entity.reference_images ?? []);
+        const referenceImages = entities.flatMap(
+          (entity) => entity.reference_images ?? []
+        );
         if (referenceImages.length === 0) {
-          throw new Error("Reference mode requires at least one entity reference image.");
+          throw new Error(
+            "Reference mode requires at least one entity reference image."
+          );
         }
         data.reference_images = referenceImages;
         data.capability = "reference_to_video";
@@ -338,19 +376,37 @@ export const useGenerateShot = (): UseGenerateShotResult => {
       if (durationSeconds !== undefined) {
         data.duration = durationSeconds;
       }
-      if (board?.videoModel) {
-        data.provider = board.videoModel.provider;
-        data.model = board.videoModel.id;
+      if (model) {
+        data.provider = model.provider;
+        data.model = model.id;
+        useStoryboardStore
+          .getState()
+          .updateShot(boardId, shot.id, { clip_model: model });
+        useLastModelStore.getState().remember("video", {
+          provider: model.provider,
+          model: model.id
+        });
+        useLastModelStore.getState().rememberForTask("video", requiredTask, {
+          provider: model.provider,
+          model: model.id
+        });
       }
+      const renderShot = model ? { ...shot, clip_model: model } : shot;
       await startDirectGeneration(
         boardId,
-        shot,
+        renderShot,
         "clip",
         data,
-        renderContext(board, shot)
+        renderContext(board, renderShot)
       );
     },
-    [startDirectGeneration, boardEntities, renderContext, videoModels, recordStartFailure]
+    [
+      startDirectGeneration,
+      boardEntities,
+      renderContext,
+      videoModels,
+      recordStartFailure
+    ]
   );
 
   const generateRevisedClip = useCallback(
@@ -374,9 +430,10 @@ export const useGenerateShot = (): UseGenerateShotResult => {
         prompt,
         source_asset_id: sourceAssetId
       };
-      if (board?.videoModel) {
-        data.provider = board.videoModel.provider;
-        data.model = board.videoModel.id;
+      const model = shot.clip_model ?? board?.videoModel;
+      if (model) {
+        data.provider = model.provider;
+        data.model = model.id;
       }
       // No render record: a revision renders the instruction over an existing
       // clip, not the shot's composed prompt, so there is nothing a later

--- a/web/src/hooks/storyboard/useRenderBatchCostEstimate.ts
+++ b/web/src/hooks/storyboard/useRenderBatchCostEstimate.ts
@@ -8,9 +8,8 @@
  *
  * Priced through the same `priceRenderStep` the inspector uses, so a shot
  * cannot be quoted one figure in the inspector and another in the toolbar.
- * Stills are identical across shots — one model, one rung — while a clip's
- * price moves with each shot's effective duration, so clips are priced shot by
- * shot and summed.
+ * A shot's remembered model wins over the board's legacy default. Clips are
+ * also priced at each shot's effective duration, then the batch is summed.
  *
  * The shots come from the caller, and they are exactly the ones the button
  * loops over: the estimate is what that click costs, not what an ideal render
@@ -18,16 +17,13 @@
  */
 
 import { useMemo } from "react";
-import type { Shot } from "@nodetool-ai/protocol";
+import type { Shot, ShotModelRef } from "@nodetool-ai/protocol";
 import { effectiveShotDuration } from "@nodetool-ai/timeline";
 
 import { CLIP_RESOLUTION, STILL_RESOLUTION } from "./renderSpec";
 import { priceRenderStep } from "./shotCostPricing";
 import { useBoardScriptLines } from "./useShotDuration";
-import {
-  useBoardImageModel,
-  useBoardVideoModel
-} from "./useShotCostEstimate";
+import { useBoardImageModel, useBoardVideoModel } from "./useShotCostEstimate";
 
 /** Which of the two render passes a batch is. */
 export type RenderStep = "still" | "clip";
@@ -56,7 +52,8 @@ const EMPTY: RenderBatchCostEstimate = {
 export function useRenderBatchCostEstimate(
   boardId: string,
   shots: Shot[],
-  step: RenderStep
+  step: RenderStep,
+  modelForShot?: (shot: Shot) => ShotModelRef | null
 ): RenderBatchCostEstimate {
   const imageModel = useBoardImageModel(boardId);
   const videoModel = useBoardVideoModel(boardId);
@@ -76,7 +73,6 @@ export function useRenderBatchCostEstimate(
     // What the step is, decided once: only the duration varies per shot.
     const isStill = step === "still";
     const label = isStill ? "Still" : "Clip";
-    const model = isStill ? imageModel : videoModel;
     const pickerLabel = isStill ? "still model" : "clip model";
     const resolution = isStill ? STILL_RESOLUTION : CLIP_RESOLUTION;
 
@@ -87,6 +83,11 @@ export function useRenderBatchCostEstimate(
         ? undefined
         : (effectiveShotDuration(shot, linesById).seconds ??
           shot.duration_seconds);
+      const model = modelForShot
+        ? modelForShot(shot)
+        : isStill
+          ? (shot.still_model ?? imageModel)
+          : (shot.clip_model ?? videoModel);
       const priced = priceRenderStep(
         label,
         model,
@@ -112,7 +113,7 @@ export function useRenderBatchCostEstimate(
       reasons: Array.from(new Set(reasons)),
       notes: Array.from(new Set(notes))
     };
-  }, [shots, step, imageModel, videoModel, linesById]);
+  }, [shots, step, imageModel, videoModel, linesById, modelForShot]);
 }
 
 export default useRenderBatchCostEstimate;

--- a/web/src/hooks/storyboard/useShotCostEstimate.ts
+++ b/web/src/hooks/storyboard/useShotCostEstimate.ts
@@ -2,8 +2,8 @@
  * useShotCostEstimate
  *
  * What rendering one shot costs, priced the way `render_storyboard_stills` and
- * `render_storyboard_clips` bill it: the board's image model for the shot's
- * still and the board's video model for its clip, both through
+ * `render_storyboard_clips` bill it: the shot's remembered image/video models,
+ * falling back to the board's legacy defaults, both through
  * `getModelUnitPrice`, at the same resolution rungs the render sends
  * (`STILL_RESOLUTION`, `CLIP_RESOLUTION`) and with the shot's effective
  * duration multiplying a per-second clip model. A `direct` shot skips the
@@ -32,7 +32,7 @@ import { priceRenderStep, type ShotCostStep } from "./shotCostPricing";
 export interface ShotCostEstimate {
   /** The whole-shot cost in USD: every priced step below, summed. */
   cost: number;
-  /** "live" priced off the board's current model selection; "stored" is the last render's own figure. */
+  /** "live" uses the current shot/default model; "stored" is the last render's figure. */
   source: "live" | "stored";
   /** The steps, in render order. Empty when the figure is stored. */
   steps: ShotCostStep[];
@@ -66,7 +66,7 @@ export function useShotCostEstimate(
       rendersStill
         ? priceRenderStep(
             "Still",
-            imageModel,
+            shot.still_model ?? imageModel,
             "still model",
             STILL_RESOLUTION,
             undefined,
@@ -75,7 +75,7 @@ export function useShotCostEstimate(
         : null,
       priceRenderStep(
         "Clip",
-        videoModel,
+        shot.clip_model ?? videoModel,
         "clip model",
         CLIP_RESOLUTION,
         seconds,
@@ -95,10 +95,15 @@ export function useShotCostEstimate(
       };
     }
     if (shot.cost_estimate != null) {
-      return { cost: shot.cost_estimate, source: "stored", steps: [], notes: [] };
+      return {
+        cost: shot.cost_estimate,
+        source: "stored",
+        steps: [],
+        notes: []
+      };
     }
     return { cost: 0, source: "live", steps, notes: [] };
-  }, [imageModel, videoModel, rendersStill, seconds, shot.cost_estimate]);
+  }, [imageModel, videoModel, rendersStill, seconds, shot]);
 }
 
 export default useShotCostEstimate;

--- a/web/src/hooks/useModelsByProvider.ts
+++ b/web/src/hooks/useModelsByProvider.ts
@@ -23,6 +23,7 @@ import {
   useVideoProviders
 } from "./useProviders";
 import { useActiveWorker } from "./useWorkers";
+import { modelMatchesTask } from "./modelTaskMatching";
 
 /**
  * Collection of React Query hooks that bridge the UI to backend model endpoints.
@@ -248,29 +249,6 @@ export type VideoModelTask =
  * exclusive, so filtering is strict: only models that explicitly declare the
  * task qualify. A model with no tasks never matches a specialized picker.
  */
-const STRICT_MODEL_TASKS = new Set<string>([
-  "inpainting",
-  "upscale",
-  "remove_background",
-  "relight",
-  "vectorize",
-  "segment",
-  "video_to_video",
-  "reference_to_video",
-  "lip_sync"
-]);
-
-const modelMatchesTask = (
-  supportedTasks: string[] | null | undefined,
-  task: string
-): boolean => {
-  if (!supportedTasks || supportedTasks.length === 0) {
-    // No tasks declared — strict tasks never match, generation tasks pass through
-    return !STRICT_MODEL_TASKS.has(task);
-  }
-  return supportedTasks.includes(task);
-};
-
 export const useImageModelsByProvider = (opts?: { task?: ImageModelTask | ImageModelTask[] }): ModelsByProviderResult<ImageModel> => {
   const { providers, isLoading: providersLoading, error: providersError } = useImageModelProviders();
 

--- a/web/src/lib/storyboard/__tests__/boardRenderContext.test.ts
+++ b/web/src/lib/storyboard/__tests__/boardRenderContext.test.ts
@@ -1,4 +1,8 @@
-import { currentRenderInputs, isVersionStale, stampRenderInputs } from "@nodetool-ai/protocol";
+import {
+  currentRenderInputs,
+  isVersionStale,
+  stampRenderInputs
+} from "@nodetool-ai/protocol";
 import type { Entity, Shot } from "@nodetool-ai/protocol";
 
 import { boardRenderContext } from "../boardRenderContext";
@@ -40,6 +44,23 @@ describe("boardRenderContext", () => {
     });
   });
 
+  it("uses the shot's remembered models ahead of board defaults", () => {
+    const shot: Shot = {
+      type: "shot",
+      id: "shot-models",
+      index: 0,
+      action: "A model-aware shot",
+      status: "planned",
+      still_model: { id: "shot/still", provider: "atlascloud" },
+      clip_model: { id: "shot/clip", provider: "atlascloud" }
+    };
+
+    expect(boardRenderContext(BOARD, LIBRARY, shot)).toMatchObject({
+      image_model: "shot/still",
+      video_model: "shot/clip"
+    });
+  });
+
   it("ignores entities that are not styles", () => {
     const board = { ...BOARD, entityIds: ["char-1", "loc-1"] };
     expect(boardRenderContext(board, LIBRARY).style_entity_id).toBeNull();
@@ -78,19 +99,57 @@ describe("boardRenderContext", () => {
   });
 
   it("matches generation selection and order, and marks changed references stale", () => {
-    const shot: Shot = { type: "shot", id: "shot", index: 0, action: "char-1 walks", status: "planned", render_mode: "reference" };
+    const shot: Shot = {
+      type: "shot",
+      id: "shot",
+      index: 0,
+      action: "char-1 walks",
+      status: "planned",
+      render_mode: "reference"
+    };
     const library: Entity[] = [
-      { ...entity("outside", "style"), reference_images: [{ type: "image", asset_id: "outside" }] },
-      { ...entity("style-a", "style"), reference_images: [{ type: "image", asset_id: "style" }] },
-      { ...entity("char-1", "character"), reference_images: [{ type: "image", asset_id: "character" }] }
+      {
+        ...entity("outside", "style"),
+        reference_images: [{ type: "image", asset_id: "outside" }]
+      },
+      {
+        ...entity("style-a", "style"),
+        reference_images: [{ type: "image", asset_id: "style" }]
+      },
+      {
+        ...entity("char-1", "character"),
+        reference_images: [{ type: "image", asset_id: "character" }]
+      }
     ];
     const context = boardRenderContext(BOARD, library, shot);
     expect(context.reference_asset_ids).toEqual(["character", "style"]);
-    const clip = { type: "video" as const, asset_id: "clip", render_inputs: stampRenderInputs(currentRenderInputs(shot, context, "clip")) };
+    const clip = {
+      type: "video" as const,
+      asset_id: "clip",
+      render_inputs: stampRenderInputs(
+        currentRenderInputs(shot, context, "clip")
+      )
+    };
     expect(isVersionStale(clip, shot, context)).toBe(false);
-    const changed = library.map((entry) => entry.id === "char-1" ? { ...entry, reference_images: [{ type: "image" as const, asset_id: "new-character" }] } : entry);
-    expect(isVersionStale(clip, shot, boardRenderContext(BOARD, changed, shot))).toBe(true);
-    expect(boardRenderContext(BOARD, library, { ...shot, entity_ids: ["style-a", "char-1"] }).reference_asset_ids).toEqual(["character", "style"]);
+    const changed = library.map((entry) =>
+      entry.id === "char-1"
+        ? {
+            ...entry,
+            reference_images: [
+              { type: "image" as const, asset_id: "new-character" }
+            ]
+          }
+        : entry
+    );
+    expect(
+      isVersionStale(clip, shot, boardRenderContext(BOARD, changed, shot))
+    ).toBe(true);
+    expect(
+      boardRenderContext(BOARD, library, {
+        ...shot,
+        entity_ids: ["style-a", "char-1"]
+      }).reference_asset_ids
+    ).toEqual(["character", "style"]);
   });
 
   it("falls back to 16:9 and empty models for a board that has none", () => {

--- a/web/src/lib/storyboard/boardRenderContext.ts
+++ b/web/src/lib/storyboard/boardRenderContext.ts
@@ -42,7 +42,9 @@ const styleEntityId = (
     return null;
   }
   const styles = new Set(
-    entities.filter((entity) => entity.kind === "style").map((entity) => entity.id)
+    entities
+      .filter((entity) => entity.kind === "style")
+      .map((entity) => entity.id)
   );
   for (let i = entityIds.length - 1; i >= 0; i -= 1) {
     if (styles.has(entityIds[i])) {
@@ -52,7 +54,9 @@ const styleEntityId = (
   return null;
 };
 
-const imageAssetId = (image: NonNullable<Entity["reference_images"]>[number]): string | undefined => {
+const imageAssetId = (
+  image: NonNullable<Entity["reference_images"]>[number]
+): string | undefined => {
   if (typeof image.asset_id === "string" && image.asset_id.length > 0) {
     return image.asset_id;
   }
@@ -71,12 +75,14 @@ export const boardRenderContext = (
   shot?: Shot
 ): BoardRenderContext => {
   const byId = new Map(entities.map((entity) => [entity.id, entity]));
-  const boardEntities = (board?.entityIds ?? []).flatMap((id) => byId.get(id) ?? []);
+  const boardEntities = (board?.entityIds ?? []).flatMap(
+    (id) => byId.get(id) ?? []
+  );
   const selected = shot ? entitiesForShot(shot, boardEntities) : boardEntities;
   return {
     aspect_ratio: board?.aspectRatio ?? "16:9",
-    image_model: board?.imageModel?.id ?? "",
-    video_model: board?.videoModel?.id ?? "",
+    image_model: shot?.still_model?.id ?? board?.imageModel?.id ?? "",
+    video_model: shot?.clip_model?.id ?? board?.videoModel?.id ?? "",
     style_entity_id: styleEntityId(board?.entityIds, entities),
     style: board?.style ?? "",
     scenes: board?.screenplay?.scenes ?? null,

--- a/web/src/stores/__tests__/lastModelStore.test.ts
+++ b/web/src/stores/__tests__/lastModelStore.test.ts
@@ -3,13 +3,14 @@ import { act } from "@testing-library/react";
 import {
   useLastModelStore,
   modelKindForBinding,
-  getRememberedModel
+  getRememberedModel,
+  getRememberedModelForTask
 } from "../lastModelStore";
 
 describe("lastModelStore", () => {
   beforeEach(() => {
     act(() => {
-      useLastModelStore.setState({ byKind: {} });
+      useLastModelStore.setState({ byKind: {}, byTask: {} });
     });
   });
 
@@ -53,7 +54,11 @@ describe("lastModelStore", () => {
         });
       });
       const stored = useLastModelStore.getState().byKind.image;
-      expect(stored).toEqual({ provider: "fal", model: "flux", voice: undefined });
+      expect(stored).toEqual({
+        provider: "fal",
+        model: "flux",
+        voice: undefined
+      });
     });
 
     it("no-ops when provider is missing", () => {
@@ -127,6 +132,29 @@ describe("lastModelStore", () => {
         model: "flux",
         voice: undefined
       });
+    });
+  });
+
+  describe("task-specific memory", () => {
+    it("remembers separate models for separate video tasks", () => {
+      act(() => {
+        const store = useLastModelStore.getState();
+        store.rememberForTask("video", "image_to_video", {
+          provider: "atlascloud",
+          model: "image-model"
+        });
+        store.rememberForTask("video", "text_to_video", {
+          provider: "atlascloud",
+          model: "text-model"
+        });
+      });
+
+      expect(getRememberedModelForTask("video", "image_to_video")?.model).toBe(
+        "image-model"
+      );
+      expect(getRememberedModelForTask("video", "text_to_video")?.model).toBe(
+        "text-model"
+      );
     });
   });
 });

--- a/web/src/stores/lastModelStore.ts
+++ b/web/src/stores/lastModelStore.ts
@@ -22,14 +22,22 @@ interface RememberedModel {
 
 interface LastModelState {
   byKind: Partial<Record<ModelKind, RememberedModel>>;
+  byTask: Partial<Record<string, RememberedModel>>;
   /** Record the last-used model for a kind. No-ops without provider + model. */
   remember: (kind: ModelKind, value: RememberedModel) => void;
+  /** Record a task-specific choice without replacing another task's choice. */
+  rememberForTask: (
+    kind: ModelKind,
+    task: string,
+    value: RememberedModel
+  ) => void;
 }
 
 export const useLastModelStore = create<LastModelState>()(
   persist(
     (set) => ({
       byKind: {},
+      byTask: {},
       remember: (kind, value) => {
         if (!value.provider || !value.model) {
           return;
@@ -48,6 +56,33 @@ export const useLastModelStore = create<LastModelState>()(
             byKind: {
               ...state.byKind,
               [kind]: {
+                provider: value.provider,
+                model: value.model,
+                voice: value.voice
+              }
+            }
+          };
+        });
+      },
+      rememberForTask: (kind, task, value) => {
+        if (!value.provider || !value.model) {
+          return;
+        }
+        const key = `${kind}:${task}`;
+        set((state) => {
+          const prev = state.byTask[key];
+          if (
+            prev &&
+            prev.provider === value.provider &&
+            prev.model === value.model &&
+            prev.voice === value.voice
+          ) {
+            return state;
+          }
+          return {
+            byTask: {
+              ...state.byTask,
+              [key]: {
                 provider: value.provider,
                 model: value.model,
                 voice: value.voice
@@ -89,3 +124,10 @@ export function modelKindForBinding(
 export const getRememberedModel = (
   kind: ModelKind
 ): RememberedModel | undefined => useLastModelStore.getState().byKind[kind];
+
+/** Non-reactive read of a remembered task-specific model. */
+export const getRememberedModelForTask = (
+  kind: ModelKind,
+  task: string
+): RememberedModel | undefined =>
+  useLastModelStore.getState().byTask[`${kind}:${task}`];


### PR DESCRIPTION
## Summary

- move still and clip model selection out of board settings and into render confirmation dialogs
- remember the selected model per shot and per clip task for fast regeneration
- support mixed clip tasks with separate compatible models, including AtlasCloud endpoints
- update the confirmation price as model choices change and reject stale model selections

## Verification

- 108 focused storyboard and model-memory web tests pass
- 23 storyboard protocol-schema tests pass
- lint passes
- storyboard harness suites pass

## Workspace-level blockers

The shared worktree contains unrelated project and asset-capability changes. Root typecheck currently fails in those project files, and the full harness fails three unrelated asset-capability tests. These files are not included in this PR.