### PR TITLE
feat: centralize JS document sync lifecycle

### DIFF
--- a/web/src/hooks/jsScript/__tests__/useJsScriptServerSync.test.tsx
+++ b/web/src/hooks/jsScript/__tests__/useJsScriptServerSync.test.tsx
@@ -130,7 +130,7 @@ describe("useJsScriptServerSync", () => {
     );
   });
 
-  it("reloads the server copy when the save loses a CAS conflict", async () => {
+  it("re-reads and retries the draft when the save loses a CAS conflict", async () => {
     updateMutate.mockRejectedValueOnce(
       new Error("JS script was modified since last read")
     );
@@ -146,14 +146,15 @@ describe("useJsScriptServerSync", () => {
     act(() => useJsScriptStore.getState().setCode("js-1", "emit('a', 1)"));
 
     await waitFor(
-      () =>
-        expect(useJsScriptStore.getState().saveStatus["js-1"]).toBe("reloaded"),
+      () => expect(updateMutate).toHaveBeenCalledTimes(2),
       { timeout: 3000 }
     );
     expect(useJsScriptStore.getState().scripts["js-1"]?.name).toBe(
-      "Won the race"
+      "Saved script"
     );
-    expect(useJsScriptStore.getState().serverRevisions["js-1"]).toBe("rev-9");
+    expect(updateMutate).toHaveBeenLastCalledWith(
+      expect.objectContaining({ baseUpdatedAt: "rev-9", name: "Saved script" })
+    );
   });
 
   it("flags an error status when an autosave fails for another reason", async () => {
@@ -423,6 +424,7 @@ describe("useJsScriptServerSync merge", () => {
     });
 
     // A no-ops notice arrives while that save is still in flight.
+    getQuery.mockResolvedValueOnce(serverScript("rev-42"));
     await act(async () => {
       handleDocumentResourceChange("jsscript", {
         event: "updated",
@@ -432,12 +434,15 @@ describe("useJsScriptServerSync merge", () => {
       await Promise.resolve();
     });
 
-    // The token the next save reads lives in the store, not only in the ref.
-    expect(useJsScriptStore.getState().serverRevisions["js-1"]).toBe("rev-42");
     await act(async () => {
       resolveSave({ updatedAt: "rev-2" });
       await Promise.resolve();
     });
+    // The foreign notice is drained after the in-flight write settles.
+    await flushJsScriptSave("js-1");
+    expect(updateMutate).toHaveBeenLastCalledWith(
+      expect.objectContaining({ baseUpdatedAt: "rev-42" })
+    );
   });
 
   it("saves the merged document with the rolled token after a merge", async () => {

--- a/web/src/hooks/jsScript/useJsScriptServerSync.ts
+++ b/web/src/hooks/jsScript/useJsScriptServerSync.ts
@@ -4,8 +4,8 @@
  * Server persistence for one JS script tab. On mount: load the server document
  * into the store (or upsert-create it when the tab refs a script the server
  * does not know). After load: watch the store and autosave with a debounce,
- * using the server's `updatedAt` as a CAS token (`baseUpdatedAt`). On a
- * conflict the server copy wins and is reloaded.
+ * using the server's `updatedAt` as a CAS token (`baseUpdatedAt`). On a CAS
+ * conflict it re-reads and retries the draft through the shared lifecycle.
  *
  * Copied from useScriptServerSync — same machinery, js-script payload.
  *
@@ -35,20 +35,18 @@ import { useConflictStore } from "../../stores/ConflictStore";
 import { getErrorMessage } from "../../utils/errorHandling";
 import {
   registerDocumentSync,
-  type DocumentLoadState
+  type DocumentLoadState,
+  createDocumentSyncController,
+  type DocumentSyncController
 } from "../../stores/documentSync";
 import {
-  isPermanentSaveError,
-  MAX_TRANSIENT_SAVE_RETRIES
+  isPermanentSaveError
 } from "../../utils/saveErrors";
 import {
   registerJsScriptSaver,
   type JsScriptSaveResult
 } from "./jsScriptSaveRegistry";
 import { creationProjectId } from "../../stores/WorkspaceTabsStore";
-
-const AUTOSAVE_DEBOUNCE_MS = 750;
-const RETRY_DELAY_MS = 5_000;
 
 const DEFAULT_NAME = "Untitled JS script";
 
@@ -97,16 +95,7 @@ export const useJsScriptServerSync = (
   const [loadState, setLoadState] = useState<DocumentLoadState>("loading");
   const syncedRef = useRef<JsScriptEntry | null>(null);
   const revisionRef = useRef<string | null>(null);
-  const inFlightRef = useRef(false);
-  // The save currently in flight, so a flush can await it instead of starting
-  // a second, overlapping save.
-  const inFlightPromiseRef = useRef<Promise<JsScriptSaveResult> | null>(null);
-  const flushAfterSaveRef = useRef(false);
-  // Consecutive failed attempts for the current edit. Reset by a new edit and
-  // by a save that lands.
-  const retriesRef = useRef(0);
   const loadPromiseRef = useRef<Promise<void> | null>(null);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const utilsRef = useRef(utils);
   utilsRef.current = utils;
 
@@ -114,6 +103,7 @@ export const useJsScriptServerSync = (
     let disposed = false;
     const store = useJsScriptStore;
     setLoadState("loading");
+    const pendingNotices: Array<{ updatedAt: string | null; ops?: DocumentOp[] }> = [];
 
     const applyResponse = (
       res: JsScriptResponse,
@@ -173,127 +163,10 @@ export const useJsScriptServerSync = (
     const currentRevision = (): string | null =>
       store.getState().serverRevisions[scriptId] ?? null;
 
-    const runSave = async (
-      entry: JsScriptEntry,
-      revision: string
-    ): Promise<JsScriptSaveResult> => {
-      let saved = false;
-      let result: JsScriptSaveResult = {
-        ok: true,
-        updatedAt: currentRevision()
-      };
-      store.getState().setSaveStatus(scriptId, "saving");
-      try {
-        const updated = await trpcClient.jsScripts.update.mutate({
-          id: scriptId,
-          baseUpdatedAt: revision,
-          name: entry.name || DEFAULT_NAME,
-          document: entry.document
-        });
-        revisionRef.current = updated.updatedAt;
-        store.getState().setServerRevision(scriptId, updated.updatedAt);
-        syncedRef.current = entry;
-        saved = true;
-        retriesRef.current = 0;
-        result = { ok: true, updatedAt: updated.updatedAt };
-        void utilsRef.current.jsScripts.list.invalidate();
-        // Only claim "saved" when the saved snapshot still matches the store;
-        // edits that landed mid-flight leave newer work queued.
-        if (store.getState().scripts[scriptId] !== syncedRef.current) {
-          store.getState().setSaveStatus(scriptId, "unsaved");
-          if (disposed || flushAfterSaveRef.current) {
-            flushAfterSaveRef.current = true;
-          } else {
-            schedule();
-          }
-        } else {
-          store.getState().setSaveStatus(scriptId, "saved");
-        }
-      } catch (error) {
-        const message = getErrorMessage(error, "JS script save failed");
-        result = { ok: false, error: message };
-        console.error("JS script autosave failed", error);
-        if (disposed) {
-          store.getState().setSaveStatus(scriptId, "error");
-          return result;
-        }
-        if (/modified since last read/i.test(getErrorMessage(error))) {
-          await load("reloaded");
-        } else {
-          store.getState().setSaveStatus(scriptId, "error");
-          // A payload the server will reject again — an invalid document, a
-          // permission error — must not be resent, and even a transient
-          // failure gets a bounded number of retries rather than a loop.
-          if (
-            !isPermanentSaveError(error) &&
-            retriesRef.current < MAX_TRANSIENT_SAVE_RETRIES
-          ) {
-            retriesRef.current += 1;
-            schedule(RETRY_DELAY_MS);
-          } else {
-            retriesRef.current = 0;
-          }
-        }
-      } finally {
-        inFlightRef.current = false;
-        inFlightPromiseRef.current = null;
-        if (saved && flushAfterSaveRef.current) {
-          flushAfterSaveRef.current = false;
-          void save(true);
-        }
-      }
-      return result;
-    };
-
-    const save = (flush = false): Promise<JsScriptSaveResult> => {
-      if (inFlightRef.current) {
-        if (flush) flushAfterSaveRef.current = true;
-        return (
-          inFlightPromiseRef.current ??
-          Promise.resolve({ ok: true, updatedAt: currentRevision() })
-        );
-      }
-      const entry = store.getState().scripts[scriptId];
-      const revision = store.getState().serverRevisions[scriptId];
-      if (
-        (disposed && !flush) ||
-        !entry ||
-        !revision ||
-        entry === syncedRef.current
-      ) {
-        return Promise.resolve({ ok: true, updatedAt: revision ?? null });
-      }
-
-      inFlightRef.current = true;
-      const pending = runSave(entry, revision);
-      inFlightPromiseRef.current = pending;
-      return pending;
-    };
-
-    /**
-     * Save now instead of on the debounce, and report the outcome. Waits out
-     * the initial load and any save already in flight, so two callers never
-     * produce two overlapping writes.
-     */
+    let controller: DocumentSyncController;
     const flushNow = async (): Promise<JsScriptSaveResult> => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-        timerRef.current = null;
-      }
       await loadPromiseRef.current;
-      while (inFlightRef.current) {
-        const pending = inFlightPromiseRef.current;
-        if (!pending) break;
-        await pending;
-      }
-      return save(true);
-    };
-
-    const schedule = (delayMs: number = AUTOSAVE_DEBOUNCE_MS): void => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => {
-        void save();
-      }, delayMs);
+      return controller.flush();
     };
 
     const unsubscribe = store.subscribe((state, prev) => {
@@ -302,8 +175,7 @@ export const useJsScriptServerSync = (
       if (!state.serverRevisions[scriptId]) return;
       store.getState().setSaveStatus(scriptId, "unsaved");
       // A new edit is new content: give it a full retry budget.
-      retriesRef.current = 0;
-      schedule();
+      controller.markDirty();
     });
 
     // Writes from outside this browser (agent tools, CLI, another tab) arrive
@@ -313,17 +185,23 @@ export const useJsScriptServerSync = (
     // in as `resource_change`. A clean tab takes the server copy; a dirty one
     // merges the change per merge unit — draft wins, refused values land in
     // the conflict banner, no undo entry for external work (ADR 0001).
-    const mergeExternal = async (notice: {
-      ops?: DocumentOp[];
-    }): Promise<void> => {
+    const mergeExternal = async (
+      notice: { ops?: DocumentOp[]; updatedAt?: string | null },
+      prefetched?: JsScriptResponse,
+      allowDisposed = false
+    ): Promise<void> => {
       let res: JsScriptResponse;
-      try {
-        res = await trpcClient.jsScripts.get.query({ id: scriptId });
-      } catch (error) {
-        console.error("Failed to fetch JS script for merge", error);
-        return;
+      if (prefetched) {
+        res = prefetched;
+      } else {
+        try {
+          res = await trpcClient.jsScripts.get.query({ id: scriptId });
+        } catch (error) {
+          console.error("Failed to fetch JS script for merge", error);
+          return;
+        }
       }
-      if (disposed) return;
+      if (disposed && !allowDisposed) return;
       const base = syncedRef.current;
       const draft = store.getState().scripts[scriptId];
       if (!base || !draft || base === draft) return;
@@ -441,19 +319,54 @@ export const useJsScriptServerSync = (
         void load("reloaded");
       },
       merge: (notice) => {
-        if (inFlightRef.current && (!notice.ops || notice.ops.length === 0)) {
-          // Roll BOTH tokens: `save()` reads the CAS base off the store, so a
-          // ref-only bump leaves the next save writing against a token the
-          // server has already moved past.
-          if (notice.updatedAt) {
-            revisionRef.current = notice.updatedAt;
-            store.getState().setServerRevision(scriptId, notice.updatedAt);
-          }
+        if (controller.isSaving()) {
+          pendingNotices.push(notice);
           return;
         }
         void mergeExternal(notice);
       }
     });
+
+    controller = createDocumentSyncController<JsScriptEntry>({
+      getDraft: () => store.getState().scripts[scriptId] ?? null,
+      getRevision: currentRevision,
+      isDirty: () =>
+        (store.getState().scripts[scriptId] ?? null) !== syncedRef.current,
+      save: async (entry, revision) => {
+        const updated = await trpcClient.jsScripts.update.mutate({
+          id: scriptId,
+          baseUpdatedAt: revision,
+          name: entry.name || DEFAULT_NAME,
+          document: entry.document
+        });
+        revisionRef.current = updated.updatedAt;
+        store.getState().setServerRevision(scriptId, updated.updatedAt);
+        void utilsRef.current.jsScripts.list.invalidate();
+        const notices = pendingNotices.splice(0, pendingNotices.length);
+        for (const notice of notices) {
+          if (notice.updatedAt === updated.updatedAt) continue;
+          await mergeExternal(notice);
+        }
+        if (store.getState().scripts[scriptId] === entry) {
+          syncedRef.current = entry;
+        }
+        if (store.getState().scripts[scriptId] !== entry) controller.markDirty();
+        return { updatedAt: updated.updatedAt };
+      },
+      recoverCasConflict: async () => {
+        const res = await trpcClient.jsScripts.get.query({ id: scriptId });
+        await mergeExternal({ updatedAt: res.updatedAt }, res, true);
+        if (!adapterStillDirty()) {
+          store.getState().setSaveStatus(scriptId, "reloaded");
+        }
+      },
+      isCasConflict: (error) => /modified since last read/i.test(getErrorMessage(error)),
+      isRetryableError: (error) => !isPermanentSaveError(error),
+      onStatus: (status) => store.getState().setSaveStatus(scriptId, status)
+    });
+
+    const adapterStillDirty = (): boolean =>
+      (store.getState().scripts[scriptId] ?? null) !== syncedRef.current;
 
     registerJsScriptSaver(scriptId, flushNow);
 
@@ -474,9 +387,7 @@ export const useJsScriptServerSync = (
       registerJsScriptSaver(scriptId, null);
       unwatch();
       unsubscribe();
-      if (timerRef.current) clearTimeout(timerRef.current);
-      if (inFlightRef.current) flushAfterSaveRef.current = true;
-      else void save(true);
+      controller.dispose();
     };
   }, [scriptId]);
 

--- a/web/src/stores/__tests__/documentSync.test.ts
+++ b/web/src/stores/__tests__/documentSync.test.ts
@@ -7,6 +7,7 @@ import {
   handleDocumentResourceChange,
   registerDocumentSync
 } from "../documentSync";
+import { createDocumentSyncController } from "../documentSync";
 import { useConflictStore, clearAllConflicts } from "../ConflictStore";
 
 const subscriber = (
@@ -188,5 +189,106 @@ describe("conflict store", () => {
     expect(
       useConflictStore.getState().byKey["storyboard:b1"].conflicts.map((c) => c.unit.id)
     ).toEqual(["s5"]);
+  });
+});
+
+describe("createDocumentSyncController", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("debounces edits and never overlaps saves", async () => {
+    let draft = "first";
+    let revision = "rev-1";
+    let resolveSave: ((value: { updatedAt: string }) => void) | null = null;
+    const save = jest.fn(
+      () =>
+        new Promise<{ updatedAt: string }>((resolve) => {
+          resolveSave = resolve;
+        })
+    );
+    const controller = createDocumentSyncController({
+      debounceMs: 10,
+      getDraft: () => draft,
+      getRevision: () => revision,
+      isDirty: () => draft !== "saved",
+      save,
+      recoverCasConflict: async () => {},
+      onStatus: jest.fn()
+    });
+
+    controller.markDirty();
+    jest.advanceTimersByTime(9);
+    expect(save).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
+    await Promise.resolve();
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(controller.isSaving()).toBe(true);
+
+    draft = "second";
+    controller.markDirty();
+    const flush = controller.flush();
+    expect(save).toHaveBeenCalledTimes(1);
+    resolveSave?.({ updatedAt: "rev-2" });
+    revision = "rev-2";
+    await Promise.resolve();
+    resolveSave?.({ updatedAt: "rev-3" });
+    await flush;
+    expect(save).toHaveBeenCalledTimes(2);
+    expect(controller.isSaving()).toBe(false);
+  });
+
+  it("recovers a CAS conflict before retrying the draft", async () => {
+    let attempts = 0;
+    let draft = "draft";
+    let revision = "rev-1";
+    const recover = jest.fn(async () => {
+      revision = "rev-2";
+    });
+    const controller = createDocumentSyncController({
+      debounceMs: 1,
+      getDraft: () => draft,
+      getRevision: () => revision,
+      isDirty: () => draft !== "saved",
+      save: jest.fn(async (_draft: string, base: string) => {
+        attempts += 1;
+        if (base === "rev-1") throw new Error("modified since last read");
+        draft = "saved";
+        return { updatedAt: "rev-3" };
+      }),
+      recoverCasConflict: recover,
+      isCasConflict: (error) => error instanceof Error && /modified/.test(error.message)
+    });
+
+    controller.markDirty();
+    const flush = controller.flush();
+    await flush;
+    expect(recover).toHaveBeenCalledTimes(1);
+    expect(attempts).toBe(2);
+  });
+
+  it("cancels the debounce but flushes a pending draft on teardown", async () => {
+    let saved = false;
+    const controller = createDocumentSyncController({
+      debounceMs: 10,
+      getDraft: () => "draft",
+      getRevision: () => "rev-1",
+      isDirty: () => !saved,
+      save: jest.fn(async () => {
+        saved = true;
+        return { updatedAt: "rev-2" };
+      }),
+      recoverCasConflict: async () => {}
+    });
+
+    controller.markDirty();
+    controller.dispose();
+    jest.advanceTimersByTime(10);
+    await Promise.resolve();
+    expect(saved).toBe(true);
   });
 });

--- a/web/src/stores/__tests__/documentSync.test.ts
+++ b/web/src/stores/__tests__/documentSync.test.ts
@@ -235,10 +235,12 @@ describe("createDocumentSyncController", () => {
     expect(save).toHaveBeenCalledTimes(1);
     resolveSave?.({ updatedAt: "rev-2" });
     revision = "rev-2";
-    await Promise.resolve();
+    for (let attempt = 0; attempt < 5 && save.mock.calls.length < 2; attempt += 1) {
+      await Promise.resolve();
+    }
+    expect(save).toHaveBeenCalledTimes(2);
     resolveSave?.({ updatedAt: "rev-3" });
     await flush;
-    expect(save).toHaveBeenCalledTimes(2);
     expect(controller.isSaving()).toBe(false);
   });
 

--- a/web/src/stores/documentSync.ts
+++ b/web/src/stores/documentSync.ts
@@ -23,6 +23,159 @@
  */
 import type { DocumentOp } from "@nodetool-ai/protocol";
 
+/** Result returned by an adapter after the server accepts a snapshot. */
+export interface DocumentSyncSaveResult {
+  readonly updatedAt: string;
+}
+
+/** Surface-specific persistence and merge behavior used by the shared lifecycle. */
+export interface DocumentSyncLifecycle<TDraft> {
+  readonly debounceMs?: number;
+  readonly retryDelayMs?: number;
+  readonly maxRetries?: number;
+  readonly getDraft: () => TDraft | null;
+  readonly getRevision: () => string | null;
+  readonly isDirty: () => boolean;
+  readonly save: (draft: TDraft, revision: string) => Promise<DocumentSyncSaveResult>;
+  readonly recoverCasConflict: () => Promise<void>;
+  readonly onStatus?: (status: "saved" | "unsaved" | "saving" | "error" | "reloaded") => void;
+  readonly isCasConflict?: (error: unknown) => boolean;
+  readonly isRetryableError?: (error: unknown) => boolean;
+}
+
+/**
+ * Owns the timing and ordering of one document's writes. The adapter supplies
+ * snapshots, persistence, and merge behavior, while this controller ensures
+ * edits are debounced, writes never overlap, flushes wait for the active write,
+ * and a CAS rejection re-reads before retrying the unchanged draft.
+ */
+export interface DocumentSyncController {
+  markDirty(): void;
+  isSaving(): boolean;
+  flush(): Promise<{ ok: true; updatedAt: string | null } | { ok: false; error: string }>;
+  dispose(): void;
+}
+
+/** Create the lifecycle controller for one open document. */
+export function createDocumentSyncController<TDraft>(
+  adapter: DocumentSyncLifecycle<TDraft>
+): DocumentSyncController {
+  const debounceMs = adapter.debounceMs ?? 750;
+  const retryDelayMs = adapter.retryDelayMs ?? 5_000;
+  const maxRetries = adapter.maxRetries ?? 3;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let inFlight: Promise<{ ok: true; updatedAt: string | null } | { ok: false; error: string }> | null = null;
+  let flushRequested = false;
+  let disposed = false;
+  let retries = 0;
+
+  const clearTimer = (): void => {
+    if (timer) clearTimeout(timer);
+    timer = null;
+  };
+
+  const schedule = (delay = debounceMs): void => {
+    clearTimer();
+    if (disposed) return;
+    timer = setTimeout(() => {
+      timer = null;
+      void save(false);
+    }, delay);
+  };
+
+  const save = (flush: boolean): Promise<{ ok: true; updatedAt: string | null } | { ok: false; error: string }> => {
+    if (inFlight) {
+      if (flush) flushRequested = true;
+      return inFlight;
+    }
+    const draft = adapter.getDraft();
+    const revision = adapter.getRevision();
+    if ((!flush && disposed) || !draft || !revision || !adapter.isDirty()) {
+      return Promise.resolve({ ok: true, updatedAt: revision });
+    }
+
+    adapter.onStatus?.("saving");
+    const pending = (async () => {
+      let nextDraft = draft;
+      let nextRevision = revision;
+      try {
+        while (true) {
+          try {
+            const result = await adapter.save(nextDraft, nextRevision);
+            retries = 0;
+            adapter.onStatus?.(adapter.isDirty() ? "unsaved" : "saved");
+            return { ok: true as const, updatedAt: result.updatedAt };
+          } catch (error) {
+            if (!adapter.isCasConflict?.(error)) {
+              adapter.onStatus?.("error");
+              if (!disposed && adapter.isRetryableError?.(error) !== false && retries < maxRetries) {
+                retries += 1;
+                schedule(retryDelayMs);
+              } else {
+                retries = 0;
+              }
+              return { ok: false as const, error: error instanceof Error ? error.message : String(error) };
+            }
+
+            try {
+              await adapter.recoverCasConflict();
+            } catch (recoveryError) {
+              adapter.onStatus?.("error");
+              return {
+                ok: false as const,
+                error: recoveryError instanceof Error ? recoveryError.message : String(recoveryError)
+              };
+            }
+            if (!flush) {
+              if (!disposed) {
+                adapter.onStatus?.("unsaved");
+                schedule(0);
+              }
+              return { ok: false as const, error: error instanceof Error ? error.message : String(error) };
+            }
+            const recoveredDraft = adapter.getDraft();
+            const recoveredRevision = adapter.getRevision();
+            if (!recoveredDraft || !recoveredRevision || !adapter.isDirty()) {
+              return { ok: true as const, updatedAt: recoveredRevision };
+            }
+            nextDraft = recoveredDraft;
+            nextRevision = recoveredRevision;
+          }
+        }
+      } finally {
+        inFlight = null;
+        if (flushRequested) {
+          flushRequested = false;
+          void save(true);
+        }
+      }
+    })();
+    inFlight = pending;
+    return pending;
+  };
+
+  return {
+    isSaving: () => inFlight !== null,
+    markDirty: () => {
+      if (disposed) return;
+      retries = 0;
+      adapter.onStatus?.("unsaved");
+      schedule();
+    },
+    flush: async () => {
+      clearTimer();
+      while (inFlight) await inFlight;
+      return save(true);
+    },
+    dispose: () => {
+      disposed = true;
+      clearTimer();
+      if (inFlight) flushRequested = true;
+      else void save(true);
+    }
+  };
+}
+
 /**
  * Where a document editor is in its initial server load. A surface that renders
  * an empty document while `"loading"` looks like an empty document, so surfaces


### PR DESCRIPTION
Introduce a shared Document sync lifecycle and migrate JS script editing through it. The controller now owns debouncing, single-flight saves, flush and teardown ordering, bounded retries, and CAS re-read/retry while the JS adapter retains payload conversion and ADR-0001 draft-wins merge behavior.

Main changes:
- Add createDocumentSyncController in web/src/stores/documentSync.ts.
- Migrate useJsScriptServerSync to the controller and queue external notices during in-flight writes.
- Add lifecycle tests for debounce, in-flight ordering, CAS retry, cancellation, and teardown flush.

Verification:
- git diff --check passed.
- Mandatory checks attempted but blocked by missing dependencies: npm run test:affected (jest), npm run typecheck (tsc), npm run lint (oxlint), npm run dev:nodetool -- harness gate --base origin/main (tsx).
- npm install was attempted but could not complete in the runner.

Follow-up: remaining editors will migrate in their planned tasks.