### PR TITLE
Fix project isolation verification suites

### DIFF
--- a/packages/base-nodes/tests/save-to-workspace.test.ts
+++ b/packages/base-nodes/tests/save-to-workspace.test.ts
@@ -6,7 +6,7 @@
  * than overwritten.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, readdir, writeFile } from "node:fs/promises";
+import { mkdtemp, realpath, rm, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { ProcessingContext } from "@nodetool-ai/runtime";
@@ -26,7 +26,9 @@ const PNG = Buffer.from(
 );
 
 beforeEach(async () => {
-  workspace = await mkdtemp(path.join(tmpdir(), "nodetool-workspace-"));
+  workspace = await realpath(
+    await mkdtemp(path.join(tmpdir(), "nodetool-workspace-"))
+  );
   context = new ProcessingContext({ jobId: "save-test", workspaceDir: workspace });
 });
 

--- a/packages/deploy/tests/index.test.ts
+++ b/packages/deploy/tests/index.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
+import * as mod from "../src/index.js";
 
 describe("deploy index exports", () => {
-  it("exports all public API", async () => {
-    const mod = await import("../src/index.js");
+  it("exports all public API", () => {
     expect(mod).toBeDefined();
 
     // deployment-config

--- a/packages/websocket/src/trpc/sandbox-coverage.ts
+++ b/packages/websocket/src/trpc/sandbox-coverage.ts
@@ -672,9 +672,10 @@ export const SANDBOX_API_COVERAGE: Readonly<
       "control."
   },
   "projects.delete": {
-    gap:
-      "Same grouping surface as `projects.create`. Deleting a project " +
-      "leaves its documents in place, so this loses a name, not content."
+    withheld:
+      "Deleting a project permanently removes its documents, conversations, " +
+      "assets, jobs and workspace files. Irreversible bulk loss stays behind " +
+      "the human-facing project lifecycle surface."
   },
   "projects.documents": {
     gap:
@@ -699,6 +700,12 @@ export const SANDBOX_API_COVERAGE: Readonly<
     gap:
       "Project lifecycle management is not exposed through a sandbox " +
       "capability yet. Restoring changes a project's visibility."
+  },
+  "projects.restoreTabs": {
+    elsewhere:
+      "Frontend session restoration validates each saved resource through " +
+      "its type-specific lookup. A run reaches those resources through the " +
+      "corresponding get and list capabilities, not the browser's tab session."
   },
   "projects.thread": {
     gap:

--- a/packages/websocket/tests/mcp-view-image.test.ts
+++ b/packages/websocket/tests/mcp-view-image.test.ts
@@ -14,6 +14,7 @@ import {
 } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Asset, initTestDb } from "@nodetool-ai/models";
 import { FileStorageAdapter } from "@nodetool-ai/storage";
 import { createMcpServer, type McpServerOptions } from "../src/mcp-server.js";
 import * as storage from "../src/lib/storage.js";
@@ -27,6 +28,7 @@ const connections: Array<{
 }> = [];
 
 beforeAll(async () => {
+  initTestDb();
   root = await mkdtemp(join(tmpdir(), "nodetool-mcp-images-"));
   vi.stubEnv(process.platform === "win32" ? "APPDATA" : "XDG_DATA_HOME", root);
   const adapter = new FileStorageAdapter(join(root, "assets"));
@@ -39,6 +41,14 @@ beforeAll(async () => {
   imagePath = join(root, "image with spaces.png");
   await writeFile(imagePath, png);
   await adapter.store("1/test-image.png", png, "image/png");
+  await new Asset({
+    id: "test-image",
+    user_id: "1",
+    name: "test-image.png",
+    content_type: "image/png",
+    size: png.length,
+    project_id: "default"
+  }).save();
 });
 
 afterEach(async () => {

--- a/web/src/components/projects/ProjectLifecycleActions.tsx
+++ b/web/src/components/projects/ProjectLifecycleActions.tsx
@@ -15,6 +15,10 @@ import {
 } from "../../hooks/useProjects";
 import { useNotificationStore } from "../../stores/NotificationStore";
 
+interface ErrorWithMessage {
+  readonly message: string;
+}
+
 interface ProjectLifecycleActionsProps {
   readonly project: {
     id: string;
@@ -33,25 +37,28 @@ const ProjectLifecycleActions = ({ project }: ProjectLifecycleActionsProps) => {
   const addNotification = useNotificationStore((state) => state.addNotification);
 
   const stop = (event: MouseEvent<HTMLButtonElement>) => event.stopPropagation();
-  const reportError = (action: string, error: Error) =>
-    addNotification({
-      type: "error",
-      alert: true,
-      content: `Could not ${action} ${project.name}: ${error.message}`
-    });
+  const reportError = useCallback(
+    (action: string, error: ErrorWithMessage) =>
+      addNotification({
+        type: "error",
+        alert: true,
+        content: `Could not ${action} ${project.name}: ${error.message}`
+      }),
+    [addNotification, project.name]
+  );
   const handleArchive = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
       stop(event);
       archive.mutate({ id: project.id }, { onError: (error) => reportError("archive", error) });
     },
-    [archive, project.id]
+    [archive, project.id, reportError]
   );
   const handleRestore = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
       stop(event);
       restore.mutate({ id: project.id }, { onError: (error) => reportError("restore", error) });
     },
-    [project.id, restore]
+    [project.id, reportError, restore]
   );
   const requestDelete = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
@@ -68,7 +75,7 @@ const ProjectLifecycleActions = ({ project }: ProjectLifecycleActionsProps) => {
         onError: (error) => reportError("delete", error)
       }
     );
-  }, [project.id, remove]);
+  }, [project.id, remove, reportError]);
 
   if (project.isPersonal) return null;
 

--- a/web/src/components/projects/__tests__/projectStarters.test.ts
+++ b/web/src/components/projects/__tests__/projectStarters.test.ts
@@ -46,6 +46,7 @@ const summary = (
       name: kind,
       kind,
       isPersonal: false,
+      archivedAt: null,
       threadId: null,
       createdAt: "",
       updatedAt: ""

--- a/web/src/demo/timeline/__tests__/timelineChrome.test.tsx
+++ b/web/src/demo/timeline/__tests__/timelineChrome.test.tsx
@@ -11,6 +11,7 @@
  * of its own. Everything below is driven by the same engine the player drives.
  */
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -46,11 +47,19 @@ function renderChrome(timeMs: number) {
 }
 
 describe("timeline demo chrome", () => {
-  it("shows the editor's actions, inert", () => {
+  it("shows the editor's actions, inert", async () => {
+    const user = userEvent.setup();
     renderChrome(0);
-    for (const name of [/project settings/i, /^save$/i, /^export$/i]) {
+    for (const name of [/^save$/i, /^export video$/i]) {
       expect(screen.getByRole("button", { name })).toBeInTheDocument();
     }
+
+    await user.click(
+      screen.getByRole("button", { name: /more timeline actions/i })
+    );
+    expect(
+      screen.getByRole("menuitem", { name: /project settings/i })
+    ).toBeInTheDocument();
   });
 
   it("reports the cast's zoom in the status bar", () => {


### PR DESCRIPTION
## Summary
- make workspace path assertions stable on macOS and remove the deploy export-test timeout
- update WebSocket MCP and sandbox coverage fixtures for project ownership
- repair project lifecycle typing and stale web demo/project fixtures

## Verification
- npm run test:affected
- NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck
- npm run lint
- npm run dev:nodetool -- harness gate --base origin/main