### PR TITLE
feat(timeline): add clip crop and film grain

### DIFF
--- a/packages/agents/src/timeline-preview/frames.ts
+++ b/packages/agents/src/timeline-preview/frames.ts
@@ -390,6 +390,12 @@ export async function renderTimelineFrames(
    */
   const maskSurfaceFor = precompositeSurfaceFor;
   const matteSurfaceFor = precompositeSurfaceFor;
+  /**
+   * Where a cropped layer's picture lands. Also from the precomposite pool: the
+   * crop stays live for the whole of one layer's draw, and the mask surfaces
+   * read from it while it does.
+   */
+  const cropSurfaceFor = precompositeSurfaceFor;
 
   /**
    * Encoded asset bytes, shared by every frame in the pass — but only a
@@ -703,6 +709,7 @@ export async function renderTimelineFrames(
       drawn.transform = anim.transform;
       drawn.parentMatrix = layer.parentMatrix;
       drawn.borderRadius = layer.borderRadius;
+      drawn.crop = layer.crop;
       drawn.shapeMask = layer.shapeMask;
       drawn.effects = anim.effects ?? layer.effects;
       drawn.trackEffects = layer.trackEffects;
@@ -789,7 +796,8 @@ export async function renderTimelineFrames(
       precomposites: drawPrecomposites,
       precompositeSurface: precompositeSurfaceFor,
       maskSurface: maskSurfaceFor,
-      matteSurface: matteSurfaceFor
+      matteSurface: matteSurfaceFor,
+      cropSurface: cropSurfaceFor
     });
     for (const layer of drawReport.skipped) {
       const report = reportFor.get(layer);

--- a/packages/execution/src/timeline-debug/validate.ts
+++ b/packages/execution/src/timeline-debug/validate.ts
@@ -29,6 +29,7 @@ import {
   resolveCustomMask,
   computeModel3DBakeHash,
   isGeneratedMatteStale,
+  isCropUsable,
   sourceRate,
   DEFAULT_TEMPO,
   resolveTempo,
@@ -533,6 +534,7 @@ function checkClip(
 
   issues.push(...maskIssues(clip));
   issues.push(...unknownEffectIssues(clip));
+  issues.push(...cropIssues(clip));
   const shapeKind = unknownShapeKindIssue(clip);
   if (shapeKind) issues.push(shapeKind);
   issues.push(...model3dIssues(clip, { fps, ...canvas }));
@@ -584,6 +586,32 @@ function fontPortabilityIssues(clip: TimelineClip): TimelineDebugIssue[] {
     });
   }
   return issues;
+}
+
+/**
+ * A crop whose insets keep no picture.
+ *
+ * `left + right >= 1` on either axis leaves nothing to draw. Both compositors
+ * fall back to the whole source rather than blanking the shot — a slider
+ * dragged to the end should show the uncropped picture, not a hole — so this is
+ * a warning about a framing that is being ignored, not an error.
+ */
+function cropIssues(clip: TimelineClip): TimelineDebugIssue[] {
+  const crop = clip.crop;
+  if (!crop || isCropUsable(crop)) return [];
+  return [
+    {
+      severity: "warning",
+      code: "crop_degenerate",
+      message:
+        `Clip "${clipLabel(clip)}" is cropped to nothing (left ${crop.left} + ` +
+        `right ${crop.right}, top ${crop.top} + bottom ${crop.bottom}); each ` +
+        "pair must stay below 1. The clip draws its whole source instead.",
+      path: "crop",
+      clipId: clip.id,
+      trackId: clip.trackId
+    }
+  ];
 }
 
 /** What an effect's `type` accepts, for the `unknown_effect` message. */

--- a/packages/execution/tests/timeline-crop.test.ts
+++ b/packages/execution/tests/timeline-crop.test.ts
@@ -1,0 +1,121 @@
+/**
+ * `crop_degenerate` — insets that keep no picture, with the fixture that
+ * triggers the code (I12) and the controls the check must stay quiet on.
+ *
+ * A warning rather than an error: both compositors fall back to the whole
+ * source, so the shot still renders. What the user needs told is that the
+ * framing they set is not the framing they are seeing.
+ *
+ * The round trip matters as much as the check. `crop` is one of the fields Zod
+ * would drop on every PATCH if the schema did not carry it, and a dropped field
+ * leaves nothing for the check below to find — every "no issues" case would
+ * then pass for the wrong reason. `field_stripped` is the validator's own
+ * mechanical guard against that, so the first case simply asserts it stays
+ * quiet about `crop`.
+ */
+import { describe, expect, it } from "vitest";
+
+import { validateTimelineSequence } from "../src/timeline-debug/index.js";
+import type { TimelineValidation } from "../src/timeline-debug/types.js";
+
+type Json = Record<string, unknown>;
+
+const clip = (over: Json): Json => ({
+  trackId: "track-1",
+  name: "Clip",
+  startMs: 0,
+  durationMs: 1000,
+  mediaType: "video",
+  sourceType: "imported",
+  status: "generated",
+  locked: false,
+  versions: [],
+  ...over
+});
+
+const doc = (clips: Json[]): Json => ({
+  tracks: [
+    {
+      id: "track-1",
+      name: "Video 1",
+      type: "video",
+      index: 0,
+      visible: true,
+      locked: false
+    }
+  ],
+  clips,
+  markers: []
+});
+
+const cropIssues = (result: TimelineValidation) =>
+  result.warnings.filter((w) => w.code === "crop_degenerate");
+
+describe("validateTimelineSequence — crop", () => {
+  it("keeps a crop through the parse instead of stripping it", () => {
+    const result = validateTimelineSequence(
+      doc([
+        clip({
+          id: "a",
+          crop: { left: 0.1, right: 0.2, top: 0.05, bottom: 0.15 }
+        })
+      ])
+    );
+    const stripped = result.warnings.filter((w) => w.code === "field_stripped");
+    expect(stripped.map((w) => w.path)).toEqual([]);
+  });
+
+  it("stays quiet on a crop that keeps picture, and on no crop at all", () => {
+    const result = validateTimelineSequence(
+      doc([
+        clip({ id: "a", crop: { left: 0.25, right: 0.25, top: 0, bottom: 0 } }),
+        clip({
+          id: "b",
+          startMs: 1000,
+          crop: { left: 0.49, right: 0.49, top: 0.49, bottom: 0.49 }
+        }),
+        clip({ id: "c", startMs: 2000 })
+      ])
+    );
+    expect(cropIssues(result)).toEqual([]);
+  });
+
+  it("reports a horizontal pair that keeps nothing", () => {
+    const result = validateTimelineSequence(
+      doc([
+        clip({ id: "a", crop: { left: 0.6, right: 0.6, top: 0, bottom: 0 } })
+      ])
+    );
+    const issues = cropIssues(result);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ clipId: "a", path: "crop" });
+    expect(issues[0]!.message).toContain("whole source");
+  });
+
+  it("reports a vertical pair that keeps nothing", () => {
+    const result = validateTimelineSequence(
+      doc([
+        clip({ id: "a", crop: { left: 0, right: 0, top: 0.5, bottom: 0.5 } })
+      ])
+    );
+    expect(cropIssues(result)).toHaveLength(1);
+  });
+
+  it("reports a negative inset, which no drag produces and no reader expects", () => {
+    const result = validateTimelineSequence(
+      doc([
+        clip({ id: "a", crop: { left: -0.2, right: 0, top: 0, bottom: 0 } })
+      ])
+    );
+    expect(cropIssues(result)).toHaveLength(1);
+  });
+
+  it("is a warning, never an error — the shot still renders", () => {
+    const result = validateTimelineSequence(
+      doc([
+        clip({ id: "a", crop: { left: 0.6, right: 0.6, top: 0, bottom: 0 } })
+      ])
+    );
+    expect(result.errors.map((e) => e.code)).not.toContain("crop_degenerate");
+  });
+});

--- a/packages/gpu/src/pool.ts
+++ b/packages/gpu/src/pool.ts
@@ -75,6 +75,7 @@ export {
   blurGaussianV1,
   sharpenUnsharpMaskV1,
   vignetteV1,
+  filtersGrainV1,
   filtersPixelateV1,
   filtersThresholdV1,
   filtersConvolve3x3V1,

--- a/packages/gpu/src/shaders/filters/grain/v1/module.ts
+++ b/packages/gpu/src/shaders/filters/grain/v1/module.ts
@@ -1,0 +1,113 @@
+/**
+ * `filters.grain@1` — film grain as a multiplicative gain wobble.
+ *
+ * **Multiplied, not added.** The input is premultiplied, so `rgb <= a` holds on
+ * every pixel and adding noise would break it: a translucent layer would come
+ * back with channels brighter than its own alpha, which reads as a bright
+ * fringe once it composites. A scalar gain preserves the invariant (the same
+ * reason `filters.vignette@1` may scale), and it is also closer to how exposed
+ * stock behaves — grain bites in the midtones and leaves black black, because
+ * there is nothing there to modulate.
+ *
+ * **Reproducible.** The pattern is a hash of the grain cell and `seed`, with no
+ * clock and no RNG state, so two renders of the same frame are byte-identical
+ * and a cached render can be handed back. A host that wants the pattern to roll
+ * passes the frame's own time as the seed.
+ */
+
+import tgpu from "typegpu";
+import * as d from "typegpu/data";
+import { defineModule } from "../../../../module.js";
+
+export const GrainParams = d.struct({
+  /** Gain wobble, 0..1. 0 leaves the picture untouched. */
+  amount: d.f32,
+  /** Grain cell size in source pixels. 1 is per-pixel. */
+  size: d.f32,
+  /** 0 = one gain for the pixel (monochrome), 1 = per-channel colour noise. */
+  colorAmount: d.f32,
+  /** Rolls the pattern. Same seed, same grain. */
+  seed: d.f32
+});
+
+const layout = tgpu.bindGroupLayout({
+  source: { texture: "float" },
+  outputTexture: { storageTexture: "rgba8unorm" },
+  params: { uniform: GrainParams }
+});
+
+export const filtersGrainV1 = defineModule({
+  id: "filters.grain",
+  version: 1,
+  surface: "internal",
+  category: "filters",
+  // A per-channel scale of premultiplied RGB, saturated against alpha — the
+  // same shape `filters.vignette@1` is tagged for.
+  linearity: "linear-in-rgb",
+  kind: "compute",
+  params: GrainParams,
+  paramDefaults: { amount: 0, size: 1, colorAmount: 0, seed: 0 },
+  paramUi: {
+    amount: { min: 0, max: 1, step: 0.01, label: "Amount" },
+    size: { min: 1, max: 16, step: 0.5, label: "Size" },
+    colorAmount: { min: 0, max: 1, step: 0.01, label: "Colour" },
+    seed: { label: "Seed" }
+  },
+  layout,
+  workgroupSize: [16, 16, 1],
+  wgsl: /* wgsl */ `
+fn hash31(p: vec3f) -> f32 {
+  var p3 = fract(p * 0.1031);
+  p3 = p3 + dot(p3, vec3f(p3.y, p3.z, p3.x) + 33.33);
+  return fract((p3.x + p3.y) * p3.z);
+}
+
+/** Signed noise in [-1, 1] for one grain cell and channel. */
+fn grainAt(cell: vec2f, seed: f32, channel: f32) -> f32 {
+  return hash31(vec3f(cell.x, cell.y, seed + channel * 19.19)) * 2.0 - 1.0;
+}
+
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let dims = textureDimensions(layout.$.source);
+  if (gid.x >= dims.x || gid.y >= dims.y) { return; }
+  let coords = vec2<i32>(i32(gid.x), i32(gid.y));
+  let v = layout.$.params;
+  let color = textureLoad(layout.$.source, coords, 0);
+
+  // Quantize to grain cells so size coarsens the stock instead of just
+  // reseeding it. Sub-pixel sizes collapse back to per-pixel.
+  let cell = floor(vec2f(f32(gid.x), f32(gid.y)) / max(v.size, 1.0));
+
+  let mono = grainAt(cell, v.seed, 0.0);
+  let perChannel = vec3f(
+    grainAt(cell, v.seed, 1.0),
+    grainAt(cell, v.seed, 2.0),
+    grainAt(cell, v.seed, 3.0)
+  );
+  let n = mix(vec3f(mono), perChannel, clamp(v.colorAmount, 0.0, 1.0));
+
+  let gain = vec3f(1.0) + n * clamp(v.amount, 0.0, 1.0);
+  // Saturating against alpha rather than 1.0 is what keeps rgb <= a when the
+  // gain runs above 1 on an already-bright premultiplied pixel.
+  let rgb = clamp(color.rgb * gain, vec3f(0.0), vec3f(color.a)); // premul: ok
+  textureStore(layout.$.outputTexture, coords, vec4<f32>(rgb, color.a));
+}
+`,
+  io: {
+    inputs: {
+      source: {
+        colorSpace: "srgb",
+        alpha: "premultiplied",
+        bindingKinds: ["texture_2d"]
+      }
+    },
+    output: {
+      colorSpace: "srgb",
+      alpha: "premultiplied",
+      format: "rgba8unorm",
+      dimensions: "same-as:source"
+    },
+    rod: "same-as:source"
+  }
+});

--- a/packages/gpu/src/shaders/index.ts
+++ b/packages/gpu/src/shaders/index.ts
@@ -37,6 +37,7 @@ import { colorLevelsV1 } from "./color/levels/v1/module.js";
 import { blurGaussianV1 } from "./filters/blur/gaussian/v1/module.js";
 import { sharpenUnsharpMaskV1 } from "./filters/sharpen/unsharpMask/v1/module.js";
 import { vignetteV1 } from "./filters/vignette/v1/module.js";
+import { filtersGrainV1 } from "./filters/grain/v1/module.js";
 import { filtersPixelateV1 } from "./filters/pixelate/v1/module.js";
 import { filtersThresholdV1 } from "./filters/threshold/v1/module.js";
 import { filtersConvolve3x3V1 } from "./filters/convolve3x3/v1/module.js";
@@ -106,6 +107,7 @@ export {
   blurGaussianV1,
   sharpenUnsharpMaskV1,
   vignetteV1,
+  filtersGrainV1,
   filtersPixelateV1,
   filtersThresholdV1,
   filtersConvolve3x3V1,
@@ -176,6 +178,7 @@ export const ALL_SHADERS: readonly ShaderModule[] = [
   blurGaussianV1,
   sharpenUnsharpMaskV1,
   vignetteV1,
+  filtersGrainV1,
   filtersPixelateV1,
   filtersThresholdV1,
   filtersConvolve3x3V1,

--- a/packages/protocol/src/api-schemas/timeline-tool-contracts.ts
+++ b/packages/protocol/src/api-schemas/timeline-tool-contracts.ts
@@ -208,6 +208,7 @@ export const CLIP_PARAM_KEYS = [
   "fadeOutMs",
   "blendMode",
   "borderRadius",
+  "crop",
   "hidden",
   "muted",
   "locked",

--- a/packages/protocol/src/api-schemas/timeline-tool-params.ts
+++ b/packages/protocol/src/api-schemas/timeline-tool-params.ts
@@ -1126,7 +1126,22 @@ export const effectParams = z.object({
     .optional()
     .describe("dropShadow shadow colour, chromaKey key colour, e.g. #00ff00."),
   opacity: z.number().optional().describe("dropShadow: 0..1."),
-  amount: z.number().optional().describe("vignette and sharpen: strength."),
+  amount: z
+    .number()
+    .optional()
+    .describe("vignette, sharpen and grain: strength."),
+  size: z
+    .number()
+    .optional()
+    .describe("grain: cell size in the clip's own pixels, 1 is per-pixel."),
+  colorAmount: z
+    .number()
+    .optional()
+    .describe("grain: 0 is monochrome grain, 1 full colour noise."),
+  animate: z
+    .boolean()
+    .optional()
+    .describe("grain: roll the pattern per frame instead of holding one."),
   softness: z
     .number()
     .optional()
@@ -1221,6 +1236,15 @@ export function buildEffect(
         tolerance: input.tolerance ?? 0.1,
         softness: input.softness ?? 0.05,
         spill: input.spill
+      };
+    case "grain":
+      return {
+        ...base,
+        type: "grain",
+        amount: input.amount ?? 0.25,
+        size: input.size,
+        colorAmount: input.colorAmount,
+        animate: input.animate
       };
     case "curves":
       return {

--- a/packages/protocol/src/api-schemas/timeline.ts
+++ b/packages/protocol/src/api-schemas/timeline.ts
@@ -651,6 +651,18 @@ export const clipLiftGammaGainEffect = z.object({
   gain: rgbTriple
 });
 
+/** Mirrors ClipGrainEffect. Absent knobs mean `filters.grain@1`'s own defaults. */
+export const clipGrainEffect = z.object({
+  id: z.string(),
+  type: z.literal("grain"),
+  enabled: z.boolean(),
+  amount: z.number(),
+  size: z.number().optional(),
+  colorAmount: z.number().optional(),
+  animate: z.boolean().optional(),
+  seed: z.number().optional()
+});
+
 /**
  * The clip effect chain. Without the members below Zod drops any effect whose
  * type it does not carry on every PATCH, so a graded clip loses that step of
@@ -666,7 +678,8 @@ const knownClipEffect = z.discriminatedUnion("type", [
   clipChromaKeyEffect,
   clipCurvesEffect,
   clipLevelsEffect,
-  clipLiftGammaGainEffect
+  clipLiftGammaGainEffect,
+  clipGrainEffect
 ]);
 
 /**
@@ -683,7 +696,8 @@ export const KNOWN_CLIP_EFFECT_TYPE_LIST = [
   "chromaKey",
   "curves",
   "levels",
-  "liftGammaGain"
+  "liftGammaGain",
+  "grain"
 ] as const;
 const KNOWN_CLIP_EFFECT_TYPES: ReadonlySet<string> = new Set(
   KNOWN_CLIP_EFFECT_TYPE_LIST
@@ -1043,6 +1057,20 @@ export const clipModel3DStyle = z.object({
 export type ClipModel3DStyle = z.infer<typeof clipModel3DStyle>;
 
 /**
+ * The part of the source a clip keeps, as the fraction of each edge dropped.
+ * Mirrors ClipCrop: a crop reframes (the kept rectangle becomes the picture and
+ * is re-fit to the canvas), where `clipMask` with `kind: "rect"` hides part of
+ * a layer that stays put.
+ */
+export const clipCrop = z.object({
+  left: z.number(),
+  right: z.number(),
+  top: z.number(),
+  bottom: z.number()
+});
+export type ClipCrop = z.infer<typeof clipCrop>;
+
+/**
  * Shape mask on one clip, in the layer's own normalized 0..1 space. `kind` is
  * a plain string for forward compat: an unknown kind parses and is skipped at
  * render time rather than failing the document.
@@ -1206,6 +1234,9 @@ export const timelineClip = z.object({
   fadeOutMs: z.number().optional(),
   transform: clipTransform.optional(),
   borderRadius: z.number().optional(),
+  /** Without this field Zod strips it on every PATCH and a cropped clip
+   * reverts to its full frame on the next save. */
+  crop: clipCrop.optional(),
   effects: z.array(clipEffect).optional(),
   transitionIn: clipTransition.optional(),
   textStyle: clipTextStyle.optional(),

--- a/packages/timeline/AGENTS.md
+++ b/packages/timeline/AGENTS.md
@@ -273,6 +273,60 @@
   `AnimatedLayerProps.shapeStyle`, not the clip's own; a host that reaches for
   `layer.shapeStyle` renders a trim animation as a held first frame.
 
+## Crop (`src/crop.ts`)
+
+- **A crop reframes; it does not knock out.** `clip.crop` is four normalized
+  insets, and the rectangle they keep *becomes* the layer's picture: the contain
+  fit is recomputed from the cropped size, the transform places the cropped
+  frame, the border radius rounds its corners, and the effect chain and masks
+  run on its pixels. Cropping a 16:9 shot to 1:1 therefore fills the frame the
+  way a 1:1 source would. Hiding part of a layer that stays where it was is
+  `ClipMask` with `kind: "rect"` — a different edit, and still the way to ask
+  for it. The equivalence both compositors are held to is
+  `render.crop.gpu.test.ts`'s: a cropped layer renders exactly like an uncropped
+  layer whose source is the crop.
+- **Insets, not pixels, and one place that resolves them.** Fractions survive
+  the asset under them changing resolution — an upscale, or `restoreVersion`
+  swapping in a generation rendered at another size. `cropRectPx` is the only
+  reader: it clamps to the source, snaps to whole texels, and answers with the
+  whole source when there is no usable crop, so a caller hands the result
+  straight to a draw without branching.
+- **Cropping happens before anything else looks at the pixels**, which is what
+  lets the rest of both compositors stay unchanged. The GPU path narrows the
+  upload with a `copyTextureToTexture` into a crop-sized texture cached by layer
+  id (an axis-aligned region of whole texels has nothing to filter, so a copy is
+  exact and cheaper than a pass); Canvas 2D blits the whole source at a negative
+  offset onto a crop-sized surface, which is the 5-argument `drawImage` spelling
+  of a sub-rectangle. A clip that *was* cropped and is not any more must drop the
+  cached copy, or it keeps drawing the stale one.
+- **A crop is source-space and says nothing about time**, so `trimClip` and
+  `splitClip` carry it across untouched — the same argument `generatedMatte`
+  makes for sharing the in-point.
+- **Insets that keep no picture render uncropped rather than blanking the
+  shot** — a slider dragged to the end should show the whole frame, not a hole.
+  `isCropUsable` decides it in one place for the ops, the renderers and the
+  validator's `crop_degenerate`. Canvas 2D needs a `cropSurface` from its host;
+  without one it draws uncropped and reports `crop_skipped` (I7).
+
+## Film grain (`filters.grain@1`)
+
+- **Grain multiplies, it does not add.** The layer arrives premultiplied, so
+  `rgb <= a` holds on every pixel and adding noise pushes a channel past its own
+  alpha — invisible on an opaque layer, a bright fringe wherever it is
+  translucent. A per-channel gain saturated against alpha preserves the
+  invariant, and it is also how stock behaves: grain bites in the midtones and
+  leaves black black. The case that catches the additive version is a *dark*
+  half-opaque source; on a bright one the readback's own saturation hides it,
+  which is why `render.grain.gpu.test.ts` says so where it picks its fixture.
+- **The pattern is a hash of the grain cell and a seed — no clock, no
+  `Math.random`.** `resolveAnimatedLayerProps` stamps the frame's time on an
+  `animate` grain, so it rolls the way exposed stock does while two renders of
+  the same frame stay byte-identical and a cached render can be handed back.
+  That is the one place the roll happens, and it is why the shader has no
+  `animate` knob: by the time the chain runs, the seed is already decided.
+- **Canvas 2D has no noise to draw with**, so it reports `grain` through
+  `unsupportedEffectTypes` rather than approximating it.
+
 ## Generated mattes (`src/generatedMatte.ts`, D2)
 
 - **A generated matte is an attribute of the clip, not a second clip.**

--- a/packages/timeline/src/crop.ts
+++ b/packages/timeline/src/crop.ts
@@ -1,0 +1,91 @@
+/**
+ * crop — the source rectangle a clip keeps, in one place.
+ *
+ * A crop is stored as four normalized insets ({@link ClipCrop}) and every
+ * surface needs the same thing from them: the pixel rectangle to read, and
+ * whether there is anything to do at all. Both compositors, the scene model
+ * and the validator go through here, so a crop cannot round one way in the
+ * preview and another in the export.
+ *
+ * **The kept rectangle becomes the clip's picture.** Cropping is applied to the
+ * source before anything else looks at it — the contain fit is computed from
+ * the cropped size, the transform places the cropped frame, the border radius
+ * rounds its corners, and the masks and effects run on its pixels. That is what
+ * separates a crop from a rect {@link ClipMask}, which hides part of a layer
+ * that stays exactly where it was.
+ */
+
+import type { ClipCrop } from "./types.js";
+
+/** A source rectangle in pixels, as {@link cropRectPx} resolves one. */
+export interface CropRectPx {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Insets below this are rounding noise from a drag, not an edit. */
+const CROP_EPSILON = 1e-4;
+
+/**
+ * Whether these insets ask for anything. Absent, all-zero, and degenerate
+ * insets all answer false — a crop that keeps nothing is treated as no crop
+ * rather than as a blank frame, which is the same call `cropRectPx` makes.
+ */
+export function hasCrop(crop: ClipCrop | undefined): crop is ClipCrop {
+  if (!crop) return false;
+  if (!isCropUsable(crop)) return false;
+  return (
+    crop.left > CROP_EPSILON ||
+    crop.right > CROP_EPSILON ||
+    crop.top > CROP_EPSILON ||
+    crop.bottom > CROP_EPSILON
+  );
+}
+
+/**
+ * Whether the insets leave a picture. `left + right >= 1` on either axis keeps
+ * nothing; the validator reports that as `crop_degenerate` and the renderers
+ * fall back to the whole source, so a slider dragged to the end shows the
+ * uncropped shot rather than a hole in the timeline.
+ */
+export function isCropUsable(crop: ClipCrop | undefined): boolean {
+  if (!crop) return false;
+  const { left, right, top, bottom } = crop;
+  if (![left, right, top, bottom].every((v) => Number.isFinite(v) && v >= 0)) {
+    return false;
+  }
+  return left + right < 1 - CROP_EPSILON && top + bottom < 1 - CROP_EPSILON;
+}
+
+/**
+ * The source rectangle to read, in pixels, for a source of this size.
+ *
+ * The rectangle is snapped to whole pixels and is always at least 1×1 inside
+ * the source: a GPU copy and a `drawImage` both reject a zero-sized or
+ * out-of-bounds region, and a crop that rounds to nothing is an edit the user
+ * cannot see anyway. Returns the whole source when there is no usable crop, so
+ * a caller can hand the result straight to a draw without branching.
+ */
+export function cropRectPx(
+  crop: ClipCrop | undefined,
+  sourceWidth: number,
+  sourceHeight: number
+): CropRectPx {
+  const full = { x: 0, y: 0, width: sourceWidth, height: sourceHeight };
+  if (sourceWidth <= 0 || sourceHeight <= 0) return full;
+  if (!hasCrop(crop)) return full;
+
+  const x = Math.floor(crop.left * sourceWidth);
+  const y = Math.floor(crop.top * sourceHeight);
+  const width = Math.round((1 - crop.left - crop.right) * sourceWidth);
+  const height = Math.round((1 - crop.top - crop.bottom) * sourceHeight);
+
+  return {
+    x: Math.min(x, sourceWidth - 1),
+    y: Math.min(y, sourceHeight - 1),
+    width: Math.max(1, Math.min(width, sourceWidth - x)),
+    height: Math.max(1, Math.min(height, sourceHeight - y))
+  };
+}

--- a/packages/timeline/src/index.ts
+++ b/packages/timeline/src/index.ts
@@ -21,6 +21,7 @@ export * from "./fill-text.js";
 export * from "./retarget.js";
 export * from "./group.js";
 export * from "./composition.js";
+export * from "./crop.js";
 export * from "./splitClip.js";
 export * from "./trimClip.js";
 export * from "./rippleEdit.js";

--- a/packages/timeline/src/ops/apply.ts
+++ b/packages/timeline/src/ops/apply.ts
@@ -56,6 +56,7 @@ import {
   textStyleWithDefaults
 } from "../authoredStyles.js";
 import { isGroupClip, moveGroup, trimGroup, ungroup } from "../group.js";
+import { isCropUsable } from "../crop.js";
 import { splitClip } from "../splitClip.js";
 import { moveTrackOrder, type TrackDestination } from "../trackOrder.js";
 import { trimClip } from "../trimClip.js";
@@ -159,6 +160,7 @@ const CLIP_PARAM_KEYS = [
   "fadeOutMs",
   "blendMode",
   "borderRadius",
+  "crop",
   "hidden",
   "muted",
   "locked",
@@ -1020,6 +1022,21 @@ async function runOp(scope: OpScope, op: TimelineOp): Promise<TimelineOpResult> 
         clip.blendMode = patch.blendMode as TimelineClip["blendMode"];
       }
       if (patch.borderRadius !== undefined) clip.borderRadius = patch.borderRadius;
+      if (patch.crop !== undefined) {
+        // Null is how a caller puts the whole source back; leaving the field
+        // with all-zero insets would store a crop that means nothing.
+        if (patch.crop === null) {
+          delete clip.crop;
+        } else {
+          if (!isCropUsable(patch.crop)) {
+            throw new Error(
+              `Crop on clip "${clip.name}" keeps no picture: left + right and ` +
+                "top + bottom must each stay below 1."
+            );
+          }
+          clip.crop = patch.crop;
+        }
+      }
       if (patch.hidden !== undefined) clip.hidden = patch.hidden;
       if (patch.muted !== undefined) clip.muted = patch.muted;
       if (patch.locked !== undefined) clip.locked = patch.locked;

--- a/packages/timeline/src/ops/op.ts
+++ b/packages/timeline/src/ops/op.ts
@@ -18,7 +18,7 @@ import type {
   TransitionParams
 } from "@nodetool-ai/protocol/api-schemas/timeline-tool-params.js";
 import type { ClipModel3DStylePatch } from "../authoredStyles.js";
-import type { TimelineClip, TimelineTrack } from "../types.js";
+import type { ClipCrop, TimelineClip, TimelineTrack } from "../types.js";
 import type { ClipAnimation } from "../animation/types.js";
 import type { TimelineAnimationInput } from "./types.js";
 
@@ -191,6 +191,8 @@ export interface SetClipParamsOp {
     fadeOutMs?: number;
     blendMode?: string;
     borderRadius?: number;
+    /** Null clears the crop and puts the whole source back. */
+    crop?: ClipCrop | null;
     hidden?: boolean;
     muted?: boolean;
     locked?: boolean;

--- a/packages/timeline/src/render/canvas2d.ts
+++ b/packages/timeline/src/render/canvas2d.ts
@@ -33,7 +33,9 @@
 import { blendModeToCanvasOp } from "@nodetool-ai/gpu";
 
 import type { AnimationSampleMask, WipeDirection } from "../animation/index.js";
+import { cropRectPx, hasCrop } from "../crop.js";
 import type {
+  ClipCrop,
   ClipDropShadowEffect,
   ClipEffect,
   ClipMask,
@@ -130,6 +132,13 @@ export interface Canvas2DLayer<TSource> {
   precomposeGroupId?: string;
   /** Rounded-corner radius in source pixels. */
   borderRadius?: number;
+  /**
+   * The part of the source this layer draws, taken before anything else reads
+   * it: the contain fit, the transform, the border radius and the masks all see
+   * the cropped rectangle as the layer's whole picture. Needs `cropSurface` to
+   * copy through, or the layer draws uncropped and reports `crop_skipped`.
+   */
+  crop?: ClipCrop;
   mask?: AnimationSampleMask;
   /**
    * The clip's shape mask, in this layer's own source-pixel space so it turns
@@ -305,6 +314,13 @@ export interface DrawTimelineFrameOptions<TSource> {
    */
   matteSurface?: CompositeSurfaceFactory<TSource>;
   /**
+   * Holds a cropped layer's picture at the crop's own size. Distinct from
+   * `maskScratch` and `maskSurface`: it stays live for the whole of one layer's
+   * draw, and both of those read from it while it does. Without it a cropped
+   * layer draws uncropped and reports `crop_skipped`.
+   */
+  cropSurface?: CompositeSurfaceFactory<TSource>;
+  /**
    * Seed the frame fully transparent instead of opaque black — an alpha export.
    * Off by default, so a preview keeps the ground it has.
    */
@@ -337,7 +353,9 @@ export type Canvas2DDegradationReason =
   /** Drop shadows past the first in the chain, not cast. */
   | "drop_shadow_extra_ignored"
   /** Brightness applied as a CSS multiply instead of the GPU's addition. */
-  | "brightness_multiplicative";
+  | "brightness_multiplicative"
+  /** A crop skipped: the layer drew its whole source, at its whole-source fit. */
+  | "crop_skipped";
 
 /** One degradation, and the clip it happened to. */
 export interface Canvas2DDegradation {
@@ -886,7 +904,8 @@ export function drawTimelineLayer<TSource>(
   surfaces: DrawTimelineFrameOptions<TSource> = {},
   degraded: Canvas2DDegradation[] = []
 ): boolean {
-  const { sourceWidth: width, sourceHeight: height } = layer;
+  const cropped = cropLayerSource(layer, surfaces, degraded);
+  const { source: layerSource, width, height } = cropped;
   if (width <= 0 || height <= 0) return false;
 
   if (layer.matte) {
@@ -955,7 +974,7 @@ export function drawTimelineLayer<TSource>(
   // path clips and cost nothing; soft ones pre-mask the source on a scratch
   // surface with `destination-in`, which is also what lets a shape mask and a
   // wipe compose without a second copy.
-  let source = layer.source;
+  let source = layerSource;
   // An animated wipe on the clip and a wipe transition both reduce to one
   // reveal; the clip's own wins, because it is the motion the author put there.
   const wipe = layer.mask ?? transition?.mask;
@@ -967,7 +986,7 @@ export function drawTimelineLayer<TSource>(
   let applied = { shape: false, wipe: false, brightness: false };
   if (softWipe || softShape || lifts) {
     const prepared = prepareSource(
-      layer.source,
+      layerSource,
       width,
       height,
       wipe,
@@ -1016,6 +1035,53 @@ export function drawTimelineLayer<TSource>(
   ctx.restore();
   resetContext(ctx);
   return drawn;
+}
+
+/**
+ * The picture a layer actually draws, and its size: the crop rectangle copied
+ * onto its own surface, or the layer's own source when there is nothing to crop.
+ *
+ * The copy is what makes a crop reframe rather than knock out — every caller
+ * downstream treats the returned size as the layer's source size, so the
+ * contain fit, the transform, the border radius and the masks all act on the
+ * cropped frame. Drawing the whole source at a negative offset onto a surface
+ * the size of the crop is the 5-argument `drawImage` spelling of a sub-rectangle
+ * blit, which is all {@link CompositeContext2D} vends.
+ *
+ * A host that vends no `cropSurface` gets the uncropped layer and a
+ * `crop_skipped` report, the same call {@link drawMattedLayer} makes: the
+ * picture is wrong in a way the caller is told about, rather than absent.
+ */
+function cropLayerSource<TSource>(
+  layer: Canvas2DLayer<TSource>,
+  surfaces: DrawTimelineFrameOptions<TSource>,
+  degraded: Canvas2DDegradation[]
+): { source: TSource; width: number; height: number } {
+  const { source, sourceWidth: width, sourceHeight: height } = layer;
+  if (!hasCrop(layer.crop) || width <= 0 || height <= 0) {
+    return { source, width, height };
+  }
+
+  const rect = cropRectPx(layer.crop, width, height);
+  const surface = surfaces.cropSurface?.(rect.width, rect.height);
+  if (!surface) {
+    degraded.push({ clipId: layer.clipId, reason: "crop_skipped" });
+    return { source, width, height };
+  }
+
+  const cctx = surface.ctx;
+  cctx.setTransform(1, 0, 0, 1, 0, 0);
+  cctx.globalAlpha = 1;
+  cctx.filter = "none";
+  cctx.globalCompositeOperation = "source-over";
+  cctx.clearRect(0, 0, rect.width, rect.height);
+  try {
+    cctx.drawImage(source, -rect.x, -rect.y, width, height);
+  } catch {
+    degraded.push({ clipId: layer.clipId, reason: "crop_skipped" });
+    return { source, width, height };
+  }
+  return { source: surface.surface, width: rect.width, height: rect.height };
 }
 
 /**

--- a/packages/timeline/src/render/effects.ts
+++ b/packages/timeline/src/render/effects.ts
@@ -9,7 +9,8 @@ import {
   isClipLevelsEffect,
   isClipLiftGammaGainEffect,
   isClipSharpenEffect,
-  isClipVignetteEffect
+  isClipVignetteEffect,
+  isClipGrainEffect
 } from "../types.js";
 import {
   createDefaultRegistry,
@@ -28,6 +29,7 @@ import {
   mixerDropShadowV1,
   sharpenUnsharpMaskV1,
   vignetteV1,
+  filtersGrainV1,
   chromaKeyV1,
   maskApplyV1,
   maskFromImageV1,
@@ -397,6 +399,19 @@ export class WebGPUEffectsProcessor {
         tolerance: effect.tolerance,
         softness: effect.softness,
         spill: effect.spill ?? chromaKeyV1.paramDefaults.spill
+      });
+      return;
+    }
+    if (isClipGrainEffect(effect)) {
+      // `animate` is not a knob here: the scene model has already stamped the
+      // frame's seed on the effect, so this only ever draws the pattern it is
+      // handed. That is what keeps a render reproducible.
+      step(filtersGrainV1, {
+        amount: effect.amount,
+        size: effect.size ?? filtersGrainV1.paramDefaults.size,
+        colorAmount:
+          effect.colorAmount ?? filtersGrainV1.paramDefaults.colorAmount,
+        seed: effect.seed ?? filtersGrainV1.paramDefaults.seed
       });
       return;
     }
@@ -809,7 +824,8 @@ function isShaderStepEffect(effect: ClipEffect): boolean {
     isClipChromaKeyEffect(effect) ||
     isClipCurvesEffect(effect) ||
     isClipLevelsEffect(effect) ||
-    isClipLiftGammaGainEffect(effect)
+    isClipLiftGammaGainEffect(effect) ||
+    isClipGrainEffect(effect)
   );
 }
 

--- a/packages/timeline/src/render/frameCompositor.ts
+++ b/packages/timeline/src/render/frameCompositor.ts
@@ -33,7 +33,13 @@ import {
 } from "@nodetool-ai/gpu/webgpu";
 
 import type { AnimationSampleMask, WipeDirection } from "../animation/index.js";
-import type { ClipEffect, ClipTransform, TrackEffect } from "../types.js";
+import type {
+  ClipCrop,
+  ClipEffect,
+  ClipTransform,
+  TrackEffect
+} from "../types.js";
+import { cropRectPx, hasCrop } from "../crop.js";
 import { parseCssColorOrBlack } from "./color.js";
 import { WebGPUEffectsProcessor } from "./effects.js";
 import type { CompositorBlendMode, MatteMode } from "./sceneModel.js";
@@ -180,6 +186,12 @@ export interface FrameLayer<TSource = FrameLayerPixels> {
   precomposeGroupId?: string;
   /** Rounded-corner radius in source pixels. */
   borderRadius?: number;
+  /**
+   * The part of the source this layer draws. The crop is taken before anything
+   * else reads the pixels, so the contain fit, the transform, the border radius
+   * and the effects all see the cropped frame as the layer's whole picture.
+   */
+  crop?: ClipCrop;
   mask?: AnimationSampleMask;
   /**
    * The clip's shape mask, already rasterized as coverage in alpha — the host
@@ -380,6 +392,8 @@ export class GpuFrameCompositor<TSource = FrameLayerPixels> {
   private readonly precompTargets = new Map<string, GPUTexture>();
   /** One 1×1 texture per colour a `dipToColor` transition fades through. */
   private readonly solids = new Map<string, GPUTexture>();
+  /** One cropped copy per cropped layer, by layer id — see {@link cropSource}. */
+  private readonly crops = new Map<string, GpuSourceTexture>();
   /** Resolves a premultiplied accumulation to the straight alpha the blend
    *  shader reads a source as. Built with the second pass. */
   private unpremultiply: GPURenderPipeline | null = null;
@@ -699,8 +713,12 @@ export class GpuFrameCompositor<TSource = FrameLayerPixels> {
     layer: FrameLayer<TSource>,
     encoder: GPUCommandEncoder
   ): ResolvedLayer | null {
-    const src = this.upload(layer.id, layer.source);
-    if (!src) return null;
+    const uploaded = this.upload(layer.id, layer.source);
+    if (!uploaded) return null;
+    // Crop first: everything below — the effect chain, the shape mask, the
+    // contain fit, the border radius — then sees the cropped rectangle as the
+    // layer's whole picture, which is what a crop means.
+    const src = this.cropSource(layer, uploaded, encoder);
 
     const clipEffects = layer.effects ?? [];
     const trackEffects = layer.trackEffects ?? [];
@@ -825,6 +843,66 @@ export class GpuFrameCompositor<TSource = FrameLayerPixels> {
       ),
       borderRadius: 0
     };
+  }
+
+  /**
+   * The layer's pixels narrowed to its crop rectangle, as a texture of exactly
+   * that size. Returns the upload untouched when there is no usable crop, which
+   * is every layer of a document nobody has cropped — that path allocates
+   * nothing and copies nothing.
+   *
+   * A plain texture-to-texture copy, not a shader pass: the crop is an axis
+   * aligned region of whole texels, so there is nothing to filter and a copy is
+   * both exact and cheaper than a render pass. The copy is recorded into the
+   * frame's own encoder, so it costs no extra submit.
+   */
+  private cropSource(
+    layer: FrameLayer<TSource>,
+    uploaded: GpuSourceTexture,
+    encoder: GPUCommandEncoder
+  ): GpuSourceTexture {
+    if (!hasCrop(layer.crop)) {
+      // A clip that was cropped and is not any more must not keep drawing the
+      // stale copy, and holding the texture for a layer with no crop would leak
+      // it until the layer left the frame.
+      const stale = this.crops.get(layer.id);
+      if (stale) {
+        stale.texture.destroy();
+        this.crops.delete(layer.id);
+      }
+      return uploaded;
+    }
+
+    const rect = cropRectPx(layer.crop, uploaded.width, uploaded.height);
+    let entry = this.crops.get(layer.id);
+    if (!entry || entry.width !== rect.width || entry.height !== rect.height) {
+      entry?.texture.destroy();
+      entry = {
+        texture: this.device.createTexture({
+          label: `${this.label}-crop-${layer.id}`,
+          size: { width: rect.width, height: rect.height },
+          format: TEXTURE_FORMAT,
+          usage:
+            GPUTextureUsage.TEXTURE_BINDING |
+            GPUTextureUsage.COPY_DST |
+            GPUTextureUsage.COPY_SRC |
+            GPUTextureUsage.RENDER_ATTACHMENT
+        }),
+        width: rect.width,
+        height: rect.height
+      };
+      this.crops.set(layer.id, entry);
+    }
+
+    // Re-copied every frame rather than versioned: the upload underneath is
+    // itself re-written whenever the pixels change, and a video layer's change
+    // every frame, so a version check here would only add a field to get wrong.
+    encoder.copyTextureToTexture(
+      { texture: uploaded.texture, origin: { x: rect.x, y: rect.y } },
+      { texture: entry.texture },
+      { width: rect.width, height: rect.height }
+    );
+    return entry;
   }
 
   /** A 1×1 opaque texture of `color`, kept for the life of the compositor. */
@@ -1300,6 +1378,12 @@ export class GpuFrameCompositor<TSource = FrameLayerPixels> {
     }
 
     this.retainSources(live);
+    for (const [id, entry] of this.crops) {
+      if (!live.has(id)) {
+        entry.texture.destroy();
+        this.crops.delete(id);
+      }
+    }
     for (const [id, texture] of this.precompTargets) {
       if (!liveTargets.has(id)) {
         texture.destroy();
@@ -1320,6 +1404,8 @@ export class GpuFrameCompositor<TSource = FrameLayerPixels> {
     for (const texture of this.solids.values()) texture.destroy();
     this.solids.clear();
     this.effects.dispose();
+    for (const entry of this.crops.values()) entry.texture.destroy();
+    this.crops.clear();
     this.core.dispose();
     this.precompCore?.dispose();
     this.precompCore = null;

--- a/packages/timeline/src/render/sceneModel.ts
+++ b/packages/timeline/src/render/sceneModel.ts
@@ -12,6 +12,7 @@
  */
 
 import type {
+  ClipCrop,
   ClipEffect,
   ClipMask,
   ClipModel3DStyle,
@@ -20,6 +21,7 @@ import type {
   TimelineTrack,
   TrackEffect
 } from "../types.js";
+import { isClipGrainEffect } from "../types.js";
 import type { Model3DCameraChannels } from "../model3d.js";
 import type {
   AnimationSample,
@@ -529,6 +531,14 @@ export interface ActiveLayer {
    */
   precomposeGroupId?: string;
   borderRadius?: number;
+  /**
+   * The part of the source this layer draws (D2's sibling for framing): the
+   * crop is taken before anything else reads the pixels, so the contain fit,
+   * the transform, the border radius and the effect chain all see the cropped
+   * rectangle as the layer's whole picture. Never set on a caption layer, which
+   * composites frame-sized and untransformed and so has no source to crop.
+   */
+  crop?: ClipCrop;
   effects?: ClipEffect[];
   trackEffects?: TrackEffect[];
   /** Present only when `kind === "caption"`: the words to draw this frame. */
@@ -986,6 +996,7 @@ export function computeActiveLayersWithHorizon(
           parentMatrix,
           precomposeGroupId,
           borderRadius: clip.borderRadius,
+          crop: clip.crop,
           effects: clip.effects,
           trackEffects: track.effects,
           textStyle: clip.textStyle,
@@ -1009,6 +1020,7 @@ export function computeActiveLayersWithHorizon(
           parentMatrix,
           precomposeGroupId,
           borderRadius: clip.borderRadius,
+          crop: clip.crop,
           effects: clip.effects,
           trackEffects: track.effects,
           shapeStyle: clip.shapeStyle,
@@ -1033,6 +1045,7 @@ export function computeActiveLayersWithHorizon(
           parentMatrix,
           precomposeGroupId,
           borderRadius: clip.borderRadius,
+          crop: clip.crop,
           effects: clip.effects,
           trackEffects: track.effects,
           shapeMask: clip.mask,
@@ -1098,6 +1111,7 @@ export function computeActiveLayersWithHorizon(
         parentMatrix,
         precomposeGroupId,
         borderRadius: clip.borderRadius,
+        crop: clip.crop,
         effects: clip.effects,
         trackEffects: track.effects,
         shapeMask: clip.mask,
@@ -1539,7 +1553,7 @@ export function resolveAnimatedLayerProps(
   const clip = layer.clip;
   const compiled = compiledFor(clip, canvas, cache);
   if (compiled.length === 0) {
-    return staticProps(layer);
+    return staticProps(layer, currentTimeMs);
   }
 
   const s = sampleAnimations(
@@ -1549,7 +1563,7 @@ export function resolveAnimatedLayerProps(
     clipSourceMsAt(clip, currentTimeMs)
   );
   if (isIdentitySample(s)) {
-    return staticProps(layer);
+    return staticProps(layer, currentTimeMs);
   }
 
   const base = layer.transform ?? IDENTITY_TRANSFORM;
@@ -1577,7 +1591,10 @@ export function resolveAnimatedLayerProps(
     transform,
     opacity: layer.opacity * s.opacity,
     mask: s.mask,
-    effects: composeAnimatedEffects(clip.effects, s),
+    effects: seedAnimatedGrain(
+      composeAnimatedEffects(clip.effects, s),
+      currentTimeMs
+    ),
     shapeStyle: composeAnimatedShapeStyle(clip.shapeStyle, s),
     cameraAzimuth: s.cameraAzimuth,
     cameraElevation: s.cameraElevation,
@@ -1587,15 +1604,18 @@ export function resolveAnimatedLayerProps(
 }
 
 /** The layer's own values, for a clip with no animation in flight. */
-function staticProps(layer: {
-  clip: TimelineClip;
-  transform?: ClipTransform;
-  opacity: number;
-}): AnimatedLayerProps {
+function staticProps(
+  layer: {
+    clip: TimelineClip;
+    transform?: ClipTransform;
+    opacity: number;
+  },
+  currentTimeMs: number
+): AnimatedLayerProps {
   return {
     transform: layer.transform,
     opacity: layer.opacity,
-    effects: layer.clip.effects,
+    effects: seedAnimatedGrain(layer.clip.effects, currentTimeMs),
     shapeStyle: layer.clip.shapeStyle,
     cameraAzimuth: 0,
     cameraElevation: 0,
@@ -1645,6 +1665,30 @@ function composeAnimatedEffects(
     out.push({ id: "anim-blur", type: "blur", enabled: true, radius: s.blur });
   }
   return out;
+}
+
+/**
+ * Give every `animate` grain the frame's own seed, so the pattern rolls the way
+ * exposed stock does instead of sitting on the picture like dirt on the lens.
+ *
+ * The seed is the frame time, not a counter and not `Math.random`: re-rendering
+ * one frame draws the same grain, which is what lets a cached render be handed
+ * back and what makes the preview and the export agree. Every host resolves its
+ * layers through {@link resolveAnimatedLayerProps}, so this is the one place
+ * the roll happens; a grain with `animate` off keeps whatever seed the document
+ * stored, and a chain with no animated grain is returned untouched.
+ */
+function seedAnimatedGrain(
+  effects: ClipEffect[] | undefined,
+  currentTimeMs: number
+): ClipEffect[] | undefined {
+  if (!effects?.some((e) => e.enabled && isClipGrainEffect(e) && e.animate)) {
+    return effects;
+  }
+  const seed = Math.floor(currentTimeMs);
+  return effects.map((e) =>
+    e.enabled && isClipGrainEffect(e) && e.animate ? { ...e, seed } : e
+  );
 }
 
 /**

--- a/packages/timeline/src/types.ts
+++ b/packages/timeline/src/types.ts
@@ -893,6 +893,12 @@ export interface TimelineClip {
   /** Rounded-corner radius in source pixels. 0 = sharp corners. */
   borderRadius?: number;
   /**
+   * Crop the source before anything else reads it. The kept rectangle becomes
+   * the clip's picture, so the contain fit, the transform, the border radius,
+   * the masks and the effects all apply to the cropped frame.
+   */
+  crop?: ClipCrop;
+  /**
    * GPU effects applied to this clip in order. On an `adjustment` clip they
    * run on the composite of the layers beneath it instead of on its own
    * pixels.
@@ -953,6 +959,36 @@ export interface TimelineClip {
  * rotates and scales with the layer. `kind` is a plain string for the same
  * forward compat `preset` has: an unknown kind parses and is skipped.
  */
+/**
+ * The part of the source a clip keeps, as the fraction of each edge thrown
+ * away. `{ left: 0.25, right: 0.25, top: 0, bottom: 0 }` keeps the middle half
+ * of the picture.
+ *
+ * **A crop reframes, it does not knock out.** The kept rectangle *becomes* the
+ * clip's picture: it is re-fit to the canvas, so cropping a 16:9 shot to 1:1
+ * and leaving the transform alone gives a square that fills the frame the way
+ * a 1:1 source would. Hiding part of a layer while it stays where it was is
+ * {@link ClipMask} with `kind: "rect"`, which is a different edit and stays
+ * the way to ask for it.
+ *
+ * The insets are fractions rather than source pixels so a crop survives the
+ * asset under it changing resolution — an upscale, or `restoreVersion` swapping
+ * in a generation rendered at another size. Both compositors read them through
+ * `cropRectPx`, which is where the clamping lives; an inset pair that leaves no
+ * picture (`left + right >= 1`) is reported by the validator as
+ * `crop_degenerate` and renders uncropped rather than blanking the shot.
+ */
+export interface ClipCrop {
+  /** Fraction of the source width dropped from the left edge, 0..1. */
+  left: number;
+  /** Fraction of the source width dropped from the right edge, 0..1. */
+  right: number;
+  /** Fraction of the source height dropped from the top edge, 0..1. */
+  top: number;
+  /** Fraction of the source height dropped from the bottom edge, 0..1. */
+  bottom: number;
+}
+
 export interface ClipMask {
   /** `"rect" | "ellipse" | "path"`. */
   kind: string;
@@ -1135,7 +1171,8 @@ export type KnownClipEffect =
   | ClipChromaKeyEffect
   | ClipCurvesEffect
   | ClipLevelsEffect
-  | ClipLiftGammaGainEffect;
+  | ClipLiftGammaGainEffect
+  | ClipGrainEffect;
 
 /**
  * An effect whose `type` this build does not apply, carried rather than
@@ -1194,6 +1231,9 @@ export const isClipLiftGammaGainEffect = (
   e: ClipEffect
 ): e is ClipLiftGammaGainEffect => e.type === "liftGammaGain";
 
+export const isClipGrainEffect = (e: ClipEffect): e is ClipGrainEffect =>
+  e.type === "grain";
+
 /**
  * Effect types this build applies. Anything else parses and rides through as an
  * {@link UnknownClipEffect} (I2); the validator reports it as `unknown_effect`
@@ -1209,7 +1249,8 @@ export const CLIP_EFFECT_TYPES = [
   "chromaKey",
   "curves",
   "levels",
-  "liftGammaGain"
+  "liftGammaGain",
+  "grain"
 ] as const;
 
 export type ClipEffectType = (typeof CLIP_EFFECT_TYPES)[number];
@@ -1300,6 +1341,53 @@ export interface ClipVignetteEffect {
    * legacy spelling made mandatory.
    */
   radius?: number;
+}
+
+/**
+ * Film grain: a per-pixel gain wobble, multiplied into the picture rather than
+ * added to it. Multiplying is what keeps a premultiplied layer legal — adding
+ * noise can push a channel past its own alpha, which reads as a bright fringe
+ * wherever the layer is translucent — and it is also how real grain behaves,
+ * biting hardest in the midtones and leaving black black.
+ *
+ * Canvas 2D has no way to draw it (`ctx.filter` carries no noise), so that path
+ * reports `grain` through `unsupportedEffectTypes` instead of approximating it.
+ */
+export interface ClipGrainEffect {
+  id: string;
+  type: "grain";
+  enabled: boolean;
+  /** Grain strength, 0..1. 0 is a no-op. */
+  amount: number;
+  /**
+   * Grain cell size in source pixels — 1 is per-pixel, larger is coarser stock.
+   * Absent means `grain@1`'s own default.
+   */
+  size?: number;
+  /**
+   * How much the three channels wobble independently: 0 is monochrome grain
+   * (one gain for the pixel), 1 is full colour noise. Absent means the module
+   * default.
+   */
+  colorAmount?: number;
+  /**
+   * Roll the pattern with the frame clock, the way exposed stock does. Absent
+   * or false holds one pattern for every frame, which is what a still wants.
+   *
+   * The roll is not a clock and not `Math.random`: `resolveAnimatedLayerProps`
+   * stamps {@link seed} from the frame's own time, so two renders of the same
+   * frame are byte-identical and a cached render can be handed back.
+   */
+  animate?: boolean;
+  /**
+   * Which pattern to draw. Any two effects sharing a seed grain identically,
+   * which is what lets two clips of the same stock match.
+   *
+   * On an `animate` grain the scene model overwrites this per frame, so the
+   * stored value is only the pattern a still — or a host that never resolves
+   * animated props — draws.
+   */
+  seed?: number;
 }
 
 export interface ClipSharpenEffect {

--- a/packages/timeline/tests/crop.test.ts
+++ b/packages/timeline/tests/crop.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { cropRectPx, hasCrop, isCropUsable } from "../src/crop.js";
+import { splitClip } from "../src/splitClip.js";
+import { trimClip } from "../src/trimClip.js";
+import type { ClipCrop, TimelineClip } from "../src/types.js";
+
+const crop = (
+  left: number,
+  right: number,
+  top: number,
+  bottom: number
+): ClipCrop => ({ left, right, top, bottom });
+
+function makeClip(overrides: Partial<TimelineClip> = {}): TimelineClip {
+  return {
+    id: "clip-1",
+    trackId: "track-1",
+    name: "Shot",
+    startMs: 0,
+    durationMs: 1000,
+    inPointMs: 0,
+    outPointMs: 1000,
+    mediaType: "video",
+    sourceType: "imported",
+    status: "generated",
+    locked: false,
+    versions: [],
+    ...overrides
+  };
+}
+
+describe("hasCrop", () => {
+  it("is false for absent, zero and sub-epsilon insets", () => {
+    expect(hasCrop(undefined)).toBe(false);
+    expect(hasCrop(crop(0, 0, 0, 0))).toBe(false);
+    // A drag that rounded to nothing is not an edit.
+    expect(hasCrop(crop(1e-6, 0, 0, 0))).toBe(false);
+  });
+
+  it("is true once any edge is actually inset", () => {
+    expect(hasCrop(crop(0.1, 0, 0, 0))).toBe(true);
+    expect(hasCrop(crop(0, 0, 0, 0.25))).toBe(true);
+  });
+
+  it("is false for insets that keep no picture", () => {
+    expect(hasCrop(crop(0.6, 0.6, 0, 0))).toBe(false);
+    expect(hasCrop(crop(0, 0, 0.5, 0.5))).toBe(false);
+  });
+});
+
+describe("isCropUsable", () => {
+  it("accepts a pair that leaves picture and refuses one that does not", () => {
+    expect(isCropUsable(crop(0.25, 0.25, 0.25, 0.25))).toBe(true);
+    expect(isCropUsable(crop(0.5, 0.5, 0, 0))).toBe(false);
+    expect(isCropUsable(crop(0, 0, 0.99, 0.02))).toBe(false);
+  });
+
+  it("refuses negative and non-finite insets", () => {
+    expect(isCropUsable(crop(-0.1, 0, 0, 0))).toBe(false);
+    expect(isCropUsable(crop(Number.NaN, 0, 0, 0))).toBe(false);
+    expect(isCropUsable(crop(0, Number.POSITIVE_INFINITY, 0, 0))).toBe(false);
+  });
+});
+
+describe("cropRectPx", () => {
+  it("returns the whole source when there is nothing to crop", () => {
+    expect(cropRectPx(undefined, 1920, 1080)).toEqual({
+      x: 0,
+      y: 0,
+      width: 1920,
+      height: 1080
+    });
+  });
+
+  it("keeps the middle half of the width", () => {
+    expect(cropRectPx(crop(0.25, 0.25, 0, 0), 1920, 1080)).toEqual({
+      x: 480,
+      y: 0,
+      width: 960,
+      height: 1080
+    });
+  });
+
+  it("crops 16:9 to a centred square", () => {
+    // (1920 - 1080) / 2 / 1920 = 0.21875 off each side.
+    const rect = cropRectPx(crop(0.21875, 0.21875, 0, 0), 1920, 1080);
+    expect(rect).toEqual({ x: 420, y: 0, width: 1080, height: 1080 });
+  });
+
+  it("never leaves the source, whatever the insets round to", () => {
+    for (const c of [
+      crop(0.999, 0, 0, 0),
+      crop(0, 0.999, 0, 0),
+      crop(0.4999, 0.4999, 0.4999, 0.4999)
+    ]) {
+      const rect = cropRectPx(c, 101, 57);
+      expect(rect.x).toBeGreaterThanOrEqual(0);
+      expect(rect.y).toBeGreaterThanOrEqual(0);
+      expect(rect.width).toBeGreaterThan(0);
+      expect(rect.height).toBeGreaterThan(0);
+      expect(rect.x + rect.width).toBeLessThanOrEqual(101);
+      expect(rect.y + rect.height).toBeLessThanOrEqual(57);
+    }
+  });
+
+  it("falls back to the whole source rather than blanking the shot", () => {
+    expect(cropRectPx(crop(0.7, 0.7, 0, 0), 640, 480)).toEqual({
+      x: 0,
+      y: 0,
+      width: 640,
+      height: 480
+    });
+  });
+
+  it("answers with the whole source for a zero-sized source", () => {
+    expect(cropRectPx(crop(0.25, 0.25, 0, 0), 0, 0)).toEqual({
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0
+    });
+  });
+});
+
+describe("a crop survives a window edit", () => {
+  // The crop is source-space and says nothing about time, so trimming and
+  // splitting carry it across untouched — the same argument `generatedMatte`
+  // makes for sharing the clip's in-point.
+  it("is kept by trimClip", () => {
+    const clip = makeClip({ crop: crop(0.1, 0.2, 0, 0) });
+    const trimmed = trimClip(clip, "start", -200, 10_000);
+    expect(trimmed.crop).toEqual(crop(0.1, 0.2, 0, 0));
+  });
+
+  it("is kept by both halves of splitClip", () => {
+    const clip = makeClip({ crop: crop(0.1, 0.2, 0.05, 0) });
+    const [left, right] = splitClip(clip, 400);
+    expect(left.crop).toEqual(crop(0.1, 0.2, 0.05, 0));
+    expect(right.crop).toEqual(crop(0.1, 0.2, 0.05, 0));
+  });
+});

--- a/packages/timeline/tests/render.clipEffects.test.ts
+++ b/packages/timeline/tests/render.clipEffects.test.ts
@@ -10,7 +10,7 @@
  * one records the context state each draw ran under.
  */
 import { describe, expect, it } from "vitest";
-import { makeClip } from "../src/index.js";
+import { CLIP_EFFECT_TYPES, makeClip } from "../src/index.js";
 import type { ClipEffect, TrackEffect } from "../src/index.js";
 import { resolveAnimatedLayerProps } from "../src/render/sceneModel.js";
 import {
@@ -79,7 +79,8 @@ const everyEffect: ClipEffect[] = [
     lift: [0, 0, 0],
     gamma: [1, 1, 1],
     gain: [1, 1, 1]
-  }
+  },
+  { id: "11", type: "grain", enabled: true, amount: 0.3 }
 ];
 
 /** The shadow state a `drawImage` ran under, alongside the filter. */
@@ -193,6 +194,16 @@ const layer = (
 });
 
 describe("Canvas 2D — the clip effect catalog", () => {
+  it("covers every type the document can carry", () => {
+    // `everyEffect` is only "one of every type" for as long as somebody keeps
+    // it that way. It had already stopped being that once — a type added to
+    // `CLIP_EFFECT_TYPES` and not to the list here leaves the report below
+    // pinned to a set that no longer describes the build, and passes.
+    expect([...new Set(everyEffect.map((e) => e.type))].sort()).toEqual(
+      [...CLIP_EFFECT_TYPES].sort()
+    );
+  });
+
   it("reports exactly the types it cannot draw", () => {
     expect(unsupportedEffectTypes([{ effects: everyEffect }])).toEqual([
       "chromaKey",
@@ -200,6 +211,7 @@ describe("Canvas 2D — the clip effect catalog", () => {
       "color.tint",
       "curves",
       "glow",
+      "grain",
       "levels",
       "liftGammaGain",
       "sharpen",

--- a/packages/timeline/tests/render.crop.gpu.test.ts
+++ b/packages/timeline/tests/render.crop.gpu.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Clip crop on the GPU path.
+ *
+ * The whole semantics reduce to one equivalence, and that is what is asserted
+ * here rather than a golden buffer: **a cropped layer renders exactly like an
+ * uncropped layer whose source is the crop.** If that holds, the crop rectangle
+ * really has become the layer's picture — the contain fit was recomputed from
+ * the cropped size, the transform placed the cropped frame, and the copy took
+ * the texels the insets name. If it fails, one of those three is reading the
+ * original source size.
+ *
+ * A missing WebGPU adapter skips the suite and says why. On headless Linux that
+ * means no Vulkan ICD — see AGENTS.md § WebGPU on a headless machine.
+ */
+import { describe, expect, it } from "vitest";
+import type { ClipCrop } from "../src/index.js";
+import {
+  HeadlessFrameCompositor,
+  type FrameLayer,
+  type FrameLayerPixels
+} from "../src/render/frameCompositor.js";
+
+const noAdapterReason = await (async (): Promise<string | null> => {
+  try {
+    const { getNodeGPUDevice } = await import("@nodetool-ai/gpu/node");
+    await getNodeGPUDevice();
+    return null;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    process.stderr.write(
+      `render.crop.gpu: skipping every case — no WebGPU device. ${reason}\n`
+    );
+    return reason;
+  }
+})();
+
+const FRAME = 64;
+
+/**
+ * A distinguishable source: every pixel encodes its own coordinates, so a
+ * render that read the wrong texels differs rather than merely looking similar.
+ */
+function coordinateRamp(
+  width: number,
+  height: number,
+  offsetX = 0,
+  offsetY = 0
+): FrameLayerPixels {
+  const rgba = new Uint8Array(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 4;
+      rgba[i] = (x + offsetX) * 3;
+      rgba[i + 1] = (y + offsetY) * 3;
+      rgba[i + 2] = 128;
+      rgba[i + 3] = 255;
+    }
+  }
+  return {
+    rgba,
+    width,
+    height,
+    version: `ramp-${width}x${height}+${offsetX}+${offsetY}`
+  };
+}
+
+function layer(over: Partial<FrameLayer> & { source: FrameLayerPixels }): FrameLayer {
+  return {
+    id: "shot",
+    opacity: 1,
+    blendMode: "normal",
+    zIndex: 0,
+    ...over
+  };
+}
+
+async function renderFrame(layers: FrameLayer[]): Promise<Uint8Array> {
+  const { getNodeGPUDevice } = await import("@nodetool-ai/gpu/node");
+  const device = await getNodeGPUDevice();
+  const compositor = new HeadlessFrameCompositor(device, FRAME, FRAME);
+  try {
+    return await compositor.renderFrame(layers);
+  } finally {
+    compositor.dispose();
+  }
+}
+
+/** Mean absolute difference per byte — 0 is identical. */
+function meanDiff(a: Uint8Array, b: Uint8Array): number {
+  let total = 0;
+  for (let i = 0; i < a.length; i++) total += Math.abs(a[i]! - b[i]!);
+  return total / a.length;
+}
+
+describe.runIf(noAdapterReason === null)("crop on the GPU path", () => {
+  it("renders a cropped source exactly like the pre-cropped source itself", async () => {
+    // Keep the middle half of a 64-wide, full-height source: x 16..48.
+    const crop: ClipCrop = { left: 0.25, right: 0.25, top: 0, bottom: 0 };
+    const cropped = await renderFrame([
+      layer({ source: coordinateRamp(64, 64), crop })
+    ]);
+    // The same picture, handed over already cut: 32×64 starting at x=16.
+    const equivalent = await renderFrame([
+      layer({ source: coordinateRamp(32, 64, 16, 0) })
+    ]);
+
+    expect(Array.from(cropped)).toEqual(Array.from(equivalent));
+  });
+
+  it("matches the pre-cropped equivalent on both axes at once", async () => {
+    const crop: ClipCrop = {
+      left: 0.25,
+      right: 0.125,
+      top: 0.125,
+      bottom: 0.25
+    };
+    // 64 wide: 16 off the left, 8 off the right → 40 wide from x=16.
+    // 64 high: 8 off the top, 16 off the bottom → 40 high from y=8.
+    const cropped = await renderFrame([
+      layer({ source: coordinateRamp(64, 64), crop })
+    ]);
+    const equivalent = await renderFrame([
+      layer({ source: coordinateRamp(40, 40, 16, 8) })
+    ]);
+
+    expect(Array.from(cropped)).toEqual(Array.from(equivalent));
+  });
+
+  it("actually changes the frame — the equivalence is not two identical renders", async () => {
+    // Without this the two cases above would pass on a crop that did nothing,
+    // as long as `coordinateRamp` happened to agree.
+    const plain = await renderFrame([layer({ source: coordinateRamp(64, 64) })]);
+    const cropped = await renderFrame([
+      layer({
+        source: coordinateRamp(64, 64),
+        crop: { left: 0.25, right: 0.25, top: 0, bottom: 0 }
+      })
+    ]);
+
+    expect(meanDiff(plain, cropped)).toBeGreaterThan(5);
+  });
+
+  it("re-fits the crop to the frame rather than shrinking the picture", async () => {
+    // A 32×64 crop of a 64×64 source is 1:2, so contain-fit makes it half the
+    // frame wide and full height. The centre column is drawn; the far left is
+    // the ground. A crop that knocked pixels out in place instead would leave
+    // the kept strip at its original width.
+    const cropped = await renderFrame([
+      layer({
+        source: coordinateRamp(64, 64),
+        crop: { left: 0.25, right: 0.25, top: 0, bottom: 0 }
+      })
+    ]);
+    const at = (x: number, y: number) => {
+      const i = (y * FRAME + x) * 4;
+      return [cropped[i]!, cropped[i + 1]!, cropped[i + 2]!] as const;
+    };
+    // Centre carries picture (blue channel 128 marks the source).
+    expect(at(FRAME / 2, FRAME / 2)[2]).toBe(128);
+    // The sides are the opaque-black ground the contain fit left behind.
+    expect(at(2, FRAME / 2)).toEqual([0, 0, 0]);
+    expect(at(FRAME - 3, FRAME / 2)).toEqual([0, 0, 0]);
+  });
+
+  it("draws the whole source when the insets keep no picture", async () => {
+    const plain = await renderFrame([layer({ source: coordinateRamp(64, 64) })]);
+    const degenerate = await renderFrame([
+      layer({
+        source: coordinateRamp(64, 64),
+        crop: { left: 0.7, right: 0.7, top: 0, bottom: 0 }
+      })
+    ]);
+
+    expect(Array.from(degenerate)).toEqual(Array.from(plain));
+  });
+
+  it("stops cropping when the crop is cleared, reusing the same layer id", async () => {
+    // The crop texture is cached by layer id, so a clip that was cropped and is
+    // not any more must not keep drawing the stale copy.
+    const { getNodeGPUDevice } = await import("@nodetool-ai/gpu/node");
+    const device = await getNodeGPUDevice();
+    const compositor = new HeadlessFrameCompositor(device, FRAME, FRAME);
+    try {
+      const source = coordinateRamp(64, 64);
+      await compositor.renderFrame([
+        layer({ source, crop: { left: 0.25, right: 0.25, top: 0, bottom: 0 } })
+      ]);
+      const after = await compositor.renderFrame([layer({ source })]);
+      const never = await compositor.renderFrame([layer({ source })]);
+      expect(Array.from(after)).toEqual(Array.from(never));
+    } finally {
+      compositor.dispose();
+    }
+  });
+});

--- a/packages/timeline/tests/render.crop.test.ts
+++ b/packages/timeline/tests/render.crop.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Clip crop on the Canvas 2D path.
+ *
+ * Pixels are the GPU suite's subject (`render.crop.gpu.test.ts`); what is
+ * asserted here is the geometry and the host contract — the two things that
+ * path decides on its own:
+ *
+ * - the crop is blitted onto its own surface at the crop's size, by drawing the
+ *   whole source at a negative offset (the 5-argument `drawImage` spelling of a
+ *   sub-rectangle, which is all `CompositeContext2D` vends);
+ * - a cropped layer is then placed exactly like an uncropped layer of the crop's
+ *   size, which is what makes the two compositors agree;
+ * - a host with no `cropSurface` draws uncropped and *says so* (I7), rather than
+ *   silently showing a different framing.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  drawTimelineFrame,
+  layerCanvasAffine,
+  type Canvas2DLayer,
+  type CompositeContext2D,
+  type CompositeSurface
+} from "../src/render/canvas2d.js";
+import type { ClipCrop } from "../src/index.js";
+
+const GEOMETRY = { canvasWidth: 100, canvasHeight: 100 };
+
+interface RecordedDraw {
+  source: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  transform: [number, number, number, number, number, number];
+}
+
+class RecordingContext implements CompositeContext2D<string> {
+  globalAlpha = 1;
+  globalCompositeOperation = "source-over";
+  filter = "none";
+  shadowColor = "rgba(0, 0, 0, 0)";
+  shadowBlur = 0;
+  shadowOffsetX = 0;
+  shadowOffsetY = 0;
+  fillStyle: string | object = "#000";
+  readonly draws: RecordedDraw[] = [];
+  private current: [number, number, number, number, number, number] = [
+    1, 0, 0, 1, 0, 0
+  ];
+
+  save(): void {}
+  restore(): void {}
+  setTransform(
+    a = 1,
+    b = 0,
+    c = 0,
+    d = 1,
+    e = 0,
+    f = 0
+  ): void {
+    this.current = [a, b, c, d, e, f];
+  }
+  clearRect(): void {}
+  fillRect(): void {}
+  beginPath(): void {}
+  closePath(): void {}
+  rect(): void {}
+  arcTo(): void {}
+  clip(): void {}
+  drawImage(source: string, x: number, y: number, w: number, h: number): void {
+    this.draws.push({ source, x, y, w, h, transform: [...this.current] });
+  }
+  createLinearGradient(): { addColorStop(o: number, c: string): void } {
+    return { addColorStop: () => {} };
+  }
+  lineTo(): void {}
+  moveTo(): void {}
+  bezierCurveTo(): void {}
+  quadraticCurveTo(): void {}
+  ellipse(): void {}
+  fill(): void {}
+  translate(): void {}
+  scale(): void {}
+  createRadialGradient(): { addColorStop(o: number, c: string): void } {
+    return { addColorStop: () => {} };
+  }
+  getImageData(
+    _x: number,
+    _y: number,
+    w: number,
+    h: number
+  ): { data: Uint8ClampedArray; width: number; height: number } {
+    return { data: new Uint8ClampedArray(w * h * 4), width: w, height: h };
+  }
+  putImageData(): void {}
+}
+
+const layer = (over: Partial<Canvas2DLayer<string>>): Canvas2DLayer<string> => ({
+  source: "src",
+  sourceWidth: 200,
+  sourceHeight: 100,
+  opacity: 1,
+  blendMode: "normal",
+  zIndex: 0,
+  ...over
+});
+
+/** Vends a distinct named surface per call, the way a real host pool does. */
+function surfacePool() {
+  const contexts: RecordingContext[] = [];
+  return {
+    contexts,
+    take: (w: number, h: number): CompositeSurface<string> => {
+      const ctx = new RecordingContext();
+      contexts.push(ctx);
+      return { surface: `crop-${w}x${h}`, ctx };
+    }
+  };
+}
+
+const HALF_WIDTH: ClipCrop = { left: 0.25, right: 0.25, top: 0, bottom: 0 };
+/** Insets on both axes, so neither blit offset is zero. */
+const INSET: ClipCrop = { left: 0.25, right: 0.25, top: 0.2, bottom: 0.3 };
+
+describe("Canvas 2D — clip crop", () => {
+  it("blits the crop onto a crop-sized surface at a negative offset", () => {
+    const ctx = new RecordingContext();
+    const pool = surfacePool();
+    drawTimelineFrame(ctx, [layer({ crop: INSET })], GEOMETRY, {
+      cropSurface: pool.take
+    });
+
+    // 200 wide, a quarter off each side → 100 wide from x = 50.
+    // 100 high, 0.2 off the top and 0.3 off the bottom → 50 high from y = 20.
+    expect(pool.contexts).toHaveLength(1);
+    expect(pool.contexts[0]!.draws).toEqual([
+      {
+        source: "src",
+        x: -50,
+        y: -20,
+        w: 200,
+        h: 100,
+        transform: [1, 0, 0, 1, 0, 0]
+      }
+    ]);
+    // The frame then draws the cropped surface, not the original source.
+    expect(ctx.draws).toHaveLength(1);
+    expect(ctx.draws[0]!.source).toBe("crop-100x50");
+    expect(ctx.draws[0]!.w).toBe(100);
+    expect(ctx.draws[0]!.h).toBe(50);
+  });
+
+  it("places a cropped layer exactly like an uncropped one of the crop's size", () => {
+    // The equivalence the GPU suite asserts in pixels, as geometry: a 200×100
+    // source cropped to its middle 100×100 must land where a 100×100 source
+    // would. Anything reading the *original* size here fails.
+    const cropped = new RecordingContext();
+    drawTimelineFrame(cropped, [layer({ crop: HALF_WIDTH })], GEOMETRY, {
+      cropSurface: surfacePool().take
+    });
+
+    const expected = layerCanvasAffine(undefined, 100, 100, GEOMETRY);
+    const [a, b, c, d, e, f] = cropped.draws[0]!.transform;
+    expect({ a, b, c, d, e, f }).toEqual(expected);
+
+    // And it is genuinely different from the uncropped placement, so the
+    // assertion above is not comparing a value to itself.
+    const uncropped = layerCanvasAffine(undefined, 200, 100, GEOMETRY);
+    expect(uncropped).not.toEqual(expected);
+  });
+
+  it("draws uncropped and reports `crop_skipped` when the host vends no surface", () => {
+    const ctx = new RecordingContext();
+    const { degraded } = drawTimelineFrame(
+      ctx,
+      [layer({ clipId: "c1", crop: HALF_WIDTH })],
+      GEOMETRY,
+      {}
+    );
+
+    expect(degraded).toEqual([{ clipId: "c1", reason: "crop_skipped" }]);
+    // The picture is wrong in a way the caller was told about, not absent.
+    expect(ctx.draws).toHaveLength(1);
+    expect(ctx.draws[0]!.source).toBe("src");
+    expect(ctx.draws[0]!.w).toBe(200);
+  });
+
+  it("asks for no surface, and reports nothing, when there is no crop", () => {
+    const ctx = new RecordingContext();
+    const pool = surfacePool();
+    const { degraded } = drawTimelineFrame(ctx, [layer({})], GEOMETRY, {
+      cropSurface: pool.take
+    });
+
+    expect(pool.contexts).toHaveLength(0);
+    expect(degraded).toEqual([]);
+    expect(ctx.draws[0]!.source).toBe("src");
+  });
+
+  it("treats insets that keep no picture as no crop at all", () => {
+    const ctx = new RecordingContext();
+    const pool = surfacePool();
+    const { degraded } = drawTimelineFrame(
+      ctx,
+      [layer({ crop: { left: 0.7, right: 0.7, top: 0, bottom: 0 } })],
+      GEOMETRY,
+      { cropSurface: pool.take }
+    );
+
+    // No surface taken, nothing reported, whole source drawn — the validator's
+    // `crop_degenerate` is where the user hears about it.
+    expect(pool.contexts).toHaveLength(0);
+    expect(degraded).toEqual([]);
+    expect(ctx.draws[0]!.w).toBe(200);
+  });
+});

--- a/packages/timeline/tests/render.grain.gpu.test.ts
+++ b/packages/timeline/tests/render.grain.gpu.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Film grain on the GPU path (`filters.grain@1`).
+ *
+ * Three properties, each one a way the effect has to be wrong before it is
+ * merely ugly:
+ *
+ * 1. **It varies the picture.** A grain that ran and changed nothing is
+ *    indistinguishable from one that never ran, so the strength cases compare
+ *    against the ungrained render rather than against a golden buffer.
+ * 2. **It stays inside its own alpha.** The layer arrives premultiplied, so
+ *    `rgb <= a` holds on every pixel and a grain that *added* noise would push
+ *    a channel past it — invisible on an opaque layer, a bright fringe on a
+ *    translucent one. That is why the module multiplies, and why the case that
+ *    would have caught it is the half-transparent one.
+ * 3. **It is reproducible.** Same seed, same bytes. A render handed back from a
+ *    cache has to be the render that would have been computed.
+ *
+ * A missing WebGPU adapter skips the suite and says why. On headless Linux that
+ * means no Vulkan ICD — see AGENTS.md § WebGPU on a headless machine.
+ */
+import { describe, expect, it } from "vitest";
+import type { ClipGrainEffect } from "../src/index.js";
+import {
+  HeadlessFrameCompositor,
+  type FrameLayer,
+  type FrameLayerPixels
+} from "../src/render/frameCompositor.js";
+
+const noAdapterReason = await (async (): Promise<string | null> => {
+  try {
+    const { getNodeGPUDevice } = await import("@nodetool-ai/gpu/node");
+    await getNodeGPUDevice();
+    return null;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    process.stderr.write(
+      `render.grain.gpu: skipping every case — no WebGPU device. ${reason}\n`
+    );
+    return reason;
+  }
+})();
+
+const SIZE = 64;
+
+function uniform(r: number, g: number, b: number, a = 255): FrameLayerPixels {
+  const rgba = new Uint8Array(SIZE * SIZE * 4);
+  for (let i = 0; i < rgba.length; i += 4) {
+    rgba[i] = r;
+    rgba[i + 1] = g;
+    rgba[i + 2] = b;
+    rgba[i + 3] = a;
+  }
+  return { rgba, width: SIZE, height: SIZE, version: `u-${r}-${g}-${b}-${a}` };
+}
+
+const grain = (over: Partial<ClipGrainEffect> = {}): ClipGrainEffect => ({
+  id: "grain",
+  type: "grain",
+  enabled: true,
+  amount: 0.5,
+  ...over
+});
+
+function layerWith(
+  source: FrameLayerPixels,
+  effects: ClipGrainEffect[],
+  over: Partial<FrameLayer> = {}
+): FrameLayer {
+  return {
+    id: "shot",
+    source,
+    opacity: 1,
+    blendMode: "normal",
+    zIndex: 0,
+    effects,
+    ...over
+  };
+}
+
+async function renderFrame(
+  layers: FrameLayer[],
+  alpha = false
+): Promise<Uint8Array> {
+  const { getNodeGPUDevice } = await import("@nodetool-ai/gpu/node");
+  const device = await getNodeGPUDevice();
+  const compositor = new HeadlessFrameCompositor(device, SIZE, SIZE);
+  try {
+    return await compositor.renderFrame(layers, [], { alpha });
+  } finally {
+    compositor.dispose();
+  }
+}
+
+/** Population standard deviation of one channel — how much the grain moved it. */
+function channelSpread(rgba: Uint8Array, channel = 0): number {
+  const values: number[] = [];
+  for (let i = channel; i < rgba.length; i += 4) values.push(rgba[i]!);
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const variance =
+    values.reduce((a, v) => a + (v - mean) * (v - mean), 0) / values.length;
+  return Math.sqrt(variance);
+}
+
+describe.runIf(noAdapterReason === null)("grain on the GPU path", () => {
+  it("varies a flat mid-grey that was perfectly uniform without it", async () => {
+    const source = uniform(128, 128, 128);
+    const plain = await renderFrame([layerWith(source, [])]);
+    const grained = await renderFrame([
+      layerWith(source, [grain({ amount: 0.5, seed: 7 })])
+    ]);
+
+    // The ungrained render is the control: flat in, flat out.
+    expect(channelSpread(plain)).toBeLessThan(1);
+    expect(channelSpread(grained)).toBeGreaterThan(5);
+  });
+
+  it("moves the picture further the higher the amount, and not at all at 0", async () => {
+    const source = uniform(128, 128, 128);
+    const off = await renderFrame([
+      layerWith(source, [grain({ amount: 0, seed: 7 })])
+    ]);
+    const light = await renderFrame([
+      layerWith(source, [grain({ amount: 0.15, seed: 7 })])
+    ]);
+    const heavy = await renderFrame([
+      layerWith(source, [grain({ amount: 0.8, seed: 7 })])
+    ]);
+
+    // Amount 0 is a gain of exactly 1 — the identity, not "a little grain".
+    expect(channelSpread(off)).toBeLessThan(1);
+    expect(channelSpread(light)).toBeGreaterThan(1);
+    expect(channelSpread(heavy)).toBeGreaterThan(channelSpread(light));
+  });
+
+  it("leaves black black — there is nothing there to modulate", async () => {
+    const grained = await renderFrame([
+      layerWith(uniform(0, 0, 0), [grain({ amount: 1, seed: 3 })])
+    ]);
+    for (let i = 0; i < grained.length; i += 4) {
+      expect(grained[i]).toBe(0);
+    }
+  });
+
+  it("keeps every channel inside its own alpha on a translucent layer", async () => {
+    // The premultiplication check, and the reason it uses a *dark* half-opaque
+    // source rather than a mid-grey one. The readback un-premultiplies and
+    // saturates at 255, so on a bright layer an overflowing channel comes back
+    // clamped and indistinguishable from a legal one — asserting `<= 255` there
+    // examines nothing. Dark leaves headroom the bug has to show up in: a gain
+    // of at most 2 can only take straight 32 to 64, while noise *added* to the
+    // premultiplied value reaches 1.0 and un-premultiplies to 255.
+    const grained = await renderFrame(
+      [layerWith(uniform(32, 32, 32, 128), [grain({ amount: 1, seed: 11 })])],
+      true
+    );
+    let peak = 0;
+    for (let i = 0; i < grained.length; i += 4) {
+      expect(grained[i + 3]).toBe(128);
+      for (const c of [grained[i]!, grained[i + 1]!, grained[i + 2]!]) {
+        peak = Math.max(peak, c);
+      }
+    }
+    // Two texels of slack for the 8-bit round trip through the premul bridge.
+    expect(peak).toBeLessThanOrEqual(66);
+  });
+
+  it("draws the same bytes twice for one seed, and different ones for another", async () => {
+    const source = uniform(128, 128, 128);
+    const first = await renderFrame([
+      layerWith(source, [grain({ amount: 0.6, seed: 42 })])
+    ]);
+    const again = await renderFrame([
+      layerWith(source, [grain({ amount: 0.6, seed: 42 })])
+    ]);
+    const other = await renderFrame([
+      layerWith(source, [grain({ amount: 0.6, seed: 43 })])
+    ]);
+
+    expect(Array.from(again)).toEqual(Array.from(first));
+    expect(Array.from(other)).not.toEqual(Array.from(first));
+  });
+
+  it("coarsens into blocks as `size` grows", async () => {
+    // A cell of 8px means the 8×8 block shares one gain; per-pixel does not.
+    const source = uniform(128, 128, 128);
+    const coarse = await renderFrame([
+      layerWith(source, [grain({ amount: 0.6, size: 8, seed: 5 })])
+    ]);
+    const fine = await renderFrame([
+      layerWith(source, [grain({ amount: 0.6, size: 1, seed: 5 })])
+    ]);
+
+    const sample = (rgba: Uint8Array, x: number, y: number) =>
+      rgba[(y * SIZE + x) * 4]!;
+    // Two pixels inside one coarse cell agree; the same two under fine grain
+    // are independent samples and (for this seed) do not.
+    expect(sample(coarse, 1, 1)).toBe(sample(coarse, 6, 6));
+    expect(sample(fine, 1, 1)).not.toBe(sample(fine, 6, 6));
+  });
+
+  it("keeps the channels together at colour 0 and splits them at 1", async () => {
+    const source = uniform(128, 128, 128);
+    const mono = await renderFrame([
+      layerWith(source, [grain({ amount: 0.6, colorAmount: 0, seed: 9 })])
+    ]);
+    const colour = await renderFrame([
+      layerWith(source, [grain({ amount: 0.6, colorAmount: 1, seed: 9 })])
+    ]);
+
+    // Monochrome grain is one gain for the pixel, so r, g and b move together.
+    for (let i = 0; i < mono.length; i += 4) {
+      expect(mono[i + 1]).toBe(mono[i]);
+      expect(mono[i + 2]).toBe(mono[i]);
+    }
+    let split = 0;
+    for (let i = 0; i < colour.length; i += 4) {
+      if (colour[i + 1] !== colour[i] || colour[i + 2] !== colour[i]) split++;
+    }
+    expect(split).toBeGreaterThan(SIZE * SIZE * 0.5);
+  });
+});

--- a/packages/video-nodes/src/nodes/timeline/compositeRender.ts
+++ b/packages/video-nodes/src/nodes/timeline/compositeRender.ts
@@ -317,6 +317,7 @@ export async function renderTimelineComposited(
           precomposeGroupId: layer.precomposeGroupId,
           mask: anim.mask,
           borderRadius: layer.borderRadius,
+          crop: layer.crop,
           effects: anim.effects ?? layer.effects,
           trackEffects: layer.trackEffects,
           transition: layer.transition
@@ -350,6 +351,7 @@ export async function renderTimelineComposited(
             transform: undefined,
             parentMatrix: undefined,
             borderRadius: undefined,
+            crop: undefined,
             effects: undefined,
             trackEffects: undefined,
             // The cut's opacity is already in `opacity`; dropping the record

--- a/web/src/components/timeline/Inspector/ClipAdjustments.tsx
+++ b/web/src/components/timeline/Inspector/ClipAdjustments.tsx
@@ -26,10 +26,12 @@ import type {
   BlendMode,
   ClipBlurEffect,
   ClipColorEffect,
+  ClipCrop,
   ClipEffect,
   ClipTransform,
   TimelineClip
 } from "@nodetool-ai/timeline";
+import { hasCrop, isCropUsable } from "@nodetool-ai/timeline";
 import { BLEND_MODES } from "@nodetool-ai/gpu";
 
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
@@ -66,6 +68,27 @@ const IDENTITY_TRANSFORM: ClipTransform = {
   rotation: 0,
   anchor: { x: 0.5, y: 0.5 }
 };
+
+const NO_CROP: ClipCrop = { left: 0, right: 0, top: 0, bottom: 0 };
+
+/** The edge opposite each one, which is what limits how far it can be dragged. */
+const CROP_OPPOSITE: Record<keyof ClipCrop, keyof ClipCrop> = {
+  left: "right",
+  right: "left",
+  top: "bottom",
+  bottom: "top"
+};
+
+/**
+ * How far this edge can come in before the pair keeps no picture. Stopping a
+ * few percent short leaves a sliver to drag back from — a slider pinned at the
+ * exact limit has nowhere to go but out.
+ */
+function cropMax(crop: ClipCrop, edge: keyof ClipCrop): number {
+  return Math.max(0, 0.95 - crop[CROP_OPPOSITE[edge]]);
+}
+
+const cropDisplay = (value: number) => `${Math.round(value * 100)}%`;
 
 const clamp = (value: number, min: number, max: number) =>
   Math.min(max, Math.max(min, value));
@@ -271,9 +294,43 @@ export const ClipAdjustments: React.FC<ClipAdjustmentsProps> = memo(
       (value: number) => patchClip(clip.id, { borderRadius: value }),
       [clip.id, patchClip]
     );
+    // A crop is stored as four insets, so one slider writes one edge and leaves
+    // the other three alone. Dragging an edge past what its opposite leaves is
+    // refused by the slider's own max rather than by a validation message: the
+    // pair has to keep some picture between them.
+    const setCropEdge = useCallback(
+      (edge: keyof ClipCrop, value: number) => {
+        const current = clipRef.current.crop ?? NO_CROP;
+        const next = { ...current, [edge]: value };
+        patchClip(clipRef.current.id, {
+          crop: isCropUsable(next) && hasCrop(next) ? next : undefined
+        });
+      },
+      [patchClip]
+    );
+    const handleCropLeftChange = useCallback(
+      (v: number) => setCropEdge("left", v),
+      [setCropEdge]
+    );
+    const handleCropRightChange = useCallback(
+      (v: number) => setCropEdge("right", v),
+      [setCropEdge]
+    );
+    const handleCropTopChange = useCallback(
+      (v: number) => setCropEdge("top", v),
+      [setCropEdge]
+    );
+    const handleCropBottomChange = useCallback(
+      (v: number) => setCropEdge("bottom", v),
+      [setCropEdge]
+    );
     const handleResetTransform = useCallback(
       () =>
-        patchClip(clip.id, { transform: undefined, borderRadius: undefined }),
+        patchClip(clip.id, {
+          transform: undefined,
+          borderRadius: undefined,
+          crop: undefined
+        }),
       [clip.id, patchClip]
     );
 
@@ -388,6 +445,7 @@ export const ClipAdjustments: React.FC<ClipAdjustmentsProps> = memo(
     // ── Derived display values ──────────────────────────────────────────────
 
     const transform = clip.transform ?? IDENTITY_TRANSFORM;
+    const crop = clip.crop ?? NO_CROP;
     const color = findColorEffect(clip);
     const colorEnabled = color?.enabled ?? false;
     const blur = findBlurEffect(clip);
@@ -567,6 +625,43 @@ export const ClipAdjustments: React.FC<ClipAdjustmentsProps> = memo(
                   value={clip.borderRadius ?? 0}
                   display={`${(clip.borderRadius ?? 0).toFixed(0)}px`}
                   onChange={handleBorderRadiusChange}
+                />
+                <InspectorDivider />
+                <InspectorSliderRow
+                  label="Crop L"
+                  min={0}
+                  max={cropMax(crop, "left")}
+                  step={0.005}
+                  value={crop.left}
+                  display={cropDisplay(crop.left)}
+                  onChange={handleCropLeftChange}
+                />
+                <InspectorSliderRow
+                  label="Crop R"
+                  min={0}
+                  max={cropMax(crop, "right")}
+                  step={0.005}
+                  value={crop.right}
+                  display={cropDisplay(crop.right)}
+                  onChange={handleCropRightChange}
+                />
+                <InspectorSliderRow
+                  label="Crop T"
+                  min={0}
+                  max={cropMax(crop, "top")}
+                  step={0.005}
+                  value={crop.top}
+                  display={cropDisplay(crop.top)}
+                  onChange={handleCropTopChange}
+                />
+                <InspectorSliderRow
+                  label="Crop B"
+                  min={0}
+                  max={cropMax(crop, "bottom")}
+                  step={0.005}
+                  value={crop.bottom}
+                  display={cropDisplay(crop.bottom)}
+                  onChange={handleCropBottomChange}
                 />
               </FlexColumn>
             </CollapsibleSection>

--- a/web/src/components/timeline/Inspector/ClipEffectsList.tsx
+++ b/web/src/components/timeline/Inspector/ClipEffectsList.tsx
@@ -23,6 +23,7 @@ import {
   isClipCurvesEffect,
   isClipDropShadowEffect,
   isClipGlowEffect,
+  isClipGrainEffect,
   isClipLevelsEffect,
   isClipLiftGammaGainEffect,
   isClipSharpenEffect,
@@ -73,7 +74,8 @@ const ADDABLE_EFFECTS = [
   { value: "chromaKey", label: "Chroma key" },
   { value: "curves", label: "Curves" },
   { value: "levels", label: "Levels" },
-  { value: "liftGammaGain", label: "Lift / gamma / gain" }
+  { value: "liftGammaGain", label: "Lift / gamma / gain" },
+  { value: "grain", label: "Film grain" }
 ] as const;
 
 type AddableEffectType = (typeof ADDABLE_EFFECTS)[number]["value"];
@@ -156,6 +158,18 @@ function makeEffect(type: AddableEffectType): ClipEffect {
         lift: [0, 0, 0],
         gamma: [1, 1, 1],
         gain: [1, 1, 1]
+      };
+    case "grain":
+      // Fine, monochrome and rolling — the stock a shot gets when somebody
+      // asks for "some grain" rather than for a look.
+      return {
+        id,
+        type,
+        enabled: true,
+        amount: 0.25,
+        size: 1,
+        colorAmount: 0,
+        animate: true
       };
   }
 }
@@ -281,6 +295,45 @@ const EffectFields: React.FC<EffectFieldsProps> = memo(
             value={effect.softness}
             display={effect.softness.toFixed(2)}
             onChange={(softness) => onPatch({ softness })}
+          />
+        </>
+      );
+    }
+
+    if (isClipGrainEffect(effect)) {
+      return (
+        <>
+          <InspectorSliderRow
+            label="Amount"
+            min={0}
+            max={1}
+            step={0.01}
+            value={effect.amount}
+            display={effect.amount.toFixed(2)}
+            onChange={(amount) => onPatch({ amount })}
+          />
+          <InspectorSliderRow
+            label="Size"
+            min={1}
+            max={16}
+            step={0.5}
+            value={effect.size ?? 1}
+            display={`${(effect.size ?? 1).toFixed(1)}px`}
+            onChange={(size) => onPatch({ size })}
+          />
+          <InspectorSliderRow
+            label="Colour"
+            min={0}
+            max={1}
+            step={0.01}
+            value={effect.colorAmount ?? 0}
+            display={(effect.colorAmount ?? 0).toFixed(2)}
+            onChange={(colorAmount) => onPatch({ colorAmount })}
+          />
+          <InspectorToggleRow
+            label="Animate"
+            checked={effect.animate ?? false}
+            onChange={(animate) => onPatch({ animate })}
           />
         </>
       );

--- a/web/src/components/timeline/preview/compositeLayers.ts
+++ b/web/src/components/timeline/preview/compositeLayers.ts
@@ -121,6 +121,7 @@ export function buildCompositeLayer(
   built.transform = anim.transform;
   built.parentMatrix = layer.parentMatrix;
   built.borderRadius = layer.borderRadius;
+  built.crop = layer.crop;
   built.shapeMask = layer.shapeMask;
   built.effects = anim.effects ?? layer.effects;
   built.trackEffects = layer.trackEffects;
@@ -214,6 +215,7 @@ export function toCanvas2DLayer(
     parentMatrix: layer.parentMatrix,
     precomposeGroupId: layer.precomposeGroupId,
     borderRadius: layer.borderRadius,
+    crop: layer.crop,
     mask: layer.mask,
     shapeMask: layer.shapeMask,
     matte,

--- a/web/src/components/timeline/preview/gpu/canvas2dCompositor.ts
+++ b/web/src/components/timeline/preview/gpu/canvas2dCompositor.ts
@@ -119,6 +119,7 @@ export class Canvas2DCompositor implements TimelineCompositor {
         precompositeSurface: (width, height) => this.takeSurface(width, height),
         maskSurface: (width, height) => this.takeSurface(width, height),
         matteSurface: (width, height) => this.takeSurface(width, height),
+        cropSurface: (width, height) => this.takeSurface(width, height),
         alpha: this.alpha
       }
     );

--- a/web/src/components/timeline/preview/gpu/compositor.ts
+++ b/web/src/components/timeline/preview/gpu/compositor.ts
@@ -266,6 +266,7 @@ export class WebGPUCompositor implements TimelineCompositor {
       parentMatrix: layer.parentMatrix,
       precomposeGroupId: layer.precomposeGroupId,
       borderRadius: layer.borderRadius,
+      crop: layer.crop,
       mask: layer.mask,
       shapeMask: shapeMask ?? undefined,
       matte: layer.matte

--- a/web/src/components/timeline/preview/gpu/types.ts
+++ b/web/src/components/timeline/preview/gpu/types.ts
@@ -1,5 +1,6 @@
 import type {
   AnimationSampleMask,
+  ClipCrop,
   ClipEffect,
   ClipMask,
   ClipTransform,
@@ -49,6 +50,13 @@ export interface CompositeLayer {
   precomposeGroupId?: string;
   /** Rounded-corner radius in source pixels. Default 0. */
   borderRadius?: number;
+  /**
+   * The part of the source this layer draws, from the scene model. Taken before
+   * anything else reads the pixels, so the contain fit, the transform, the
+   * border radius and the masks all see the cropped rectangle as the layer's
+   * whole picture.
+   */
+  crop?: ClipCrop;
   /**
    * Wipe mask (from a `wipe` animation) applied in the layer's own quad
    * space, so the wipe edge rotates with the layer. Absent means unmasked.


### PR DESCRIPTION
## What changed

Adds the two clip transformations from [Maestro](https://github.com/Blizaine/Maestro) that NodeTool had no equivalent for. Its other clip edits — trim, split, duplicate, speed, opacity, canvas transform, volume, transitions — already exist here, so this covers the gap rather than the whole list. **Crop** stores four normalized insets on the clip and reframes: the kept rectangle *becomes* the picture, so the contain fit, the transform, the border radius, the masks and the effect chain all act on it. Insets rather than pixels so a crop survives the asset under it changing resolution; reframing rather than knocking out because a rect `ClipMask` already does the latter. `cropRectPx` is the one place the arithmetic lives — the GPU path narrows the upload with a `copyTextureToTexture` before the effect chain, the Canvas 2D path blits onto a crop-sized surface, so both see a genuinely cropped source and nothing downstream branches. **Grain** (`filters.grain@1`) is a multiplicative gain wobble: multiplying keeps a premultiplied layer legal where adding noise pushes a channel past its own alpha, and it is also how stock behaves. The pattern is a hash of the grain cell and a seed, never a clock; `resolveAnimatedLayerProps` stamps the frame's time on an `animate` grain, so it rolls while a re-render of one frame stays byte-identical. Canvas 2D cannot draw grain and reports it through `unsupportedEffectTypes`. Insets that keep no picture render uncropped rather than blanking the shot, which the validator reports as `crop_degenerate`.

Nothing here replaces a clip's asset, so the version-history requirement that motivated the ask does not arise in this PR — `clip.versions` and `restoreVersion` are untouched. The asset-replacing transformations Maestro also offers (upscale, frame interpolation, outpaint) are **not** in this PR; those are the ones that would append a `ClipVersion`, and they are a separate change.

## Verification

- [x] `npm run test:affected`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run dev:nodetool -- harness gate --base main`

```
Gate: 8/8 selfchecks passed
packages/timeline   93 files, 1179 tests passed
packages/execution  53 files,  514 tests passed
packages/agents    289 files, 4517 tests passed
packages/gpu        31 files,  798 tests passed
packages/protocol   85 files, 1488 tests passed
web               1452 suites, 15973 tests passed
electron            63 suites,  692 tests passed
lint: exit 0, no findings in any file this diff touches
typecheck: web exit 0, electron exit 0
```

Two `test:affected` failures are pre-existing and environmental, both confirmed by re-running on a stashed tree:

- `packages/video-nodes` `timeline-time-remap-decode` — its `beforeAll` builds an `.mkv` fixture and times out at 60s because there is no `ffmpeg` on this container's PATH. All 7 tests skip; fails identically without this diff. The rest of the package passes (331 tests).
- `packages/blender-nodes` `settings.test.ts` — spawns real subprocesses on a 5s budget and times out only under 27-package parallel turbo load. Passes alone with and without this diff, and passed on the one re-run.

Also of note for anyone reproducing: this container's `node_modules` was missing the `godot`, `godot-templates`, `storyboard` and `game-nodes` workspace links, so four packages failed to build on an untouched tree until `npm install`. `mobile/node_modules` is absent entirely, which is every error `npm run typecheck` prints for `mobile/`.

## Agent capabilities

`set_clip_params` gains `crop`; the effect params gain `grain` plus `size`, `colorAmount` and `animate`.

- [x] `npm run capabilities:check` passes — `capability table is current (282 capabilities)`
- [x] Both are covered by the checks below rather than by new eval cases: the crop op's refusal of degenerate insets and the `crop_degenerate` report are in `packages/execution/tests/timeline-crop.test.ts`, and grain's parameters reach the shader through `packages/timeline/tests/render.grain.gpu.test.ts`.

## New checks

- [x] Each new check was inverted once and observed failing.

**Grain, made additive** (`color.rgb + n` clamped to 1, instead of `color.rgb * gain` clamped to alpha):

```
× leaves black black — there is nothing there to modulate
  AssertionError: expected 218 to be +0
× keeps every channel inside its own alpha on a translucent layer
  AssertionError: expected 255 to be less than or equal to 66
  Tests  2 failed | 5 passed (7)
```

Worth calling out: the premultiplication case *passed* against the additive shader on the first attempt. It asserted `<= 255` on a mid-grey layer, which the readback's own saturation satisfies no matter what the shader did — it examined nothing. It now uses a dark half-opaque source, where a gain of at most 2 has a ceiling an additive grain sails past, and the failure above is that corrected version.

**Crop, disabled** (`cropSource` always returns the upload):

```
× renders a cropped source exactly like the pre-cropped source itself
× matches the pre-cropped equivalent on both axes at once
× actually changes the frame — the equivalence is not two identical renders
× re-fits the crop to the frame rather than shrinking the picture
  Tests  4 failed | 2 passed (6)
```

**`crop` dropped from the protocol schema** — which is also what proves the validator cases were not passing vacuously:

```
× keeps a crop through the parse instead of stripping it
× reports a horizontal pair that keeps nothing
× reports a vertical pair that keeps nothing
× reports a negative inset, which no drag produces and no reader expects
  Tests  4 failed | 2 passed (6)
```

**`isCropUsable` always true**:

```
× reports a horizontal pair that keeps nothing
× reports a vertical pair that keeps nothing
  Tests  2 failed | 4 passed (6)
```

- [x] The one enumerating check asserts it found its targets: `everyEffect` in `render.clipEffects.test.ts` is now compared against `CLIP_EFFECT_TYPES` instead of being maintained by hand. It had already silently stopped being every effect — that is how grain first went unreported by Canvas 2D — so a type added to the union and not to the fixture now fails there rather than leaving the unsupported-types assertion pinned to a stale set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUCgrfM5gJEqY4mNdemfH3

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUCgrfM5gJEqY4mNdemfH3)_